### PR TITLE
fixing required value validator, and adding replacelane generator

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -399,10 +399,10 @@ class JsonPointerFilter:
         if token == "*":
             matching_keys = config.keys()
         elif token.startswith("*|"):
-            suffix = token[2:]
+            suffix = token[1:] # the suffix will be `|...`
             matching_keys = [key for key in config.keys() if key.endswith(suffix)]
         elif token.endswith("|*"):
-            prefix = token[:-2]
+            prefix = token[:-1] # the prefix will be `...|`
             matching_keys = [key for key in config.keys() if key.startswith(prefix)]
         elif token in config:
             matching_keys = [token]
@@ -543,6 +543,66 @@ class RequiredValueIdentifier:
                 return setting["default_value"]
 
         return None
+
+class LaneReplacementMoveValidator:
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
+    def validate(self, move, diff):
+        current_config = diff.current_config
+        target_config = diff.target_config # Final config after applying whole patch
+
+        if "PORT" not in current_config:
+            return True
+
+        current_ports = current_config["PORT"]
+        if not current_ports:
+            return True
+
+        if "PORT" not in target_config:
+            return True
+
+        target_ports = target_config["PORT"]
+        if not target_ports:
+            return True
+
+        simulated_config = move.apply(current_config) # Config after applying just this move
+
+        for port_name in current_ports:
+            if port_name not in target_ports:
+                continue
+
+            if not self._validate_port(port_name, current_config, target_config, simulated_config):
+                return False
+
+        return True
+
+    def _validate_port(self, port_name, current_config, target_config, simulated_config):
+        current_lanes = self._get_lanes(current_config, port_name)
+        target_lanes = self._get_lanes(target_config, port_name)
+
+        if current_lanes == target_lanes:
+            return True
+
+        simulated_port = self.path_addressing.get_from_path(simulated_config, f"/PORT/{port_name}")
+
+        if simulated_port == None:
+            return True
+
+        current_admin_status = self.path_addressing.get_from_path(current_config, f"/PORT/{port_name}/admin_status")
+        simulated_admin_status = self.path_addressing.get_from_path(simulated_config, f"/PORT/{port_name}/admin_status")
+        if current_admin_status != simulated_admin_status and current_admin_status != "up":
+            return False
+
+        port_path = f"/PORT/{port_name}"
+        for ref_path in self.path_addressing.find_ref_paths(port_path, simulated_config):
+            if not self.path_addressing.has_path(current_config, ref_path):
+                return False
+
+        return True
+
+    def _get_lanes(self, config, port_name):
+        return config["PORT"][port_name].get("lanes", None)
 
 class DeleteWholeConfigMoveValidator:
     """
@@ -921,6 +981,8 @@ class RequiredValueMoveValidator:
                 for required_path, required_value in data[path]:
                     current_value = self.identifier.get_value_or_default(current_config, required_path)
                     simulated_value = self.identifier.get_value_or_default(simulated_config, required_path)
+                    if simulated_value == None: # Simulated config does not have this value at all.
+                        continue
                     if current_value != simulated_value and simulated_value != required_value:
                         return False
 
@@ -999,6 +1061,43 @@ class LowLevelMoveGenerator:
         single_run_generator = SingleRunLowLevelMoveGenerator(diff, self.path_addressing)
         for move in single_run_generator.generate():
             yield move
+
+class LaneReplacementMoveGenerator:
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
+    def generate(self, diff):
+        current_config = diff.current_config
+        target_config = diff.target_config # Final config after applying whole patch
+
+        current_ports = current_config["PORT"]
+        if not current_ports:
+            return
+
+        if "PORT" not in target_config:
+            return
+
+        target_ports = target_config["PORT"]
+        if not target_ports:
+            return
+
+        for port_name in current_ports:
+            if port_name not in target_ports:
+                continue
+
+            current_lanes = self._get_lanes(current_config, port_name)
+            target_lanes = self._get_lanes(target_config, port_name)
+
+            if current_lanes == target_lanes:
+                continue
+
+            port_path = f"/PORT/{port_name}"
+
+            for ref_path in self.path_addressing.find_ref_paths(port_path, current_config):
+                yield JsonMove(diff, OperationType.REMOVE, self.path_addressing.get_path_tokens(ref_path))
+
+    def _get_lanes(self, config, port_name):
+        return config["PORT"][port_name].get("lanes", None)
 
 class SingleRunLowLevelMoveGenerator:
     """
