### PR TITLE
[config/show] Configure and retrieve the value of high memory alert and memory threshold of each container.

### DIFF
--- a/config/feature.py
+++ b/config/feature.py
@@ -159,17 +159,25 @@ def feature_high_memory_alert(db, feature_name, high_memory_alert_status):
 
         feature_config = config_db.get_entry('FEATURE', feature_name)
         if not feature_config:
-            click.echo("Failed to retrieve configuration of feature '{}' from 'FEATURE' table!".format(feature_name))
+            click.echo("Failed to retrieve configuration of feature '{}' from 'FEATURE' table!"
+                       .format(feature_name))
             sys.exit(3)
 
-        feature_high_memory_alert_status.add(feature_config['high_mem_alert'])
+        if "high_mem_alert" in feature_config:
+            feature_high_memory_alert_status.add(feature_config['high_mem_alert'])
+        else:
+            click.echo("Failed to retrieve 'high_mem_alert' field of feature '{}' from 'FEATURE' table!"
+                       .format(feature_name))
+            sys.exit(4)
 
     if len(feature_high_memory_alert_status) > 1:
-        click.echo("High memory alert status of feature '{}' is not consistent across different namespaces!".format(feature_name))
-        sys.exit(4)
+        click.echo("High memory alert status of feature '{}' is not consistent across different namespaces!"
+                   .format(feature_name))
+        sys.exit(5)
 
     if feature_config['high_mem_alert'] == "always_enabled":
-        click.echo("High memory alert of feature '{}' is always enabled and can not be modified!".format(feature_name))
+        click.echo("High memory alert of feature '{}' is always enabled and can not be modified!"
+                   .format(feature_name))
         return
 
     for namespace, config_db in db.cfgdb_clients.items():
@@ -191,19 +199,25 @@ def feature_memory_threshold(db, feature_name, mem_threshold):
         feature_table = config_db.get_table('FEATURE')
         if not feature_table:
             click.echo("Failed to retrieve 'FEATURE' table from 'Config_ DB'!")
-            sys.exit(5)
+            sys.exit(6)
 
         feature_config = config_db.get_entry('FEATURE', feature_name)
         if not feature_config:
-            click.echo("Failed to retrieve configuration of feature '{}' from 'FEATURE' table!".format(feature_name))
-            sys.exit(6)
+            click.echo("Failed to retrieve configuration of feature '{}' from 'FEATURE' table!"
+                       .format(feature_name))
+            sys.exit(7)
 
-        feature_memory_threshold.add(feature_config['mem_threshold'])
+        if "mem_threshold" in feature_config:
+            feature_memory_threshold.add(feature_config['mem_threshold'])
+        else:
+            click.echo("Failed to retrieve 'mem_threshold' field of feature '[]' from 'FEATURE' table!"
+                       .format(feature_name))
+            sys.exit(8)
 
     if len(feature_memory_threshold) > 1:
-        click.echo("Memory threshold of feature '{}' is not consistent across different namespaces!".format(feature_name))
-        sys.exit(7)
+        click.echo("Memory threshold of feature '{}' is not consistent across different namespaces!"
+                   .format(feature_name))
+        sys.exit(9)
 
     for namespace, config_db in db.cfgdb_clients.items():
         config_db.mod_entry('FEATURE', feature_name, {'mem_threshold': mem_threshold})
-

--- a/config/feature.py
+++ b/config/feature.py
@@ -139,3 +139,71 @@ def feature_autorestart(db, name, autorestart):
     for ns, cfgdb in db.cfgdb_clients.items():
         cfgdb.mod_entry('FEATURE', name, {'auto_restart': autorestart})
 
+
+#
+# 'hign_memory_alert' command ('config feature high_memory_alert ...')
+#
+@feature.command(name='high_memory_alert', short_help="Enable/disable high memory alerting of a feature")
+@click.argument('feature_name', metavar='<feature_name>', required=True)
+@click.argument('high_memory_alert_status', metavar='<high_memory_alert_status>', required=True, type=click.Choice(["enabled", "disabled"]))
+@pass_db
+def feature_high_memory_alert(db, feature_name, high_memory_alert_status):
+    """Enable/disable the high memory alert of a feature"""
+    feature_high_memory_alert_status = set()
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        feature_table = config_db.get_table('FEATURE')
+        if not feature_table:
+            click.echo("Failed to retrieve 'FEATURE' table from 'Config_DB'!")
+            sys.exit(2)
+
+        feature_config = config_db.get_entry('FEATURE', feature_name)
+        if not feature_config:
+            click.echo("Failed to retrieve configuration of feature '{}' from 'FEATURE' table!".format(feature_name))
+            sys.exit(3)
+
+        feature_high_memory_alert_status.add(feature_config['high_mem_alert'])
+
+    if len(feature_high_memory_alert_status) > 1:
+        click.echo("High memory alert status of feature '{}' is not consistent across different namespaces!".format(feature_name))
+        sys.exit(4)
+
+    if feature_config['high_mem_alert'] == "always_enabled":
+        click.echo("High memory alert of feature '{}' is always enabled and can not be modified!".format(feature_name))
+        return
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        config_db.mod_entry('FEATURE', feature_name, {'high_mem_alert': high_memory_alert_status})
+
+
+#
+# 'memory_threshold' command ('config feature mem_threshold ...')
+#
+@feature.command(name='memory_threshold', short_help="Configure the memory threshold (in Bytes) of a feature")
+@click.argument('feature_name', metavar='<feature_name>', required=True)
+@click.argument('mem_threshold', metavar='<mem_threshold_in_bytes>', required=True)
+@pass_db
+def feature_memory_threshold(db, feature_name, mem_threshold):
+    """Configure the memory threshold of a feature"""
+    feature_memory_threshold = set()
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        feature_table = config_db.get_table('FEATURE')
+        if not feature_table:
+            click.echo("Failed to retrieve 'FEATURE' table from 'Config_ DB'!")
+            sys.exit(5)
+
+        feature_config = config_db.get_entry('FEATURE', feature_name)
+        if not feature_config:
+            click.echo("Failed to retrieve configuration of feature '{}' from 'FEATURE' table!".format(feature_name))
+            sys.exit(6)
+
+        feature_memory_threshold.add(feature_config['mem_threshold'])
+
+    if len(feature_memory_threshold) > 1:
+        click.echo("Memory threshold of feature '{}' is not consistent across different namespaces!".format(feature_name))
+        sys.exit(7)
+
+    for namespace, config_db in db.cfgdb_clients.items():
+        config_db.mod_entry('FEATURE', feature_name, {'mem_threshold': mem_threshold})
+

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2995,34 +2995,50 @@ likelihood of entering a healthy state.
 
 ### Feature show commands
 
+This sub-section of commands is used to show the configurations of each feature.
+
 **show feature config**
 
-Shows the config of given feature or all if no feature is given. The "fallback" is shown only if configured. The fallback defaults to "true" when not configured.
+Shows the configuration of a given feature or all if no feature is given. The "fallback" 
+is shown only if configured. The fallback defaults to "true" when not configured.
 
 - Usage:
   ```
-  show feature config [<feature name>]
+  show feature config
   ```
 
 - Example:
   ```
   admin@sonic:~$ show feature config
-  Feature         State     AutoRestart    Owner    fallback
-  --------------  --------  -------------  -------  ----------
-  bgp             enabled   enabled        local
-  database        enabled   disabled       local
-  dhcp_relay      enabled   enabled        kube
-  lldp            enabled   enabled        kube     true
-  mgmt-framework  enabled   enabled        local
-  nat             disabled  enabled        local
-  pmon            enabled   enabled        kube
-  radv            enabled   enabled        kube
-  sflow           disabled  enabled        local
-  snmp            enabled   enabled        kube
-  swss            enabled   enabled        local
-  syncd           enabled   enabled        local
-  teamd           enabled   enabled        local
-  telemetry       enabled   enabled        kube
+  Feature         State     AutoRestart    HighMemAlert    MemThreshold    Owner    fallback
+  --------------  --------  -------------  --------------  --------------  -------  ----------
+  bgp             enabled   enabled        enabled         1073741824      local
+  database        enabled   disabled       enabled         1073741824      local
+  dhcp_relay      enabled   enabled        enabled         1073741824      kube
+  lldp            enabled   enabled        enabled         1073741824      kube     true
+  mgmt-framework  enabled   enabled        enabled         1073741824      local
+  nat             disabled  enabled        enabled         1073741824      local
+  pmon            enabled   enabled        enabled         1073741824      kube
+  radv            enabled   enabled        enabled         1073741824      kube
+  sflow           disabled  enabled        enabled         1073741824      local
+  snmp            enabled   enabled        enabled         1073741824      kube
+  swss            enabled   enabled        enabled         1073741824      local
+  syncd           enabled   enabled        enabled         1073741824      local
+  teamd           enabled   enabled        enabled         1073741824      local
+  telemetry       enabled   enabled        enabled         1073741824      kube
+  ```
+
+- Usage:
+  ```
+  show feature config [<feature_name>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show feature config bgp
+  Feature         State     AutoRestart    HighMemAlert    MemThreshold    Owner    fallback
+  --------------  --------  -------------  --------------  --------------  -------  ----------
+  bgp             enabled   enabled        enabled         1073741824      local
   ```
 
 **show feature status**
