### PR TITLE
Add a subcommand to display a hexdump of transceiver EEPROM page

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -44,6 +44,9 @@ CDB_DEFAULT_HOST_PASSWORD = 0x00001011
 
 MAX_LPL_FIRMWARE_BLOCK_SIZE = 116 #Bytes
 
+PAGE_SIZE = 128
+PAGE_OFFSET = 128
+
 # TODO: We should share these maps and the formatting functions between sfputil and sfpshow
 QSFP_DATA_MAP = {
     'model': 'Vendor PN',
@@ -688,6 +691,88 @@ def eeprom(port, dump_dom, namespace):
 
     click.echo(output)
 
+# 'eeprom-hexdump' subcommand
+@show.command()
+@click.option('-p', '--port', metavar='<port_name>', required=True, help="Display SFP EEPROM hexdump for port <port_name>")
+@click.option('-r', '--page', metavar='<page_number>', required=True, help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
+def eeprom_hexdump(port, page):
+    """Display EEPROM hexdump of SFP transceiver(s) for a given port name and page number"""
+    output = ""
+
+    if platform_sfputil.is_logical_port(port) == 0:
+        click.echo("Error: invalid port '{}'\n".format(port))
+        print_all_valid_port_values()
+        sys.exit(ERROR_INVALID_PORT)
+
+    logical_port_name = port
+    physical_port = logical_port_to_physical_port_index(logical_port_name)
+
+    if is_port_type_rj45(logical_port_name):
+        click.echo("{}: SFP EEPROM is not applicable for RJ45 port\n")
+        sys.exit(ERROR_INVALID_PORT)
+
+    try:
+        presence = platform_chassis.get_sfp(physical_port).get_presence()
+    except NotImplementedError:
+        click.echo("Sfp.get_presence() is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    if not presence:
+        click.echo("SFP EEPROM not detected\n")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+    else:
+        try:
+            indent = ' ' * 8
+            output += 'EEPROM hexdump for port {} page {}h'.format(port, page)
+            output += '\n{}Lower page 0h'.format(indent)
+            page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(0, PAGE_SIZE)
+            if page_dump is None:
+                click.echo("Error: Failed to read EEPROM for page 0!")
+                sys.exit(ERROR_NOT_IMPLEMENTED)
+
+            output += hexdump(indent, page_dump, 0)
+            page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(int(page, base=16) * PAGE_SIZE + PAGE_OFFSET, PAGE_SIZE)
+            if page_dump is None:
+                click.echo("Error: Failed to read EEPROM!")
+                sys.exit(ERROR_NOT_IMPLEMENTED)
+            else:
+                output += '\n\n{}Upper page {}h'.format(indent, page)
+                output += hexdump(indent, page_dump, PAGE_OFFSET)
+        except NotImplementedError:
+            click.echo("Sfp.read_eeprom() is currently not implemented for this platform")
+            sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    output += '\n'
+
+    click.echo(output)
+
+def convert_byte_to_valid_ascii_char(byte):
+    if byte < 32 or 126 < byte:
+        return '.'
+    else:
+        return chr(byte)
+
+def hexdump(indent, data, mem_address):
+    ascii_string = ''
+    result = ''
+    for byte in data:
+        ascii_string = ascii_string + convert_byte_to_valid_ascii_char(byte)
+        byte_string = "{:02x}".format(byte)
+        if mem_address % 16 == 0:
+            mem_address_string = "{:08x}".format(mem_address)
+            result += '\n{}{} '.format(indent, mem_address_string)
+            result += '{} '.format(byte_string)
+        elif mem_address % 16 == 15:
+            result += '{} '.format(byte_string)
+            result += '|{}|'.format(ascii_string)
+            ascii_string = ""
+        elif mem_address % 16 == 7:
+            result += ' {} '.format(byte_string)
+        else:
+            result += '{} '.format(byte_string)
+        mem_address += 1
+
+    return result
 
 # 'presence' subcommand
 @show.command()

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -47,6 +47,8 @@ MAX_LPL_FIRMWARE_BLOCK_SIZE = 116 #Bytes
 PAGE_SIZE = 128
 PAGE_OFFSET = 128
 
+SFF8472_A0_SIZE = 256
+
 # TODO: We should share these maps and the formatting functions between sfputil and sfpshow
 QSFP_DATA_MAP = {
     'model': 'Vendor PN',
@@ -694,21 +696,24 @@ def eeprom(port, dump_dom, namespace):
 # 'eeprom-hexdump' subcommand
 @show.command()
 @click.option('-p', '--port', metavar='<port_name>', required=True, help="Display SFP EEPROM hexdump for port <port_name>")
-@click.option('-r', '--page', metavar='<page_number>', required=True, help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
+@click.option('-r', '--page', metavar='<page_number>', help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
 def eeprom_hexdump(port, page):
     """Display EEPROM hexdump of SFP transceiver(s) for a given port name and page number"""
     output = ""
 
     if platform_sfputil.is_logical_port(port) == 0:
-        click.echo("Error: invalid port '{}'\n".format(port))
+        click.echo("Error: invalid port {}".format(port))
         print_all_valid_port_values()
         sys.exit(ERROR_INVALID_PORT)
+
+    if page is None:
+        page = '0'
 
     logical_port_name = port
     physical_port = logical_port_to_physical_port_index(logical_port_name)
 
     if is_port_type_rj45(logical_port_name):
-        click.echo("{}: SFP EEPROM is not applicable for RJ45 port\n")
+        click.echo("{}: SFP EEPROM Hexdump is not applicable for RJ45 port".format(port))
         sys.exit(ERROR_INVALID_PORT)
 
     try:
@@ -718,33 +723,90 @@ def eeprom_hexdump(port, page):
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
     if not presence:
-        click.echo("SFP EEPROM not detected\n")
+        click.echo("SFP EEPROM not detected")
         sys.exit(ERROR_NOT_IMPLEMENTED)
     else:
         try:
-            indent = ' ' * 8
-            output += 'EEPROM hexdump for port {} page {}h'.format(port, page)
-            output += '\n{}Lower page 0h'.format(indent)
-            page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(0, PAGE_SIZE)
-            if page_dump is None:
-                click.echo("Error: Failed to read EEPROM for page 0!")
+            id = platform_chassis.get_sfp(physical_port).read_eeprom(0, 1)
+            if id is None:
+                click.echo("Error: Failed to read EEPROM for offset 0!")
                 sys.exit(ERROR_NOT_IMPLEMENTED)
-
-            output += hexdump(indent, page_dump, 0)
-            page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(int(page, base=16) * PAGE_SIZE + PAGE_OFFSET, PAGE_SIZE)
-            if page_dump is None:
-                click.echo("Error: Failed to read EEPROM!")
-                sys.exit(ERROR_NOT_IMPLEMENTED)
-            else:
-                output += '\n\n{}Upper page {}h'.format(indent, page)
-                output += hexdump(indent, page_dump, PAGE_OFFSET)
         except NotImplementedError:
             click.echo("Sfp.read_eeprom() is currently not implemented for this platform")
             sys.exit(ERROR_NOT_IMPLEMENTED)
 
+        if id[0] == 0x3:
+            output = eeprom_hexdump_sff8472(port, physical_port, page)
+        else:
+            output = eeprom_hexdump_sff8636(port, physical_port, page)
+
     output += '\n'
 
     click.echo(output)
+
+def eeprom_hexdump_sff8472(port, physical_port, page):
+    try:
+        output = ""
+        indent = ' ' * 8
+        output += 'EEPROM hexdump for port {} page {}h'.format(port, page)
+        output += '\n{}A0h dump'.format(indent)
+        page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(0, SFF8472_A0_SIZE)
+        if page_dump is None:
+            click.echo("Error: Failed to read EEPROM for A0h!")
+            sys.exit(ERROR_NOT_IMPLEMENTED)
+
+        output += hexdump(indent, page_dump, 0)
+        page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(SFF8472_A0_SIZE, PAGE_SIZE)
+        if page_dump is None:
+            click.echo("Error: Failed to read EEPROM for A2h!")
+            sys.exit(ERROR_NOT_IMPLEMENTED)
+        else:
+            output += '\n\n{}A2h dump (Lower 128 bytes)'.format(indent)
+            output += hexdump(indent, page_dump, 0)
+
+        page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(SFF8472_A0_SIZE + PAGE_OFFSET + (int(page, base=16) * PAGE_SIZE), PAGE_SIZE)
+        if page_dump is None:
+            click.echo("Error: Failed to read EEPROM for A2h upper page!")
+            sys.exit(ERROR_NOT_IMPLEMENTED)
+        else:
+            output += '\n\n{}A2h dump (upper 128 bytes) page {}h'.format(indent, page)
+            output += hexdump(indent, page_dump, PAGE_OFFSET)
+    except NotImplementedError:
+        click.echo("Sfp.read_eeprom() is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+    except ValueError:
+        click.echo("Please enter a numeric page number")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    return output
+
+def eeprom_hexdump_sff8636(port, physical_port, page):
+    try:
+        output = ""
+        indent = ' ' * 8
+        output += 'EEPROM hexdump for port {} page {}h'.format(port, page)
+        output += '\n{}Lower page 0h'.format(indent)
+        page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(0, PAGE_SIZE)
+        if page_dump is None:
+            click.echo("Error: Failed to read EEPROM for page 0!")
+            sys.exit(ERROR_NOT_IMPLEMENTED)
+
+        output += hexdump(indent, page_dump, 0)
+        page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(int(page, base=16) * PAGE_SIZE + PAGE_OFFSET, PAGE_SIZE)
+        if page_dump is None:
+            click.echo("Error: Failed to read EEPROM!")
+            sys.exit(ERROR_NOT_IMPLEMENTED)
+        else:
+            output += '\n\n{}Upper page {}h'.format(indent, page)
+            output += hexdump(indent, page_dump, PAGE_OFFSET)
+    except NotImplementedError:
+        click.echo("Sfp.read_eeprom() is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+    except ValueError:
+        click.echo("Please enter a numeric page number")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    return output
 
 def convert_byte_to_valid_ascii_char(byte):
     if byte < 32 or 126 < byte:

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -696,7 +696,7 @@ def eeprom(port, dump_dom, namespace):
 # 'eeprom-hexdump' subcommand
 @show.command()
 @click.option('-p', '--port', metavar='<port_name>', required=True, help="Display SFP EEPROM hexdump for port <port_name>")
-@click.option('-r', '--page', metavar='<page_number>', help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
+@click.option('-n', '--page', metavar='<page_number>', help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
 def eeprom_hexdump(port, page):
     """Display EEPROM hexdump of SFP transceiver(s) for a given port name and page number"""
     output = ""
@@ -761,7 +761,7 @@ def eeprom_hexdump_sff8472(port, physical_port, page):
             click.echo("Error: Failed to read EEPROM for A2h!")
             sys.exit(ERROR_NOT_IMPLEMENTED)
         else:
-            output += '\n\n{}A2h dump (Lower 128 bytes)'.format(indent)
+            output += '\n\n{}A2h dump (lower 128 bytes)'.format(indent)
             output += hexdump(indent, page_dump, 0)
 
         page_dump = platform_chassis.get_sfp(physical_port).read_eeprom(SFF8472_A0_SIZE + PAGE_OFFSET + (int(page, base=16) * PAGE_SIZE), PAGE_SIZE)

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -17,6 +17,8 @@ sys.modules['sonic_platform'] = mock.MagicMock()
 import sfputil.main as sfputil
 
 EXIT_FAIL = -1
+ERROR_NOT_IMPLEMENTED = 5
+ERROR_INVALID_PORT = 6
 
 class TestSfputil(object):
     def test_format_dict_value_to_string(self):
@@ -416,6 +418,139 @@ Ethernet0  N/A
         result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom'], ["-p", "Ethernet16", "-d"])
         assert result.exit_code == 0
         expected_output = "Ethernet16: SFP EEPROM is not applicable for RJ45 port\n\n\n"
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=0)))
+    def test_show_eeprom_hexdump_invalid_port(self, mock_chassis):
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet"])
+        assert result.exit_code == ERROR_INVALID_PORT
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    def test_show_eeprom_hexdump_invalid_page(self, mock_chassis):
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet1", "-r", "INVALID"])
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=True))
+    def test_show_eeprom_hexdump_RJ45(self, mock_chassis):
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet16"])
+        assert result.exit_code == ERROR_INVALID_PORT
+        expected_output = "Ethernet16: SFP EEPROM Hexdump is not applicable for RJ45 port\n"
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    def test_show_eeprom_hexdump_sff8636_page(self, mock_chassis):
+        lower_page_bytearray = bytearray([13, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 129, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        upper_page0_bytearray = bytearray([13, 0, 35, 8, 0, 0, 0, 65, 128, 128, 245, 0, 0, 0, 0, 0, 0, 0, 1, 160, 77, 111, 108, 101, 120, 32, 73, 110, 99, 46, 32, 32, 32, 32, 32, 32, 7, 0, 9, 58, 49, 49, 49, 48, 52, 48, 49, 48, 53, 52, 32, 32, 32, 32, 32, 32, 32, 32, 3, 4, 0, 0, 70, 196, 0, 0, 0, 0, 54, 49, 49, 48, 51, 48, 57, 50, 57, 32, 32, 32, 32, 32, 32, 32, 49, 54, 48, 52, 49, 57, 32, 32, 0, 0, 0, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        expected_output = '''EEPROM hexdump for port Ethernet0 page 0h
+        Lower page 0h
+        00000000 0d 00 06 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000010 00 00 00 00 00 00 01  81 00 00 00 00 00 00 00 00 |................|
+        00000020 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000030 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000040 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000050 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000060 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+
+        Upper page 0h
+        00000080 0d 00 23 08 00 00 00  41 80 80 f5 00 00 00 00 00 |..#....A........|
+        00000090 00 00 01 a0 4d 6f 6c  65 78 20 49 6e 63 2e 20 20 |....Molex Inc.  |
+        000000a0 20 20 20 20 07 00 09  3a 31 31 31 30 34 30 31 30 |    ...:11104010|
+        000000b0 35 34 20 20 20 20 20  20 20 20 03 04 00 00 46 c4 |54        ....F.|
+        000000c0 00 00 00 00 36 31 31  30 33 30 39 32 39 20 20 20 |....611030929   |
+        000000d0 20 20 20 20 31 36 30  34 31 39 20 20 00 00 00 24 |    160419  ...$|
+        000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+
+'''
+        def side_effect(offset, num_bytes):
+            if offset == 0:
+                return lower_page_bytearray
+            else:
+                return upper_page0_bytearray
+        mock_sfp = MagicMock()
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.read_eeprom = MagicMock(side_effect=side_effect)
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet0", "-r", "0"])
+        assert result.exit_code == 0
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    def test_show_eeprom_hexdump_sff8472_page(self, mock_chassis):
+        a0h_bytearray = bytearray([3, 4, 7, 16, 0, 0, 0, 0, 0, 0, 0, 6, 103, 0, 0, 0, 8, 3, 0, 30, 70, 73, 78, 73, 83, 65, 82, 32, 67, 79, 82, 80, 46, 32, 32, 32, 0, 0, 144, 101, 70, 84, 76, 88, 56, 53, 55, 49, 68, 51, 66, 67, 76, 32, 32, 32, 65, 32, 32, 32, 3, 82, 0, 72, 0, 26, 0, 0, 65, 85, 74, 48, 82, 67, 74, 32, 32, 32, 32, 32, 32, 32, 32, 32, 49, 53, 49, 48, 50, 57, 32, 32, 104, 240, 3, 246, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        a2h_lower_bytearray = bytearray([78, 0, 243, 0, 73, 0, 248, 0, 144, 136, 113, 72, 140, 160, 117, 48, 25, 200, 7, 208, 24, 156, 9, 196, 39, 16, 9, 208, 31, 7, 12, 90, 39, 16, 0, 100, 31, 7, 0, 158, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 63, 128, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 27, 20, 2, 129, 177, 13, 90, 23, 165, 21, 135, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 1])
+        a2h_upper_bytearray = bytearray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        expected_output = '''EEPROM hexdump for port Ethernet256 page 0h
+        A0h dump
+        00000000 03 04 07 10 00 00 00  00 00 00 00 06 67 00 00 00 |............g...|
+        00000010 08 03 00 1e 46 49 4e  49 53 41 52 20 43 4f 52 50 |....FINISAR CORP|
+        00000020 2e 20 20 20 00 00 90  65 46 54 4c 58 38 35 37 31 |.   ...eFTLX8571|
+        00000030 44 33 42 43 4c 20 20  20 41 20 20 20 03 52 00 48 |D3BCL   A   .R.H|
+        00000040 00 1a 00 00 41 55 4a  30 52 43 4a 20 20 20 20 20 |....AUJ0RCJ     |
+        00000050 20 20 20 20 31 35 31  30 32 39 20 20 68 f0 03 f6 |    151029  h...|
+        00000060 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000080 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000090 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000a0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000b0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000c0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000d0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+
+        A2h dump (Lower 128 bytes)
+        00000000 4e 00 f3 00 49 00 f8  00 90 88 71 48 8c a0 75 30 |N...I.....qH..u0|
+        00000010 19 c8 07 d0 18 9c 09  c4 27 10 09 d0 1f 07 0c 5a |........'......Z|
+        00000020 27 10 00 64 1f 07 00  9e 00 00 00 00 00 00 00 00 |'..d............|
+        00000030 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000040 00 00 00 00 3f 80 00  00 00 00 00 00 01 00 00 00 |....?...........|
+        00000050 01 00 00 00 01 00 00  00 01 00 00 00 00 00 00 1b |................|
+        00000060 14 02 81 b1 0d 5a 17  a5 15 87 00 00 00 00 30 00 |.....Z........0.|
+        00000070 00 00 00 00 00 00 00  00 ff ff ff ff ff ff ff 01 |................|
+
+        A2h dump (upper 128 bytes) page 0h
+        00000080 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        00000090 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000a0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000b0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000c0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000d0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
+
+'''
+        SFF8472_A0_SIZE = 256
+        def side_effect(offset, num_bytes):
+            if offset == 0:
+                return a0h_bytearray
+            elif (offset == SFF8472_A0_SIZE):
+                return a2h_lower_bytearray
+            else:
+                return a2h_upper_bytearray
+        mock_sfp = MagicMock()
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.read_eeprom = MagicMock(side_effect=side_effect)
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet256", "-r", "0"])
+        assert result.exit_code == 0
         assert result.output == expected_output
 
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=1))

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -431,7 +431,7 @@ Ethernet0  N/A
     @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
     def test_show_eeprom_hexdump_invalid_page(self, mock_chassis):
         runner = CliRunner()
-        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet1", "-r", "INVALID"])
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet1", "-n", "INVALID"])
         assert result.exit_code == ERROR_NOT_IMPLEMENTED
 
     @patch('sfputil.main.platform_chassis')
@@ -542,7 +542,7 @@ Ethernet0  N/A
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
         mock_sfp.read_eeprom = MagicMock(side_effect=side_effect)
         runner = CliRunner()
-        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet0", "-r", "0"])
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet0", "-n", "0"])
         assert result.exit_code == 0
         assert result.output == expected_output
 
@@ -573,7 +573,7 @@ Ethernet0  N/A
         000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
         000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
 
-        A2h dump (Lower 128 bytes)
+        A2h dump (lower 128 bytes)
         00000000 4e 00 f3 00 49 00 f8  00 90 88 71 48 8c a0 75 30 |N...I.....qH..u0|
         00000010 19 c8 07 d0 18 9c 09  c4 27 10 09 d0 1f 07 0c 5a |........'......Z|
         00000020 27 10 00 64 1f 07 00  9e 00 00 00 00 00 00 00 00 |'..d............|
@@ -607,7 +607,7 @@ Ethernet0  N/A
         mock_sfp.get_presence.return_value = True
         mock_sfp.read_eeprom = MagicMock(side_effect=side_effect)
         runner = CliRunner()
-        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet256", "-r", "0"])
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet256", "-n", "0"])
         assert result.exit_code == 0
         assert result.output == expected_output
 

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -449,6 +449,64 @@ Ethernet0  N/A
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
     @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    def test_show_eeprom_hexdump_xcvr_presence_not_implemented(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_presence = MagicMock(side_effect=NotImplementedError)
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet16"])
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        expected_output = "Sfp.get_presence() is currently not implemented for this platform\n"
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    def test_show_eeprom_hexdump_xcvr_not_present(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_presence.return_value = False
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet16"])
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        expected_output = "SFP EEPROM not detected\n"
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    def test_show_eeprom_hexdump_read_eeprom_failure(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_presence.return_value = True
+        mock_sfp.read_eeprom = MagicMock(return_value=None)
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet16"])
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        expected_output = "Error: Failed to read EEPROM for offset 0!\n"
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    def test_show_eeprom_hexdump_read_eeprom_not_implemented(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_presence.return_value = True
+        mock_sfp.read_eeprom = MagicMock(side_effect=NotImplementedError)
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet16"])
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        expected_output = "Sfp.read_eeprom() is currently not implemented for this platform\n"
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
     def test_show_eeprom_hexdump_sff8636_page(self, mock_chassis):
         lower_page_bytearray = bytearray([13, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 129, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         upper_page0_bytearray = bytearray([13, 0, 35, 8, 0, 0, 0, 65, 128, 128, 245, 0, 0, 0, 0, 0, 0, 0, 1, 160, 77, 111, 108, 101, 120, 32, 73, 110, 99, 46, 32, 32, 32, 32, 32, 32, 7, 0, 9, 58, 49, 49, 49, 48, 52, 48, 49, 48, 53, 52, 32, 32, 32, 32, 32, 32, 32, 32, 3, 4, 0, 0, 70, 196, 0, 0, 0, 0, 54, 49, 49, 48, 51, 48, 57, 50, 57, 32, 32, 32, 32, 32, 32, 32, 49, 54, 48, 52, 49, 57, 32, 32, 0, 0, 0, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
@@ -545,8 +603,8 @@ Ethernet0  N/A
             else:
                 return a2h_upper_bytearray
         mock_sfp = MagicMock()
-        mock_sfp.get_presence.return_value = True
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_presence.return_value = True
         mock_sfp.read_eeprom = MagicMock(side_effect=side_effect)
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'], ["-p", "Ethernet256", "-r", "0"])


### PR DESCRIPTION
**What I did**
Added a subcommand to display the hexdump of transceiver EEPROM page specified by the user.
"sfputil show eeprom-hexdump -p <port_name> -n <page_number>" has been added for this purpose. Specifying the port name is mandatory. If page number is not mentioned, page 0 content will be displayed by default.
For SFF-8472 based transceivers, following is the behavior
The entire 256 byte region of A0h will displayed. In addition to this, the lower 128 byte of A2h will be displayed.
The upper 128 bytes of A2h will be displayed based on the page number specified by the user. If no page number is specified, page 0 relevant data will be shown.

For non SFF-8472 based transceiver, following is the behavior
Lower page 0h is always displayed and the upper page is displayed based on the page number specified by the user

**How to verify it**
Verified the utility with 400G DD, 100G QSFP28, 40G DAC and 10G transceiver
```
400G DD
Page 0
CLI
sfputil show eeprom-hexdump -p Ethernet16 -n 0
root@str2-z9332f-05:/usr/local/lib/python3.9/dist-packages/sfputil# sfputil show eeprom-hexdump -p Ethernet16 -n 0
EEPROM hexdump for port Ethernet16 page 0h
        Lower page 0h
        00000000 18 30 80 00 00 00 00  00 00 00 00 00 00 00 00 00 |.0..............|
        00000010 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000020 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000030 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000040 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000050 00 00 00 00 00 03 1d  01 88 01 ff 00 00 00 00 00 |................|
        00000060 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

        Upper page 0h
        00000080 18 44 45 4c 4c 20 45  4d 43 20 20 20 20 20 20 20 |.DELL EMC       |
        00000090 20 3c 18 a0 32 32 56  36 52 20 20 20 20 20 20 20 | <..22V6R       |
        000000a0 20 20 20 20 41 30 43  4e 30 4c 58 44 30 30 30 36 |    A0CN0LXD0006|
        000000b0 4b 49 39 35 33 20 32  30 30 36 32 30 20 20 00 00 |KI953 200620  ..|
        000000c0 00 00 00 00 00 00 00  00 00 02 41 23 05 06 0a 16 |..........A#....|
        000000d0 00 00 00 02 0a 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000f0 df 10 04 93 01 00 00  00 00 00 00 00 00 00 00 00 |................|

root@str2-z9332f-05:/usr/local/lib/python3.9/dist-packages/sfputil# 

File dump
hexdump -C -n 256 12-0050/eeprom 
root@str2-z9332f-05:/sys/bus/i2c/devices# hexdump -C -n 256 12-0050/eeprom 
00000000  18 30 80 00 00 00 00 00  00 00 00 00 00 00 00 00  |.0..............|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000050  00 00 00 00 00 03 1d 01  88 01 ff 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000080  18 44 45 4c 4c 20 45 4d  43 20 20 20 20 20 20 20  |.DELL EMC       |
00000090  20 3c 18 a0 32 32 56 36  52 20 20 20 20 20 20 20  | <..22V6R       |
000000a0  20 20 20 20 41 30 43 4e  30 4c 58 44 30 30 30 36  |    A0CN0LXD0006|
000000b0  4b 49 39 35 33 20 32 30  30 36 32 30 20 20 00 00  |KI953 200620  ..|
000000c0  00 00 00 00 00 00 00 00  00 02 41 23 05 06 0a 16  |..........A#....|
000000d0  00 00 00 02 0a 00 00 00  00 00 00 00 00 00 00 00  |................|
000000e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000f0  df 10 04 93 01 00 00 00  00 00 00 00 00 00 00 00  |................|
00000100
root@str2-z9332f-05:/sys/bus/i2c/devices# 

Page 2
CLI
sfputil show eeprom-hexdump -p Ethernet16 -n 2
root@str2-z9332f-05:/usr/local/lib/python3.9/dist-packages/sfputil# sfputil show eeprom-hexdump -p Ethernet16 -n 2
EEPROM hexdump for port Ethernet16 page 2h
        Lower page 0h
        00000000 18 30 80 00 00 00 00  00 00 00 00 00 00 00 00 00 |.0..............|
        00000010 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000020 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000030 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000040 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000050 00 00 00 00 00 03 1d  01 88 01 ff 00 00 00 00 00 |................|
        00000060 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

        Upper page 2h

root@str2-z9332f-05:/usr/local/lib/python3.9/dist-packages/sfputil# 

File dump
hexdump -C -n 512 12-0050/eeprom 
root@str2-z9332f-05:/sys/bus/i2c/devices# hexdump -C -n 512 12-0050/eeprom 
00000000  18 30 80 00 00 00 00 00  00 00 00 00 00 00 00 00  |.0..............|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000050  00 00 00 00 00 03 1d 01  88 01 ff 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000080  18 44 45 4c 4c 20 45 4d  43 20 20 20 20 20 20 20  |.DELL EMC       |
00000090  20 3c 18 a0 32 32 56 36  52 20 20 20 20 20 20 20  | <..22V6R       |
000000a0  20 20 20 20 41 30 43 4e  30 4c 58 44 30 30 30 36  |    A0CN0LXD0006|
000000b0  4b 49 39 35 33 20 32 30  30 36 32 30 20 20 00 00  |KI953 200620  ..|
000000c0  00 00 00 00 00 00 00 00  00 02 41 23 05 06 0a 16  |..........A#....|
000000d0  00 00 00 02 0a 00 00 00  00 00 00 00 00 00 00 00  |................|
000000e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000f0  df 10 04 93 01 00 00 00  00 00 00 00 00 00 00 00  |................|
00000100
root@str2-z9332f-05:/sys/bus/i2c/devices# 

100G QSFP28
str2-a7280cr3-3
Page 0
CLI
sfputil show eeprom-hexdump -p Ethernet0 -n 0
root@str2-a7280cr3-3:/usr/local/lib/python3.9/dist-packages/sfputil# sfputil show eeprom-hexdump -p Ethernet0 -n 0
EEPROM hexdump for port Ethernet0 page 0h
        Lower page 0h
        00000000 11 08 00 10 00 10 00  00 00 00 00 00 00 00 00 00 |................|
        00000010 00 00 00 00 00 00 13  85 00 00 80 d3 00 00 00 00 |................|
        00000020 00 00 32 c9 34 d9 2b  b9 2f 43 00 00 0f 9f 0f 80 |..2.4.+./C......|
        00000030 0f 80 00 01 36 17 34  d2 30 43 00 00 00 00 00 00 |....6.4.0C......|
        00000040 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000050 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000060 00 00 ff 00 00 00 00  00 00 00 00 00 00 04 08 00 |................|
        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

        Upper page 0h
        00000080 11 8c 23 80 00 00 00  00 00 00 00 07 ff 00 00 00 |..#.............|
        00000090 00 00 05 00 46 49 4e  49 53 41 52 20 43 4f 52 50 |....FINISAR CORP|
        000000a0 20 20 20 20 00 00 90  65 46 43 42 52 34 32 35 51 |    ...eFCBR425Q|
        000000b0 45 32 43 30 35 2d 4d  53 41 30 42 68 00 00 00 30 |E2C05-MSA0Bh...0|
        000000c0 01 07 ff dc 55 33 53  41 48 36 37 20 20 20 20 20 |....U3SAH67     |
        000000d0 20 20 20 20 32 30 30  37 30 37 20 20 38 00 67 e3 |    200707  8.g.|
        000000e0 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20 20 |                |
        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

root@str2-a7280cr3-3:/usr/local/lib/python3.9/dist-packages/sfputil# 

File dump
hexdump -C -n 256 15-0050/eeprom
root@str2-a7280cr3-3:/sys/bus/i2c/devices# hexdump -C -n 256 15-0050/eeprom
00000000  11 08 00 10 00 10 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 13 c3  00 00 80 f4 00 00 00 00  |................|
00000020  00 00 32 00 34 ed 34 b2  30 3e 00 00 0f 9f 0f 80  |..2.4.4.0>......|
00000030  0f 80 00 01 36 14 34 ce  30 41 00 00 00 00 00 00  |....6.4.0A......|
00000040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000060  00 00 ff 00 00 00 00 00  00 00 00 00 00 04 08 00  |................|
00000070  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000080  11 8c 23 80 00 00 00 00  00 00 00 07 ff 00 00 00  |..#.............|
00000090  00 00 05 00 46 49 4e 49  53 41 52 20 43 4f 52 50  |....FINISAR CORP|
000000a0  20 20 20 20 00 00 90 65  46 43 42 52 34 32 35 51  |    ...eFCBR425Q|
000000b0  45 32 43 30 35 2d 4d 53  41 30 42 68 00 00 00 30  |E2C05-MSA0Bh...0|
000000c0  01 07 ff dc 55 33 53 41  48 36 37 20 20 20 20 20  |....U3SAH67     |
000000d0  20 20 20 20 32 30 30 37  30 37 20 20 38 00 67 e3  |    200707  8.g.|
000000e0  20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20  |                |
000000f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000100
root@str2-a7280cr3-3:/sys/bus/i2c/devices# 

Page 3
CLI
sfputil show eeprom-hexdump -p Ethernet0 -n 3
root@str2-a7280cr3-3:/sys/bus/i2c/devices# sfputil show eeprom-hexdump -p Ethernet0 -n 3
EEPROM hexdump for port Ethernet0 page 3h
        Lower page 0h
        00000000 11 08 00 10 00 10 00  00 00 00 00 00 00 00 00 00 |................|
        00000010 00 00 00 00 00 00 13  ab 00 00 81 12 00 00 00 00 |................|
        00000020 00 00 32 c2 35 55 35  80 2f b5 00 00 0f 9f 0f 80 |..2.5U5./.......|
        00000030 0f 80 00 01 36 15 34  cf 30 42 00 00 00 00 00 00 |....6.4.0B......|
        00000040 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000050 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000060 00 00 ff 00 00 00 00  00 00 00 00 00 00 04 08 00 |................|
        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

        Upper page 3h
        00000080 4b 00 fb 00 46 00 00  00 00 00 00 00 00 00 00 00 |K...F...........|
        00000090 8d cc 74 04 87 5a 79  18 00 00 00 00 00 00 00 00 |..t..Zy.........|
        000000a0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000b0 55 76 01 8e 43 e2 03  1a 17 70 05 dc 15 7c 07 d0 |Uv..C....p...|..|
        000000c0 7b 87 03 e8 4d f1 06  31 00 00 00 00 00 00 00 00 |{...M..1........|
        000000d0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000e0 a7 0f 00 00 00 00 00  00 00 00 22 22 22 22 33 33 |..........""""33|
        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

root@str2-a7280cr3-3:/sys/bus/i2c/devices# 

File dump
hexdump -C -n 640 15-0050/eeprom
root@str2-a7280cr3-3:/sys/bus/i2c/devices# hexdump -C -n 640 15-0050/eeprom
00000000  11 08 00 10 00 10 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 13 cb  00 00 80 83 00 00 00 00  |................|
00000020  00 00 32 4e 35 14 34 df  2f c7 00 00 0f 9f 0f 80  |..2N5.4./.......|
00000030  0f 80 00 01 36 14 34 ce  30 41 00 00 00 00 00 00  |....6.4.0A......|
00000040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000060  00 00 ff 00 00 00 00 00  00 00 00 00 00 04 08 00  |................|
00000070  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000080  11 8c 23 80 00 00 00 00  00 00 00 07 ff 00 00 00  |..#.............|
00000090  00 00 05 00 46 49 4e 49  53 41 52 20 43 4f 52 50  |....FINISAR CORP|
000000a0  20 20 20 20 00 00 90 65  46 43 42 52 34 32 35 51  |    ...eFCBR425Q|
000000b0  45 32 43 30 35 2d 4d 53  41 30 42 68 00 00 00 30  |E2C05-MSA0Bh...0|
000000c0  01 07 ff dc 55 33 53 41  48 36 37 20 20 20 20 20  |....U3SAH67     |
000000d0  20 20 20 20 32 30 30 37  30 37 20 20 38 00 67 e3  |    200707  8.g.|
000000e0  20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20  |                |
000000f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000200  4b 00 fb 00 46 00 00 00  00 00 00 00 00 00 00 00  |K...F...........|
00000210  8d cc 74 04 87 5a 79 18  00 00 00 00 00 00 00 00  |..t..Zy.........|
00000220  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000230  55 76 01 8e 43 e2 03 1a  17 70 05 dc 15 7c 07 d0  |Uv..C....p...|..|
00000240  7b 87 03 e8 4d f1 06 31  00 00 00 00 00 00 00 00  |{...M..1........|
00000250  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000260  a7 0f 00 00 00 00 00 00  00 00 22 22 22 22 33 33  |..........""""33|
00000270  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000280
root@str2-a7280cr3-3:/sys/bus/i2c/devices# 

10G
str-7260cx3-acs-7
sfputil show eeprom-hexdump -p Ethernet256 -n 0
root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# sfputil show eeprom-hexdump -p Ethernet256 -n 0
EEPROM hexdump for port Ethernet256 page 0h
        A0h dump
        00000000 03 04 07 10 00 00 00  00 00 00 00 06 67 00 00 00 |............g...|
        00000010 08 03 00 1e 46 49 4e  49 53 41 52 20 43 4f 52 50 |....FINISAR CORP|
        00000020 2e 20 20 20 00 00 90  65 46 54 4c 58 38 35 37 31 |.   ...eFTLX8571|
        00000030 44 33 42 43 4c 20 20  20 41 20 20 20 03 52 00 48 |D3BCL   A   .R.H|
        00000040 00 1a 00 00 41 55 4a  30 52 43 4a 20 20 20 20 20 |....AUJ0RCJ     |
        00000050 20 20 20 20 31 35 31  30 32 39 20 20 68 f0 03 f6 |    151029  h...|
        00000060 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000080 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000090 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000a0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000b0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000c0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000d0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

        A2h dump (lower 128 bytes)
        00000000 4e 00 f3 00 49 00 f8  00 90 88 71 48 8c a0 75 30 |N...I.....qH..u0|
        00000010 19 c8 07 d0 18 9c 09  c4 27 10 09 d0 1f 07 0c 5a |........'......Z|
        00000020 27 10 00 64 1f 07 00  9e 00 00 00 00 00 00 00 00 |'..d............|
        00000030 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000040 00 00 00 00 3f 80 00  00 00 00 00 00 01 00 00 00 |....?...........|
        00000050 01 00 00 00 01 00 00  00 01 00 00 00 00 00 00 1b |................|
        00000060 14 00 81 ad 0d 5f 17  a4 15 18 00 00 00 00 30 00 |....._........0.|
        00000070 00 00 00 00 00 00 00  00 ff ff ff ff ff ff ff 01 |................|

        A2h dump (upper 128 bytes) page 0h
        00000080 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000090 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000a0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000b0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000c0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000d0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# 

File dump
hexdump -C -n 512 7-0050/eeprom
root@str-7260cx3-acs-7:/sys/bus/i2c/devices# hexdump -C -n 512 7-0050/eeprom
00000000  03 04 07 10 00 00 00 00  00 00 00 06 67 00 00 00  |............g...|
00000010  08 03 00 1e 46 49 4e 49  53 41 52 20 43 4f 52 50  |....FINISAR CORP|
00000020  2e 20 20 20 00 00 90 65  46 54 4c 58 38 35 37 31  |.   ...eFTLX8571|
00000030  44 33 42 43 4c 20 20 20  41 20 20 20 03 52 00 48  |D3BCL   A   .R.H|
00000040  00 1a 00 00 41 55 4a 30  52 43 4a 20 20 20 20 20  |....AUJ0RCJ     |
00000050  20 20 20 20 31 35 31 30  32 39 20 20 68 f0 03 f6  |    151029  h...|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000100  4e 00 f3 00 49 00 f8 00  90 88 71 48 8c a0 75 30  |N...I.....qH..u0|
00000110  19 c8 07 d0 18 9c 09 c4  27 10 09 d0 1f 07 0c 5a  |........'......Z|
00000120  27 10 00 64 1f 07 00 9e  00 00 00 00 00 00 00 00  |'..d............|
00000130  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000140  00 00 00 00 3f 80 00 00  00 00 00 00 01 00 00 00  |....?...........|
00000150  01 00 00 00 01 00 00 00  01 00 00 00 00 00 00 1b  |................|
00000160  14 73 81 ab 0d 5d 17 7e  15 1a 00 00 00 00 30 00  |.s...].~......0.|
00000170  00 00 00 00 00 00 00 00  ff ff ff ff ff ff ff 01  |................|
00000180  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000200
root@str-7260cx3-acs-7:/sys/bus/i2c/devices# 

Page 2
sfputil show eeprom-hexdump -p Ethernet256 -n 2
root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# sfputil show eeprom-hexdump -p Ethernet256 -n 2
EEPROM hexdump for port Ethernet256 page 2h
        A0h dump
        00000000 03 04 07 10 00 00 00  00 00 00 00 06 67 00 00 00 |............g...|
        00000010 08 03 00 1e 46 49 4e  49 53 41 52 20 43 4f 52 50 |....FINISAR CORP|
        00000020 2e 20 20 20 00 00 90  65 46 54 4c 58 38 35 37 31 |.   ...eFTLX8571|
        00000030 44 33 42 43 4c 20 20  20 41 20 20 20 03 52 00 48 |D3BCL   A   .R.H|
        00000040 00 1a 00 00 41 55 4a  30 52 43 4a 20 20 20 20 20 |....AUJ0RCJ     |
        00000050 20 20 20 20 31 35 31  30 32 39 20 20 68 f0 03 f6 |    151029  h...|
        00000060 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000070 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000080 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000090 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000a0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000b0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000c0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000d0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000e0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        000000f0 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|

        A2h dump (lower 128 bytes)
        00000000 4e 00 f3 00 49 00 f8  00 90 88 71 48 8c a0 75 30 |N...I.....qH..u0|
        00000010 19 c8 07 d0 18 9c 09  c4 27 10 09 d0 1f 07 0c 5a |........'......Z|
        00000020 27 10 00 64 1f 07 00  9e 00 00 00 00 00 00 00 00 |'..d............|
        00000030 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 00 |................|
        00000040 00 00 00 00 3f 80 00  00 00 00 00 00 01 00 00 00 |....?...........|
        00000050 01 00 00 00 01 00 00  00 01 00 00 00 00 00 00 1b |................|
        00000060 14 80 81 ad 0d 59 17  75 15 11 00 00 00 00 30 00 |.....Y.u......0.|
        00000070 00 00 00 00 00 00 00  00 ff ff ff ff ff ff ff 01 |................|

        A2h dump (upper 128 bytes) page 2h

root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# 

File dump
hexdump -C 7-0050/eeprom
root@str-7260cx3-acs-7:/sys/bus/i2c/devices# hexdump -C 7-0050/eeprom
00000000  03 04 07 10 00 00 00 00  00 00 00 06 67 00 00 00  |............g...|
00000010  08 03 00 1e 46 49 4e 49  53 41 52 20 43 4f 52 50  |....FINISAR CORP|
00000020  2e 20 20 20 00 00 90 65  46 54 4c 58 38 35 37 31  |.   ...eFTLX8571|
00000030  44 33 42 43 4c 20 20 20  41 20 20 20 03 52 00 48  |D3BCL   A   .R.H|
00000040  00 1a 00 00 41 55 4a 30  52 43 4a 20 20 20 20 20  |....AUJ0RCJ     |
00000050  20 20 20 20 31 35 31 30  32 39 20 20 68 f0 03 f6  |    151029  h...|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000100  4e 00 f3 00 49 00 f8 00  90 88 71 48 8c a0 75 30  |N...I.....qH..u0|
00000110  19 c8 07 d0 18 9c 09 c4  27 10 09 d0 1f 07 0c 5a  |........'......Z|
00000120  27 10 00 64 1f 07 00 9e  00 00 00 00 00 00 00 00  |'..d............|
00000130  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000140  00 00 00 00 3f 80 00 00  00 00 00 00 01 00 00 00  |....?...........|
00000150  01 00 00 00 01 00 00 00  01 00 00 00 00 00 00 1b  |................|
00000160  14 27 81 ad 0d 62 17 68  15 0f 00 00 00 00 30 00  |.'...b.h......0.|
00000170  00 00 00 00 00 00 00 00  ff ff ff ff ff ff ff 01  |................|
00000180  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000200
root@str-7260cx3-acs-7:/sys/bus/i2c/devices# 

sfputil show eeprom -p Ethernet256
root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# sfputil show eeprom -p Ethernet256
Ethernet256: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length OM3(10m): 30.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: Unknown
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2015-10-29   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTLX8571D3BCL   
        Vendor Rev: A   
        Vendor SN: AUJ0RCJ         


root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# 

Help options
sfputil show eeprom-hexdump --help
root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# sfputil show eeprom-hexdump --help
Usage: sfputil show eeprom-hexdump [OPTIONS]

  Display EEPROM hexdump of SFP transceiver(s) for a given port name and
  page number

Options:
  -p, --port <port_name>    Display SFP EEPROM hexdump for port <port_name>
                            [required]
  -n, --page <page_number>  Display SFP EEEPROM hexdump for
                            <page_number_in_hex>
  --help                    Show this message and exit.
root@str-7260cx3-acs-7:/usr/local/lib/python3.9/dist-packages/sfputil# 
```
Signed-off-by: Mihir Patel <patelmi@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->