### PR TITLE
[show] invalid acl table output with single port

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -706,7 +706,10 @@ class AclLoader(object):
                 if not val["ports"]:
                     data.append([key, val["type"], "", val["policy_desc"], stage])
                 else:
-                    ports = natsorted(val["ports"])
+                    if isinstance(val['ports'], str):
+                        ports = [val['ports']]
+                    else:
+                        ports = natsorted(val["ports"])
                     data.append([key, val["type"], ports[0], val["policy_desc"], stage])
 
                     if len(ports) > 1:


### PR DESCRIPTION
**- What I did**
Fixed the bug "Observing the binding field is not proper while executing "show acl table" command"
fixes https://github.com/Azure/SONiC/issues/305

**- How I did it**
Added changes to the function show_table in acl_lader.
Added the checking of a value type for the ports. If the value is a string then we print it as is in other cases we split and sort the values.

**- How to verify it**
Follow the description in the bug.

1.Create an acl :
```
"ACL_TABLE": {
	"1": {
		"stage": "INGRESS",
		"type": "MIRROR",
		"policy_desc": "Mirror Session",
		"ports": "Ethernet16"
	}
}
```
2. $ config reload -y
3. $ show acl table


**- Previous command output (if the output of a command-line utility has changed)**
```
Name    Type    Binding    Description     Stage
------  ------  ---------  --------------  -------
1       MIRROR  1          Mirror Session  ingress
                6
                E
                e
                e
                h
                n
                r
                t
                t
```

**- New command output (if the output of a command-line utility has changed)**
```
  Name  Type    Binding     Description     Stage
------  ------  ----------  --------------  -------
     1  MIRROR  Ethernet16  Mirror Session  ingress
```
