### PR TITLE
[ssdutil] Inform if the disk is not SSD

### DIFF
--- a/ssdutil/main.py
+++ b/ssdutil/main.py
@@ -97,22 +97,18 @@ def ssdutil():
         sys.exit(1)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--device", help="Device name to show health info", default=None)
+    parser.add_argument("-d", "--device", help="Device name to show health info", default=get_default_disk())
     parser.add_argument("-v", "--verbose", action="store_true", default=False, help="Show verbose output (some additional parameters)")
     parser.add_argument("-e", "--vendor", action="store_true", default=False, help="Show vendor output (extended output if provided by platform vendor)")
     args = parser.parse_args()
 
-    if args.device:
-        disk_device = args.device
-    else:
-        disk_device = get_default_disk()
 
-    disk_type = get_disk_type(disk_device)
-    if disk_type != DISK_TYPE_SSD:
+    disk_type = get_disk_type(args.device)
+    if DISK_TYPE_SSD not in disk_type:
         print("Disk type is not SSD")
-        sys.exit(1)
 
-    ssd = import_ssd_api(disk_device)
+    ssd = import_ssd_api(args.device)
+
 
     print("Device Model : {}".format(ssd.get_model()))
     if args.verbose:

--- a/ssdutil/main.py
+++ b/ssdutil/main.py
@@ -30,7 +30,7 @@ def get_disk_type(diskdev):
     proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
     outs = proc.stdout.readlines()
     for out in outs:
-        if out.split()[0] in diskdev_name:
+        if out.split()[0] is diskdev_name:
               cmd = "cat /sys/block/{}/queue/rotational".format(diskdev_name)
               proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
               out = proc.stdout.readline()

--- a/ssdutil/main.py
+++ b/ssdutil/main.py
@@ -18,26 +18,44 @@ except ImportError as e:
 DEFAULT_DEVICE="/dev/sda"
 SYSLOG_IDENTIFIER = "ssdutil"
 DISK_TYPE_SSD = "0"
+DISK_INVALID = "-1"
 
 # Global logger instance
 log = logger.Logger(SYSLOG_IDENTIFIER)
+
+def get_default_disk():
+    """Check default disk"""
+    default_device = DEFAULT_DEVICE
+    host_mnt = '/host'
+    cmd = "lsblk -l -n |grep {}".format(host_mnt)
+    proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    out = proc.stdout.readline()
+    if host_mnt in out:
+        dev_nums = out.split()[1]
+        dev_maj_num = out.split(':')[0]
+
+        cmd = "lsblk -l -I {} |grep disk".format(dev_maj_num)
+        proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
+        out = proc.stdout.readline()
+        if "disk" in out:
+            default_device = os.path.join("/dev/", out.split()[0])
+
+    return default_device
 
 
 def get_disk_type(diskdev):
     """Check disk type"""
     diskdev_name = diskdev.replace('/dev/','')
-    cmd = "lsblk -l -n |grep disk"
+    cmd = "lsblk -l -n |grep {}".format(diskdev_name)
     proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
-    outs = proc.stdout.readlines()
-    for out in outs:
-        if out.split()[0] is diskdev_name:
-              cmd = "cat /sys/block/{}/queue/rotational".format(diskdev_name)
-              proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
-              out = proc.stdout.readline()
-              return out.rstrip()
-
-    print("disk {} does not exist in the device".format(diskdev_name))
-    sys.exit(1)
+    out = proc.stdout.readline()
+    if diskdev_name not in out:
+        return DISK_INVAILD
+    cmd = "cat /sys/block/{}/queue/rotational".format(diskdev_name)
+    proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    out = proc.stdout.readline()
+    disk_type = out.rstrip()
+    return disk_type
 
 
 def import_ssd_api(diskdev):
@@ -79,17 +97,22 @@ def ssdutil():
         sys.exit(1)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--device", help="Device name to show health info", default=DEFAULT_DEVICE)
+    parser.add_argument("-d", "--device", help="Device name to show health info", default=None)
     parser.add_argument("-v", "--verbose", action="store_true", default=False, help="Show verbose output (some additional parameters)")
     parser.add_argument("-e", "--vendor", action="store_true", default=False, help="Show vendor output (extended output if provided by platform vendor)")
     args = parser.parse_args()
 
