### PR TITLE
print cisco-8000 sdk version build info 

### DIFF
--- a/show/plugins/cisco-8000.py
+++ b/show/plugins/cisco-8000.py
@@ -16,12 +16,24 @@ except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
 PLATFORM_PY = '/opt/cisco/bin/platform.py'
+BUILD_INFO = '/opt/cisco/etc/build_info.yaml'
 
 @click.command()
 def inventory():
     """Show Platform Inventory"""
     args = [ PLATFORM_PY, 'inventoryshow' ]
     clicommon.run_command(args)
+
+@click.command()
+def version():
+    """Show Platform SDK Version"""
+    try: 
+        with open(BUILD_INFO,'r') as f:
+            contents = f.read()
+        print(contents)
+        f.close()
+    except Exception as e:
+        print(e)
 
 @click.command()
 def idprom():
@@ -34,3 +46,4 @@ def register(cli):
     if (version_info and version_info.get('asic_type') == 'cisco-8000'):
         cli.commands['platform'].add_command(inventory)
         cli.commands['platform'].add_command(idprom)
+        cli.commands['platform'].add_command(version)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
support in cisco-8000.py plugin to print cisco-8000 SDK specific version info. 

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

