### PR TITLE
Potential risk of acl_loader missing ctx in main function

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -1078,11 +1078,3 @@ def delete(ctx, table, rule):
 
     acl_loader.delete(table, rule)
 
-
-if __name__ == "__main__":
-    try:
-        cli()
-    except AclLoaderException as e:
-        error(e)
-    except Exception as e:
-        error("Unknown error: %s" % repr(e))


### PR DESCRIPTION
Issue:
Potential risk about cli() function without ctx in main function of acl_loader

Root cause:
SONiC will call cli() directly in acl-loader.
But it still exist potential risk when run main in acl-loader

Solution:
Remover main funcion which missing ctx object and remain cli() function for acl-loader call directly
