### PR TITLE
ECN Config support to enable per color

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2646,8 +2646,8 @@ def add(ctx, interface_name, ip_addr, gw):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    # Add a validation to check this interface is not a member in vlan before 
-    # changing it to a router port 
+    # Add a validation to check this interface is not a member in vlan before
+    # changing it to a router port
     vlan_member_table = config_db.get_table('VLAN_MEMBER')
     if (interface_is_in_vlan(vlan_member_table, interface_name)):
             click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))
@@ -3544,8 +3544,11 @@ def remove_reasons(counter_name, reasons, verbose):
 @click.option('-rdrop', metavar='<red drop probability>', type=click.IntRange(0, 100), help="Set red drop probability")
 @click.option('-ydrop', metavar='<yellow drop probability>', type=click.IntRange(0, 100), help="Set yellow drop probability")
 @click.option('-gdrop', metavar='<green drop probability>', type=click.IntRange(0, 100), help="Set green drop probability")
+@click.option('-renable', metavar="<true|false>", type=click.Choice(['true', 'false']))
+@click.option('-yenable', metavar="<true|false>", type=click.Choice(['true', 'false']))
+@click.option('-genable', metavar="<true|false>", type=click.Choice(['true', 'false']))
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, verbose):
+def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, renable, yenable, genable, verbose):
     """ECN-related configuration tasks"""
     log.log_info("'ecn -profile {}' executing...".format(profile))
     command = "ecnconfig -p %s" % profile
@@ -3558,6 +3561,9 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, verbos
     if rdrop is not None: command += " -rdrop %d" % rdrop
     if ydrop is not None: command += " -ydrop %d" % ydrop
     if gdrop is not None: command += " -gdrop %d" % gdrop
+    if renable is not None: command += " -renable %s" % renable
+    if yenable is not None: command += " -yenable %s" % yenable
+    if genable is not None: command += " -genable %s" % genable
     if verbose: command += " -vv"
     clicommon.run_command(command, display_cmd=verbose)
 

--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -11,20 +11,23 @@ usage: ecnconfig [-h] [-v] [-l] [-p PROFILE] [-gmin GREEN_MIN]
                  [-ydrop YELLOW_DROP_PROB] [-rdrop RED_DROP_PROB] [-vv]
 
 optional arguments:
-  -h     --help                show this help message and exit
-  -v     --version             show program's version number and exit
-  -vv    --verbose             verbose output
-  -l     --list                show ECN WRED configuration
-  -p     --profile             specify WRED profile name
-  -gmin  --green-min           set min threshold for packets marked green
-  -gmax  --green-max           set max threshold for packets marked green
-  -ymin  --yellow-min          set min threshold for packets marked yellow
-  -ymax  --yellow-max          set max threshold for packets marked yellow
-  -rmin  --red-min             set min threshold for packets marked red
-  -rmax  --red-max             set max threshold for packets marked red
-  -gdrop --green-drop-prob     set max drop/mark probability for packets marked green
-  -ydrop --yellow-drop-prob    set max drop/mark probability for packets marked yellow
-  -rdrop --red-drop-prob       set max drop/mark probability for packets marked red
+  -h        --help                show this help message and exit
+  -v        --version             show program's version number and exit
+  -vv       --verbose             verbose output
+  -l        --list                show ECN WRED configuration
+  -p        --profile             specify WRED profile name
+  -gmin     --green-min           set min threshold for packets marked green
+  -gmax     --green-max           set max threshold for packets marked green
+  -ymin     --yellow-min          set min threshold for packets marked yellow
+  -ymax     --yellow-max          set max threshold for packets marked yellow
+  -rmin     --red-min             set min threshold for packets marked red
+  -rmax     --red-max             set max threshold for packets marked red
+  -gdrop    --green-drop-prob     set max drop/mark probability for packets marked green
+  -ydrop    --yellow-drop-prob    set max drop/mark probability for packets marked yellow
+  -rdrop    --red-drop-prob       set max drop/mark probability for packets marked red
+  -genable  --green-enable        set green WRED/ECN enable
+  -yenable  --yellow-enable       set yellow WRED/ECN enable
+  -renable  --red-enable          set red WRED/ECN enable
 
 2) show and change ECN on/off status on queues
 
