### PR TITLE
YANG Validation for ConfigDB Updates: Fix Decorator Bug

### DIFF
--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -4,7 +4,6 @@ from jsonpointer import JsonPointer
 from sonic_py_common import device_info
 from generic_config_updater.generic_updater import GenericUpdater, ConfigFormat
 from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogging
-from swsscommon.swsscommon import ConfigDBConnector
 
 class ValidatedConfigDBConnector(object):
     

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -66,4 +66,4 @@ def validated_set_entry(self, table, key, value):
     try:
         GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
     except EmptyTableError:
-        validated_delete_table(table)
+        validated_delete_table(self, table)

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -10,13 +10,10 @@ class ValidatedConfigDBConnector(object):
     
     def __init__(self, config_db_connector):
         self.connector = config_db_connector
+        self.yang_enabled = device_info.is_yang_config_validation_enabled(self.connector)
 
     def __getattr__(self, name):
-        config_db_connector = ConfigDBConnector()
-        config_db_connector.connect()
-        yang_enabled = device_info.is_yang_config_validation_enabled(config_db_connector)
-
-        if yang_enabled:
+        if self.yang_enabled:
             if name == "set_entry":
                 return self.validated_set_entry
             if name == "delete_table":

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -7,10 +7,14 @@ from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogg
 
 def ValidatedConfigDBConnector(config_db_connector):
     yang_enabled = device_info.is_yang_config_validation_enabled(config_db_connector) 
-    if yang_enabled:
-        config_db_connector.set_entry = validated_set_entry
-        config_db_connector.delete_table = validated_delete_table
-    return config_db_connector
+    if not yang_enabled:
+        return config_db_connector
+
+    validated_config_db_connector = ConfigDBConnector()
+    validated_config_db_connector.connect()
+    validated_config_db_connector.set_entry = validated_set_entry
+    validated_config_db_connector.delete_table = validated_delete_table
+    return valudated_config_db_connector
 
 def make_path_value_jsonpatch_compatible(table, key, value):
     if type(key) == tuple:

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -24,7 +24,7 @@ class ValidatedConfigDBConnector(object):
         if name == "delete_table":
             return validated_delete_table
 
-    def make_path_value_jsonpatch_compatible(table, key, value):
+    def make_path_value_jsonpatch_compatible(self, table, key, value):
         if type(key) == tuple:
             path = JsonPointer.from_parts([table, '|'.join(key)]).path
         else:
@@ -33,7 +33,7 @@ class ValidatedConfigDBConnector(object):
             value = {}
         return path, value
 
-    def create_gcu_patch(op, table, key=None, value=None):
+    def create_gcu_patch(self, op, table, key=None, value=None):
         if key:
             path, value = make_path_value_jsonpatch_compatible(table, key, value)
         else: 
@@ -72,4 +72,4 @@ class ValidatedConfigDBConnector(object):
         try:
             GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
         except EmptyTableError:
-            validated_delete_table(self, table)
+            validated_delete_table(table)

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -1,4 +1,5 @@
 import jsonpatch
+import types
 from jsonpointer import JsonPointer
 
 from sonic_py_common import device_info
@@ -13,8 +14,8 @@ def ValidatedConfigDBConnector(config_db_connector):
 
     validated_config_db_connector = ConfigDBConnector()
     validated_config_db_connector.connect()
-    validated_config_db_connector.set_entry = validated_set_entry
-    validated_config_db_connector.delete_table = validated_delete_table
+    validated_config_db_connector.set_entry = types.MethodType(validated_set_entry, validated_config_db_connector)
+    validated_config_db_connector.delete_table = types.MethodType(validated_delete_table, validated_config_db_connector)
     return validated_config_db_connector
 
 def make_path_value_jsonpatch_compatible(table, key, value):
@@ -42,7 +43,7 @@ def create_gcu_patch(op, table, key=None, value=None):
     gcu_patch = jsonpatch.JsonPatch(gcu_json_input)
     return gcu_patch
 
