### PR TITLE
Add IP remove warnings for VRF commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5017,6 +5017,7 @@ def bind(ctx, interface_name, vrf_name):
     else:
         config_db.set_entry(table_name, interface_name, {"vrf_name": vrf_name})
 
+    click.echo("Interface {} IPv4 disabled and address(es) removed due to binding VRF {}.".format(interface_name, vrf_name))
 #
 # 'unbind' subcommand
 #
@@ -5052,7 +5053,8 @@ def unbind(ctx, interface_name):
         config_db.set_entry(table_name, interface_name, subintf_entry)
     else:
         config_db.set_entry(table_name, interface_name, None)
-
+    
+    click.echo("Interface {} IPv4 disabled and address(es) removed due to unbinding VRF.".format(interface_name))
 #
 # 'ipv6' subgroup ('config interface ipv6 ...')
 #
@@ -5226,7 +5228,7 @@ def del_vrf(ctx, vrf_name):
     else:
         del_interface_bind_to_vrf(config_db, vrf_name)
         config_db.set_entry('VRF', vrf_name, None)
-
+        click.echo("VRF {} deleted and all associated IPv4 addresses removed.".format(vrf_name))
 
 @vrf.command('add_vrf_vni_map')
 @click.argument('vrfname', metavar='<vrf-name>', required=True, type=str)

--- a/config/main.py
+++ b/config/main.py
@@ -5017,7 +5017,7 @@ def bind(ctx, interface_name, vrf_name):
     else:
         config_db.set_entry(table_name, interface_name, {"vrf_name": vrf_name})
 
-    click.echo("Interface {} IPv4 disabled and address(es) removed due to binding VRF {}.".format(interface_name, vrf_name))
+    click.echo("Interface {} IP disabled and address(es) removed due to binding VRF {}.".format(interface_name, vrf_name))
 #
 # 'unbind' subcommand
 #
@@ -5054,7 +5054,7 @@ def unbind(ctx, interface_name):
     else:
         config_db.set_entry(table_name, interface_name, None)
     
-    click.echo("Interface {} IPv4 disabled and address(es) removed due to unbinding VRF.".format(interface_name))
+    click.echo("Interface {} IP disabled and address(es) removed due to unbinding VRF.".format(interface_name))
 #
 # 'ipv6' subgroup ('config interface ipv6 ...')
 #
@@ -5228,7 +5228,7 @@ def del_vrf(ctx, vrf_name):
     else:
         del_interface_bind_to_vrf(config_db, vrf_name)
         config_db.set_entry('VRF', vrf_name, None)
-        click.echo("VRF {} deleted and all associated IPv4 addresses removed.".format(vrf_name))
+        click.echo("VRF {} deleted and all associated IP addresses removed.".format(vrf_name))
 
 @vrf.command('add_vrf_vni_map')
 @click.argument('vrfname', metavar='<vrf-name>', required=True, type=str)

--- a/tests/show_vrf_test.py
+++ b/tests/show_vrf_test.py
@@ -66,49 +66,49 @@ Vrf103  Ethernet4
 
         obj = {'config_db':db.cfgdb}
 
-        expected_output_unbind = "Interface Ethernet4 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Ethernet4 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet4"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'Ethernet4' not in db.cfgdb.get_table('INTERFACE')
         assert result.output == expected_output_unbind
         
-        expected_output_unbind = "Interface Loopback0 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Loopback0 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Loopback0"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'Loopback0' not in db.cfgdb.get_table('LOOPBACK_INTERFACE')
         assert result.output == expected_output_unbind
 
-        expected_output_unbind = "Interface Vlan40 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Vlan40 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Vlan40"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'Vlan40' not in db.cfgdb.get_table('VLAN_INTERFACE')
         assert result.output == expected_output_unbind
 
-        expected_output_unbind = "Interface PortChannel0002 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface PortChannel0002 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["PortChannel0002"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'PortChannel002' not in db.cfgdb.get_table('PORTCHANNEL_INTERFACE')
         assert result.output == expected_output_unbind
         