@@ -3032,29 +3048,171 @@ The subset of features are configurable for remote management and only those rep
 
 - Usage:
   ```
-  show feature status [<feature name>]
+  show feature status
   ```
 
 - Example:
   ```
   admin@sonic:~$ show feature status
-  Feature         State     AutoRestart    SystemState    UpdateTime           ContainerId    ContainerVersion    SetOwner    CurrentOwner    RemoteState
-  --------------  --------  -------------  -------------  -------------------  -------------  ------------------  ----------  --------------  -------------
-  bgp             enabled   enabled        up                                                                     local       local           none
-  database        enabled   disabled                                                                              local
-  dhcp_relay      enabled   enabled        up             2020-11-15 18:21:09  249e70102f55   20201230.100        kube        local
-  lldp            enabled   enabled        up             2020-11-15 18:21:09  779c2d55ee12   20201230.100        kube        local
-  mgmt-framework  enabled   enabled        up                                                                     local       local           none
-  nat             disabled  enabled                                                                               local
-  pmon            enabled   enabled        up             2020-11-15 18:20:27  a2b9ffa8aba3   20201230.100        kube        local
-  radv            enabled   enabled        up             2020-11-15 18:21:05  d8ff27dcfe46   20201230.100        kube        local
-  sflow           disabled  enabled                                                                               local
-  snmp            enabled   enabled        up             2020-11-15 18:25:51  8b7d5529e306   20201230.111        kube        kube            running
-  swss            enabled   enabled        up                                                                     local       local           none
-  syncd           enabled   enabled        up                                                                     local       local           none
-  teamd           enabled   enabled        up                                                                     local       local           none
-  telemetry       enabled   enabled        down           2020-11-15 18:24:59                 20201230.100        kube        none
+  Feature         State     AutoRestart    HighMemAlert    MemThreshold    SystemState    UpdateTime           ContainerId    ContainerVersion    SetOwner    CurrentOwner    RemoteState
+  --------------  --------  -------------  --------------  --------------  -------------  -------------------  -------------  ------------------  ----------  --------------  -------------
+  bgp             enabled   enabled        enabled         1073741824      up                                                                     local       local           none
+  database        enabled   disabled       enabled         1073741824                                                                             local
+  dhcp_relay      enabled   enabled        enabled         1073741824      up             2020-11-15 18:21:09  249e70102f55   20201230.100        kube        local
+  lldp            enabled   enabled        enabled         1073741824      up             2020-11-15 18:21:09  779c2d55ee12   20201230.100        kube        local
+  mgmt-framework  enabled   enabled        enabled         1073741824      up                                                                     local       local           none
+  nat             disabled  enabled        enabled         1073741824                                                                             local
+  pmon            enabled   enabled        enabled         1073741824      up             2020-11-15 18:20:27  a2b9ffa8aba3   20201230.100        kube        local
+  radv            enabled   enabled        enabled         1073741824      up             2020-11-15 18:21:05  d8ff27dcfe46   20201230.100        kube        local
+  sflow           disabled  enabled        enabled         1073741824                                                                             local
+  snmp            enabled   enabled        enabled         1073741824      up             2020-11-15 18:25:51  8b7d5529e306   20201230.111        kube        kube            running
+  swss            enabled   enabled        enabled         1073741824      up                                                                     local       local           none
+  syncd           enabled   enabled        enabled         1073741824      up                                                                     local       local           none
+  teamd           enabled   enabled        enabled         1073741824      up                                                                     local       local           none
+  telemetry       enabled   enabled        enabled         1073741824      down           2020-11-15 18:24:59                 20201230.100        kube        none
   ```
+
+- Usage:
+  ```
+  show feature status [<feature_name>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show feature status bgp
+  Feature         State     AutoRestart    HighMemAlert    MemThreshold    SystemState    UpdateTime           ContainerId    ContainerVersion    SetOwner    CurrentOwner    RemoteState
+  --------------  --------  -------------  --------------  --------------  -------------  -------------------  -------------  ------------------  ----------  --------------  -------------
+  bgp             enabled   enabled        enabled         1073741824      up                                                                     local       local           none
+  ```
+
+
+**show feature autorestart**
+
+By default, this command will show the auto-restart status of all features.
+If a feature name is provided as an argument, then only auto-restart status of
+this feature will be shown.
+
+- Usage:
+  show feature autorestart
+
+- Example:
+  ```
+  admin@sonic:~$ show feature autorestart
+  Feature     AutoRestart
+  ----------  --------------
+  bgp         enabled
+  database    always_enabled
+  dhcp_relay  enabled
+  lldp        enabled
+  pmon        enabled
+  radv        enabled
+  snmp        enabled
+  swss        enabled
+  syncd       enabled
+  teamd       enabled
+  telemetry   enabled
+  ```
+
+- Usage:
+  ```
+  show feature autorestart [<feature_name>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show feature autorestart bgp
+  Feature     AutoRestart
+  ----------  --------------
+  bgp         enabled
+  ```
+
+**show feature high_memory_alert**
+
+By default, this command will show the high memory alerting status of all features.
+If a feature name is provided as an argument, then only high memory alerting status of
+this feature will be shown.
+
+- Usage:
+  ```
+  show feature high_memory_alert
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show feature high_memory_alert
+  feature     HighMemAlert 
+  ----------  --------------
+  bgp         enabled
+  database    enabled
+  dhcp_relay  enabled
+  lldp        enabled
+  pmon        enabled
+  radv        enabled
+  snmp        enabled
+  swss        enabled
+  syncd       enabled
+  teamd       enabled
+  telemetry   enabled
+  ```
+
+- Usage:
+  ```
+  show feature high_memory_alert [<feature_name>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show feature high_memory_alert bgp
+  feature     HighMemAlert 
+  ----------  --------------
+  bgp         enabled
+  ```
+
+**show feature memory_threshold**
+
+By default, this command will show memory thresholds of all features.
+If a feature name is provided as an argument, then only memory threshold of
+this feature will be shown.
+
+- Usage:
+  ```
+  show feature memory_threshold
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show feature memory_threshold
+  feature      MemThreshold  
+  ----------   --------------
+  bgp          1073741824    
+  database     1073741824    
+  dhcp_relay   1073741824    
+  lldp         1073741824    
+  pmon         1073741824    
+  radv         1073741824    
+  snmp         1073741824    
+  swss         1073741824    
+  syncd        1073741824    
+  teamd        1073741824    
+  telemetry    1073741824    
+  ```
+
+- Usage:
+  ```
+  show feature memory_threshold [<feature_name>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show feature memory_threshold bgp
+  feature     MemThreshold
+  ----------  --------------
+  bgp         1073741824
+  ```
+
+### Feature config commands
+
+This sub-section of commands is used to change the configurations of each feature.
 
 **config feature owner**
 
