### PR TITLE
[show/config] The subcommands related to features of high memory restart and memory threshold.

### DIFF
--- a/config/feature.py
+++ b/config/feature.py
@@ -127,11 +127,11 @@ def feature_high_mem_restart(db, feature_name, high_mem_restart_status):
         feature_high_mem_restart_status.add(feature_config['high_mem_restart'])
 
     if len(feature_high_mem_restart_status) > 1:
-        click.echo("High memory restart status of feature '{}' is not consistent across namespaces.".format(name))
+        click.echo("High memory restart status of feature '{}' is not consistent across namespaces.".format(feature_name))
         sys.exit(4)
 
     if feature_config['high_mem_restart'] == "always_enabled":
-        click.echo("High memory restart of feature '{}' is always enabled and can not be modified".format(name))
+        click.echo("High memory restart of feature '{}' is always enabled and can not be modified".format(feature_name))
         return
 
     for namespace, config_db in db.cfgdb_clients.items():
@@ -163,7 +163,7 @@ def feature_mem_threshold(db, feature_name, mem_threshold):
         feature_mem_thresholds.add(feature_config['mem_threshold'])
 
     if len(feature_mem_thresholds) > 1:
-        click.echo("Memory threshold of feature '{}' is not consistent across namespaces.".format(name))
+        click.echo("Memory threshold of feature '{}' is not consistent across namespaces.".format(feature_name))
         sys.exit(7)
 
     for namespace, config_db in db.cfgdb_clients.items():

--- a/config/feature.py
+++ b/config/feature.py
@@ -100,3 +100,71 @@ def feature_autorestart(db, name, autorestart):
 
     for ns, cfgdb in db.cfgdb_clients.items():
         cfgdb.mod_entry('FEATURE', name, {'auto_restart': autorestart})
+
+
+#
+# 'hign_mem_restart' command ('config feature high_mem_restart ...')
+#
+@feature.command(name='high_mem_restart', short_help="Enable/disable high memory restart of a feature")
+@click.argument('feature_name', metavar='<feature_name>', required=True)
+@click.argument('high_mem_restart_status', metavar='<high_mem_restart_status>', required=True, type=click.Choice(["enabled", "disabled"]))
+@pass_db
+def feature_high_mem_restart(db, feature_name, high_mem_restart_status):
+    """Enable/disable the high memory restart of a feature"""
+    feature_high_mem_restart_status = set()
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        feature_table = config_db.get_table('FEATURE')
+        if not feature_table:
+            click.echo("Unable to retrieve 'FEATURE' table from Config DB.")
+            sys.exit(2)
+
+        feature_config = config_db.get_entry('FEATURE', feature_name)
+        if not feature_config:
+            click.echo("Unable to retrieve configuration of feature '{}' from 'FEATURE' table.".format(feature_name))
+            sys.exit(3)
+
+        feature_high_mem_restart_status.add(feature_config['high_mem_restart'])
+
+    if len(feature_high_mem_restart_status) > 1:
+        click.echo("High memory restart status of feature '{}' is not consistent across namespaces.".format(name))
+        sys.exit(4)
+
+    if feature_config['high_mem_restart'] == "always_enabled":
+        click.echo("High memory restart of feature '{}' is always enabled and can not be modified".format(name))
+        return
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        config_db.mod_entry('FEATURE', feature_name, {'high_mem_restart': high_mem_restart_status})
+
+
+#
+# 'mem_threshold' command ('config feature mem_threshold ...')
+#
+@feature.command(name='mem_threshold', short_help="Configure the memory threshold (in Bytes) of a feature")
+@click.argument('feature_name', metavar='<feature_name>', required=True)
+@click.argument('mem_threshold', metavar='<mem_threshold_in_bytes>', required=True)
+@pass_db
+def feature_mem_threshold(db, feature_name, mem_threshold):
+    """Configure the memory threshold of a feature"""
+    feature_mem_thresholds = set()
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        feature_table = config_db.get_table('FEATURE')
+        if not feature_table:
+            click.echo("Unable to retrieve 'FEATURE' table from Config DB.")
+            sys.exit(5)
+
+        feature_config = config_db.get_entry('FEATURE', feature_name)
+        if not feature_config:
+            click.echo("Unable to retrieve configuration of feature '{}' from 'FEATURE' table.".format(feature_name))
+            sys.exit(6)
+
+        feature_mem_thresholds.add(feature_config['mem_threshold'])
+
+    if len(feature_mem_thresholds) > 1:
+        click.echo("Memory threshold of feature '{}' is not consistent across namespaces.".format(name))
+        sys.exit(7)
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        config_db.mod_entry('FEATURE', feature_name, {'mem_threshold': mem_threshold})

