### PR TITLE
Fix output bug on 'show vlan config' command.

### DIFF
--- a/show/vlan.py
+++ b/show/vlan.py
@@ -164,7 +164,7 @@ def config(db):
         table = []
 
         for k in natsorted(keys):
-            members = set([(vlan, member) for vlan, member in member_data if vlan == k] + [(k, member) for member in set(data[k].get('members', []))])
+            members = set([(vlan, member) for vlan, member in member_data if vlan == k])
             # vlan with no members
             if not members:
                 members = [(k, '')]


### PR DESCRIPTION
Signed-off-by: Emma Lin <emma_lin@edge-core.com>

#### What I did
Fix output bug on 'show vlan config' command.

bug: When user executes 'show vlan config' command, it also outputs ports from the 'members' field on VLAN_TABLE entry even it does not exist on VLAN_MEMBER_TABLE in redis-db.

```
// vlan data in /etc/sonic/config_db.json
    "VLAN": {
        "Vlan100": {
            "vlanid": "100",
            "members": [
                "Ethernet2"
            ]
        }
    },
    "VLAN_MEMBER": {
        "Vlan100|Ethernet1": {
            "tagging_mode": "tagged"
        }
    }

root@sonic:~# config reload -y
...
root@sonic:~# show vlan con
Name       VID  Member     Mode
-------  -----  ---------  ------
Vlan100    100  Ethernet1  tagged
Vlan100    100  Ethernet2  ?
root@sonic:~# show vlan b
+-----------+--------------+-----------+----------------+-----------------------+-------------+
|   VLAN ID | IP Address   | Ports     | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
+===========+==============+===========+================+=======================+=============+
|       100 |              | Ethernet1 | tagged         |                       | disabled    |
+-----------+--------------+-----------+----------------+-----------------------+-------------+
root@sonic:~#
``` 

#### How I did it
It shall not get members from the 'members' field on VLAN_TABLE entry, so I remove the codes.

#### How to verify it
Execute 'show vlan config' command to make sure the output is correct.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

