### PR TITLE
Load MIRROR_DSCP config files at ```load_minigraph```

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -92,6 +92,12 @@ DEFAULT_TPID = "0x8100"
 
 asic_type = None
 
+# Everflow always on
+TYPE_MIRROR_DSCP = "MIRROR_DSCP"
+DSCP_ACL_RULE_CONFIG_PATH = "/etc/sonic/everflow_dscp/acl_rule.json"
+DSCP_POLICER_CONFIG_PATH = "/etc/sonic/everflow_dscp/policer.json"
+DSCP_MIRROR_SESSION_CONFIG_PATH = "/etc/sonic/everflow_dscp/mirror_session.json"
+
 #
 # Helper functions
 #
@@ -1417,6 +1423,16 @@ def load_mgmt_config(filename):
     clicommon.run_command(command, display_cmd=True, ignore_error=True)
     click.echo("Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.")
 
+def is_mirror_dscp_present(config_db):
+    """Check if any ACL table is present with type MIRROR_DSCP
+    This is an indicatitor for whether we need to enable everflow-always-on 
+    """
+    acl_tables = config_db.get_table('ACL_TABLE')
+    for _, v in acl_tables.items():
+        if v.get('type', '') == TYPE_MIRROR_DSCP:
+            return True
+    return False
+
 @config.command("load_minigraph")
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
                 expose_value=False, prompt='Reload config from minigraph?')
@@ -1456,6 +1472,22 @@ def load_minigraph(db, no_service_restart):
         else:
             command = "{} -H -m --write-to-db {}".format(SONIC_CFGGEN_PATH, cfggen_namespace_option)
         clicommon.run_command(command, display_cmd=True)
