### PR TITLE
Added 'config core' and 'show cores' CLI commands

### DIFF
--- a/config/coredump.py
+++ b/config/coredump.py
@@ -8,7 +8,6 @@ def coredump():
     """ Configure coredump """
     if os.geteuid() != 0:
         exit("Root privileges are required for this operation")
-    pass
 
 @coredump.command()
 @click.argument('disable', required=False)

--- a/config/coredump.py
+++ b/config/coredump.py
@@ -1,0 +1,31 @@
+import os
+import click
+import utilities_common.cli as clicommon
+from swsssdk import ConfigDBConnector
+
+@click.group(cls=clicommon.AbbreviationGroup, name="coredump")
+def coredump():
+    """ Configure coredump """
+    if os.geteuid() != 0:
+        exit("Root privileges are required for this operation")
+    pass
+
+@coredump.command()
+@click.argument('disable', required=False)
+def disable(disable):
+    """Administratively Disable coredump generation"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    table = "COREDUMP"
+    key = "config"
+    config_db.set_entry(table, key, {"enabled": "false"})
+
+@coredump.command()
+@click.argument('enable', required=False)
+def enable(enable):
+    """Administratively Enable coredump generation"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    table = "COREDUMP"
+    key = "config"
+    config_db.set_entry(table, key, {"enabled": "true"})

--- a/config/main.py
+++ b/config/main.py
@@ -27,6 +27,7 @@ from .utils import log
 from . import aaa
 from . import chassis_modules
 from . import console
+from . import coredump
 from . import feature
 from . import kube
 from . import mlnx
@@ -877,6 +878,7 @@ config.add_command(aaa.aaa)
 config.add_command(aaa.tacacs)
 config.add_command(chassis_modules.chassis_modules)
 config.add_command(console.console)
+config.add_command(coredump.coredump)
 config.add_command(feature.feature)
 config.add_command(kube.kubernetes)
 config.add_command(muxcable.muxcable)
@@ -1900,33 +1902,6 @@ def bgp():
 def shutdown():
     """Shut down BGP session(s)"""
     pass
-
-@config.group(cls=clicommon.AbbreviationGroup)
-def core():
-    """ Configure coredump """
-    if os.geteuid() != 0:
-        exit("Root privileges are required for this operation")
-    pass
-
-@core.command()
-@click.argument('disable', required=False)
-def disable(disable):
-    """Administratively Disable coredump generation"""
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    table = "COREDUMP"
-    key = "config"
-    config_db.set_entry(table, key, {"enabled": "false"})
-
-@core.command()
-@click.argument('enable', required=False)
-def enable(enable):
-    """Administratively Enable coredump generation"""
-    config_db = ConfigDBConnector()
-    config_db.connect()
-    table = "COREDUMP"
-    key = "config"
-    config_db.set_entry(table, key, {"enabled": "true"})
 
 @config.group(cls=clicommon.AbbreviationGroup)
 def kdump():

--- a/config/main.py
+++ b/config/main.py
@@ -1902,6 +1902,33 @@ def shutdown():
     pass
 
 @config.group(cls=clicommon.AbbreviationGroup)
+def core():
+    """ Configure coredump """
+    if os.geteuid() != 0:
+        exit("Root privileges are required for this operation")
+    pass
+
+@core.command()
+@click.argument('disable', required=False)
+def disable(disable):
+    """Administratively Disable coredump generation"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    table = "COREDUMP"
+    key = "config"
+    config_db.set_entry(table, key, {"enabled": "false"})
+
+@core.command()
+@click.argument('enable', required=False)
+def enable(enable):
+    """Administratively Enable coredump generation"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    table = "COREDUMP"
+    key = "config"
+    config_db.set_entry(table, key, {"enabled": "true"})
+
+@config.group(cls=clicommon.AbbreviationGroup)
 def kdump():
     """ Configure kdump """
     if os.geteuid() != 0:

--- a/show/coredump.py
+++ b/show/coredump.py
@@ -1,0 +1,75 @@
+import os
+import click
+import utilities_common.cli as clicommon
+from swsssdk import ConfigDBConnector
+
+#
+# 'coredumpctl' group ("show coredump")
+#
+
+@click.group(cls=clicommon.AliasedGroup, name="coredump")
+def coredump():
+    """Show core dump events encountered"""
+    pass
+
+# 'config' subcommand ("show coredump config")
+@coredump.command('config')
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def core_config(verbose):
+    """ Show coredump configuration """
+    # Default admin mode
+    admin_mode = True
+    # Obtain config from Config DB
+    config_db = ConfigDBConnector()
+    if config_db is not None:
+        config_db.connect()
+        table_data = config_db.get_table('COREDUMP')
+        if table_data is not None:
+            config_data = table_data.get('config')
+            if config_data is not None:
+                admin_mode = config_data.get('enabled')
+                if admin_mode is not None and admin_mode.lower() == 'false':
+                    admin_mode = False
+
+    # Core dump administrative mode
+    if admin_mode:
+        click.echo('Coredump : %s' % 'Enabled')
+    else:
+        click.echo('Coredump : %s' % 'Disabled')
+
+# 'list' subcommand ("show coredump list")
+@coredump.command('list')
+@click.argument('pattern', required=False)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def core_list(verbose, pattern):
+    """ List available coredumps """
+
+    if not os.geteuid()==0:
+        click.echo("Note: To list all the core files please run the command with root privileges\n")
+
+    if os.path.exists("/usr/bin/coredumpctl"):
+        cmd = "coredumpctl list"
+        if pattern is not None:
+            cmd = cmd + " " + pattern
+        clicommon.run_command(cmd, display_cmd=verbose)
+    else:
+        exit("Note: Install systemd-coredump package to run this command")
+
+# 'info' subcommand ("show coredump info")
+@coredump.command('info')
+@click.argument('pattern', required=False)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def core_info(verbose, pattern):
+    """ Show information about one or more coredumps """
+
+    if not os.geteuid()==0:
+        click.echo("Note: To view all the core files please run the command with root privileges\n")
+
+    if os.path.exists("/usr/bin/coredumpctl"):
+        cmd = "coredumpctl info"
+        if pattern is not None:
+            cmd = cmd + " " + pattern
+        clicommon.run_command(cmd, display_cmd=verbose)
+    else:
+        exit("Note: Install systemd-coredump package to run this command")
+