@@ -3084,33 +3242,6 @@ Features configured for "kube" deployment could be allowed to fallback to using 
   admin@sonic:~$ sudo config feature fallback snmp on
   ```
 
-**show feature autorestart**
-
-This command will display the status of auto-restart for feature container.
-
-- Usage:
-  ```
-  show feature autorestart [<feature_name>]
-  admin@sonic:~$ show feature autorestart
-  Feature     AutoRestart
-  ----------  --------------
-  bgp         enabled
-  database    always_enabled
-  dhcp_relay  enabled
-  lldp        enabled
-  pmon        enabled
-  radv        enabled
-  snmp        enabled
-  swss        enabled
-  syncd       enabled
-  teamd       enabled
-  telemetry   enabled
-  ```
-
-Optionally, you can specify a feature name in order to display
-status for that feature
-
-### Feature config commands
 
 **config feature state <feature_name> <state>**
 
@@ -3133,6 +3264,34 @@ This command will configure the status of auto-restart for a specific feature co
   ``` 
 NOTE: If the existing state or auto-restart value for a feature is "always_enabled" then config
 commands are don't care and will not update state/auto-restart value.
+
+**config feature high_memory_alert <feature_name> <high_memory_alert_status>**
+
+This command will configure the high memory alert status of a specific feature.
+
+- Usage:
+  ```
+  config feature high_memory_alert <feature_name> (enabled | disabled)
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config feature high_memory_alert bgp disabled
+  ``` 
+
+**config feature memory_threshold <feature_name> <threshold_value>**
+
+This command will configure the memory threshold (maximum memory usage) of a specific feature.
+
+- Usage:
+  ```
+  config feature memory <feature_name> <threshold_value>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config feature memory_threshold bgp 1073741824
+  ``` 
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#feature)
 

--- a/show/feature.py
+++ b/show/feature.py
@@ -44,6 +44,8 @@ def feature_status(db, feature_name):
     fields_info = [
             ('State', 'state', ""),
             ('AutoRestart', 'auto_restart', ""),
+            ('HighMemAlert', 'high_mem_alert', ""),
+            ('MemThreshold', 'mem_threshold', ""),
             ('SystemState', 'system_state', ""),
             ('UpdateTime', 'update_time', ""),
             ('ContainerId', 'container_id', ""),
@@ -113,6 +115,8 @@ def feature_config(db, feature_name):
     fields_info = [
             ('State', 'state', ""),
             ('AutoRestart', 'auto_restart', ""),
+            ('HighMemAlert', 'high_mem_alert', ""),
+            ('MemThreshold', 'mem_threshold', ""),
             ('Owner', 'set_owner', "local"),
             ('fallback', 'no_fallback_to_local', "")
             ]
@@ -163,4 +167,58 @@ def feature_autorestart(db, feature_name):
     else:
         for name in natsorted(list(feature_table.keys())):
             body.append([name, feature_table[name]['auto_restart']])
+    click.echo(tabulate(body, header))
+
+
+# 'high_memory_alert' subcommand (show feature high_memory_alert)
+#
+@feature.command('high_memory_alert', short_help="Show high memory alerting state of feature(s)")
+@click.argument('feature_name', required=False)
+@pass_db
+def feature_high_mem_alert(db, feature_name):
+    header = ['Feature', 'HighMemAlert']
+    body = []
+
+    feature_table = db.cfgdb.get_table('FEATURE')
+    if not feature_table:
+        click.echo("Unable to retrieve the 'FEATURE' table from 'CONIFG_DB'!")
+        sys.exit(2)
+
+    if feature_name:
+        if feature_name in feature_table:
+            body.append([feature_name, feature_table[feature_name]['high_mem_alert']])
+        else:
+            click.echo("Unable to retrieve the feature '{}' from 'FEATURE' table!".format(feature_name))
+            sys.exit(3)
+    else:
+        for name in natsorted(list(feature_table.keys())):
+            body.append([name, feature_table[name]['high_mem_alert']])
+
+    click.echo(tabulate(body, header))
+
+
+# 'memory_threshold' subcommand (show feature memory_threshold)
+#
+@feature.command('memory_threshold', short_help="Show memory threshold of feature(s)")
+@click.argument('feature_name', required=False)
+@pass_db
+def feature_mem_threshold(db, feature_name):
+    header = ['Feature', 'MemThreshold']
+    body = []
+
+    feature_table = db.cfgdb.get_table('FEATURE')
+    if not feature_table:
+        click.echo("Unable to retrieve the 'FEATURE' table from 'CONIFG_DB'!")
+        sys.exit(4)
+
+    if feature_name:
+        if feature_name in feature_table:
+            body.append([feature_name, feature_table[feature_name]['mem_threshold']])
+        else:
+            click.echo("Unable to retrieve the feature '{}' from 'FEATURE' table!".format(feature_name))
+            sys.exit(5)
+    else:
+        for name in natsorted(list(feature_table.keys())):
+            body.append([name, feature_table[name]['mem_threshold']])
+
     click.echo(tabulate(body, header))

--- a/show/feature.py
+++ b/show/feature.py
@@ -185,14 +185,19 @@ def feature_high_memory_alert(db, feature_name):
         sys.exit(2)
 
     if feature_name:
-        if feature_name in feature_table:
+        if feature_name in feature_table and "high_mem_alert" in feature_table[feature_name]:
             body.append([feature_name, feature_table[feature_name]['high_mem_alert']])
         else:
-            click.echo("Failed to retrieve the feature '{}' from 'FEATURE' table!".format(feature_name))
+            click.echo("failed to retrieve the 'high_mem_alert' field of feature '{}' from 'feature' table!"
+                       .format(feature_name))
             sys.exit(3)
     else:
-        for name in natsorted(list(feature_table.keys())):
-            body.append([name, feature_table[name]['high_mem_alert']])
+        for feature_name in natsorted(list(feature_table.keys())):
+            if "high_mem_alert" not in feature_table[feature_name]:
+                click.echo("failed to retrieve the 'high_mem_alert' field of feature '{}' from 'feature' table!"
+                           .format(feature_name))
+                sys.exit(4)
+            body.append([feature_name, feature_table[feature_name]['high_mem_alert']])
 
     click.echo(tabulate(body, header))
 
@@ -208,17 +213,22 @@ def feature_memory_threshold(db, feature_name):
 
     feature_table = db.cfgdb.get_table('FEATURE')
     if not feature_table:
-        click.echo("Unable to retrieve the 'FEATURE' table from 'CONIFG_DB'!")
-        sys.exit(4)
+        click.echo("Failed to retrieve the 'FEATURE' table from 'CONIFG_DB'!")
+        sys.exit(5)
 
     if feature_name:
-        if feature_name in feature_table:
+        if feature_name in feature_table and "mem_threshold" in feature_table[feature_name]:
             body.append([feature_name, feature_table[feature_name]['mem_threshold']])
         else:
-            click.echo("Unable to retrieve the feature '{}' from 'FEATURE' table!".format(feature_name))
-            sys.exit(5)
+            click.echo("Failed to retrieve the 'mem_threshold' field of feature '{}' from 'FEATURE' table!"
+                       .format(feature_name))
+            sys.exit(6)
     else:
         for name in natsorted(list(feature_table.keys())):
+            if "mem_threshold" not in feature_table[feature_name]:
+                click.echo("Failed to retrieve the 'mem_threshold' field of feature '{}' from 'FEATURE' table!"
+                           .format(feature_name))
+                sys.exit(7)
             body.append([name, feature_table[name]['mem_threshold']])
 
     click.echo(tabulate(body, header))

--- a/show/feature.py
+++ b/show/feature.py
@@ -188,13 +188,13 @@ def feature_high_memory_alert(db, feature_name):
         if feature_name in feature_table and "high_mem_alert" in feature_table[feature_name]:
             body.append([feature_name, feature_table[feature_name]['high_mem_alert']])
         else:
-            click.echo("failed to retrieve the 'high_mem_alert' field of feature '{}' from 'feature' table!"
+            click.echo("Failed to retrieve the 'high_mem_alert' field of feature '{}' from 'Feature' table!"
                        .format(feature_name))
             sys.exit(3)
     else:
         for feature_name in natsorted(list(feature_table.keys())):
             if "high_mem_alert" not in feature_table[feature_name]:
-                click.echo("failed to retrieve the 'high_mem_alert' field of feature '{}' from 'feature' table!"
+                click.echo("Failed to retrieve the 'high_mem_alert' field of feature '{}' from 'Feature' table!"
                            .format(feature_name))
                 sys.exit(4)
             body.append([feature_name, feature_table[feature_name]['high_mem_alert']])
@@ -224,11 +224,11 @@ def feature_memory_threshold(db, feature_name):
                        .format(feature_name))
             sys.exit(6)
     else:
-        for name in natsorted(list(feature_table.keys())):
+        for feature_name in natsorted(list(feature_table.keys())):
             if "mem_threshold" not in feature_table[feature_name]:
                 click.echo("Failed to retrieve the 'mem_threshold' field of feature '{}' from 'FEATURE' table!"
                            .format(feature_name))
                 sys.exit(7)
-            body.append([name, feature_table[name]['mem_threshold']])
+            body.append([feature_name, feature_table[feature_name]['mem_threshold']])
 
     click.echo(tabulate(body, header))

--- a/show/feature.py
+++ b/show/feature.py
@@ -175,20 +175,20 @@ def feature_autorestart(db, feature_name):
 @feature.command('high_memory_alert', short_help="Show high memory alerting state of feature(s)")
 @click.argument('feature_name', required=False)
 @pass_db
-def feature_high_mem_alert(db, feature_name):
+def feature_high_memory_alert(db, feature_name):
     header = ['Feature', 'HighMemAlert']
     body = []
 
     feature_table = db.cfgdb.get_table('FEATURE')
     if not feature_table:
-        click.echo("Unable to retrieve the 'FEATURE' table from 'CONIFG_DB'!")
+        click.echo("Failed to retrieve the 'FEATURE' table from 'CONIFG_DB'!")
         sys.exit(2)
 
     if feature_name:
         if feature_name in feature_table:
             body.append([feature_name, feature_table[feature_name]['high_mem_alert']])
         else:
-            click.echo("Unable to retrieve the feature '{}' from 'FEATURE' table!".format(feature_name))
+            click.echo("Failed to retrieve the feature '{}' from 'FEATURE' table!".format(feature_name))
             sys.exit(3)
     else:
         for name in natsorted(list(feature_table.keys())):
@@ -202,7 +202,7 @@ def feature_high_mem_alert(db, feature_name):
 @feature.command('memory_threshold', short_help="Show memory threshold of feature(s)")
 @click.argument('feature_name', required=False)
 @pass_db
-def feature_mem_threshold(db, feature_name):
+def feature_memory_threshold(db, feature_name):
     header = ['Feature', 'MemThreshold']
     body = []
 

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -370,7 +370,7 @@ class TestFeature(object):
         result = runner.invoke(show.cli.commands["feature"].commands["memory_threshold"], ["non_existing_container"])
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 5
+        assert result.exit_code == 6
 
     def test_fail_autorestart(self, get_cmd_module):
         (config, show) = get_cmd_module

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -573,13 +573,13 @@ class TestFeature(object):
 
         result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["non_existing_container", "104857600"], obj=db)
         print(result.output)
-        assert result.exit_code == 6
+        assert result.exit_code == 7
 
         db.cfgdb.delete_table("FEATURE")
 
         result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["lldp", "2048"], obj=db)
         print(result.output)
