### PR TITLE
Fix DBConfig not initialize issue in pfcwd (#2238)

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -9,6 +9,7 @@ from sonic_py_common.multi_asic import get_external_ports
 from tabulate import tabulate
 from utilities_common import multi_asic as multi_asic_util
 from utilities_common import constants
+from utilities_common.general import load_db_config
 from sonic_py_common import logger
 
 SYSLOG_IDENTIFIER = "config"
@@ -62,7 +63,7 @@ PORT_QOS_MAP =  "PORT_QOS_MAP"
 @click.group()
 def cli():
     """ SONiC PFC Watchdog """
-
+    load_db_config()
 
 def get_all_queues(db, namespace=None, display=constants.DISPLAY_ALL):
     queue_names = db.get_all(db.COUNTERS_DB, 'COUNTERS_QUEUE_NAME_MAP')


### PR DESCRIPTION
#### What I did
Fix pfcwd connect DB with exception issue: https://github.com/Azure/sonic-buildimage/issues/11269

pfcwd implicit depends on InterfaceAliasConverter() to initialize DB config, however following PR change InterfaceAliasConverter() behavior to lazy initialize, then pfcwd failed when try connect to DB without initialize DB config:

https://github.com/Azure/sonic-utilities/pull/2183

#### How I did it
Load  DB config in pfcwd.

#### How to verify it
Pass all UT.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

