### PR TITLE
Mgmt vrf namespace2

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -185,7 +185,16 @@ def add(address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
         if key is not None:
             data['passkey'] = key
         if use_mgmt_vrf :
-            data['vrf'] = "mgmt"
+            entry = config_db.get_entry('MGMT_VRF_CONFIG',"vrf_global")
+            if not entry or entry['mgmtVrfEnabled'] == 'false' :
+                # Either VRF entry does not exist or it is disabled.
+                # Silenty ignore the --use-mgmt-vrf if VRF is not enabled
+                data['vrf'] = "None"
+            else:
+                data['vrf'] = "mgmt"
+
+        else:
+            data['vrf'] = "None"
         config_db.set_entry('TACPLUS_SERVER', address, data)
 tacacs.add_command(add)
 

--- a/config/main.py
+++ b/config/main.py
@@ -15,7 +15,7 @@ import sonic_platform
 from swsssdk import ConfigDBConnector
 from natsort import natsorted
 from minigraph import parse_device_desc_xml
-from sonic_snmp_trap_conf import snmptrap_modify_cfg
+from sonic_snmp_trap_conf import snmptrap_del_old_nat_rule 
 
 import aaa
 import mlnx
@@ -854,6 +854,7 @@ def modify_snmptrap_server(ctx, ver, serverip, trapport, use_mgmt_vrf):
         if entry['mgmtVrfEnabled'] == "false" :
             click.echo('Cannot set SNMPTrap server using --use-mgmt-vrf when management VRF is not yet enabled.')
             return
+    snmptrap_del_old_nat_rule  (ver, serverip, trapport, use_mgmt_vrf)
     if ver == "1":
         if use_mgmt_vrf: 
             config_db.mod_entry('SNMP_TRAP_CONFIG',"v1TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf": "mgmt"})
@@ -869,7 +870,8 @@ def modify_snmptrap_server(ctx, ver, serverip, trapport, use_mgmt_vrf):
             config_db.mod_entry('SNMP_TRAP_CONFIG',"v3TrapDest",{"DestIp": serverip, "DestPort": trapport, "vrf":"mgmt"})
         else:
             config_db.set_entry('SNMP_TRAP_CONFIG',"v3TrapDest",{"DestIp": serverip, "DestPort": trapport})
-    snmptrap_modify_cfg (ver, serverip, trapport, use_mgmt_vrf)
+    cmd="systemctl restart snmp"
+    os.system (cmd)
 
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -1052,8 +1052,9 @@ def ip(ctx):
 
 @ip.command()
 @click.argument("ip_addr", metavar="<ip_addr>", required=True)
+@click.argument('gw1', metavar='<default gateway IP address>', required=False)
 @click.pass_context
-def add(ctx, ip_addr):
+def add(ctx, ip_addr, gw1):
     """Add an IP address towards the interface"""
     config_db = ctx.obj["config_db"]
     interface_name = ctx.obj["interface_name"]

