### PR TITLE
Allow show ztp to display non-sensitive information visible to non-ro…

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2654,10 +2654,6 @@ def ztp(status, verbose):
     if os.path.isfile('/usr/bin/ztp') is False:
         exit("ZTP feature unavailable in this image version")
 
-    if os.geteuid() != 0:
-        exit("Root privileges are required for this operation")
-    pass
-
     cmd = "ztp status"
     if verbose:
        cmd = cmd + " --verbose"


### PR DESCRIPTION

Allow show ztp to display non-sensitive information visible to non-root user

Signed-off-by: Rajendra Dendukuri rajendra.dendukuri@broadcom.com

- What I did
Removed user privileges checks. These changes fix https://github.com/Azure/sonic-buildimage/issues/5377. Requires https://github.com/Azure/sonic-ztp/pull/21

- How I did it
Removed root user check.

- How to verify it
show ztp status

- Previous command output (if the output of a command-line utility has changed)
admin@sonic:~$ show ztp status
Root privileges are required for this operation

- New command output (if the output of a command-line utility has changed)
root@sonic:/usr/lib/ztp/tests# ztp status
ZTP Admin Mode : True
ZTP Service    : Inactive
ZTP Status     : SUCCESS
ZTP Source     : dhcp-opt67
Runtime        : 09s
Timestamp      : 2020-10-14 03:15:20 UTC

ZTP Service is not running

0001-test-plugin: SUCCESS

root@sonic:/usr/lib/ztp/tests# exit
admin@sonic:~$ ztp status
ZTP Admin Mode : True
ZTP Service    : Inactive
ZTP Status     : SUCCESS
ZTP Source     : dhcp-opt67
Runtime        : 09s
Timestamp      : 2020-10-14 03:15:20 UTC

ZTP Service is not running

0001-test-plugin: SUCCESS

admin@sonic:~$ show ztp status
ZTP Admin Mode : True
ZTP Service    : Inactive
ZTP Status     : SUCCESS
ZTP Source     : dhcp-opt67
Runtime        : 09s
Timestamp      : 2020-10-14 03:15:20 UTC

ZTP Service is not running

0001-test-plugin: SUCCESS

