### PR TITLE
[scripts/fast-reboot] Shutdown remaining containers through systemd

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -738,13 +738,6 @@ for service in ${SERVICES_TO_STOP}; do
     fi
 done
 
-if test -f /usr/local/bin/ctrmgr_tools.py
-then
-    debug "Stopping all remaining containers ..."
-    /usr/local/bin/ctrmgr_tools.py kill-all
-    debug "Stopped all remaining containers ..."
-fi
-
 # Stop the docker container engine. Otherwise we will have a broken docker storage
 systemctl stop docker.service || debug "Ignore stopping docker service error $?"
 


### PR DESCRIPTION
The current implementation has two issues:

1. In case containers from "docker ps" output are ordered in a way that database is first in the list, the "systemctl stop database" followed by "docker kill database" will stop all other containers through systemd and ruin this optimization
2. After "docker kill database" there are lots of errors from daemons like hostcfgd, system-healthd, caclmgrd, etc. Also it causes those daemons to hang when received SIGTERM making a delay on following "systemctl stop database".

In the new implementation, services are implicitly stopped by systemd in the order that is correct. If a certain container needs an optimization that will kill the container instead of stopping it the container may implement this optimization in its /usr/local/bin/*.sh script.

It is also more optimal since independent services might be stopped in parallel.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Stop services using systemd

#### How I did it

Stop services using systemd

#### How to verify it

Run warm-reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


*Required to chery-pick*: 202012, 202111.

DEPENDS ON: https://github.com/Azure/sonic-buildimage/pull/10510 https://github.com/Azure/sonic-buildimage/pull/10511