### PR TITLE
SONiC installer - check new image type before checking installed version and small improvements

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -305,6 +305,13 @@ def install(url, force, skip_migration=False):
         click.echo("Image file does not exist or is not a valid SONiC image file")
         raise click.Abort()
 
+    # Verify that the binary image is of the same type as the running image
+    if not bootloader.verify_binary_image(image_path) and not force:
+        click.echo("Image file {} is of a different type than running image.\n\
+            If you are sure you want to install this image, use -f|--force.\n\
+            Aborting...".format(image_path))
+        raise click.Abort()
+
     # Is this version already installed?
     if binary_image_version in bootloader.get_installed_images():
         click.echo("Image {} is already installed. Setting it as default...".format(binary_image_version))
@@ -312,13 +319,6 @@ def install(url, force, skip_migration=False):
             click.echo('Error: Failed to set image as default')
             raise click.Abort()
     else:
-        # Verify that the binary image is of the same type as the running image
-        if not bootloader.verify_binary_image(image_path) and not force:
-            click.echo("Image file '{}' is of a different type than running image.\n"
-                       "If you are sure you want to install this image, use -f|--force.\n"
-                       "Aborting...".format(image_path))
-            raise click.Abort()
-
         click.echo("Installing image {} and setting it as default...".format(binary_image_version))
         bootloader.install_image(image_path)
         # Take a backup of current configuration

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -307,9 +307,9 @@ def install(url, force, skip_migration=False):
 
     # Verify that the binary image is of the same type as the running image
     if not bootloader.verify_binary_image(image_path) and not force:
-        click.echo("Image file {} is of a different type than running image.\n\
-            If you are sure you want to install this image, use -f|--force.\n\
-            Aborting...".format(image_path))
+        click.echo("Image file {} is of a different type than running image.\n".format(url) +\
+            "If you are sure you want to install this image, use -f|--force.\n" +\
+            "Aborting...")
         raise click.Abort()
 
     # Is this version already installed?


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
SONiC master and 201911 images check the OS version of the new image before checking new image  type (ABOOT/ONIE).
Ideally, image type should be verified first and then proceed with checking the OS version along with setting default OS version.

Fixes https://github.com/Azure/sonic-utilities/issues/1195
Before: (note that type `bin` is incompatible on `aboot` platform. But the installation did not give an error:
```
admin@abc-7060:~$ sudo sonic_installer install -y http://1.1.1.1/sonic-broadcom.bin
Downloading image...
...99%, 756 MB, 48399 KB/s, 0 seconds left...   Image SONiC-OS-20191130.51 is already installed. Setting it as default...
Command: sync;sync;sync

Command: sleep 3

Done
admin@abc-7060:~$
```

Now:
```
admin@str2-7060cx-32s-29:~$ sudo sonic_installer install -yhttp://1.1.1.1/sonic-broadcom.bin
Downloading image...
...95%, 724 MB, 57044 KB/s, 0 seconds left...   Image file 'http://1.1.1.1/sonic-broadcom.bin' is of a different type than running image.
If you are sure you want to install this image, use -f|--force.
Aborting...
Aborted!
```

**- How I did it**
Check compatibility of new image type before verifying the installed version.
Fix error message.

**- How to verify it**
Verified on a `aboot` platform and the incompatible image installation fails with an error instead of a success message.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