-        expected_output_unbind = "Interface Eth36.10 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Eth36.10 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Eth36.10"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert ('vrf_name', 'Vrf102') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth36.10']
         assert result.output == expected_output_unbind
 
-        expected_output_unbind = "Interface Ethernet0.10 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Ethernet0.10 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet0.10"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert ('vrf_name', 'Vrf101') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.10']
         assert result.output == expected_output_unbind
 
-        expected_output_unbind = "Interface Po0002.101 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Po0002.101 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Po0002.101"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
@@ -117,43 +117,43 @@ Vrf103  Ethernet4
 
         vrf_obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
         
-        expected_output_bind = "Interface Ethernet0 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
+        expected_output_bind = "Interface Ethernet0 IP disabled and address(es) removed due to binding VRF Vrf1.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet0", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_bind
         assert ('Vrf1') in db.cfgdb.get_table('INTERFACE')['Ethernet0']['vrf_name']
 
-        expected_output_bind = "Interface Loopback0 IPv4 disabled and address(es) removed due to binding VRF Vrf101.\n"
+        expected_output_bind = "Interface Loopback0 IP disabled and address(es) removed due to binding VRF Vrf101.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Loopback0", "Vrf101"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_bind
         assert ('Vrf101') in db.cfgdb.get_table('LOOPBACK_INTERFACE')['Loopback0']['vrf_name']
 
-        expected_output_bind = "Interface Vlan40 IPv4 disabled and address(es) removed due to binding VRF Vrf101.\n"
+        expected_output_bind = "Interface Vlan40 IP disabled and address(es) removed due to binding VRF Vrf101.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Vlan40", "Vrf101"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_bind
         assert ('Vrf101') in db.cfgdb.get_table('VLAN_INTERFACE')['Vlan40']['vrf_name']
 
-        expected_output_bind = "Interface PortChannel0002 IPv4 disabled and address(es) removed due to binding VRF Vrf101.\n"
+        expected_output_bind = "Interface PortChannel0002 IP disabled and address(es) removed due to binding VRF Vrf101.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["PortChannel0002", "Vrf101"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_bind
         assert ('Vrf101') in db.cfgdb.get_table('PORTCHANNEL_INTERFACE')['PortChannel0002']['vrf_name']
 
-        expected_output_bind = "Interface Eth36.10 IPv4 disabled and address(es) removed due to binding VRF Vrf102.\n"
+        expected_output_bind = "Interface Eth36.10 IP disabled and address(es) removed due to binding VRF Vrf102.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Eth36.10", "Vrf102"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_bind
         assert ('Vrf102') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth36.10']['vrf_name']
 
-        expected_output_bind = "Interface Ethernet0.10 IPv4 disabled and address(es) removed due to binding VRF Vrf103.\n"
+        expected_output_bind = "Interface Ethernet0.10 IP disabled and address(es) removed due to binding VRF Vrf103.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet0.10", "Vrf103"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_bind
         assert ('Vrf103') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.10']['vrf_name']
 
-        expected_output_bind = "Interface Po0002.101 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
+        expected_output_bind = "Interface Po0002.101 IP disabled and address(es) removed due to binding VRF Vrf1.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Po0002.101", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_bind
@@ -185,25 +185,25 @@ Vrf103  Ethernet4
         db = Db()
         vrf_obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
         
-        expected_output_del = "VRF Vrf1 deleted and all associated IPv4 addresses removed.\n"
+        expected_output_del = "VRF Vrf1 deleted and all associated IP addresses removed.\n"
         result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_del
         assert ('Vrf1') not in db.cfgdb.get_table('VRF')
 
-        expected_output_del = "VRF Vrf101 deleted and all associated IPv4 addresses removed.\n"
+        expected_output_del = "VRF Vrf101 deleted and all associated IP addresses removed.\n"
         result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf101"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_del
         assert ('Vrf101') not in db.cfgdb.get_table('VRF')
 
-        expected_output_del = "VRF Vrf102 deleted and all associated IPv4 addresses removed.\n"
+        expected_output_del = "VRF Vrf102 deleted and all associated IP addresses removed.\n"
         result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf102"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_del
         assert ('Vrf102') not in db.cfgdb.get_table('VRF')
 
