### PR TITLE
[202205] Fix typo in platform_sfputil_helper.is_rj45_port (#2374)

### DIFF
--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -133,7 +133,7 @@ def is_rj45_port(port_name):
 
         port_type = None
         try:
-            physical_port = platform_sfputil.logical_port_name_to_physical_port_list(port_name)
+            physical_port = platform_sfputil.get_logical_to_physical(port_name)
             if physical_port:
                 port_type = platform_chassis.get_port_or_cage_type(physical_port[0])
         except Exception as e:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

This is to backport https://github.com/sonic-net/sonic-utilities/pull/2374

#### What I did
Fix typo in `platform_sfputil_helper.is_rj45_port`.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

