### PR TITLE
[acl_loader/main.py]: Use get to fetch key 'ports'.

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -700,7 +700,7 @@ class AclLoader(object):
                     for service in services[1:]:
                         data.append(["", "", service, "", ""])
             else:
-                if not val["ports"]:
+                if not val.get("ports"):
                     data.append([key, val["type"], "", val["policy_desc"], stage])
                 else:
                     ports = natsorted(val["ports"])


### PR DESCRIPTION
With if condition, always get must be used otherwise code will never receive None.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Use get instead of []. With if condition, always get must be used otherwise code will never receive None.

**- How I did it**
Use get instead of [].

**- How to verify it**
```
root@fec26aa9f1be:/praveen# sonic-cfggen -d --print-data | grep -A 10 -B 5 NO-NSW-PACL-TEST
{
    "ACL_TABLE": {
        "NO-NSW-PACL-TEST": {
            "policy_desc": "NO-NSW-PACL-TEST",
            "ports": [
                ""
            ],
            "type": "L3"
        }
    },

root@fec26aa9f1be:/praveen# show acl table
Name              Type    Binding    Description       Stage
----------------  ------  ---------  ----------------  -------
NO-NSW-PACL-TEST  L3                 NO-NSW-PACL-TEST  ingress
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

