### PR TITLE
[config] Fix issues on config remove_portchannel

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1312,8 +1312,12 @@ def remove_portchannel(ctx, portchannel_name):
     db = ctx.obj['db']
     if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0:
         click.echo("Error: Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
+    elif len([(k, v) for k, v in db.get_table('PORTCHANNEL_INTERFACE').items() if type(k)==tuple and k[0]==portchannel_name]) != 0:
+                click.echo("Error: Portchannel {} contains ip. Remove ip before deleting Portchannel!".format(portchannel_name))
     else:
         db.set_entry('PORTCHANNEL', portchannel_name, None)
+        # Remove junk portchannel interface
+        db.set_entry('PORTCHANNEL_INTERFACE', portchannel_name, None)
 
 @portchannel.group(cls=clicommon.AbbreviationGroup, name='member')
 @click.pass_context


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Fixed the behaviour of ```config portchannel del``` command

In current remove_portchannel code, it didn't check whether the portchannel is configured with an ip address before delete, as a result, it messed up the redis config db.

Also in current code, it didn't remove the PortChannel interface under PORTCHANNEL_INTERFACE when deleting, so also leaving junk when deleting PortChannel

**- How I did it**

In addition to previous implemented portchannel member check code, now it also checks if the ip is configured on portchannel.

If the IP is configured the delete process is aborted.

While deleting now it will also delete  the interface under PORTCHANNEL_INTERFACE.

**- How to verify it**
```
root@sonic:~# config portchannel add PortChannel0
root@sonic:~# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------
    0  PortChannel0  LACP(A)(Dw)  N/A
root@sonic:~# config interface ip add PortChannel0 1.1.1.1/32
root@sonic:~# show run all | grep -i port
        "PORT": {
    "PORT": {
    "PORTCHANNEL": {
        "PortChannel0": {
    "PORTCHANNEL_INTERFACE": {
        "PortChannel0": {},
        "PortChannel0|1.1.1.1/32": {}
            "port": "8080"
# Now proceed to delete
root@sonic:~# config portchannel del PortChannel0
root@sonic:~# show run all | grep -i port
        "PORT": {
    "PORT": {
    "PORTCHANNEL_INTERFACE": {
        "PortChannel0": {},
        "PortChannel0|1.1.1.1/32": {}
            "port": "8080"
```
As You can see the PortChannel's IP address and Portchannel under PORTCHANNEL_INTERFACE still exists.

**- Previous command output (if the output of a command-line utility has changed)**

```
root@sonic:~# config portchannel add PortChannel0
root@sonic:~# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------
    0  PortChannel0  LACP(A)(Dw)  N/A
root@sonic:~# config interface ip add PortChannel0 1.1.1.1/32
root@sonic:~# show run all | grep -i port
        "PORT": {
    "PORT": {
    "PORTCHANNEL": {
        "PortChannel0": {
    "PORTCHANNEL_INTERFACE": {
        "PortChannel0": {},
        "PortChannel0|1.1.1.1/32": {}
            "port": "8080"
# Now proceed to delete
root@sonic:~# config portchannel del PortChannel0
root@sonic:~# show run all | grep -i port
        "PORT": {
    "PORT": {
    "PORTCHANNEL_INTERFACE": {
        "PortChannel0": {},
        "PortChannel0|1.1.1.1/32": {}
            "port": "8080"
root@sonic:~# config interface ip remove PortChannel0 1.1.1.1/32
Cannot find device "PortChannel0"
```


**- New command output (if the output of a command-line utility has changed)**

```
root@sonic:~# config portchannel add PortChannel0
root@sonic:~# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------
    0  PortChannel0  LACP(A)(Dw)  N/A
root@sonic:~# config interface ip add PortChannel0 1.1.1.1/32
root@sonic:~# show run all | grep -i port
        "PORT": {
    "PORT": {
    "PORTCHANNEL": {
        "PortChannel0": {
    "PORTCHANNEL_INTERFACE": {
        "PortChannel0": {},
        "PortChannel0|1.1.1.1/32": {}
            "port": "8080"
root@sonic:~# config portchannel del PortChannel0
Error: Portchannel PortChannel0 contains ips. Remove ip before deleting Portchannel!
root@sonic:~# config interface ip remove PortChannel0 1.1.1.1/32
root@sonic:~# config portchannel del PortChannel0
root@sonic:~# show run all | grep -i port
        "PORT": {
    "PORT": {
            "port": "8080"
```