@@ -79,7 +82,10 @@ WRED_CONFIG_FIELDS = {
     "rmin": "red_min_threshold",
     "gdrop": "green_drop_probability",
     "ydrop": "yellow_drop_probability",
-    "rdrop": "red_drop_probability"
+    "rdrop": "red_drop_probability",
+    "genable": "wred_green_enable",
+    "yenable": "wred_yellow_enable",
+    "renable": "wred_red_enable"
 }
 
 PORT_TABLE_NAME            = "PORT"
@@ -274,6 +280,9 @@ def main():
     parser.add_argument('-gdrop', '--green-drop-prob', type=str, help='set max drop/mark probability for packets marked \'green\'', default=None)
     parser.add_argument('-ydrop', '--yellow-drop-prob', type=str, help='set max drop/mark probability for packets marked \'yellow\'', default=None)
     parser.add_argument('-rdrop', '--red-drop-prob', type=str, help='set max drop/mark probability for packets marked \'red\'', default=None)
+    parser.add_argument('-genable', '--green-enable', type=str, metavar='(true or false)', help='set WRED enable as (true|false) for packets marked \'green\'', default=None)
+    parser.add_argument('-yenable', '--yellow-enable', type=str, metavar='(true or false)', help='set WRED enable as (true|false) for packets marked \'yellow\'', default=None)
+    parser.add_argument('-renable', '--red-enable', type=str, metavar='(true or false)', help='set WRED enable as (true|false) for packets marked \'red\'', default=None)
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     parser.add_argument('-vv', '--verbose', action='store_true', help='Verbose output', default=False)
 
@@ -330,6 +339,13 @@ def main():
                     wred_profile_data[WRED_CONFIG_FIELDS["ydrop"]] = args.yellow_drop_prob
                 if args.red_drop_prob:
                     wred_profile_data[WRED_CONFIG_FIELDS["rdrop"]] = args.red_drop_prob
+                if args.green_enable:
+                    wred_profile_data[WRED_CONFIG_FIELDS["genable"]] = args.green_enable
+                if args.yellow_enable:
+                    wred_profile_data[WRED_CONFIG_FIELDS["yenable"]] = args.yellow_enable
+                if args.red_enable:
+                    wred_profile_data[WRED_CONFIG_FIELDS["renable"]] = args.red_enable
+
 
                 # validate new configuration data
                 if prof_cfg.validate_profile_data(wred_profile_data) == False:
@@ -355,6 +371,13 @@ def main():
                     prof_cfg.set_wred_prob(args.profile, "ydrop", args.yellow_drop_prob)
                 if args.red_drop_prob:
                     prof_cfg.set_wred_prob(args.profile, "rdrop", args.red_drop_prob)
+                if args.green_enable:
+                    prof_cfg.set_wred_prob(args.profile, "genable", args.green_enable)
+                if args.yellow_enable:
+                    prof_cfg.set_wred_prob(args.profile, "yenable", args.yellow_enable)
+                if args.red_enable:
+                    prof_cfg.set_wred_prob(args.profile, "renable", args.red_enable)
+
 
         elif args.queue:
             if len(sys.argv) < (4 if args.verbose else 3):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Fixes#4545
**- What I did**
ecnconfig support to set/unset wred_green_enable, wred_yellow_enable and wred_red_enable

**- How I did it**
Added cmdline options for red, yellow and green enable

**- How to verify it**
ecnconfig -p AZURE_LOSSLESS -gmin 50000 -gmax 100000 -genable true
ecnconfig -p AZURE_LOSSLESS -ymin 40000 -ymax 80000 -yenable true
ecnconfig -p AZURE_LOSSLESS -rmin 30000 -rmax 70000 -renable true

show ecn
Profile: AZURE_LOSSLESS
--------------------  ------
red_max_threshold     70000
wred_green_enable     true
green_min_threshold   50000
red_min_threshold     30000
yellow_min_threshold  40000
green_max_threshold   100000
wred_yellow_enable    true
yellow_max_threshold  80000
wred_red_enable       true
--------------------  ------
