### PR TITLE
[static route] Modify the condition statement of "static route entry already exists" in "con…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5246,7 +5246,8 @@ def add_route(ctx, command_str):
 
     # Check if exist entry with key
     keys = config_db.get_keys('STATIC_ROUTE')
-    if key in keys:
+    prefix_tuple = tuple(key.split('|'))
+    if key in keys or prefix_tuple in keys:
         # If exist update current entry
         current_entry = config_db.get_entry('STATIC_ROUTE', key)
 


### PR DESCRIPTION
Signed-off-by: liuteng <liuteng@asterfusion.com>

#### What I did
There is a small problem in the condition statement of "static route entry already exists". It doesn't handle vrf ecmp.
#### How I did it
modify the condition to handle vrf ecmp.
#### How to verify it
Added unit tests.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

