### PR TITLE
fix show mac slow

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -79,6 +79,7 @@ class FdbShow(object):
         """
         self.db.connect(self.db.ASIC_DB)
         self.bridge_mac_list = []
+        vlan_bvid_map = {}
 
         if not self.if_br_oid_map:
             return
@@ -111,15 +112,20 @@ class FdbShow(object):
                 if 'bvid' not in fdb:
                     # no possibility to find the Vlan id. skip the FDB entry
                     continue
-                try:
-                    vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
-                    if vlan_id is None:
-                        # the situation could be faced if the system has an FDB entries,
-                        # which are linked to default Vlan(caused by untagged trafic)
-                        continue
-                except Exception:
-                    vlan_id = fdb["bvid"]
-                    print("Failed to get Vlan id for bvid {}\n".format(fdb["bvid"]))
+                if fdb["bvid"] in vlan_bvid_map:
+                    vlan_id = vlan_bvid_map[fdb["bvid"]]
+                else:
+                    try:
+                        vlan_id = port_util.get_vlan_id_from_bvid(self.db, fdb["bvid"])
+                        if vlan_id is None:
+                            # the situation could be faced if the system has an FDB entries,
+                            # which are linked to default Vlan(caused by untagged trafic)
+                            continue
+                        else:
+                            vlan_bvid_map[fdb["bvid"]] = vlan_id
+                    except Exception:
+                        vlan_id = fdb["bvid"]
+                        print("Failed to get Vlan id for bvid {}\n".format(fdb["bvid"]))
             self.bridge_mac_list.append((int(vlan_id),) + (fdb["mac"],) + (if_name,) + (fdb_type,))
 
         self.bridge_mac_list.sort(key = lambda x: x[0])


### PR DESCRIPTION
Signed-off-by: pettershao-ragilenetworks <pettershao@ragilenetworks.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
fix https://github.com/Azure/sonic-buildimage/issues/7136

#### How I did it
In testing, I found that ' port_util.get_vlan_id_from_bvid' will do many db actions to get vlan id, this really take times, so I store it temporarily when find the mapping info at first time, and use it when try to find vlan id for same bvid later.
#### How to verify it
big datastream, and show mac.
#### Previous command output (if the output of a command-line utility has changed)
before change, it takes long time .(5k, up to 15 seconds)
#### New command output (if the output of a command-line utility has changed)
after change, it takes only a while(5k, less than 1 seconds)

