### PR TITLE
Filter port invalid MTU configuration

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4180,7 +4180,7 @@ def _get_all_mgmtinterface_keys():
 @interface.command()
 @click.pass_context
 @click.argument('interface_name', metavar='<interface_name>', required=True)
-@click.argument('interface_mtu', metavar='<interface_mtu>', required=True)
+@click.argument('interface_mtu', metavar='<interface_mtu>', required=True, type=click.IntRange(68, 9216))
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def mtu(ctx, interface_name, interface_mtu, verbose):
     """Set interface mtu"""

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -5,21 +5,21 @@ class TestConfigInterfaceMtu(object):
     def test_interface_mtu_check():
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", 68])
+            ["Ethernet0", "68"])
         assert result.exit_code != 0
         
         result1 = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", 9216])
+            ["Ethernet0", "9216"])
         assert result1.exit_code != 0
         
     def test_interface_invalid_mtu_check():
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", 67])
+            ["Ethernet0", "67"])
         assert not "Error: Invalid value" in result.output
         
         result1 = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", 9217])
+            ["Ethernet0", "9217"])
         assert not "Error: Invalid value" in result1.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -17,9 +17,9 @@ class TestConfigInterfaceMtu(object):
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", 67])
-        assert not "Error: Invalid value for /"<interface_mtu>/"" in result.output
+        assert not "Error: Invalid value" in result.output
         
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", 9216])
-        assert not "Error: Invalid value for /"<interface_mtu>/"" in result.output
+        assert not "Error: Invalid value" in result.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -8,10 +8,10 @@ class TestConfigInterfaceMtu(object):
             ["Ethernet0", 68])
         assert result.exit_code != 0
         
-        result = runner.invoke(
+        result1 = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", 9216])
-        assert result.exit_code != 0
+        assert result1.exit_code != 0
         
     def test_interface_invalid_mtu_check():
         result = runner.invoke(
@@ -19,7 +19,7 @@ class TestConfigInterfaceMtu(object):
             ["Ethernet0", 67])
         assert not "Error: Invalid value" in result.output
         
-        result = runner.invoke(
+        result1 = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", 9217])
-        assert not "Error: Invalid value" in result.output
+        assert not "Error: Invalid value" in result1.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -21,5 +21,5 @@ class TestConfigInterfaceMtu(object):
         
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", 9216])
+            ["Ethernet0", 9217])
         assert not "Error: Invalid value" in result.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -4,9 +4,9 @@ from click.testing import CliRunner
 from utilities_common.db import Db
 
 class TestConfigInterfaceMtu(object):
-    runner = CliRunner()
-    db = Db()
     def test_interface_mtu_check(self):
+        runner = CliRunner()
+        db = Db()
         result = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "68"], obj=db)
         assert result.exit_code != 0
@@ -16,6 +16,8 @@ class TestConfigInterfaceMtu(object):
         assert result1.exit_code != 0
 
     def test_interface_invalid_mtu_check(self):
+        runner = CliRunner()
+        db = Db()
         result = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "67"], obj=db)
         assert not "Error: Invalid value" in result.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -20,8 +20,7 @@ class TestConfigInterfaceMtu(object):
         db = Db()
         result = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "67"], obj=db)
-        assert not 'Usage: mtu [OPTIONS] <interface_name> <interface_mtu>\nTry "mtu --help" for help.\n\nError: Invalid value for "<interface_mtu>": 67 is not in the valid range of 68 to 9216.\n' in result.output
-
+        assert result.exit_code == 0
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9217"], obj=db)
-        assert not 'Usage: mtu [OPTIONS] <interface_name> <interface_mtu>\nTry "mtu --help" for help.\n\nError: Invalid value for "<interface_mtu>": 9217 is not in the valid range of 68 to 9216.\n' in result1.output
+        assert result1.exit_code == 0

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -1,25 +1,25 @@
 import pytest
 import config.main as config
+from click.testing import CliRunner
+from utilities_common.db import Db
 
 class TestConfigInterfaceMtu(object):
+    runner = CliRunner()
+    db = Db()
     def test_interface_mtu_check():
-        result = runner.invoke(
-            config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "68"])
+        result = runner.invoke(config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "68"], obj=db)
         assert result.exit_code != 0
         
-        result1 = runner.invoke(
-            config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "9216"])
+        result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "9216"], obj=db)
         assert result1.exit_code != 0
         
     def test_interface_invalid_mtu_check():
-        result = runner.invoke(
-            config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "67"])
+        result = runner.invoke(config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "67"], obj=db)
         assert not "Error: Invalid value" in result.output
         
