### PR TITLE
Fix counters of portstat are abnormal after config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1037,6 +1037,9 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart):
         else:
             cfg_hwsku = cfg_hwsku.strip()
 
+    log_info("Delete portstat data file to ensure accuracy after reload")
+    os.system("rm -rf /tmp/portstat-*")
+
     #Stop services before config push
     if not no_service_restart:
         log.log_info("'reload' stopping services...")


### PR DESCRIPTION
Signed-off-by: Aster-zhangben <zhangben@asterfusion.com>

**- What I did**
Fix packets&bytes counters of 'portstat' or 'show interfaces counters' are huge numbers or negative numbers after config reload.

**- How I did it**
Delete the data file of 'portstat' when 'config reload' is executed. The path of 'portstat' data file is '/tmp/portstat-1000'

**- How to verify it**
step1: Injection flow into the port of DUT before reload
step2: Execute 'portstat -c' and then 'config reload'
step3: After restarting, check whether the 'portstat' data file still exists and whether the packets&bytes counters display is normal.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

