### PR TITLE
Add time-based ACL support for acl-loader

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -85,7 +85,7 @@ class AclLoader(object):
     ACL_ACTIONS_CAPABILITY_FIELD = "action_list"
     ACL_ACTION_CAPABILITY_FIELD = "ACL_ACTION"
     DEFAULT_RULE = "DEFAULT_RULE"
-    CONFIG_DB_DYNAMIC_ACL_RULE_TABLE = "DYNAMIC_ACL_RULE_TABLE"
+    DYNAMIC_ACL_RULE_TABLE = "DYNAMIC_ACL_RULE"
 
     min_priority = 1
     max_priority = 10000
@@ -622,7 +622,7 @@ class AclLoader(object):
             entry['ttl'] = str(ttl)
             entry['creation_time'] = str(timenow)
             entry['expiration_time'] = str(timenow + ttl)
-            self.configdb.mod_entry(self.CONFIG_DB_DYNAMIC_ACL_RULE_TABLE, key, entry)
+            self.configdb.mod_entry(self.DYNAMIC_ACL_RULE_TABLE, key, entry)
             info("Added CONFIG_DB entry for rule {}".format(rule))
             info(str(entry))
         except Exception as e:
@@ -848,7 +848,7 @@ class AclLoader(object):
         :return:
         """
         key = str(table) + '|' + "DYNAMIC_RULE_" + str(rule)
-        self.configdb.set_entry(self.CONFIG_DB_DYNAMIC_ACL_RULE_TABLE, key, None)
+        self.configdb.set_entry(self.DYNAMIC_ACL_RULE_TABLE, key, None)
         info("Removed a dynamic ACL rule {}".format(key))
 
     def delete(self, table=None, rule=None):

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -10,7 +10,6 @@ import tabulate
 import pyangbind.lib.pybindJSON as pybindJSON
 from natsort import natsorted
 from sonic_py_common import multi_asic
-from swsscommon import swsscommon
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from utilities_common.general import load_db_config
 import time
@@ -596,7 +595,7 @@ class AclLoader(object):
             if 'is_dynamic' in data and data['is_dynamic'].lower() == 'true':
                 return True
             return False
-        except:
+        except BaseException as e:
             return False
         
     def is_dynamic_rule(self, rule):

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -618,7 +618,8 @@ class AclLoader(object):
         key = table + '|' + rule
         try:
             timenow = int(time.time())
-            entry['ttl'] = str(ttl)
+            del entry['is_dynamic']
+            #entry['ttl'] = str(ttl)
             entry['creation_time'] = str(timenow)
             entry['expiration_time'] = str(timenow + ttl)
             self.configdb.mod_entry(self.TIME_BASED_ACL_RULE_TABLE, key, entry)

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -656,7 +656,10 @@ class AclLoader(object):
         """
         rule_props = {}
         if is_dynamic and not self.is_dynamic_rule(rule):
-            warning("Attempting to insert a dynamic ACL rule without TTL, refused")
+            warning("Attempting to insert time-based ACL rule without TTL, refused")
+            return {}
+        if not is_dynamic and self.is_dynamic_rule(rule):
+            warning("Attempting to insert time-based ACL rule to non-time-based ACL table, refused")
             return {}
         rule_idx = int(rule.config.sequence_id)
         if not rule_name:
@@ -722,7 +725,7 @@ class AclLoader(object):
                 try:
                     acl_name_to_use = None
                     if is_dynamic:
-                        acl_name_to_use = "DYNAMIC_RULE_" + acl_entry_name
+                        acl_name_to_use = "TIME_BASED_RULE_" + acl_entry_name
                     rule = self.convert_rule_to_db_schema(table_name=table_name,
                                                           rule=acl_entry,
                                                           rule_name=acl_name_to_use,
@@ -846,7 +849,7 @@ class AclLoader(object):
         Remove entry from CONFIG_DB (must be dynamic)
         :return:
         """
-        key = str(table) + '|' + "DYNAMIC_RULE_" + str(rule)
+        key = str(table) + '|' + "TIME_BASED_RULE_" + str(rule)
         self.configdb.set_entry(self.DYNAMIC_ACL_RULE_TABLE, key, None)
         info("Removed a dynamic ACL rule {}".format(key))
 

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -84,7 +84,7 @@ class AclLoader(object):
     ACL_ACTIONS_CAPABILITY_FIELD = "action_list"
     ACL_ACTION_CAPABILITY_FIELD = "ACL_ACTION"
     DEFAULT_RULE = "DEFAULT_RULE"
-    DYNAMIC_ACL_RULE_TABLE = "DYNAMIC_ACL_RULE"
+    TIME_BASED_ACL_RULE_TABLE = "TIME_BASED_ACL_RULE"
 
     min_priority = 1
     max_priority = 10000
@@ -621,7 +621,7 @@ class AclLoader(object):
             entry['ttl'] = str(ttl)
             entry['creation_time'] = str(timenow)
             entry['expiration_time'] = str(timenow + ttl)
-            self.configdb.mod_entry(self.DYNAMIC_ACL_RULE_TABLE, key, entry)
+            self.configdb.mod_entry(self.TIME_BASED_ACL_RULE_TABLE, key, entry)
             info("Added CONFIG_DB entry for rule {}".format(rule))
             info(str(entry))
         except Exception as e:
@@ -850,7 +850,7 @@ class AclLoader(object):
         :return:
         """
         key = str(table) + '|' + "TIME_BASED_RULE_" + str(rule)
-        self.configdb.set_entry(self.DYNAMIC_ACL_RULE_TABLE, key, None)
+        self.configdb.set_entry(self.TIME_BASED_ACL_RULE_TABLE, key, None)
         info("Removed a dynamic ACL rule {}".format(key))
 
     def delete(self, table=None, rule=None):

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -618,12 +618,11 @@ class AclLoader(object):
         key = table + '|' + rule
         try:
             timenow = int(time.time())
-            del entry['is_dynamic']
-            #entry['ttl'] = str(ttl)
+            entry.pop('is_dynamic', None)
             entry['creation_time'] = str(timenow)
             entry['expiration_time'] = str(timenow + ttl)
             self.configdb.mod_entry(self.TIME_BASED_ACL_RULE_TABLE, key, entry)
-            info("Added CONFIG_DB entry for rule {}".format(rule))
+            info("Added CONFIG_DB entry: time-based ACL rule {}".format(key))
             info(str(entry))
         except Exception as e:
             raise AclLoaderException("Failed to add CONFIG_DB entry for {}; error is {}".format(rule, str(e)))
@@ -852,7 +851,7 @@ class AclLoader(object):
         """
         key = str(table) + '|' + "TIME_BASED_RULE_" + str(rule)
         self.configdb.set_entry(self.TIME_BASED_ACL_RULE_TABLE, key, None)
-        info("Removed a dynamic ACL rule {}".format(key))
+        info("Removed CONFIG_DB entry: time-based ACL rule {}".format(key))
 
     def delete(self, table=None, rule=None):
         """

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -595,7 +595,7 @@ class AclLoader(object):
             if 'is_dynamic' in data and data['is_dynamic'].lower() == 'true':
                 return True
             return False
-        except BaseException as e:
+        except Exception as e:
             return False
         
     def is_dynamic_rule(self, rule):

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -12,8 +12,6 @@ from natsort import natsorted
 from sonic_py_common import multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from utilities_common.general import load_db_config
-import time
-
 
 def info(msg):
     click.echo(click.style("Info: ", fg='cyan') + click.style(str(msg), fg='green'))

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -118,7 +118,6 @@ class AclLoader(object):
         self.tables_db_info = {}
         self.rules_db_info = {}
         self.rules_info = {}
-        self.rules_ttl = {}
 
         # Load database config files
         load_db_config()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add time-based ACL support for acl-loader

#### How I did it
Modify code according to HLD: Dynamic-ACL-Design.md (Currently is under PR review)
New acl-loader CLIs are introduced:
acl-loader update time-based-acl <filename.json>
acl-loader delete-time-based-acl <table name> <rule name>

#### How to verify it
See HLD unit test and system test.
https://github.com/sonic-net/SONiC/pull/1078

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)

admin@hostname: acl-loader update time-based-acl dacl.json
Info: Added CONFIG_DB entry for rule DYNAMIC_RULE_1
Info: {'PRIORITY': '9999', 'ETHER_TYPE': '2048', 'PACKET_ACTION': 'DROP', 'DST_IP': '10.0.0.57/32', 'is_dynamic': 'True', 'ttl': '3600', 'creation_time': '1662515645', 'expiration_time': '1662519245'}
Info: Added CONFIG_DB entry for rule DYNAMIC_RULE_2
Info: {'PRIORITY': '9998', 'ETHER_TYPE': '2048', 'PACKET_ACTION': 'DROP', 'DST_IP': '192.168.0.101/32', 'is_dynamic': 'True', 'ttl': '10', 'creation_time': '1662515645', 'expiration_time': '1662515655'}

admin@hostname: acl-loader delete-time-based-acl BMC_ACL_SOUTHBOUND 1
Info: Removed a dynamic ACL rule BMC_ACL_SOUTHBOUND|DYNAMIC_RULE_1