-def validated_delete_table(table):
+def validated_delete_table(self, table):
     gcu_patch = create_gcu_patch("remove", table)
     format = ConfigFormat.CONFIGDB.name
     config_format = ConfigFormat[format.upper()]
@@ -52,7 +53,7 @@ def validated_delete_table(table):
         logger = genericUpdaterLogging.get_logger(title="Patch Applier", print_all_to_console=True)
         logger.log_notice("Unable to remove entry, as doing so will result in invalid config. Error: {}".format(e))
 
-def validated_set_entry(table, key, value):
+def validated_set_entry(self, table, key, value):
     if value is not None:
         op = "add"
     else:

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -15,7 +15,7 @@ def ValidatedConfigDBConnector(config_db_connector):
     validated_config_db_connector.connect()
     validated_config_db_connector.set_entry = validated_set_entry
     validated_config_db_connector.delete_table = validated_delete_table
-    return valudated_config_db_connector
+    return validated_config_db_connector
 
 def make_path_value_jsonpatch_compatible(table, key, value):
     if type(key) == tuple:

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -7,63 +7,69 @@ from generic_config_updater.generic_updater import GenericUpdater, ConfigFormat
 from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogging
 from swsscommon.swsscommon import ConfigDBConnector
 
-def ValidatedConfigDBConnector(config_db_connector):
-    yang_enabled = device_info.is_yang_config_validation_enabled(config_db_connector) 
-    if not yang_enabled:
-        return config_db_connector
-
-    validated_config_db_connector = ConfigDBConnector()
-    validated_config_db_connector.connect()
-    validated_config_db_connector.set_entry = types.MethodType(validated_set_entry, validated_config_db_connector)
-    validated_config_db_connector.delete_table = types.MethodType(validated_delete_table, validated_config_db_connector)
-    return validated_config_db_connector
-
-def make_path_value_jsonpatch_compatible(table, key, value):
-    if type(key) == tuple:
-        path = JsonPointer.from_parts([table, '|'.join(key)]).path
-    else:
-        path = JsonPointer.from_parts([table, key]).path
-    if value == {"NULL" : "NULL"}:
-        value = {}
-    return path, value
-
-def create_gcu_patch(op, table, key=None, value=None):
-    if key:
-        path, value = make_path_value_jsonpatch_compatible(table, key, value)
-    else: 
-        path = "/{}".format(table)
-
-    gcu_json_input = []
-    gcu_json = {"op": "{}".format(op),
-                "path": "{}".format(path)}
-    if op == "add":
-        gcu_json["value"] = value
-
-    gcu_json_input.append(gcu_json)
-    gcu_patch = jsonpatch.JsonPatch(gcu_json_input)
-    return gcu_patch
-
-def validated_delete_table(self, table):
-    gcu_patch = create_gcu_patch("remove", table)
-    format = ConfigFormat.CONFIGDB.name
-    config_format = ConfigFormat[format.upper()]
-    try:
-        GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
-    except ValueError as e:
-        logger = genericUpdaterLogging.get_logger(title="Patch Applier", print_all_to_console=True)
-        logger.log_notice("Unable to remove entry, as doing so will result in invalid config. Error: {}".format(e))
-
-def validated_set_entry(self, table, key, value):
-    if value is not None:
-        op = "add"
-    else:
-        op = "remove"
+class ValidatedConfigDBConnector(object):
     
-    gcu_patch = create_gcu_patch(op, table, key, value)
-    format = ConfigFormat.CONFIGDB.name
-    config_format = ConfigFormat[format.upper()]
+    def __init__(self, config_db_connector):
+        self.connector = config_db_connector
 
