### PR TITLE
fix show acl table exception

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -796,12 +796,16 @@ class AclLoader(object):
             stage = val.get("stage", Stage.INGRESS).lower()
 
             if val["type"] == AclLoader.ACL_TABLE_TYPE_CTRLPLANE:
-                services = natsorted(val["services"])
-                data.append([key, val["type"], services[0], val["policy_desc"], stage])
+                services = val.get("services", [])
+                if not services:
+                    data.append([key, val["type"], "", val["policy_desc"], stage])
+                else:
+                    services = natsorted(val["services"])
+                    data.append([key, val["type"], services[0], val["policy_desc"], stage])
 
-                if len(services) > 1:
-                    for service in services[1:]:
-                        data.append(["", "", service, "", ""])
+                    if len(services) > 1:
+                        for service in services[1:]:
+                            data.append(["", "", service, "", ""])
             else:
                 if not val["ports"]:
                     data.append([key, val["type"], "", val["policy_desc"], stage])

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -796,15 +796,14 @@ class AclLoader(object):
             stage = val.get("stage", Stage.INGRESS).lower()
 
             if val["type"] == AclLoader.ACL_TABLE_TYPE_CTRLPLANE:
-                services = val.get("services", [])
-                if not services:
+                service_array = val.get("services", [])
+                if not service_array:
                     data.append([key, val["type"], "", val["policy_desc"], stage])
                 else:
-                    services = natsorted(val["services"])
-                    data.append([key, val["type"], services[0], val["policy_desc"], stage])
+                    data.append([key, val["type"], service_array[0], val["policy_desc"], stage])
 
-                    if len(services) > 1:
-                        for service in services[1:]:
+                    if len(service_array) > 1:
+                        for service in service_array[1:]:
                             data.append(["", "", service, "", ""])
             else:
                 if not val["ports"]:

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -800,10 +800,11 @@ class AclLoader(object):
                 if not service_array:
                     data.append([key, val["type"], "", val["policy_desc"], stage])
                 else:
-                    data.append([key, val["type"], service_array[0], val["policy_desc"], stage])
+                    services = natsorted(service_array)
+                    data.append([key, val["type"], services[0], val["policy_desc"], stage])
 
-                    if len(service_array) > 1:
-                        for service in service_array[1:]:
+                    if len(services) > 1:
+                        for service in services[1:]:
                             data.append(["", "", service, "", ""])
             else:
                 if not val["ports"]:

--- a/tests/show_acl_test.py
+++ b/tests/show_acl_test.py
@@ -15,7 +15,7 @@ class TestShowAcl(object):
     def test_show_ctrl_table(self):
         runner = CliRunner()
         aclloader = AclLoader()
-        aclloader.configdb.set_entry("ACL_TABLE", "CTRL_TEST", {"type": "CTRLPLANE", "policy_desc": "CTRL_TEST", "services@": ["SNMP","NTP"]})
+        aclloader.configdb.set_entry("ACL_TABLE", "CTRL_TEST", {"type": "CTRLPLANE", "policy_desc": "CTRL_TEST", "services": ["SNMP","NTP"]})
         aclloader.read_tables_info()
         context = {
             "acl_loader": aclloader

--- a/tests/show_acl_test.py
+++ b/tests/show_acl_test.py
@@ -1,0 +1,37 @@
+import imp
+import os
+import sys
+import pytest
+
+import acl_loader.main as acl_loader_show
+from acl_loader import *
+from acl_loader.main import *
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+import mock_tables.dbconnector
+
+class TestShowAcl(object):
+    def test_show_ctrl_table(self):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        aclloader.configdb.set_entry("ACL_TABLE", "CTRL_TEST", {"type": "CTRLPLANE", "policy_desc": "CTRL_TEST", "services@": ["SNMP","NTP"]})
+        aclloader.read_tables_info()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['table'], ['CTRL_TEST'], obj=context)
+        assert result.exit_code == 0
+        assert "CTRL_TEST" in result.output
+
+    def test_show_ctrl_table_without_services(self):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        aclloader.configdb.set_entry("ACL_TABLE", "CTRL_TEST", {"type": "CTRLPLANE", "policy_desc": "CTRL_TEST"})
+        aclloader.read_tables_info()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['table'], ['CTRL_TEST'], obj=context)
+        assert result.exit_code == 0
+        assert "CTRL_TEST" in result.output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix KeyError exception for show acl table
root@sonic:/home/admin# config acl add table test CTRLPLANE
root@sonic:/home/admin# show acl table
Traceback (most recent call last):
  File "/usr/local/bin/acl-loader", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/acl_loader/main.py", line 967, in table
    acl_loader.show_table(table_name)
  File "/usr/local/lib/python3.9/dist-packages/acl_loader/main.py", line 798, in show_table
    services = natsorted(val["services"])
KeyError: 'services'
root@sonic:/home/admin# 
#### How I did it
Check if  value is empty
#### How to verify it
Run test
#### Previous command output (if the output of a command-line utility has changed)
root@sonic:/home/admin# show acl table
Traceback (most recent call last):
  File "/usr/local/bin/acl-loader", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/acl_loader/main.py", line 967, in table
    acl_loader.show_table(table_name)
  File "/usr/local/lib/python3.9/dist-packages/acl_loader/main.py", line 798, in show_table
    services = natsorted(val["services"])
KeyError: 'services'
#### New command output (if the output of a command-line utility has changed)
![image](https://user-images.githubusercontent.com/81281940/194741313-8efaea21-f22f-426a-b9b0-2a97dc2a11ae.png)

