### PR TITLE
CLI command to load config in Yang format

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -67,7 +67,7 @@ SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
 ASIC_CONF_FILENAME = 'asic.conf'
 DEFAULT_CONFIG_DB_FILE = '/etc/sonic/config_db.json'
-DEFAULT_CONFIG_YANG_FILE  = '/etc/sonic/config_yang.json'
+DEFAULT_CONFIG_YANG_FILE = '/etc/sonic/config_yang.json'
 NAMESPACE_PREFIX = 'asic'
 INTF_KEY = "interfaces"
 
@@ -1018,7 +1018,7 @@ def save(filename):
         num_cfg_file += num_asic
 
     # If the user give the filename[s], extract the file names.
-    if filename:
+    if filename is not None:
         cfg_files = filename.split(',')
 
         if len(cfg_files) != num_cfg_file:
@@ -1055,8 +1055,21 @@ def save(filename):
         with open(file, 'w') as config_db_file:
             json.dump(config_db, config_db_file, indent=4)
 
+@config.command()
+@click.option('-y', '--yes', is_flag=True)
+@click.argument('filename', required=False)
+def load(filename, yes):
+    """Import a previous saved config DB dump file.
+       <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
+    """
+    if filename is None:
+        message = 'Load config from the default config file(s) ?'
+    else:
+        message = 'Load config from the file(s) {} ?'.format(filename)
 
-def load_cfg_from_config_db_file(filename):
+    if not yes:
+        click.confirm(message, abort=True)
+
     num_asic = multi_asic.get_num_asics()
     cfg_files = []
 
@@ -1074,7 +1087,7 @@ def load_cfg_from_config_db_file(filename):
 
     # In case of multi-asic mode we have additional config_db{NS}.json files for
     # various namespaces created per ASIC. {NS} is the namespace index.
-    for inst in range(-1, num_cfg_file - 1):
+    for inst in range(-1, num_cfg_file-1):
         #inst = -1, refers to the linux host where there is no namespace.
         if inst == -1:
             namespace = None
@@ -1083,7 +1096,7 @@ def load_cfg_from_config_db_file(filename):
 
         # Get the file from user input, else take the default file /etc/sonic/config_db{NS_id}.json
         if cfg_files:
-            file = cfg_files[inst + 1]
+            file = cfg_files[inst+1]
         else:
             if namespace is None:
                 file = DEFAULT_CONFIG_DB_FILE
@@ -1102,60 +1115,6 @@ def load_cfg_from_config_db_file(filename):
 
         log.log_info("'load' executing...")
         clicommon.run_command(command, display_cmd=True)
-
-
-def load_cfg_from_yang_config_file(filename, restart_service):
-
-    if not filename:
-        file = DEFAULT_CONFIG_YANG_FILE 
-    else:
-        file = filename
-
-    if not os.path.exists(file):
-        click.echo("The yang config file {} doesn't exist".format(file))
-        return
-
-    if restart_service:
-        log.log_info("'load config' stopping services...")
-        _stop_services()
-
-    command = "{} -H -Y {} -j /etc/sonic/init_cfg.json --write-to-db".format( SONIC_CFGGEN_PATH, file)
-
-    log.log_info("'load' executing...")
-    clicommon.run_command(command, display_cmd=True)
-
-    if restart_service:
-        _reset_failed_services()
-        log.log_info("'load config' restarting services...")
-        _restart_services()
-
-    # Update SONiC env file
-    update_sonic_environment()
-
-    click.echo("Please note setting loaded from config file will be lost after system reboot.To preserve setting, run `config save`.")
-
-
-@config.command()
-@click.option('-y', '--yes', is_flag=True)
-@click.option('-t', '--file_format', default='config_db',type=click.Choice(['config_yang', 'config_db']),show_default=True,help='specify the file format')
-@click.option('-r', '--restart_service',default=False,is_flag=True,help='Restart the services after config load')
-@click.argument('filename', required=False)
-def load(filename, yes, file_format, restart_service):
-    """Import a previous saved config DB dump file.
-       <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
-    """
-    if filename is None:
-        message = 'Load config in {} format from the default config file(s) ?'.format(file_format)
-    else:
-        message = 'Load config in {} format from the file(s) {} ?'.format(file_format, filename)
-
-    if not yes:
-        click.confirm(message, abort=True)
-
-    if file_format == 'config_db':
-        load_cfg_from_config_db_file(filename)
-    else:
-        load_cfg_from_yang_config_file(filename, restart_service)
 
 @config.command('apply-patch')
 @click.argument('patch-file-path', type=str, required=True)
@@ -1287,9 +1246,10 @@ def list_checkpoints(ctx, verbose):
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
 @click.option('-d', '--disable_arp_cache', default=False, is_flag=True, help='Do not cache ARP table before reloading (applies to dual ToR systems only)')
 @click.option('-f', '--force', default=False, is_flag=True, help='Force config reload without system checks')
+@click.option('-t', '--file_format', default='config_db',type=click.Choice(['config_yang', 'config_db']),show_default=True,help='specify the file format')
 @click.argument('filename', required=False)
 @clicommon.pass_db
