### PR TITLE
[route_check]: Ignore standalone tunnel routes

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -451,8 +451,16 @@ def filter_out_vnet_routes(routes):
 
 
 def filter_out_standalone_tunnel_routes(routes):
-    db = swsscommon.DBConnector('APPL_DB', 0)
-    neigh_table = swsscommon.Table(db, 'NEIGH_TABLE')
+    config_db = swsscommon.ConfigDBConnector()
+    config_db.connect()
+    device_metadata = config_db.get_table('DEVICE_METADATA')
+    subtype = device_metadata['localhost'].get('subtype', '')
+
+    if subtype.lower() != 'dualtor':
+        return routes
+
+    app_db = swsscommon.DBConnector('APPL_DB', 0)
+    neigh_table = swsscommon.Table(app_db, 'NEIGH_TABLE')
     neigh_keys = neigh_table.getKeys()
     standalone_tunnel_route_ips = []
     updated_routes = []

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -472,6 +472,9 @@ def filter_out_standalone_tunnel_routes(routes):
             neigh_ip = ':'.join(neigh.split(':')[1:])
             standalone_tunnel_route_ips.append(neigh_ip)
 
+    if not standalone_tunnel_route_ips:
+        return routes
+
     for route in routes:
         ip, subnet = route.split('/')
         ip_version = ipaddress.ip_address(ip).version

--- a/scripts/route_check_test.sh
+++ b/scripts/route_check_test.sh
@@ -2,22 +2,36 @@
 
 # add a route, interface & route-entry to simulate error
 #
-sonic-db-cli APPL_DB hmset "ROUTE_TABLE:20c0:d9b8:99:80::/64" "nexthop" "fc00::72,fc00::76,fc00::7a,fc00::7e" "ifname" "PortChannel01,PortChannel02,PortChannel03,PortChannel04"
+sonic-db-cli APPL_DB hmset "ROUTE_TABLE:20c0:d9b8:99:80::/64" "nexthop" "fc00::72,fc00::76,fc00::7a,fc00::7e" "ifname" "PortChannel01,PortChannel02,PortChannel03,PortChannel04" > /dev/null
+sonic-db-cli ASIC_DB hmset "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}" "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID" "oid:0x5000000000614" > /dev/null
+sonic-db-cli APPL_DB hmset  "INTF_TABLE:PortChannel01:10.0.0.99/31" "scope" "global" "family" "IPv4" > /dev/null
 
-
-sonic-db-cli ASIC_DB hmset "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}" "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID" "oid:0x5000000000614"
-
-sonic-db-cli APPL_DB hmset  "INTF_TABLE:PortChannel01:10.0.0.99/31" "scope" "global" "family" "IPv4"
-
-echo "expect errors!\n------\nRunning Route Check...\n"
+echo "------"
+echo "expect errors!"
+echo "Running Route Check..."
 ./route_check.py
 echo "return value: $?"
 
-sonic-db-cli APPL_DB del "ROUTE_TABLE:20c0:d9b8:99:80::/64"
-sonic-db-cli ASIC_DB del "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}"
-sonic-db-cli APPL_DB del "INTF_TABLE:PortChannel01:10.0.0.99/31"
+sonic-db-cli APPL_DB del "ROUTE_TABLE:20c0:d9b8:99:80::/64" > /dev/null
+sonic-db-cli ASIC_DB del "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}" > /dev/null
+sonic-db-cli APPL_DB del "INTF_TABLE:PortChannel01:10.0.0.99/31" > /dev/null
 
+# add standalone tunnel route to simulate unreachable neighbor scenario on dual ToR
+# in this scenario, we expect the route mismatch to be ignored
+sonic-db-cli APPL_DB hmset "NEIGH_TABLE:Vlan1000:fc02:1000::99" "neigh" "00:00:00:00:00:00" "family" "IPv6" > /dev/null
+sonic-db-cli ASIC_DB hmset 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"fc02:1000::99/128","switch_id":"oid:0x21000000000000","vr":"oid:0x300000000007c"}' "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID" "oid:0x400000000167d" "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION" "SAI_PACKET_ACTION_FORWARD" > /dev/null
 
-echo "expect success!\n------\nRunning Route Check...\n"
+echo "------"
+echo "expect success!"
+echo "Running Route Check..."
+./route_check.py
+echo "return value: $?"
+
+sonic-db-cli APPL_DB del "NEIGH_TABLE:Vlan1000:fc02:1000::99" > /dev/null
+sonic-db-cli ASIC_DB del 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"fc02:1000::99/128","switch_id":"oid:0x21000000000000","vr":"oid:0x300000000007c"}' > /dev/null
+
+echo "------"
+echo "expect success!"
+echo "Running Route Check..."
 ./route_check.py
 echo "return value: $?"

--- a/scripts/route_check_test.sh
+++ b/scripts/route_check_test.sh
@@ -22,7 +22,7 @@ sonic-db-cli APPL_DB hmset "NEIGH_TABLE:Vlan1000:fc02:1000::99" "neigh" "00:00:0
 sonic-db-cli ASIC_DB hmset 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"fc02:1000::99/128","switch_id":"oid:0x21000000000000","vr":"oid:0x300000000007c"}' "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID" "oid:0x400000000167d" "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION" "SAI_PACKET_ACTION_FORWARD" > /dev/null
 
 echo "------"
-echo "expect success!"
+echo "expect success on dualtor, expect error on all other devices!"
 echo "Running Route Check..."
 ./route_check.py
 echo "return value: $?"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -222,7 +222,7 @@ class TestConfigReload(object):
             obj = {'config_db': db.cfgdb}
 
             # simulate 'config reload' to provoke load_sys_info option
