### PR TITLE
[reboot] Remove exec from the platform_reboot call to handle any hang issue during reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -198,7 +198,7 @@ fi
 
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
     VERBOSE=yes debug "Rebooting with platform ${PLATFORM} specific tool ..."
-    exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} $@
+    ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} $@
 
     # There are a couple reasons execution reaches here:
     #


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove exec from the platform_reboot call  to handle any hang issue during reboot

#### How I did it
Remove "exec" from    " exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} $@"
#### How to verify it
Perform `sudo reboot` after DE initializing the platfom driver and see if the device gracefully reboots by /sbin/reboot after failing on platform_reboot.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

