### PR TITLE
[DPB] fix optional fields for child ports in scope DPB

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2382,9 +2382,14 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     if not _validate_interface_mode(ctx, breakout_cfg_file, interface_name, mode, cur_brkout_mode):
         raise click.Abort()
 
+    # Get hwsku dict from hwsku.json file
+    _, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
+    hwsku_filepath = os.path.join(hwsku_path, "hwsku.json")
+    hwsku_dict = readJsonFile(hwsku_filepath)
+
     """ Interface Deletion Logic """
     # Get list of interfaces to be deleted
-    del_ports = get_child_ports(interface_name, cur_brkout_mode, breakout_cfg_file)
+    del_ports = get_child_ports(interface_name, cur_brkout_mode, breakout_cfg_file, hwsku_dict)
     del_intf_dict = {intf: del_ports[intf]["speed"] for intf in del_ports}
 
     if del_intf_dict:
@@ -2400,7 +2405,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
 
     """ Interface Addition Logic """
     # Get list of interfaces to be added
-    add_ports = get_child_ports(interface_name, target_brkout_mode, breakout_cfg_file)
+    add_ports = get_child_ports(interface_name, target_brkout_mode, breakout_cfg_file, hwsku_dict)
     add_intf_dict = {intf: add_ports[intf]["speed"] for intf in add_ports}
 
     if add_intf_dict:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

As part of PR:
https://github.com/Azure/sonic-buildimage/pull/6660

#### What I did
After DPB cli command, optional fields 'fec' has N/A state
Before DPB:
```
  Interface            Lanes    Speed    MTU    FEC        Alias    Vlan    Oper    Admin             Type    Asym PFC
-----------  ---------------  -------  -----  -----  -----------  ------  ------  -------  ---------------  ----------
 Ethernet32      32,33,34,35     100G   9100     rs   Ethernet32  routed      up       up  QSFP28 or later         N/A
```
After DPB:
```
  Interface            Lanes    Speed    MTU    FEC        Alias    Vlan    Oper    Admin             Type    Asym PFC
-----------  ---------------  -------  -----  -----  -----------  ------  ------  -------  ---------------  ----------
 Ethernet32            32,33      50G   9100    N/A   Ethernet32  routed    down       up  QSFP28 or later         N/A
 Ethernet34            34,35      50G   9100    N/A   Ethernet34  routed    down       up              N/A         N/A
```

Expect that, fields from parent ports must be produced in child ports.

#### How I did it

#### How to verify it
Execute: `sudo config interface breakout Ethernet0 2x50G -f`

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

