### PR TITLE
[config] Unconditionally reset failed status of all SONiC services

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -322,19 +322,13 @@ def _reset_failed_services():
         'teamd'
     ]
 
-    command = "systemctl --failed | grep failed | awk '{ print $2 }' | awk -F'.' '{ print $1 }'"
-    proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-    (out, err) = proc.communicate()
-    failed_services = out.rstrip('\n').split('\n')
-
-    for service in failed_services:
-        if service in services_to_reset:
-            try:
-                click.echo("Resetting failed service {} ...".format(service))
-                run_command("systemctl reset-failed {}".format(service))
-            except SystemExit as e:
-                log_error("Failed to reset service {}".format(service))
-                raise
+    for service in services_to_reset:
+        try:
+            click.echo("Resetting failed status for service {} ...".format(service))
+            run_command("systemctl reset-failed {}".format(service))
+        except SystemExit as e:
+            log_error("Failed to reset failed status for service {}".format(service))
+            raise
 
 def _restart_services():
     services_to_restart = [


### PR DESCRIPTION
This will reset the systemd counters which dictate when a service should be placed in the "failed" state for all specified SONiC services whenever calling `config reload`, `config load_minigraph`. The previous behavior only performed the reset if the services were already in the "failed" state. However, there is the chance that a process is one restart away from being marked as failed, so a call to one of the above commands could have still resulted in a process which failed to start.

Resolves https://github.com/Azure/sonic-utilities/issues/616