### PR TITLE
Fix bug with checking VRF's routes in route_check.py 

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -281,7 +281,10 @@ def get_routes():
 
     valid_rt = []
     for k in keys:
-        if not is_vrf(k) and not is_local(k):
+        if (is_vrf(k)):
+            k = k.split(":", 1)[1]
+
+        if not is_local(k):
             valid_rt.append(add_prefix_ifnot(k.lower()))
 
     print_message(syslog.LOG_DEBUG, json.dumps({"ROUTE_TABLE": sorted(valid_rt)}, indent=4))

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -293,6 +293,33 @@ test_data = {
                 }
             }
         }
+    },
+    "7": {
+        DESCR: "Good one with VRF routes",
+        ARGS: "route_check",
+        PRE: {
+            APPL_DB: {
+                ROUTE_TABLE: {
+                    "Vrf1:0.0.0.0/0" : { "ifname": "portchannel0" },
+                    "Vrf1:10.10.196.12/31" : { "ifname": "portchannel0" },
+                    "Vrf1:10.10.196.20/31" : { "ifname": "portchannel0" }
+                },
+                INTF_TABLE: {
+                    "PortChannel1013:10.10.196.24/31": {},
+                    "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                    "PortChannel1024": {}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Petro Bratash <petrox.bratash@intel.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add capability to check routes with VRF

#### How I did it
All routes in VRF have a specific prefix in name.

**_Route table when we have VRF:_**
```
admin@igk-5-dut:~$ redis-cli -n 0 keys "ROUTE_TABLE*" 
    1) "ROUTE_TABLE:Vrf2:20c0:cb50:0:80::/64"
    2) "ROUTE_TABLE:Vrf2:192.211.48.0/25"
    3) "ROUTE_TABLE:Vrf1:192.246.8.128/25"
    4) "ROUTE_TABLE:Vrf1:192.222.8.0/25"
    5) "ROUTE_TABLE:Vrf2:192.246.64.0/25"
    .......
```

**_Route table without VRF:_**
```
admin@cab18-2-dut:~$ redis-cli -n 0 keys "ROUTE_TABLE*"
1) "ROUTE_TABLE:192.168.0.0/21"
2) "ROUTE_TABLE:10.1.0.32"
3) "ROUTE_TABLE:fc02:1000::/64"
4) "ROUTE_TABLE:fe80::/64"
5) "ROUTE_TABLE:fc00:1::32"
.......
```
Remove **_Vrf_** prefix from route. Without Vrf, we can compare routes from APP and ASIC DB.



#### How to verify it
Run next command on SONiC:
1. `sudo config vrf add Vrf1`
2. `sudo config interface vrf bind PortChannel101 Vrf1`
3. `sudo config interface ip add PortChannel101 10.0.0.56/31`
4. `/usr/local/bin/route_check.py`

Also can run SONiC TC  `vrf/test_vrf.py::TestVrfDeletion::test_vrf1_neigh_after_restore` and check syslog 

#### Previous command output (if the output of a command-line utility has changed)
```
$ /usr/local/bin/route_check.py
Failure results: {{
    "Unaccounted_ROUTE_ENTRY_TABLE_entries": [
        "10.0.0.56/31"
    ]
}}
Failed. Look at reported mismatches above
add: []
del: []
```
#### New command output (if the output of a command-line utility has changed)