--- a/show/main.py
+++ b/show/main.py
@@ -1424,6 +1424,76 @@ def system_memory(verbose):
     run_command(cmd, display_cmd=verbose)
 
 #
+# 'coredumpctl' group ("show cores")
+#
+
+@cli.group(cls=clicommon.AliasedGroup)
+def cores():
+    """Show core dump events encountered"""
+    pass
+
+# 'config' subcommand ("show cores config")
+@cores.command('config')
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def core_config(verbose):
+    """ Show coredump configuration """
+    # Default admin mode
+    admin_mode = True
+    # Obtain config from Config DB
+    config_db = ConfigDBConnector()
+    if config_db is not None:
+        config_db.connect()
+        table_data = config_db.get_table('COREDUMP')
+        if table_data is not None:
+            config_data = table_data.get('config')
+            if config_data is not None:
+                admin_mode = config_data.get('enabled')
+                if admin_mode is not None and admin_mode.lower() == 'false':
+                    admin_mode = False
+
+    # Core dump administrative mode
+    if admin_mode:
+        click.echo('Coredump : %s' % 'Enabled')
+    else:
+        click.echo('Coredump : %s' % 'Disabled')
+
+# 'list' subcommand ("show cores list")
+@cores.command('list')
+@click.argument('pattern', required=False)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def core_list(verbose, pattern):
+    """ List available coredumps """
+
+    if not os.geteuid()==0:
+        click.echo("Note: To list all the core files please run the command with root privileges\n")
+
+    if os.path.exists("/usr/bin/coredumpctl"):
+        cmd = "coredumpctl list"
+        if pattern is not None:
+            cmd = cmd + " " + pattern
+        run_command(cmd, display_cmd=verbose)
+    else:
+        exit("Note: Install systemd-coredump package to run this command")
+
+# 'info' subcommand ("show cores info")
+@cores.command('info')
+@click.argument('pattern', required=False)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def core_info(verbose, pattern):
+    """ Show information about one or more coredumps """
+
+    if not os.geteuid()==0:
+        click.echo("Note: To view all the core files please run the command with root privileges\n")
+
+    if os.path.exists("/usr/bin/coredumpctl"):
+        cmd = "coredumpctl info"
+        if pattern is not None:
+            cmd = cmd + " " + pattern
+        run_command(cmd, display_cmd=verbose)
+    else:
+        exit("Note: Install systemd-coredump package to run this command")
+
+#
 # 'kdump command ("show kdump ...")
 #
 @cli.group(cls=clicommon.AliasedGroup)


### PR DESCRIPTION
Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added wrapper CLI commands to see core files information. Also added CLI command to enable/disable
corefile generation.

**- How I did it**
Added new commands
config core
show cores

**- How to verify it**
show cores list
config core enable
config core disable

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
root@sonic:/home/admin# show cores
Usage: show cores [OPTIONS] COMMAND [ARGS]...

Show core dump events encountered

Options:
-?, -h, --help Show this message and exit.

Commands:
config Show coredump configuration
info Show information about one or more coredumps
list List available coredumps
root@sonic:/home/admin# show cores list
TIME PID UID GID SIG COREFILE EXE
Sat 2016-12-31 22:46:22 UTC 4933 0 0 6 present /usr/bin/vlanmgrd
root@sonic:/home/admin# show cores info
PID: 4933 (vlanmgrd)
UID: 0 (root)
GID: 0 (root)
Signal: 6 (ABRT)
Timestamp: Sat 2016-12-31 22:46:22 UTC (6min ago)
Command Line: /usr/bin/vlanmgrd
Executable: /usr/bin/vlanmgrd
Control Group: /docker/38e40a3313bd46ff4e282f897cdc25502a2b15febe9839715f92b035b6f2cffe
Slice: -.slice
Boot ID: 3f776b83fa704d089bd81e0b108c2a09
Machine ID: a0c0523aae8c4c21a8d9fa12e18d85b0
Hostname: sonic
Storage: /var/lib/systemd/coredump/core.vlanmgrd.0.3f776b83fa704d089bd81e0b108c2a09.4933.1483224382000000000000.lz4
Message: Process 4933 (vlanmgrd) of user 0 dumped core.
