### PR TITLE
[log_ssd_health] use --foreground timeout on docker operation

### DIFF
--- a/scripts/log_ssd_health
+++ b/scripts/log_ssd_health
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-timeout 30 smartctl -a /dev/sda > /tmp/smartctl
+timeout --foreground 30 smartctl -a /dev/sda > /tmp/smartctl
 if [ -f /tmp/smartctl ];then
     logger -f /tmp/smartctl
 fi


### PR DESCRIPTION
#### What I did
Added --foreground option to timeout command to address docker exec stuck issue.


#### How to verify it
Tested manually, observed the stuck as suggested without the --foreground parameter and verified that the change indeed fixed the issue.

Will add a sonic-mgmt test to catch this issue.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
