### PR TITLE
Add Vrf-Lite CLI Commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -394,6 +394,15 @@ def is_interface_bind_to_vrf(config_db, interface_name):
         return True
     return False
 
+def is_interface_bind_to_vrf_lite(config_db, interface_name):
+    """Get interface if bind to vrf-lite or not
+    """
+    if is_interface_bind_to_vrf(config_db, interface_name):
+        entry = config_db.get_entry(get_interface_table_name(interface_name), interface_name)
+        if entry and "Vrflite" in entry.get("vrf_name"):
+            return True
+    return False
+
 def is_portchannel_name_valid(portchannel_name):
     """Port channel name validation
     """
@@ -5013,6 +5022,91 @@ def unbind(ctx, interface_name):
         config_db.set_entry(table_name, interface_name, None)
 
 #
+# 'vrflite' subgroup ('config interface vrf ...')
+#
+
+
+@interface.group(cls=clicommon.AbbreviationGroup)
+@click.pass_context
+def vrflite(ctx):
+    """Bind or unbind VRF Lite"""
+    pass
+
+#
+# 'bind' subcommand
+#
+@vrflite.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('vrflite_name', metavar='<vrflite_name>', required=True)
+@click.pass_context
+def bind(ctx, interface_name, vrflite_name):
+    """Bind the interface to VRF LITE"""
+    # Get the config_db connector
+    config_db = ctx.obj["config_db"]
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    table_name = get_interface_table_name(interface_name)
+    if not clicommon.is_interface_in_config_db(config_db, interface_name):
+        ctx.fail('interface {} doesn`t exist'.format(interface_name))
+    if table_name == "":
+        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
+    config_db.set_entry(table_name, interface_name, {"mpls": "disable"})
+
+    if is_interface_bind_to_vrf(config_db, interface_name) is True and \
+        config_db.get_entry(table_name, interface_name).get('vrf_name') == vrflite_name:
+        return
+    # Clean ip addresses if interface configured
+    if vrflite_name.startswith("Vrflite"):
+        interface_addresses = get_interface_ipaddresses(config_db, interface_name)
+        for ipaddress in interface_addresses:
+            remove_router_interface_ip_address(config_db, interface_name, ipaddress)
+        config_db.set_entry(table_name, interface_name, None)
+        # When config_db del entry and then add entry with same key, the DEL will lost.
+        if ctx.obj['namespace'] is DEFAULT_NAMESPACE:
+            state_db = SonicV2Connector(use_unix_socket_path=True)
+        else:
+            state_db = SonicV2Connector(use_unix_socket_path=True, namespace=ctx.obj['namespace'])
+        state_db.connect(state_db.STATE_DB, False)
+        _hash = '{}{}'.format('INTERFACE_TABLE|', interface_name)
+        while state_db.exists(state_db.STATE_DB, _hash):
+            time.sleep(0.01)
+        state_db.close(state_db.STATE_DB)
+        config_db.set_entry(table_name, interface_name, {"vrf_name": vrflite_name})
+    else:
+        ctx.fail("Invalid Vrflite name")
+
+#
+# 'unbind' subcommand
+#
+
+@vrflite.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.pass_context
+def unbind(ctx, interface_name):
+    """Unbind the interface to VRF LITE"""
+    # Get the config_db connector
+    config_db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail("interface is None!")
+
+    table_name = get_interface_table_name(interface_name)
+    if table_name == "":
+        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Loopback]")
+    if is_interface_bind_to_vrf_lite(config_db, interface_name) is False:
+        ctx.fail("Interface is not bound to Vrflite")
+        return
+    interface_ipaddresses = get_interface_ipaddresses(config_db, interface_name)
+    for ipaddress in interface_ipaddresses:
+        remove_router_interface_ip_address(config_db, interface_name, ipaddress)
+    config_db.set_entry(table_name, interface_name, None)
+
+#
 # 'ipv6' subgroup ('config interface ipv6 ...')
 #
 
@@ -5237,6 +5331,51 @@ def del_vrf_vni_map(ctx, vrfname):
 
     config_db.mod_entry('VRF', vrfname, {"vni": 0})
 
