### PR TITLE
[crm] add crm config clear cli command

### DIFF
--- a/crm/main.py
+++ b/crm/main.py
@@ -21,6 +21,15 @@ class Crm:
 
         configdb.mod_entry("CRM", 'Config', {attr: val})
 
+    def clear(self):
+        """
+        CRM handler for 'config clear' CLI commands.
+        """
+        configdb = swsssdk.ConfigDBConnector()
+        configdb.connect()
+
+        configdb.delete_table('CRM')
+
     def show_summary(self):
         """
         CRM Handler to display general information.
@@ -161,6 +170,12 @@ def cli(ctx):
 def config(ctx):
     """CRM related configuration"""
     pass
+
+@config.command()
+@click.pass_context
+def clear(ctx):
+    """CRM config clear"""
+    ctx.obj["crm"].clear()
 
 @config.group()
 @click.pass_context


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added the "crm config clear" cli command to remove the polling interval configured and remove the threshold settings configured. 

**- How I did it**
Added crm config clear command in crm/main.py by deleting the deleting the CRM table from the config DB.

**- How to verify it**
Default:
  crm show thresholds all => Error: will show empty table at reset
  crm show summary => Error! could not get CRM configuration
Configure Polling interval and CRM threshold for any resource (say fdb)
  crm config polling interval 10
  crm config thresholds fdb type percentage
  crm config thresholds fdb low 10
  crm config thresholds fdb high 60
Verify the config
  crm show thresholds all => Will show the configure Thresholds entries for FDB
  crm show summary => Will show Polling interval as 10 second(s)
 Execute Clear command
   crm config clear
Verify the config
  crm show thresholds all => Error: will show empty table at reset
  crm show summary => Error! could not get CRM configuration

**- Previous command output (if the output of a command-line utility has changed)**
NA- no change in the format of  the output.
**- New command output (if the output of a command-line utility has changed)**
NA
-->

