### PR TITLE
[ACL] Suppoprt add rule incrementally for data plan rules

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -478,14 +478,14 @@ class AclLoader(object):
 
         if rule.ip.config.source_ip_address:
             source_ip_address = rule.ip.config.source_ip_address
-            if ipaddress.ip_network(source_ip_address).version == 4:
+            if ipaddress.ip_network(source_ip_address, strict=False).version == 4:
                 rule_props["SRC_IP"] = source_ip_address
             else:
                 rule_props["SRC_IPV6"] = source_ip_address
 
         if rule.ip.config.destination_ip_address:
             destination_ip_address = rule.ip.config.destination_ip_address
-            if ipaddress.ip_network(destination_ip_address).version == 4:
+            if ipaddress.ip_network(destination_ip_address, strict=False).version == 4:
                 rule_props["DST_IP"] = destination_ip_address
             else:
                 rule_props["DST_IPV6"] = destination_ip_address
@@ -694,12 +694,6 @@ class AclLoader(object):
         modifications.
         :return:
         """
-
-        # TODO: Until we test ASIC behavior, we cannot assume that we can insert
-        # dataplane ACLs and shift existing ACLs. Therefore, we perform a full
-        # update on dataplane ACLs, and only perform an incremental update on
-        # control plane ACLs.
-
         new_rules = set(self.rules_info.keys())
         new_dataplane_rules = set()
         new_controlplane_rules = set()
@@ -720,14 +714,6 @@ class AclLoader(object):
                 current_controlplane_rules.add(key)
             else:
                 current_dataplane_rules.add(key)
-
-        # Remove all existing dataplane rules
-        for key in current_dataplane_rules:
-            self.configdb.mod_entry(self.ACL_RULE, key, None)
-            # Program for per-asic namespace also if present
-            for namespace_configdb in self.per_npu_configdb.values():
-                namespace_configdb.mod_entry(self.ACL_RULE, key, None)
-
 
         # Add all new dataplane rules
         for key in new_dataplane_rules:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1356,17 +1356,6 @@ When the optional argument "max_priority"  is specified, each rule’s priority 
 
 This command is used to perform incremental update of ACL rule table. This command gets existing rules from Config DB and compares with rules specified in input file and performs corresponding modifications.
 
-With respect to DATA ACLs, the command does not assume that new dataplane ACLs can be inserted in betweeen by shifting existing ACLs in all ASICs. Therefore, this command performs a full update on dataplane ACLs.
-With respect to control plane ACLs, this command performs an incremental update.
-If we assume that "file1.json" is the already loaded ACL rules file and if "file2.json" is the input file that is passed as parameter for this command, the following requirements are valid for the input file.
-1) First copy the file1.json to file2.json.
-2) Remove the unwanted ACL rules from file2.json
-3) Add the newly required ACL rules into file2.json.
-4) Modify the existing ACL rules (that require changes) in file2.json.
-
-NOTE: If any ACL rule that is already available in file1.json is required even after this command execution, such rules should remain unalterted in file2.json. Don't remove them.
-Note that "incremental" is working like "full".
-
 When "--session_name" optional argument is specified, command sets the session_name for the ACL table with this mirror session name. It fails if the specified mirror session name does not exist.
 
 When "--mirror_stage" optional argument is specified, command sets the mirror action to ingress/egress based on this parameter. By default command sets ingress mirror action in case argument is not specified.


### PR DESCRIPTION
#### What I did
- Fix "config acl update increment" command to add rule incrementally.
- Fix acl_loader can't add source-ip or destination-ip with IP prefix is not 32

#### How I did it
Do not delete all existed rules for data plan rules, just add the new rules to configDB.

#### How to verify it
Verify on broadcom platform

1. Add ACL table L3_TABLE
```
  admin@sonic:~$ sudo config acl add table L3_TABLE L3 -p Ethernet0
```
2. Add rule.json
```
  admin@sonic:~$ sudo config acl update incremental rule.json
  # rule.json
  {
    "acl": {
      "acl-sets": {
        "acl-set": {
          "L3_TABLE": {
            "acl-entries": {
              "acl-entry": {
                "1": {
                  "actions": {
                    "config": {
                      "forwarding-action": "DROP"
                    }
                  },
                  "config": {
                    "sequence-id": 1
                  },
                  "ip": {
                    "config": {
                      "source-ip-address": "10.0.0.1/16",
                      "destination-ip-address": "10.0.0.2/32"
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
```
3. Update rule increment with rule2.json
```
  admin@sonic:~$
  # rule2.json
  {
    "acl": {
      "acl-sets": {
        "acl-set": {
          "L3_TABLE": {
            "acl-entries": {
              "acl-entry": {
                "2": {
                  "actions": {
                    "config": {
                      "forwarding-action": "ACCEPT"
                    }
                  },
                  "config": {
                    "sequence-id": 2
                  },
                  "ip": {
                    "config": {
                      "source-ip-address": "10.0.0.3/16",
                      "destination-ip-address": "10.0.0.4/32"
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
```
4. Verify rules
```
  admin@sonic:~$ aclshow -a
  RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
  ------------  ------------  ------  ---------------  -------------
  RULE_1        L3_TABLE        9999                0              0
  RULE_2        L3_TABLE        9998                0              0
  DEFAULT_RULE  L3_TABLE           1                0              0
```

