### PR TITLE
[minigraph] add option to specify golden path in load_minigraph

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1718,8 +1718,9 @@ def load_mgmt_config(filename):
                 expose_value=False, prompt='Reload config from minigraph?')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
 @click.option('-t', '--traffic_shift_away', default=False, is_flag=True, help='Keep device in maintenance with TSA')
+@click.option('-p', '--golden_config_path', help='specify Golden Config path')
 @clicommon.pass_db
-def load_minigraph(db, no_service_restart, traffic_shift_away):
+def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_path):
     """Reconfigure based on minigraph."""
     log.log_info("'load_minigraph' executing...")
 
@@ -1797,8 +1798,15 @@ def load_minigraph(db, no_service_restart, traffic_shift_away):
             click.secho("[WARNING] Golden configuration may override Traffic-shift-away state. Please execute TSC to check the current System mode")
 
     # Load golden_config_db.json
-    if os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
-        override_config_by(DEFAULT_GOLDEN_CONFIG_DB_FILE)
+    if golden_config_path:
+        if not os.path.isfile(golden_config_path):
+            click.secho("Cannot find '{}'!".format(golden_config_path),
+                        fg='magenta')
+            raise click.Abort()
+        override_config_by(golden_config_path)
+    else:
+        if os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
+            override_config_by(DEFAULT_GOLDEN_CONFIG_DB_FILE)
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them

--- a/config/main.py
+++ b/config/main.py
@@ -1793,7 +1793,7 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_pat
     # Keep device isolated with TSA 
     if traffic_shift_away:
         clicommon.run_command("TSA", display_cmd=True)
-        if os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
+        if golden_config_path or not golden_config_path and os.path.isfile(DEFAULT_GOLDEN_CONFIG_DB_FILE):
             log.log_warning("Golden configuration may override System Maintenance state. Please execute TSC to check the current System mode")
             click.secho("[WARNING] Golden configuration may override Traffic-shift-away state. Please execute TSC to check the current System mode")
 

--- a/config/main.py
+++ b/config/main.py
@@ -1718,7 +1718,7 @@ def load_mgmt_config(filename):
                 expose_value=False, prompt='Reload config from minigraph?')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
 @click.option('-t', '--traffic_shift_away', default=False, is_flag=True, help='Keep device in maintenance with TSA')
-@click.option('-p', '--golden_config_path', help='specify Golden Config path')
+@click.option('-p', '--golden_config_path', help='The path of golden config file')
 @clicommon.pass_db
 def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_path):
     """Reconfigure based on minigraph."""

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -430,6 +430,20 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert expected_output in result.output
 
+    def test_load_minigraph_with_golden_config_path(self, get_cmd_module):
+        def is_file_side_effect(filename):
+            return True if 'golden_config' in filename else False
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-p", "golden_config.json", "-y"])
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code == 0
+            assert "config override-config-table golden_config.json" in result.output
+
     def test_load_minigraph_with_traffic_shift_away(self, get_cmd_module):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
             (config, show) = get_cmd_module

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -430,6 +430,17 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert expected_output in result.output
 
+    def test_load_minigraph_with_non_exist_golden_config_path(self, get_cmd_module):
+        def is_file_side_effect(filename):
+            return True if 'golden_config' in filename else False
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-p", "non_exist.json", "-y"])
+            assert result.exit_code != 0
+            assert "Cannot find 'non_exist.json'" in result.output
+
     def test_load_minigraph_with_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add an option for load_minigraph to specify golden path
#### How I did it
Add an option for load_minigraph
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)
sudo config load_minigraph -h
Usage: config load_minigraph [OPTIONS]

Reconfigure based on minigraph.

Options:
-y, --yes
-n, --no_service_restart Do not restart docker services
-t, --traffic_shift_away Keep device in maintenance with TSA
-?, -h, --help Show this message and exit.
#### New command output (if the output of a command-line utility has changed)
sudo config load_minigraph -h
Usage: config load_minigraph [OPTIONS]

Reconfigure based on minigraph.

Options:
-y, --yes
-n, --no_service_restart Do not restart docker services
-t, --traffic_shift_away Keep device in maintenance with TSA
**-p, --golden_config_path TEXT  specify Golden Config path**
-?, -h, --help Show this message and exit.
