### PR TITLE
Fix sudo sfputil show error-status on a multiasic platform issue

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1009,15 +1009,15 @@ def error_status(port, fetch_from_hardware):
     if fetch_from_hardware:
         output_table = fetch_error_status_from_platform_api(port)
     else:
-        # Connect to STATE_DB
-        state_db = SonicV2Connector(host='127.0.0.1')
-        if state_db is not None:
-            state_db.connect(state_db.STATE_DB)
-        else:
-            click.echo("Failed to connect to STATE_DB")
-            return
-
-        output_table = fetch_error_status_from_state_db(port, state_db)
+        namespaces = multi_asic.get_front_end_namespaces()
+        for namespace in namespaces:
+            state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+            if state_db is not None:
+                state_db.connect(state_db.STATE_DB)
+                output_table.extend(fetch_error_status_from_state_db(port, state_db))
+            else:
+                click.echo("Failed to connect to STATE_DB")
+                return
 
     click.echo(tabulate(output_table, table_header, tablefmt='simple'))
 

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -367,6 +367,33 @@ Ethernet36  Present
 """
         assert result.output == expected_output
 
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    def test_show_error_status(self):
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['error-status'], [])
+        assert result.exit_code == 0
+        expected_output = """Port        Error Status
+----------  -------------------------------
+Ethernet0   Blocking Error|High temperature
+Ethernet4   OK
+Ethernet8   Unplugged
+Ethernet12  Unknown state: 255
+Ethernet16  Unplugged
+Ethernet28  Unplugged
+Ethernet36  Unknown
+"""
+        assert result.output == expected_output
+
+    @patch('sfputil.main.SonicV2Connector', MagicMock(return_value=None))
+    def test_show_error_status_error_case(self):
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['error-status'], [])
+        assert result.exit_code == 0
+        expected_output = """Failed to connect to STATE_DB\n"""
+        assert result.output == expected_output
+
+
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
     @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))


### PR DESCRIPTION
#### What I did
Fixed  "sudo sfputil show error-status" on a multiasic platform issue.  Fixes https://github.com/sonic-net/sonic-buildimage/issues/8504

This change is also applicable to 202205 branch

#### How I did it
The current implementation is only hard code to  connect STATE_DB on host database  with SonicV2Connector(127.,0.0.1).   To support the multiasic platform, we need to query the data entry from STATE_DB of namespace database.   Following the existing design to  use multi_asic.get_front_end_namespaces.  And looping the namespaces to get the output_table for each namespace.  
#### How to verify it
1) running the image on a multasic platform which front panel ports have  SFP inserted. 
2) execute "sudo sfptuil show error-status". The output should show all ports with status.
```
admin@sonic:~$ sudo sfputil show error-status
Port        Error Status
----------  --------------
Ethernet0   OK
Ethernet1   OK
Ethernet2   OK
Ethernet3   OK
Ethernet4   OK
Ethernet5   OK
Ethernet6   OK
Ethernet7   OK
Ethernet8   OK
Ethernet9   OK
Ethernet10  OK
Ethernet11  OK
Ethernet12  OK
Ethernet13  OK
Ethernet14  OK
Ethernet15  OK
Ethernet16  OK
Ethernet17  OK
Ethernet18  OK
Ethernet19  OK
Ethernet20  OK
Ethernet21  OK
Ethernet22  OK
Ethernet23  OK
Ethernet24  OK
Ethernet25  OK
Ethernet26  OK
Ethernet27  OK
Ethernet28  OK
Ethernet29  OK
Ethernet30  OK
Ethernet31  OK
Ethernet32  OK
Ethernet33  OK
Ethernet34  OK
Ethernet35  OK
```
#### Previous command output (if the output of a command-line utility has changed)
Previous output doesn't have any port name
```
admin@sonic:~$ sudo sfputil show error-status
Port    Error Status
------  --------------
admin@sonic:~$ 
```
#### New command output (if the output of a command-line utility has changed)

