### PR TITLE
[master] fix del portchannel but vlan_member still contain portchannel

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1314,6 +1314,10 @@ def remove_portchannel(ctx, portchannel_name):
         click.echo("Error: Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
     else:
         db.set_entry('PORTCHANNEL', portchannel_name, None)
+        # VLAN_MEMBER will contain portchannel also
+        keys = [ (k, v) for k, v in db.get_table('VLAN_MEMBER') if v == portchannel_name ]
+        for k in keys:
+            db.set_entry('VLAN_MEMBER', k, None)
 
 @portchannel.group(cls=clicommon.AbbreviationGroup, name='member')
 @click.pass_context


### PR DESCRIPTION
Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
fix https://github.com/Azure/sonic-buildimage/issues/5456
**- How I did it**
remove portchannel in VLAN_MEMBER table together when del a portchannel
**- How to verify it**
```
config del portchannel xxx
show vlan brief
show vlan configure
```
**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# config portchannel del PortChannel0001
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# show vlan brief
+-----------+--------------+-----------------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports           | Port Tagging   | DHCP Helper Address   |
+===========+==============+=================+================+=======================+
|         2 | 12.1.1.1/16  | Ethernet1       | tagged         | 100.100.1.1           |
|           | 12::1/64     | PortChannel0001 | untagged       |                       |
+-----------+--------------+-----------------+----------------+-----------------------+

root@sonic:/home/admin# show vlan config
Name      VID  Member           Mode
------  -----  ---------------  --------
Vlan2       2  PortChannel0001  untagged
Vlan2       2  Ethernet1        tagged


root@sonic:/home/admin# show interfaces  portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  -------------
 0002  PortChannel0002  LACP(A)(Dw)  Ethernet2(D)
 0003  PortChannel0003  LACP(A)(Dw)  Ethernet3(D)
 0004  PortChannel0004  LACP(A)(Dw)  Ethernet4(D)
 0005  PortChannel0005  LACP(A)(Dw)  N/A
 0023  PortChannel0023  LACP(A)(Dw)  Ethernet23(D)
 0024  PortChannel0024  LACP(A)(Up)  Ethernet24(S)
 0025  PortChannel0025  LACP(A)(Up)  Ethernet25(S)
 0026  PortChannel0026  LACP(A)(Up)  Ethernet26(S)
 0027  PortChannel0027  LACP(A)(Up)  Ethernet27(S)
 0028  PortChannel0028  LACP(A)(Up)  Ethernet28(S)
 0029  PortChannel0029  LACP(A)(Up)  Ethernet29(S)
 0030  PortChannel0030  LACP(A)(Up)  Ethernet30(S)
 0031  PortChannel0031  LACP(A)(Up)  Ethernet31(S)
 0032  PortChannel0032  LACP(A)(Up)  Ethernet32(S)
 0033  PortChannel0033  LACP(A)(Up)  Ethernet33(S)
 0034  PortChannel0034  LACP(A)(Up)  Ethernet34(S)
 0035  PortChannel0035  LACP(A)(Up)  Ethernet35(S)
 0036  PortChannel0036  LACP(A)(Up)  Ethernet36(S)


```

**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# config portchannel del PortChannel0001
root@sonic:/home/admin# show vlan brief
+-----------+--------------+-----------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   |
+===========+==============+===========+================+=======================+
|         2 | 12.1.1.1/16  | Ethernet1 | tagged         | 100.100.1.1           |
|           | 12::1/64     |           |                |                       |
+-----------+--------------+-----------+----------------+-----------------------+
root@sonic:/home/admin# show vlan config
Name      VID  Member     Mode
------  -----  ---------  ------
Vlan2       2  Ethernet1  tagged
root@sonic:/home/admin# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  -------------
 0002  PortChannel0002  LACP(A)(Dw)  Ethernet2(D)
 0003  PortChannel0003  LACP(A)(Dw)  Ethernet3(D)
 0004  PortChannel0004  LACP(A)(Dw)  Ethernet4(D)
 0005  PortChannel0005  LACP(A)(Dw)  N/A
 0023  PortChannel0023  LACP(A)(Dw)  Ethernet23(D)
 0024  PortChannel0024  LACP(A)(Up)  Ethernet24(S)
 0025  PortChannel0025  LACP(A)(Up)  Ethernet25(S)
 0026  PortChannel0026  LACP(A)(Up)  Ethernet26(S)
 0027  PortChannel0027  LACP(A)(Up)  Ethernet27(S)
 0028  PortChannel0028  LACP(A)(Up)  Ethernet28(S)
 0029  PortChannel0029  LACP(A)(Up)  Ethernet29(S)
 0030  PortChannel0030  LACP(A)(Up)  Ethernet30(S)
 0031  PortChannel0031  LACP(A)(Up)  Ethernet31(S)
 0032  PortChannel0032  LACP(A)(Up)  Ethernet32(S)
 0033  PortChannel0033  LACP(A)(Up)  Ethernet33(S)
 0034  PortChannel0034  LACP(A)(Up)  Ethernet34(S)
 0035  PortChannel0035  LACP(A)(Up)  Ethernet35(S)
 0036  PortChannel0036  LACP(A)(Up)  Ethernet36(S)
root@sonic:/home/admin# config portchannel del PortChannel0005
root@sonic:/home/admin# show vlan brief
+-----------+--------------+-----------+----------------+-----------------------+
|   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   |
+===========+==============+===========+================+=======================+
|         2 | 12.1.1.1/16  | Ethernet1 | tagged         | 100.100.1.1           |
|           | 12::1/64     |           |                |                       |
+-----------+--------------+-----------+----------------+-----------------------+


```
