### PR TITLE
Replace cmp in acl_loader with operator.eq

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -759,7 +759,7 @@ class AclLoader(object):
                 namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
         for key in existing_controlplane_rules:
-            if operator.eq(self.rules_info[key], self.rules_db_info[key]) != 0:
+            if operator.eq(self.rules_info[key], self.rules_db_info[key]) == False:
                 self.configdb.set_entry(self.ACL_RULE, key, self.rules_info[key])
                 # Program for per-asic namespace corresponding to front asic also if present.
                 # For control plane ACL it's not needed but to keep all db in sync program everywhere

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -4,6 +4,7 @@ import click
 import ipaddress
 import json
 import syslog
+import operator
 
 import openconfig_acl
 import tabulate
@@ -758,7 +759,7 @@ class AclLoader(object):
                 namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
         for key in existing_controlplane_rules:
-            if cmp(self.rules_info[key], self.rules_db_info[key]) != 0:
+            if operator.eq(self.rules_info[key], self.rules_db_info[key]) != 0:
                 self.configdb.set_entry(self.ACL_RULE, key, self.rules_info[key])
                 # Program for per-asic namespace corresponding to front asic also if present.
                 # For control plane ACL it's not needed but to keep all db in sync program everywhere

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -759,7 +759,7 @@ class AclLoader(object):
                 namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
         for key in existing_controlplane_rules:
-            if operator.eq(self.rules_info[key], self.rules_db_info[key]) == False:
+            if not operator.eq(self.rules_info[key], self.rules_db_info[key]):
                 self.configdb.set_entry(self.ACL_RULE, key, self.rules_info[key])
                 # Program for per-asic namespace corresponding to front asic also if present.
                 # For control plane ACL it's not needed but to keep all db in sync program everywhere

--- a/tests/acl_input/incremental_1.json
+++ b/tests/acl_input/incremental_1.json
@@ -1,0 +1,32 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "ntp-acl": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "20.0.0.12/32"
+                                    }
+                                }, 
+                                "config": {
+                                    "sequence-id": 1
+                                }, 
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                }
+                            }
+                        }
+                    }, 
+                    "config": {
+                        "name": "ntp-acl"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/acl_input/incremental_2.json
+++ b/tests/acl_input/incremental_2.json
@@ -1,0 +1,32 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "ntp-acl": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "20.0.0.12/32"
+                                    }
+                                }, 
+                                "config": {
+                                    "sequence-id": 1
+                                }, 
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                }
+                            }
+                        }
+                    }, 
+                    "config": {
+                        "name": "ntp-acl"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Zhaohui Sun <zhaohuisun@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When run try to add a new rule for existing rule table with this command `acl-loader update incremental`, it will throw a traceback like this:

```
admin@vlab-03:~$ sudo acl-loader update incremental /home/admin/external_acl.json 
Traceback (most recent call last):
  File "/usr/local/bin/acl-loader", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/acl_loader/main.py", line 1066, in incremental
    acl_loader.incremental_update()
  File "/usr/local/lib/python3.9/dist-packages/acl_loader/main.py", line 761, in incremental_update
    if cmp(self.rules_info[key], self.rules_db_info[key]) != 0:
NameError: name 'cmp' is not defined

```
cmp is deprecated in python3.

#### How I did it
1. Use `operator.eq` instead.
The return type of `operator.eq` is bool, it returns True if x is equal to y, False, otherwise.
`cmp` syntax:
`cmp(a, b)`
Parameters:
a and b are the two numbers in which the comparison is being done.
Returns:
-1 if a<b
0 if a=b
1 if a>b

2. Add unit test
#### How to verify it
Load acl json file with existing rule table in the config file with this command:
` acl-loader update incremental**.json`
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