+        # Load everflow-always-on config
+        everflow_dscp_commands = []
+        if is_mirror_dscp_present(config_db):
+            json_to_load = [DSCP_POLICER_CONFIG_PATH, DSCP_MIRROR_SESSION_CONFIG_PATH, DSCP_ACL_RULE_CONFIG_PATH]
+            for json in json_to_load:
+                if os.path.isfile(json):
+                    everflow_dscp_commands.append(
+                        "{} -j {} {} --write-to-db".format(SONIC_CFGGEN_PATH, json, cfggen_namespace_option)
+                        )
+                else:
+                    break
+            # Load config only if all config files are present
+            if len(everflow_dscp_commands) == len(json_to_load):
+                for cmd in everflow_dscp_commands:
+                    clicommon.run_command(cmd, display_cmd=True)
+
         client.set(config_db.INIT_INDICATOR, 1)
 
     # get the device type

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -28,6 +28,19 @@ Reloading Monit configuration ...
 Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
 """
 
+load_minigraph_command_output_with_dscp="""\
+Stopping SONiC target ...
+Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /sonic/src/sonic-utilities/tests/everflow_dscp_input/policer.json   --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /sonic/src/sonic-utilities/tests/everflow_dscp_input/mirror_session.json   --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /sonic/src/sonic-utilities/tests/everflow_dscp_input/acl_rule.json   --write-to-db
+Running command: pfcwd start_default
+Running command: config qos reload --no-dynamic-buffer
+Restarting SONiC target ...
+Reloading Monit configuration ...
+Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
+"""
+
 def mock_run_command_side_effect(*args, **kwargs):
     command = args[0]
 
@@ -61,9 +74,9 @@ class TestLoadMinigraph(object):
             traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
-            # Verify "systemctl reset-failed" is called for services under sonic.target 
+            # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call('systemctl reset-failed swss')
-            # Verify "systemctl reset-failed" is called for services under sonic-delayed.target 
+            # Verify "systemctl reset-failed" is called for services under sonic-delayed.target
             mock_run_command.assert_any_call('systemctl reset-failed snmp')
             assert mock_run_command.call_count == 10
 
@@ -108,29 +121,28 @@ class TestLoadMinigraph(object):
             db.cfgdb.set_entry("PORT", "Ethernet0", {"admin_status": "down"})
             port_config = [{"PORT": {"Ethernet0": {"admin_status": "up"}}}]
             self.check_port_config(db, config, port_config, "config interface startup Ethernet0")
-    
+
     def test_load_minigraph_with_mirror_dscp(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
             "utilities_common.cli.run_command",
             mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
-            (config, show) = get_cmd_module
-            db = Db()
-            # Insert ACL_TABLE with type MIRROR_DSCP
-            db.cfgdb.set_entry("ACL_TABLE", "EVERFLOW_DSCP", {"type": config.TYPE_MIRROR_DSCP})
-            # Verify load_minigraph is completed without error if config files are not present
-            runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
-            assert result.exit_code == 0
-            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
-            assert mock_run_command.call_count == 10
+            with mock.patch("config.main.is_mirror_dscp_present", return_value=True):
+                # Verify load_minigraph is completed without error if config files are not present
+                runner = CliRunner()
+                result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
+                assert result.exit_code == 0
+                assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
+                assert mock_run_command.call_count == 10
 
-            config.DSCP_ACL_RULE_CONFIG_PATH = "./everflow_dscp_input/acl_rule.json"
-            config.DSCP_POLICER_CONFIG_PATH = "./everflow_dscp_input/policer.json"
-            config.DSCP_MIRROR_SESSION_CONFIG_PATH = "./everflow_dscp_input/mirror_session.json"
-            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
-            assert result.exit_code == 0
-            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
-            assert mock_run_command.call_count == 13
+                mock_run_command.call_count = 0
+                test_path = os.path.dirname(os.path.abspath(__file__))
+                config.DSCP_ACL_RULE_CONFIG_PATH = os.path.join(test_path, "everflow_dscp_input/acl_rule.json")
+                config.DSCP_POLICER_CONFIG_PATH = os.path.join(test_path, "everflow_dscp_input/policer.json")
+                config.DSCP_MIRROR_SESSION_CONFIG_PATH = os.path.join(test_path, "everflow_dscp_input/mirror_session.json")
+                result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
+                assert result.exit_code == 0
+                assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output_with_dscp
+                assert mock_run_command.call_count == 13
 
 
     def check_port_config(self, db, config, port_config, expected_output):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -108,6 +108,30 @@ class TestLoadMinigraph(object):
             db.cfgdb.set_entry("PORT", "Ethernet0", {"admin_status": "down"})
             port_config = [{"PORT": {"Ethernet0": {"admin_status": "up"}}}]
             self.check_port_config(db, config, port_config, "config interface startup Ethernet0")
+    
+    def test_load_minigraph_with_mirror_dscp(self, get_cmd_module, setup_single_broadcom_asic):
+        with mock.patch(
+            "utilities_common.cli.run_command",
+            mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            (config, show) = get_cmd_module
+            db = Db()
+            # Insert ACL_TABLE with type MIRROR_DSCP
+            db.cfgdb.set_entry("ACL_TABLE", "EVERFLOW_DSCP", {"type": config.TYPE_MIRROR_DSCP})
+            # Verify load_minigraph is completed without error if config files are not present
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
+            assert result.exit_code == 0
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
+            assert mock_run_command.call_count == 10
+
+            config.DSCP_ACL_RULE_CONFIG_PATH = "./everflow_dscp_input/acl_rule.json"
+            config.DSCP_POLICER_CONFIG_PATH = "./everflow_dscp_input/policer.json"
+            config.DSCP_MIRROR_SESSION_CONFIG_PATH = "./everflow_dscp_input/mirror_session.json"
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
+            assert result.exit_code == 0
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
+            assert mock_run_command.call_count == 13
+
 
     def check_port_config(self, db, config, port_config, expected_output):
         def read_json_file_side_effect(filename):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -28,18 +28,20 @@ Reloading Monit configuration ...
 Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
 """
 