-        assert result.exit_code == 5
+        assert result.exit_code == 6
 
 
     def test_config_unknown_feature(self, get_cmd_module):
@@ -649,13 +649,13 @@ class TestFeatureMultiAsic(object):
         result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["bgp", "disabled"], obj=db)
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 4
+        assert result.exit_code == 5
         assert result.output == config_feature_high_memory_alert_bgp_inconsistent_output
 
         result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["bgp", "enabled"], obj=db)
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 4
+        assert result.exit_code == 5
         assert result.output == config_feature_high_memory_alert_bgp_inconsistent_output
 
     def test_config_feature_memory_threshold_bgp_inconsistent(self, get_cmd_module):
@@ -670,13 +670,13 @@ class TestFeatureMultiAsic(object):
         result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["bgp", "2048"], obj=db)
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 7
+        assert result.exit_code == 9
         assert result.output == config_feature_memory_threshold_bgp_inconsistent_output
 
         result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["bgp", "2048"], obj=db)
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 7
+        assert result.exit_code == 9
         assert result.output == config_feature_memory_threshold_bgp_inconsistent_output
 
 

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -10,102 +10,102 @@ from utilities_common.db import Db
 from swsscommon import swsscommon
 
 show_feature_status_output="""\
-Feature     State           AutoRestart     SetOwner
-----------  --------------  --------------  ----------
-bgp         enabled         enabled         local
-database    always_enabled  always_enabled  local
-dhcp_relay  enabled         enabled         kube
-lldp        enabled         enabled         kube
-nat         enabled         enabled         local
-pmon        enabled         enabled         kube
-radv        enabled         enabled         kube
-restapi     disabled        enabled         local
-sflow       disabled        enabled         local
-snmp        enabled         enabled         kube
-swss        enabled         enabled         local
-syncd       enabled         enabled         local
-teamd       enabled         enabled         local
-telemetry   enabled         enabled         kube
+Feature     State           AutoRestart     HighMemAlert      MemThreshold    SetOwner
+----------  --------------  --------------  ----------------  --------------  ----------
+bgp         enabled         enabled         enabled           1073741824      local
+database    always_enabled  always_enabled  enabled           1073741824      local
+dhcp_relay  enabled         enabled         enabled           1073741824      kube
+lldp        enabled         enabled         enabled           1073741824      kube
+nat         enabled         enabled         enabled           1073741824      local
+pmon        enabled         enabled         enabled           1073741824      kube
+radv        enabled         enabled         enabled           1073741824      kube
+restapi     disabled        enabled         enabled           1073741824      local
+sflow       disabled        enabled         enabled           1073741824      local
+snmp        enabled         enabled         enabled           1073741824      kube
+swss        enabled         enabled         enabled           1073741824      local
+syncd       enabled         enabled         enabled           1073741824      local
+teamd       enabled         enabled         enabled           1073741824      local
+telemetry   enabled         enabled         enabled           1073741824      kube
 """
 
 show_feature_status_output_with_remote_mgmt="""\
-Feature     State           AutoRestart     SystemState    UpdateTime           ContainerId    Version       SetOwner    CurrentOwner    RemoteState
-----------  --------------  --------------  -------------  -------------------  -------------  ------------  ----------  --------------  -------------
-bgp         enabled         enabled                                                                          local
-database    always_enabled  always_enabled                                                                   local
-dhcp_relay  enabled         enabled                                                                          kube
-lldp        enabled         enabled                                                                          kube
-nat         enabled         enabled                                                                          local
-pmon        enabled         enabled                                                                          kube
-radv        enabled         enabled                                                                          kube
-restapi     disabled        enabled                                                                          local
-sflow       disabled        enabled                                                                          local
-snmp        enabled         enabled         up             2020-11-12 23:32:56  aaaabbbbcccc   20201230.100  kube        kube            kube
-swss        enabled         enabled                                                                          local
-syncd       enabled         enabled                                                                          local
-teamd       enabled         enabled                                                                          local
-telemetry   enabled         enabled                                                                          kube
+Feature     State           AutoRestart     HighMemAlert      MemThreshold    SystemState    UpdateTime           ContainerId    Version       SetOwner    CurrentOwner    RemoteState
+----------  --------------  --------------  ----------------  --------------  -------------  -------------------  -------------  ------------  ----------  --------------  -------------
+bgp         enabled         enabled         enabled           1073741824                                                                       local
+database    always_enabled  always_enabled  enabled           1073741824                                                                       local
+dhcp_relay  enabled         enabled         enabled           1073741824                                                                       kube
+lldp        enabled         enabled         enabled           1073741824                                                                       kube
+nat         enabled         enabled         enabled           1073741824                                                                       local
+pmon        enabled         enabled         enabled           1073741824                                                                       kube
+radv        enabled         enabled         enabled           1073741824                                                                       kube
+restapi     disabled        enabled         enabled           1073741824                                                                       local
+sflow       disabled        enabled         enabled           1073741824                                                                       local
+snmp        enabled         enabled         enabled           1073741824      up             2020-11-12 23:32:56  aaaabbbbcccc   20201230.100  kube        kube            kube
+swss        enabled         enabled         enabled           1073741824                                                                       local
+syncd       enabled         enabled         enabled           1073741824                                                                       local
+teamd       enabled         enabled         enabled           1073741824                                                                       local
+telemetry   enabled         enabled         enabled           1073741824                                                                       kube
 """
 
 show_feature_config_output="""\
-Feature     State     AutoRestart
-----------  --------  -------------
-bgp         enabled   enabled
-database    enabled   disabled
-dhcp_relay  enabled   enabled
-lldp        enabled   enabled
-nat         enabled   enabled
-pmon        enabled   enabled
-radv        enabled   enabled
-restapi     disabled  enabled
-sflow       disabled  enabled
-snmp        enabled   enabled
-swss        enabled   enabled
-syncd       enabled   enabled
-teamd       enabled   enabled
-telemetry   enabled   enabled
+Feature     State     AutoRestart    HighMemAlert      MemThreshold
+----------  --------  -------------  ----------------  --------------
+bgp         enabled   enabled        enabled           1073741824
+database    enabled   disabled       enabled           1073741824
+dhcp_relay  enabled   enabled        enabled           1073741824
+lldp        enabled   enabled        enabled           1073741824
+nat         enabled   enabled        enabled           1073741824
+pmon        enabled   enabled        enabled           1073741824
+radv        enabled   enabled        enabled           1073741824
+restapi     disabled  enabled        enabled           1073741824
+sflow       disabled  enabled        enabled           1073741824
+snmp        enabled   enabled        enabled           1073741824
+swss        enabled   enabled        enabled           1073741824
+syncd       enabled   enabled        enabled           1073741824
+teamd       enabled   enabled        enabled           1073741824
+telemetry   enabled   enabled        enabled           1073741824
 """
 
 show_feature_config_output_with_remote_mgmt="""\
-Feature     State           AutoRestart     Owner
-----------  --------------  --------------  -------
-bgp         enabled         enabled         local
-database    always_enabled  always_enabled  local
-dhcp_relay  enabled         enabled         kube
-lldp        enabled         enabled         kube
-nat         enabled         enabled         local
-pmon        enabled         enabled         kube
-radv        enabled         enabled         kube
-restapi     disabled        enabled         local
-sflow       disabled        enabled         local
-snmp        enabled         enabled         kube
-swss        enabled         enabled         local
-syncd       enabled         enabled         local
-teamd       enabled         enabled         local
-telemetry   enabled         enabled         kube
+Feature     State           AutoRestart     HighMemAlert      MemThreshold    Owner
+----------  --------------  --------------  ----------------  --------------  -------
+bgp         enabled         enabled         enabled           1073741824      local
+database    always_enabled  always_enabled  enabled           1073741824      local
+dhcp_relay  enabled         enabled         enabled           1073741824      kube
+lldp        enabled         enabled         enabled           1073741824      kube
+nat         enabled         enabled         enabled           1073741824      local
+pmon        enabled         enabled         enabled           1073741824      kube
+radv        enabled         enabled         enabled           1073741824      kube
+restapi     disabled        enabled         enabled           1073741824      local
+sflow       disabled        enabled         enabled           1073741824      local
+snmp        enabled         enabled         enabled           1073741824      kube
+swss        enabled         enabled         enabled           1073741824      local
+syncd       enabled         enabled         enabled           1073741824      local
+teamd       enabled         enabled         enabled           1073741824      local
+telemetry   enabled         enabled         enabled           1073741824      kube
 """
 
 show_feature_bgp_status_output="""\
-Feature    State    AutoRestart    SetOwner
----------  -------  -------------  ----------
-bgp        enabled  enabled        local
+Feature    State    AutoRestart    HighMemAlert    MemThreshold    SetOwner
+---------  -------  -------------  --------------  --------------  ---------
+bgp        enabled  enabled        enabled         1073741824      local
 """
 
 show_feature_bgp_disabled_status_output="""\
-Feature    State     AutoRestart    SetOwner
----------  --------  -------------  ----------
-bgp        disabled  enabled        local
+Feature    State     AutoRestart   HighMemAlert   MemThreshold    SetOwner
+---------  --------  ------------  -------------  --------------  ----------
+bgp        disabled  enabled       enabled        1073741824      local
 """
 show_feature_snmp_config_owner_output="""\
-Feature    State    AutoRestart    Owner    fallback
----------  -------  -------------  -------  ----------
-snmp       enabled  enabled        local    true
+Feature    State    AutoRestart    HighMemAlert   MemThreshold    Owner    fallback
+---------  -------  -------------  -------------  --------------  -------  ----------
+snmp       enabled  enabled        enabled        1073741824      local    true
 """
 
 show_feature_snmp_config_fallback_output="""\
-Feature    State    AutoRestart    Owner    fallback
----------  -------  -------------  -------  ----------
-snmp       enabled  enabled        kube     false
+Feature    State    AutoRestart    HighMemAlert   MemThreshold    Owner    fallback
+---------  -------  -------------  -------------  --------------  -------  ----------
+snmp       enabled  enabled        enabled        1073741824      kube     false
 """
 
 show_feature_autorestart_output="""\
@@ -133,7 +133,6 @@ Feature    AutoRestart
 bgp        enabled
 """
 
