### PR TITLE
[VxLAN]Fix Vxlan delete command to throw error when there are references

### DIFF
--- a/config/vxlan.py
+++ b/config/vxlan.py
@@ -38,6 +38,10 @@ def del_vxlan(db, vxlan_name):
     """Del VXLAN"""
     ctx = click.get_current_context()
 
+    vxlan_keys = db.cfgdb.get_keys('VXLAN_TUNNEL')
+    if vxlan_name not in vxlan_keys:
+        ctx.fail("Vxlan tunnel {} does not exist".format(vxlan_name))
+
     vxlan_keys = db.cfgdb.get_keys('VXLAN_EVPN_NVO')
     if not vxlan_keys:
       vxlan_count = 0
@@ -55,6 +59,12 @@ def del_vxlan(db, vxlan_name):
 
     if(vxlan_count > 0):
         ctx.fail("Please delete all VLAN VNI mappings.")  
+
+    vnet_table = db.cfgdb.get_table('VNET')
+    vnet_keys = vnet_table.keys()
+    for vnet_key in vnet_keys:
+        if ('vxlan_tunnel' in vnet_table[vnet_key] and vnet_table[vnet_key]['vxlan_tunnel'] == vxlan_name):
+            ctx.fail("Please delete all VNET configuration referencing the tunnel " + vxlan_name)
 
     db.cfgdb.set_entry('VXLAN_TUNNEL', vxlan_name, None)
 

--- a/tests/vnet_input/config_db.json
+++ b/tests/vnet_input/config_db.json
@@ -1,0 +1,10 @@
+{
+    "VNET|Vnet_2000": {
+        "peer_list": "",
+        "vni": "2000",
+        "vxlan_tunnel": "tunnel1"
+    },
+    "VXLAN_TUNNEL|tunnel1": {
+        "src_ip": "10.10.10.10"
+    }
+}

--- a/tests/vxlan_test.py
+++ b/tests/vxlan_test.py
@@ -7,6 +7,10 @@ from click.testing import CliRunner
 import config.main as config
 import show.main as show
 from utilities_common.db import Db
+from .mock_tables import dbconnector
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+mock_db_path = os.path.join(test_path, "vnet_input")
 
 show_vxlan_interface_output="""\
 VTEP Information:
@@ -246,6 +250,24 @@ class TestVxlan(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_vxlan_vlanvnimap_output
+
+    def test_config_vxlan_del(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db')
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["del"], ["tunnel_invalid"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Vxlan tunnel tunnel_invalid does not exist" in result.output
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["del"], ["tunnel1"], obj=db)
+        dbconnector.dedicated_dbs = {}
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Please delete all VNET configuration referencing the tunnel" in result.output
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fix for https://github.com/sonic-net/sonic-buildimage/issues/12063
#### What I did
Check for VNET references for vxlan before deleting vxlan object


#### How I did it
Check VNET table and throw error if vxlan is referenced


#### How to verify it
Added UT to verify it.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

