### PR TITLE
[201911] Fix #5594 config vlan member del port not a member issue

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1555,19 +1555,23 @@ def del_vlan_member(ctx, vid, interface_name):
         ctx.fail("{} doesn't exist".format(vlan_name))
     members = vlan.get('members', [])
     if interface_name not in members:
-        if get_interface_naming_mode() == "alias":
-            interface_name = interface_name_to_alias(db, interface_name)
-            if interface_name is None:
-                ctx.fail("'interface_name' is None!")
-            ctx.fail("{} is not a member of {}".format(interface_name, vlan_name))
+        vlan_member = db.get_entry('VLAN_MEMBER', (vlan_name, interface_name))
+        if len(vlan_member) == 0:
+            if get_interface_naming_mode() == "alias":
+                interface_name = interface_name_to_alias(db, interface_name)
+                if interface_name is None:
+                    ctx.fail("'interface_name' is None!")
+                ctx.fail("{} is not a member of {}".format(interface_name, vlan_name))
+            else:
+                ctx.fail("{} is not a member of {}".format(interface_name, vlan_name))
+    if interface_name in members:
+        members.remove(interface_name)
+        if len(members) == 0:
+            del vlan['members']
         else:
-            ctx.fail("{} is not a member of {}".format(interface_name, vlan_name))
-    members.remove(interface_name)
-    if len(members) == 0:
-        del vlan['members']
-    else:
-        vlan['members'] = members
-    db.set_entry('VLAN', vlan_name, vlan)
+            vlan['members'] = members
+        db.set_entry('VLAN', vlan_name, vlan)
+
     db.set_entry('VLAN_MEMBER', (vlan_name, interface_name), None)
 
 def mvrf_restart_services():


### PR DESCRIPTION
Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fix https://github.com/Azure/sonic-buildimage/issues/5594  vlan member delete fail
**- How I did it**
when del a vlan member, need check  table 'VLAN_MEMBER' together
**- How to verify it**
since this is sometimes issue, I just simple modify config_db.json(remove vlan("members")) and reboot device, at this time, VLAN table does not include port member, but VLAN_MEMBER does
```
 "VLAN": {
        "Vlan2": {   <--no members 
            "vlanid": "2"
        }
    },
    "VLAN_INTERFACE": {
        "Vlan2": {},
        "Vlan2|12.1.1.1/16": {},
        "Vlan2|12::1/64": {}
    },
    "VLAN_MEMBER": { <-- has members
        "Vlan2|Ethernet1": {
            "tagging_mode": "tagged"
        },
        "Vlan2|PortChannel0001": {
            "tagging_mode": "untagged"
        }
    }

```
**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# config vlan member del 2 Ethernet1
Usage: config vlan member del [OPTIONS] <vid> <interface_name>

Error: Ethernet1 is not a member of Vlan2

```
**- New command output (if the output of a command-line utility has changed)**

```
root@sonic:/home/admin# config vlan member del 2 Ethernet1
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# show vlan brief
+-----------+--------------+-----------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports           | Port Tagging   | DHCP Helper Address   |
+===========+==============+=================+================+=======================+
|         2 | 12.1.1.1/16  | PortChannel0001 | untagged       |                       |
|           | 12::1/64     |                 |                |                       |
+-----------+--------------+-----------------+----------------+-----------------------+

root@sonic:/home/admin#
root@sonic:/home/admin# config vlan member add 2 Ethernet1
root@sonic:/home/admin# show vlan brief
+-----------+--------------+-----------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports           | Port Tagging   | DHCP Helper Address   |
+===========+==============+=================+================+=======================+
|         2 | 12.1.1.1/16  | Ethernet1       | tagged         |                       |
|           | 12::1/64     | PortChannel0001 | untagged       |                       |
+-----------+--------------+-----------------+----------------+-----------------------+
root@sonic:/home/admin# config vlan member del 2 Ethernet1
root@sonic:/home/admin# show vlan brief
+-----------+--------------+-----------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports           | Port Tagging   | DHCP Helper Address   |
+===========+==============+=================+================+=======================+
|         2 | 12.1.1.1/16  | PortChannel0001 | untagged       |                       |
|           | 12::1/64     |                 |                |                       |
+-----------+--------------+-----------------+----------------+-----------------------+

```