-    try:
-        GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
-    except EmptyTableError:
-        validated_delete_table(self, table)
+    def __getattr__(self, name):
+        config_db_connector = ConfigDBConnector()
+        config_db_connector.connect()
+        yang_enabled = device_info.is_yang_config_validation_enabled(config_db_connector)
+
+        if not yang_enabled:
+            return self.connector.__getattribute__(name)
+        if name == "set_entry":
+            return validated_set_entry
+        if name == "delete_table":
+            return validated_delete_table
+
+    def make_path_value_jsonpatch_compatible(table, key, value):
+        if type(key) == tuple:
+            path = JsonPointer.from_parts([table, '|'.join(key)]).path
+        else:
+            path = JsonPointer.from_parts([table, key]).path
+        if value == {"NULL" : "NULL"}:
+            value = {}
+        return path, value
+
+    def create_gcu_patch(op, table, key=None, value=None):
+        if key:
+            path, value = make_path_value_jsonpatch_compatible(table, key, value)
+        else: 
+            path = "/{}".format(table)
+
+        gcu_json_input = []
+        gcu_json = {"op": "{}".format(op),
+                    "path": "{}".format(path)}
+        if op == "add":
+            gcu_json["value"] = value
+
+        gcu_json_input.append(gcu_json)
+        gcu_patch = jsonpatch.JsonPatch(gcu_json_input)
+        return gcu_patch
+
+    def validated_delete_table(self, table):
+        gcu_patch = create_gcu_patch("remove", table)
+        format = ConfigFormat.CONFIGDB.name
+        config_format = ConfigFormat[format.upper()]
+        try:
+            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
+        except ValueError as e:
+            logger = genericUpdaterLogging.get_logger(title="Patch Applier", print_all_to_console=True)
+            logger.log_notice("Unable to remove entry, as doing so will result in invalid config. Error: {}".format(e))
+
+    def validated_set_entry(self, table, key, value):
+        if value is not None:
+            op = "add"
+        else:
+            op = "remove"
+    
+        gcu_patch = create_gcu_patch(op, table, key, value)
+        format = ConfigFormat.CONFIGDB.name
+        config_format = ConfigFormat[format.upper()]
+
+        try:
+            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
+        except EmptyTableError:
+            validated_delete_table(self, table)

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -4,6 +4,7 @@ from jsonpointer import JsonPointer
 from sonic_py_common import device_info
 from generic_config_updater.generic_updater import GenericUpdater, ConfigFormat
 from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogging
+from swsscommon.swsscommon import ConfigDBConnector
 
 def ValidatedConfigDBConnector(config_db_connector):
     yang_enabled = device_info.is_yang_config_validation_enabled(config_db_connector) 

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -16,12 +16,12 @@ class ValidatedConfigDBConnector(object):
         config_db_connector.connect()
         yang_enabled = device_info.is_yang_config_validation_enabled(config_db_connector)
 
