### PR TITLE
[config] Verify syslog server IP address is configured before removal

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1396,8 +1396,12 @@ def del_syslog_server(ctx, syslog_ip_address):
     if not is_ipaddress(syslog_ip_address):
         ctx.fail('Invalid IP address')
     db = ctx.obj['db']
-    db.set_entry('SYSLOG_SERVER', '{}'.format(syslog_ip_address), None)
-    click.echo("Syslog server {} removed from configuration".format(syslog_ip_address))
+    syslog_servers = db.get_table("SYSLOG_SERVER")
+    if syslog_ip_address in syslog_servers:
+        db.set_entry('SYSLOG_SERVER', '{}'.format(syslog_ip_address), None)
+        click.echo("Syslog server {} removed from configuration".format(syslog_ip_address))
+    else: 
+        ctx.fail("Syslog server {} is not configured.".format(syslog_ip_address))
     try:
         click.echo("Restarting rsyslog-config service...")
         run_command("systemctl restart rsyslog-config", display_cmd=False)


### PR DESCRIPTION
**- What I did**
Added check to the 'config syslog del <ip-address>' command

**- How I did it**
I'm checking the Redis DB to verify if there is an IP address configured or not. 

**- How to verify it**
show run syslog 

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
```
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ show run syslog
Syslog Servers
----------------
1.1.1.1
4.4.4.4
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config syslog del 4.4.4.4 
Syslog server 4.4.4.4 removed from configuration
Restarting rsyslog-config service...
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ show run syslog
Syslog Servers
----------------
1.1.1.1
admin@str-s6000-acs-11:/usr/lib/python2.7/dist-packages/config$ sudo config syslog del 5.5.5.5
Usage: config syslog del [OPTIONS] <syslog_ip_address>

Error: Syslog server 5.5.5.5 is not configured.
```
-->

