### PR TITLE
[service_mgmt]: Fix fetch MULTI_INST_DEPENDENT bug in service_mgmt.sh.j2

### DIFF
--- a/sonic-utilities-data/templates/service_mgmt.sh.j2
+++ b/sonic-utilities-data/templates/service_mgmt.sh.j2
@@ -28,7 +28,7 @@ if [[ -f /etc/sonic/${SERVICE}_dependent ]]; then
 fi
 
 if [[ -f /etc/sonic/${SERVICE}_multi_inst_dependent ]]; then
-    MULTI_INST_DEPENDENT="${MULTI_INST_DEPENDENT} cat /etc/sonic/${SERVICE}_multi_inst_dependent"
+    MULTI_INST_DEPENDENT="${MULTI_INST_DEPENDENT} $(cat /etc/sonic/${SERVICE}_multi_inst_dependent)"
 fi
 
 function debug()


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix an obvious script typo in service_mgmt.sh.j2 to fetch the MULTI_INST_DEPENDENT 

#### How I did it
Fix typo

#### How to verify it
Check it manually.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

