### PR TITLE
[Subport] Add the parent admin status to the display of the sub-interface status

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4223,6 +4223,7 @@ The type of interfaces include the following.
   admin@sonic:~$ show ip interfaces
   Interface       Master          IPv4 address/mask     Admin/Oper      BGP Neighbor     Neighbor IP     Flags
   -------------   ------------    ------------------    --------------  -------------    -------------   -------
+  Ethernet8.10                    1.1.1.1/24            down/down       N/A              N/A
   Loopback0                       1.0.0.1/32            up/up           N/A              N/A
   Loopback11      Vrf-red         11.1.1.1/32           up/up           N/A              N/A
   Loopback100     Vrf-blue        100.0.0.1/32          up/up           N/A              N/A
@@ -4236,6 +4237,7 @@ The type of interfaces include the following.
   eth0                            10.3.147.252/23       up/up           N/A              N/A
   lo                              127.0.0.1/8           up/up           N/A              N/A
   ```
+  Note: The admin status of the IP interface on sub port will also consider the admin status of its parent interface.
 
 **show ip protocol**
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -35,6 +35,7 @@ PORT_LANES_STATUS = "lanes"
 PORT_ALIAS = "alias"
 PORT_OPER_STATUS = "oper_status"
 PORT_ADMIN_STATUS = "admin_status"
+PORT_PARENT_ADMIN_STATUS = "parent_admin_status"
 PORT_SPEED = "speed"
 PORT_MTU_STATUS = "mtu"
 PORT_FEC = "fec"
@@ -318,11 +319,20 @@ def appl_db_sub_intf_status_get(appl_db, config_db, front_panel_ports_list, port
 
         full_intf_table_name = "INTF_TABLE" + ":" + sub_intf_name
 
+        if parent_port_name.startswith("Ethernet"):
+            full_port_table_name = "PORT_TABLE" + ":" + parent_port_name
+        else:
+            full_port_table_name = "LAG_TABLE" + ":" + parent_port_name
+
         if status_type == "vlan":
             return vlan_id
 
         if status_type == "admin_status":
             status = appl_db.get(appl_db.APPL_DB, full_intf_table_name, status_type)
+            return status if status is not None else "N/A"
+
+        if status_type == "parent_admin_status":
+            status = appl_db.get(appl_db.APPL_DB, full_port_table_name, PORT_ADMIN_STATUS)
             return status if status is not None else "N/A"
 
         if status_type == "type":
@@ -341,8 +351,7 @@ def appl_db_sub_intf_status_get(appl_db, config_db, front_panel_ports_list, port
 # ========================== interface-status logic ==========================
 
 header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'FEC', 'Alias', 'Vlan', 'Oper', 'Admin', 'Type', 'Asym PFC']
-header_stat_sub_intf = ['Sub port interface', 'Speed', 'MTU', 'Vlan', 'Admin', 'Type']
-
+header_stat_sub_intf = ['Sub port interface', 'Speed', 'MTU', 'Vlan', 'Admin', 'Parent admin', 'Type']
 
 class IntfStatus(object):
 
@@ -439,6 +448,7 @@ class IntfStatus(object):
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_MTU_STATUS),
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, "vlan"),
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_ADMIN_STATUS),
+                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_PARENT_ADMIN_STATUS),
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_OPTICS_TYPE)))
         return table
 

--- a/tests/intfutil_test.py
+++ b/tests/intfutil_test.py
@@ -182,9 +182,10 @@ class TestIntfutil(TestCase):
         result = self.runner.invoke(show.cli.commands["subinterfaces"].commands["status"], [])
         print(result.output, file=sys.stderr)
         expected_output = (
-            "Sub port interface    Speed    MTU    Vlan    Admin                  Type\n"
-          "--------------------  -------  -----  ------  -------  --------------------\n"
-          "        Ethernet0.10      25G   9100      10       up  802.1q-encapsulation"
+            "Sub port interface    Speed    MTU    Vlan    Admin    Parent admin                  Type\n"
+          "--------------------  -------  -----  ------  -------  --------------  --------------------\n"
+          "        Ethernet0.10      25G   9100      10       up              up  802.1q-encapsulation"
+
         )
         self.assertEqual(result.output.strip(), expected_output)
 
@@ -207,9 +208,9 @@ class TestIntfutil(TestCase):
         result = self.runner.invoke(show.cli.commands["subinterfaces"].commands["status"], ["Ethernet0.10"])
         print(result.output, file=sys.stderr)
         expected_output = (
-            "Sub port interface    Speed    MTU    Vlan    Admin                  Type\n"
-          "--------------------  -------  -----  ------  -------  --------------------\n"
-          "        Ethernet0.10      25G   9100      10       up  802.1q-encapsulation"
+            "Sub port interface    Speed    MTU    Vlan    Admin    Parent admin                  Type\n"
+          "--------------------  -------  -----  ------  -------  --------------  --------------------\n"
+          "        Ethernet0.10      25G   9100      10       up              up  802.1q-encapsulation"
         )
         self.assertEqual(result.output.strip(), expected_output)
 
@@ -233,9 +234,9 @@ class TestIntfutil(TestCase):
         result = self.runner.invoke(show.cli.commands["subinterfaces"].commands["status"], ["etp1.10"])
         print(result.output, file=sys.stderr)
         expected_output = (
-            "Sub port interface    Speed    MTU    Vlan    Admin                  Type\n"
-          "--------------------  -------  -----  ------  -------  --------------------\n"
-          "        Ethernet0.10      25G   9100      10       up  802.1q-encapsulation"
+            "Sub port interface    Speed    MTU    Vlan    Admin    Parent admin                  Type\n"
+          "--------------------  -------  -----  ------  -------  --------------  --------------------\n"
+          "        Ethernet0.10      25G   9100      10       up              up  802.1q-encapsulation"
         )
         self.assertEqual(result.output.strip(), expected_output)
 


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The admin status of the IP interface on sub port will also consider the admin status of its parent interface.
Shutdown parent interface, the admin status of the sub-port will be down (show ip interface).
But config_db and app_db are still admin up (show subinterfaces status).


```
root@sonic:~# config interface shutdown  Ethernet8
root@sonic:~# show ip interface
Interface        Master    IPv4 address/mask    Pri/Sec    Admin/Oper    BGP Neighbor    Neighbor IP
---------------  --------  -------------------  ---------  ------------  --------------  -------------
Ethernet8.10               192.169.1.1/24       Primary    down/down     N/A             N/A
Loopback0                  10.1.0.32/32         Primary    up/up         N/A             N/A
PortChannel0001            10.0.0.56/31         Primary    up/up         ARISTA01T1      10.0.0.57
PortChannel0002            10.0.0.58/31         Primary    up/up         ARISTA02T1      10.0.0.59
PortChannel0003            10.0.0.60/31         Primary    up/up         ARISTA03T1      10.0.0.61
PortChannel0004            10.0.0.62/31         Primary    up/up         ARISTA04T1      10.0.0.63
Vlan1000                   192.168.0.1/21       Primary    up/up         N/A             N/A
docker0                    240.127.1.1/24       Primary    up/down       N/A             N/A
eth0                       10.250.0.178/16      Primary    up/up         N/A             N/A
lo                         127.0.0.1/8          Primary    up/up         N/A             N/A
root@sonic:~# show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin                  Type
--------------------  -------  -----  ------  -------  --------------------
        Ethernet8.10     100G   9100      10       up  802.1q-encapsulation
root@sonic:~#
```

#### How I did it
Add the parent admin status to the display of the sub-interface status
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:~$ show subinterfaces status
  Sub port interface    Speed    MTU    Vlan    Admin    Parent_Admin                  Type
--------------------  -------  -----  ------  -------  --------------  --------------------
        Ethernet8.10     100G   9100      10       up            down  802.1q-encapsulation
     PortChannel1.20     100G   9100      20       up            down  802.1q-encapsulation
```
