### PR TITLE
[decode-syseeprom] Fix setting use_db based on support_eeprom_db

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -228,8 +228,6 @@ def main():
 
     (opts, args) = get_cmdline_opts()
 
-    use_db = opts.db and support_eeprom_db
-
     # Get platform name
     platform = device_info.get_platform()
 
@@ -237,6 +235,8 @@ def main():
     platforms_without_eeprom_db = ['.*arista.*', '.*kvm.*']
     if any(re.match(p, platform) for p in platforms_without_eeprom_db):
         support_eeprom_db = False
+
+    use_db = opts.db and support_eeprom_db
 
     if opts.mgmtmac:
         print_mgmt_mac(use_db)

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -192,3 +192,12 @@ CRC-32               0xFE        4  0xAC518FB3
         decode_syseeprom.print_model(True)
         captured = capsys.readouterr()
         assert captured.out == 'S6100-ON\n'
+
+    @mock.patch('os.geteuid', lambda: 0)
+    @mock.patch('sonic_py_common.device_info.get_platform', lambda: 'arista')
+    @mock.patch('decode-syseeprom.read_and_print_eeprom')
+    @mock.patch('decode-syseeprom.read_eeprom_from_db')
+    def test_support_platforms_not_db_based(self, mockDbBased, mockNotDbBased):
+        decode_syseeprom.main()
+        assert mockNotDbBased.called
+        assert not mockDbBased.called


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Set use_db after support_eeprom_db is determined. The issue was affecting platform Arista platforms, where db is not used for syseeprom.

#### How I did it

#### How to verify it
Verified on dut by running "show platform syseeprom" and "decode-syseeprom -d"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

