### PR TITLE
[config/main.py]: Inform user to enable sflow feature with 'config sflow enable'.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5179,6 +5179,16 @@ def enable(ctx):
         ctx.fail("Unable to check sflow status {}".format(e))
 
     if out != "active":
+        # check if service is masked, if yes, unmask it
+        try:
+            proc = subprocess.Popen("systemctl is-enabled sflow", shell=True, text=True, stdout=subprocess.PIPE)
+            (out_mask, _) = proc.communicate()
+        except SystemExit as e:
+            ctx.fail("Unable to check sflow mask status {}".format(e))
+        if out_mask.strip() == "masked":
+            click.echo("Unmasking sflow service")
+            clicommon.run_command("sudo systemctl unmask sflow")
+
         log.log_info("sflow service is not enabled. Starting sflow docker...")
         clicommon.run_command("sudo systemctl enable sflow")
         clicommon.run_command("sudo systemctl start sflow")

--- a/config/main.py
+++ b/config/main.py
@@ -5179,15 +5179,13 @@ def enable(ctx):
         ctx.fail("Unable to check sflow status {}".format(e))
 
     if out != "active":
-        # check if service is masked, if yes, unmask it
-        try:
-            proc = subprocess.Popen("systemctl is-enabled sflow", shell=True, text=True, stdout=subprocess.PIPE)
-            (out_mask, _) = proc.communicate()
-        except SystemExit as e:
-            ctx.fail("Unable to check sflow mask status {}".format(e))
-        if out_mask.strip() == "masked":
-            click.echo("Unmasking sflow service")
-            clicommon.run_command("sudo systemctl unmask sflow")
+        # check if sflow feature is enabled, if not, inform user
+        feature_table = config_db.get_table('FEATURE')
+        if feature_table is not None:
+            if feature_table.get('sflow') is None or \
+                feature_table['sflow']['state'].lower() != 'enabled':
+                click.echo("sflow feature is not enabled. Enable sflow using 'config feature' command first.")
+                return
 
         log.log_info("sflow service is not enabled. Starting sflow docker...")
         clicommon.run_command("sudo systemctl enable sflow")

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -15,7 +15,7 @@ nat         enabled         enabled         local
 pmon        enabled         enabled         kube
 radv        enabled         enabled         kube
 restapi     disabled        enabled         local
-sflow       disabled        enabled         local
+sflow       enabled         enabled         local
 snmp        enabled         enabled         kube
 swss        enabled         enabled         local
 syncd       enabled         enabled         local
@@ -34,7 +34,7 @@ nat         enabled         enabled                                             
 pmon        enabled         enabled                                                                          kube
 radv        enabled         enabled                                                                          kube
 restapi     disabled        enabled                                                                          local
-sflow       disabled        enabled                                                                          local
+sflow       enabled         enabled                                                                          local
 snmp        enabled         enabled         up             2020-11-12 23:32:56  aaaabbbbcccc   20201230.100  kube        kube            kube
 swss        enabled         enabled                                                                          local
 syncd       enabled         enabled                                                                          local
@@ -53,7 +53,7 @@ nat         enabled   enabled
 pmon        enabled   enabled
 radv        enabled   enabled
 restapi     disabled  enabled
-sflow       disabled  enabled
+sflow       enabled   enabled
 snmp        enabled   enabled
 swss        enabled   enabled
 syncd       enabled   enabled
@@ -72,7 +72,7 @@ nat         enabled         enabled         local
 pmon        enabled         enabled         kube
 radv        enabled         enabled         kube
 restapi     disabled        enabled         local
-sflow       disabled        enabled         local
+sflow       enabled         enabled         local
 snmp        enabled         enabled         kube
 swss        enabled         enabled         local
 syncd       enabled         enabled         local

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -685,7 +685,7 @@
         "set_owner": "local"
     },
     "FEATURE|sflow": {
-        "state": "disabled",
+        "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_alert": "disabled",
         "set_owner": "local"


### PR DESCRIPTION
Inform user to enable sflow feature with 'config sflow enable', if disabled.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
We add sflow service as masked to start with in build_scripts/mask_disabled_services.py. So sysctmctl enable will not work directly.  Service is unmasked when user runs config feature command for sflow. So it is better to inform user that the feature sflow is disabled, when user runs the command 'config sflow enable'.

#### How I did it
Inform user to enable sflow feature with 'config sflow enable' if disabled. 

#### How to verify it

Before fix:

admin@asw04:~$ sudo config sflow enable
Failed to enable unit: Unit file /etc/systemd/system/sflow.service is masked.

 

After fix:

admin@lnos-x1-a-asw04:~$ sudo config sflow enable
sflow feature is not enabled. Enable sflow using 'config feature' command first.



#### Previous command output (if the output of a command-line utility has changed)
Output is changed when below command runs first time.
admin@asw04:/usr/lib/systemd/system$ sudo config sflow enable


#### New command output (if the output of a command-line utility has changed)
admin@lnos-x1-a-asw04:~$ sudo config sflow enable
sflow feature is not enabled. Enable sflow using 'config feature' command first.
