### PR TITLE
[port_breakout] Add eeprom information for breakout ports

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 
-import sonic_platform
 from natsort import natsorted
 from tabulate import tabulate
 from utilities_common import constants
@@ -155,10 +154,15 @@ def state_db_port_optics_get(state_db, config_db, intf_name, type):
     full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + intf_name
     optics_type = state_db.get(state_db.STATE_DB, full_table_id, type)
     if optics_type is None:
-        ports_dict = config_db.get_table('PORT')
-        index = int(ports_dict[intf_name]['index'])
-        platform_chassis = sonic_platform.platform.Platform().get_chassis()
-        parent_port = platform_chassis.get_sfp(index).get_name()
+        try:
+            import sonic_platform
+            ports_dict = config_db.get_table('PORT')
+            index = int(ports_dict[intf_name]['index'])
+            platform_chassis = sonic_platform.platform.Platform().get_chassis()
+            parent_port = platform_chassis.get_sfp(index).get_name()
+        except:
+            parent_port = intf_name
+
         if parent_port != intf_name:
             parent_full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + parent_port
             optics_type = state_db.get(state_db.STATE_DB, parent_full_table_id, type)

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 
+import sonic_platform
 from natsort import natsorted
 from tabulate import tabulate
 from utilities_common import constants
@@ -147,13 +148,22 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
         status = ','.join(new_speed_list)
     return status
 
-def state_db_port_optics_get(state_db, intf_name, type):
+def state_db_port_optics_get(state_db, config_db, intf_name, type):
     """
     Get optic type info for port
     """
     full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + intf_name
     optics_type = state_db.get(state_db.STATE_DB, full_table_id, type)
     if optics_type is None:
+        ports_dict = config_db.get_table('PORT')
+        index = int(ports_dict[intf_name]['index'])
+        platform_chassis = sonic_platform.platform.Platform().get_chassis()
+        parent_port = platform_chassis.get_sfp(index).get_name()
+        if parent_port != intf_name:
+            parent_full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + parent_port
+            optics_type = state_db.get(state_db.STATE_DB, parent_full_table_id, type)
+            if optics_type is not None:
+                return optics_type
         return "N/A"
     return optics_type
 
@@ -411,7 +421,7 @@ class IntfStatus(object):
                                 config_db_vlan_port_keys_get(self.combined_int_to_vlan_po_dict, self.front_panel_ports_list, key),
                                 appl_db_port_status_get(self.db, key, PORT_OPER_STATUS),
                                 appl_db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
-                                state_db_port_optics_get(self.db, key, PORT_OPTICS_TYPE),
+                                state_db_port_optics_get(self.db, self.config_db, key, PORT_OPTICS_TYPE),
                                 appl_db_port_status_get(self.db, key, PORT_PFC_ASYM_STATUS)))
 
             for po, value in self.portchannel_speed_dict.items():

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -12,7 +12,6 @@ import re
 import sys
 
 import click
-import sonic_platform
 from natsort import natsorted
 from sonic_py_common.interface import front_panel_prefix, backplane_prefix, inband_prefix
 from sonic_py_common import multi_asic
@@ -405,10 +404,14 @@ class SFPShow(object):
         return output
 
     def get_presence_from_parent_port(self, intf_name):
-        intf_port_table = self.db.get_all(self.db.APPL_DB, 'PORT_TABLE:{}'.format(intf_name))
-        index = int(intf_port_table['index'])
-        platform_chassis = sonic_platform.platform.Platform().get_chassis()
-        parent_port = platform_chassis.get_sfp(index).get_name()
+        try:
+            import sonic_platform
+            intf_port_table = self.db.get_all(self.db.APPL_DB, 'PORT_TABLE:{}'.format(intf_name))
+            index = int(intf_port_table['index'])
+            platform_chassis = sonic_platform.platform.Platform().get_chassis()
+            parent_port = platform_chassis.get_sfp(index).get_name()
+        except:
+            parent_port = intf_name
 
         if parent_port == intf_name:
             return(False, None)

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -12,6 +12,7 @@ import re
 import sys
 
 import click
+import sonic_platform
 from natsort import natsorted
 from sonic_py_common.interface import front_panel_prefix, backplane_prefix, inband_prefix
 from sonic_py_common import multi_asic
@@ -387,21 +388,36 @@ class SFPShow(object):
         return output_dom
 
     # Convert sfp info and dom sensor info in DB to cli output string
-    def convert_interface_sfp_info_to_cli_output_string(self, state_db, interface_name, dump_dom):
+    def convert_interface_sfp_info_to_cli_output_string(self, state_db, interface_name, parent_name, dump_dom):
         output = ''
 
-        sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
+        sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(parent_name))
         output = interface_name + ': ' + 'SFP EEPROM detected' + '\n'
         sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict)
         output += sfp_info_output
 
         if dump_dom:
             sfp_type = sfp_info_dict['type']
-            dom_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_SENSOR|{}'.format(interface_name))
+            dom_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_SENSOR|{}'.format(parent_name))
             dom_output = self.convert_dom_to_output_string(sfp_type, dom_info_dict)
             output += dom_output
 
         return output
