### PR TITLE
Fix issue: port_type is referenced before initialized

### DIFF
--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -131,12 +131,13 @@ def is_rj45_port(port_name):
         if not platform_porttab_mapping_read:
             platform_sfputil_read_porttab_mappings()
 
+        port_type = None
         try:
             physical_port = logical_port_name_to_physical_port_list(port_name)
             if physical_port:
                 port_type = platform_chassis.get_port_or_cage_type(physical_port[0])
         except Exception as e:
-            port_type = None
+            pass
 
         return port_type == platform_sfp_base.SFP_PORT_TYPE_BIT_RJ45
 


### PR DESCRIPTION
Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Followup fixes : https://github.com/sonic-net/sonic-utilities/issues/2312

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

