### PR TITLE
[config]Fixes mclag subcommand issue

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1212,8 +1212,6 @@ config.add_command(vxlan.vxlan)
 
 #add mclag commands
 config.add_command(mclag.mclag)
-config.add_command(mclag.mclag_member)
-config.add_command(mclag.mclag_unique_ip)
 
 # syslog module
 config.add_command(syslog.syslog)


### PR DESCRIPTION
Signed-off-by: ouxiaolong <ouxiaolong@asterfusion.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The mclag subcommand 'member' and 'unique_ip' has been incorrectly added to the click node of 'config', so we can find commands like this：
```
admin@102:~$ sudo config member -h
Usage: config member [OPTIONS] COMMAND [ARGS]...

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  add  Add member MCLAG interfaces from MCLAG Domain
  del  Delete member MCLAG interfaces from MCLAG Domain

admin@102:~$ sudo config unique-ip -h
Usage: config unique-ip [OPTIONS] COMMAND [ARGS]...

  Configure Unique IP on MCLAG Vlan interface

Options:
  -h, -?, --help  Show this message and exit.

Commands:
  add  Add Unique IP on MCLAG Vlan interface
  del  Delete Unique IP from MCLAG Vlan interface
```

#### How I did it
Remove unnecessary code.

#### How to verify it
Execute these commands will report “No such command”
```
sudo config member -h
sudo config unique-ip -h 
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

