### PR TITLE
Fix watermark stat display title as "Buffer Pool" instead of "Shared Pool"

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -167,7 +167,7 @@ class Watermarkstat(object):
                                "idx_func": self.get_queue_index,
                                "wm_name" : "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
                                "header_prefix": "MC"},
-            "buffer_pool"   : {"message": "Shared pool maximum occupancy:",
+            "buffer_pool"   : {"message": "Buffer pool maximum occupancy:",
                                "wm_name": "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES",
                                "header" : headerBufferPool},
             "headroom_pool" : {"message": "Headroom pool maximum occupancy:",

--- a/tests/wm_input/wm_test_vectors.py
+++ b/tests/wm_input/wm_test_vectors.py
@@ -62,7 +62,7 @@ Ethernet8     N/A     N/A     N/A     N/A     N/A     N/A     N/A     N/A     N/
 """
 
 show_buffer_pool_wm_output="""\
-Shared pool maximum occupancy:
+Buffer pool maximum occupancy:
                  Pool    Bytes
 ---------------------  -------
  egress_lossless_pool     1000
@@ -71,7 +71,7 @@ ingress_lossless_pool     3000
 """
 
 show_buffer_pool_persistent_wm_output="""\
-Shared pool maximum occupancy:
+Buffer pool maximum occupancy:
                  Pool    Bytes
 ---------------------  -------
  egress_lossless_pool     2000


### PR DESCRIPTION
"show buffer_pool watermark" reads SAI_BUFFER_POOL_STAT_WATERMARK_BYTES. This corresponds to the total buffer occupancy and not the shared buffer pool occupancy.

fixes #1321 

**- What I did**
Fixed the display string in the watermarkstat script.

**- How to verify it**
show buffer_pool watermark

**- Previous command output (if the output of a command-line utility has changed)**
```
$ show buffer_pool watermark
Shared pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool        0
           lossy_pool     4032
```
**- New command output (if the output of a command-line utility has changed)**
```
$ show buffer_pool watermark
Buffer pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool        0
           lossy_pool     1568
```