### PR TITLE
[minigraph] new workflow for golden path

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1720,8 +1720,8 @@ def load_mgmt_config(filename):
                 expose_value=False, prompt='Reload config from minigraph?')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
 @click.option('-t', '--traffic_shift_away', default=False, is_flag=True, help='Keep device in maintenance with TSA')
-@click.option('-p', '--golden_config_path', is_flag=True, help='The path of golden config file')
-@click.argument('golden_config', metavar='', required=False)
+@click.option('-p', '--golden_config', default=False, is_flag=True, help='Enable golden config override. Provide golden config path or it will proceed with default path.')
+@click.argument('golden_config_path', metavar='', required=False)
 @clicommon.pass_db
 def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_path, golden_config):
     """Reconfigure based on minigraph."""
@@ -1796,19 +1796,19 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_pat
     # Keep device isolated with TSA 
     if traffic_shift_away:
         clicommon.run_command("TSA", display_cmd=True)
-        if golden_config_path:
+        if golden_config:
             log.log_warning("Golden configuration may override System Maintenance state. Please execute TSC to check the current System mode")
             click.secho("[WARNING] Golden configuration may override Traffic-shift-away state. Please execute TSC to check the current System mode")
 
     # Load golden_config_db.json
-    if golden_config_path:
-        if golden_config is None:
-            golden_config = DEFAULT_GOLDEN_CONFIG_DB_FILE
-        if not os.path.isfile(golden_config):
-            click.secho("Cannot find '{}'!".format(golden_config),
+    if golden_config:
+        if golden_config_path is None:
+            golden_config_path = DEFAULT_GOLDEN_CONFIG_DB_FILE
+        if not os.path.isfile(golden_config_path):
+            click.secho("Cannot find '{}'!".format(golden_config_path),
                         fg='magenta')
             raise click.Abort()
-        override_config_by(golden_config)
+        override_config_by(golden_config_path)
 
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them

--- a/config/main.py
+++ b/config/main.py
@@ -1720,10 +1720,10 @@ def load_mgmt_config(filename):
                 expose_value=False, prompt='Reload config from minigraph?')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
 @click.option('-t', '--traffic_shift_away', default=False, is_flag=True, help='Keep device in maintenance with TSA')
-@click.option('-p', '--golden_config', default=False, is_flag=True, help='Enable golden config override. Provide golden config path or it will proceed with default path.')
-@click.argument('golden_config_path', metavar='', required=False)
+@click.option('-o', '--override_config', default=False, is_flag=True, help='Enable config override. Proceed with default path.')
+@click.option('-p', '--golden_config_path', help='Provide golden config path to override. Use with --override_config')
 @clicommon.pass_db
-def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_path, golden_config):
+def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, golden_config_path):
     """Reconfigure based on minigraph."""
     log.log_info("'load_minigraph' executing...")
 
@@ -1796,12 +1796,12 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, golden_config_pat
     # Keep device isolated with TSA 
     if traffic_shift_away:
         clicommon.run_command("TSA", display_cmd=True)
-        if golden_config:
+        if override_config:
             log.log_warning("Golden configuration may override System Maintenance state. Please execute TSC to check the current System mode")
             click.secho("[WARNING] Golden configuration may override Traffic-shift-away state. Please execute TSC to check the current System mode")
 
     # Load golden_config_db.json
-    if golden_config:
+    if override_config:
         if golden_config_path is None:
             golden_config_path = DEFAULT_GOLDEN_CONFIG_DB_FILE
         if not os.path.isfile(golden_config_path):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -409,27 +409,6 @@ class TestLoadMinigraph(object):
                 assert result.exit_code == 0
                 assert expected_output in result.output
 
-    def test_load_minigraph_with_golden_config(self, get_cmd_module, setup_single_broadcom_asic):
-        with mock.patch(
-            "utilities_common.cli.run_command",
-            mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
-            (config, show) = get_cmd_module
-            db = Db()
-            golden_config = {}
-            self.check_golden_config(db, config, golden_config,
-                                     "config override-config-table /etc/sonic/golden_config_db.json")
-
-    def check_golden_config(self, db, config, golden_config, expected_output):
-        def is_file_side_effect(filename):
-            return True if 'golden_config' in filename else False
-        with mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
-            runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"], obj=db)
-            print(result.exit_code)
-            print(result.output)
-            assert result.exit_code == 0
-            assert expected_output in result.output
-
     def test_load_minigraph_with_non_exist_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
@@ -437,23 +416,31 @@ class TestLoadMinigraph(object):
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["-p", "non_exist.json", "-y"])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config_path", "non_exist.json", "-y"])
             assert result.exit_code != 0
             assert "Cannot find 'non_exist.json'" in result.output
 
