### PR TITLE
[crm/show]fix the 'crm show' error for acl table which bind point typ…

### DIFF
--- a/crm/main.py
+++ b/crm/main.py
@@ -102,11 +102,12 @@ class Crm:
 
                 if crm_stats:
                     for res in ["acl_group", "acl_table"]:
-                        data.append([
-                                        stage, bind_point, res,
-                                        crm_stats['crm_stats_' + res + "_used"],
-                                        crm_stats['crm_stats_' + res + "_available"]
-                                    ])
+                        if "crm_stats_" + res + "_used" in crm_stats:
+                            data.append([
+                                            stage, bind_point, res,
+                                            crm_stats['crm_stats_' + res + "_used"],
+                                            crm_stats['crm_stats_' + res + "_available"]
+                                        ])
 
         click.echo()
         click.echo(tabulate(data, headers=header, tablefmt="simple", missingval=""))


### PR DESCRIPTION
…e is not PORT.

Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
 Fix the 'crm show' error for acl table which bind point type is LAG.
**- How I did it**
 check whether the key exists in the dict  before dump the data. 
**- How to verify it**
admin@sonic:~$ cat acl_redirect_portchannel.json 
{
"ACL_TABLE":{
	"Test2":{
		"policy_desc":"test2",
        	"type":"L3",
        	"ports":["PortChannel0001"]
         }																			               
},
"ACL_RULE":{
	"Test2|RULE1":{
		"PRIORITY":"100",
		"SRC_IP":"2.1.1.1",
		"PACKET_ACTION":"DROP"
          }
}
}
admin@sonic:~$ sudo config load acl_redirect_portchannel.json 
Load config from the file(s) acl_redirect_portchannel.json ? [y/N]: y
Running command: /usr/local/bin/sonic-cfggen -j acl_redirect_portchannel.json --write-to-db
admin@sonic:~$ show acl table
Name    Type    Binding          Description    Stage
------  ------  ---------------  -------------  -------
Test2   L3      PortChannel0001  test2          ingress
**- Previous command output (if the output of a command-line utility has changed)**
admin@sonic:~$ crm show resources acl group 
Traceback (most recent call last):
  File "/usr/bin/crm", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/crm/main.py", line 480, in group
    ctx.obj["crm"].show_acl_resources()
  File "/usr/lib/python2.7/dist-packages/crm/main.py", line 109, in show_acl_resources
    crm_stats['crm_stats_' + res + "_used"],
KeyError: 'crm_stats_acl_table_used'

127.0.0.1:6379[2]> HGETALL "CRM:ACL_STATS:INGRESS:LAG"
1) "crm_stats_acl_group_used"
2) "1"
3) "crm_stats_acl_group_available"
4) "0"
127.0.0.1:6379[2]> 

**- New command output (if the output of a command-line utility has changed)**
admin@sonic:~$ crm show resources acl group 
Stage    Bind Point    Resource Name      Used Count    Available Count
-------  ------------  ---------------  ------------  -----------------
INGRESS  PORT          acl_group                   0                  0
INGRESS  PORT          acl_table                   2                  0
INGRESS  LAG           acl_group                   1                  0