--- a/config/sonic_snmp_trap_conf.py
+++ b/config/sonic_snmp_trap_conf.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+
+'''
+Motivation: Backend API implementation for manipulation of the SNMP configuration file.
+
+Functionalities:
+               Add trap recipient host(s) config entries
+               modifiy/delete a trap recipient host entry
+'''
+
+import os
+import sys
+import click
+import json
+import subprocess
+import fileinput
+import netaddr
+import syslog
+import logging
+import logging.handlers
+from swsssdk import ConfigDBConnector
+
+SNMP_SERVER_LOCAL_IP="127.100.100.1"
+
+
+def snmptrap_modify_cfg(ver, hostaddr, port, use_mgmt_vrf):
+    """
+    Function to set snmp-server configuration for the destination to
+    send the notifications to.
+    """
+    syslog.syslog(syslog.LOG_DEBUG, "SNMP " + \
+     "mod_cfg() : received : " + \
+     " snmp version - %s"%(ver) + \
+     " host address - port %s %s"%(hostaddr, port))
+    try :
+        # use_mgmt_vrf is valid only when vrf is enabled . 
+        # If VRF enabled, delete old NAT rule based on old serverip/port and add new NAT rule
+        if use_mgmt_vrf:
+            #vrf is enabled. Get the local_port based on version number. For v1 serverIP, local port 62101 is used
+            # for v2 serverIP, local port 62102 is used. For v3, 62103 is used.
+            local_port = "6210{0}".format(ver)
+            # Get the previously configured serverip and delete the corresponding iptables rule before adding the new rule.
+            TrapVar = "v{0}TrapDest".format(ver)
+            config_db = ConfigDBConnector()
+            config_db.connect()
+            snmp_config=config_db.get_entry('SNMP_TRAP_CONFIG',TrapVar)
+            if snmp_config:
+                old_server_ip = snmp_config['DestIp']
+                old_server_port = snmp_config['DestPort']
+                cmd = "ip netns exec mgmt iptables -t nat -D PREROUTING -i if1 -p udp -d {0} --dport {1} -j DNAT --to-destination {2}:{3}".format(SNMP_SERVER_LOCAL_IP, local_port, old_server_ip, old_server_port)
+                syslog.syslog(syslog.LOG_DEBUG, "Deleting iptables rule for old SNMPv{0} Trap Destination Config. Rule={1}".format(ver,cmd))
+                os.system(cmd)
+
+        cmd="systemctl restart snmp"
+        os.system (cmd)
+        
+    except :
+        syslog.syslog(syslog.LOG_ERR, "Exception in modifying the snmp trap destination")
+        return 1
+    return 0
+

--- a/config/sonic_snmp_trap_conf.py
+++ b/config/sonic_snmp_trap_conf.py
@@ -23,7 +23,7 @@ from swsssdk import ConfigDBConnector
 SNMP_SERVER_LOCAL_IP="127.100.100.1"
 
 
-def snmptrap_modify_cfg(ver, hostaddr, port, use_mgmt_vrf):
+def snmptrap_del_old_nat_rule (ver, hostaddr, port, use_mgmt_vrf):
     """
     Function to set snmp-server configuration for the destination to
     send the notifications to.
@@ -51,8 +51,6 @@ def snmptrap_modify_cfg(ver, hostaddr, port, use_mgmt_vrf):
                 syslog.syslog(syslog.LOG_DEBUG, "Deleting iptables rule for old SNMPv{0} Trap Destination Config. Rule={1}".format(ver,cmd))
                 os.system(cmd)
 
-        cmd="systemctl restart snmp"
-        os.system (cmd)
         
     except :
         syslog.syslog(syslog.LOG_ERR, "Exception in modifying the snmp trap destination")

--- a/show/main.py
+++ b/show/main.py
@@ -402,6 +402,92 @@ def ndp(ip6address, iface, verbose):
     run_command(cmd, display_cmd=verbose)
 
 #
+# 'mgmt-vrf' group ("show mgmt-vrf ...")
+#
+
+@cli.group('mgmt-vrf', invoke_without_command=True)
+@click.pass_context
+def mgmt_vrf(ctx):
+
+	"""Show management VRF attributes"""
+
+	if ctx.invoked_subcommand is None:
+		cmd = 'sonic-cfggen -d --var-json "MGMT_VRF_CONFIG"'
+		
+		p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		res = p.communicate()
+		if p.returncode == 0 :
+			p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+			mvrf_dict = json.loads(p.stdout.read())
+		
+			# if the mgmtVrfEnabled attribute is configured, check the value
+			# and print Enabled or Disabled accordingly.
+			if 'mgmtVrfEnabled' in mvrf_dict['vrf_global']:
+				if (mvrf_dict['vrf_global']['mgmtVrfEnabled'] == "true"):
+					click.echo("\nManagementVRF : Enabled")
+				else:
+					click.echo("\nManagementVRF : Disabled")
+	
+		click.echo("\nNameSpaces in Linux:")
+		cmd = "sudo ip netns list"
+		run_command(cmd)
+
+@mgmt_vrf.command('interfaces')
+def mgmt_vrf_interfaces ():
+	"""Show management VRF attributes"""
+	
+	click.echo("\nInterfaces in Management VRF:")
+	cmd = "sudo ip netns exec mgmt ifconfig"
+	run_command(cmd)
+	return None
+
+@mgmt_vrf.command('route')
+def mgmt_vrf_route ():
+	"""Show management VRF routes"""
+	
+	click.echo("\nRoutes in Management VRF Routing Table:")
+	cmd = "sudo ip netns exec mgmt ip route show"
+	run_command(cmd)
+	return None
+
+
+@mgmt_vrf.command('addresses')
+def mgmt_vrf_addresses ():
+	"""Show management VRF addresses"""
+	
+	click.echo("\nIP Addresses for interfaces in Management VRF:")
+	cmd = "sudo ip netns exec mgmt ip address show"
+	run_command(cmd)
+	return None
+
+
+
+#
+# 'management_interface' group ("show management_interface ...")
+#
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def management_interface():
+    """Show management interface parameters"""
+    pass
+
+# 'address' subcommand ("show management_interface address")
+@management_interface.command()
+def address ():
+    """Show IP address configured for management interface"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    header = ['IFNAME', 'IP Address', 'PrefixLen',]
+    body = []
+
+    # Fetching data from config_db for MGMT_INTERFACE
+    mgmt_ip_data = config_db.get_table('MGMT_INTERFACE')
+    for key in natsorted(mgmt_ip_data.keys()):
+        click.echo("Management IP address = {0}".format(key[1]))
+        click.echo("Management NetWork Default Gateway = {0}".format(mgmt_ip_data[key]['gwaddr']))
+
+#
 # 'interfaces' group ("show interfaces ...")
 #
 


