### PR TITLE
[gearbox] Show per lane speed consistently

### DIFF
--- a/scripts/gearboxutil
+++ b/scripts/gearboxutil
@@ -159,10 +159,8 @@ class InterfaceStatus(object):
             name = name[0]
                         
             mac_lanes = get_appl_key_attr(self.appl_db, PORT_TABLE_ETHERNET_PREFIX.format(name), INTF_LANES)
-            lanes = mac_lanes.split(',')
-            lane_count = 0
-            for lane in lanes:
-                lane_count += 1
+            system_lanes = get_appl_key_attr(self.appl_db, GEARBOX_TABLE_INTERFACE_PREFIX.format(index), PHY_SYSTEM_LANES)
+            line_lanes = get_appl_key_attr(self.appl_db, GEARBOX_TABLE_INTERFACE_PREFIX.format(index), PHY_LINE_LANES)
 
             phy_id = get_appl_key_attr(self.appl_db, GEARBOX_TABLE_INTERFACE_PREFIX.format(index), PHY_ID)
                         
@@ -170,11 +168,14 @@ class InterfaceStatus(object):
                 phy_id,
                 name,
                 mac_lanes,
-                get_appl_key_attr(self.appl_db, PORT_TABLE_ETHERNET_PREFIX.format(name), INTF_SPEED, lane_count),
-                get_appl_key_attr(self.appl_db, GEARBOX_TABLE_INTERFACE_PREFIX.format(index), PHY_SYSTEM_LANES),
-                get_appl_key_attr(self.appl_db, GEARBOX_TABLE_PORT_PREFIX.format(phy_id, index), PORT_SYSTEM_SPEED),
-                get_appl_key_attr(self.appl_db, GEARBOX_TABLE_INTERFACE_PREFIX.format(index), PHY_LINE_LANES),
-                get_appl_key_attr(self.appl_db, GEARBOX_TABLE_PORT_PREFIX.format(phy_id, index), PORT_LINE_SPEED),
+                get_appl_key_attr(self.appl_db, PORT_TABLE_ETHERNET_PREFIX.format(name),
+                    INTF_SPEED, len(mac_lanes.split(','))),
+                system_lanes,
+                get_appl_key_attr(self.appl_db, GEARBOX_TABLE_PORT_PREFIX.format(phy_id, index),
+                    PORT_SYSTEM_SPEED, len(system_lanes.split(','))),
+                line_lanes,
+                get_appl_key_attr(self.appl_db, GEARBOX_TABLE_PORT_PREFIX.format(phy_id, index),
+                    PORT_LINE_SPEED, len(line_lanes.split(','))),
                 get_appl_key_attr(self.appl_db, PORT_TABLE_ETHERNET_PREFIX.format(name), PORT_OPER_STATUS),
                 get_appl_key_attr(self.appl_db, PORT_TABLE_ETHERNET_PREFIX.format(name), PORT_ADMIN_STATUS))
 

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -164,8 +164,8 @@
     },
     "_GEARBOX_TABLE:phy:1:ports:200": {
         "index": "200",
-        "line_speed": "50000",
-        "system_speed": "25000"
+        "line_speed": "100000",
+        "system_speed": "100000"
     },
     "LAG_MEMBER_TABLE:PortChannel0001:Ethernet112": {
         "status": "disabled"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
In command `show gearbox interfaces status`, show all Speed columns with the same semantics – speed per lane.

#### How I did it

#### How to verify it
```
admin@sonic:~$ show gearbox interfaces status
  PHY Id    Interface    MAC Lanes    MAC Lane Speed    PHY Lanes    PHY Lane Speed    Line Lanes    Line Lane Speed    Oper    Admin
--------  -----------  -----------  ----------------  -----------  ----------------  ------------  -----------------  ------  -------
       1    Ethernet0  25,26,27,28               10G      200,201               20G           206                40G      up       up
       1    Ethernet4  29,30,31,32               10G      202,203               20G           207                40G      up       up
       1    Ethernet8  33,34,35,36               10G      204,205               20G           208                40G      up       up
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

