### PR TITLE
Remove disabled and not loaded services before calling reset-failed and restart services

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -559,12 +559,11 @@ def _get_disabled_services_list():
 
 def _get_not_loaded_services_list(services_list):
     not_loaded_services_list = []
-    with open(os.devnull, 'w') as devnull:
-        for service in services_list:
-            command = "sudo systemctl show -p LoadState --value %s" % service
-            status = subprocess.check_output(command, shell=True).decode()
-            if status != "loaded\n":
-                not_loaded_services_list.append(service)
+    for service in services_list:
+        command = "sudo systemctl show -p LoadState --value %s" % service
+        status = subprocess.check_output(command, shell=True).decode()
+        if status != "loaded\n":
+            not_loaded_services_list.append(service)
 
     return not_loaded_services_list
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added logic to remove disabled and not loaded services before calling reset-failed/restart services. Certain services like telemetry can go down and become disabled, which would cause load_minigraph to fail when resetting failed services. Services that are not loaded or disabled should not impact reset or start of other services.

#### How I did it

Added logic to remove services that are disabled or not loaded from the group of listed services for that specific operation. such as resetting failed or restart.

#### How to verify it

Manual testing. Bring down a service such as telemetry via mask or config feature state telemetry disabled, and it should not impact load_minigraph

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

