### PR TITLE
Use 'default' VRF when VRF name is not provided

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5315,7 +5315,7 @@ def add_route(ctx, command_str):
 
     # Check if exist entry with key
     keys = config_db.get_keys('STATIC_ROUTE')
-    if key in keys:
+    if tuple(key.split("|")) in keys:
         # If exist update current entry
         current_entry = config_db.get_entry('STATIC_ROUTE', key)
 
@@ -5340,7 +5340,7 @@ def del_route(ctx, command_str):
     key, route = cli_sroute_to_config(ctx, command_str, strict_nh=False)
     keys = config_db.get_keys('STATIC_ROUTE')
     prefix_tuple = tuple(key.split('|'))
-    if not key in keys and not prefix_tuple in keys:
+    if not tuple(key.split("|")) in keys and not prefix_tuple in keys:
         ctx.fail('Route {} doesnt exist'.format(key))
     else:
         # If not defined nexthop or intf name remove entire route

--- a/config/main.py
+++ b/config/main.py
@@ -1019,6 +1019,7 @@ def cli_sroute_to_config(ctx, command_str, strict_nh = True):
         elif 'prefix' in prefix_str:
             # prefix_str: ['prefix', ip]
             ip_prefix = prefix_str[1]
+            vrf_name = "default"
         else:
             ctx.fail("prefix is not in pattern!")
 

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -45,8 +45,8 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "1.2.3.4/32", "nexthop", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('1.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '1.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+        assert ('default', '1.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|1.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
 
         # config route del prefix 1.2.3.4/32 nexthop 30.0.0.5
         result = runner.invoke(config.config.commands["route"].commands["del"], \
@@ -119,8 +119,8 @@ class TestStaticRoutes(object):
         ["prefix", "3.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
         print(db.cfgdb.get_table('STATIC_ROUTE'))
-        assert ('3.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '3.2.3.4/32') == {'nexthop': '30.0.0.6', 'nexthop-vrf': 'Vrf-RED', 'blackhole': 'false', 'distance': '0', 'ifname': ''}
+        assert ('default', '3.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|3.2.3.4/32') == {'nexthop': '30.0.0.6', 'nexthop-vrf': 'Vrf-RED', 'blackhole': 'false', 'distance': '0', 'ifname': ''}
 
         # config route del prefix 3.2.3.4/32 nexthop vrf Vrf-RED 30.0.0.6
         result = runner.invoke(config.config.commands["route"].commands["del"], \
@@ -140,22 +140,22 @@ class TestStaticRoutes(object):
             result = runner.invoke(config.config.commands["route"].commands["add"], \
             ["prefix", "6.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.6,30.0.0.7"], obj=obj)
             print(result.exit_code, result.output)
-            assert ('6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-            assert db.cfgdb.get_entry('STATIC_ROUTE', '6.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': 'Vrf-RED,Vrf-RED'}
+            assert ('default', '6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+            assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|6.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': 'Vrf-RED,Vrf-RED'}
 
             ''' Del '''
             # config route del prefix 6.2.3.4/32 nexthop vrf Vrf-RED 30.0.0.7
             result = runner.invoke(config.config.commands["route"].commands["del"], \
             ["prefix", "6.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.7"], obj=obj)
             print(result.exit_code, result.output)
-            assert ('6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-            assert db.cfgdb.get_entry('STATIC_ROUTE', '6.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': 'Vrf-RED'}
+            assert ('default', '6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+            assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|6.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': 'Vrf-RED'}
 
             # config route del prefix 6.2.3.4/32 nexthop vrf Vrf-RED 30.0.0.6
             result = runner.invoke(config.config.commands["route"].commands["del"], \
             ["prefix", "6.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.6"], obj=obj)
             print(result.exit_code, result.output)
-            assert not ('6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+            assert not ('default', '6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
 
     def test_multiple_nexthops_static_route(self):
         db = Db()
@@ -167,30 +167,30 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "6.2.3.4/32", "nexthop", "30.0.0.6,30.0.0.7"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '6.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': ','}
+        assert ('default', '6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|6.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': ','}
 
         # config route add prefix 6.2.3.4/32 nexthop 30.0.0.8
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "6.2.3.4/32", "nexthop", "30.0.0.8"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '6.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7,30.0.0.8', 'blackhole': 'false,false,false', 'distance': '0,0,0', 'ifname': ',,', 'nexthop-vrf': ',,'}
+        assert ('default', '6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|6.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7,30.0.0.8', 'blackhole': 'false,false,false', 'distance': '0,0,0', 'ifname': ',,', 'nexthop-vrf': ',,'}
 
         ''' Del '''
         # config route del prefix 6.2.3.4/32 nexthop 30.0.0.8
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "6.2.3.4/32", "nexthop", "30.0.0.8"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '6.2.3.4/32') == {"nexthop": '30.0.0.6,30.0.0.7', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': ','}
+        assert ('default', '6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|6.2.3.4/32') == {"nexthop": '30.0.0.6,30.0.0.7', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': ','}
         
         # config route del prefix 6.2.3.4/32 nexthop 30.0.0.7
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "6.2.3.4/32", "nexthop", "30.0.0.7"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '6.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+        assert ('default', '6.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|6.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
 
         # config route del prefix 6.2.3.4/32 nexthop 30.0.0.6
         result = runner.invoke(config.config.commands["route"].commands["del"], \
@@ -228,23 +228,23 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "10.2.3.4/32", "nexthop", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('10.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '10.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+        assert ('default', '10.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|10.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
         
         # config route add prefix 10.2.3.4/32 nexthop 30.0.0.6
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "10.2.3.4/32", "nexthop", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('10.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '10.2.3.4/32') == {'nexthop': '30.0.0.5,30.0.0.6', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': ','}
+        assert ('default', '10.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|10.2.3.4/32') == {'nexthop': '30.0.0.5,30.0.0.6', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ',', 'nexthop-vrf': ','}
 
         ''' Del '''
         # config route del prefix 10.2.3.4/32 nexthop 30.0.0.5
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "10.2.3.4/32", "nexthop", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('10.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '10.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+        assert ('default', '10.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|10.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
         
         # config route del prefix 1.2.3.4/32 nexthop 30.0.0.6
         result = runner.invoke(config.config.commands["route"].commands["del"], \
@@ -264,8 +264,8 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "11.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '11.2.3.4/32') == {'nexthop': '30.0.0.5', 'nexthop-vrf': 'Vrf-RED', 'blackhole': 'false', 'distance': '0', 'ifname': ''}
+        assert ('default', '11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|11.2.3.4/32') == {'nexthop': '30.0.0.5', 'nexthop-vrf': 'Vrf-RED', 'blackhole': 'false', 'distance': '0', 'ifname': ''}
         
         result = runner.invoke(config.config.commands["vrf"].commands["add"], ["Vrf-BLUE"], obj=obj)
         print(result.exit_code, result.output)
@@ -273,22 +273,22 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "11.2.3.4/32", "nexthop", "vrf", "Vrf-BLUE", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '11.2.3.4/32') == {"nexthop": "30.0.0.5,30.0.0.6", "nexthop-vrf": "Vrf-RED,Vrf-BLUE", 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ','}
+        assert ('default', '11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|11.2.3.4/32') == {"nexthop": "30.0.0.5,30.0.0.6", "nexthop-vrf": "Vrf-RED,Vrf-BLUE", 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ','}
 
         ''' Del '''
         # config route del prefix 11.2.3.4/32 nexthop vrf Vrf-RED 30.0.0.5
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "11.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '11.2.3.4/32') == {"nexthop": "30.0.0.6", "nexthop-vrf": "Vrf-BLUE", 'blackhole': 'false', 'distance': '0', 'ifname': ''}
+        assert ('default', '11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|11.2.3.4/32') == {"nexthop": "30.0.0.6", "nexthop-vrf": "Vrf-BLUE", 'blackhole': 'false', 'distance': '0', 'ifname': ''}
         
         # config route del prefix 11.2.3.4/32 nexthop vrf Vrf-BLUE 30.0.0.6
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "11.2.3.4/32", "nexthop", "vrf", "Vrf-BLUE", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert not ('11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert not ('default', '11.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
    
     def test_static_route_ECMP_mixed_nextfop(self):
         db = Db()
@@ -300,8 +300,8 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "12.2.3.4/32", "nexthop", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '12.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+        assert ('default', '12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|12.2.3.4/32') == {'nexthop': '30.0.0.6', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
 
         result = runner.invoke(config.config.commands["vrf"].commands["add"], ["Vrf-RED"], obj=obj)
         print(result.exit_code, result.output)
@@ -309,22 +309,22 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "12.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.7"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '12.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7', 'nexthop-vrf': ',Vrf-RED', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ','}
+        assert ('default', '12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|12.2.3.4/32') == {'nexthop': '30.0.0.6,30.0.0.7', 'nexthop-vrf': ',Vrf-RED', 'blackhole': 'false,false', 'distance': '0,0', 'ifname': ','}
 
         ''' Del '''
         # config route del prefix 12.2.3.4/32 nexthop vrf Vrf-Red 30.0.0.7
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "12.2.3.4/32", "nexthop", "vrf", "Vrf-RED", "30.0.0.7"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '12.2.3.4/32') == {'nexthop': '30.0.0.6', 'nexthop-vrf': '', 'ifname': '', 'blackhole': 'false', 'distance': '0'}
+        assert ('default', '12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|12.2.3.4/32') == {'nexthop': '30.0.0.6', 'nexthop-vrf': '', 'ifname': '', 'blackhole': 'false', 'distance': '0'}
         
         # config route del prefix 12.2.3.4/32 nexthop 30.0.0.6
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "12.2.3.4/32", "nexthop", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert not ('12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert not ('default', '12.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
       
     def test_del_nonexist_key_static_route(self):
         db = Db()
@@ -335,7 +335,7 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "17.2.3.4/32", "nexthop", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert ERROR_DEL_NONEXIST_KEY_STR.format("17.2.3.4/32") in result.output
+        assert ERROR_DEL_NONEXIST_KEY_STR.format("default|17.2.3.4/32") in result.output
         
     def test_del_nonexist_entry_static_route(self):
         db = Db()
@@ -346,20 +346,20 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "13.2.3.4/32", "nexthop", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('13.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '13.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+        assert ('default', '13.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|13.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
 
         # config route del prefix 13.2.3.4/32 nexthop 30.0.0.6 <- nh ip that doesnt exist
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "13.2.3.4/32", "nexthop", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert ERROR_DEL_NONEXIST_ENTRY_STR.format(('30.0.0.6', '', ''), "13.2.3.4/32") in result.output
+        assert ERROR_DEL_NONEXIST_ENTRY_STR.format(('30.0.0.6', '', ''), "default|13.2.3.4/32") in result.output
 
         # config route del prefix 13.2.3.4/32 nexthop 30.0.0.5
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "13.2.3.4/32", "nexthop", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert not '13.2.3.4/32' in db.cfgdb.get_table('STATIC_ROUTE')
+        assert not ('default', '13.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
 
     def test_del_entire_ECMP_static_route(self):
         db = Db()
@@ -370,20 +370,20 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "14.2.3.4/32", "nexthop", "30.0.0.5"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('14.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '14.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
+        assert ('default', '14.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|14.2.3.4/32') == {'nexthop': '30.0.0.5', 'blackhole': 'false', 'distance': '0', 'ifname': '', 'nexthop-vrf': ''}
 
         # config route add prefix 14.2.3.4/32 nexthop 30.0.0.6
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "14.2.3.4/32", "nexthop", "30.0.0.6"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('14.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '14.2.3.4/32') == {'nexthop': '30.0.0.5,30.0.0.6', 'nexthop-vrf': ',', 'ifname': ',', 'blackhole': 'false,false', 'distance': '0,0'}
+        assert ('default', '14.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|14.2.3.4/32') == {'nexthop': '30.0.0.5,30.0.0.6', 'nexthop-vrf': ',', 'ifname': ',', 'blackhole': 'false,false', 'distance': '0,0'}
 
         # config route del prefix 14.2.3.4/32
         result = runner.invoke(config.config.commands["route"].commands["del"], ["prefix", "14.2.3.4/32"], obj=obj)
         print(result.exit_code, result.output)
-        assert not '14.2.3.4/32' in db.cfgdb.get_table('STATIC_ROUTE')
+        assert not ('default', '14.2.3.4/32') in db.cfgdb.get_table('STATIC_ROUTE')
 
     def test_static_route_nexthop_subinterface(self):
         db = Db()
@@ -394,27 +394,27 @@ class TestStaticRoutes(object):
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "2.2.3.5/32", "nexthop", "dev", "Ethernet0.10"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Ethernet0.10', 'nexthop-vrf': ''}
+        assert ('default', '2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Ethernet0.10', 'nexthop-vrf': ''}
 
         # config route del prefix 2.2.3.5/32 nexthop dev Ethernet0.10
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "2.2.3.5/32", "nexthop", "dev", "Ethernet0.10"], obj=obj)
         print(result.exit_code, result.output)
-        assert not ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert not ('default', '2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
 
         # config route add prefix 2.2.3.5/32 nexthop dev Eth36.10
         result = runner.invoke(config.config.commands["route"].commands["add"], \
         ["prefix", "2.2.3.5/32", "nexthop", "dev", "Eth36.10"], obj=obj)
         print(result.exit_code, result.output)
-        assert ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', '2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Eth36.10', 'nexthop-vrf': ''}
+        assert ('default', '2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Eth32.10', 'nexthop-vrf': ''}
 
         # config route del prefix 2.2.3.5/32 nexthop dev Eth36.10
         result = runner.invoke(config.config.commands["route"].commands["del"], \
         ["prefix", "2.2.3.5/32", "nexthop", "dev", "Eth36.10"], obj=obj)
         print(result.exit_code, result.output)
-        assert not ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert not ('default', '2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
 
     @classmethod
     def teardown_class(cls):

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -408,7 +408,7 @@ class TestStaticRoutes(object):
         ["prefix", "2.2.3.5/32", "nexthop", "dev", "Eth36.10"], obj=obj)
         print(result.exit_code, result.output)
         assert ('default', '2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
-        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Eth32.10', 'nexthop-vrf': ''}
+        assert db.cfgdb.get_entry('STATIC_ROUTE', 'default|2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Eth36.10', 'nexthop-vrf': ''}
 
         # config route del prefix 2.2.3.5/32 nexthop dev Eth36.10
         result = runner.invoke(config.config.commands["route"].commands["del"], \


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fix for https://github.com/sonic-net/sonic-buildimage/issues/11803
#### What I did
While adding static routes, if VRF name is not present, use `default` VRF
#### How I did it
In the `add` and `del` route implementations, I check if VRF name is present or not.
#### How to verify it
Unittests have been updated
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

