### PR TITLE
pfc config asymmetric port interface check

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -15,8 +15,12 @@ def configPfcAsym(interface, pfc_asym):
     configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
 
-    configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
+    port_dict = configdb.get_table('PORT')
 
+    if interface in port_dict:
+        configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
+    else:
+        click.echo('Port {} not found'.format(interface))
 
 def showPfcAsym(interface):
     """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Added interface check in "pfc config asymmetric"

**- How I did it**
Modified the script to validate the interface from the DB.

**- How to verify it**
pfc config asymmetric on Ethernet2 <- non-existing interface

**- Previous command output (if the output of a command-line utility has changed)**
root@sonic:~# pfc config asymmetric on Ethernet2 (No error here, accepted)

**- New command output (if the output of a command-line utility has changed)**
root@sonic:~# pfc config asymmetric on Ethernet2
Port Ethernet2 not found
