### PR TITLE
[warm-reboot] fix warm-reboot when /tmp/cache is missing

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -466,10 +466,13 @@ function save_counters_folder() {
         debug "Saving counters folder before warmboot..."
 
         counters_folder="/host/counters"
+        counters_cache="/tmp/cache"
         if [[ ! -d $counters_folder ]]; then
             mkdir $counters_folder
         fi
-        cp -rf /tmp/cache $counters_folder
+        if [[ -d $counters_cache ]]; then
+           cp -rf $counters_cache $counters_folder
+        fi
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

