### PR TITLE
[doc] update "config feature" section with "--block" option

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3131,6 +3131,13 @@ This command will configure the state for a specific feature.
   admin@sonic:~$ sudo config feature state bgp disabled
   ``` 
 
+To make the command wait until the corresponding feature container stops(starts) use ```--block``` options:
+
+- Usage:
+    ```
+    admin@sonic:~$ config feature state bgp enabled --block
+    ```
+
 **config feature autorestart <feature_name> <autorestart_status>**
 
 This command will configure the status of auto-restart for a specific feature container.


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Updated "config feature" section with "--block" option

#### How I did it

Added missing documentation on "config feature" command

#### How to verify it

N/A

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

