### PR TITLE
[GCU] Optimizing moves by adding generators for keys/tables

### DIFF
--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -388,38 +388,56 @@
                     "op": "add",
                     "path": "/ACL_TABLE",
                     "value": {
-                        "DATAACL": {
-                            "policy_desc": "DATAACL",
-                            "ports": [
-                                "Ethernet4"
-                            ],
-                            "stage": "ingress",
-                            "type": "L3"
-                        },
-                        "EVERFLOW": {
-                            "policy_desc": "EVERFLOW",
-                            "ports": [
-                                "Ethernet8"
-                            ],
-                            "stage": "ingress",
-                            "type": "MIRROR"
-                        },
-                        "EVERFLOWV6": {
-                            "policy_desc": "EVERFLOWV6",
-                            "ports": [
-                                "Ethernet4",
-                                "Ethernet8"
-                            ],
-                            "stage": "ingress",
-                            "type": "MIRRORV6"
-                        },
                         "NO-NSW-PACL-V4": {
+                            "type": "L3",
                             "policy_desc": "NO-NSW-PACL-V4",
                             "ports": [
                                 "Ethernet0"
-                            ],
-                            "type": "L3"
+                            ]
                         }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/DATAACL",
+                    "value": {
+                        "policy_desc": "DATAACL",
+                        "ports": [
+                            "Ethernet4"
+                        ],
+                        "stage": "ingress",
+                        "type": "L3"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOW",
+                    "value": {
+                        "policy_desc": "EVERFLOW",
+                        "ports": [
+                            "Ethernet8"
+                        ],
+                        "stage": "ingress",
+                        "type": "MIRROR"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_TABLE/EVERFLOWV6",
+                    "value": {
+                        "policy_desc": "EVERFLOWV6",
+                        "ports": [
+                            "Ethernet4",
+                            "Ethernet8"
+                        ],
+                        "stage": "ingress",
+                        "type": "MIRRORV6"
                     }
                 }
             ]
@@ -849,28 +867,46 @@
                     "value": {
                         "Ethernet0": {
                             "alias": "Eth1/1",
-                            "description": "",
                             "lanes": "65",
-                            "speed": "10000"
-                        },
-                        "Ethernet1": {
-                            "alias": "Eth1/2",
                             "description": "",
-                            "lanes": "66",
-                            "speed": "10000"
-                        },
-                        "Ethernet2": {
-                            "alias": "Eth1/3",
-                            "description": "",
-                            "lanes": "67",
-                            "speed": "10000"
-                        },
-                        "Ethernet3": {
-                            "alias": "Eth1/4",
-                            "description": "",
-                            "lanes": "68",
                             "speed": "10000"
                         }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet3",
+                    "value": {
+                        "alias": "Eth1/4",
+                        "lanes": "68",
+                        "description": "",
+                        "speed": "10000"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet2",
+                    "value": {
+                        "alias": "Eth1/3",
+                        "lanes": "67",
+                        "description": "",
+                        "speed": "10000"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/PORT/Ethernet1",
+                    "value": {
+                        "alias": "Eth1/2",
+                        "lanes": "66",
+                        "description": "",
+                        "speed": "10000"
                     }
                 }
             ],
@@ -881,16 +917,34 @@
                     "value": {
                         "Vlan100|Ethernet0": {
                             "tagging_mode": "untagged"
-                        },
-                        "Vlan100|Ethernet1": {
-                            "tagging_mode": "untagged"
-                        },
-                        "Vlan100|Ethernet2": {
-                            "tagging_mode": "untagged"
-                        },
-                        "Vlan100|Ethernet3": {
-                            "tagging_mode": "untagged"
                         }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet1",
+                    "value": {
+                        "tagging_mode": "untagged"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet3",
+                    "value": {
+                        "tagging_mode": "untagged"
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet2",
+                    "value": {
+                        "tagging_mode": "untagged"
                     }
                 }
             ],
@@ -1478,10 +1532,22 @@
                     "op": "add",
                     "path": "/VLAN_INTERFACE",
                     "value": {
-                        "Vlan1000": {},
-                        "Vlan1000|192.168.0.1/21": {},
-                        "Vlan1000|fc02:1000::1/64": {}
+                        "Vlan1000": {}
                     }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE/Vlan1000|fc02:1000::1~164",
+                    "value": {}
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE/Vlan1000|192.168.0.1~121",
+                    "value": {}
                 }
             ]
         ]
