### PR TITLE
[link-local]Modify RIF check to include link-local enabled interfaces

### DIFF
--- a/tests/ipv6_link_local_test.py
+++ b/tests/ipv6_link_local_test.py
@@ -30,7 +30,7 @@ show_ipv6_link_local_mode_output="""\
 +------------------+----------+
 | Ethernet36       | Disabled |
 +------------------+----------+
-| Ethernet40       | Disabled |
+| Ethernet40       | Enabled  |
 +------------------+----------+
 | Ethernet44       | Disabled |
 +------------------+----------+
@@ -223,6 +223,16 @@ class TestIPv6LinkLocal(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == ''
+
+    def test_vlan_member_add_on_link_local_interface(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
+
+        result = runner.invoke(config.config.commands["vlan"].commands["member"].commands["add"], ["4000", "Ethernet40"], obj=obj)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Ethernet40 is a router interface!' in result.output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -708,6 +708,9 @@
     "INTERFACE|Ethernet0|14.14.0.1/24": {
         "NULL": "NULL"
     },
+    "INTERFACE|Ethernet40": {
+        "ipv6_use_link_local_only": "enable"
+    },
     "DEBUG_COUNTER|DEBUG_0": {
         "type": "PORT_INGRESS_DROPS"
     },

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -294,7 +294,7 @@ def is_port_router_interface(config_db, port):
 
     interface_table = config_db.get_table('INTERFACE')
     for intf in interface_table:
-        if port == intf[0]:
+        if port == intf:
             return True
 
     return False
@@ -304,7 +304,7 @@ def is_pc_router_interface(config_db, pc):
 
     pc_interface_table = config_db.get_table('PORTCHANNEL_INTERFACE')
     for intf in pc_interface_table:
-        if pc == intf[0]:
+        if pc == intf:
             return True
 
     return False


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modify RIF check to include interfaces with link-local mode. The existing RIF check will only work if the key is tuple which is applicable only when interface has IP address. However if the interface has IPv6 only enable the key is of type string.
So in common if the interface is either IPv6 enabled or ip configured it has both string and tuple keys as illustrated below. Hence modified the if check to check directly for interface name which will match the key of type string

127.0.0.1:6379[4]> keys INTERFACE|Ethernet48

"INTERFACE|Ethernet48"
"INTERFACE|Ethernet48|1.1.1.1/16"
127.0.0.1:6379[4]> keys INTERFACE|Ethernet0
"INTERFACE|Ethernet0"

#### How I did it
Modified the logic to check if port has Router interface


#### How to verify it
Added UT to verify it.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