-        expected_output_del = "VRF Vrf103 deleted and all associated IPv4 addresses removed.\n"
+        expected_output_del = "VRF Vrf103 deleted and all associated IP addresses removed.\n"
         result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf103"], obj=vrf_obj)
         assert result.exit_code == 0
         assert result.output == expected_output_del

--- a/tests/show_vrf_test.py
+++ b/tests/show_vrf_test.py
@@ -66,44 +66,99 @@ Vrf103  Ethernet4
 
         obj = {'config_db':db.cfgdb}
 
+        expected_output_unbind = "Interface Ethernet4 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet4"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'Ethernet4' not in db.cfgdb.get_table('INTERFACE')
+        assert result.output == expected_output_unbind
         
+        expected_output_unbind = "Interface Loopback0 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Loopback0"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'Loopback0' not in db.cfgdb.get_table('LOOPBACK_INTERFACE')
-        
+        assert result.output == expected_output_unbind
+
+        expected_output_unbind = "Interface Vlan40 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Vlan40"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'Vlan40' not in db.cfgdb.get_table('VLAN_INTERFACE')
-        
+        assert result.output == expected_output_unbind
+
+        expected_output_unbind = "Interface PortChannel0002 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["PortChannel0002"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert 'PortChannel002' not in db.cfgdb.get_table('PORTCHANNEL_INTERFACE')
+        assert result.output == expected_output_unbind
         
+        expected_output_unbind = "Interface Eth36.10 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Eth36.10"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert ('vrf_name', 'Vrf102') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth36.10']
+        assert result.output == expected_output_unbind
 
+        expected_output_unbind = "Interface Ethernet0.10 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet0.10"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert ('vrf_name', 'Vrf101') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.10']
+        assert result.output == expected_output_unbind
 
+        expected_output_unbind = "Interface Po0002.101 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Po0002.101"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert ('vrf_name', 'Vrf103') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Po0002.101']
+        assert result.output == expected_output_unbind
 
+        vrf_obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
+        
+        expected_output_bind = "Interface Ethernet0 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet0", "Vrf1"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_bind
+        assert ('Vrf1') in db.cfgdb.get_table('INTERFACE')['Ethernet0']['vrf_name']
 