-    def test_load_minigraph_with_golden_config_path(self, get_cmd_module):
+    def test_load_minigraph_with_specified_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["-p", "golden_config.json", "-y"])
-            print(result.exit_code)
-            print(result.output)
-            traceback.print_tb(result.exc_info[2])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config_path", "golden_config.json", "-y"])
             assert result.exit_code == 0
             assert "config override-config-table golden_config.json" in result.output
+
+    def test_load_minigraph_with_default_golden_config_path(self, get_cmd_module):
+        def is_file_side_effect(filename):
+            return True if 'golden_config' in filename else False
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config_path", "-y"])
+            assert result.exit_code == 0
+            assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
     def test_load_minigraph_with_traffic_shift_away(self, get_cmd_module):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
@@ -475,7 +462,7 @@ class TestLoadMinigraph(object):
                 db = Db()
                 golden_config = {}
                 runner = CliRunner()
-                result = runner.invoke(config.config.commands["load_minigraph"], ["-ty"])
+                result = runner.invoke(config.config.commands["load_minigraph"], ["-ty", "--golden_config_path"])
                 print(result.exit_code)
                 print(result.output)
                 traceback.print_tb(result.exc_info[2])

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -416,7 +416,7 @@ class TestLoadMinigraph(object):
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config_path", "non_exist.json", "-y"])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config", "non_exist.json", "-y"])
             assert result.exit_code != 0
             assert "Cannot find 'non_exist.json'" in result.output
 
@@ -427,7 +427,7 @@ class TestLoadMinigraph(object):
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config_path", "golden_config.json", "-y"])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config", "golden_config.json", "-y"])
             assert result.exit_code == 0
             assert "config override-config-table golden_config.json" in result.output
 
@@ -438,7 +438,7 @@ class TestLoadMinigraph(object):
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config_path", "-y"])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config", "-y"])
             assert result.exit_code == 0
             assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
@@ -462,7 +462,7 @@ class TestLoadMinigraph(object):
                 db = Db()
                 golden_config = {}
                 runner = CliRunner()
-                result = runner.invoke(config.config.commands["load_minigraph"], ["-ty", "--golden_config_path"])
+                result = runner.invoke(config.config.commands["load_minigraph"], ["-ty", "--golden_config"])
                 print(result.exit_code)
                 print(result.output)
                 traceback.print_tb(result.exc_info[2])

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -416,7 +416,7 @@ class TestLoadMinigraph(object):
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config", "non_exist.json", "-y"])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "--golden_config_path", "non_exist.json", "-y"])
             assert result.exit_code != 0
             assert "Cannot find 'non_exist.json'" in result.output
 
@@ -427,7 +427,7 @@ class TestLoadMinigraph(object):
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config", "golden_config.json", "-y"])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "--golden_config_path",  "golden_config.json", "-y"])
             assert result.exit_code == 0
             assert "config override-config-table golden_config.json" in result.output
 
@@ -438,7 +438,7 @@ class TestLoadMinigraph(object):
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["load_minigraph"], ["--golden_config", "-y"])
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "-y"])
             assert result.exit_code == 0
             assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
@@ -462,7 +462,7 @@ class TestLoadMinigraph(object):
                 db = Db()
                 golden_config = {}
                 runner = CliRunner()
-                result = runner.invoke(config.config.commands["load_minigraph"], ["-ty", "--golden_config"])
+                result = runner.invoke(config.config.commands["load_minigraph"], ["-ty", "--override_config"])
                 print(result.exit_code)
                 print(result.output)
                 traceback.print_tb(result.exc_info[2])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Change the behavior that load_minigraph will consume golden config by default.
New behavior:
`config load_minigraph`: No longer consume golden config.
`config load_minigraph --golden_config`: Consume default golden config. /etc/sonic/golden_config_db.json
`config load_minigraph --golden_config FilePath`: Consume golden config with FilePath
#### How I did it
Make golden_config click.Option() and add an argument for golden config path.
#### How to verify it
UT test.
#### Previous command output (if the output of a command-line utility has changed)
sudo config load_minigraph -h
Usage: config load_minigraph [OPTIONS]

Reconfigure based on minigraph.

Options:
-y, --yes
-n, --no_service_restart Do not restart docker services
-t, --traffic_shift_away Keep device in maintenance with TSA
-p, --golden_config_path TEXT specify Golden Config path
-?, -h, --help Show this message and exit.
#### New command output (if the output of a command-line utility has changed)
admin@vlab-01:~$ sudo config load_minigraph --golden_config_path -h
Usage: config load_minigraph [OPTIONS]

  Reconfigure based on minigraph.

Options:
  -y, --yes
  -n, --no_service_restart       Do not restart docker services
  -t, --traffic_shift_away       Keep device in maintenance with TSA
  -o, --override_config          Enable config override. Proceed with default path.
  -p, --golden_config_path TEXT  Provide golden config path to override. Use with --override_config
  -h, -?, --help                 Show this message and exit.

