### PR TITLE
[GCU] Fix missing backend in dry run

### DIFF
--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -65,6 +65,10 @@ class DryRunChangeApplier:
         self.config_wrapper.apply_change_to_config_db(change)
 
 
+    def remove_backend_tables_from_config(self, data):
+        return data
+
+
 class ChangeApplier:
 
     updater_conf = None

--- a/tests/generic_config_updater/change_applier_test.py
+++ b/tests/generic_config_updater/change_applier_test.py
@@ -281,6 +281,7 @@ class TestDryRunChangeApplier(unittest.TestCase):
 
         # Act
         applier.apply(change)
+        applier.remove_backend_tables_from_config(change)
 
         # Assert
         applier.config_wrapper.apply_change_to_config_db.assert_has_calls([call(change)])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix https://github.com/sonic-net/sonic-buildimage/issues/11912
#### How I did it
Add the missing 'remove_backend_tables_from_config' in dry run.
#### How to verify it
Run unit test and manual test locally.

Previous:
```
admin@vlab-01:~$ sudo config apply-patch t2.json -d
** DRY RUN EXECUTION **
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/VLAN/Vlan250"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Patch Applier: The patch was sorted into 1 change:
Patch Applier:   * [{"op": "remove", "path": "/VLAN/Vlan250"}]
Patch Applier: Applying 1 change in order:
Patch Applier:   * [{"op": "remove", "path": "/VLAN/Vlan250"}]
** DryRun: Would apply [{"op": "remove", "path": "/VLAN/Vlan250"}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: 'DryRunChangeApplier' object has no attribute 'get_config_without_backend_tables'
```

After fix:
```
admin@vlab-01:~$ sudo config apply-patch t2.json -d
** DRY RUN EXECUTION **
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/VLAN/Vlan250"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Patch Applier: The patch was sorted into 1 change:
Patch Applier:   * [{"op": "remove", "path": "/VLAN/Vlan250"}]
Patch Applier: Applying 1 change in order:
Patch Applier:   * [{"op": "remove", "path": "/VLAN/Vlan250"}]
** DryRun: Would apply [{"op": "remove", "path": "/VLAN/Vlan250"}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.

```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