-        result1 = runner.invoke(
-            config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "9217"])
+        result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "9217"], obj=db)
         assert not "Error: Invalid value" in result1.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -5,21 +5,21 @@ class TestConfigInterfaceMtu(object):
     def test_interface_mtu_check():
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "68"])
+            ["Ethernet0", 68])
         assert result.exit_code != 0
         
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "9216"])
+            ["Ethernet0", 9216])
         assert result.exit_code != 0
         
     def test_interface_invalid_mtu_check():
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "67"])
-        assert not result.exit_code != 0
+            ["Ethernet0", 67])
+        assert not "Error: Invalid value for /"<interface_mtu>/"" in result.output
         
         result = runner.invoke(
             config.config.commands["interface"].commands["mtu"],
-            ["Ethernet0", "9216"])
-        assert not result.exit_code != 0
+            ["Ethernet0", 9216])
+        assert not "Error: Invalid value for /"<interface_mtu>/"" in result.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -1,0 +1,25 @@
+import pytest
+import config.main as config
+
+class TestConfigInterfaceMtu(object):
+    def test_interface_mtu_check():
+        result = runner.invoke(
+            config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "68"])
+        assert result.exit_code != 0
+        
+        result = runner.invoke(
+            config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "9216"])
+        assert result.exit_code != 0
+        
+    def test_interface_invalid_mtu_check():
+        result = runner.invoke(
+            config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "67"])
+        assert not result.exit_code != 0
+        
+        result = runner.invoke(
+            config.config.commands["interface"].commands["mtu"],
+            ["Ethernet0", "9216"])
+        assert not result.exit_code != 0

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -20,8 +20,8 @@ class TestConfigInterfaceMtu(object):
         db = Db()
         result = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "67"], obj=db)
-        assert not "Error: Invalid value" in result.output
+        assert not 'Usage: mtu [OPTIONS] <interface_name> <interface_mtu>\nTry "mtu --help" for help.\n\nError: Invalid value for "<interface_mtu>": 67 is not in the valid range of 68 to 9216.\n' in result.output
 
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9217"], obj=db)
-        assert not "Error: Invalid value" in result1.output
+        assert not 'Usage: mtu [OPTIONS] <interface_name> <interface_mtu>\nTry "mtu --help" for help.\n\nError: Invalid value for "<interface_mtu>": 9217 is not in the valid range of 68 to 9216.\n' in result1.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -6,20 +6,20 @@ from utilities_common.db import Db
 class TestConfigInterfaceMtu(object):
     runner = CliRunner()
     db = Db()
-    def test_interface_mtu_check():
+    def test_interface_mtu_check(self):
         result = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "68"], obj=db)
         assert result.exit_code != 0
-        
+
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9216"], obj=db)
         assert result1.exit_code != 0
-        
-    def test_interface_invalid_mtu_check():
+
+    def test_interface_invalid_mtu_check(self):
         result = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "67"], obj=db)
         assert not "Error: Invalid value" in result.output
-        
+
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9217"], obj=db)
         assert not "Error: Invalid value" in result1.output

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -20,7 +20,7 @@ class TestConfigInterfaceMtu(object):
         db = Db()
         result = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "67"], obj=db)
-        assert result.exit_code == 0
+        assert "Error: Invalid value" in result.output
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9217"], obj=db)
-        assert result1.exit_code == 0
+        assert "Error: Invalid value" in result1.output


### PR DESCRIPTION
What I did
Filter port invalid MTU configuration

How I did it
Adjust the MTU value to the range of [68,9216]

How to verify it
Use "config interface mtu Ethernet1 40" command to configure the port MTU. The following error will occur in SWSS.
```
Sep 16 14:53:39.051202 sonic NOTICE swss#orchagent: :- doPortTask: Set port Ethernet1 MTU to 40
Sep 16 14:53:39.052217 sonic INFO swss#/supervisord: portmgrd Error: mtu less than device minimum.
Sep 16 14:53:39.052600 sonic ERR swss#portmgrd: :- main: Runtime error: /sbin/ip link set dev "Ethernet1" mtu "40" : 
Sep 16 14:53:39.325117 sonic INFO swss#supervisord 2022-09-16 06:53:39,324 INFO exited: portmgrd (exit status 255; not expected)
Sep 16 14:53:40.339256 sonic INFO swss#/supervisor-proc-exit-listener: Process 'portmgrd' exited unexpectedly. Terminating supervisor 'swss'
Sep 16 14:53:40.352537 sonic INFO swss#supervisord 2022-09-16 06:53:40,339 WARN received SIGTERM indicating exit request
```

We use the iproute2 tool to set the kernel MTU in portmgrd. The command is:
```
ip link set dev <port_name> mtu <mtu>
```

I have tested that iproute2 tool will not report an error when the MTU is in the 68-9216 range.
```
root@sonic:/home/admin# ip link set dev Ethernet10 mtu 68
root@sonic:/home/admin# ifconfig Ethernet10          
Ethernet10: flags=4099<UP,BROADCAST,MULTICAST>  mtu 68
        inet 10.0.0.18  netmask 255.255.255.254  broadcast 0.0.0.0
        ether 58:69:6c:fb:21:38  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

root@sonic:/home/admin# ip link set dev Ethernet10 mtu 67
Error: mtu less than device minimum.
root@sonic:/home/admin# 
root@sonic:/home/admin# ip link set dev Ethernet10 mtu 9216
root@sonic:/home/admin# ifconfig Ethernet10            
Ethernet10: flags=4099<UP,BROADCAST,MULTICAST>  mtu 9216
        inet 10.0.0.18  netmask 255.255.255.254  broadcast 0.0.0.0
        ether 58:69:6c:fb:21:38  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# ip link set dev Ethernet10 mtu 9217
RTNETLINK answers: Invalid argument
root@sonic:/home/admin#
```