### PR TITLE
Fix version in db_migrator  for `PORT_QOS_MAP|global`

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_3_0_6'
+        self.CURRENT_VERSION = 'version_3_0_5'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -617,13 +617,13 @@ class DBMigrator():
             abandon_method = self.mellanox_buffer_migrator.mlnx_abandon_pending_buffer_configuration
             append_method = self.mellanox_buffer_migrator.mlnx_append_item_on_pending_configuration_list
 
-            if self.mellanox_buffer_migrator.mlnx_migrate_buffer_pool_size('version_1_0_6', 'version_3_0_0') \
-               and self.mellanox_buffer_migrator.mlnx_migrate_buffer_profile('version_1_0_6', 'version_3_0_0') \
+            if self.mellanox_buffer_migrator.mlnx_migrate_buffer_pool_size('version_1_0_6', 'version_2_0_0') \
+               and self.mellanox_buffer_migrator.mlnx_migrate_buffer_profile('version_1_0_6', 'version_2_0_0') \
                and (not self.mellanox_buffer_migrator.mlnx_is_buffer_model_dynamic() or \
                     self.migrate_config_db_buffer_tables_for_dynamic_calculation(speed_list, cable_len_list, '0', abandon_method, append_method)) \
                and self.mellanox_buffer_migrator.mlnx_flush_new_buffer_configuration() \
                and self.prepare_dynamic_buffer_for_warm_reboot(buffer_pools, buffer_profiles, buffer_pgs):
-                self.set_version('version_3_0_0')
+                self.set_version('version_2_0_0')
         else:
             self.prepare_dynamic_buffer_for_warm_reboot()
 
@@ -632,8 +632,26 @@ class DBMigrator():
             self.configDB.set_entry('DEVICE_METADATA', 'localhost', metadata)
             log.log_notice('Setting buffer_model to traditional')
 
-            self.set_version('version_3_0_0')
+            self.set_version('version_2_0_0')
 
+        return 'version_2_0_0'
+
+    def version_2_0_0(self):
+        """
+        Version 2_0_0
+        """
+        log.log_info('Handling version_2_0_0')
+        self.migrate_port_qos_map_global()
+        self.set_version('version_2_0_1')
+        return 'version_2_0_1'
+
+    def version_2_0_1(self):
+        """
+        Version 2_0_1.
+        This is the latest version for 202012 branch 
+        """
+        log.log_info('Handling version_2_0_1')
+        self.set_version('version_3_0_0')
         return 'version_3_0_0'
 
     def version_3_0_0(self):
@@ -694,21 +712,14 @@ class DBMigrator():
             if 'pfc_enable' in v:
                 v['pfcwd_sw_enable'] = v['pfc_enable']
                 self.configDB.set_entry('PORT_QOS_MAP', k, v)
+        self.set_version('version_3_0_5')
         return 'version_3_0_5'
 
     def version_3_0_5(self):
         """
-        Version 3_0_5
-        """
-        log.log_info('Handling version_3_0_5')
-        self.migrate_port_qos_map_global()
-        return 'version_3_0_6'
-
-    def version_3_0_6(self):
-        """
         Current latest version. Nothing to do here.
         """
-        log.log_info('Handling version_3_0_6')
+        log.log_info('Handling version_3_0_5')
         return None
 
     def get_version(self):

--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -480,8 +480,8 @@ class MellanoxBufferMigrator():
                                   "spc2_3800-d24c52_t1_pool_shp", "spc2_3800-d28c50_t1_pool_shp"],
             }
         },
-        "version_3_0_0": {
-            # Version 3.0.0 is introduced for dynamic buffer calculation
+        "version_2_0_0": {
+            # Version 2.0.0 is introduced for dynamic buffer calculation
             #
             "pool_mapped_from_old_version": {
                 "spc1_t0_pool": "spc1_pool",

--- a/tests/db_migrator_input/config_db/qos_map_table_expected.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_expected.json
@@ -1,6 +1,6 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_5"
+        "VERSION": "version_3_0_4"
     },
     "PORT_QOS_MAP|Ethernet0": {
         "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",

--- a/tests/db_migrator_input/config_db/qos_map_table_expected.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_expected.json
@@ -1,34 +1,34 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_4"
+        "VERSION": "version_3_0_5"
     },
     "PORT_QOS_MAP|Ethernet0": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "dscp_to_tc_map": "AZURE",
         "pfc_enable": "3,4",
         "pfcwd_sw_enable": "3,4",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     },
     "PORT_QOS_MAP|Ethernet100": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "dscp_to_tc_map": "AZURE",
         "pfc_enable": "3,4",
         "pfcwd_sw_enable": "3,4",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     },
     "PORT_QOS_MAP|Ethernet92": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "dscp_to_tc_map": "AZURE",
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     },
     "PORT_QOS_MAP|Ethernet96": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "dscp_to_tc_map": "AZURE",
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     }
 }
 

