### PR TITLE
Remove `TC_TO_DSCP_MAP` in `config qos clear` command

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -739,6 +739,7 @@ def _clear_qos():
             'MAP_PFC_PRIORITY_TO_QUEUE',
             'TC_TO_QUEUE_MAP',
             'DSCP_TO_TC_MAP',
+            'TC_TO_DSCP_MAP',
             'MPLS_TC_TO_TC_MAP',
             'SCHEDULER',
             'PFC_PRIORITY_TO_PRIORITY_GROUP_MAP',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to update command `config qos clear`.
Before the update:
`config qos clear` doesn't clear the `TC_TO_DSCP_MAP`.
After the update
`TC_TO_DSCP_MAP` is cleared when running `config qos clear`.
I have confirmed that even if `TC_TO_DSCP_MAP` doesn't exist, deleting an inexistent table won't cause exception.
 
#### How I did it
Update the list `QOS_TABLE_NAMES` to add `TC_TO_DSCP_MAP`.

#### How to verify it
The change is verified on a physical testbed.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

