### PR TITLE
Fix display disorder problem of show vrf 

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -325,6 +325,7 @@ def vrf(vrf_name):
             vrfs = [vrf_name]
         for vrf in vrfs:
             intfs = get_interface_bind_to_vrf(config_db, vrf)
+            intfs = natsorted(intfs)
             if len(intfs) == 0:
                 body.append([vrf, ""])
             else:

--- a/tests/show_vrf_test.py
+++ b/tests/show_vrf_test.py
@@ -112,9 +112,9 @@ VRF     Interfaces
 ------  ---------------
 Vrf1
 Vrf101  Ethernet0.10
-Vrf102  PortChannel0002
+Vrf102  Eth36.10
         Vlan40
-        Eth36.10
+        PortChannel0002
 Vrf103  Ethernet4
         Loopback0
         Po0002.101

--- a/tests/show_vrf_test.py
+++ b/tests/show_vrf_test.py
@@ -113,8 +113,8 @@ VRF     Interfaces
 Vrf1
 Vrf101  Ethernet0.10
 Vrf102  Eth36.10
-        Vlan40
         PortChannel0002
+        Vlan40
 Vrf103  Ethernet4
         Loopback0
         Po0002.101

--- a/tests/show_vrf_test.py
+++ b/tests/show_vrf_test.py
@@ -27,9 +27,9 @@ VRF     Interfaces
 ------  ---------------
 Vrf1
 Vrf101  Ethernet0.10
-Vrf102  PortChannel0002
+Vrf102  Eth36.10
+        PortChannel0002
         Vlan40
-        Eth36.10
 Vrf103  Ethernet4
         Loopback0
         Po0002.101
@@ -51,9 +51,9 @@ VRF     Interfaces
 ------  ---------------
 Vrf1
 Vrf101  Ethernet0.10
-Vrf102  PortChannel0002
+Vrf102  Eth36.10
+        PortChannel0002
         Vlan40
-        Eth36.10
 Vrf103  Ethernet4
         Loopback0
         Po0002.101


### PR DESCRIPTION
#### What I did
Fix display disorder problem of show vrf 

The problem is as follows, the vlan interfaces are not sorted in the interface column：
```
root@sonic:/home/admin# show vrf
VRF             Interfaces
--------------  ------------
Vrf1            Vlan30
                Vlan399
                Vlan40
Vrf2            Vlan41
                Vlan422
                Vlan50
                Vlan599
                Vlan60
```
#### How I did it
Sort the interface column with natsorted
#### How to verify it
use “show vrf”
#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show vrf
VRF             Interfaces
--------------  ------------
Vrf1            Vlan30
                Vlan399
                Vlan40
Vrf2            Vlan41
                Vlan422
                Vlan50
                Vlan599
                Vlan60
```
#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show vrf
VRF             Interfaces
--------------  ------------
Vrf1            Vlan30
                Vlan40
                Vlan399
Vrf2            Vlan41
                Vlan50
                Vlan60
                Vlan422
                Vlan599
```