### PR TITLE
[generate_dump]: Enhance show techsupport for cisco-8000 platform

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1088,6 +1088,32 @@ collect_barefoot() {
 } 
 
 ###############################################################################
+# Collect Cisco-8000 specific information
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+collect_cisco_8000() {
+    trap 'handle_error $? $LINENO' ERR
+    local platform=$(show platform summary --json | python -c 'import sys, json; \
+        print(json.load(sys.stdin)["platform"])')
+
+    if [ -d /usr/share/sonic/device/${platform} ]; then
+        pushd /usr/share/sonic/device/${platform} > /dev/null
+        for file in $(find . -path "./*plugin*" -prune -o -path "./*.xml" -prune -o -path "./*.yaml" -prune -o -print); do
+            save_file ${file} sai false
+        done
+        popd > /dev/null
+    else
+        echo "'/usr/share/sonic/device/${platform}' does not exist" > /tmp/error
+        save_file /tmp/error sai false
+    fi
+}
+
+###############################################################################
 # Save log file
 # Globals:
 #  TAR, TARFILE, DUMPDIR, BASE, TARDIR, TECHSUPPORT_TIME_INFO
@@ -1410,6 +1436,10 @@ main() {
 
     if [ "$asic" = "broadcom" ]; then
         collect_broadcom
+    fi
+
+    if [ "$asic" = "cisco-8000" ]; then
+        collect_cisco_8000
     fi
 
     # 2nd counter snapshot late. Need 2 snapshots to make sense of counters trend.


### PR DESCRIPTION
Signed-off-by: Geert Vlaemynck <gvlaemyn@cisco.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added cisco-8000 specific platform information to "show techsupport" tarfile

#### How I did it
Added collect_cisco_8000 function to scripts/generate_dump which filters out the wanted files from /usr/share/sonic/device/${platform} and saves them in the techsupport tarfile under sai subdirectory

#### How to verify it
Run "show techsupport" and grep sai in the generated techsupport tarfile

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

