### PR TITLE
[show][vrf] Improve the speed of show command for vrf

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -205,17 +205,21 @@ if is_gearbox_configured():
 # 'vrf' command ("show vrf")
 #
 
-def get_interface_bind_to_vrf(config_db, vrf_name):
-    """Get interfaces belong to vrf
+def get_interface_bind_to_vrf(config_db, vrf_name_list):
+    """Get all interfaces belong to all vrfs of vrf_name_list
     """
     tables = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE', 'LOOPBACK_INTERFACE']
-    data = []
+    data = {}
     for table_name in tables:
         interface_dict = config_db.get_table(table_name)
         if interface_dict:
-            for interface in interface_dict:
-                if 'vrf_name' in interface_dict[interface] and vrf_name == interface_dict[interface]['vrf_name']:
-                    data.append(interface)
+            for vrf_name in vrf_name_list:
+                for interface in interface_dict:
+                    if 'vrf_name' in interface_dict[interface] and vrf_name == interface_dict[interface]['vrf_name']:
+                        if vrf_name in data:
+                            data[vrf_name].append(interface)
+                        else:
+                            data[vrf_name] = [interface]
     return data
 
 @cli.command()
@@ -233,11 +237,13 @@ def vrf(vrf_name):
             vrfs = list(vrf_dict.keys())
         elif vrf_name in vrf_dict:
             vrfs = [vrf_name]
+        intfs_dict = get_interface_bind_to_vrf(config_db, vrfs)
+        vrfs = natsorted(vrfs)
         for vrf in vrfs:
-            intfs = get_interface_bind_to_vrf(config_db, vrf)
-            if len(intfs) == 0:
+            if vrf not in intfs_dict:
                 body.append([vrf, ""])
             else:
+                intfs = intfs_dict[vrf]
                 body.append([vrf, intfs[0]])
                 for intf in intfs[1:]:
                     body.append(["", intf])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Improve the speed of `show vrf` command

#### How I did it
It would get interface information from configDB each time for each vrf in `vrfs`, and if the amount of vrf is large, the command will take much time.
Therefore, it will reduce the execution time to let it just get interface information once, and using it with all vrf.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


Signed-off-by: MuLin <mulin_huang@edge-core.com>
