### PR TITLE
Fix vrf UT failed issue

### DIFF
--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -190,19 +190,6 @@ class TestConfigIP(object):
         print(result.exit_code, result.output)
         assert result.exit_code == 0
 
-    def test_intf_vrf_bind_unbind(self):
-        runner = CliRunner()
-        db = Db()
-        obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
-
-        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet64", "Vrf1"], obj=obj)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-
-        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet64"], obj=obj)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -177,6 +177,31 @@ class TestConfigIP(object):
         print(result.exit_code, result.output)
         assert "converted ipv6 address to lowercase fc00::1~1126 with prefix /INTERFACE/Ethernet12| in value: /INTERFACE/Ethernet12|FC00::1~1126" in result.output
 
+    def test_intf_vrf_bind_unbind(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
+
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet64", "Vrf1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet64"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+    def test_intf_vrf_bind_unbind(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
+
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet64", "Vrf1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet64"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/dbconnector.py
+++ b/tests/mock_tables/dbconnector.py
@@ -60,6 +60,8 @@ def connect_SonicV2Connector(self, db_name, retry_on=True):
 def _subscribe_keyspace_notification(self, db_name, client):
     pass
 
+def mock_close(self, db_name):
+    pass
 
 def config_set(self, *args):
     pass
@@ -201,6 +203,7 @@ class CounterTable:
 
 
 swsssdk.interface.DBInterface._subscribe_keyspace_notification = _subscribe_keyspace_notification
+swsssdk.interface.DBInterface.close = mock_close
 mockredis.MockRedis.config_set = config_set
 redis.StrictRedis = SwssSyncClient
 SonicV2Connector.connect = connect_SonicV2Connector


### PR DESCRIPTION
#### What I did
    Fix VRF bind/unbind UT failed issue.

#### How I did it
    Mock DBInterface.close() method.

#### How to verify it
    Add new UT.
    Pass all UT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

