### PR TITLE
[Warmboot] teamsyncd timer support 'disable' to skip teamd reconciliation

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -52,14 +52,10 @@ CFG_LOOPBACK_NAME_TOTAL_LEN_MAX = 11
 CFG_LOOPBACK_ID_MAX_VAL = 999
 CFG_LOOPBACK_NO="<0-999>"
 
-<<<<<<< HEAD
 MAXIMUM_WARMRESTART_TIMER_VALUE = 9999
 
 asic_type = None
 config_db = None
-=======
-DISABLE_WARMRESTART_TIMER_VALUE = 9999
->>>>>>> [warmboot] using disable keyword to set timer
 # ========================== Syslog wrappers ==========================
 
 def log_debug(msg):

--- a/config/main.py
+++ b/config/main.py
@@ -51,35 +51,7 @@ CFG_LOOPBACK_PREFIX_LEN = len(CFG_LOOPBACK_PREFIX)
 CFG_LOOPBACK_NAME_TOTAL_LEN_MAX = 11
 CFG_LOOPBACK_ID_MAX_VAL = 999
 CFG_LOOPBACK_NO="<0-999>"
-
-MAXIMUM_WARMRESTART_TIMER_VALUE = 9999
-
-asic_type = None
-config_db = None
-# ========================== Syslog wrappers ==========================
-
-def log_debug(msg):
-    syslog.openlog(SYSLOG_IDENTIFIER)
-    syslog.syslog(syslog.LOG_DEBUG, msg)
-    syslog.closelog()
-
-
-def log_info(msg):
-    syslog.openlog(SYSLOG_IDENTIFIER)
-    syslog.syslog(syslog.LOG_INFO, msg)
-    syslog.closelog()
-
-
-def log_warning(msg):
-    syslog.openlog(SYSLOG_IDENTIFIER)
-    syslog.syslog(syslog.LOG_WARNING, msg)
-    syslog.closelog()
-
-
-def log_error(msg):
-    syslog.openlog(SYSLOG_IDENTIFIER)
-    syslog.syslog(syslog.LOG_ERR, msg)
-    syslog.closelog()
+DISABLE_WARMRESTART_TIMER_VALUE = 9999
 
 
 asic_type = None

--- a/config/main.py
+++ b/config/main.py
@@ -52,6 +52,35 @@ CFG_LOOPBACK_NAME_TOTAL_LEN_MAX = 11
 CFG_LOOPBACK_ID_MAX_VAL = 999
 CFG_LOOPBACK_NO="<0-999>"
 
+MAXIMUM_WARMRESTART_TIMER_VALUE = 9999
+
+asic_type = None
+config_db = None
+# ========================== Syslog wrappers ==========================
+
+def log_debug(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_DEBUG, msg)
+    syslog.closelog()
+
+
+def log_info(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_INFO, msg)
+    syslog.closelog()
+
+
+def log_warning(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_WARNING, msg)
+    syslog.closelog()
+
+
+def log_error(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_ERR, msg)
+    syslog.closelog()
+
 
 asic_type = None
 
@@ -1679,8 +1708,8 @@ def warm_restart_bgp_timer(ctx, seconds):
 @click.pass_context
 def warm_restart_teamsyncd_timer(ctx, seconds):
     db = ctx.obj['db']
-    if seconds not in range(1,3600):
-        ctx.fail("teamsyncd warm restart timer must be in range 1-3600")
+    if seconds not in range(1,3600) and seconds != MAXIMUM_WARMRESTART_TIMER_VALUE:
+        ctx.fail("teamsyncd warm restart timer must be in range 1-3600 or value 9999")
     db.mod_entry('WARM_RESTART', 'teamd', {'teamsyncd_timer': seconds})
 
 @warm_restart.command('bgp_eoiu')

--- a/config/main.py
+++ b/config/main.py
@@ -52,10 +52,14 @@ CFG_LOOPBACK_NAME_TOTAL_LEN_MAX = 11
 CFG_LOOPBACK_ID_MAX_VAL = 999
 CFG_LOOPBACK_NO="<0-999>"
 
+<<<<<<< HEAD
 MAXIMUM_WARMRESTART_TIMER_VALUE = 9999
 
 asic_type = None
 config_db = None
+=======
+DISABLE_WARMRESTART_TIMER_VALUE = 9999
+>>>>>>> [warmboot] using disable keyword to set timer
 # ========================== Syslog wrappers ==========================
 
 def log_debug(msg):
@@ -1704,13 +1708,20 @@ def warm_restart_bgp_timer(ctx, seconds):
     db.mod_entry('WARM_RESTART', 'bgp', {'bgp_timer': seconds})
 
 @warm_restart.command('teamsyncd_timer')
-@click.argument('seconds', metavar='<seconds>', required=True, type=int)
+@click.argument('seconds', metavar='<seconds>', required=True)
 @click.pass_context
 def warm_restart_teamsyncd_timer(ctx, seconds):
