### PR TITLE
Don't return error when execute "portstat -d"

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -382,26 +382,32 @@ Examples:
     cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
 
     if delete_all_stats:
-        for file in os.listdir(cnstat_dir):
-            os.remove(cnstat_dir + "/" + file)
+        if os.path.isdir(cnstat_dir):
+            for file in os.listdir(cnstat_dir):
+                os.remove(cnstat_dir + "/" + file)
 
-        try:
-            os.rmdir(cnstat_dir)
+            try:
+                os.rmdir(cnstat_dir)
+                sys.exit(0)
+            except IOError as e:
+                print e.errno, e
+                sys.exit(e)
+        else:
             sys.exit(0)
-        except IOError as e:
-            print(e.errno, e)
-            sys.exit(e)
 
     if delete_saved_stats:
-        try:
-            os.remove(cnstat_fqn_file)
-        except IOError as e:
-            if e.errno != ENOENT:
-                print(e.errno, e)
-                sys.exit(1)
-        finally:
-            if os.listdir(cnstat_dir) == []:
-                os.rmdir(cnstat_dir)
+        if os.path.exists(cnstat_fqn_file):
+            try:
+                os.remove(cnstat_fqn_file)
+            except IOError as e:
+                if e.errno != ENOENT:
+                    print e.errno, e
+                    sys.exit(1)
+            finally:
+                if os.listdir(cnstat_dir) == []:
+                    os.rmdir(cnstat_dir)
+                sys.exit(0)
+        else:
             sys.exit(0)
 
     intf_list = parse_interface_in_filter(intf_fs)


### PR DESCRIPTION
If execute "portstat -d" without execute "portstat" first,
then this command would fail due to "No such file or directory"

**- What I did**
   Don't return error when there is no directory or file.

**- How to verify it**
   Boot the DUT and execute "portstat -d"

**- Previous command output**
root@as5812-54x:/home/admin# portstat -d
Traceback (most recent call last):
  File "/usr/bin/portstat", line 411, in <module>
    main()
  File "/usr/bin/portstat", line 355, in main
    if os.listdir(cnstat_dir) == []:
OSError: [Errno 2] No such file or directory: '/tmp/portstat-0'

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

