### PR TITLE
Fixing the delete vlan function

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -630,6 +630,9 @@ def del_vlan(ctx, vid):
     for k in keys:
         db.set_entry('VLAN_MEMBER', k, None)
     db.set_entry('VLAN', 'Vlan{}'.format(vid), None)
+    keys = [ (k, v) for k, v in db.get_table('VLAN_INTERFACE') if k == 'Vlan{}'.format(vid)]
+    for k in keys:
+        db.set_entry('VLAN_INTERFACE',k,None)
 
 
 #


### PR DESCRIPTION
Base on this link https://github.com/Azure/SONiC/wiki/Configuration, there are three tables involve when configuring vlan:  VLAN, VLAN_MEMBER and VLAN_INTERFACE. 
However, in the delete vlan function in https://github.com/Azure/sonic-utilities/blob/master/config/main.py, just two table are deleted, and the VLAN_INTERFACE has been left. 

**- What I did**
    Deleting VLAN_INTERFACE table as well when deleting a vlan. 


**- How I did it**
Find the Vlan in VLAN_INTERFACE table and delete that table: 
    keys = [ (k, v) for k, v in db.get_table('VLAN_INTERFACE') if k == 'Vlan{}'.format(vid)]
    for k in keys:
        db.set_entry('VLAN_INTERFACE',k,None)

**- How to verify it** 
Config a vlan with 3 tables: VLAN, VLAN_MEMBER and VLAN_INTERFACE as in https://github.com/Azure/SONiC/wiki/Configuration
Checking information in redis before and after delete vlan as below: 


root@leaf2-10-58-0-22:/# redis-cli -n 4 keys \*Vlan5\*
1) "VLAN_INTERFACE|Vlan5|192.168.5.1/24"
2) "VLAN_MEMBER|Vlan5|Ethernet16"
3) "VLAN|Vlan5"

root@leaf2-10-58-0-22:/# config vlan del 5
root@leaf2-10-58-0-22:/# redis-cli -n 4 keys \*Vlan5\*
(empty list or set)
root@leaf2-10-58-0-22:/#