### PR TITLE
[kdump] Fix API to read the current running image

### DIFF
--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -82,7 +82,7 @@ def run_command(cmd, use_shell=False):
 def get_current_image():
     bootloader = get_bootloader()
     curimage = bootloader.get_current_image()
-    if IMAGE_PREFIX in curimage:
+    if curimage.startswith(IMAGE_PREFIX):
         return curimage[len(IMAGE_PREFIX):]
     print_err("Unable to locate current SONiC image")
     sys.exit(1)
@@ -99,7 +99,7 @@ def get_crash_kernel_size():
 def get_next_image():
     bootloader = get_bootloader()
     nextimage = bootloader.get_next_image()
-    if IMAGE_PREFIX in nextimage:
+    if nextimage.startswith(IMAGE_PREFIX):
         return nextimage[len(IMAGE_PREFIX):]
     print_err("Unable to locate next SONiC image")
     sys.exit(1)

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -97,10 +97,11 @@ def get_crash_kernel_size():
 
 ## Search which SONiC image is the Next image
 def get_next_image():
-    (rc, img, err_str) = run_command("sonic-installer list | grep 'Next: ' | cut -d '-' -f 3-", use_shell=True);
-    if type(img) == list and len(img) == 1:
-        return img[0]
-    print_err("Unable to locate current SONiC image")
+    bootloader = get_bootloader()
+    nextimage = bootloader.get_next_image()
+    if IMAGE_PREFIX in nextimage:
+        return nextimage[len(IMAGE_PREFIX):]
+    print_err("Unable to locate next SONiC image")
     sys.exit(1)
 
 ## Search for Current/Next SONiC image in grub configuration

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -26,6 +26,8 @@ import syslog
 import subprocess
 
 from swsscommon.swsscommon import ConfigDBConnector
+from sonic_installer.bootloader import get_bootloader
+from sonic_installer.common import IMAGE_PREFIX
 
 aboot_cfg_template ="/host/image-%s/kernel-cmdline"
 grub_cfg = "/host/grub/grub.cfg"
@@ -78,9 +80,10 @@ def run_command(cmd, use_shell=False):
 
 ## Search which SONiC image is the Current image
 def get_current_image():
-    (rc, img, err_str) = run_command("sonic-installer list | grep 'Current: ' | cut -d '-' -f 3-", use_shell=True);
-    if type(img) == list and len(img) == 1:
-        return img[0]
+    bootloader = get_bootloader()
+    curimage = bootloader.get_current_image()
+    if IMAGE_PREFIX in curimage:
+        return curimage[len(IMAGE_PREFIX):]
     print_err("Unable to locate current SONiC image")
     sys.exit(1)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Simplify the API used to get the current active image name.

#### How I did it
Instead of relying on the output of the "sonic-installer list" command, use the API  get_current_image() from the sonic_installer.bootloader py library.

#### How to verify it
config reload
config kdump disable
config kdump enable
config kdump memory 768M

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