-def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cache, force):
+def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cache, force, file_format):
     """Clear current configuration and import a previous saved config DB dump file.
        <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
@@ -1307,9 +1267,9 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
             return
 
     if filename is None:
-        message = 'Clear current config and reload config from the default config file(s) ?'
+        message = 'Clear current config and reload config in {} format from the default config file(s) ?'.format(file_format)
     else:
-        message = 'Clear current config and reload config from the file(s) {} ?'.format(filename)
+        message = 'Clear current config and reload config in {} from the file(s) {} ?'.format(file_format, filename)
 
     if not yes:
         click.confirm(message, abort=True)
@@ -1320,7 +1280,8 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
     cfg_files = []
 
     num_cfg_file = 1
-    if multi_asic.is_multi_asic():
+    # single config_yang file for the multi asic device
+    if multi_asic.is_multi_asic() and file_format == 'config_db':
         num_cfg_file += num_asic
 
     # Remove cached PG drop counters data
@@ -1373,14 +1334,18 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
         if cfg_files:
             file = cfg_files[inst+1]
         else:
-            if namespace is None:
-                file = DEFAULT_CONFIG_DB_FILE
+            if file_format == 'config_db':
+                if namespace is None:
+                    file = DEFAULT_CONFIG_DB_FILE
+                else:
+                    file = "/etc/sonic/config_db{}.json".format(inst)
             else:
-                file = "/etc/sonic/config_db{}.json".format(inst)
+                file = DEFAULT_CONFIG_YANG_FILE
+
 
         # Check the file exists before proceeding.
         if not os.path.exists(file):
-            click.echo("The config_db file {} doesn't exist".format(file))
+            click.echo("The config file {} doesn't exist".format(file))
             continue
 
         if namespace is None:
@@ -1391,6 +1356,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
         config_db.connect()
         client = config_db.get_redis_client(config_db.CONFIG_DB)
         client.flushdb()
+
         if load_sysinfo:
             if namespace is None:
                 command = "{} -H -k {} --write-to-db".format(SONIC_CFGGEN_PATH, cfg_hwsku)
@@ -1401,16 +1367,23 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
         # For the database service running in linux host we use the file user gives as input
         # or by default DEFAULT_CONFIG_DB_FILE. In the case of database service running in namespace,
         # the default config_db<namespaceID>.json format is used.
-        if namespace is None:
-            if os.path.isfile(INIT_CFG_FILE):
-                command = "{} -j {} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, INIT_CFG_FILE, file)
-            else:
-                command = "{} -j {} --write-to-db".format(SONIC_CFGGEN_PATH, file)
+
+        config_gen_opts = ""
+        if file_format == 'config_db':
+            config_gen_opts += ' -j {} '.format(file)
         else:
-            if os.path.isfile(INIT_CFG_FILE):
-                command = "{} -j {} -j {} -n {} --write-to-db".format(SONIC_CFGGEN_PATH, INIT_CFG_FILE, file, namespace)
-            else:
-                command = "{} -j {} -n {} --write-to-db".format(SONIC_CFGGEN_PATH, file, namespace)
+            config_gen_opts += ' -Y {} '.format(file)
+
+        if os.path.isfile(INIT_CFG_FILE):
+            config_gen_opts += " -j {} ".format(INIT_CFG_FILE)
+
+        if namespace is not None:
+            config_gen_opts += " -n {} ".format(namespace)
+
+
+        command = "{sonic_cfggen} {options} --write-to-db".format(
+            sonic_cfggen=SONIC_CFGGEN_PATH,
+            options=config_gen_opts)
 
         clicommon.run_command(command, display_cmd=True)
         client.set(config_db.INIT_INDICATOR, 1)
@@ -1753,9 +1726,9 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
     # Dont allow a port to be member of port channel if its MTU does not match with portchannel
     portchannel_entry =  db.get_entry('PORTCHANNEL', portchannel_name)
     if portchannel_entry and portchannel_entry.get(PORT_MTU) is not None :
-       port_entry = db.get_entry('PORT', port_name)
+        port_entry = db.get_entry('PORT', port_name)
 
-       if port_entry and port_entry.get(PORT_MTU) is not None:
+        if port_entry and port_entry.get(PORT_MTU) is not None:
             port_mtu = port_entry.get(PORT_MTU)
 
             portchannel_mtu = portchannel_entry.get(PORT_MTU)
@@ -1768,9 +1741,9 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
     # new member by SAI.
     port_entry = db.get_entry('PORT', port_name)
     if port_entry and port_entry.get(PORT_TPID) is not None:
-       port_tpid = port_entry.get(PORT_TPID)
-       if port_tpid != DEFAULT_TPID:
-           ctx.fail("Port TPID of {}: {} is not at default 0x8100".format(port_name, port_tpid))
+        port_tpid = port_entry.get(PORT_TPID)
+        if port_tpid != DEFAULT_TPID:
+            ctx.fail("Port TPID of {}: {} is not at default 0x8100".format(port_name, port_tpid))
 
     db.set_entry('PORTCHANNEL_MEMBER', (portchannel_name, port_name),
             {'NULL': 'NULL'})
@@ -3174,10 +3147,10 @@ def startup(ctx, interface_name):
 
     intf_fs = parse_interface_in_filter(interface_name)
     if len(intf_fs) > 1 and multi_asic.is_multi_asic():
-         ctx.fail("Interface range not supported in multi-asic platforms !!")
+        ctx.fail("Interface range not supported in multi-asic platforms !!")
 
     if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
-         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     log.log_info("'interface startup {}' executing...".format(interface_name))
     port_dict = config_db.get_table('PORT')
@@ -3215,7 +3188,7 @@ def shutdown(ctx, interface_name):
 
     intf_fs = parse_interface_in_filter(interface_name)
     if len(intf_fs) > 1 and multi_asic.is_multi_asic():
-         ctx.fail("Interface range not supported in multi-asic platforms !!")
+        ctx.fail("Interface range not supported in multi-asic platforms !!")
 
     if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
@@ -3651,8 +3624,8 @@ def add(ctx, interface_name, ip_addr, gw):
     # changing it to a router port
     vlan_member_table = config_db.get_table('VLAN_MEMBER')
     if (interface_is_in_vlan(vlan_member_table, interface_name)):
-            click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))
-            return
+        click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))
+        return
 
     try:
         net = ipaddress.ip_network(ip_addr, strict=False)
@@ -4086,7 +4059,7 @@ def add(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    table_name = get_interface_table_name(interface_name)  
+    table_name = get_interface_table_name(interface_name)
     if not clicommon.is_interface_in_config_db(config_db, interface_name):
         ctx.fail('interface {} doesn`t exist'.format(interface_name))
     if table_name == "":
@@ -4108,7 +4081,7 @@ def remove(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    table_name = get_interface_table_name(interface_name) 
+    table_name = get_interface_table_name(interface_name)
     if not clicommon.is_interface_in_config_db(config_db, interface_name):
         ctx.fail('interface {} doesn`t exist'.format(interface_name))
     if table_name == "":
@@ -4426,7 +4399,7 @@ def route(ctx):
     ctx.obj = {}
     ctx.obj['config_db'] = config_db
 
-@route.command('add', context_settings={"ignore_unknown_options":True})
+@route.command('add', context_settings={"ignore_unknown_options": True})
 @click.argument('command_str', metavar='prefix [vrf <vrf_name>] <A.B.C.D/M> nexthop <[vrf <vrf_name>] <A.B.C.D>>|<dev <dev_name>>', nargs=-1, type=click.Path())
 @click.pass_context
 def add_route(ctx, command_str):
@@ -4497,7 +4470,7 @@ def add_route(ctx, command_str):
     else:
         config_db.set_entry("STATIC_ROUTE", key, route)
 
-@route.command('del', context_settings={"ignore_unknown_options":True})
+@route.command('del', context_settings={"ignore_unknown_options": True})
 @click.argument('command_str', metavar='prefix [vrf <vrf_name>] <A.B.C.D/M> nexthop <[vrf <vrf_name>] <A.B.C.D>>|<dev <dev_name>>', nargs=-1, type=click.Path())
 @click.pass_context
 def del_route(ctx, command_str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 
 import pytest
-from sonic_py_common import device_info
+from sonic_py_common import device_info, multi_asic
 from swsscommon.swsscommon import ConfigDBConnector
 
 from .mock_tables import dbconnector
@@ -104,10 +104,14 @@ def setup_multi_broadcom_masic():
 
     set_mock_apis()
     device_info.get_num_npus = mock.MagicMock(return_value=2)
+    multi_asic.get_num_asics = mock.MagicMock(return_value=2)
+    multi_asic.is_multi_asic= mock.MagicMock(return_value=True)
 
     yield
 
     device_info.get_num_npus = mock.MagicMock(return_value=1)
+    multi_asic.get_num_asics = mock.MagicMock(return_value=1)
+    multi_asic.is_multi_asic= mock.MagicMock(return_value=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
To support loading configuration data in yang schema, the `config load` command is enchanced with the below options
- `-t` `--file-format` to specify the file-format. The config file can be `yang` or `config_db` format
-  `-r` to restart the services. Currently this option is supported for yang file format only.
- 
#### How I did it
Add the above mentioned cli options.
Add Unit tests

#### How to verify it
Verify the command on VS.
```
admin@vlab-01:~$ sudo config load -y -c yang -r /etc/sonic/yang_cfg.json
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -Y /etc/sonic/yang_cfg.json -j /etc/sonic/init_cfg.json --write-to-db
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot.To preserve setting, run `config save`.
admin@vlab-01:~$ sudo config load -y -c yang  /etc/sonic/yang_cfg.json
Running command: /usr/local/bin/sonic-cfggen -H -Y /etc/sonic/yang_cfg.json -j /etc/sonic/init_cfg.json --write-to-db
Please note setting loaded from minigraph will be lost after system reboot.To preserve setting, run `config save`.
admin@vlab-01:~$ sudo config load
Load config in config_db format from the default config file(s) ? [y/N]: y
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
admin@vlab-01:~$ sudo config load -y
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

