### PR TITLE
Fix sfputil/psuutil issues due to dependencies on minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -13,8 +13,6 @@ import aaa
 import mlnx
 
 SONIC_CFGGEN_PATH = "sonic-cfggen"
-MINIGRAPH_PATH = "/etc/sonic/minigraph.xml"
-MINIGRAPH_BGP_SESSIONS = "minigraph_bgp"
 
 #
 # Helper functions

--- a/psuutil/main.py
+++ b/psuutil/main.py
@@ -27,7 +27,6 @@ PLATFORM_SPECIFIC_CLASS_NAME = "PsuUtil"
 PLATFORM_ROOT_PATH = '/usr/share/sonic/device'
 PLATFORM_ROOT_PATH_DOCKER = '/usr/share/sonic/platform'
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
-MINIGRAPH_PATH = '/etc/sonic/minigraph.xml'
 HWSKU_KEY = 'DEVICE_METADATA.localhost.hwsku'
 PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 
@@ -78,7 +77,7 @@ def get_platform_and_hwsku():
         proc.wait()
         platform = stdout.rstrip('\n')
 
-        proc = subprocess.Popen([SONIC_CFGGEN_PATH, '-m', MINIGRAPH_PATH, '-v', HWSKU_KEY],
+        proc = subprocess.Popen([SONIC_CFGGEN_PATH, '-d', '-v', HWSKU_KEY],
                                 stdout=subprocess.PIPE,
                                 shell=False,
                                 stderr=subprocess.STDOUT)

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -27,7 +27,6 @@ PLATFORM_SPECIFIC_CLASS_NAME = "SfpUtil"
 
 PLATFORM_ROOT_PATH = '/usr/share/sonic/device'
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
-MINIGRAPH_PATH = '/etc/sonic/minigraph.xml'
 HWSKU_KEY = 'DEVICE_METADATA.localhost.hwsku'
 PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 
@@ -296,7 +295,7 @@ def get_platform_and_hwsku():
         proc.wait()
         platform = stdout.rstrip('\n')
 
-        proc = subprocess.Popen([SONIC_CFGGEN_PATH, '-m', MINIGRAPH_PATH, '-v', HWSKU_KEY],
+        proc = subprocess.Popen([SONIC_CFGGEN_PATH, '-d', '-v', HWSKU_KEY],
                                 stdout=subprocess.PIPE,
                                 shell=False,
                                 stderr=subprocess.STDOUT)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Remove the dependencies on minigraph for certain commands. 

**- How I did it**
Use configDB values instead.

**- How to verify it**
In cases the minigraph is missing or mismatch, you would see errors in sfputil/psuutil commands.
One example is that if you upgrade SONiC by sonic_installer, the minigraph will be missing and sfputil command will fail.  After this fix, the sfputil is fine. 

**- Previous command output (if the output of a command-line utility has changed)**
In case minigraph is missing:
sudo sfputil show eeprom 
Error reading port info ([Errno 2] No such file or directory: '/usr/share/sonic/device/x86_64-cel_seastone-r0/Traceback (most recent call last):\n  File "/usr/local/bin/sonic-cfggen", line 238, in <module>\n    main()\n  File "/usr/local/bin/sonic-cfggen", line 173, in main\n    deep_update(data, parse_xml(minigraph, platform))\n  File "/usr/local/lib/python2.7/dist-packages/minigraph.py", line 352, in parse_xml\n    root = ET.parse(filename).getroot()\n  File "lxml.etree.pyx", line 3299, in lxml.etree.parse (src/lxml/lxml.etree.c:72655)\n  File "parser.pxi", line 1791, in lxml.etree._parseDocument (src/lxml/lxml.etree.c:106263)\n  File "parser.pxi", line 1817, in lxml.etree._parseDocumentFromURL (src/lxml/lxml.etree.c:106564)\n  File "parser.pxi", line 1721, in lxml.etree._parseDocFromFile (src/lxml/lxml.etree.c:105561)\n  File "parser.pxi", line 1122, in lxml.etree._BaseParser._parseDocFromFile (src/lxml/lxml.etree.c:100456)\n  File "parser.pxi", line 580, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:94543)\n  File "parser.pxi", line 690, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:96003)\n  File "parser.pxi", line 618, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:95015)\nIOError: Error reading file \'/etc/sonic/minigraph.xml\': failed to load external entity "/etc/sonic/minigraph.xml"/portmap.ini')

**- New command output (if the output of a command-line utility has changed)**
 sudo sfputil show eeprom 
Ethernet0: SFP EEPROM detected
        Connector: MPOx12
        Encoding: NRZ
  ...
-->

