### PR TITLE
Add UT to check sonic installer does not depend on database

### DIFF
--- a/tests/installer_dependency_test.py
+++ b/tests/installer_dependency_test.py
@@ -34,4 +34,4 @@ def test_sonic_installer_not_depends_on_database_docker():
     except RuntimeError:
         exception_happen = True
 
-    assert result.exception_happen == True
+    assert exception_happen == True

--- a/tests/installer_dependency_test.py
+++ b/tests/installer_dependency_test.py
@@ -20,7 +20,7 @@ class MockSonicDBConfig:
         return False
 
 @mock.patch("swsscommon.swsscommon.SonicDBConfig", MockSonicDBConfig)
-def test_sonic_installer_not_depends_on_database_docker():
+def test_sonic_installer_not_depends_on_database_container():
     runner = CliRunner()
     result = runner.invoke(
             sonic_installer.sonic_installer.commands['list']

--- a/tests/installer_dependency_test.py
+++ b/tests/installer_dependency_test.py
@@ -1,0 +1,37 @@
+import pytest
+import sonic_installer.main as sonic_installer
+import utilities_common.cli as clicommon
+
+from click.testing import CliRunner
+from unittest import mock
+
+# mock load_db_config to throw exception
+class MockSonicDBConfig:
+    def load_sonic_db_config():
+        raise RuntimeError("sonic installer 'list' command should not depends on database")
+
+    def load_sonic_global_db_config():
+        raise RuntimeError("sonic installer 'list' command should not depends on database")
+
+    def isInit():
+        return False
+
+    def isGlobalInit():
+        return False
+
+@mock.patch("swsscommon.swsscommon.SonicDBConfig", MockSonicDBConfig)
+def test_sonic_installer_not_depends_on_database_docker():
+    runner = CliRunner()
+    result = runner.invoke(
+            sonic_installer.sonic_installer.commands['list']
+        )
+    assert result.exit_code == 0
+
+    # check InterfaceAliasConverter will break by the mock method, sonic installer use it to load db config.
+    exception_happen = False
+    try:
+        clicommon.InterfaceAliasConverter()
+    except RuntimeError:
+        exception_happen = True
+
+    assert result.exception_happen == True

--- a/tests/installer_dependency_test.py
+++ b/tests/installer_dependency_test.py
@@ -25,7 +25,7 @@ def test_sonic_installer_not_depends_on_database_docker():
     result = runner.invoke(
             sonic_installer.sonic_installer.commands['list']
         )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
 
     # check InterfaceAliasConverter will break by the mock method, sonic installer use it to load db config.
     exception_happen = False


### PR DESCRIPTION
### Description of PR
Add new test cases to test sonic-installer does not depends on database docker.

### Type of change
- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Back port request

### Approach
#### What is the motivation for this PR?
Add new test cases to test sonic-installer does not depends on database docker.

#### How did you do it?
Add new test case to cover user scenarios.

#### How did you verify/test it?
Run new UT make sure they are all pass.
Make sure all current UT not break during merge validation.

#### Any platform specific information?
N/A

#### Supported testbed topology if it's a new test case?.
