### PR TITLE
[sflow] Fix sflow polling_interval.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6252,7 +6252,7 @@ def disable(ctx):
 def polling_int(ctx, interval):
     """Set polling-interval for counter-sampling (0 to disable)"""
     if interval not in range(5, 301) and interval != 0:
-        click.echo("Polling interval must be between 5-300 (0 to disable)")
+        ctx.fail("Polling interval must be between 5-300 (0 to disable)")
 
     config_db = ctx.obj['db']
     sflow_tbl = config_db.get_table('SFLOW')

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -206,6 +206,18 @@ class TestShowSflow(object):
         print(result.exit_code, result.output)
         assert result.exit_code == 0
 
+        #set to 301
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["polling-interval"], ["301"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+
+        # run show and check
+        result = runner.invoke(show.cli.commands["sflow"], [], obj=db)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert result.output == show_sflow_output
+
         return
 
     def test_config_sflow_intf_enable_disable(self):


### PR DESCRIPTION
Signed-off-by: liuteng <liuteng@asterfusion.com>

#### What I did
If polling interval is not between 5-300, echo "Polling interval must be between 5-300 (0 to disable)". It should return instead of writing to  db.
#### How I did it
Replace click.echo with ctx.fail in "config sflow polling-interval" command.
#### How to verify it
Added unit test.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

