### PR TITLE
 [config]: Implement a process level lock

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -297,7 +297,7 @@ def state(state, port):
     if port is not None and port != "all":
         click.confirm(('Muxcable at port {} will be changed to {} state. Continue?'.format(port, state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.reacquireLock()
+        cdblock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
         if port not in logical_port_list:
             click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
@@ -387,7 +387,7 @@ def state(state, port):
 
         click.confirm(('Muxcables at all ports will be changed to {} state. Continue?'.format(state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.reacquireLock()
+        cdblock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
         rc = True
@@ -496,7 +496,7 @@ def setswitchmode(state, port):
     if port is not None and port != "all":
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.reacquireLock()
+        cdblock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
         if port not in logical_port_list:
             click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
@@ -570,7 +570,7 @@ def setswitchmode(state, port):
 
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.reacquireLock()
+        cdblock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
         rc = True

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -296,6 +296,8 @@ def state(state, port):
 
     if port is not None and port != "all":
         click.confirm(('Muxcable at port {} will be changed to {} state. Continue?'.format(port, state)), abort=True)
+        # Reacquire lock, if confirmation is needed for this command
+        cdblock.reacquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
         if port not in logical_port_list:
             click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
@@ -344,7 +346,7 @@ def state(state, port):
 
         logical_port_list_per_port = logical_port_list_for_physical_port.get(physical_port, None)
 
-        """ This check is required for checking whether or not this logical port is the one which is 
+        """ This check is required for checking whether or not this logical port is the one which is
         actually mapped to physical port and by convention it is always the first port.
         TODO: this should be removed with more logic to check which logical port maps to actual physical port
         being used"""
@@ -384,6 +386,8 @@ def state(state, port):
     elif port == "all" and port is not None:
 
         click.confirm(('Muxcables at all ports will be changed to {} state. Continue?'.format(state)), abort=True)
+        # Reacquire lock, if confirmation is needed for this command
+        cdblock.reacquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
         rc = True
@@ -491,6 +495,8 @@ def setswitchmode(state, port):
 
     if port is not None and port != "all":
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
+        # Reacquire lock, if confirmation is needed for this command
+        cdblock.reacquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
         if port not in logical_port_list:
             click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
@@ -563,6 +569,8 @@ def setswitchmode(state, port):
     elif port == "all" and port is not None:
 
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
+        # Reacquire lock, if confirmation is needed for this command
+        cdblock.reacquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
         rc = True

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -9,6 +9,7 @@ from sonic_py_common import multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import platform_sfputil_helper
+from .utils import cfglock
 
 platform_sfputil = None
 
@@ -297,7 +298,7 @@ def state(state, port):
     if port is not None and port != "all":
         click.confirm(('Muxcable at port {} will be changed to {} state. Continue?'.format(port, state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.acquireLock()
+        cfglock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
         if port not in logical_port_list:
             click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
@@ -387,7 +388,7 @@ def state(state, port):
 
         click.confirm(('Muxcables at all ports will be changed to {} state. Continue?'.format(state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.acquireLock()
+        cfglock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
         rc = True
@@ -496,7 +497,7 @@ def setswitchmode(state, port):
     if port is not None and port != "all":
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.acquireLock()
+        cfglock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
         if port not in logical_port_list:
             click.echo("ERR: This is not a valid port, valid ports ({})".format(", ".join(logical_port_list)))
@@ -570,7 +571,7 @@ def setswitchmode(state, port):
 
         click.confirm(('Muxcable at port {} will be changed to {} switching mode. Continue?'.format(port, state)), abort=True)
         # Reacquire lock, if confirmation is needed for this command
-        cdblock.acquireLock()
+        cfglock.acquireLock()
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
         rc = True

--- a/config/utils.py
+++ b/config/utils.py
@@ -1,6 +1,95 @@
+import os
+import sys
+import click
+
 from sonic_py_common import logger
+from swsscommon.swsscommon import ConfigDBConnector
 
 SYSLOG_IDENTIFIER = "config"
 
 # Global logger instance
 log = logger.Logger(SYSLOG_IDENTIFIER)
+
+# class for locking entire config process
+class ConfigLock():
+    def __init__(self):
+        self.lockName = "LOCK|configLock"
+        self.field = "PID"
+        self.timeout = 10
+        self.pid = os.getpid()
+        self.client = None
+        return
+
+    def acquireLock(self):
+        try:
+            # connect to db
+            configdb = ConfigDBConnector()
+            configdb.connect()
+            self.client = configdb.get_redis_client('CONFIG_DB')
+            # Set lock and expire time. Process may get killed b/w set lock and
+            # expire call.
+            if self.client.hsetnx(self.lockName, self.field, self.pid):
+                self.client.expire(self.lockName, self.timeout)
+                log.log_debug(":::Lock Acquired:::")
+                return
+
+            # Lock exists already in DB,
+            p = self.client.pipeline(True)
+            # watch, we do not want to work on modified lock
+            p.watch(self.lockName)
+            # if current process is holding lock then extend the timer
+            if p.hget(self.lockName, self.field) == str(self.pid):
+                self.client.expire(self.lockName, self.timeout)
+                log.log_debug(":::Lock Timer Extended:::");
+                p.unwatch()
+                return
+            elif self.client.ttl(self.lockName) == -1:
+                # if lock exists with other PID and expire timer not running,
+                # run expire time and abort.
+                self.client.expire(self.lockName, self.timeout)
+                click.echo(":::Can not acquire lock, Reset Timer & Abort:::");
+                sys.exit(1)
+            else:
+                # some other process is holding the lock with time on.
+                click.echo(":::Can not acquire config lock, LOCK PID: {} and self.pid:{}:::".\
+                    format(p.hget(self.lockName, self.field), self.pid))
+                p.unwatch()
+                sys.exit(1)
+        except Exception as e:
+            click.echo(":::Exception in acquireLock {}:::".format(e))
+            sys.exit(1)
+        return
+
+    def _releaseLock(self):
+        try:
+            """
+            If LOCK was never acquired, self.client should be None. This
+            happens with 'config ?' command
+            """
+            if self.client is None:
+                return
+
+            p = self.client.pipeline(True)
+            # watch, we do not want to work on modified lock
+            p.watch(self.lockName)
+            # if current process holding the lock then release it.
+            if p.hget(self.lockName, self.field) == str(self.pid):
+                p.multi()
+                p.delete(self.lockName)
+                p.execute()
+                return
+            else:
+                # some other process is holding the lock. Do nothing.
+                pass
+            p.unwatch()
+        except Exception as e:
+            raise e
+        return
+
+    def __del__(self):
+        self._releaseLock()
+        return
+# end of class configdblock
+
+# global instance of config lock
+cfglock = ConfigLock()

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -563,11 +563,11 @@ def json_dump(data):
         data, sort_keys=True, indent=2, ensure_ascii=False, default=json_serial
     )
 
-    
+
 def interface_is_untagged_member(db, interface_name):
-    """ Check if interface is already untagged member"""    
+    """ Check if interface is already untagged member"""
     vlan_member_table = db.get_table('VLAN_MEMBER')
-    
+
     for key,val in vlan_member_table.items():
         if(key[1] == interface_name):
             if (val['tagging_mode'] == 'untagged'):


### PR DESCRIPTION
- What I did
Implement a config process level lock.

- How I did it
Changes:
1.) Implement a class, which uses hsetnx for lock.
2.) lock is expired within timeout period or will be released by config python click process.
3.) After -y prompt, lock is reacquired, because timer could have expired,
before user enters yes.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

### Note: VS Test PR:  I will raise it after confirmation###
### Depends on: sonic-py-swsssdk PR which will be raised with below diff after confirmation ### 

```
@@ -22,6 +22,7 @@
 from .dbconnector import SonicV2Connector
 
 PY3K = sys.version_info >= (3, 0)
+FILTER_TABLE = ['LOCK']
 
 class ConfigDBConnector(SonicV2Connector):
 
@@ -318,6 +319,8 @@
                 key = key.decode('utf-8')
             try:
                 (table_name, row) = key.split(self.TABLE_NAME_SEPARATOR, 1)
+                if table_name in FILTER_TABLE:
+                    continue
                 entry = self.__raw_to_typed(client.hgetall(key))
                 if entry != None:
                     data.setdefault(table_name, {})[self.deserialize_key(row)] = entry
```



>>> Why lock is acquired at process level, not just when we interact with DB.

command such as port breakout or apply-patch interects with DB 3 or more times:
1.) Read Config DB,
---Processing---
2.) Delete Ports
---Processing---
3.) Add Ports.
Here we need to take the lock before step one and then have to release the lock after step three. If we take the lock only while interacting with DB then we have to take lock three times in above situation and that also doesn't solve the problem, because some process can update the DB in between Step 1 and step 2.

Similar command can be written in future with config validation in picture.



- How to verify it

Testing: [With Debug Logs]  [### Note: VS Test PR: <Pending> ###]

Test 1: acquire a lock with command config. Run another config command in between to make sure lock is not acquired. Then say yes on the prompt of first command before timer expires.

Expectation: Second command should not acquire lock, first command should re-extend the timer.

Terminal 1:
```
admin@lnos-x1-a-fab01:~$ sudo config save
:::Lock Acquired:::
Existing file will be overwritten, continue? [y/N]: y
:::Lock Timer Extended:::
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
```


Terminal 2:
```
admin@lnos-x1-a-fab01:~$ sudo config save
:::Can not acuire lock, Abort:::
```


Test 2: run first command, let the timer expires, run second command, then immediately say yes on the prompt of first command.

Expectation: Second command should acquire lock, first command should not be acquire lock after prompt.

Terminal 1:
```
admin@lnos-x1-a-fab01:~$ sudo config save
:::Lock Acquired:::
Existing file will be overwritten, continue? [y/N]: y
:::Can not acquire lock LOCK PID: 10903 and self.pid:10877:::
:::Lock PID: 10903 and self.pid:10877:::
```

Terminal 2:
```
admin@lnos-x1-a-fab01:~$ sudo config load
:::Lock Acquired:::
Load config from the file /etc/sonic/config_db.json? [y/N]: N
Aborted!
```


Test 3: run first command, let the timer expires, then say yes on the prompt of first command to reacquire the lock.

admin@lnos-x1-a-fab01:~$ sudo config save
```
:::Lock Acquired:::
Existing file will be overwritten, continue? [y/N]: y
:::Lock Reacquired:::
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
admin@lnos-x1-a-fab01:~$
```


- Previous command output (if the output of a command-line utility has changed)

- New command output (if the output of a command-line utility has changed)