-    disk_type = get_disk_type(args.device)
+    if args.device:
+        disk_device = args.device
+    else:
+        disk_device = get_default_disk()
+
+    disk_type = get_disk_type(disk_device)
     if disk_type != DISK_TYPE_SSD:
         print("Disk is not SSD")
         sys.exit(1)
 
-    ssd = import_ssd_api(args.device)
+    ssd = import_ssd_api(disk_device)
 
     print("Device Model : {}".format(ssd.get_model()))
     if args.verbose:

--- a/ssdutil/main.py
+++ b/ssdutil/main.py
@@ -32,7 +32,7 @@ def get_default_disk():
     out = proc.stdout.readline()
     if host_mnt in out:
         dev_nums = out.split()[1]
-        dev_maj_num = out.split(':')[0]
+        dev_maj_num = dev_nums.split(':')[0]
 
         cmd = "lsblk -l -I {} |grep disk".format(dev_maj_num)
         proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
@@ -109,7 +109,7 @@ def ssdutil():
 
     disk_type = get_disk_type(disk_device)
     if disk_type != DISK_TYPE_SSD:
-        print("Disk is not SSD")
+        print("Disk type is not SSD")
         sys.exit(1)
 
     ssd = import_ssd_api(disk_device)

--- a/ssdutil/main.py
+++ b/ssdutil/main.py
@@ -25,10 +25,19 @@ log = logger.Logger(SYSLOG_IDENTIFIER)
 
 def get_disk_type(diskdev):
     """Check disk type"""
-    cmd = "cat /sys/block/{}/queue/rotational".format(diskdev.replace('/dev/',''))
+    diskdev_name = diskdev.replace('/dev/','')
+    cmd = "lsblk -l -n |grep disk"
     proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
-    out = proc.stdout.readline()
-    return out.rstrip()
+    outs = proc.stdout.readlines()
+    for out in outs:
+        if out.split()[0] in diskdev_name:
+              cmd = "cat /sys/block/{}/queue/rotational".format(diskdev_name)
+              proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
+              out = proc.stdout.readline()
+              return out.rstrip()
+
+    print("disk {} does not exist in the device".format(diskdev_name))
+    sys.exit(1)
 
 
 def import_ssd_api(diskdev):

--- a/ssdutil/main.py
+++ b/ssdutil/main.py
@@ -8,6 +8,7 @@
 try:
     import argparse
     import os
+    import subprocess
     import sys
 
     from sonic_py_common import device_info, logger
@@ -16,9 +17,18 @@ except ImportError as e:
 
 DEFAULT_DEVICE="/dev/sda"
 SYSLOG_IDENTIFIER = "ssdutil"
+DISK_TYPE_SSD = "0"
 
 # Global logger instance
 log = logger.Logger(SYSLOG_IDENTIFIER)
+
+
+def get_disk_type(diskdev):
+    """Check disk type"""
+    cmd = "cat /sys/block/{}/queue/rotational".format(diskdev.replace('/dev/',''))
+    proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    out = proc.stdout.readline()
+    return out.rstrip()
 
 
 def import_ssd_api(diskdev):
@@ -64,6 +74,11 @@ def ssdutil():
     parser.add_argument("-v", "--verbose", action="store_true", default=False, help="Show verbose output (some additional parameters)")
     parser.add_argument("-e", "--vendor", action="store_true", default=False, help="Show vendor output (extended output if provided by platform vendor)")
     args = parser.parse_args()
+
+    disk_type = get_disk_type(args.device)
+    if disk_type != DISK_TYPE_SSD:
+        print("Disk is not SSD")
+        sys.exit(1)
 
     ssd = import_ssd_api(args.device)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

https://github.com/Azure/sonic-buildimage/issues/9407

#### What I did
Inform that the disk is not SSD for the platform with non-SSD disk

#### How I did it
Check disk type and exit the ssdutil command 

#### How to verify it
Check `show platform ssdhealth` command on the platform with non SSD disk

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

