### PR TITLE
Fix issue where generate_dump will abort if docker is not running lea…

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -284,6 +284,13 @@ copy_from_docker() {
     local dstpath=$3
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
 
+    docker ps | grep ${docker}
+    if [ $? != 0 ]
+    then
+        echo "Error: Docker ${docker} not running.  Skipping..."
+        return
+    fi
+
     local touch_cmd="sudo docker exec ${docker} touch ${filename}"
     local cp_cmd="sudo docker cp ${docker}:${filename} ${dstpath}"
 


### PR DESCRIPTION
…ving

an incomplete support file.

Signed-off-by: Jeff Henning <jeffhtgt@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix generate_dump to not abort if a docker is not running.

#### How I did it

Add check for running docker in copy_from_docker() and return if the docker is not running (ported
from a 202012 branch).

#### How to verify it

Got a successful dump.tgz after running "show techsupport".  Previously the file would be
incomplete due to command abort.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

