### PR TITLE
Set untagged VLANs to tagged before adding a new untagged VLAN member…

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -137,6 +137,12 @@ def add_vlan_member(db, vid, port, untagged):
        (not is_port and clicommon.is_pc_router_interface(db.cfgdb, port)):
         ctx.fail("{} is a router interface!".format(port))
 
+    if untagged:
+        vlan_ports_data = db.cfgdb.get_table('VLAN_MEMBER')
+        for key in vlan_ports_data.keys():
+            if str(key[1]) == port and vlan_ports_data[key]['tagging_mode'] == "untagged":
+                db.cfgdb.set_entry('VLAN_MEMBER', (key[0], port), {'tagging_mode': "tagged" })
+
     db.cfgdb.set_entry('VLAN_MEMBER', (vlan, port), {'tagging_mode': "untagged" if untagged else "tagged" })
 
 @vlan_member.command('del')


### PR DESCRIPTION
… for a port

    fix Azure/sonic-buildimage#6271

    Check whether the port is already an untagged member of another VLAN
    when adding an untagged member to a VLAN. If true, set the previous
    one as tagged.

Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
```
fix Azure/sonic-buildimage#6271
```
**- How I did it**
```
Check whether the port is already an untagged member of another VLAN when adding an untagged member to a VLAN.
If true, set the previous one as tagged.
```
**- How to verify it**
```
1. Adding a port as an untagged VLAN member
2. Adding the same port as an untagged member of another VLAN
3. show vlan brief
```
**- Previous command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# config vlan member add 10 Ethernet11 -u
root@sonic:/home/admin# config vlan member add 20 Ethernet11 -u
root@sonic:/home/admin# show vlan brief
+-----------+--------------+------------+----------------+-----------------------+-------------+
|   VLAN ID | IP Address   | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
+===========+==============+============+================+=======================+=============+
|        10 |              | Ethernet11 | untagged       |                       | disabled    |
+-----------+--------------+------------+----------------+-----------------------+-------------+
|        20 |              | Ethernet11 | untagged       |                       | disabled    |
+-----------+--------------+------------+----------------+-----------------------+-------------+
```
**- New command output (if the output of a command-line utility has changed)**
```
root@sonic:/home/admin# show vlan brief
+-----------+--------------+------------+----------------+-----------------------+-------------+
|   VLAN ID | IP Address   | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
+===========+==============+============+================+=======================+=============+
|        10 |              | Ethernet11 | untagged       |                       | disabled    |
+-----------+--------------+------------+----------------+-----------------------+-------------+
|        20 |              | Ethernet11 | untagged       |                       | disabled    |
+-----------+--------------+------------+----------------+-----------------------+-------------+
root@sonic:/home/admin# config vlan member del 10 Ethernet11
root@sonic:/home/admin# config vlan member add 10 Ethernet11 -u
root@sonic:/home/admin# show vlan brief
+-----------+--------------+------------+----------------+-----------------------+-------------+
|   VLAN ID | IP Address   | Ports      | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
+===========+==============+============+================+=======================+=============+
|        10 |              | Ethernet11 | untagged       |                       | disabled    |
+-----------+--------------+------------+----------------+-----------------------+-------------+
|        20 |              | Ethernet11 | tagged         |                       | disabled    |
+-----------+--------------+------------+----------------+-----------------------+-------------+
```
