### PR TITLE
[201811] Drop explict 3 seconds pause between two object updates/deletes. 

### DIFF
--- a/scripts/configlet
+++ b/scripts/configlet
@@ -208,11 +208,6 @@ def main():
             if parse_only == False:
                 for i in data:
                     process_entry (do_update, i)
-                    # Artificial sleep to give a pause between two entries
-                    # so as to ensure that all internal daemons have digested the 
-                    # previous update, before the next one arrives.
-                    #
-                    time.sleep(3)
             else:
                 print("Parsed:")
                 print(data)


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Drop explicitly introduced 3 seconds pause between object updates using configlet.
Master [PR #1359](https://github.com/Azure/sonic-utilities/pull/1359)

#### How I did it
Remove the added time.sleep(3)

#### How to verify it
Loaded original minigraph that has all T0s
Get redis-dump of Asic-DB.
Manipulate minigraph to remove a T0
Load that minigraph
Add that removed T0 via configlet
Get the red-dump of ASIC-DB

Compared the two ASIC dumps using saiasiccmp tool to match.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