@@ -1271,6 +1370,8 @@ class RequiredValueMoveExtender:
                 for required_path, required_value in data[path]:
                     current_value = self.identifier.get_value_or_default(current_config, required_path)
                     simulated_value = self.identifier.get_value_or_default(simulated_config, required_path)
+                    if simulated_value == None: # Simulated config does not have this value at all.
+                        continue
                     if current_value != simulated_value and simulated_value != required_value:
                         flip_path_value_tuples.add((required_path, required_value))
 
@@ -1473,7 +1574,8 @@ class SortAlgorithmFactory:
         self.path_addressing = path_addressing
 
     def create(self, algorithm=Algorithm.DFS):
-        move_generators = [LowLevelMoveGenerator(self.path_addressing)]
+        move_generators = [LaneReplacementMoveGenerator(self.path_addressing),
+                           LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
         move_non_extendable_generators = [KeyLevelMoveGenerator()]
         move_extenders = [RequiredValueMoveExtender(self.path_addressing, self.operation_wrapper),
@@ -1485,6 +1587,7 @@ class SortAlgorithmFactory:
                            NoDependencyMoveValidator(self.path_addressing, self.config_wrapper),
                            CreateOnlyMoveValidator(self.path_addressing),
                            RequiredValueMoveValidator(self.path_addressing),
+                           LaneReplacementMoveValidator(self.path_addressing),
                            NoEmptyTableMoveValidator(self.path_addressing)]
 
         move_wrapper = MoveWrapper(move_generators, move_non_extendable_generators, move_extenders, move_validators)

--- a/tests/generic_config_updater/files/config_db_with_port_critical.json
+++ b/tests/generic_config_updater/files/config_db_with_port_critical.json
@@ -36,6 +36,23 @@
             "lanes": "41,42,43,44",
             "pfc_asym": "off",
             "speed": "40000"
+        },
+        "Ethernet28": {
+            "alias": "fortyGigE0/28",
+            "description": "Servers5:eth0",
+            "index": "6",
+            "lanes": "53,54,55,56",
+            "pfc_asym": "off",
+            "speed": "40000"
+        },
+        "Ethernet32": {
+            "alias": "fortyGigE0/32",
+            "description": "Servers6:eth0",
+            "index": "7",
+            "lanes": "57,58,59,60",
+            "mtu": "9100",
+            "pfc_asym": "off",
+            "speed": "40000"
         }
     },
     "BUFFER_PG": {
@@ -43,6 +60,9 @@
             "profile": "ingress_lossy_profile"
         },
         "Ethernet12|0": {
+            "profile": "ingress_lossy_profile"
+        },
+        "Ethernet28|0": {
             "profile": "ingress_lossy_profile"
         }
     }


### PR DESCRIPTION
#### What I did
Fixes #2263

What is the problem?
* Lanes is create-only field, so the parent `/PORT/Ethernet124` for example needs to be deleted then added.
* Deletion of the `/PORT/Ethernet124` requires deletion of all of its dependencies.
* In the DUT there are around 18 different dependencies
* The search algorithm to find the moves to apply is not very efficient in this case, what it does is find the first dependency delete it. Then it will try to add the dependency back because it thinks this will bring us closer to the final goal config. But then it realizes adding the config back, will bring us back to a visited state. So we move on and try to delete another dependency, after that the search algorithm will try to add the first dependency, but this time the config state was not visited before because that's a new state.

Check the following to better understand:
initial state:
```
port ethernet124
dep1
dep2
dep3
```
Deletion dep1
```
port ethernet124
dep2
dep3
```
Adding dep1 back will rejected, because it will move us back to the initial state
Try and delete dep2
```
port ethernet124
dep3
```
Try and add dep1
```
port ethernet124
dep1
dep3
```
Now the above is a valid state, but it is useless. If you can expand that to 18 dependencies we end up with a lot of tries that are useless.

Solution is to add a custom validator that understand that once a dependency is deleted, do not add it back until we delete the `/PORT/Ethernet124`

Also add a generator for the deletion to make it faster to pick the dependencies to remove.

#### How I did it
Added new validator/generator for handling the lane replacement case. The validator/generator understand that for lane replacement the port and its dependencies need to be removed.

#### How to verify it
UTs TBA

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

