### PR TITLE
fanshow: Keep some backward compatibility before FanDrawer introduction

### DIFF
--- a/scripts/fanshow
+++ b/scripts/fanshow
@@ -60,9 +60,17 @@ class FanShow(object):
             else:
                 status = 'N/A'
 
-            table.append((data_dict[DRAWER_FIELD_NAME], data_dict[LED_STATUS_FIELD_NAME], name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status, 
-                          data_dict[TIMESTAMP_FIELD_NAME]))
-        
+            table.append((
+                data_dict.get(DRAWER_FIELD_NAME, 'Unknown'),
+                data_dict[LED_STATUS_FIELD_NAME],
+                name,
+                speed,
+                data_dict[DIRECTION_FIELD_NAME],
+                presence,
+                status,
+                data_dict[TIMESTAMP_FIELD_NAME],
+            ))
+
         if table:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
         else:


### PR DESCRIPTION
The new FanDrawer API is meant to supersede the direct Fan declaration
in the platform API.
However, some vendors might have not yet implemented it.
For those, the `show platform fan` cli got broken when the DRAWER_NAME
column was added to the output.

To preserve some backward compatibility with the platform API before the
introduction of the FanDrawer, if the DRAWER_NAME is not defined in the
database, `Unknown` will be displayed.

This simple change avoids breaking `show platform fans`

Reformat the tuple vertically to avoid a long line and improve clarity.