### PR TITLE
Provide QoS Scheduler CLI command and user guide

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1831,6 +1831,43 @@ def is_dynamic_buffer_enabled(config_db):
     return 'dynamic' == device_metadata.get('buffer_model')
 
 #
+# 'qos scheduler' group ('config qos scheduler ...')
+#
+@qos.group()
+def scheduler():
+    """QoS-Scheduler-related configuration tasks"""
+    pass
+
+@scheduler.command(name='add')
+@click.argument('profile_name', metavar='<profile_name>', required=True)
+@click.option('--meter_type', help='Meter type', type=click.Choice(['bytes', 'packets']), default='bytes')
+@click.option('--pir', help='Maximum bandwidth rate', type=click.IntRange(1, 50000000000), required=True)
+@click.option('--pbs', help='Maximum bandwidth burst', type=click.IntRange(1, 256000000), required=True)
+def add(profile_name, meter_type, pir, pbs):
+    """Add QoS-Scheduler profile."""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+
+    data = {
+        'meter_type': meter_type,
+        'pir': pir,
+        'pbs': pbs
+    }
+
+    config_db.set_entry("SCHEDULER", profile_name, data)
+
+@scheduler.command(name='del')
+@click.argument('profile_name', metavar='<profile_name>', required=True)
+def delete(profile_name):
+    """Delete QoS-Scheduler profile."""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+
+    config_db.set_entry("SCHEDULER", profile_name, None)
+
+#
 # 'warm_restart' group ('config warm_restart ...')
 #
 @config.group(cls=clicommon.AbbreviationGroup, name='warm_restart')

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6107,6 +6107,64 @@ Some of the example QOS configurations that users can modify are given below.
   When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
   ```
 
+**config qos scheduler add**
+
+This command is used for creating QoS scheduler profile.
+
+- Usage:
+  ```
+  config qos scheduler add <profile_name> [--meter_type (bytes | packets)] --pir=<pir> --pbs=<pbs>
+  ```
+
+Parameters
+
+* profile_name: QoS scheduler profile name.
+
+* meter_type: scheduler meter type. One of:
+
+  * "bytes": metering is done based on bytes.
+
+  * "packets": metering is done based on packets.
+
+  Default: "bytes".
+
+* pir: shaper maximum bandwidth rate.
+
+  * When meter type is "bytes":
+
+  Unit: Bps(bytes per second). Minimum: "1000" (AS8000 and AS9716-32D: "4000"). Maximum: "50000000000".
+
+  * When meter type is "packets":
+
+  Unit: pps(packets per second). Minimum: "1". Maximum: "50000000000".
+
+* pbs: shaper maximum bandwidth burst. Unit: bytes if meter type is "bytes", otherwise packets. Minimum: "1". Maximum: "256000000".
+
+The following example shows how to create a QoS scheduler profile named profile-1. meter_type: bytes. pir: 100000. pbs: 8000.
+- Example:
+  ```
+  admin@sonic:~$ sudo config qos scheduler add profile-1 --meter_type=bytes --pbs=100000 --pir=8000
+  ```
+
+**config qos scheduler del**
+
+This command is used for removing QoS scheduler profile.
+
+- Usage:
+  ```
+  config qos scheduler del <profile_name>
+  ```
+
+Parameters
+
+* profile_name: QoS scheduler profile name.
+
+The following example shows how to remove a QoS scheduler profile named profile-1.
+- Example:
+  ```
+  admin@sonic:~$ sudo config qos scheduler del profile-1
+  ```
+
 Go Back To [Beginning of the document](#) or [Beginning of this section](#qos)
 
 ## sFlow


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Provide CLI to create and delete QoS Scheduler profiles.

Syntax for QoS Scheduler
* config qos scheduler del <profile_name>
* config qos scheduler add <profile_name> [--meter_type=(byte | packet)] --pir=\<pir\> --pbs=\<pbs\>

**- How I did it**
Add "scheduler" sub-command in QoS command group.

**- How to verify it**
We can create and delete QoS Scheduler profiles through CLI command.

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

**- Details if related**
Signed-off-by: Fred Yu fred_yu@edge-core.com