### PR TITLE
[show] Fix 'show ipv6 interfaces' prints v4 label (#1757)

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -193,8 +193,13 @@ def get_ip_intfs_in_namespace(af, namespace, display):
     return ip_intfs
 
 
-def display_ip_intfs(ip_intfs):
-    header = ['Interface', 'Master', 'IPv4 address/mask',
+def display_ip_intfs(ip_intfs, af):
+    if af == netifaces.AF_INET:
+        IP_version = 'IPv4 address/mask'
+    elif af == netifaces.AF_INET6:
+        IP_version = 'IPv6 address/mask'
+
+    header = ['Interface', 'Master', IP_version,
               'Admin/Oper', 'BGP Neighbor', 'Neighbor IP']
     data = []
     for ip_intf, v in natsorted(ip_intfs.items()):
@@ -265,7 +270,7 @@ def main():
 
     load_db_config()
     ip_intfs = get_ip_intfs(af, namespace, display)
-    display_ip_intfs(ip_intfs)
+    display_ip_intfs(ip_intfs, af)
 
     sys.exit(0)
 

--- a/tests/show_ip_int_test.py
+++ b/tests/show_ip_int_test.py
@@ -19,7 +19,7 @@ PortChannel0001            30.1.1.1/24          error/down    T0-Peer         30
 Vlan100                    40.1.1.1/24          error/down    N/A             N/A"""
 
 show_ipv6_intf_with_multiple_ips = """\
-Interface        Master    IPv4 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
+Interface        Master    IPv6 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  --------------------------------------------  ------------  --------------  -------------
 Ethernet0                  2100::1/64                                    error/down    N/A             N/A
                            aa00::1/64                                                  N/A             N/A
@@ -36,7 +36,7 @@ Loopback0                  40.1.1.1/32          error/down    N/A             N/
 PortChannel0001            20.1.1.1/24          error/down    T2-Peer         20.1.1.5"""
 
 show_multi_asic_ipv6_intf = """\
-Interface        Master    IPv4 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
+Interface        Master    IPv6 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  --------------------------------------  ------------  --------------  -------------
 Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
 PortChannel0001            aa00::1/64                              error/down    N/A             N/A
@@ -54,7 +54,7 @@ veth@eth1                  192.1.1.1/24         error/down    N/A             N/
 veth@eth2                  193.1.1.1/24         error/down    N/A             N/A"""
 
 show_multi_asic_ipv6_intf_all = """\
-Interface        Master    IPv4 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
+Interface        Master    IPv6 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  --------------------------------------  ------------  --------------  -------------
 Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
 PortChannel0001            aa00::1/64                              error/down    N/A             N/A


### PR DESCRIPTION
Signed-off-by: Mykola Horb <mykola_horb@jabil.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
#### What I did
Modified scripts/ipintutil to fix output of 'show ipv6 interfaces' command

#### How to verify it
run 'show ipv6 interfaces' CLI command

#### Previous command output (if the output of a command-line utility has changed)
Interface    Master    IPv4 address/mask                        Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  ---------------------------------------  ------------  --------------  -------------

#### New command output (if the output of a command-line utility has changed)
Interface    Master    IPv6 address/mask                        Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  ---------------------------------------  ------------  --------------  -------------