### PR TITLE
FIX: scripts/configlet, TypeError: 'dict_keys' object is not subscriptable

### DIFF
--- a/scripts/configlet
+++ b/scripts/configlet
@@ -159,7 +159,7 @@ def do_delete(t, k, lst):
 
 def do_operate(op_upd, t, k, lst):
     if lst:
-        if type(lst[lst.keys()[0]]) == dict:
+        if type(lst[next(iter(lst))]) == dict:
             for i in lst:
                 do_operate(op_upd, t, k+(i,), lst[i])
             return


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
tested on SONiC.202012.77, python 3.7.3
#### How I did it
rewrote it on Python 3.8.5
#### How to verify it
lst={'test':{'nested':1}}

type(lst[next(iter(lst))])

#### Previous command output (if the output of a command-line utility has changed)
TypeError: 'dict_keys' object is not subscriptable
#### New command output (if the output of a command-line utility has changed)
<class 'dict'>
