### PR TITLE
disk_check: Publish event  for RO state

### DIFF
--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -69,7 +69,6 @@ def event_pub():
     param_dict = FieldValueMap()
     param_dict["fail_type"] = "read_only"
     rc = event_publish(events_handle, EVENTS_PUBLISHER_TAG, param_dict)
-    print("DROP: event_publish rc={}".format(rc))
 
 
 def test_writable(dirs): 

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -68,7 +68,7 @@ def log_debug(m):
 def event_pub():
     param_dict = FieldValueMap()
     param_dict["fail_type"] = "read_only"
-    rc = event_publish(events_handle, EVENTS_PUBLISHER_TAG, param_dict)
+    event_publish(events_handle, EVENTS_PUBLISHER_TAG, param_dict)
 
 
 def test_writable(dirs): 

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -33,17 +33,26 @@ import os
 import sys
 import syslog
 import subprocess
+from swsscommon.swsscommon import events_init_publisher, events_deinit_publisher, event_publish
+from swsscommon.swsscommon import Logger, FieldValueMap
+from sonic_py_common import logger
 
 UPPER_DIR = "/run/mount/upper"
 WORK_DIR = "/run/mount/work"
 MOUNTS_FILE = "/proc/mounts"
 
+EVENTS_PUBLISHER_SOURCE = "sonic-events-host"
+EVENTS_PUBLISHER_TAG = "event-disk"
+events_handle = None
+
+Logger.setMinPrio(Logger.SWSS_INFO)
 chk_log_level = syslog.LOG_ERR
 
 def _log_msg(lvl, pfx, msg):
     if lvl <= chk_log_level:
         print("{}: {}".format(pfx, msg))
         syslog.syslog(lvl, msg)
+
 
 def log_err(m):
     _log_msg(syslog.LOG_ERR, "Err", m)
@@ -57,11 +66,19 @@ def log_debug(m):
     _log_msg(syslog.LOG_DEBUG, "Debug", m)
 
 
+def event_pub():
+    param_dict = FieldValueMap()
+    param_dict["fail_type"] = "read_only"
+    rc = event_publish(events_handle, EVENTS_PUBLISHER_TAG, param_dict)
+    print("DROP: event_publish rc={}".format(rc))
+
+
 def test_writable(dirs): 
     for d in dirs:
         rw = os.access(d, os.W_OK)
         if not rw:
             log_err("{} is not read-write".format(d))
+            event_pub()
             return False
         else:
             log_debug("{} is Read-Write".format(d))
@@ -145,12 +162,13 @@ def do_check(skip_mount, dirs):
     # Check if mounted
     if (not ret) and is_mounted(dirs):
         log_err("READ-ONLY: Mounted {} to make Read-Write".format(dirs))
+        event_pub()
 
     return ret
 
 
 def main():
-    global chk_log_level
+    global chk_log_level, events_handle
 
     parser=argparse.ArgumentParser(
             description="check disk for Read-Write and mount etc & home as Read-Write")
@@ -163,7 +181,12 @@ def main():
     args = parser.parse_args()
 
     chk_log_level = args.loglvl
+
+    events_handle = events_init_publisher(EVENTS_PUBLISHER_SOURCE)
+
     ret = do_check(args.skip_mount, args.dirs.split(","))
+
+    events_deinit_publisher(events_handle)
     return ret
 
 

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -35,7 +35,6 @@ import syslog
 import subprocess
 from swsscommon.swsscommon import events_init_publisher, events_deinit_publisher, event_publish
 from swsscommon.swsscommon import Logger, FieldValueMap
-from sonic_py_common import logger
 
 UPPER_DIR = "/run/mount/upper"
 WORK_DIR = "/run/mount/work"

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -34,7 +34,7 @@ import sys
 import syslog
 import subprocess
 from swsscommon.swsscommon import events_init_publisher, events_deinit_publisher, event_publish
-from swsscommon.swsscommon import Logger, FieldValueMap
+from swsscommon.swsscommon import FieldValueMap
 
 UPPER_DIR = "/run/mount/upper"
 WORK_DIR = "/run/mount/work"
@@ -44,7 +44,6 @@ EVENTS_PUBLISHER_SOURCE = "sonic-events-host"
 EVENTS_PUBLISHER_TAG = "event-disk"
 events_handle = None
 
-Logger.setMinPrio(Logger.SWSS_INFO)
 chk_log_level = syslog.LOG_ERR
 
 def _log_msg(lvl, pfx, msg):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added event_publish for read-only state

#### How I did it
Added API

#### How to verify it
Run this script w/o sudo, which will publish error, as the script can't do write to /etc or /home.
Look for event published and corresponding syslog message.
You may use events_tool or gnmi_cli to capture the event.
The events tool can be obtained from eventd docker /usr/sbin/

Sample message:
"`Aug 18 18:16:02.451626 sonic-switch INFO disk_check.py: :- publish: EVENT_PUBLISHED: {"sonic-events-host:event-disk":{"fail_type":"read_only","timestamp":"2022-08-18T18:16:02.451089Z"}}`"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

