### PR TITLE
CPU port queues support

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -128,6 +128,9 @@ class Portstat(object):
         if counter_port_name_map is None:
             return cnstat_dict
         for port in natsorted(counter_port_name_map):
+            if  port[:3] == "CPU" :
+                continue
+
             port_name = port.split(":")[0]
             if self.multi_asic.skip_display(constants.PORT_OBJ, port_name):
                 continue


### PR DESCRIPTION
Signed-off-by: Prabhu Sreenivasan <prabhu.sreenivasan@broadcom.com>

HLD: https://github.com/Azure/SONiC/pull/743

**- What I did**
Added CPU queues support.

**- How I did it**
Skip CPU port while fetching front panel port stats.

**- Related PRs -**
https://github.com/Azure/sonic-swss/pull/1544
https://github.com/Azure/sonic-py-swsssdk/pull/98
https://github.com/Azure/sonic-snmpagent/pull/182
https://github.com/Azure/sonic-sairedis/pull/732