-        if not yang_enabled:
-            return self.connector.__getattribute__(name)
-        if name == "set_entry":
-            return self.validated_set_entry
-        if name == "delete_table":
-            return self.validated_delete_table
+        if yang_enabled:
+            if name == "set_entry":
+                return self.validated_set_entry
+            if name == "delete_table":
+                return self.validated_delete_table
+        return self.connector.__getattribute__(name)
 
     def make_path_value_jsonpatch_compatible(self, table, key, value):
         if type(key) == tuple:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1651,7 +1651,7 @@ class TestConfigLoopback(object):
         importlib.reload(config.main)
     
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
-    @patch("config.validated_config_db_connector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
     def test_add_loopback_with_invalid_name_yang_validation(self):
         config.ADHOC_VALIDATION = False
         runner = CliRunner()
@@ -1700,7 +1700,7 @@ class TestConfigLoopback(object):
         assert result.exit_code != 0
         assert "Loopbax1 is invalid, name should have prefix 'Loopback' and suffix '<0-999>'" in result.output
     
-    @patch("config.validated_config_db_connector.validated_set_entry", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(return_value=True))
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     def test_add_loopback_yang_validation(self):
         config.ADHOC_VALIDATION = False

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -19,7 +19,7 @@ class TestPortChannel(object):
         print("SETUP")
 
     @patch("config.main.is_portchannel_present_in_db", mock.Mock(return_value=False))
-    @patch("config.validated_config_db_connector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     def test_add_portchannel_with_invalid_name_yang_validation(self):
         config.ADHOC_VALIDATION = False
@@ -46,7 +46,7 @@ class TestPortChannel(object):
         assert result.exit_code != 0
         assert "Error: PortChan005 is invalid!, name should have prefix 'PortChannel' and suffix '<0-9999>'" in result.output
 
-    @patch("config.validated_config_db_connector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     def test_delete_nonexistent_portchannel_yang_validation(self):
         config.ADHOC_VALIDATION = False

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -26,5 +26,5 @@ class TestValidatedConfigDBConnector(TestCase):
         mock_generic_updater = mock.Mock()
         mock_generic_updater.apply_patch = mock.Mock(side_effect=EmptyTableError)
         with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
-            remove_entry_success = validated_config_db_connector.validated_set_entry(mock_generic_updater, SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
+            remove_entry_success = validated_config_db_connector.validated_set_entry(SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
             assert not remove_entry_success

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -26,5 +26,5 @@ class TestValidatedConfigDBConnector(TestCase):
         mock_generic_updater = mock.Mock()
         mock_generic_updater.apply_patch = mock.Mock(side_effect=EmptyTableError)
         with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
-            remove_entry_success = validated_config_db_connector.validated_set_entry(SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
+            remove_entry_success = validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry(mock.Mock(), SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
             assert not remove_entry_success

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -26,5 +26,5 @@ class TestValidatedConfigDBConnector(TestCase):
         mock_generic_updater = mock.Mock()
         mock_generic_updater.apply_patch = mock.Mock(side_effect=EmptyTableError)
         with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
-            remove_entry_success = validated_config_db_connector.validated_set_entry(SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
+            remove_entry_success = validated_config_db_connector.validated_set_entry(mock_generic_updater, SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
             assert not remove_entry_success

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -1,6 +1,7 @@
 import imp
 import os
 import mock
+import jsonpatch
 
 imp.load_source('validated_config_db_connector', \
     os.path.join(os.path.dirname(__file__), '..', 'config', 'validated_config_db_connector.py'))
@@ -9,6 +10,9 @@ import validated_config_db_connector
 from unittest import TestCase
 from mock import patch
 from generic_config_updater.gu_common import EmptyTableError
+from validated_config_db_connector import ValidatedConfigDBConnector
+from swsscommon.swsscommon import ConfigDBConnector
+
 from utilities_common.db import Db
 
 SAMPLE_TABLE = 'VLAN'
@@ -22,9 +26,21 @@ class TestValidatedConfigDBConnector(TestCase):
         Test Class for validated_config_db_connector.py
 
     '''
-    def test_validated_config_db_connector_empty_table(self): 
+    def test_validated_set_entry_empty_table(self): 
         mock_generic_updater = mock.Mock()
         mock_generic_updater.apply_patch = mock.Mock(side_effect=EmptyTableError)
         with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
             remove_entry_success = validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry(mock.Mock(), SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
             assert not remove_entry_success
+
+    def test_validated_delete_table_invalid_delete(self):
+        mock_generic_updater = mock.Mock()
+        mock_generic_updater.apply_patch = mock.Mock(side_effect=ValueError)
+        with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
+            delete_table_success = validated_config_db_connector.ValidatedConfigDBConnector.validated_delete_table(mock.Mock(), SAMPLE_TABLE)
+            assert not delete_table_success
+
+    def test_create_gcu_patch(self):
+        expected_gcu_patch = jsonpatch.JsonPatch([{"op": "add", "path": "/PORTCHANNEL/PortChannel01", "value": "test"}])
+        created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(ValidatedConfigDBConnector(ConfigDBConnector()), "add", "PORTCHANNEL", "PortChannel01", "test")
+        assert expected_gcu_patch == created_gcu_patch


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
In ValidatedConfigDBConnector decorator code, create a new instance of ConfigDBConnector so that original instance is not modified.
#### How I did it

#### How to verify it
Tested locally - ensure that GCU is used when YANG Config Validation is enabled, and ADHOC_VALIDATION is False

