### PR TITLE
If port channel contains IP, Remove ip before deleting Portchannel

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1701,8 +1701,12 @@ def remove_portchannel(ctx, portchannel_name):
 
     if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0:
         click.echo("Error: Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
+    elif len([(k, v) for k, v in db.get_table('PORTCHANNEL_INTERFACE').items() if type(k)==tuple and k[0]==portchannel_name]) != 0:
+        click.echo("Error: Portchannel {} contains ip. Remove ip before deleting Portchannel!".format(portchannel_name))
     else:
         db.set_entry('PORTCHANNEL', portchannel_name, None)
+        # Remove junk portchannel interface
+        db.set_entry('PORTCHANNEL_INTERFACE', portchannel_name, None)
 
 @portchannel.group(cls=clicommon.AbbreviationGroup, name='member')
 @click.pass_context


### PR DESCRIPTION
This fix handles interface removal more gracefully. 

Signed-off-by: Venkat Garigipati <venkatg@cisco.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
We have seen scenarios where stale ip address is left over when the interface is removed. This fix handles removal of ip address followed by removal of port channel interface 

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