--- a/tests/db_migrator_input/config_db/qos_map_table_global_expected.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_global_expected.json
@@ -1,6 +1,6 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_6"
+        "VERSION": "version_2_0_1"
     },
     "DSCP_TO_TC_MAP|AZURE": {
         "0": "0",

--- a/tests/db_migrator_input/config_db/qos_map_table_global_input.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_global_input.json
@@ -1,6 +1,6 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_5"
+        "VERSION": "version_2_0_0"
     },
     "DSCP_TO_TC_MAP|AZURE": {
         "0": "0",

--- a/tests/db_migrator_input/config_db/qos_map_table_input.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_input.json
@@ -1,6 +1,6 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_4"
+        "VERSION": "version_1_0_6"
     },
     "PORT_QOS_MAP|Ethernet0": {
         "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",

--- a/tests/db_migrator_input/config_db/qos_map_table_input.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_input.json
@@ -1,31 +1,31 @@
 {
     "VERSIONS|DATABASE": {
-        "VERSION": "version_1_0_6"
+        "VERSION": "version_3_0_4"
     },
     "PORT_QOS_MAP|Ethernet0": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "dscp_to_tc_map": "AZURE",
         "pfc_enable": "3,4",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     },
     "PORT_QOS_MAP|Ethernet100": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
+        "dscp_to_tc_map": "AZURE",
         "pfc_enable": "3,4",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     },
     "PORT_QOS_MAP|Ethernet92": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "dscp_to_tc_map": "AZURE",
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     },
     "PORT_QOS_MAP|Ethernet96": {
-        "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
-        "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
-        "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-        "tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
+        "dscp_to_tc_map": "AZURE",
+        "pfc_to_queue_map": "AZURE",
+        "tc_to_pg_map": "AZURE",
+        "tc_to_queue_map": "AZURE"
     }
 }

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
@@ -2043,6 +2043,6 @@
         "admin_status": "up"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_4"
+        "VERSION": "version_3_0_5"
     }
 }

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -400,6 +400,7 @@ class TestGlobalDscpToTcMapMigrator(object):
 
         diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
         assert not diff
+        assert dbmgtr.configDB.get_table('VERSIONS') == expected_db.cfgdb.get_table('VERSIONS')
 
         # Check port_qos_map|global is not generated on mellanox asic
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'qos_map_table_global_input')
@@ -409,4 +410,5 @@ class TestGlobalDscpToTcMapMigrator(object):
         dbmgtr_mlnx.migrate()
         resulting_table = dbmgtr_mlnx.configDB.get_table('PORT_QOS_MAP')
         assert resulting_table == {}
+        assert dbmgtr.configDB.get_table('VERSIONS') == expected_db.cfgdb.get_table('VERSIONS')
 

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -400,7 +400,6 @@ class TestGlobalDscpToTcMapMigrator(object):
 
         diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
         assert not diff
-        assert dbmgtr.configDB.get_table('VERSIONS') == expected_db.cfgdb.get_table('VERSIONS')
 
         # Check port_qos_map|global is not generated on mellanox asic
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'qos_map_table_global_input')
@@ -410,5 +409,4 @@ class TestGlobalDscpToTcMapMigrator(object):
         dbmgtr_mlnx.migrate()
         resulting_table = dbmgtr_mlnx.configDB.get_table('PORT_QOS_MAP')
         assert resulting_table == {}
-        assert dbmgtr.configDB.get_table('VERSIONS') == expected_db.cfgdb.get_table('VERSIONS')
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to fix the db_migrator version for table `PORT_QOS_MAP|global`.

Because the migrator version for table `PORT_QOS_MAP|global` is `version_2_0_0` in `202012` branch (PR #2215), we should use the same version in `master` and `202205` branch to be compatible.

#### How I did it
Change the migrator version for table `PORT_QOS_MAP|global` from `version_3_0_5` to `version_2_0_0` .

#### How to verify it
Verified by UT.
```
collected 78 items                                                                                                                                                                                    

tests/db_migrator_test.py ..............................................................................                                                                                        [100%]

===================================================================================== 78 passed in 21.88 seconds ======================================================================================
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

