### PR TITLE
lldp-show: skip containers not in running state

### DIFF
--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -37,6 +37,19 @@ LLDP_INSTANCE_IN_HOST_NAMESPACE = ''
 LLDP_DEFAULT_INTERFACE_LIST_IN_ASIC_NAMESPACE = ''
 SPACE_TOKEN = ' '
 
+# Global helper function to check if LLDP docker is running for a given namespace
+def is_instance_running(instance_num):
+    lldp_container_cmd = 'sudo docker container inspect -f {{.State.Status}} lldp{} '.format(instance_num)
+    p = subprocess.Popen(lldp_container_cmd, stdout=subprocess.PIPE, shell=True, text=True)
+    (output, err) = p.communicate()
+
+    ## Wait for end of command. Get return returncode ##
+    returncode = p.wait()
+
+    if returncode == 0:
+        if output == 'running':
+            return True
+    return False
 
 class Lldpshow(object):
     def __init__(self):
@@ -78,6 +91,11 @@ class Lldpshow(object):
         """
         for lldp_instace_num in range(len(self.lldp_instance)):
             lldp_interface_list = lldp_port if lldp_port is not None else self.lldp_interface[lldp_instace_num]
+
+            # Skip instances that are not in 'running' state
+            if is_instance_running(self.lldp_instance[lldp_instace_num]) == False:
+                continue
+
             # In detail mode we will pass interface list (only front ports) and get O/P as plain text
             # and in table format we will get xml output
             lldp_cmd = 'sudo docker exec -i lldp{} lldpctl '.format(self.lldp_instance[lldp_instace_num]) + (


### PR DESCRIPTION
With https://github.com/Azure/sonic-buildimage/pull/7477 asic-dependent containers are created/started only when the ASIC is detected by the platform. The `lldp show` command throws exception/errors if some containers are not present.

#### What I did
Add an additional check for container to be in `running` state before processing additional container state information.

#### How I did it
Introduced a is_instance_running() routine which will use docker-inspect to check for the state of the container.

#### How to verify it
Verified using `lldp show table` command

#### Previous command output (if the output of a command-line utility has changed)

```
admin@Linecard3:~$ show lldp table
Error response from daemon: Container e19fbab07c3789790a38c9d3348ee7b9d766dfcdba4269ab5c2fb66a6de073d0 is not running
Error response from daemon: Container 5362b5ef03a0eabdbdf1702b4974eddf2d11b8f97901c4187a54388d16278ffa is not running
Error response from daemon: Container 2e47a66771aaa68301a05a823537912d14170371f9798347c6ce6da9bb9c9c64 is not running
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice    RemotePortID    Capability    RemotePortDescr
-----------  --------------  --------------  ------------  -----------------
--------------------------------------------------
Total entries displayed:  0
```
#### New command output (if the output of a command-line utility has changed)
```
admin@Linecard3:~$ show lldp table
```
