### PR TITLE
convert ingress/egress of ACL_TABLE in CONFIG_DB to INGRESS/EGRESS

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5288,7 +5288,7 @@ def parse_acl_table_info(table_name, table_type, description, ports, stage):
 
     table_info["ports"] = port_list
 
-    table_info["stage"] = stage
+    table_info["stage"] = stage.upper()
 
     return table_info
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The stage in ACL_TABLE in CONFIG_DB is ingress/egress when using config acl command. However, the leaf stage defined in sonic-acl.yang is EGRESS/INGRESS.
I convert ingress/egress of ACL_TABLE in CONFIG_DB to INGRESS/EGRESS to  to make sure stage in CONFIG_DB and sonic-acl.yang are consistent.

#### How I did it
convert stage field of ACL_TABLE to upper case
#### How to verify it
use redis-cli to view ACL_TABLE  contents in CONFIG_DB

#### Previous command output (if the output of a command-line utility has changed)
127.0.0.1:6379[4]> HGETALL "ACL_TABLE|test"
1) "policy_desc"
2) "test"
3) "ports@"
4) "Ethernet20"
5) "stage"
6) "ingress"
7) "type"
8) "L3"

#### New command output (if the output of a command-line utility has changed)
127.0.0.1:6379[4]> HGETALL "ACL_TABLE|test"
1) "policy_desc"
2) "test"
3) "ports@"
4) "Ethernet20"
5) "stage"
6) "INGRESS"
7) "type"
8) "L3"

