### PR TITLE
[generate_dump] remove secrets from dump files

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -248,7 +248,7 @@ dummy_cleanup_method() {
 save_cmd_all_ns() {
     trap 'handle_error $? $LINENO' ERR
     local do_zip=${3:-false}
-    local cleanup_method=${4:-null}
+    local cleanup_method=${4:-dummy_cleanup_method}
 
     # host or default namespace
     save_cmd "$1" "$2" "$do_zip" $cleanup_method
@@ -662,7 +662,7 @@ save_proc() {
 #  None
 ###############################################################################
 save_redis() {
-    local cleanup_method=${3:-null}
+    local cleanup_method=${3:-dummy_cleanup_method}
     trap 'handle_error $? $LINENO' ERR
     local db_name=$1
     if [ $# -ge 2 ] && [ -n "$2" ]; then


### PR DESCRIPTION
Remove secrets from dump files.

#### What I did
    Add bash functions to remove secrets from dump files.

#### How I did it
    For tacacs key, radius key, snmp community srring, use sed command with regex to remove user secrets from dump files.
    For certs, update tar command exclude list to remove those certs from dump file.

#### How to verify it
    Run 'show techsupport' command and check secrets removed from dump files.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

