### PR TITLE
Fix the python error for handle download image error

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -298,7 +298,7 @@ def install(url, force, skip_migration=False):
             urlretrieve(url, bootloader.DEFAULT_IMAGE_PATH, reporthook)
             click.echo('')
         except Exception as e:
-            echo_and_log("Download error", e)
+            echo_and_log("Download error: {}".format(e), LOG_ERR)
             raise click.Abort()
         image_path = bootloader.DEFAULT_IMAGE_PATH
     else:


### PR DESCRIPTION
#### What I did
Correct python error

#### How to verify it
run sonic_installer install http://XXX
(Use wrong URL to lead download error )

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>