### PR TITLE
[generate dump]Added error message when saisdkdump fails

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -885,6 +885,10 @@ collect_mellanox() {
     ${CMD_PREFIX}docker exec syncd mkdir -p $sai_dump_folder
     ${CMD_PREFIX}docker exec syncd saisdkdump -f $sai_dump_filename
 
+    if [ $? != 0 ]; then
+        echo "Failed to collect saisdkdump."
+    fi
+
     copy_from_docker syncd $sai_dump_folder $sai_dump_folder
     echo "$sai_dump_folder"
     for file in `ls $sai_dump_folder`; do


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added error message when saisdkdump fails and cont to gather the rest. This is done to provide more readable information to the user when it cannot be avaialble (syncd for example is not running, during restart, etc).

#### How I did it
Checked error code and print log

#### How to verify it
Simulate saisdkdump error and verify the console output.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