-
 show_feature_bgp_disabled_autorestart_output="""\
 Feature    AutoRestart
 ---------  -------------
@@ -151,9 +150,61 @@ Feature    AutoRestart
 ---------  --------------
 database   always_enabled
 """
+
 config_feature_bgp_inconsistent_state_output="""\
 Feature 'bgp' state is not consistent across namespaces
 """
+
+show_feature_high_mem_alert="""\
+Feature     HighMemAlert
+----------  ----------------
+bgp         enabled
+database    enabled
+dhcp_relay  enabled
+lldp        enabled
+nat         enabled
+pmon        enabled
+radv        enabled
+restapi     enabled
+sflow       enabled
+snmp        enabled
+swss        enabled
+syncd       enabled
+teamd       enabled
+telemetry   enabled
+"""
+
+show_feature_high_mem_alert_lldp="""\
+Feature    HighMemRestart
+---------  ----------------
+lldp       enabled
+"""
+
+show_feature_mem_threshold="""\
+Feature     MemThreshold
+----------  --------------
+bgp         1073741824
+database    1073741824
+dhcp_relay  1073741824
+lldp        1073741824
+nat         1073741824
+pmon        1073741824
+radv        1073741824
+restapi     1073741824
+sflow       1073741824
+snmp        1073741824
+swss        1073741824
+syncd       1073741824
+teamd       1073741824
+telemetry   1073741824
+"""
+
+show_feature_mem_threshold_lldp="""\
+Feature    MemThreshold
+---------  --------------
+lldp       1073741824
+"""
+
 config_feature_bgp_inconsistent_autorestart_output="""\
 Feature 'bgp' auto-restart is not consistent across namespaces
 """