-        #Bind click CLI cannot be tested as it tries to connecte to statedb
-        #for verification of all IP address delete before applying new vrf configuration
+        expected_output_bind = "Interface Loopback0 IPv4 disabled and address(es) removed due to binding VRF Vrf101.\n"
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Loopback0", "Vrf101"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_bind
+        assert ('Vrf101') in db.cfgdb.get_table('LOOPBACK_INTERFACE')['Loopback0']['vrf_name']
+
+        expected_output_bind = "Interface Vlan40 IPv4 disabled and address(es) removed due to binding VRF Vrf101.\n"
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Vlan40", "Vrf101"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_bind
+        assert ('Vrf101') in db.cfgdb.get_table('VLAN_INTERFACE')['Vlan40']['vrf_name']
+
+        expected_output_bind = "Interface PortChannel0002 IPv4 disabled and address(es) removed due to binding VRF Vrf101.\n"
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["PortChannel0002", "Vrf101"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_bind
+        assert ('Vrf101') in db.cfgdb.get_table('PORTCHANNEL_INTERFACE')['PortChannel0002']['vrf_name']
+
+        expected_output_bind = "Interface Eth36.10 IPv4 disabled and address(es) removed due to binding VRF Vrf102.\n"
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Eth36.10", "Vrf102"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_bind
+        assert ('Vrf102') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth36.10']['vrf_name']
+
+        expected_output_bind = "Interface Ethernet0.10 IPv4 disabled and address(es) removed due to binding VRF Vrf103.\n"
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet0.10", "Vrf103"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_bind
+        assert ('Vrf103') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.10']['vrf_name']
+
+        expected_output_bind = "Interface Po0002.101 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
+        result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Po0002.101", "Vrf1"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_bind
+        assert ('Vrf1') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Po0002.101']['vrf_name']
+
         jsonfile_config = os.path.join(mock_db_path, "config_db")
         dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
 
@@ -124,3 +179,32 @@ Vrf103  Ethernet4
         dbconnector.dedicated_dbs = {}
         assert result.exit_code == 0
         assert result.output == expected_output
+
+    def test_vrf_del(self):
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
+        
+        expected_output_del = "VRF Vrf1 deleted and all associated IPv4 addresses removed.\n"
+        result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf1"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_del
+        assert ('Vrf1') not in db.cfgdb.get_table('VRF')
+
+        expected_output_del = "VRF Vrf101 deleted and all associated IPv4 addresses removed.\n"
+        result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf101"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_del
+        assert ('Vrf101') not in db.cfgdb.get_table('VRF')
+
+        expected_output_del = "VRF Vrf102 deleted and all associated IPv4 addresses removed.\n"
+        result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf102"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_del
+        assert ('Vrf102') not in db.cfgdb.get_table('VRF')
+
+        expected_output_del = "VRF Vrf103 deleted and all associated IPv4 addresses removed.\n"
+        result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf103"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert result.output == expected_output_del
+        assert ('Vrf103') not in db.cfgdb.get_table('VRF')

--- a/tests/subintf_test.py
+++ b/tests/subintf_test.py
@@ -173,14 +173,14 @@ class TestSubinterface(object):
         assert ('Ethernet0.102') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
         assert db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.102']['admin_status'] == 'up'
 
-        expected_output_bind = "Interface Ethernet0.102 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
+        expected_output_bind = "Interface Ethernet0.102 IP disabled and address(es) removed due to binding VRF Vrf1.\n"
         vrf_obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet0.102", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('Vrf1') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.102']['vrf_name']
         assert result.output == expected_output_bind
 
-        expected_output_unbind = "Interface Ethernet0.102 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Ethernet0.102 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet0.102"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('vrf_name') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.102']
@@ -197,13 +197,13 @@ class TestSubinterface(object):
         assert result.exit_code == 0
         assert ('Eth0.1002') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
-        expected_output_bind = "Interface Eth0.1002 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
+        expected_output_bind = "Interface Eth0.1002 IP disabled and address(es) removed due to binding VRF Vrf1.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Eth0.1002", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('Vrf1') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth0.1002']['vrf_name']
         assert result.output == expected_output_bind
 
-        expected_output_unbind = "Interface Eth0.1002 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Eth0.1002 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Eth0.1002"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('vrf_name') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth0.1002']
@@ -220,13 +220,13 @@ class TestSubinterface(object):
         assert result.exit_code == 0
         assert ('Po0004.1004') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
-        expected_output_bind = "Interface Po0004.1004 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
+        expected_output_bind = "Interface Po0004.1004 IP disabled and address(es) removed due to binding VRF Vrf1.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Po0004.1004", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('Vrf1') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Po0004.1004']['vrf_name']
         assert result.output == expected_output_bind
 
-        expected_output_unbind = "Interface Po0004.1004 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
+        expected_output_unbind = "Interface Po0004.1004 IP disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Po0004.1004"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('vrf_name') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Po0004.1004']

--- a/tests/subintf_test.py
+++ b/tests/subintf_test.py
@@ -173,14 +173,18 @@ class TestSubinterface(object):
         assert ('Ethernet0.102') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
         assert db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.102']['admin_status'] == 'up'
 
+        expected_output_bind = "Interface Ethernet0.102 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
         vrf_obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Ethernet0.102", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('Vrf1') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.102']['vrf_name']
+        assert result.output == expected_output_bind
 
+        expected_output_unbind = "Interface Ethernet0.102 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Ethernet0.102"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('vrf_name') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Ethernet0.102']
+        assert result.output == expected_output_unbind
 
         result = runner.invoke(config.config.commands["subinterface"].commands["del"], ["Ethernet0.102"], obj=obj)
         print(result.exit_code, result.output)
@@ -193,13 +197,17 @@ class TestSubinterface(object):
         assert result.exit_code == 0
         assert ('Eth0.1002') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
+        expected_output_bind = "Interface Eth0.1002 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Eth0.1002", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('Vrf1') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth0.1002']['vrf_name']
+        assert result.output == expected_output_bind
 
+        expected_output_unbind = "Interface Eth0.1002 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Eth0.1002"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('vrf_name') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Eth0.1002']
+        assert result.output == expected_output_unbind
 
         result = runner.invoke(config.config.commands["subinterface"].commands["del"], ["Eth0.1002"], obj=obj)
         print(result.exit_code, result.output)
@@ -212,13 +220,17 @@ class TestSubinterface(object):
         assert result.exit_code == 0
         assert ('Po0004.1004') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
+        expected_output_bind = "Interface Po0004.1004 IPv4 disabled and address(es) removed due to binding VRF Vrf1.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["bind"], ["Po0004.1004", "Vrf1"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('Vrf1') in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Po0004.1004']['vrf_name']
+        assert result.output == expected_output_bind
 
+        expected_output_unbind = "Interface Po0004.1004 IPv4 disabled and address(es) removed due to unbinding VRF.\n"
         result = runner.invoke(config.config.commands["interface"].commands["vrf"].commands["unbind"], ["Po0004.1004"], obj=vrf_obj)
         assert result.exit_code == 0
         assert ('vrf_name') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')['Po0004.1004']
+        assert result.output == expected_output_unbind
 
         result = runner.invoke(config.config.commands["subinterface"].commands["del"], ["Po0004.1004"], obj=obj)
         print(result.exit_code, result.output)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added IP address remove warnings when performing various VRF commands i.e.,
    - `vrf bind`
    - `vrf unbind`
    - `del vrf`
#### How I did it
* Modify `config/main.py` to include `click.echo` warnings.
* Add test cases for interface/subinterface vrf bind, unbind and del.
#### How to verify it
Tested the changes locally by building sonic-utilities Python wheel package inside Bullseye slave container
<pre>mdanish@3be53d98ab67:/sonic/src/sonic-utilities$ pytest-3 tests/show_vrf_test.py
<b>==================================================================== test session starts =====================================================================</b>
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-utilities/tests, configfile: pytest.ini
plugins: pyfakefs-5.0.0, cov-2.10.1
<b>collected 3 items                                                                                                                                            </b>

tests/show_vrf_test.py <font color="#4E9A06">....                                                                                                                            [100%]</font>

<font color="#4E9A06">===================================================================== </font><font color="#4E9A06"><b>3 passed</b></font><font color="#4E9A06"> in 0.36s ======================================================================</font>
mdanish@3be53d98ab67:/sonic/src/sonic-utilities$ pytest-3 tests/subintf_test.py 
<b>==================================================================== test session starts =====================================================================</b>
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-utilities/tests, configfile: pytest.ini
plugins: pyfakefs-5.0.0, cov-2.10.1
<b>collected 7 items                                                                                                                                            </b>

tests/subintf_test.py <font color="#4E9A06">.......                                                                                                                          [100%]</font>

<font color="#4E9A06">===================================================================== </font><font color="#4E9A06"><b>7 passed</b></font><font color="#4E9A06"> in 0.50s ======================================================================</font>
mdanish@3be53d98ab67:/sonic/src/sonic-utilities$ 
</pre>

#### Previous command output (if the output of a command-line utility has changed)
Example output with interface name `Ethernet0` and vrf name `Vrf1`:
```
admin@sonic:~$ sudo config interface vrf bind Ethernet0 Vrf1
admin@sonic:~$ sudo config interface vrf unbind Ethernet0
admin@sonic:~$ sudo config vrf del Vrf1
```
#### New command output (if the output of a command-line utility has changed)
Example output with interface name `Ethernet0` and vrf name `Vrf1`:
```
admin@sonic:~$ sudo config interface vrf bind Ethernet0 Vrf1
Interface Ethernet0 IPv4 disabled and address(es) removed due to binding VRF Vrf1
admin@sonic:~$ sudo config interface vrf unbind Ethernet0
Interface Ethernet0 IPv4 disabled and address(es) removed due to unbinding VRF
admin@sonic:~$ sudo config vrf del Vrf1
VRF Vrf1 deleted and all associated IPv4 addresses removed.
```
