### PR TITLE
[PFC] Fix the issue that cannot enable or disable PFC by CLI command.

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -53,13 +53,9 @@ def configPfcPrio(status, interface, priority):
     configdb = ConfigDBConnector()
     configdb.connect()
 
-    if interface not in configdb.get_keys('PORT_QOS_MAP'):
-        click.echo('Cannot find interface {0}'.format(interface))
-        return 
-
     """Current lossless priorities on the interface""" 
     entry = configdb.get_entry('PORT_QOS_MAP', interface)
-    enable_prio = entry.get('pfc_enable').split(',')
+    enable_prio = entry.get('pfc_enable', '').split(',')
     
     """Avoid '' in enable_prio"""
     enable_prio = [x.strip() for x in enable_prio if x.strip()]


### PR DESCRIPTION
#### What I did
Fix the issue that cannot enable or disable PFC by CLI command.

#### How I did it
It's not user freindly for configure PFC enable or disable, if user want to configure PFC by CLI command, user shall enable PFC on the interfaces by configuring the table "PORT_QOS_MAP" in json file and issue **sonic-cfggen** command.

#### How to verify it
Verify that user can configure PFC enable or disable on switch by CLI command, need not to configuring the table "PORT_QOS_MAP" in json file and issue **sonic-cfggen** command.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

