### PR TITLE
[pfcwd] Configuring to 'stop' ports

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1567,12 +1567,17 @@ def start(action, restoration_time, ports, detection_time, verbose):
 
 @pfcwd.command()
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def stop(verbose):
-    """ Stop PFC watchdog """
+@click.argument('ports', nargs=-1)
+def stop(verbose, ports):
+	""" Stop PFC watchdog """
+	
+	cmd = "pfcwd stop"
 
-    cmd = "pfcwd stop"
+	if ports:
+		ports = set(ports)
+		cmd += " {}".format(' '.join(ports))
 
-    clicommon.run_command(cmd, display_cmd=verbose)
+	clicommon.run_command(cmd, display_cmd=verbose)
 
 @pfcwd.command()
 @click.option('--verbose', is_flag=True, help="Enable verbose output")

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5325,7 +5325,8 @@ This command stops PFC Watchdog
 
 - Usage:
   ```
-  config pfcwd stop
+  config pfcwd stop Ethernet0
+  config pfcwd stop all
   ```
 
 **config pfcwd interval \<interval_in_ms\>**

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -105,9 +105,7 @@ class PfcwdCli(object):
     ):
         self.db = None
         self.config_db = None
-        self.multi_asic = multi_asic_util.MultiAsic(
-            display, namespace, db
-        )
+        self.multi_asic = multi_asic_util.MultiAsic(display, namespace, db)
         self.table = []
         self.all_ports = []
 
@@ -339,6 +337,10 @@ class PfcwdCli(object):
         )
 
         if len(ports) == 0:
+            click.echo("Ports not selected")
+            return
+
+        if 'all' in ports:
             ports = all_ports
 
         for port in ports:


### PR DESCRIPTION
**- What I did**
 Refactored the pfcwd stop command to look like pfcwd start. 
 It provides an update to stop a specific port:
	config pfcwd stop Ethernet0
 Or for all ports at once:
	config pfcwd stop all
	
fixes https://github.com/Azure/sonic-buildimage/issues/6338
	
**- How to verify it**
 Create pfcwd instances for ports:
	pfcwd start --action drop Ethernet0 400
	pfcwd start --action drop Ethernet80 400
	show pfcwd config
	
 Remove one port
	config pfcwd stop Ethernet0
	show pfcwd config
	
 Or remove all of them
	config pfcwd stop all
	show pfcwd config

**- Previous command input**
	config pfcwd stop
	
**- New command input**
	config pfcwd stop <port name / 'all'>