### PR TITLE
Fix GCU bug when backend service modifying config

### DIFF
--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -147,8 +147,8 @@ class ChangeApplier:
         ret = self._services_validate(run_data, upd_data, upd_keys)
         if not ret:
             run_data = self._get_running_config()
-            upd_data = self.get_config_without_backend_tables(upd_data)
-            run_data = self.get_config_without_backend_tables(run_data)
+            self.remove_backend_tables_from_config(upd_data)
+            self.remove_backend_tables_from_config(run_data)
             if upd_data != run_data:
                 self._report_mismatch(run_data, upd_data)
                 ret = -1
@@ -157,11 +157,9 @@ class ChangeApplier:
         return ret
 
 
-    def get_config_without_backend_tables(self, data):
-        cropped_data = {
-            k: v for k, v in data.items() if k not in self.backend_tables
-        }
-        return cropped_data
+    def remove_backend_tables_from_config(self, data):
+        for key in self.backend_tables:
+            data.pop(key, None)
 
 
     def _get_running_config(self):

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -77,6 +77,8 @@ class PatchApplier:
         # Validate config updated successfully
         self.logger.log_notice("Verifying patch updates are reflected on ConfigDB.")
         new_config = self.config_wrapper.get_config_db_as_json()
+        target_config = self.changeapplier.get_config_without_backend_tables(target_config)
+        new_config = self.changeapplier.get_config_without_backend_tables(new_config)
         if not(self.patch_wrapper.verify_same_json(target_config, new_config)):
             raise GenericConfigUpdaterError(f"After applying patch to config, there are still some parts not updated")
 

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -77,8 +77,8 @@ class PatchApplier:
         # Validate config updated successfully
         self.logger.log_notice("Verifying patch updates are reflected on ConfigDB.")
         new_config = self.config_wrapper.get_config_db_as_json()
-        target_config = self.changeapplier.get_config_without_backend_tables(target_config)
-        new_config = self.changeapplier.get_config_without_backend_tables(new_config)
+        self.changeapplier.remove_backend_tables_from_config(target_config)
+        self.changeapplier.remove_backend_tables_from_config(new_config)
         if not(self.patch_wrapper.verify_same_json(target_config, new_config)):
             raise GenericConfigUpdaterError(f"After applying patch to config, there are still some parts not updated")
 

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -73,8 +73,6 @@ class TestPatchApplier(unittest.TestCase):
 
         changeapplier = Mock()
         changeapplier.apply.side_effect = create_side_effect_dict({(str(changes[0]),): 0, (str(changes[1]),): 0})
-        changeapplier.get_config_without_backend_tables.side_effect = \
-            [Files.CONFIG_DB_AFTER_MULTI_PATCH, Files.CONFIG_DB_AFTER_MULTI_PATCH]
 
         return gu.PatchApplier(patchsorter, changeapplier, config_wrapper, patch_wrapper)
 

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -73,6 +73,8 @@ class TestPatchApplier(unittest.TestCase):
 
         changeapplier = Mock()
         changeapplier.apply.side_effect = create_side_effect_dict({(str(changes[0]),): 0, (str(changes[1]),): 0})
+        changeapplier.get_config_without_backend_tables.side_effect = \
+            [Files.CONFIG_DB_AFTER_MULTI_PATCH, Files.CONFIG_DB_AFTER_MULTI_PATCH]
 
         return gu.PatchApplier(patchsorter, changeapplier, config_wrapper, patch_wrapper)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Modifying PORT `admin_status` will result in backend service changing the running config. e.g. buffermgrd will modify `BUFFER_PG|EthernetXX|3-4` when one of the EthernetXX in `PORT` table admin down.
This PR is to skip comparison of config that is possiblly being modified by backend service

#### What I did
Fixes https://github.com/sonic-net/sonic-buildimage/issues/11576
#### How I did it
Add a workaround to only compare config without backend service impact.
#### How to verify it
Manual test on specific platform and check operation success.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