+#
+# 'vrflite' group ('config vrflite ...')
+#
+@config.group(cls=clicommon.AbbreviationGroup, name='vrflite')
+@click.pass_context
+def vrflite(ctx):
+    """VRFLITE configuration tasks"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    ctx.obj = {}
+    ctx.obj['config_db'] = config_db
+
+@vrflite.command('add')
+@click.argument('vrflite_name', metavar='<vrflite_name>', required=True)
+@click.pass_context
+def add_vrflite(ctx, vrflite_name):
+    """Add vrflite"""
+    config_db = ctx.obj['config_db']
+    if not vrflite_name.startswith("Vrflite"):
+        ctx.fail("'vrflite_name' is not start with Vrflite!")
+    if len(vrflite_name) > 19:
+        ctx.fail("'vrf_name' is too long!")
+    else:
+        config_db.set_entry('VRF', vrflite_name, {"NULL": "NULL"})
+
+@vrflite.command('del')
+@click.argument('vrflite_name', metavar='<vrflite_name>', required=True)
+@click.pass_context
+def del_vrflite(ctx, vrflite_name):
+    """Del vrflite"""
+    config_db = ctx.obj['config_db']
+    if not vrf_name.startswith("Vrflite"):
+        ctx.fail("'vrflite_name' is not start with Vrflite!")
+    if len(vrflite_name) > 19:
+        ctx.fail("'vrflite_name' is too long!")
+    syslog_table = config_db.get_table("SYSLOG_SERVER")
+    syslog_vrf_dev = vrflite_name
+    for syslog_entry, syslog_data in syslog_table.items():
+        syslog_vrf = syslog_data.get("vrf")
+        if syslog_vrf == syslog_vrf_dev:
+            ctx.fail("Failed to remove VRF device: {} is in use by SYSLOG_SERVER|{}".format(syslog_vrf, syslog_entry))
+    if vrflite_name == 'Vrflite':
+        del_interface_bind_to_vrf(config_db, vrflite_name)
+        config_db.set_entry('VRF', vrflite_name, None)
+ 
 #
 # 'route' group ('config route ...')
 #

--- a/show/main.py
+++ b/show/main.py
@@ -334,6 +334,42 @@ def vrf(vrf_name):
     click.echo(tabulate(body, header))
 
 #
+# 'vrflite' command ("show vrflite")
+#
+def get_vrflite_table():
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    vrf_dict = config_db.get_table('VRF')
+    vrflite_dict ={}
+    for key in list(vrf_dict.keys()):
+        if "Vrflite" in key:
+            vrflite_dict[key] = vrf_dict[key]
+    return vrflite_dict
+
+@cli.command()
+@click.argument('vrflite_name', required=False)
+def vrflite(vrflite_name):
+    """Show vrflite config"""
+    header = ['VRF-LITE', 'Interfaces']
+    body = []
+    vrflite_dict = get_vrflite_table()
+    if vrflite_dict:
+        vrfs = []
+        if vrflite_name is None:
+            vrfs = list(vrflite_dict.keys())
+        elif vrflite_name in vrflite_dict:
+            vrfs = [vrflite_name]
+        for vrf in vrfs:
+            intfs = get_interface_bind_to_vrf(config_db, vrf)
+            if len(intfs) == 0:
+                body.append([vrf, ""])
+            else:
+                body.append([vrf, intfs[0]])
+                for intf in intfs[1:]:
+                    body.append(["", intf])
+    click.echo(tabulate(body, header))
+
+#
 # 'arp' command ("show arp")
 #
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

### What I did
Added the following CLI commands for Vrf Lite:
    - `config add vrflite`
    - `config del vrflite`
    - `config interface vrflite bind`
    - `config interface vrflite unbind`
    -  `show vrflite`
### How I did it
#### vrflite add
- Ensure the prefix is `Vrflite`. 
- Add vrf's with above prefix to vrf table.
#### vrflite bind
- Check whether `MPLS` enabled on an interface. If so, disable it first before binding to a vrf.
#### vrflite unbind
- Check to see whether the interface is bound to vrf-lite before performing unbind.
#### show vrflite
- Filter out vrflite entries from original vrf table.
### How to verify it
Test cases are to be added in future.
 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