-            result = runner.invoke(config.config.commands["reload"], ["-l", "-n", "-y"], obj=obj)
+            result = runner.invoke(config.config.commands["reload"], ["-l", "-n", "-y", "--disable_arp_cache"], obj=obj)
 
             print(result.exit_code)
             print(result.output)
@@ -484,7 +484,7 @@ class TestReloadConfig(object):
 
             result = runner.invoke(
                 config.config.commands["reload"],
-                [self.dummy_cfg_file, '-y', '-f'])
+                [self.dummy_cfg_file, '-y', '-f', "--disable_arp_cache"])
 
             print(result.exit_code)
             print(result.output)
@@ -501,7 +501,7 @@ class TestReloadConfig(object):
             (config, show) = get_cmd_module
 
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["reload"], [self.dummy_cfg_file, "-y"])
+            result = runner.invoke(config.config.commands["reload"], [self.dummy_cfg_file, "-y", "--disable_arp_cache"])
 
             print(result.exit_code)
             print(result.output)
@@ -526,7 +526,7 @@ class TestReloadConfig(object):
                             self.dummy_cfg_file)
             result = runner.invoke(
                 config.config.commands["reload"],
-                [cfg_files, '-y', '-f'])
+                [cfg_files, '-y', '-f', "--disable_arp_cache"])
 
             print(result.exit_code)
             print(result.output)
@@ -545,7 +545,7 @@ class TestReloadConfig(object):
             runner = CliRunner()
 
             result = runner.invoke(config.config.commands["reload"],
-                                    [self.dummy_cfg_file, '-y','-f' ,'-t', 'config_yang'])
+                                    [self.dummy_cfg_file, "--disable_arp_cache", '-y', '-f', '-t', 'config_yang'])
 
             print(result.exit_code)
             print(result.output)

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -813,7 +813,8 @@
         "mac": "1d:34:db:16:a6:00",
         "platform": "x86_64-mlnx_msn3800-r0",
         "peer_switch": "sonic-switch",
-        "type": "ToRRouter"
+        "type": "ToRRouter",
+        "subtype": "DualToR"
     },
     "SNMP_COMMUNITY|msft": {
         "TYPE": "RO"

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -333,7 +333,7 @@ test_data = {
             },
             ASIC_DB: {
                 RT_ENTRY_TABLE: {
-                    RT_ENTRY_KEY_PREFIX + "fc02:1000::99" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "fc02:1000::99/128" + RT_ENTRY_KEY_SUFFIX: {},
                 }
             }
         }
@@ -418,6 +418,11 @@ class Table:
     def get(self, key):
         ret = copy.deepcopy(self.data.get(key, {}))
         return (True, ret)
+
+
+    def hget(self, key, field):
+        ret = copy.deepcopy(self.data.get(key, {}).get(field, {}))
+        return True, ret
 
 
 db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB}

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -296,6 +296,22 @@ test_data = {
         }
     },
     "7": {
+        DESCR: "dualtor standalone tunnel route case",
+        ARGS: "route_check",
+        PRE: {
+            APPL_DB: {
+                NEIGH_TABLE: {
+                    "Vlan1000:fc02:1000::99": { "neigh": "00:00:00:00:00:00", "family": "IPv6"}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "fc02:1000::99/128" + RT_ENTRY_KEY_SUFFIX: {},
+                }
+            }
+        }
+    },
+    "8": {
         DESCR: "Good one with VRF routes",
         ARGS: "route_check",
         PRE: {
@@ -318,22 +334,6 @@ test_data = {
                     RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
-                }
-            }
-        }
-    },
-    "8": {
-        DESCR: "dualtor standalone tunnel route case",
-        ARGS: "route_check",
-        PRE: {
-            APPL_DB: {
-                NEIGH_TABLE: {
-                    "Vlan1000:fc02:1000::99": { "neigh": "00:00:00:00:00:00", "family": "IPv6"}
-                }
-            },
-            ASIC_DB: {
-                RT_ENTRY_TABLE: {
-                    RT_ENTRY_KEY_PREFIX + "fc02:1000::99/128" + RT_ENTRY_KEY_SUFFIX: {},
                 }
             }
         }

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -24,6 +24,7 @@ RESULT = "res"
 OP_SET = "SET"
 OP_DEL = "DEL"
 
+NEIGH_TABLE = 'NEIGH_TABLE'
 ROUTE_TABLE = 'ROUTE_TABLE'
 VNET_ROUTE_TABLE = 'VNET_ROUTE_TABLE'
 INTF_TABLE = 'INTF_TABLE'
@@ -317,6 +318,22 @@ test_data = {
                     RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                }
+            }
+        }
+    },
+    "8": {
+        DESCR: "dualtor standalone tunnel route case",
+        ARGS: "route_check",
+        PRE: {
+            APPL_DB: {
+                NEIGH_TABLE: {
+                    "Vlan1000:fc02:1000::99": { "neigh": "00:00:00:00:00:00", "family": "IPv6"}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "fc02:1000::99" + RT_ENTRY_KEY_SUFFIX: {},
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When checking for route entry mismatches, ignore mismatched routes where an APPL_DB neighbor entry with a zero MAC is present. 

These routes are introduced by this change in SWSS and are expected: https://github.com/sonic-net/sonic-swss/pull/2137

#### How I did it

#### How to verify it
Run the updated `route_check_test.sh` script

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

