### PR TITLE
Update vrf unbind command in Command-References.md

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -4484,7 +4484,7 @@ This will move the interface to default vrf.
 
 - Usage:
   ```
-  config interface vrf unbind <interface_name> <vrf_name>
+  config interface vrf unbind <interface_name>
   ```
   
   ### Interface vrf binding show commands


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Updated VRF unbind command to remove additional `<vrf_name>` argument.

#### How I did it
- N/A

#### How to verify it
- The argument `<vrf_name>` is unrecognized for `unbind` command.
![image](https://user-images.githubusercontent.com/77692425/186337004-733405fd-ae52-4632-977d-c21b7bdbbce8.png)

- `--help` for VRF unbind shows its `USAGE` without the `<vrf_name>` argument.
![image](https://user-images.githubusercontent.com/77692425/186337307-2bb6c309-56d1-49f3-a89f-f4c9b79ca150.png)


#### Previous command output (if the output of a command-line utility has changed)
- N/A

#### New command output (if the output of a command-line utility has changed)
- N/A