+
+    def get_presence_from_parent_port(self, intf_name):
+        intf_port_table = self.db.get_all(self.db.APPL_DB, 'PORT_TABLE:{}'.format(intf_name))
+        index = int(intf_port_table['index'])
+        platform_chassis = sonic_platform.platform.Platform().get_chassis()
+        parent_port = platform_chassis.get_sfp(index).get_name()
+
+        if parent_port == intf_name:
+            return(False, None)
+        else:
+            presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(parent_port))
+            if presence:
+                return(True, parent_port)
+            else:
+                return(False, None)
 
     @multi_asic_util.run_on_multi_asic
     def get_eeprom(self):
@@ -409,9 +425,14 @@ class SFPShow(object):
             presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(self.intf_name))
             if presence:
                 self.output = self.convert_interface_sfp_info_to_cli_output_string(
-                    self.db, self.intf_name, self.dump_dom)
+                    self.db, self.intf_name, self.intf_name, self.dump_dom)
             else:
-                self.output += (self.intf_name + ': ' + 'SFP EEPROM Not detected' + '\n')
+                (presence, parent_port) = self.get_presence_from_parent_port(self.intf_name)
+                if presence:
+                    self.output = self.convert_interface_sfp_info_to_cli_output_string(
+                        self.db, self.intf_name, parent_port, self.dump_dom)
+                else:
+                    self.output += (self.intf_name + ': ' + 'SFP EEPROM Not detected' + '\n')
         else:
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             sorted_table_keys = natsorted(port_table_keys)
@@ -421,9 +442,14 @@ class SFPShow(object):
                     presence = self.db.exists(self.db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface))
                     if presence:
                         self.output += self.convert_interface_sfp_info_to_cli_output_string(
-                            self.db, interface, self.dump_dom)
+                            self.db, interface, interface, self.dump_dom)
                     else:
-                        self.output += (interface + ': ' + 'SFP EEPROM Not detected' + '\n')
+                        (presence, parent_port) = self.get_presence_from_parent_port(interface)
+                        if presence:
+                            self.output += self.convert_interface_sfp_info_to_cli_output_string(
+                                self.db, interface, parent_port, self.dump_dom)
+                        else:
+                            self.output += (interface + ': ' + 'SFP EEPROM Not detected' + '\n')
 
                     self.output += '\n'
 
@@ -436,7 +462,11 @@ class SFPShow(object):
             if presence:
                 port_table.append((self.intf_name, 'Present'))
             else:
-                port_table.append((self.intf_name, 'Not present'))
+                (presence, parent_port) = self.get_presence_from_parent_port(self.intf_name)
+                if presence:
+                    port_table.append((self.intf_name, 'Present'))
+                else:
+                    port_table.append((self.intf_name, 'Not present'))
         else:
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
@@ -446,7 +476,11 @@ class SFPShow(object):
                     if presence:
                         port_table.append((key, 'Present'))
                     else:
-                        port_table.append((key, 'Not present'))
+                        (presence, parent_port) = self.get_presence_from_parent_port(key)
+                        if presence:
+                            port_table.append((key, 'Present'))
+                        else:
+                            port_table.append((key, 'Not present'))
 
         self.table += port_table
 


### PR DESCRIPTION
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Get the transceiver information from parent port for breakout ports.

#### How I did it
Get the transceiver information from parent port for breakout ports.

#### How to verify it
Ethernet57/58/59 are breakout from Ethernet56
#### Previous command output (if the output of a command-line utility has changed)
`  Interface    Lanes    Speed    MTU    FEC            Alias    Vlan    Oper    Admin             Type    Asym PFC `
`-----------  -------  -------  -----  -----  ---------------  ------  ------  -------  ---------------  ----------`
` Ethernet56       69      25G   9100   none  Eth54/1(Port54)  routed    down     down  QSFP28 or later         N/A`
` Ethernet57       70      25G   9100   none  Eth54/2(Port54)  routed    down     down                    N/A         N/A`
` Ethernet58       71      25G   9100   none  Eth54/3(Port54)  routed    down     down                    N/A         N/A`
` Ethernet59       72      25G   9100   none  Eth54/4(Port54)  routed    down     down                    N/A         N/A`

#### New command output (if the output of a command-line utility has changed)
`  Interface    Lanes    Speed    MTU    FEC            Alias    Vlan    Oper    Admin             Type    Asym PFC`
`-----------  -------  -------  -----  -----  ---------------  ------  ------  -------  ---------------  ----------`
` Ethernet56       69      25G   9100   none  Eth54/1(Port54)  routed    down     down  QSFP28 or later         N/A`
` Ethernet57       70      25G   9100   none  Eth54/2(Port54)  routed    down     down  QSFP28 or later         N/A`
` Ethernet58       71      25G   9100   none  Eth54/3(Port54)  routed    down     down  QSFP28 or later         N/A`
` Ethernet59       72      25G   9100   none  Eth54/4(Port54)  routed    down     down  QSFP28 or later         N/A`