### PR TITLE
fix portchannel member admin is restricted to portchannel(#5319)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1334,6 +1334,11 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
     if interface_name_is_valid(db, port_name) is False:
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
+    # if port is a member of a portchannel. can't be startup while portchannel is down
+    entry = db.get_entry("PORTCHANNEL", portchannel_name)
+    if entry and entry.get('admin_status') == "down":
+        db.mod_entry('PORT', (port_name), {'admin_status': "down"})
+
     db.set_entry('PORTCHANNEL_MEMBER', (portchannel_name, port_name),
             {'NULL': 'NULL'})
 
@@ -2137,12 +2142,20 @@ def startup(ctx, interface_name):
     port_dict = config_db.get_table('PORT')
     for port_name in port_dict.keys():
         if port_name in intf_fs:
+            # if port is a member of a portchannel. can't startup when portchannel is down
+            keys = [ (k, v) for k, v in config_db.get_table('PORTCHANNEL_MEMBER') if v == port_name ]
+            for k in keys:
+                if config_db.get_entry("PORTCHANNEL",  k[0]).get('admin_status') == "down":
+                    ctx.fail("{} is a member of a portchannel. and portchannel admin is down".format(port_name))
             config_db.mod_entry("PORT", port_name, {"admin_status": "up"})
-
     portchannel_list = config_db.get_table("PORTCHANNEL")
     for po_name in portchannel_list.keys():
         if po_name in intf_fs:
             config_db.mod_entry("PORTCHANNEL", po_name, {"admin_status": "up"})
+            # if PORTCHANNEL startup, PORTCHANNEL member will be up.
+            keys = [ (k, v) for k, v in config_db.get_table('PORTCHANNEL_MEMBER') if k == po_name ]
+            for k in keys:
+                config_db.mod_entry('PORT', (k[1]), {"admin_status": "up"})
 
     subport_list = config_db.get_table("VLAN_SUB_INTERFACE")
     for sp_name in subport_list.keys():
@@ -2182,6 +2195,10 @@ def shutdown(ctx, interface_name):
     portchannel_list = config_db.get_table("PORTCHANNEL")
     for po_name in portchannel_list.keys():
         if po_name in intf_fs:
+            # if PORTCHANNEL shutdown, PORTCHANNEL member should be shutdown.
+            portchannel_member_list = config_db.get_table("PORTCHANNEL_MEMBER")
+            for pc_mbr in portchannel_member_list.keys():
+                config_db.mod_entry('PORT', (pc_mbr[1]), {"admin_status": "down"})
             config_db.mod_entry("PORTCHANNEL", po_name, {"admin_status": "down"})
 
     subport_list = config_db.get_table("VLAN_SUB_INTERFACE")


### PR DESCRIPTION
Previous code will cause when portchannel member admin is up
while portchannel admin is down.

Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

1. title:  [master] fix portchannel member port admin status is restricted to portchannel port

 - What I did
         fix https://github.com/Azure/sonic-buildimage/issues/5319  、
 - How I did it
         portchannel member port admin status is limited to portchannel port。
         when portchannel admin is down, portchannel member admin can't be up
         when portchannel admin is up, portchannel member admin can be up and down

- How to verify it 
        create a portchannel and add member port for this portchannel,
        config portchannel admin status down, member status all down.
        config portchannel admin status up, member status all up.
        if portchannel admin status is up, member status can config up or down.
        if portchannel admin status is down, member status can't config up.
            
- Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show interfaces portchannel 
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  -------------
 0001  PortChannel0001  LACP(A)(Up)  Ethernet51(S)
 0002  PortChannel0002  LACP(A)(Dw)  N/A
root@sonic:/home/admin# config interface shutdown PortChannel0001 
root@sonic:/home/admin# show interfaces portchannel               
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  -------------
 0001  PortChannel0001  LACP(A)(Dw)  Ethernet51(D)
 0002  PortChannel0002  LACP(A)(Dw)  N/A
root@sonic:/home/admin# show int st
      Interface            Lanes    Speed    MTU    FEC               Alias             Vlan    Oper    Admin             Type    Asym PFC
---------------  ---------------  -------  -----  -----  ------------------  ---------------  ------  -------  ---------------  ----------
      Ethernet1                1      25G   9100    N/A   twentyfiveGigE0/1            trunk    down       up              N/A         N/A
      Ethernet2                2      25G   9100    N/A   twentyfiveGigE0/2           routed    down       up              N/A         N/A
      Ethernet3                3      25G   9100    N/A   twentyfiveGigE0/3           routed    down       up              N/A         N/A
      Ethernet4                4      25G   9100    N/A   twentyfiveGigE0/4           routed    down       up              N/A         N/A
      Ethernet5                5      25G   9100    N/A   twentyfiveGigE0/5           routed    down       up              N/A         N/A
      Ethernet6                6      25G   9100    N/A   twentyfiveGigE0/6           routed    down       up              N/A         N/A
      Ethernet7                7      25G   9100    N/A   twentyfiveGigE0/7           routed    down       up              N/A         N/A
      Ethernet8                8      25G   9100    N/A   twentyfiveGigE0/8           routed    down       up              N/A         N/A
      Ethernet9               13      25G   9100    N/A   twentyfiveGigE0/9           routed    down       up              N/A         N/A
     Ethernet10               14      25G   9100    N/A  twentyfiveGigE0/10           routed    down       up              N/A         N/A
     Ethernet11               15      25G   9100    N/A  twentyfiveGigE0/11           routed    down       up              N/A         N/A
     Ethernet12               16      25G   9100    N/A  twentyfiveGigE0/12           routed    down       up              N/A         N/A
     Ethernet13               21      25G   9100    N/A  twentyfiveGigE0/13           routed    down       up              N/A         N/A
     Ethernet14               22      25G   9100    N/A  twentyfiveGigE0/14           routed    down       up              N/A         N/A
     Ethernet15               23      25G   9100    N/A  twentyfiveGigE0/15           routed    down       up              N/A         N/A
     Ethernet16               24      25G   9100    N/A  twentyfiveGigE0/16           routed    down       up              N/A         N/A
     Ethernet17               29      25G   9100    N/A  twentyfiveGigE0/17           routed    down       up              N/A         N/A
     Ethernet18               30      25G   9100    N/A  twentyfiveGigE0/18           routed    down       up              N/A         N/A
     Ethernet19               31      25G   9100    N/A  twentyfiveGigE0/19           routed    down       up              N/A         N/A
     Ethernet20               32      25G   9100    N/A  twentyfiveGigE0/20           routed    down       up              N/A         N/A
     Ethernet21               33      25G   9100    N/A  twentyfiveGigE0/21           routed    down       up              N/A         N/A
     Ethernet22               34      25G   9100    N/A  twentyfiveGigE0/22           routed    down       up              N/A         N/A
     Ethernet23               35      25G   9100    N/A  twentyfiveGigE0/23           routed    down       up              N/A         N/A
     Ethernet24               36      25G   9100    N/A  twentyfiveGigE0/24           routed    down       up              N/A         N/A
     Ethernet25               41      25G   9100    N/A  twentyfiveGigE0/25           routed    down       up              N/A         N/A
     Ethernet26               42      25G   9100    N/A  twentyfiveGigE0/26           routed    down       up              N/A         N/A
     Ethernet27               43      25G   9100    N/A  twentyfiveGigE0/27           routed    down       up              N/A         N/A
     Ethernet28               44      25G   9100    N/A  twentyfiveGigE0/28           routed    down       up              N/A         N/A
     Ethernet29               49      25G   9100    N/A  twentyfiveGigE0/29           routed    down       up              N/A         N/A
     Ethernet30               50      25G   9100    N/A  twentyfiveGigE0/30           routed    down       up              N/A         N/A
     Ethernet31               51      25G   9100    N/A  twentyfiveGigE0/31           routed    down       up              N/A         N/A
     Ethernet32               52      25G   9100    N/A  twentyfiveGigE0/32           routed    down       up              N/A         N/A
     Ethernet33               57      25G   9100    N/A  twentyfiveGigE0/33           routed    down       up              N/A         N/A
     Ethernet34               58      25G   9100    N/A  twentyfiveGigE0/34           routed    down       up              N/A         N/A
     Ethernet35               59      25G   9100    N/A  twentyfiveGigE0/35           routed    down       up              N/A         N/A
     Ethernet36               60      25G   9100    N/A  twentyfiveGigE0/36           routed    down       up              N/A         N/A
     Ethernet37               61      25G   9100    N/A  twentyfiveGigE0/37           routed    down       up              N/A         N/A
     Ethernet38               62      25G   9100    N/A  twentyfiveGigE0/38           routed    down       up              N/A         N/A
     Ethernet39               63      25G   9100    N/A  twentyfiveGigE0/39           routed    down       up              N/A         N/A
     Ethernet40               64      25G   9100    N/A  twentyfiveGigE0/40           routed    down       up              N/A         N/A
     Ethernet41               65      25G   9100    N/A  twentyfiveGigE0/41           routed    down       up              N/A         N/A
     Ethernet42               66      25G   9100    N/A  twentyfiveGigE0/42           routed    down       up              N/A         N/A
     Ethernet43               67      25G   9100    N/A  twentyfiveGigE0/43           routed    down       up              N/A         N/A
     Ethernet44               68      25G   9100    N/A  twentyfiveGigE0/44           routed    down       up              N/A         N/A
     Ethernet45               69      25G   9100    N/A  twentyfiveGigE0/45           routed    down       up              N/A         N/A
     Ethernet46               70      25G   9100    N/A  twentyfiveGigE0/46           routed    down       up              N/A         N/A
     Ethernet47               71      25G   9100    N/A  twentyfiveGigE0/47           routed    down       up              N/A         N/A
     Ethernet48               72      25G   9100    N/A  twentyfiveGigE0/48           routed    down       up              N/A         N/A
     Ethernet49      85,86,87,88     100G   9100    N/A      hundredGigE0/1           routed      up       up  QSFP28 or later         N/A
     Ethernet50      77,78,79,80     100G   9100    N/A      hundredGigE0/2           routed    down       up              N/A         N/A
     Ethernet51     97,98,99,100     100G   9100    N/A      hundredGigE0/3  PortChannel0001      up       up  QSFP28 or later         N/A
     Ethernet52      93,94,95,96     100G   9100    N/A      hundredGigE0/4           routed    down       up              N/A         N/A
     Ethernet53  113,114,115,116     100G   9100    N/A      hundredGigE0/5           routed    down       up              N/A         N/A
     Ethernet54  105,106,107,108     100G   9100    N/A      hundredGigE0/6           routed    down       up              N/A         N/A
     Ethernet55  121,122,123,124     100G   9100    N/A      hundredGigE0/7           routed    down       up              N/A         N/A
     Ethernet56  125,126,127,128     100G   9100    N/A      hundredGigE0/8           routed    down       up              N/A         N/A
PortChannel0001              N/A     100G   9100    N/A                 N/A            trunk    down     down  
```

- New command output (if the output of a command-line utility has changed)
```
# and Ethernet6 Ethernet7 Ethernet11 to  PortChannel7000
root@sonic:/home/admin# config  portchannel  add PortChannel7000
root@sonic:/home/admin#   config  portchannel  member  add PortChannel7000 Ethernet6
root@sonic:/home/admin#   config  portchannel  member  add PortChannel7000 Ethernet7
root@sonic:/home/admin#   config  portchannel  member  add PortChannel7000 Ethernet11
root@sonic:/home/admin# show int status | grep PortChannel7000
      Ethernet6                6      25G   9100    N/A   twentyfiveGigE0/6  PortChannel7000    down       up              N/A         N/A
      Ethernet7                7      25G   9100    N/A   twentyfiveGigE0/7  PortChannel7000    down       up              N/A         N/A
     Ethernet11               15      25G   9100    N/A  twentyfiveGigE0/11  PortChannel7000      up       up   SFP/SFP+/SFP28         N/A
PortChannel7000              N/A      75G   9100    N/A                 N/A           routed      up       up              N/A


# shutdown PortChannel7000, and its members' admin be down 
root@sonic:/home/admin#  config interface shutdown  PortChannel7000
root@sonic:/home/admin# show int status | grep PortChannel7000     
      Ethernet6                6      25G   9100    N/A   twentyfiveGigE0/6  PortChannel7000    down     down              N/A         N/A
      Ethernet7                7      25G   9100    N/A   twentyfiveGigE0/7  PortChannel7000    down     down              N/A         N/A
     Ethernet11               15      25G   9100    N/A  twentyfiveGigE0/11  PortChannel7000    down     down   SFP/SFP+/SFP28         N/A
PortChannel7000              N/A      75G   9100    N/A                 N/A           routed    down     down              N/A         N/A


# and port Ethernet13 to PortChannel7000 ,Ethernet13 will be down for PortChannel7000 isdown
root@sonic:/home/admin# show int status |grep Ethernet13
     Ethernet13               21      25G   9100    N/A  twentyfiveGigE0/13           routed      up       up   SFP/SFP+/SFP28         N/A
root@sonic:/home/admin# config  portchannel  member  add PortChannel7000 Ethernet13
root@sonic:/home/admin# show int status | grep PortChannel7000                     
      Ethernet6                6      25G   9100    N/A   twentyfiveGigE0/6  PortChannel7000    down     down              N/A         N/A
      Ethernet7                7      25G   9100    N/A   twentyfiveGigE0/7  PortChannel7000    down     down              N/A         N/A
     Ethernet11               15      25G   9100    N/A  twentyfiveGigE0/11  PortChannel7000    down     down   SFP/SFP+/SFP28         N/A
     Ethernet13               21      25G   9100    N/A  twentyfiveGigE0/13  PortChannel7000    down     down   SFP/SFP+/SFP28         N/A
PortChannel7000              N/A     100G   9100    N/A                 N/A           routed    down     down              N/A  


# PortChannel7000 member can't  be startup  for PortChannel7000 is down
root@sonic:/home/admin# show int status | grep PortChannel7000                    
      Ethernet6                6      25G   9100    N/A   twentyfiveGigE0/6  PortChannel7000    down     down              N/A         N/A
      Ethernet7                7      25G   9100    N/A   twentyfiveGigE0/7  PortChannel7000    down     down              N/A         N/A
     Ethernet11               15      25G   9100    N/A  twentyfiveGigE0/11  PortChannel7000    down     down   SFP/SFP+/SFP28         N/A
     Ethernet13               21      25G   9100    N/A  twentyfiveGigE0/13  PortChannel7000    down     down   SFP/SFP+/SFP28         N/A
PortChannel7000              N/A     100G   9100    N/A                 N/A           routed    down     down              N/A         N/A
root@sonic:/home/admin#  config interface startup  Ethernet11 
Usage: config interface startup [OPTIONS] <interface_name>
Try "config interface startup -h" for help.

Error: Ethernet11 is a member of a portchannel. and portchannel admin is down
root@sonic:/home/admin# 


# PortChannel7000 member will  be startup  when PortChannel7000 startup
root@sonic:/home/admin#  config interface startup  PortChannel7000
root@sonic:/home/admin# show int status | grep PortChannel7000    
      Ethernet6                6      25G   9100    N/A   twentyfiveGigE0/6  PortChannel7000    down       up              N/A         N/A
      Ethernet7                7      25G   9100    N/A   twentyfiveGigE0/7  PortChannel7000    down       up              N/A         N/A
     Ethernet11               15      25G   9100    N/A  twentyfiveGigE0/11  PortChannel7000      up       up   SFP/SFP+/SFP28         N/A
     Ethernet13               21      25G   9100    N/A  twentyfiveGigE0/13  PortChannel7000      up       up   SFP/SFP+/SFP28         N/A
PortChannel7000              N/A     100G   9100    N/A                 N/A           routed      up       up              N/A         N/A

```