### PR TITLE
[Inspur][utilities][201911] Fix warm-reboot may cause orchagent is frozened and wait forever

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -344,6 +344,24 @@ function unload_kernel()
     fi
 }
 
+function check_warm_restart_state()
+{
+    debug "Check orchagent warm restart state ..."
+    TABLE="WARM_RESTART_TABLE|orchagent"
+    STATE=`/usr/bin/redis-cli -n 6 hget "${TABLE}" state`
+    if [[ -n "$STATE" ]]; then
+        if [[ ${STATE} == "disabled" || ${STATE} == "reconciled" ]]; then
+            debug "orchagent warm restart state is ${STATE}"
+        else
+            debug "Failed to exec warm-reboot, orchagent warm restart state is ${STATE}"
+            exit ${EXIT_FAILURE}
+        fi
+    else
+        debug "Failed to exec warm-reboot, orchagent is not ready"
+        exit ${EXIT_FAILURE}
+    fi
+}
+
 # main starts here
 parseOptions $@
 
@@ -374,6 +392,7 @@ case "$REBOOT_TYPE" in
         else
             BOOT_TYPE_ARG="warm"
         fi
+        check_warm_restart_state
         trap clear_warm_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
         config warm_restart enable system
         ;;


### PR DESCRIPTION
[Inspur][utilities][201911] Fix warm-reboot may cause orchagent is frozened and wait forever
    Description:
        1. When executing warm-reboot continuously, the orchagent cannot finish pre-warm task within 10 seconds.
        2. And then, the orchagent will be frozen by "second" warm restart.
        3. In order to prevent the orchagent is frozen, add warm start default status.
        4. If executing warm-reboot, will check orchagent wart start status.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
    When executing warm-reboot continuously, will check orchagent wart start status.
#### How I did it
    In order to prevent the orchagent is frozen, when executing warm-reboot, will check orchagent wart start status.
#### How to verify it
    1. When executing warm-reboot continuously, check syslog "orchagent warm restart state is disabled".
    2. And then, execute warm-reboot successfully.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