### PR DESCRIPTION
**- What I did**
Added support for management VRF using namespace solution.
Requirements that are covered are explained in the design document. Enhancements required to support tacacs and snmptrap are also added. Enhanced the configuration for using --use-mgmt-vrf for tacacs server & snmptrap server configuration on top of namespace based solution for management VRF to configure the required rules for namespace solution.
Two PRs are raised, one for sonic-buildimage (https://github.com/Azure/sonic-buildimage/pull/2431) and other for sonic-utilities (this PR#431).
**- How I did it**
Added commands to enable/disable the management VRF. On enabling, it creates the management namespace, attached eth0 to management namespace, creates the required iptables rules and restarts the networking service. Detailed design is explained in the design document https://github.com/kannankvs/mvrf_namespace/blob/master/Management%20VRF%20Design%20Document%20Namespace.md. Namespace solution requires DNAT as explained in the design document. hostcfgd is enhanced to support maximum of 10 tacacs servers. Mapping between the user configured tacacs server IP/port and internally used local IP/port are maintained in this file for adding and deleting those NAT rules. For supporting snmptrap configuration, enhanced main.py & created sonic_snmp_trap_conf.py to configure the snmptrap server IP address/port and enhanced the file docker_image_ctl.j2 to create the required /usr/bin/snmp.sh script that adds the required DNAT rules during snmp service restart process.
**- How to verify it**
Use the following commands to enable/disable mgmt vrf and test the basic management VRF features.
config vrf add mgmt
config vrf del mgmt
config interface eth0 ip add ip/mask gatewayIP
Ex: config interface eth0 ip add 10.16.206.11/24 10.16.206.1
Using the above configuration, all applications like Ping, SSH, SCP, apt-get, etc., can be tested on management VRF using “ip netns exec mgmt COMMAND” as explained in the design document.
Use the following steps to test tacacs.
1.	First, checkout all the modified files and build an image with these changes.
2.	With the new image, enable mgmt vrf using command "config vrf add mgmt" and configure tacacs client using following commands.
(a) config aaa authentication login tacacs+
(b) config tacacs authtype login
(c) config tacacs passkey testing123
(d) config tacacs add --use-mgmt-vrf serveripaddress
3.	Configure the tacacs server accordingly.
4.	Then, do SSH to the device and verify that the user is authenticated using tacacs server via the management VRF port eth0.
Use the following steps to test snmptrap.
1.	First, checkout all the modified files and build an image with these changes.
2.	Use the command “config snmptrap modify snmp_version snmptrapserver_ipaddress” (ex: config snmptrap modify 2 10.11.150.7) and listen for the traps in the trapserver.
3.	When the above command is configured, it restarts the snmp service. Netsnmp service sends few traps during bootup sequence that can be viewed in the trapserver.