+    if seconds != 'disable' and not seconds.isdigit():
+        ctx.fail("Invalid value for 'seconds': {} is not a valid integer or 'disable'".format(seconds))
+
     db = ctx.obj['db']
-    if seconds not in range(1,3600) and seconds != MAXIMUM_WARMRESTART_TIMER_VALUE:
-        ctx.fail("teamsyncd warm restart timer must be in range 1-3600 or value 9999")
-    db.mod_entry('WARM_RESTART', 'teamd', {'teamsyncd_timer': seconds})
+    if seconds == 'disable':
+        db.mod_entry('WARM_RESTART', 'teamd', {'teamsyncd_timer': DISABLE_WARMRESTART_TIMER_VALUE})
+    else:
+        seconds = int(seconds)
+        if seconds not in range(1,3600):
+            ctx.fail("teamsyncd warm restart timer must be in range 1-3600 or disable")
+        db.mod_entry('WARM_RESTART', 'teamd', {'teamsyncd_timer': seconds})
 
 @warm_restart.command('bgp_eoiu')
 @click.argument('enable', metavar='<enable>', default='true', required=False, type=click.Choice(["true", "false"]))

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6573,7 +6573,7 @@ teamsyncd_timer holds the time interval utilized by teamsyncd during warm-restar
 The timer is started when teamsyncd starts. During the timer interval, teamsyncd will preserve all LAG interface changes, but it will not apply them.
 The changes will only be applied when the timer expires.
 When the changes are applied, the stale LAG entries will be removed, the new LAG entries will be created.
-Supported range: 1-9999. 0 is invalid
+Supported range: 1-9999. 0 is invalid. disable is skipping teamsyncd reconciliation logic.
 
 - Usage:
   ```
@@ -6581,11 +6581,12 @@ Supported range: 1-9999. 0 is invalid
   ```
 
   - Parameters:
-    - seconds: Range from 1 to 9999
+    - seconds: Range from 1 to 9999 or 'disable'
 
 - Example:
   ```
   admin@sonic:~$ sudo config warm_restart teamsyncd_timer 3000
+  admin@sonic:~$ sudo config warm_restart teamsyncd_timer disable
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#warm-restart)

--- a/show/main.py
+++ b/show/main.py
@@ -30,6 +30,7 @@ HWSKU_JSON = 'hwsku.json'
 PORT_STR = "Ethernet"
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
+DISABLE_WARMRESTART_TIMER_VALUE = '9999'
 
 # To be enhanced. Routing-stack information should be collected from a global
 # location (configdb?), so that we prevent the continous execution of this
@@ -2058,7 +2059,10 @@ def config(redis_unix_socket_path):
                     r.append("NULL")
             elif 'teamsyncd_timer' in data[k]:
                 r.append("teamsyncd_timer")
-                r.append(data[k]['teamsyncd_timer'])
+                if data[k]['teamsyncd_timer'] == DISABLE_WARMRESTART_TIMER_VALUE:
+                    r.append('disable')
+                else:
+                    r.append(data[k]['teamsyncd_timer'])
                 r.append("NULL")
             else:
                 r.append("NULL")


### PR DESCRIPTION
* accept 'disable' as a indicator which means to skip teamd warmboot reconciliation
* internally it is using value 9999 as disable_warmstart_teamsyncd_timer_value
* show cmd modification
* this PR works with https://github.com/Azure/sonic-swss/pull/1364

* UT:
```
admin@ASW-A1-2.NA62:~$ sudo config warm_restart teamsyncd_timer 0
Usage: config warm_restart teamsyncd_timer [OPTIONS] <seconds>

Error: teamsyncd warm restart timer must be in range 1-3600 or disable

admin@ASW-A1-2.NA62:~$ sudo config warm_restart teamsyncd_timer 1
admin@ASW-A1-2.NA62:~$ redis-cli -n 4 hgetall "WARM_RESTART|teamd"
1) "teamsyncd_timer"
2) "1"

admin@ASW-A1-2.NA62:~$ sudo config warm_restart teamsyncd_timer disabl
Usage: config warm_restart teamsyncd_timer [OPTIONS] <seconds>

Error: Invalid value for 'seconds': disabl is not a valid integer or 'disable'

admin@ASW-A1-2.NA62:~$ sudo config warm_restart teamsyncd_timer disable
admin@ASW-A1-2.NA62:~$ redis-cli -n 4 hgetall "WARM_RESTART|teamd"
1) "teamsyncd_timer"
2) "9999"
```

```
admin@ASW-A1-2.NA62:~$ sudo config warm_restart teamsyncd_timer 45
admin@ASW-A1-2.NA62:~$ show warm_restart config
name    enable    timer_name         timer_duration
------  --------  ---------------  ----------------
teamd   false     teamsyncd_timer                45
admin@ASW-A1-2.NA62:~$ sudo config warm_restart teamsyncd_timer disable
admin@ASW-A1-2.NA62:~$ show warm_restart config
name    enable    timer_name       timer_duration
------  --------  ---------------  ----------------
teamd   false     teamsyncd_timer  disable
```


Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com