@@ -2206,6 +2272,24 @@
             }
         ],
         "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/DATAACL"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOW"
+                }
+            ],
             [
                 {
                     "op": "remove",

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2014,6 +2014,12 @@ class TestKeyLevelMoveGenerator(unittest.TestCase):
                               {"op": "remove", 'path': '/NonExistingTable2/NonExistingKey21'},
                               {"op": "remove", 'path': '/NonExistingTable2/NonExistingKey22'}])
 
+
+    def test_generate__single_key_in_current_but_not_target__whole_table_deleted(self):
+        self.verify(current = { "ExistingTable1": { "NonExistingKey11" : "Value11" }},
+                    target = {},
+                    ex_ops = [{"op": "remove", 'path': '/ExistingTable1'}])
+
     def test_generate__keys_in_target_but_not_current__keys_added_moves(self):
         self.verify(current = {
                             "ExistingTable1": {
@@ -3024,8 +3030,7 @@ class TestSortAlgorithmFactory(unittest.TestCase):
         config_wrapper = ConfigWrapper()
         factory = ps.SortAlgorithmFactory(OperationWrapper(), config_wrapper, PathAddressing(config_wrapper))
         expected_generators = [ps.LowLevelMoveGenerator]
-        expected_non_extendable_generators = [ps.TableLevelMoveGenerator,
-                                              ps.KeyLevelMoveGenerator]
+        expected_non_extendable_generators = [ps.KeyLevelMoveGenerator]
         expected_extenders = [ps.RequiredValueMoveExtender,
                               ps.UpperLevelMoveExtender,
                               ps.DeleteInsteadOfReplaceMoveExtender,


### PR DESCRIPTION
#### What I did
Fixes #2099

Grouping all fields under tables/keys to be added/deleted in 1 JsonChange.


**BEFORE** how did we generate moves to try?
- Start with the low level differences, low level means differences that has no children
- Then extend this low level by different extenders, the most used is the `UpperLevelMoveExtender`
- Extended the already extended moves to go upper in level, and do that multiple times until there are no possible moves to extend

The diagram below shows:
- Generation (low level):
```json
{"op":"replace", "path":"/ACL_RULE/SNMP_ACL|RULE_1/SRC_IP", "value": "1.1.1.1/21"}
{"op":"remove", "path":"/ACL_RULE/SNMP_ACL|RULE_2/PRIORITY"}
{"op":"remove", "path":"/ACL_RULE/SNMP_ACL|RULE_2/SRC_IP"}
{"op":"remove", "path":"/ACL_RULE/SNMP_ACL|RULE_2/IP_PROTOCOL"}
{"op":"remove", "path":"/ACL_RULE/SNMP_ACL|RULE_2/PACKET_ACTION"}
{"op":"add", "path":"/ACL_RULE/SNMP_ACL|RULE_3/PRIORITY", "value": "9997"}
{"op":"add", "path":"/ACL_RULE/SNMP_ACL|RULE_3/SRC_IP", "value": "3.3.3.3/20"}
{"op":"add", "path":"/ACL_RULE/SNMP_ACL|RULE_3/IP_PROTOCOL", "value": "17"}
{"op":"add", "path":"/ACL_RULE/SNMP_ACL|RULE_3/PACKET_ACTION", "value": "ACCEPT"}
```
- Extension - 1st level
```json
{"op":"replace", "path":"/ACL_RULE/SNMP_ACL|RULE_1", "value": {"PRIORITY": "9999","SRC_IP": "2.2.2.2/21","SRC_IP": "1.1.1.1/21","IP_PROTOCOL": "17","PACKET_ACTION": "ACCEPT"}}
{"op":"remove", "path":"/ACL_RULE/SNMP_ACL|RULE_2"}
{"op":"add", "path":"/ACL_RULE/SNMP_ACL|RULE_3", "value": {"PRIORITY": "9997","SRC_IP": "3.3.3.3/20","IP_PROTOCOL": "17","PACKET_ACTION": "ACCEPT"}}
```
- Extension - 2nd level
```json
{"op":"replace", "path":"/ACL_RULE", "value": {"SNMP_ACL|RULE_1": {"PRIORITY": "9999","SRC_IP": "1.1.1.1/21","IP_PROTOCOL": "17","PACKET_ACTION": "ACCEPT"},"SNMP_ACL|RULE_3": {"PRIORITY": "9997","SRC_IP": "3.3.3.3/20","IP_PROTOCOL": "17","PACKET_ACTION": "ACCEPT"},"SNMP_ACL|DEFAULT_RULE": {"PRIORITY": "1","ETHER_TYPE": "2048","PACKET_ACTION": "DROP"}}}
```
- Extension - 3rd level
 ```json
{"op":"replace", "path":"", "value": {"ACL_RULE": {"SNMP_ACL|RULE_1": {"PRIORITY": "9999","SRC_IP": "1.1.1.1/21","IP_PROTOCOL": "17","PACKET_ACTION": "ACCEPT"},"SNMP_ACL|RULE_3": {"PRIORITY": "9997","SRC_IP": "3.3.3.3/20","IP_PROTOCOL": "17","PACKET_ACTION": "ACCEPT"},"SNMP_ACL|DEFAULT_RULE": {"PRIORITY": "1","ETHER_TYPE": "2048","PACKET_ACTION": "DROP"}},"ACL_TABLE": {"SNMP_ACL": {"type": "CTRLPLANE","policy_desc": "SNMP_ACL","services": ["SNMP"]}}}}
```
![image](https://user-images.githubusercontent.com/3927651/160676723-29688656-3382-4247-8358-cb988cda5134.png)


**AFTER**
In this PR, we introduce a different kind of generator. The non-extendable generators i.e. generators that their moves do not get extended using the extenders. We added 2 generators:
- KeyLevelGenerator: if a whole key to be deleted or added, do that directly.
- TableLevelGenerator: if a whole table to be deleted or added, do that directly.

Only **enabled** KeyLevelGenerator, to enable **TableLevelGenerator** we have to confirm with Renuka if it is possible to update a whole table at once in the `ChangeApplier` (instead of just keys like it is today). We have to be able to update a table as a whole because within the table there can be internal dependencies between the object, so we have to guarantee all objects are deleted together. For the keys it is guaranteed for the whole key to be updated at once according to the `ChangeApplier`.

**Why non-extendable generators?**
Calling the non-extendable generators precedes the extendable ones, it is like checking for the low hanging fruits. If we use the same extenders for these new generators we will always go up the config tree. Imaging a move that tries to update a key but fails, then we call the extenders on this move. What will happen is the extenders will go up the config tree to the table level, will first try to replace the table, then try to delete the table. Deleting the table is a problem because it affects multiple more than intended and thus violates the minimum disruption guarantee. We decided to leave the extenders only for the LowLevelGenerator thus making sure we try all possible moves from the lowest levels and go up from there.

Another way to look at it is like this:
- Non-extendable generators do top-down search: Check tables, keys in this order
- Extendable generators and extenders do bottom-up approach: Check fields, keys, tables in this order

#### How I did it
Modifying the `MoveWrapper.Generate` method to allow for different type of move generators

#### How to verify it
Unit-test

Please check `tests/generic_config_updater/files/patch_sorter_test_success.json` to see how the moved generated got much compacted.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

