### PR TITLE
mgmt_vrf_namespace_tacacs: Tacacs enhancement on top of namespace sol…

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -185,7 +185,16 @@ def add(address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
         if key is not None:
             data['passkey'] = key
         if use_mgmt_vrf :
-            data['vrf'] = "mgmt"
+            entry = config_db.get_entry('MGMT_VRF_CONFIG',"vrf_global")
+            if not entry or entry['mgmtVrfEnabled'] == 'false' :
+                # Either VRF entry does not exist or it is disabled.
+                # Silenty ignore the --use-mgmt-vrf if VRF is not enabled
+                data['vrf'] = "None"
+            else:
+                data['vrf'] = "mgmt"
+
+        else:
+            data['vrf'] = "None"
         config_db.set_entry('TACPLUS_SERVER', address, data)
 tacacs.add_command(add)
 


### PR DESCRIPTION
**- What I did**
Enhanced the configuration for using --use-mgmt-vrf for tacacs server configuration on top of namespace based solution for management VRF.

**- How I did it**
Added checks for vrf and set the variable to "mgmt" if management VRF is enabled, else use "None". There is no change in the command syntax. Its just the value that is being passed for non-mgmt-vrf and for mgmt-vrf.

**- How to verify it**
1) First, checkout the namespace solution once if the following two PRs are merged.
(a) https://github.com/Azure/sonic-buildimage/pull/2405
(b) https://github.com/Azure/sonic-utilities/pull/422. 
Checkout this file aaa.py along with the files/image_config/hostcfgd/hostcfgd PR.
With all these files, enable mgmt vrf using command "config vrf add mgmt" and configure tacacs client using following commands. 
(a) config aaa authentication login tacacs+
(b) config tacacs authtype login
(c) config tacacs passkey testing123
(d) config tacacs add --use-mgmt-vrf serveripaddress
Configure the tacacs server accordingly.
Then, do SSH to the device and verify that the user is authenticated using tacacs server via the management VRF port eth0.