--- a/show/feature.py
+++ b/show/feature.py
@@ -44,6 +44,8 @@ def feature_status(db, feature_name):
     fields_info = [
             ('State', 'state', ""),
             ('AutoRestart', 'auto_restart', ""),
+            ('HighMemRestart', 'high_mem_restart', ""),
+            ('MemThreshold', 'mem_threshold', ""),
             ('SystemState', 'system_state', ""),
             ('UpdateTime', 'update_time', ""),
             ('ContainerId', 'container_id', ""),
@@ -111,6 +113,8 @@ def feature_config(db, feature_name):
     fields_info = [
             ('State', 'state', ""),
             ('AutoRestart', 'auto_restart', ""),
+            ('HighMemRestart', 'high_mem_restart', ""),
+            ('MemThreshold', 'mem_threshold', ""),
             ('Owner', 'set_owner', "local"),
             ('fallback', 'no_fallback_to_local', "")
             ]
@@ -161,4 +165,59 @@ def feature_autorestart(db, feature_name):
     else:
         for name in natsorted(list(feature_table.keys())):
             body.append([name, feature_table[name]['auto_restart']])
+    click.echo(tabulate(body, header))
+
+
+#
+# 'high_mem_restart' subcommand (show feature high_mem_restart)
+#
+@feature.command('high_mem_restart', short_help="Show high memory restart state of a feature")
+@click.argument('feature_name', required=False)
+@pass_db
+def feature_high_mem_restart(db, feature_name):
+    header = ['Feature', 'HighMemRestart']
+    body = []
+
+    feature_table = db.cfgdb.get_table('FEATURE')
+    if not feature_table:
+        click.echo("Unable to retrieve the 'FEATURE' table from CONIFG DB.")
+        sys.exit(2)
+
+    if feature_name:
+        if feature_name in feature_table:
+            body.append([feature_name, feature_table[feature_name]['high_mem_restart']])
+        else:
+            click.echo("Unable to retrieve the feature '{}' from 'FEATURE' table".format(feature_name))
+            sys.exit(3)
+    else:
+        for name in natsorted(list(feature_table.keys())):
+            body.append([name, feature_table[name]['high_mem_restart']])
+
+    click.echo(tabulate(body, header))
+
+
+# 'mem_threshold' subcommand (show feature mem_threshold)
+#
+@feature.command('mem_threshold', short_help="Show memory threshold of a feature")
+@click.argument('feature_name', required=False)
+@pass_db
+def feature_mem_threshold(db, feature_name):
+    header = ['Feature', 'MemThreshold']
+    body = []
+
+    feature_table = db.cfgdb.get_table('FEATURE')
+    if not feature_table:
+        click.echo("Unable to retrieve the 'FEATURE' table from CONIFG DB.")
+        sys.exit(4)
+
+    if feature_name:
+        if feature_name in feature_table:
+            body.append([feature_name, feature_table[feature_name]['mem_threshold']])
+        else:
+            click.echo("Unable to retrieve the feature '{}' from 'FEATURE' table".format(feature_name))
+            sys.exit(5)
+    else:
+        for name in natsorted(list(feature_table.keys())):
+            body.append([name, feature_table[name]['mem_threshold']])
+
     click.echo(tabulate(body, header))

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -383,6 +383,24 @@ class TestFeature(object):
         print(result.exit_code)
         assert result.exit_code == 1
 
+    def test_config_lldp_feature_high_mem_restart(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["lldp", "enabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+    def test_config_lldp_feature_mem_threshold(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands["mem_threshold"], ["lldp", "2048"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -5,102 +5,102 @@ from click.testing import CliRunner
 from utilities_common.db import Db
 
 show_feature_status_output="""\
-Feature     State           AutoRestart     SetOwner
-----------  --------------  --------------  ----------
-bgp         enabled         enabled         local
-database    always_enabled  always_enabled  local
-dhcp_relay  enabled         enabled         kube
-lldp        enabled         enabled         kube
-nat         enabled         enabled         local
-pmon        enabled         enabled         kube
-radv        enabled         enabled         kube
-restapi     disabled        enabled         local
-sflow       disabled        enabled         local
-snmp        enabled         enabled         kube
-swss        enabled         enabled         local
-syncd       enabled         enabled         local
-teamd       enabled         enabled         local
-telemetry   enabled         enabled         kube
+Feature     State           AutoRestart     HighMemRestart    MemThreshold    SetOwner
+----------  --------------  --------------  ----------------  --------------  ----------
+bgp         enabled         enabled         disabled          314572800       local
+database    always_enabled  always_enabled  disabled          157286400       local
+dhcp_relay  enabled         enabled         disabled          83886080        kube
+lldp        enabled         enabled         disabled          104857600       kube
+nat         enabled         enabled         disabled          104857600       local
+pmon        enabled         enabled         disabled          209715200       kube
+radv        enabled         enabled         disabled          104857600       kube
+restapi     disabled        enabled         disabled          104857600       local
+sflow       disabled        enabled         disabled          104857600       local
+snmp        enabled         enabled         disabled          157286400       kube
+swss        enabled         enabled         disabled          104857600       local
+syncd       enabled         enabled         disabled          629145600       local
+teamd       enabled         enabled         disabled          104857600       local
+telemetry   enabled         enabled         disabled          209715200       kube
 """
 
 show_feature_status_output_with_remote_mgmt="""\
-Feature     State           AutoRestart     SystemState    UpdateTime           ContainerId    Version       SetOwner    CurrentOwner    RemoteState
-----------  --------------  --------------  -------------  -------------------  -------------  ------------  ----------  --------------  -------------
-bgp         enabled         enabled                                                                          local
-database    always_enabled  always_enabled                                                                   local
-dhcp_relay  enabled         enabled                                                                          kube
-lldp        enabled         enabled                                                                          kube
-nat         enabled         enabled                                                                          local
-pmon        enabled         enabled                                                                          kube
-radv        enabled         enabled                                                                          kube
-restapi     disabled        enabled                                                                          local
-sflow       disabled        enabled                                                                          local
-snmp        enabled         enabled         up             2020-11-12 23:32:56  aaaabbbbcccc   20201230.100  kube        kube            kube
-swss        enabled         enabled                                                                          local
-syncd       enabled         enabled                                                                          local
-teamd       enabled         enabled                                                                          local
-telemetry   enabled         enabled                                                                          kube
+Feature     State           AutoRestart     HighMemRestart    MemThreshold    SystemState    UpdateTime           ContainerId    Version       SetOwner    CurrentOwner    RemoteState
+----------  --------------  --------------  ----------------  --------------  -------------  -------------------  -------------  ------------  ----------  --------------  -------------
+bgp         enabled         enabled         disabled          314572800                                                                        local
+database    always_enabled  always_enabled  disabled          157286400                                                                        local
+dhcp_relay  enabled         enabled         disabled          83886080                                                                         kube
+lldp        enabled         enabled         disabled          104857600                                                                        kube
+nat         enabled         enabled         disabled          104857600                                                                        local
+pmon        enabled         enabled         disabled          209715200                                                                        kube
+radv        enabled         enabled         disabled          104857600                                                                        kube
+restapi     disabled        enabled         disabled          104857600                                                                        local
+sflow       disabled        enabled         disabled          104857600                                                                        local
+snmp        enabled         enabled         disabled          157286400       up             2020-11-12 23:32:56  aaaabbbbcccc   20201230.100  kube        kube            kube
+swss        enabled         enabled         disabled          104857600                                                                        local
+syncd       enabled         enabled         disabled          629145600                                                                        local
+teamd       enabled         enabled         disabled          104857600                                                                        local
+telemetry   enabled         enabled         disabled          209715200                                                                        kube
 """
 
 show_feature_config_output="""\
-Feature     State     AutoRestart
-----------  --------  -------------
-bgp         enabled   enabled
-database    enabled   disabled
-dhcp_relay  enabled   enabled
-lldp        enabled   enabled
-nat         enabled   enabled
-pmon        enabled   enabled
-radv        enabled   enabled
-restapi     disabled  enabled
-sflow       disabled  enabled
-snmp        enabled   enabled
-swss        enabled   enabled
-syncd       enabled   enabled
-teamd       enabled   enabled
-telemetry   enabled   enabled
+Feature     State     AutoRestart    HighMemRestart    MemThreshold    Owner
+----------  --------  -------------  ----------------  --------------  -------
+bgp         enabled   enabled        disabled          314572800       local
+database    enabled   disabled       disabled          157286400       local
+dhcp_relay  enabled   enabled        disabled          83886080        kube
+lldp        enabled   enabled        disabled          104857600       kube
+nat         enabled   enabled        disabled          104857600       local
+pmon        enabled   enabled        disabled          209715200       kube
+radv        enabled   enabled        disabled          104857600       kube
+restapi     disabled  enabled        disabled          104857600       local
+sflow       disabled  enabled        disabled          104857600       local
+snmp        enabled   enabled        disabled          157286400       kube
+swss        enabled   enabled        disabled          104857600       local
+syncd       enabled   enabled        disabled          629145600       local
+teamd       enabled   enabled        disabled          104857600       local
+telemetry   enabled   enabled        disabled          209715200       kube
 """
 
 show_feature_config_output_with_remote_mgmt="""\
-Feature     State           AutoRestart     Owner
-----------  --------------  --------------  -------
-bgp         enabled         enabled         local
-database    always_enabled  always_enabled  local
-dhcp_relay  enabled         enabled         kube
-lldp        enabled         enabled         kube
-nat         enabled         enabled         local
-pmon        enabled         enabled         kube
-radv        enabled         enabled         kube
-restapi     disabled        enabled         local
-sflow       disabled        enabled         local
-snmp        enabled         enabled         kube
-swss        enabled         enabled         local
-syncd       enabled         enabled         local
-teamd       enabled         enabled         local
-telemetry   enabled         enabled         kube
+Feature     State           AutoRestart     HighMemRestart    MemThreshold    Owner
+----------  --------------  --------------  ----------------  --------------  -------
+bgp         enabled         enabled         disabled          314572800       local
+database    always_enabled  always_enabled  disabled          157286400       local
+dhcp_relay  enabled         enabled         disabled          83886080        kube
+lldp        enabled         enabled         disabled          104857600       kube
+nat         enabled         enabled         disabled          104857600       local
+pmon        enabled         enabled         disabled          209715200       kube
+radv        enabled         enabled         disabled          104857600       kube
+restapi     disabled        enabled         disabled          104857600       local
+sflow       disabled        enabled         disabled          104857600       local
+snmp        enabled         enabled         disabled          157286400       kube
+swss        enabled         enabled         disabled          104857600       local
+syncd       enabled         enabled         disabled          629145600       local
+teamd       enabled         enabled         disabled          104857600       local
+telemetry   enabled         enabled         disabled          209715200       kube
 """
 
 show_feature_bgp_status_output="""\
-Feature    State    AutoRestart    SetOwner
----------  -------  -------------  ----------
-bgp        enabled  enabled        local
+Feature    State    AutoRestart    HighMemRestart    MemThreshold    SetOwner
+---------  -------  -------------  ----------------  --------------  ----------
+bgp        enabled  enabled        disabled          314572800       local
 """
 
 show_feature_bgp_disabled_status_output="""\
-Feature    State     AutoRestart    SetOwner
----------  --------  -------------  ----------
-bgp        disabled  enabled        local
+Feature    State     AutoRestart    HighMemRestart    MemThreshold    SetOwner
+---------  --------  -------------  ----------------  --------------  ----------
+bgp        disabled  enabled        disabled          314572800       local
 """
 show_feature_snmp_config_owner_output="""\
-Feature    State    AutoRestart    Owner    fallback
----------  -------  -------------  -------  ----------
-snmp       enabled  enabled        local    true
+Feature    State    AutoRestart    HighMemRestart    MemThreshold    Owner    fallback
+---------  -------  -------------  ----------------  --------------  -------  ----------
+snmp       enabled  enabled        disabled          157286400       local    true
 """
 
 show_feature_snmp_config_fallback_output="""\
-Feature    State    AutoRestart    Owner    fallback
----------  -------  -------------  -------  ----------
-snmp       enabled  enabled        kube     false
+Feature    State    AutoRestart    HighMemRestart    MemThreshold    Owner    fallback
+---------  -------  -------------  ----------------  --------------  -------  ----------
+snmp       enabled  enabled        disabled          157286400       kube     false
 """
 
 show_feature_autorestart_output="""\
@@ -122,12 +122,73 @@ teamd       enabled
 telemetry   enabled
 """
 
+show_feature_high_mem_restart_output="""\
+Feature     HighMemRestart
+----------  ----------------
+bgp         disabled
+database    disabled
+dhcp_relay  disabled
+lldp        disabled
+nat         disabled
+pmon        disabled
+radv        disabled
+restapi     disabled
+sflow       disabled
+snmp        disabled
+swss        disabled
+syncd       disabled
+teamd       disabled
+telemetry   disabled
+"""
+
+show_feature_high_mem_restart_lldp_output="""\
+Feature    HighMemRestart
+---------  ----------------
+lldp       disabled
+"""
+
+show_feature_high_mem_restart_lldp_enabled_output="""\
+Feature    HighMemRestart
+---------  ----------------
+lldp       enabled
+"""
+
+show_feature_mem_threshold_output="""\
+Feature       MemThreshold
+----------  --------------
+bgp              314572800
+database         157286400
+dhcp_relay        83886080
+lldp             104857600
+nat              104857600
+pmon             209715200
+radv             104857600
+restapi          104857600
+sflow            104857600
+snmp             157286400
+swss             104857600
+syncd            629145600
+teamd            104857600
+telemetry        209715200
+"""
+
+show_feature_mem_threshold_lldp_output="""\
+Feature      MemThreshold
+---------  --------------
+lldp            104857600
+"""
+
+show_feature_mem_threshold_lldp_updated_output="""\
+Feature      MemThreshold
+---------  --------------
+lldp                 2048
+"""
+
 show_feature_bgp_autorestart_output="""\
 Feature    AutoRestart
 ---------  -------------
 bgp        enabled
 """
-
 
 show_feature_bgp_disabled_autorestart_output="""\
 Feature    AutoRestart
@@ -135,10 +196,28 @@ Feature    AutoRestart
 bgp        disabled
 """
 
+show_feature_bgp_high_mem_restart_disabled_output="""\
+Feature    HighMemRestart
+---------  ----------------
+bgp        disabled
+"""
+
+show_feature_bgp_high_mem_restart_enabled_output="""\
+Feature    HighMemRestart
+---------  ----------------
+bgp        enabled
+"""
+
+show_feature_bgp_mem_threshold_output="""\
+Feature      MemThreshold
+---------  --------------
+bgp             104857600
+"""
+
 show_feature_database_always_enabled_state_output="""\
-Feature    State           AutoRestart     SetOwner
----------  --------------  --------------  ----------
-database   always_enabled  always_enabled  local
+Feature    State           AutoRestart     HighMemRestart    MemThreshold    SetOwner
+---------  --------------  --------------  ----------------  --------------  ----------
+database   always_enabled  always_enabled  disabled          157286400       local
 """
 
 show_feature_database_always_enabled_autorestart_output="""\
@@ -146,12 +225,23 @@ Feature    AutoRestart
 ---------  --------------
 database   always_enabled
 """
+
 config_feature_bgp_inconsistent_state_output="""\
 Feature 'bgp' state is not consistent across namespaces
 """
+
 config_feature_bgp_inconsistent_autorestart_output="""\
 Feature 'bgp' auto-restart is not consistent across namespaces
 """
+
+config_feature_inconsistent_high_mem_restart_output="""\
+High memory restart status of feature 'bgp' is not consistent across namespaces.
+"""
+
+config_feature_inconsistent_mem_threshold_output="""\
+Memory threshold of feature 'bgp' is not consistent across namespaces.
+"""
+
 
 class TestFeature(object):
     @classmethod
@@ -192,6 +282,7 @@ class TestFeature(object):
         result = runner.invoke(show.cli.commands["feature"].commands["config"], [])
         print(result.exit_code)
         print(result.output)
+        print(show_feature_config_output_with_remote_mgmt)
         assert result.exit_code == 0
         if "Owner" in result.output:
             assert result.output == show_feature_config_output_with_remote_mgmt
@@ -232,6 +323,51 @@ class TestFeature(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_feature_autorestart_output
+
+    def test_show_feature_high_mem_restart(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_mem_restart_output
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["lldp"])
+        print(result.exit_code)
+        print(result.output)
+        print(show_feature_high_mem_restart_lldp_output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_mem_restart_lldp_output
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["not_existing_container"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 3
+
+    def test_show_feature_mem_threshold(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_mem_threshold_output
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["lldp"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_mem_threshold_lldp_output
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["non_existing_container"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 5
 
     def test_fail_autorestart(self, get_cmd_module):
         (config, show) = get_cmd_module
@@ -383,23 +519,63 @@ class TestFeature(object):
         print(result.exit_code)
         assert result.exit_code == 1
 
-    def test_config_lldp_feature_high_mem_restart(self, get_cmd_module):
+    def test_config_feature_high_mem_restart(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
         runner = CliRunner()
+
         result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["lldp", "enabled"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
 
-    def test_config_lldp_feature_mem_threshold(self, get_cmd_module):
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["lldp"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_mem_restart_lldp_enabled_output
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["non_existing_container", "enabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 3
+
+        # Delete the 'FEATURE' table.
+        db.cfgdb.delete_table("FEATURE")
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["lldp", "enabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 2
+
+    def test_config_feature_mem_threshold(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
         runner = CliRunner()
+
         result = runner.invoke(config.config.commands["feature"].commands["mem_threshold"], ["lldp", "2048"], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["lldp"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_mem_threshold_lldp_updated_output
+
+        result = runner.invoke(config.config.commands["feature"].commands["mem_threshold"], ["non_existing_container", "2048"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 6
+
+        # Delete the 'FEATURE' table.
+        db.cfgdb.delete_table("FEATURE")
+
+        result = runner.invoke(config.config.commands["feature"].commands["mem_threshold"], ["lldp", "2048"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 5
 
     @classmethod
     def teardown_class(cls):
@@ -447,6 +623,42 @@ class TestFeatureMultiAsic(object):
         print(result.output)
         assert result.exit_code == 1
         assert result.output == config_feature_bgp_inconsistent_autorestart_output
+
+    def test_config_feature_inconsistent_high_mem_restart(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic_3_asics
+        importlib.reload(mock_multi_asic_3_asics)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["bgp", "disabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 4
+        assert result.output == config_feature_inconsistent_high_mem_restart_output
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["bgp", "enabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 4
+        assert result.output == config_feature_inconsistent_high_mem_restart_output
+
+    def test_config_feature_inconsistent_mem_threshold(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic_3_asics
+        importlib.reload(mock_multi_asic_3_asics)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["mem_threshold"], ["bgp", "104857600"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 7
+        assert result.output == config_feature_inconsistent_mem_threshold_output
 
     def test_config_bgp_feature_consistent_state(self, get_cmd_module):
         from .mock_tables import dbconnector
@@ -497,7 +709,54 @@ class TestFeatureMultiAsic(object):
         assert result.exit_code == 0
         assert result.output == show_feature_bgp_autorestart_output
  
+    def test_config_feature_consistent_high_mem_restart(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["bgp", "disabled"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["bgp"], obj=db)
+        print(result.output)
+        print(result.exit_code)
+        assert result.exit_code == 0
+        assert result.output == show_feature_bgp_high_mem_restart_disabled_output
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_mem_restart"], ["bgp", "enabled"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["bgp"], obj=db)
+        print(result.output)
+        print(result.exit_code)
+        assert result.exit_code == 0
+        assert result.output == show_feature_bgp_high_mem_restart_enabled_output
  
+    def test_config_feature_consistent_mem_threshold(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["mem_threshold"], ["bgp", "104857600"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["bgp"], obj=db)
+        print(result.output)
+        print(result.exit_code)
+        assert result.exit_code == 0
+        assert result.output == show_feature_bgp_mem_threshold_output
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -202,7 +202,7 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_restart": "disabled"
+        "high_mem_restart": "disabled",
         "mem_threshold": "314572800"
     },
     "VLAN|Vlan1000": {

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -202,7 +202,8 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled"
+        "high_mem_restart": "disabled"
+        "mem_threshold": "314572800"
     },
     "VLAN|Vlan1000": {
         "vlanid": "1000"

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -170,7 +170,8 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled"
+        "high_mem_restart": "disabled"
+        "mem_threshold": "314572800"
     },
     "BGP_INTERNAL_NEIGHBOR|10.1.0.1": {
         "rrclient": "0",

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -170,7 +170,7 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_restart": "disabled"
+        "high_mem_restart": "disabled",
         "mem_threshold": "314572800"
     },
     "BGP_INTERNAL_NEIGHBOR|10.1.0.1": {

--- a/tests/mock_tables/asic2/config_db.json
+++ b/tests/mock_tables/asic2/config_db.json
@@ -123,6 +123,7 @@
     "FEATURE|bgp": {
         "state": "disabled",
         "auto_restart": "disabled",
-        "high_mem_alert": "disabled"
+        "high_mem_restart": "disabled",
+        "mem_threshold": "1024"
     }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -640,98 +640,98 @@
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1011,
+        "mem_threshold": "314572800",
         "set_owner": "local"
     },
     "FEATURE|database": {
         "state": "always_enabled",
         "auto_restart": "always_enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1012,
+        "mem_threshold": "157286400",
         "set_owner": "local"
     },
     "FEATURE|dhcp_relay": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1013,
+        "mem_threshold": "83886080",
         "set_owner": "kube"
     },
     "FEATURE|lldp": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1014,
+        "mem_threshold": "104857600",
         "set_owner": "kube"
     },
     "FEATURE|nat": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1015,
+        "mem_threshold": "104857600",
         "set_owner": "local"
     },
     "FEATURE|pmon": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1016,
+        "mem_threshold": "209715200",
         "set_owner": "kube"
     },
     "FEATURE|radv": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1017,
+        "mem_threshold": "104857600",
         "set_owner": "kube"
     },
     "FEATURE|restapi": {
         "state": "disabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1018,
+        "mem_threshold": "104857600",
         "set_owner": "local"
     },
     "FEATURE|sflow": {
         "state": "disabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1019,
+        "mem_threshold": "104857600",
         "set_owner": "local"
     },
     "FEATURE|snmp": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1020,
+        "mem_threshold": "157286400",
         "set_owner": "kube"
     },
     "FEATURE|swss": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1019,
+        "mem_threshold": "104857600",
         "set_owner": "local"
     },
     "FEATURE|syncd": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1020,
+        "mem_threshold": "629145600",
         "set_owner": "local"
     },
     "FEATURE|teamd": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1021,
+        "mem_threshold": "104857600",
         "set_owner": "local"
     },
     "FEATURE|telemetry": {
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_restart": "disabled",
-        "mem_threshold": 1022,
+        "mem_threshold": "209715200",
         "set_owner": "kube"
     },
     "DEVICE_METADATA|localhost": {

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -639,85 +639,99 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1011,
         "set_owner": "local"
     },
     "FEATURE|database": {
         "state": "always_enabled",
         "auto_restart": "always_enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1012,
         "set_owner": "local"
     },
     "FEATURE|dhcp_relay": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1013,
         "set_owner": "kube"
     },
     "FEATURE|lldp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1014,
         "set_owner": "kube"
     },
     "FEATURE|nat": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1015,
         "set_owner": "local"
     },
     "FEATURE|pmon": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1016,
         "set_owner": "kube"
     },
     "FEATURE|radv": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1017,
         "set_owner": "kube"
     },
     "FEATURE|restapi": {
         "state": "disabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1018,
         "set_owner": "local"
     },
     "FEATURE|sflow": {
         "state": "disabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1019,
         "set_owner": "local"
     },
     "FEATURE|snmp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1020,
         "set_owner": "kube"
     },
     "FEATURE|swss": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1019,
         "set_owner": "local"
     },
     "FEATURE|syncd": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1020,
         "set_owner": "local"
     },
     "FEATURE|teamd": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1021,
         "set_owner": "local"
     },
     "FEATURE|telemetry": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_restart": "disabled",
+        "mem_threshold": 1022,
         "set_owner": "kube"
     },
     "DEVICE_METADATA|localhost": {


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR aims to implement the subcommands of `show`/`config` which can help users configure the status of high memory restart and memory threshold of a specific container. 

#### How I did it
I implemented two functions in `config/feature.py` and `show/feature.py` files separately according to the following logic:
- Check whether the container is configured in the `FEATURE` table of  `CONFIG_DB`
- Check whether the `high_mem_restart` or `mem_threshold` field exists in configuration of the container
- Get or update the value of `high_mem_restart` or `mem_threshold` field which was provided by user

#### How to verify it
I tested this implementation on DuT `str-msn2700-01`.

Test result of Unit Test:

            test/feature_test.py::TestFeature::test_show_feature_status_no_kube_status PASSED                                                                               
            tests/feature_test.py::TestFeature::test_show_feature_status PASSED                                                                                              
            tests/feature_test.py::TestFeature::test_show_feature_config PASSED                                                                                             
            tests/feature_test.py::TestFeature::test_show_feature_status_abbrev_cmd PASSED                                                                                 
            tests/feature_test.py::TestFeature::test_show_bgp_feature_status PASSED                                                                                         
            tests/feature_test.py::TestFeature::test_show_unknown_feature_status PASSED                                                                                     
            tests/feature_test.py::TestFeature::test_show_feature_autorestart PASSED                                                                                         
            tests/feature_test.py::TestFeature::test_fail_autorestart PASSED                                                                                                 
            tests/feature_test.py::TestFeature::test_show_bgp_autorestart_status PASSED                                                                                      
            tests/feature_test.py::TestFeature::test_show_unknown_autorestart_status PASSED                                                                                  
            tests/feature_test.py::TestFeature::test_config_bgp_feature_state PASSED                                                                                         
            tests/feature_test.py::TestFeature::test_config_snmp_feature_owner PASSED                                                                                        
            tests/feature_test.py::TestFeature::test_config_unknown_feature_owner PASSED                                                                                     
            tests/feature_test.py::TestFeature::test_config_snmp_feature_fallback PASSED                                                                                     
            tests/feature_test.py::TestFeature::test_config_bgp_autorestart PASSED                                                                                           
            tests/feature_test.py::TestFeature::test_config_database_feature_state PASSED                                                                                    
            tests/feature_test.py::TestFeature::test_config_database_feature_autorestart PASSED                                                                              
            tests/feature_test.py::TestFeature::test_config_unknown_feature PASSED                                                                                           
            tests/feature_test.py::TestFeature::test_config_lldp_feature_high_mem_restart PASSED                                                                             
            tests/feature_test.py::TestFeature::test_config_lldp_feature_mem_threshold PASSED                                                                                
            tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_inconsistent_state PASSED                                                                   
            tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_inconsistent_autorestart PASSED                                                             
            tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_consistent_state PASSED                                                                     
            tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_consistent_autorestart PASSED                                                              
                                                             

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

