### PR TITLE
Add vrf naming restrictions

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2654,6 +2654,14 @@ def add_vrf(ctx, vrf_name):
         ctx.fail("'vrf_name' is not start with Vrf, mgmt or management!")
     if len(vrf_name) > 15:
         ctx.fail("'vrf_name' is too long!")
+    if len(vrf_name) < 4:
+        ctx.fail("'vrf_name' is too short!")
+
+    allowed = re.compile(r'^[A-Za-z0-9_.\-]*$')
+    result = allowed.match(vrf_name)
+    if not result:
+        ctx.fail("'vrf_name' is invalid!")
+
     if (vrf_name == 'mgmt' or vrf_name == 'management'):
         vrf_add_management_vrf(config_db)
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add vrf naming restrictions

**- How I did it**
Limit the characters that can be used in naming

**- Why I did it**
When VRF is named with some special symbols, the vrfmgrd process will be terminated
For example:  sudo config vrf add Vrf:a

**- How to verify it**
sudo config vrf add Vrf:a
ps -ef|grep vrfmgrd