### PR TITLE
Fix issue: exception in is_rj45_port in multi ASIC env

### DIFF
--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -131,10 +131,10 @@ def is_rj45_port(port_name):
         if not platform_porttab_mapping_read:
             platform_sfputil_read_porttab_mappings()
 
-        physical_port = logical_port_name_to_physical_port_list(port_name)[0]
         try:
+            physical_port = logical_port_name_to_physical_port_list(port_name)
             port_type = platform_chassis.get_port_or_cage_type(physical_port)
-        except NotImplementedError as e:
+        except Exception as e:
             port_type = None
 
         return port_type == platform_sfp_base.SFP_PORT_TYPE_BIT_RJ45

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -133,7 +133,8 @@ def is_rj45_port(port_name):
 
         try:
             physical_port = logical_port_name_to_physical_port_list(port_name)
-            port_type = platform_chassis.get_port_or_cage_type(physical_port)
+            if physical_port:
+                port_type = platform_chassis.get_port_or_cage_type(physical_port[0])
         except Exception as e:
             port_type = None
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix issue #2312. On some platforms, `logical_port_name_to_physical_port_list` doesn't return a valid port name list, which causes exception in `is_rj45_port`.
Fix it by catching the exception and treating it as a non-RJ45 port.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