@@ -237,6 +288,52 @@ class TestFeature(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_feature_autorestart_output
+
+    def test_show_feature_high_mem_restart(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_mem_alert
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["lldp"])
+        print(result.exit_code)
+        print(result.output)
+        print(show_feature_high_mem_alert_lldp)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_mem_alert_lldp
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["not_existing_container"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 3
+
+    def test_show_feature_mem_threshold(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_mem_threshold
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["lldp"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_mem_threshold_lldp
+
+        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["non_existing_container"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 5
+
 
     def test_fail_autorestart(self, get_cmd_module):
         (config, show) = get_cmd_module

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -10,102 +10,102 @@ from utilities_common.db import Db
 from swsscommon import swsscommon
 
 show_feature_status_output="""\
-Feature     State           AutoRestart     HighMemAlert      MemThreshold    SetOwner
-----------  --------------  --------------  ----------------  --------------  ----------
-bgp         enabled         enabled         enabled           1073741824      local
-database    always_enabled  always_enabled  enabled           1073741824      local
-dhcp_relay  enabled         enabled         enabled           1073741824      kube
-lldp        enabled         enabled         enabled           1073741824      kube
-nat         enabled         enabled         enabled           1073741824      local
-pmon        enabled         enabled         enabled           1073741824      kube
-radv        enabled         enabled         enabled           1073741824      kube
-restapi     disabled        enabled         enabled           1073741824      local
-sflow       disabled        enabled         enabled           1073741824      local
-snmp        enabled         enabled         enabled           1073741824      kube
-swss        enabled         enabled         enabled           1073741824      local
-syncd       enabled         enabled         enabled           1073741824      local
-teamd       enabled         enabled         enabled           1073741824      local
-telemetry   enabled         enabled         enabled           1073741824      kube
+Feature     State           AutoRestart     HighMemAlert    MemThreshold    SetOwner
+----------  --------------  --------------  --------------  --------------  ----------
+bgp         enabled         enabled         enabled         1073741824      local
+database    always_enabled  always_enabled  enabled         1073741824      local
+dhcp_relay  enabled         enabled         enabled         1073741824      kube
+lldp        enabled         enabled         enabled         1073741824      kube
+nat         enabled         enabled         enabled         1073741824      local
+pmon        enabled         enabled         enabled         1073741824      kube
+radv        enabled         enabled         enabled         1073741824      kube
+restapi     disabled        enabled         enabled         1073741824      local
+sflow       disabled        enabled         enabled         1073741824      local
+snmp        enabled         enabled         enabled         1073741824      kube
+swss        enabled         enabled         enabled         1073741824      local
+syncd       enabled         enabled         enabled         1073741824      local
+teamd       enabled         enabled         enabled         1073741824      local
+telemetry   enabled         enabled         enabled         1073741824      kube
 """
 
 show_feature_status_output_with_remote_mgmt="""\
-Feature     State           AutoRestart     HighMemAlert      MemThreshold    SystemState    UpdateTime           ContainerId    Version       SetOwner    CurrentOwner    RemoteState
-----------  --------------  --------------  ----------------  --------------  -------------  -------------------  -------------  ------------  ----------  --------------  -------------
-bgp         enabled         enabled         enabled           1073741824                                                                       local
-database    always_enabled  always_enabled  enabled           1073741824                                                                       local
-dhcp_relay  enabled         enabled         enabled           1073741824                                                                       kube
-lldp        enabled         enabled         enabled           1073741824                                                                       kube
-nat         enabled         enabled         enabled           1073741824                                                                       local
-pmon        enabled         enabled         enabled           1073741824                                                                       kube
-radv        enabled         enabled         enabled           1073741824                                                                       kube
-restapi     disabled        enabled         enabled           1073741824                                                                       local
-sflow       disabled        enabled         enabled           1073741824                                                                       local
-snmp        enabled         enabled         enabled           1073741824      up             2020-11-12 23:32:56  aaaabbbbcccc   20201230.100  kube        kube            kube
-swss        enabled         enabled         enabled           1073741824                                                                       local
-syncd       enabled         enabled         enabled           1073741824                                                                       local
-teamd       enabled         enabled         enabled           1073741824                                                                       local
-telemetry   enabled         enabled         enabled           1073741824                                                                       kube
+Feature     State           AutoRestart     HighMemAlert    MemThreshold    SystemState    UpdateTime           ContainerId    Version       SetOwner    CurrentOwner    RemoteState
+----------  --------------  --------------  --------------  --------------  -------------  -------------------  -------------  ------------  ----------  --------------  -------------
+bgp         enabled         enabled         enabled         1073741824                                                                       local
+database    always_enabled  always_enabled  enabled         1073741824                                                                       local
+dhcp_relay  enabled         enabled         enabled         1073741824                                                                       kube
+lldp        enabled         enabled         enabled         1073741824                                                                       kube
+nat         enabled         enabled         enabled         1073741824                                                                       local
+pmon        enabled         enabled         enabled         1073741824                                                                       kube
+radv        enabled         enabled         enabled         1073741824                                                                       kube
+restapi     disabled        enabled         enabled         1073741824                                                                       local
+sflow       disabled        enabled         enabled         1073741824                                                                       local
+snmp        enabled         enabled         enabled         1073741824      up             2020-11-12 23:32:56  aaaabbbbcccc   20201230.100  kube        kube            kube
+swss        enabled         enabled         enabled         1073741824                                                                       local
+syncd       enabled         enabled         enabled         1073741824                                                                       local
+teamd       enabled         enabled         enabled         1073741824                                                                       local
+telemetry   enabled         enabled         enabled         1073741824                                                                       kube
 """
 
 show_feature_config_output="""\
-Feature     State     AutoRestart    HighMemAlert      MemThreshold
-----------  --------  -------------  ----------------  --------------
-bgp         enabled   enabled        enabled           1073741824
-database    enabled   disabled       enabled           1073741824
-dhcp_relay  enabled   enabled        enabled           1073741824
-lldp        enabled   enabled        enabled           1073741824
-nat         enabled   enabled        enabled           1073741824
-pmon        enabled   enabled        enabled           1073741824
-radv        enabled   enabled        enabled           1073741824
-restapi     disabled  enabled        enabled           1073741824
-sflow       disabled  enabled        enabled           1073741824
-snmp        enabled   enabled        enabled           1073741824
-swss        enabled   enabled        enabled           1073741824
-syncd       enabled   enabled        enabled           1073741824
-teamd       enabled   enabled        enabled           1073741824
-telemetry   enabled   enabled        enabled           1073741824
+Feature     State     AutoRestart    HighMemAlert    MemThreshold
+----------  --------  -------------  --------------  --------------
+bgp         enabled   enabled        enabled         1073741824
+database    enabled   disabled       enabled         1073741824
+dhcp_relay  enabled   enabled        enabled         1073741824
+lldp        enabled   enabled        enabled         1073741824
+nat         enabled   enabled        enabled         1073741824
+pmon        enabled   enabled        enabled         1073741824
+radv        enabled   enabled        enabled         1073741824
+restapi     disabled  enabled        enabled         1073741824
+sflow       disabled  enabled        enabled         1073741824
+snmp        enabled   enabled        enabled         1073741824
+swss        enabled   enabled        enabled         1073741824
+syncd       enabled   enabled        enabled         1073741824
+teamd       enabled   enabled        enabled         1073741824
+telemetry   enabled   enabled        enabled         1073741824
 """
 
 show_feature_config_output_with_remote_mgmt="""\
-Feature     State           AutoRestart     HighMemAlert      MemThreshold    Owner
-----------  --------------  --------------  ----------------  --------------  -------
-bgp         enabled         enabled         enabled           1073741824      local
-database    always_enabled  always_enabled  enabled           1073741824      local
-dhcp_relay  enabled         enabled         enabled           1073741824      kube
-lldp        enabled         enabled         enabled           1073741824      kube
-nat         enabled         enabled         enabled           1073741824      local
-pmon        enabled         enabled         enabled           1073741824      kube
-radv        enabled         enabled         enabled           1073741824      kube
-restapi     disabled        enabled         enabled           1073741824      local
-sflow       disabled        enabled         enabled           1073741824      local
-snmp        enabled         enabled         enabled           1073741824      kube
-swss        enabled         enabled         enabled           1073741824      local
-syncd       enabled         enabled         enabled           1073741824      local
-teamd       enabled         enabled         enabled           1073741824      local
-telemetry   enabled         enabled         enabled           1073741824      kube
+Feature     State           AutoRestart     HighMemAlert    MemThreshold    Owner
+----------  --------------  --------------  --------------  --------------  -------
+bgp         enabled         enabled         enabled         1073741824      local
+database    always_enabled  always_enabled  enabled         1073741824      local
+dhcp_relay  enabled         enabled         enabled         1073741824      kube
+lldp        enabled         enabled         enabled         1073741824      kube
+nat         enabled         enabled         enabled         1073741824      local
+pmon        enabled         enabled         enabled         1073741824      kube
+radv        enabled         enabled         enabled         1073741824      kube
+restapi     disabled        enabled         enabled         1073741824      local
+sflow       disabled        enabled         enabled         1073741824      local
+snmp        enabled         enabled         enabled         1073741824      kube
+swss        enabled         enabled         enabled         1073741824      local
+syncd       enabled         enabled         enabled         1073741824      local
+teamd       enabled         enabled         enabled         1073741824      local
+telemetry   enabled         enabled         enabled         1073741824      kube
 """
 
 show_feature_bgp_status_output="""\
 Feature    State    AutoRestart    HighMemAlert    MemThreshold    SetOwner
----------  -------  -------------  --------------  --------------  ---------
+---------  -------  -------------  --------------  --------------  ----------
 bgp        enabled  enabled        enabled         1073741824      local
 """
 
 show_feature_bgp_disabled_status_output="""\
-Feature    State     AutoRestart   HighMemAlert   MemThreshold    SetOwner
----------  --------  ------------  -------------  --------------  ----------
-bgp        disabled  enabled       enabled        1073741824      local
+Feature    State     AutoRestart    HighMemAlert    MemThreshold    SetOwner
+---------  --------  -------------  --------------  --------------  ----------
+bgp        disabled  enabled        enabled         1073741824      local
 """
 show_feature_snmp_config_owner_output="""\
-Feature    State    AutoRestart    HighMemAlert   MemThreshold    Owner    fallback
----------  -------  -------------  -------------  --------------  -------  ----------
-snmp       enabled  enabled        enabled        1073741824      local    true
+Feature    State    AutoRestart    HighMemAlert    MemThreshold    Owner    fallback
+---------  -------  -------------  --------------  --------------  -------  ----------
+snmp       enabled  enabled        enabled         1073741824      local    true
 """
 
 show_feature_snmp_config_fallback_output="""\
-Feature    State    AutoRestart    HighMemAlert   MemThreshold    Owner    fallback
----------  -------  -------------  -------------  --------------  -------  ----------
-snmp       enabled  enabled        enabled        1073741824      kube     false
+Feature    State    AutoRestart    HighMemAlert    MemThreshold    Owner    fallback
+---------  -------  -------------  --------------  --------------  -------  ----------
+snmp       enabled  enabled        enabled         1073741824      kube     false
 """
 
 show_feature_autorestart_output="""\
@@ -140,9 +140,9 @@ bgp        disabled
 """
 
 show_feature_database_always_enabled_state_output="""\
-Feature    State           AutoRestart     SetOwner
----------  --------------  --------------  ----------
-database   always_enabled  always_enabled  local
+Feature    State           AutoRestart     HighMemAlert    MemThreshold    SetOwner
+---------  --------------  --------------  --------------  --------------  ----------
+database   always_enabled  always_enabled  enabled         1073741824      local
 """
 
 show_feature_database_always_enabled_autorestart_output="""\
@@ -155,9 +155,9 @@ config_feature_bgp_inconsistent_state_output="""\
 Feature 'bgp' state is not consistent across namespaces
 """
 
-show_feature_high_mem_alert="""\
+show_feature_high_memory_alert="""\
 Feature     HighMemAlert
-----------  ----------------
+----------  --------------
 bgp         enabled
 database    enabled
 dhcp_relay  enabled
@@ -174,39 +174,77 @@ teamd       enabled
 telemetry   enabled
 """
 
-show_feature_high_mem_alert_lldp="""\
-Feature    HighMemRestart
----------  ----------------
+show_feature_high_memory_alert_lldp="""\
+Feature    HighMemAlert
+---------  --------------
 lldp       enabled
 """
 
-show_feature_mem_threshold="""\
-Feature     MemThreshold
-----------  --------------
-bgp         1073741824
-database    1073741824
-dhcp_relay  1073741824
-lldp        1073741824
-nat         1073741824
-pmon        1073741824
-radv        1073741824
-restapi     1073741824
-sflow       1073741824
-snmp        1073741824
-swss        1073741824
-syncd       1073741824
-teamd       1073741824
-telemetry   1073741824
+show_feature_high_memory_alert_lldp_disabled="""\
+Feature    HighMemAlert
+---------  --------------
+lldp       disabled
 """
 
-show_feature_mem_threshold_lldp="""\
-Feature    MemThreshold
+show_feature_memory_threshold="""\
+Feature       MemThreshold
+----------  --------------
+bgp             1073741824
+database        1073741824
+dhcp_relay      1073741824
+lldp            1073741824
+nat             1073741824
+pmon            1073741824
+radv            1073741824
+restapi         1073741824
+sflow           1073741824
+snmp            1073741824
+swss            1073741824
+syncd           1073741824
+teamd           1073741824
+telemetry       1073741824
+"""
+
+show_feature_memory_threshold_lldp="""\
+Feature      MemThreshold
 ---------  --------------
-lldp       1073741824
+lldp           1073741824
+"""
+
+show_feature_memory_threshold_lldp_updated="""\
+Feature      MemThreshold
+---------  --------------
+lldp                 2048
+"""
+
+show_feature_high_memory_alert_bgp_disabled_output="""\
+Feature    HighMemAlert
+---------  --------------
+bgp        disabled
+"""
+
+show_feature_high_memory_alert_bgp_enabled_output="""\
+Feature    HighMemAlert
+---------  --------------
+bgp        enabled
+"""
+
+show_feature_memory_threshold_bgp_output="""\
+Feature      MemThreshold
+---------  --------------
+bgp                  2048
 """
 
 config_feature_bgp_inconsistent_autorestart_output="""\
 Feature 'bgp' auto-restart is not consistent across namespaces
+"""
+
+config_feature_high_memory_alert_bgp_inconsistent_output = """\
+High memory alert status of feature 'bgp' is not consistent across different namespaces!
+"""
+
+config_feature_memory_threshold_bgp_inconsistent_output = """\
+Memory threshold of feature 'bgp' is not consistent across different namespaces!
 """
 
 class TestFeature(object):
@@ -289,51 +327,50 @@ class TestFeature(object):
         assert result.exit_code == 0
         assert result.output == show_feature_autorestart_output
 
-    def test_show_feature_high_mem_restart(self, get_cmd_module):
+    def test_show_feature_high_memory_alert(self, get_cmd_module):
         (config, show) = get_cmd_module
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], [])
+        result = runner.invoke(show.cli.commands["feature"].commands["high_memory_alert"], [])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert result.output == show_feature_high_mem_alert
+        assert result.output == show_feature_high_memory_alert
 
-        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["lldp"])
+        result = runner.invoke(show.cli.commands["feature"].commands["high_memory_alert"], ["lldp"])
         print(result.exit_code)
         print(result.output)
-        print(show_feature_high_mem_alert_lldp)
+        print(show_feature_high_memory_alert_lldp)
         assert result.exit_code == 0
-        assert result.output == show_feature_high_mem_alert_lldp
+        assert result.output == show_feature_high_memory_alert_lldp
 
-        result = runner.invoke(show.cli.commands["feature"].commands["high_mem_restart"], ["not_existing_container"])
+        result = runner.invoke(show.cli.commands["feature"].commands["high_memory_alert"], ["not_existing_container"])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 3
 
-    def test_show_feature_mem_threshold(self, get_cmd_module):
+    def test_show_feature_memory_threshold(self, get_cmd_module):
         (config, show) = get_cmd_module
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], [])
+        result = runner.invoke(show.cli.commands["feature"].commands["memory_threshold"], [])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert result.output == show_feature_mem_threshold
+        assert result.output == show_feature_memory_threshold
 
-        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["lldp"])
+        result = runner.invoke(show.cli.commands["feature"].commands["memory_threshold"], ["lldp"])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert result.output == show_feature_mem_threshold_lldp
+        assert result.output == show_feature_memory_threshold_lldp
 
-        result = runner.invoke(show.cli.commands["feature"].commands["mem_threshold"], ["non_existing_container"])
+        result = runner.invoke(show.cli.commands["feature"].commands["memory_threshold"], ["non_existing_container"])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 5
-
 
     def test_fail_autorestart(self, get_cmd_module):
         (config, show) = get_cmd_module
@@ -352,7 +389,6 @@ class TestFeature(object):
         result = runner.invoke(config.config.commands["feature"].commands["autorestart"], ["bgp", "disabled"], obj=db)
         print(result.exit_code)
         assert result.exit_code == 1
-
 
     def test_show_bgp_autorestart_status(self, get_cmd_module):
         (config, show) = get_cmd_module
@@ -495,6 +531,57 @@ class TestFeature(object):
         assert result.exit_code == 0
         assert result.output == show_feature_database_always_enabled_autorestart_output
 
+    def test_config_feature_high_memory_alert_lldp(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["lldp", "disabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_memory_alert"], ["lldp"], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_memory_alert_lldp_disabled
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["non_existing_container", "disabled"], obj=db)
+        print(result.output)
+        assert result.exit_code == 3
+
+        db.cfgdb.delete_table("FEATURE")
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["lldp, diabled"], obj=db)
+        print(result.output)
+        assert result.exit_code == 2
+
+    def test_config_feature_memory_threshold_lldp(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["lldp", "2048"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["memory_threshold"], ["lldp"], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_memory_threshold_lldp_updated
+
+        result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["non_existing_container", "104857600"], obj=db)
+        print(result.output)
+        assert result.exit_code == 6
+
+        db.cfgdb.delete_table("FEATURE")
+
+        result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["lldp", "2048"], obj=db)
+        print(result.output)
+        assert result.exit_code == 5
+
+
     def test_config_unknown_feature(self, get_cmd_module):
         (config, show) = get_cmd_module
         runner = CliRunner()
@@ -550,6 +637,49 @@ class TestFeatureMultiAsic(object):
         assert result.exit_code == 1
         assert result.output == config_feature_bgp_inconsistent_autorestart_output
 
+    def test_config_feature_high_memory_alert_bgp_inconsistent_state(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic_3_asics
+        importlib.reload(mock_multi_asic_3_asics)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["bgp", "disabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 4
+        assert result.output == config_feature_high_memory_alert_bgp_inconsistent_output
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["bgp", "enabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 4
+        assert result.output == config_feature_high_memory_alert_bgp_inconsistent_output
+
+    def test_config_feature_memory_threshold_bgp_inconsistent(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic_3_asics
+        importlib.reload(mock_multi_asic_3_asics)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["bgp", "2048"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 7
+        assert result.output == config_feature_memory_threshold_bgp_inconsistent_output
+
+        result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["bgp", "2048"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 7
+        assert result.output == config_feature_memory_threshold_bgp_inconsistent_output
+
+
     def test_config_bgp_feature_consistent_state(self, get_cmd_module):
         from .mock_tables import dbconnector
         from .mock_tables import mock_multi_asic
@@ -599,6 +729,51 @@ class TestFeatureMultiAsic(object):
         assert result.exit_code == 0
         assert result.output == show_feature_bgp_autorestart_output
 
+    def test_config_feature_high_memory_alert_bgp_consistent_state(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["bgp", "disabled"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_memory_alert"], ["bgp"], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_memory_alert_bgp_disabled_output
+
+        result = runner.invoke(config.config.commands["feature"].commands["high_memory_alert"], ["bgp", "enabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["high_memory_alert"], ["bgp"], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_high_memory_alert_bgp_enabled_output
+
+    def test_config_feature_memory_threshold_bgp_consistent(self, get_cmd_module):
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["feature"].commands["memory_threshold"], ["bgp", "2048"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["feature"].commands["memory_threshold"], ["bgp"], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_memory_threshold_bgp_output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -208,7 +208,8 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled"
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824"
     },
     "VLAN|Vlan1000": {
         "vlanid": "1000"

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -176,7 +176,8 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled"
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824"
     },
     "BGP_INTERNAL_NEIGHBOR|10.1.0.1": {
         "rrclient": "0",

--- a/tests/mock_tables/asic2/config_db.json
+++ b/tests/mock_tables/asic2/config_db.json
@@ -123,6 +123,7 @@
     "FEATURE|bgp": {
         "state": "disabled",
         "auto_restart": "disabled",
-        "high_mem_alert": "disabled"
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824"
     }
 }

--- a/tests/mock_tables/asic2/config_db.json
+++ b/tests/mock_tables/asic2/config_db.json
@@ -123,7 +123,7 @@
     "FEATURE|bgp": {
         "state": "disabled",
         "auto_restart": "disabled",
-        "high_mem_alert": "enabled",
-        "mem_threshold": "1073741824"
+        "high_mem_alert": "disabled",
+        "mem_threshold": "2044"
     }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -716,85 +716,99 @@
     "FEATURE|bgp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|database": {
         "state": "always_enabled",
         "auto_restart": "always_enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|dhcp_relay": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "kube"
     },
     "FEATURE|lldp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "kube"
     },
     "FEATURE|nat": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|pmon": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "kube"
     },
     "FEATURE|radv": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "kube"
     },
     "FEATURE|restapi": {
         "state": "disabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|sflow": {
         "state": "disabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|snmp": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "kube"
     },
     "FEATURE|swss": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|syncd": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|teamd": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "local"
     },
     "FEATURE|telemetry": {
         "state": "enabled",
         "auto_restart": "enabled",
-        "high_mem_alert": "disabled",
+        "high_mem_alert": "enabled",
+        "mem_threshold": "1073741824",
         "set_owner": "kube"
     },
     "DEVICE_METADATA|localhost": {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR aims to propose the implementation of `show/config` commands and users can borrow these two commands to enable/disable high memory alerting and configure memory threshold (maximum memory usage) of each container.

The design proposal is: https://github.com/sonic-net/SONiC/pull/1016

#### How I did it
I added two functions to implement the `show` CLI and `config` CLI respectively such that user can issue the following commands:

`show feature memory_threshold`
`show feature memory_threshold <feature_name>`
`config feature memory_threshold <feature_name> <threshold_value`

`show feature high_memory_alert`
`show feature high_memory_alert <feature_name>`
`config feature high_memory_alert <feature_name> <enabled|disabled>`

#### How to verify it
I verified this change by adding and running the unittest:
        
        tests/feature_test.py::TestFeature::test_show_feature_status_no_kube_status PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_show_feature_status PASSED      [ 33%]
        tests/feature_test.py::TestFeature::test_show_feature_config PASSED      [ 33%]
        tests/feature_test.py::TestFeature::test_show_feature_status_abbrev_cmd PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_show_bgp_feature_status PASSED  [ 33%]
        tests/feature_test.py::TestFeature::test_show_unknown_feature_status PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_show_feature_autorestart PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_show_feature_high_memory_alert PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_show_feature_memory_threshold PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_fail_autorestart PASSED         [ 33%]
        tests/feature_test.py::TestFeature::test_show_bgp_autorestart_status PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_show_unknown_autorestart_status PASSED [ 33%]
        tests/feature_test.py::TestFeature::test_config_bgp_feature_state PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_bgp_feature_state_blocking[disabled-0] PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_bgp_feature_state_blocking[failed-1] PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_snmp_feature_owner PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_unknown_feature_owner PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_snmp_feature_fallback PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_bgp_autorestart PASSED   [ 34%]
        tests/feature_test.py::TestFeature::test_config_database_feature_state PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_database_feature_autorestart PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_feature_high_memory_alert_lldp PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_feature_memory_threshold_lldp PASSED [ 34%]
        tests/feature_test.py::TestFeature::test_config_unknown_feature PASSED   [ 34%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_inconsistent_state PASSED [ 34%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_inconsistent_autorestart PASSED [ 34%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_feature_high_memory_alert_bgp_inconsistent_state PASSED [ 34%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_feature_memory_threshold_bgp_inconsistent PASSED [ 34%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_consistent_state PASSED [ 34%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_bgp_feature_consistent_autorestart PASSED [ 34%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_feature_high_memory_alert_bgp_consistent_state PASSED [ 35%]
        tests/feature_test.py::TestFeatureMultiAsic::test_config_feature_memory_threshold_bgp_consistent PASSED [ 35%]

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

        admin@sonic:~$ show feature high_memory_alert
        feature     HighMemAlert 
        ----------  --------------
        bgp         enabled
        database    enabled
        dhcp_relay  enabled
        lldp        enabled
        pmon        enabled
        radv        enabled
        snmp        enabled
        swss        enabled
        syncd       enabled
        teamd       enabled
        telemetry   enabled

        admin@sonic:~$ show feature high_memory_alert bgp
        feature     HighMemAlert 
        ----------  --------------
        bgp         enabled

        admin@sonic:~$ show feature memory_threshold
        feature      MemThreshold  
        ----------   --------------
        bgp          1073741824    
        database     1073741824    
        dhcp_relay   1073741824    
        lldp         1073741824    
        pmon         1073741824    
        radv         1073741824    
        snmp         1073741824    
        swss         1073741824    
        syncd        1073741824    
        teamd        1073741824    
        telemetry    1073741824 

        admin@sonic:~$ show feature memory_threshold bgp
        feature     MemThreshold
        ----------  --------------
        bgp         1073741824

        admin@sonic:~$ sudo config feature high_memory_alert bgp disabled

        admin@sonic:~$ sudo config feature memory_threshold bgp 1073741824

