### PR TITLE
[acl-loader] Add no_default_deny_rule option to acl-loader

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -340,15 +340,16 @@ class AclLoader(object):
                 raise AclLoaderException("Invalid input file %s" % filename)
         return yang_acl
 
-    def load_rules_from_file(self, filename):
+    def load_rules_from_file(self, filename, no_default_deny_rule=False):
         """
         Load file with ACL rules configuration in openconfig ACL format. Convert rules
         to Config DB schema.
         :param filename: File in openconfig ACL format
+        :param no_default_deny_rule: Don't apply default deny rules (False in default)
         :return:
         """
         self.yang_acl = AclLoader.parse_acl_json(filename)
-        self.convert_rules()
+        self.convert_rules(no_default_deny_rule)
 
     def convert_action(self, table_name, rule_idx, rule):
         rule_props = {}
@@ -642,9 +643,10 @@ class AclLoader(object):
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
         return rule_data
 
-    def convert_rules(self):
+    def convert_rules(self, no_default_deny_rule):
         """
         Convert rules in openconfig ACL format to Config DB schema
+        :param no_default_deny_rule: Don't apply default deny rules
         :return:
         """
         for acl_set_name in self.yang_acl.acl.acl_sets.acl_set:
@@ -666,7 +668,7 @@ class AclLoader(object):
                 except AclLoaderException as ex:
                     error("Error processing rule %s: %s. Skipped." % (acl_entry_name, ex))
 
-            if not self.is_table_mirror(table_name) and not self.is_table_egress(table_name):
+            if not self.is_table_mirror(table_name) and not self.is_table_egress(table_name) and not no_default_deny_rule:
                 deep_update(self.rules_info, self.deny_rule(table_name))
 
     def full_update(self):
@@ -1019,11 +1021,13 @@ def update(ctx):
 @click.option('--session_name', type=click.STRING, required=False)
 @click.option('--mirror_stage', type=click.Choice(["ingress", "egress"]), default="ingress")
 @click.option('--max_priority', type=click.INT, required=False)
+@click.option('--no_default_deny_rule', is_flag=True, required=False)
 @click.pass_context
-def full(ctx, filename, table_name, session_name, mirror_stage, max_priority):
+def full(ctx, filename, table_name, session_name, mirror_stage, max_priority, no_default_deny_rule):
     """
     Full update of ACL rules configuration.
     If a table_name is provided, the operation will be restricted in the specified table.
+    The default deny rules will be applied to ingress ACL table unless no_default_deny_rule is set.
     """
     acl_loader = ctx.obj["acl_loader"]
 
@@ -1038,7 +1042,7 @@ def full(ctx, filename, table_name, session_name, mirror_stage, max_priority):
     if max_priority:
         acl_loader.set_max_priority(max_priority)
 
-    acl_loader.load_rules_from_file(filename)
+    acl_loader.load_rules_from_file(filename, no_default_deny_rule)
     acl_loader.full_update()
 
 
@@ -1047,10 +1051,12 @@ def full(ctx, filename, table_name, session_name, mirror_stage, max_priority):
 @click.option('--session_name', type=click.STRING, required=False)
 @click.option('--mirror_stage', type=click.Choice(["ingress", "egress"]), default="ingress")
 @click.option('--max_priority', type=click.INT, required=False)
+@click.option('--no_default_deny_rule', is_flag=True, required=False)
 @click.pass_context
-def incremental(ctx, filename, session_name, mirror_stage, max_priority):
+def incremental(ctx, filename, session_name, mirror_stage, max_priority, no_default_deny_rule):
     """
     Incremental update of ACL rule configuration.
+    The default deny rules will be applied to ingress ACL table unless no_default_deny_rule is set.
     """
     acl_loader = ctx.obj["acl_loader"]
 
@@ -1062,7 +1068,7 @@ def incremental(ctx, filename, session_name, mirror_stage, max_priority):
     if max_priority:
         acl_loader.set_max_priority(max_priority)
 
-    acl_loader.load_rules_from_file(filename)
+    acl_loader.load_rules_from_file(filename, no_default_deny_rule)
     acl_loader.incremental_update()
 
 

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -148,6 +148,13 @@ class TestAclLoader(object):
             'IP_TYPE': 'IPV6ANY'
         }
 
+    def test_no_default_deny_rule_option(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'), no_default_deny_rule=True)
+        print(acl_loader.rules_info)
+        assert ('DATAACL', 'DEFAULT_RULE') not in acl_loader.rules_info
+        assert ('DATAACL_2', 'DEFAULT_RULE') not in acl_loader.rules_info
+
     def test_egress_no_default_deny_rule(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl_egress.json'))


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
This PR is to add a new option `no_default_deny_rule` to `acl-loader`.
The script will not create default deny rules when loading acl file when `no_default_deny_rule` is set. 
This optional is optional, and the default value is `False`. So the default behavior is not changed.
 
#### What I did
Fix https://github.com/Azure/sonic-utilities/issues/2026
Add a new option `no_default_deny_rule` to `acl-loader`.

#### How I did it
Add an optional option.

#### How to verify it
1. Vefified by UT
2. Verified by running the new script on a testbed.
 
#### Previous command output (if the output of a command-line utility has changed)
```
Usage: acl-loader update full [OPTIONS] FILENAME

  Full update of ACL rules configuration. If a table_name is provided, the
  operation will be restricted in the specified table. 

Options:
  --table_name TEXT
  --session_name TEXT
  --mirror_stage [ingress|egress]
  --max_priority INTEGER
  --help                          Show this message and exit.
```
#### New command output (if the output of a command-line utility has changed)
```
Usage: acl-loader update full [OPTIONS] FILENAME

  Full update of ACL rules configuration. If a table_name is provided, the
  operation will be restricted in the specified table. The default deny
  rules will be applied to ingress ACL table unless no_default_deny_rule is
  set.

Options:
  --table_name TEXT
  --session_name TEXT
  --mirror_stage [ingress|egress]
  --max_priority INTEGER
  --no_default_deny_rule
  --help                          Show this message and exit.
```
