### PR TITLE
Fixed the description of the command ‘show ipv6 bgp summary’

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -10785,7 +10785,7 @@ Optionally, you can specify an IP address in order to display only that particul
 
 **show ipv6 bgp summary**
 
-This command displays the summary of all IPv4 bgp neighbors that are configured and the corresponding states.
+This command displays the summary of all IPv6 bgp neighbors that are configured and the corresponding states.
 
 - Usage:
   ```


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed the description of the command ‘show ipv6 bgp summary’
#### How I did it
modify IPv4 to IPv6
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