+TEST_PATH = os.path.dirname(os.path.abspath(__file__))
+
 load_minigraph_command_output_with_dscp="""\
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /sonic/src/sonic-utilities/tests/everflow_dscp_input/policer.json   --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /sonic/src/sonic-utilities/tests/everflow_dscp_input/mirror_session.json   --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /sonic/src/sonic-utilities/tests/everflow_dscp_input/acl_rule.json   --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j {}/everflow_dscp_input/policer.json   --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j {}/everflow_dscp_input/mirror_session.json   --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j {}/everflow_dscp_input/acl_rule.json   --write-to-db
 Running command: pfcwd start_default
 Running command: config qos reload --no-dynamic-buffer
 Restarting SONiC target ...
 Reloading Monit configuration ...
 Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
-"""
+""".format(TEST_PATH, TEST_PATH, TEST_PATH)
 
 def mock_run_command_side_effect(*args, **kwargs):
     command = args[0]
@@ -135,10 +137,9 @@ class TestLoadMinigraph(object):
                 assert mock_run_command.call_count == 10
 
                 mock_run_command.call_count = 0
-                test_path = os.path.dirname(os.path.abspath(__file__))
-                config.DSCP_ACL_RULE_CONFIG_PATH = os.path.join(test_path, "everflow_dscp_input/acl_rule.json")
-                config.DSCP_POLICER_CONFIG_PATH = os.path.join(test_path, "everflow_dscp_input/policer.json")
-                config.DSCP_MIRROR_SESSION_CONFIG_PATH = os.path.join(test_path, "everflow_dscp_input/mirror_session.json")
+                config.DSCP_ACL_RULE_CONFIG_PATH = os.path.join(TEST_PATH, "everflow_dscp_input/acl_rule.json")
+                config.DSCP_POLICER_CONFIG_PATH = os.path.join(TEST_PATH, "everflow_dscp_input/policer.json")
+                config.DSCP_MIRROR_SESSION_CONFIG_PATH = os.path.join(TEST_PATH, "everflow_dscp_input/mirror_session.json")
                 result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
                 assert result.exit_code == 0
                 assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output_with_dscp

--- a/tests/everflow_dscp_input/acl_rule.json
+++ b/tests/everflow_dscp_input/acl_rule.json
@@ -1,0 +1,9 @@
+{
+	"ACL_RULE": {
+		"EVERFLOW_DSCP|RULE_1": {
+			"DSCP": "5",
+			"MIRROR_INGRESS_ACTION": "mirror_session_dscp",
+			"PRIORITY": "9999"
+		}
+	}
+}

--- a/tests/everflow_dscp_input/mirror_session.json
+++ b/tests/everflow_dscp_input/mirror_session.json
@@ -1,0 +1,12 @@
+{
+	"MIRROR_SESSION": {
+		"mirror_session_dscp": {
+			"dscp": "5",
+			"dst_ip": "2.2.2.2",
+			"policer": "everflow_static_policer",
+			"src_ip": "1.1.1.1",
+			"ttl": "64",
+			"type": "ERSPAN"
+		}
+	}
+}

--- a/tests/everflow_dscp_input/policer.json
+++ b/tests/everflow_dscp_input/policer.json
@@ -1,0 +1,11 @@
+{
+	"POLICER": {
+		"everflow_static_policer": {
+			"meter_type": "bytes",
+			"mode": "sr_tcm",
+			"cir": "12500000",
+			"cbs": "12500000",
+			"red_packet_action": "drop"
+		}
+	}
+}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to update ```load_minigraph``` to load ```MIRROR_DSCP``` related configuration files at ```config load_minigraph```.
Below config files are loaded if present
| config|file name|
|---|---|
| policer|/etc/sonic/everflow_dscp/policer.json|
|mirror_session|/etc/sonic/everflow_dscp/mirror_session.json|
|acl_rule|/etc/sonic/everflow_dscp/acl_rule.json|

#### How I did it
1. Read ```ACL_TABLE``` from config_db to check if an EVERFLOW ACL table is present with type ```MIRROR_DSCP```
2. Load 3 config files if ```MIRROR_DSCP``` is present and all 3 config files are present 

#### How to verify it
1. Verified by UT
2. Verified by running on a device

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

