### PR TITLE
Loads db config during load_port_config

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -20,6 +20,7 @@ from swsscommon.swsscommon import SonicV2Connector
 from natsort import natsorted
 from sonic_py_common import device_info, logger, multi_asic
 from tabulate import tabulate
+from utilities_common.general import load_db_config
 
 VERSION = '3.0'
 
@@ -575,6 +576,7 @@ def load_sfputilhelper():
 
 def load_port_config():
     try:
+        load_db_config()
         if multi_asic.is_multi_asic():
             # For multi ASIC platforms we pass DIR of port_config_file_path and the number of asics
             (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed invalid namespace issues that would occur when making sfputil CLI calls.

#### How I did it
Made a call to `load_db_config()` in `load_port_config()`

#### How to verify it
```bash
sfputil show presence
```

#### Previous command output (if the output of a command-line utility has changed)
```bash
root@sonic:/home/cisco# sfputil show presence
Error reading port info (:- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig)
```
#### New command output (if the output of a command-line utility has changed)
```bash
root@sonic:/home/cisco# sfputil show presence
Port        Presence
----------  -----------
Ethernet18  Not present
Ethernet38  Not present
Ethernet45  Not present
Ethernet41  Not present
Ethernet44  Not present
Ethernet47  Not present
Ethernet28  Not present
Ethernet36  Not present
Ethernet7   Present
Ethernet19  Not present
Ethernet16  Not present
Ethernet25  Not present
Ethernet29  Not present
Ethernet43  Not present
Ethernet32  Not present
Ethernet33  Not present
Ethernet11  Not present
Ethernet2   Not present
Ethernet10  Not present
Ethernet6   Present
Ethernet22  Not present
Ethernet42  Not present
Ethernet37  Not present
Ethernet5   Present
Ethernet30  Not present
Ethernet9   Not present
Ethernet14  Not present
Ethernet26  Not present
Ethernet46  Not present
Ethernet31  Not present
Ethernet35  Not present
Ethernet17  Not present
Ethernet4   Not present
Ethernet8   Present
Ethernet1   Not present
Ethernet20  Not present
Ethernet24  Not present
Ethernet23  Not present
Ethernet27  Not present
Ethernet40  Not present
Ethernet3   Not present
Ethernet12  Not present
Ethernet21  Not present
Ethernet0   Present
Ethernet39  Not present
Ethernet34  Not present
Ethernet13  Not present
Ethernet15  Not present
```