### PR TITLE
Prevent shutdown/startup commands on invalid interface names "fixes (SONiC/issues/268)"

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -11,7 +11,6 @@ import syslog
 
 import sonic_platform
 from swsssdk import ConfigDBConnector
-from natsort import natsorted
 from minigraph import parse_device_desc_xml
 
 import aaa
@@ -77,7 +76,7 @@ def interface_alias_to_name(interface_alias):
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
-        for port_name in natsorted(port_dict.keys()):
+        for port_name in port_dict.keys():
             if interface_alias == port_dict[port_name]['alias']:
                 return port_name
         click.echo("Invalid interface {}".format(interface_alias))
@@ -96,7 +95,7 @@ def interface_name_is_valid(interface_name):
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
-        for port_name in natsorted(port_dict.keys()):
+        for port_name in port_dict.keys():
             if interface_name == port_name:
                 return True
     return False
@@ -112,11 +111,9 @@ def interface_name_to_alias(interface_name):
         if not port_dict:
             click.echo("port_dict is None!")
             raise click.Abort()
-        for port_name in natsorted(port_dict.keys()):
+        for port_name in port_dict.keys():
             if interface_name == port_name:
                 return port_dict[port_name]['alias']
-
-        click.echo("Invalid interface {}".format(interface_alias))
 
     return None
 
@@ -841,7 +838,7 @@ def startup(ctx):
     interface_name = ctx.obj['interface_name']
 
     if interface_name_is_valid(interface_name) is False:
-        ctx.fail("Enter valid interface name!!")
+        ctx.fail("Interface name is invalid. Please enter a  valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
         config_db.mod_entry("PORT", interface_name, {"admin_status": "up"})
@@ -859,7 +856,7 @@ def shutdown(ctx):
     interface_name = ctx.obj['interface_name']
 
     if interface_name_is_valid(interface_name) is False:
-        ctx.fail("Enter valid interface name!!")
+        ctx.fail("Interface name is invalid. Please enter a  valid interface name!!")
 
     if interface_name.startswith("Ethernet"):
         config_db.mod_entry("PORT", interface_name, {"admin_status": "down"})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Invalid interface names are pushed into the CONFIG DB though they don't have a valid alias name, due to a missing check in shutdown/startup functions.
Later show commands that check for alias names on the interfaces fail.

**- How I did it**
In the main.py utilities script, check if the given interface name exists in the PORT_TABLE in config db. If not, fail the shutdown/startup functions there throwing an error to the user prompting for a valid interface name.

**- How to verify it**
Issue shutdown or startup commands on invalid interface names, followed by show interfaces status.

**- Previous command output (if the output of a command-line utility has changed)**

root@sonic-testing:/home/admin# config interface Ethernet99 shutdown
root@sonic-testing:/home/admin# show interface status
Traceback (most recent call last):
  File "/usr/bin/show", line 9, in <module>
    load_entry_point('sonic-utilities==1.2', 'console_scripts', 'show')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 561, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2291, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2297, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 193, in <module>
    iface_alias_converter = InterfaceAliasConverter()
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 58, in __init__
    self.port_dict[port_name]['alias']):
KeyError: 'alias'

**- New command output (if the output of a command-line utility has changed)**

root@sonic:/home/admin# config interface Ethernet99 shutdown
Usage: config interface shutdown [OPTIONS]

Error: Enter valid interface name!!

root@sonic:/home/admin# show interface status
  Interface    Lanes    Speed    MTU      Alias    Oper    Admin    Type
-----------  -------  -------  -----  ---------  ------  -------  ------
  Ethernet0       13      N/A   9100   tenGigE0    down       up     SFP
  Ethernet1       14      N/A   9100   tenGigE1    down       up     N/A
  Ethernet2       15      N/A   9100   tenGigE2    down       up     SFP
....
-->

