### PR TITLE
[config]: Filter table from input config while config validation\DPB

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -156,6 +156,24 @@ class ConfigMgmt():
 
         return
 
+    def _filterTablesInConfig(self, config):
+        """
+            Check if any table should not be considered in Input Config, remove
+            such table from Input Config.
+            Parameters:
+                config(dict): Input Config
+            Returns:
+                void
+        """
+        # nonConfigTables should not be considered in Input Config.
+        nonConfigTables = ['BREAKOUT_CFG']
+        for t in nonConfigTables:
+            if t in config.keys():
+                self.sysLog(msg='Filtering {}'.format(t))
+                del config[t]
+
+        return
+
     def readConfigDBJson(self, source=CONFIG_DB_JSON_FILE):
         '''
         Read the config from a Config File.
@@ -172,7 +190,7 @@ class ConfigMgmt():
         if not self.configdbJsonIn:
             raise Exception("Can not load config from config DB json file")
         self.sysLog(msg='Reading Input {}'.format(self.configdbJsonIn))
-
+        self._filterTablesInConfig(self.configdbJsonIn)
         return
 
     """
@@ -197,7 +215,7 @@ class ConfigMgmt():
         self.configdbJsonIn =  FormatConverter.to_serialized(data)
         self.sysLog(syslog.LOG_DEBUG, 'Reading Input from ConfigDB {}'.\
             format(self.configdbJsonIn))
-
+        self._filterTablesInConfig(self.configdbJsonIn)
         return
 
     def writeConfigDB(self, jDiff):

--- a/config/main.py
+++ b/config/main.py
@@ -186,12 +186,18 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
     try:
         # check if any extra tables exist
         eTables = cm.tablesWithOutYang()
-        if len(eTables):
-            # find relavent tables in extra tables, i.e. one which can have deleted
-            # ports
-            tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
+        if len(eTables) == 0:
+            return
+        # let user know that extra tables exist in config
+        click.secho("Below Table(s) can not be verified using YANG models:")
+        click.secho("{}".format(eTables.keys()))
+        # find relavent tables in extra tables, i.e. one which can have deleted
+        # ports
+        tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
+        if len(tables):
             click.secho("Below Config can not be verified, It may cause harm "\
-                "to the system\n {}".format(json.dumps(tables, indent=2)))
+                "to the system:\n{}".format(json.dumps(tables, indent=2)))
+            # Need to confirm if extra Tables have any deleted ports.
             click.confirm('Do you wish to Continue?', abort=True)
     except Exception as e:
         raise Exception("Failed in breakout_warnUser_extraTables. Error: {}".format(str(e)))
@@ -697,7 +703,6 @@ def _restart_services():
 
     click.echo("Enabling container monitoring ...")
     clicommon.run_command("sudo monit monitor container_checker")
-
 
 def interface_is_in_vlan(vlan_member_table, interface_name):
     """ Check if an interface is in a vlan """

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -78,6 +78,30 @@ class TestConfigMgmt(TestCase):
         self.dpb_port4_4x25G_2x50G_f_l(curConfig)
         return
 
+    def test_extra_brk_cfg_tables_cases(self):
+        # make sure no prompt with BREAKOUT_CFG
+        curConfig = dict(configDbJson)
+        brk_cfg = {
+                    "BREAKOUT_CFG": {
+                      "Ethernet0": {
+                        "brkout_mode": "1x100G[40G]"
+                      }
+                    }
+                  }
+        self.updateConfig(curConfig, brk_cfg)
+        prevLen = len(curConfig)
+        cm = self.config_mgmt_dpb(curConfig)
+        # Assert BREAKOUT_CFG is removed from Input Config
+        assert (len(cm.configdbJsonIn) ==  prevLen-1) and \
+            'BREAKOUT_CFG' not in cm.configdbJsonIn.keys()
+        # Test by direct Call
+        prevLen = len(curConfig)
+        cm._filterTablesInConfig(curConfig)
+        assert (len(curConfig) == prevLen-1) and \
+            'BREAKOUT_CFG' not in curConfig.keys()
+
+        return
+
     def tearDown(self):
         try:
             os.remove(config_mgmt.CONFIG_DB_JSON_FILE)


### PR DESCRIPTION
Changes:
-- Filter table, which does not impact Back-End, from input config
   while config validation or while Dynamic Port Breakout(DPB).
-- Ask for confirmation from user while DPB, only when deleted ports
   exists in extra tables[i.e in tables without YANG].
-- Test for filter Table.
-- Filter BREAKOUT_CFG table while DPB, because back-end does not process
   BREAKOUT_CFG table.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
-- Filter table, which does not impact Back-End, from input config
   while config validation or while Dynamic Port Breakout(DPB).
-- Ask for confirmation from user while DPB, only when deleted ports
   exists in extra tables[i.e in tables without YANG].
-- Test for filter Table.
-- Filter BREAKOUT_CFG table while DPB, because back-end does not process
   BREAKOUT_CFG table.

**- How I did it**
Added a function which filter predefined tables from config. There predefined tables do not impact back-end, so better to filter them.

Change in config/main.py to ask for user permission when any table exists in config for which YANG models are not written. Note: Now, We ask user confirmation only if delete PORTs exist in these extra tables. 

Added test code.

**- How to verify it**
```
Test First Approach: Wrote the test first to Make Sure, It fails without fix:

   def test_extra_brk_cfg_tables_cases(self):
        # make sure no prompt with LOCK
        curConfig = dict(configDbJson)
        brk_cfg = { "BREAKOUT_CFG": {
                    "Ethernet0": {
                        "brkout_mode": "1x100G[40G]"
                    }
                  }
                }
        self.updateConfig(curConfig, brk_cfg)
        prevLen = len(curConfig)
        cm = self.config_mgmt_dpb(curConfig)
        # Assert LOCK is removed from Input Config
>       assert (len(cm.configdbJsonIn) ==  prevLen-1) and \
            'BREAKOUT_CFG' not in cm.configdbJsonIn.keys()
E       AssertionError: assert (6 == (6 - 1))
E        +  where 6 = len({'ACL_TABLE': {'NO-NSW-PACL-TEST': {'policy_desc': 'NO-NSW-PACL-TEST', 'ports': ['Ethernet11'], 'stage': 'INGRESS', 't...66', ...}, 'Ethernet10': {'lanes': '75', 'speed': '25000'}, 'Ethernet11': {'lanes': '76', 'speed': '25000'}, ...}, ...})
E        +    where {'ACL_TABLE': {'NO-NSW-PACL-TEST': {'policy_desc': 'NO-NSW-PACL-TEST', 'ports': ['Ethernet11'], 'stage': 'INGRESS', 't...66', ...}, 'Ethernet10': {'lanes': '75', 'speed': '25000'}, 'Ethernet11': {'lanes': '76', 'speed': '25000'}, ...}, ...} = <config_mgmt.ConfigMgmtDPB instance at 0x7f702c1829e0>.configdbJsonIn


Now After Fix, it build fine.

make[1]: Leaving directory '/home/pchaudha/srcCode/azure_myforks/sonic-buildimage'
pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$ date
Fri Jul 31 12:48:57 PDT 2020
pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$ ls -l target/python-debs/python-sonic-utilities_1.2-1_all.deb
-rw-r--r-- 1 pchaudha pchaudha 182780 Jul 31 12:48 target/python-debs/python-sonic-utilities_1.2-1_all.deb
pchaudha@server05:/home/pchaudha/srcCode/azure_myforks/sonic-buildimage$
```
**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

