### PR TITLE
[config] Enhance the Sonic CLI command "config save"

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -8,6 +8,7 @@ import netaddr
 import re
 import syslog
 import time
+import tempfile
 import netifaces
 import threading
 
@@ -171,7 +172,7 @@ def execute_systemctl(list_of_services, action):
                     if e.is_set():
                         sys.exit(1)
 
-def run_command(command, display_cmd=False, ignore_error=False):
+def run_command(command, display_cmd=False, ignore_error=False, raise_exception_when_error=False):
     """Run bash command and print output to stdout
     """
     if display_cmd == True:
@@ -184,6 +185,8 @@ def run_command(command, display_cmd=False, ignore_error=False):
         click.echo(out)
 
     if proc.returncode != 0 and not ignore_error:
+        if raise_exception_when_error:
+            raise Exception("Return code is not zero(exit_code={})".format(proc.returncode))
         sys.exit(proc.returncode)
 
 # Validate whether a given namespace name is valid in the device.
@@ -783,13 +786,24 @@ def save(filename):
             else:
                 file = "/etc/sonic/config_db{}.json".format(inst)
 
+        tmp_file_hdl=tempfile.NamedTemporaryFile(suffix='.db', prefix='config{}'.format(inst), delete=False)
+        tmp_filename=tmp_file_hdl.name
+        tmp_file_hdl.close()
+
         if namespace is None:
-            command = "{} -d --print-data > {}".format(SONIC_CFGGEN_PATH, file)
+            command = "{} -d --print-data > {}".format(SONIC_CFGGEN_PATH, tmp_filename)
         else:
-            command = "{} -n {} -d --print-data > {}".format(SONIC_CFGGEN_PATH, namespace, file)
+            command = "{} -n {} -d --print-data > {}".format(SONIC_CFGGEN_PATH, namespace, tmp_filename)
 
         log_info("'save' executing...")
-        run_command(command, display_cmd=True)
+        try:
+            run_command(command, display_cmd=True, raise_exception_when_error=True)
+            if os.path.isfile(file):
+                os.remove(file)
+            os.rename(tmp_filename, file)
+        except Exception as e:
+            os.remove(tmp_filename)
+            exit(str(e))
 
 @config.command()
 @click.option('-y', '--yes', is_flag=True)


### PR DESCRIPTION
* Enhance the Sonic CLI command "config save" to roll back the existing
  config file when an error occurs during the operation.

Signed-off-by: Charlie Chen <charlie_chen@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Enhance the Sonic CLI command "config save" to roll back the existing config file when an error occurs during the operation.

**- How I did it**
Redirect the output of 'SONIC_CFGGEN' to a temp file. Rename/replace the destination config file by the temp file when 
 'SONIC_CFGGEN' returns zero.

**- How to verify it**
Stop 'database.service' and execute 'config save -y config_db.json'. The content of the existing file "config_db.json" will not be changed when "config save -y" returns error.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

