### PR TITLE
Tech-support export manager

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -25,11 +25,13 @@ DO_COMPRESS=true
 CMD_PREFIX=
 SINCE_DATE="@0" # default is set to January 1, 1970 at 00:00:00 GMT
 REFERENCE_FILE=/tmp/reference
-BASE=sonic_dump_`hostname`_`date +%Y%m%d_%H%M%S`
+BASE=${BASE:-sonic_dump_`hostname`_`date +%Y%m%d_%H%M%S`}
 DUMPDIR=/var/dump
 TARDIR=$DUMPDIR/$BASE
 TARFILE=$DUMPDIR/$BASE.tar
 LOGDIR=$DUMPDIR/$BASE/dump
+HOME=${HOME:-/root}
+USER=${USER:-root}
 
 ###############################################################################
 # Runs a comamnd and saves its output to the incrementally built tar.

--- a/show/main.py
+++ b/show/main.py
@@ -2040,5 +2040,19 @@ def config(redis_unix_socket_path):
     click.echo(tabulate(tablelize(keys, data, enable_table_keys, prefix), header))
     state_db.close(state_db.STATE_DB)
 
+@cli.command('export')
+def export():
+    """ show tech-support export configurations """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    cfg_entry = config_db.get_entry('EXPORT', 'export')
+
+    if 'servername' in cfg_entry:
+        del cfg_entry['password']
+        print "Export Info : {}".format(cfg_entry)
+    else:
+        print "Export info is not configured/enabled"
+
+
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
# Tech-support export service

The tech-support data is a piece of vital information for debugging of a system and is captured by collecting the device configuration, system information, log files and core files. Added a new service called 'export service' which captures the tech-support data and export it to a remote server for better offline debugging.  The tech-support data is captured and exported under the following conditions

  1.  On detection of a new core file
  2.  On a periodical interval

The export service is configured to monitors the coredump path for any new core file creation. Upon detection of a new core file, it triggers the tech-support data collection and export it to a remote server.   In addition, export service can be configured to capture and upload the tech-support data periodically.

**- How I did it**
Added a new service 'export service'  to the systemd service group which gets started during system bootup. New CLI is also added to configure/show the remote information like server IP, directory, username and password info into the ConfigDB.  The export service uses the remote info from ConfigDB for exporting the tech-support data.

**- How to verify it**
    Tech-support data shall be available on the configured remote path
      1.  When a new core file is generated
      2.  On a configured interval 

**-HLD PR**

  https://github.com/Azure/SONiC/pull/468

**-Code PR**

https://github.com//Azure/sonic-buildimage/pull/3447
https://github.com//Azure/sonic-utilities/pull/643


**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

-->

