### PR TITLE
[show][muxcable] add some new commands health, reset-cause, queue_info support for muxcable

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5968,6 +5968,15 @@ While displaying the muxcable health, users need to provide the following fields
 - PORT     required - Port name should be a valid port
 - --json   optional - -- option to display the result in json format. By default output will be in tabular format.
 
+-Ok means the cable is healthy
+
+in order to detemine whether the health of the cable is Ok
+the following are checked
+- the vendor name is correct able to be read
+- the FW is correctly loaded for SerDes by reading the appropriate register val
+- the Counters for UART are displaying healthy status 
+       i.e Error Counters , retry Counters for UART or internal xfer protocols are below a threshold
+
 
 - Example:
     ```
@@ -6001,6 +6010,10 @@ While displaying the muxcable queueinfo, users need to provide the following fie
 - PORT     required - Port name should be a valid port
 - --json   optional - -- option to display the result in json format. By default output will be in tabular format.
 
+the result will be displayed like this, each item in the dictionary shows the health of the attribute in the queue
+```
+"{'VSC': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 0, 'node_size': 0}, 'UART1': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 209870, 'node_size': 1682183}, 'UART2': {'r_ptr': 13262, 'w_ptr': 3, 'total_count': 0, 'free_count': 0, 'buff_addr': 12, 'node_size': 0}
+```
 
 - Example:
     ```
@@ -6023,7 +6036,7 @@ While displaying the muxcable queueinfo, users need to provide the following fie
 
 **show muxcable operationtime <port>**
 
-This command displays the operationtime of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current operation time of the cable as `hh:mm:ss` format.
+This command displays the operationtime of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current operation time of the cable as `hh:mm:ss` format. Operation time means the time since the last time the start/reset of the cable is done, and the time would be in the format specified
 
 - Usage:
   ```
@@ -6066,6 +6079,10 @@ While displaying the muxcable resetcause, users need to provide the following fi
 - PORT     required - Port name should be a valid port
 - --json   optional - -- option to display the result in json format. By default output will be in tabular format.
 
+Currently the known resetcauses that could be displayed are
+- Reset Issue by the ToR
+- Cable Powered on/off from the NiC
+- Cable reseated from server side
 
 - Example:
     ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5953,6 +5953,77 @@ This command displays the eye info in mv(milli volts) of the port user provides 
         632      622
     ```
 
+
+**show muxcable health <port>**
+
+This command displays the hardware health of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current hadrware health of the cable as Ok, Not Ok, Unknown.
+
+- Usage:
+  ```
+  show muxcable health [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable health, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable health Ethernet4
+      PORT       ATTR    HEALTH
+      ---------  ------  --------
+      Ethernet4  health  Ok
+    ```
+    ```
+      admin@sonic:~$ show muxcable health Ethernet4 --json
+    ```
+    ```json
+           {
+               "health": "Ok"
+           }
+
+    ```
+
+
+**show muxcable queueinfo <port>**
+
+This command displays the queue info of  the Y-cable which are connected to muxcable. The resultant table or json output will show the queue info in terms transactions for the UART stats in particular currently relevant to the MCU of the cable.
+
+- Usage:
+  ```
+  show muxcable queueinfo [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable queueinfo, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable queueinfo Ethernet0
+      PORT       ATTR          VALUE
+      ---------  ----------  -------
+      Ethernet0  uart_stat1        2
+      Ethernet0  uart_stat2        1
+    ```
+    ```
+      admin@sonic:~$ show muxcable health Ethernet4 --json
+    ```
+    ```json
+           {
+               "uart_stat1": "2",
+               "uart_stat2": "1",
+                 
+           }
+    ```
+
+
+
+
 ### Muxcable Config commands
 
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6036,7 +6036,7 @@ the result will be displayed like this, each item in the dictionary shows the he
 
 **show muxcable operationtime <port>**
 
-This command displays the operationtime of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current operation time of the cable as `hh:mm:ss` format. Operation time means the time since the last time the start/reset of the cable is done, and the time would be in the format specified
+This command displays the operationtime of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current operation time of the cable as `hh:mm:ss` format. Operation time means the time since the last time the reseated/reset of the cable is done, and the time would be in the format specified
 
 - Usage:
   ```
@@ -6079,24 +6079,24 @@ While displaying the muxcable resetcause, users need to provide the following fi
 - PORT     required - Port name should be a valid port
 - --json   optional - -- option to display the result in json format. By default output will be in tabular format.
 
-Currently the known resetcauses that could be displayed are
-- Reset Issue by the ToR
-- Cable Powered on/off from the NiC
-- Cable reseated from server side
+the reset cause only records NIC MCU reset status. The NIC MCU will automatically broadcast the reset cause status to each TORs, corresponding values returned
+return 0 if the last reset is cold reset (ex. HW/SW reset, power reset the cable, or reboot the NIC server)
+return 1 if the last reset is warn reset (ex. sudo config mux firmware activate....)
+the value is persistent, no clear on read
 
 - Example:
     ```
       admin@sonic:~$ show muxcable resetcause Ethernet4
       PORT       ATTR           RESETCAUSE
       ---------  -----------  ------------
-      Ethernet4  reset_cause  reset by ToR
+      Ethernet4  reset_cause             0
     ```
     ```
       admin@sonic:~$ show muxcable resetcause Ethernet4 --json
     ```
     ```json
            {
-               "reset_cause": "reset by ToR"
+               "reset_cause": "0"
            }
     ```
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6021,7 +6021,67 @@ While displaying the muxcable queueinfo, users need to provide the following fie
            }
     ```
 
+**show muxcable operationtime <port>**
 
+This command displays the operationtime of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current operation time of the cable as `hh:mm:ss` format.
+
+- Usage:
+  ```
+  show muxcable operationtime [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable operationtime, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable operationtime Ethernet4
+      PORT       ATTR            OPERATION_TIME
+      ---------  --------------  ----------------
+      Ethernet4  operation_time  22.22
+    ```
+    ```
+      admin@sonic:~$ show muxcable operationtime Ethernet4 --json
+    ```
+    ```json
+           {
+               "operation_time": "22.22"
+           }
+    ```
+
+**show muxcable resetcause <port>**
+
+This command displays the resetcause of  the Y-cable which are connected to muxcable. The resultant table or json output will show the most recent reset cause of the cable as string format.
+
+- Usage:
+  ```
+  show muxcable resetcause [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable resetcause, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable resetcause Ethernet4
+      PORT       ATTR           RESETCAUSE
+      ---------  -----------  ------------
+      Ethernet4  reset_cause             0
+    ```
+    ```
+      admin@sonic:~$ show muxcable resetcause Ethernet4 --json
+    ```
+    ```json
+           {
+               "reset_cause": "0"
+           }
+    ```
 
 
 ### Muxcable Config commands

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6024,7 +6024,7 @@ the result will be displayed like this, each item in the dictionary shows the he
       Ethernet0  uart_stat2        1
     ```
     ```
-      admin@sonic:~$ show muxcable health Ethernet4 --json
+      admin@sonic:~$ show muxcable queueinfo Ethernet4 --json
     ```
     ```json
            {
@@ -6054,14 +6054,14 @@ While displaying the muxcable operationtime, users need to provide the following
       admin@sonic:~$ show muxcable operationtime Ethernet4
       PORT       ATTR            OPERATION_TIME
       ---------  --------------  ----------------
-      Ethernet4  operation_time  22.22
+      Ethernet4  operation_time  00:22:22
     ```
     ```
       admin@sonic:~$ show muxcable operationtime Ethernet4 --json
     ```
     ```json
            {
-               "operation_time": "22.22"
+               "operation_time": "00:22:22"
            }
     ```
 
@@ -6080,8 +6080,8 @@ While displaying the muxcable resetcause, users need to provide the following fi
 - --json   optional - -- option to display the result in json format. By default output will be in tabular format.
 
 the reset cause only records NIC MCU reset status. The NIC MCU will automatically broadcast the reset cause status to each TORs, corresponding values returned
-return 0 if the last reset is cold reset (ex. HW/SW reset, power reset the cable, or reboot the NIC server)
-return 1 if the last reset is warn reset (ex. sudo config mux firmware activate....)
+display cold reset if the last reset is cold reset (ex. HW/SW reset, power reset the cable, or reboot the NIC server)
+display warm reset if the last reset is warm reset (ex. sudo config mux firmware activate....)
 the value is persistent, no clear on read
 
 - Example:
@@ -6089,14 +6089,14 @@ the value is persistent, no clear on read
       admin@sonic:~$ show muxcable resetcause Ethernet4
       PORT       ATTR           RESETCAUSE
       ---------  -----------  ------------
-      Ethernet4  reset_cause             0
+      Ethernet4  reset_cause    warm reset
     ```
     ```
       admin@sonic:~$ show muxcable resetcause Ethernet4 --json
     ```
     ```json
            {
-               "reset_cause": "0"
+               "reset_cause": "warm reset"
            }
     ```
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6089,14 +6089,14 @@ Currently the known resetcauses that could be displayed are
       admin@sonic:~$ show muxcable resetcause Ethernet4
       PORT       ATTR           RESETCAUSE
       ---------  -----------  ------------
-      Ethernet4  reset_cause             0
+      Ethernet4  reset_cause  reset by ToR
     ```
     ```
       admin@sonic:~$ show muxcable resetcause Ethernet4 --json
     ```
     ```json
            {
-               "reset_cause": "0"
+               "reset_cause": "reset by ToR"
            }
     ```
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2271,6 +2271,7 @@ def muxdirection(db, port, json_output):
         if rc_exit == False:
             sys.exit(EXIT_FAIL)
 
+@delete_all_keys_in_db_tables_helper()
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('option', required=False, default=None)
@@ -2280,7 +2281,6 @@ def queueinfo(db, port, option, json_output):
     """Show muxcable queue info information, preagreed by vendors"""
 
     port = platform_sfputil_helper.get_interface_name(port, db)
-    delete_all_keys_in_db_tables_helper()
 
     if port is not None:
 
@@ -2300,7 +2300,6 @@ def queueinfo(db, port, option, json_output):
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
 
 
-        delete_all_keys_in_db_tables_helper()
         port = platform_sfputil_helper.get_interface_alias(port, db)
 
         if json_output:
@@ -2314,6 +2313,7 @@ def queueinfo(db, port, option, json_output):
         sys.exit(CONFIG_FAIL)
 
 
+@delete_all_keys_in_db_tables_helper()
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2331,7 +2331,6 @@ def health(db, port, json_output):
     """
 
     port = platform_sfputil_helper.get_interface_name(port, db)
-    delete_all_keys_in_db_tables_helper()
 
     if port is not None:
 
@@ -2349,7 +2348,6 @@ def health(db, port, json_output):
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
 
 
-        delete_all_keys_in_db_tables_helper()
 
         port = platform_sfputil_helper.get_interface_alias(port, db)
 
@@ -2374,6 +2372,7 @@ def health(db, port, json_output):
         click.echo("Did not get a valid Port for cable health status".format(port))
         sys.exit(CONFIG_FAIL)
 
+@delete_all_keys_in_db_tables_helper()
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2382,7 +2381,6 @@ def resetcause(db, port, json_output):
     """Show muxcable resetcause information """
 
     port = platform_sfputil_helper.get_interface_name(port, db)
-    delete_all_keys_in_db_tables_helper()
 
     if port is not None:
 
@@ -2400,7 +2398,6 @@ def resetcause(db, port, json_output):
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
 
 
-        delete_all_keys_in_db_tables_helper()
 
         port = platform_sfputil_helper.get_interface_alias(port, db)
 
@@ -2414,6 +2411,7 @@ def resetcause(db, port, json_output):
         click.echo("Did not get a valid Port for cable resetcause information".format(port))
         sys.exit(CONFIG_FAIL)
 
+@delete_all_keys_in_db_tables_helper()
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2422,7 +2420,6 @@ def operationtime(db, port, json_output):
     """Show muxcable operation time hh:mm:ss forrmat"""
 
     port = platform_sfputil_helper.get_interface_name(port, db)
-    delete_all_keys_in_db_tables_helper()
 
     if port is not None:
 
@@ -2440,7 +2437,6 @@ def operationtime(db, port, json_output):
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
 
         
-        delete_all_keys_in_db_tables_helper()
 
         port = platform_sfputil_helper.get_interface_alias(port, db)
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -415,7 +415,7 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
     return res_dict
 
 
-def delete_all_keys_in_db_tables_helper():
+def delete_all_keys_in_db_tables_helper(db= None):
 
     delete_all_keys_in_db_table("APPL_DB", XCVRD_GET_BER_CMD_TABLE)
     delete_all_keys_in_db_table("STATE_DB", XCVRD_GET_BER_RSP_TABLE)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2382,6 +2382,12 @@ def resetcause(db, port, json_output):
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
+    """
+    the reset cause only records NIC MCU reset status. The NIC MCU will automatically broadcast the reset cause status to each TORs, corresponding values returned
+    return 0 if the last reset is cold reset (ex. HW/SW reset, power reset the cable, or reboot the NIC server)
+    return 1 if the last reset is warn reset (ex. sudo config mux firmware activate....)
+    the value is persistent, no clear on read
+    """
     if port is not None:
 
         res_dict = {}

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2353,14 +2353,14 @@ def health(db, port, json_output):
 
         port = platform_sfputil_helper.get_interface_alias(port, db)
 
-        cable_health = result.get("cable_health", None)
+        cable_health = result.get("health_check", None)
 
         if cable_health == "False":
-            result["cable_health"] = "Not Ok"
+            result["health_check"] = "Not Ok"
         elif cable_health == "True":
-            result["cable_health"] = "Ok"
+            result["health_check"] = "Ok"
         else:
-            result["cable_health"] = "Unknown"
+            result["health_check"] = "Unknown"
 
             
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2390,7 +2390,7 @@ def resetcause(db, port, json_output):
     """
     the reset cause only records NIC MCU reset status. The NIC MCU will automatically broadcast the reset cause status to each TORs, corresponding values returned
     return 0 if the last reset is cold reset (ex. HW/SW reset, power reset the cable, or reboot the NIC server)
-    return 1 if the last reset is warn reset (ex. sudo config mux firmware activate....)
+    return 1 if the last reset is warm reset (ex. sudo config mux firmware activate....)
     the value is persistent, no clear on read
     """
     if port is not None:
@@ -2411,6 +2411,15 @@ def resetcause(db, port, json_output):
 
 
         port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        reset_cause = result.get("reset_cause", None)
+
+        if cable_health == "0":
+            result["reset_cause"] = "cold reset"
+        elif cable_health == "1":
+            result["reset_cause"] = "warm reset"
+        else:
+            result["reset_cause"] = "Unknown"
 
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2255,4 +2255,188 @@ def muxdirection(db, port, json_output):
         if rc_exit == False:
             sys.exit(EXIT_FAIL)
 
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.argument('option', required=False, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def queueinfo(db, port, option, json_output):
+    """Show muxcable debug deump registers information, preagreed by vendors"""
 
+    port = platform_sfputil_helper.get_interface_name(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        param_dict = {}
+        param_dict["option"] = option
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 100, param_dict, "queue_info")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD_ARG")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for debug dump registers".format(port))
+        sys.exit(CONFIG_FAIL)
+
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def health(db, port, json_output):
+    """Show muxcable health information """
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "health_check")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'HEALTH']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for cable alive status".format(port))
+        sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def resetcause(db, port, json_output):
+    """Show muxcable health information """
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "reset_cause")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'RESETCAUSE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for cable alive status".format(port))
+        sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def operationtime(db, port, json_output):
+    """Show muxcable operation time """
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+    delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+    delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "operation_time")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+
+
+        delete_all_keys_in_db_table("APPL_DB", "XCVRD_GET_BER_CMD")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RSP")
+        delete_all_keys_in_db_table("STATE_DB", "XCVRD_GET_BER_RES")
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        actual_time = result.get("cable")
+        if actual_time is not None:
+            time = '{0:02.0f}:{1:02.0f}'.format(*divmod(int(actual_time) * 60, 60))
+            result['cable'] = time
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'OPERATION_TIME']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for cable alive status".format(port))
+        sys.exit(CONFIG_FAIL)

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2271,7 +2271,7 @@ def muxdirection(db, port, json_output):
         if rc_exit == False:
             sys.exit(EXIT_FAIL)
 
-@delete_all_keys_in_db_tables_helper()
+@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('option', required=False, default=None)
@@ -2313,7 +2313,7 @@ def queueinfo(db, port, option, json_output):
         sys.exit(CONFIG_FAIL)
 
 
-@delete_all_keys_in_db_tables_helper()
+@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2372,7 +2372,7 @@ def health(db, port, json_output):
         click.echo("Did not get a valid Port for cable health status".format(port))
         sys.exit(CONFIG_FAIL)
 
-@delete_all_keys_in_db_tables_helper()
+@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2411,7 +2411,7 @@ def resetcause(db, port, json_output):
         click.echo("Did not get a valid Port for cable resetcause information".format(port))
         sys.exit(CONFIG_FAIL)
 
-@delete_all_keys_in_db_tables_helper()
+@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2429,7 +2429,7 @@ def operationtime(db, port, json_output):
         actual_time = result.get("cable")
         if actual_time is not None:
             time = '{0:02.0f}:{1:02.0f}'.format(*divmod(int(actual_time) * 60, 60))
-            result['cable'] = time
+            result['operation_time'] = time
 
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2414,9 +2414,9 @@ def resetcause(db, port, json_output):
 
         reset_cause = result.get("reset_cause", None)
 
-        if cable_health == "0":
+        if reset_cause == "0":
             result["reset_cause"] = "cold reset"
-        elif cable_health == "1":
+        elif reset_cause == "1":
             result["reset_cause"] = "warm reset"
         else:
             result["reset_cause"] = "Unknown"

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -427,6 +427,9 @@ def delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_
     if cmd_arg_table is not None:
         delete_all_keys_in_db_table("APPL_DB", cmd_arg_table_name)
 
+    if res_table_name is not None:
+        delete_all_keys_in_db_table("STATE_DB", res_table_name)
+
     return 0 
 
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -424,7 +424,7 @@ def delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_
 
     delete_all_keys_in_db_table("APPL_DB", cmd_table_name)
     delete_all_keys_in_db_table("STATE_DB", rsp_table_name)
-    if cmd_arg_table is not None:
+    if cmd_arg_table_name is not None:
         delete_all_keys_in_db_table("APPL_DB", cmd_arg_table_name)
 
     if res_table_name is not None:

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2357,9 +2357,9 @@ def health(db, port, json_output):
 
         if cable_health == "False":
             result["health_check"] = "Not Ok"
-        else if cable_health == "True":
+        elif cable_health == "True":
             result["health_check"] = "Ok"
-        else if cable_health is None:
+        else:
             result["health_check"] = "Unknown"
 
             

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2319,7 +2319,15 @@ def queueinfo(db, port, option, json_output):
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
 def health(db, port, json_output):
-    """Show muxcable health information as Ok or Not Ok """
+    """Show muxcable health information as Ok or Not Ok"""
+
+    """
+    in order to detemine whether the health of the cable is Ok
+    the following are checked
+     - the vendor name is correct able to be read
+     - the FW is correctly loaded for SerDes by reading the appropriate register val
+     - the Counters for UART are displaying healthy status 
+       i.e Error Counters , retry Counters for UART or internal xfer protocols are below a threshold
 
     port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_tables_helper()

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -281,9 +281,11 @@ def get_result(port, res_dict, cmd ,result, table_name):
     (status, fvp) = xcvrd_show_fw_res_tbl[asic_index].get(port)
     res_dir = dict(fvp)
 
+    delete_all_keys_in_db_table("STATE_DB", table_name)
+
     return res_dir
 
-def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, cmd_arg_table_name, rsp_table_name ,port, cmd_timeout_secs, param_dict= None, arg=None):
+def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, cmd_arg_table_name, rsp_table_name , res_table_name, port, cmd_timeout_secs, param_dict= None, arg=None):
 
     res_dict = {}
     state_db, appl_db = {}, {}
@@ -295,6 +297,8 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
     CMD_TIMEOUT_SECS = cmd_timeout_secs
 
     time_start = time.time()
+
+    delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_table_name, res_table_name)
 
     sel = swsscommon.Select()
     namespaces = multi_asic.get_front_end_namespaces()
@@ -410,17 +414,18 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
             firmware_rsp_tbl[asic_index]._del(port)
             break
 
-    delete_all_keys_in_db_table("STATE_DB", rsp_table_name)
+
+    delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_table_name, None)
 
     return res_dict
 
 
-def delete_all_keys_in_db_tables_helper(db= None):
+def delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_table_name = None, res_table_name = None):
 
-    delete_all_keys_in_db_table("APPL_DB", XCVRD_GET_BER_CMD_TABLE)
-    delete_all_keys_in_db_table("STATE_DB", XCVRD_GET_BER_RSP_TABLE)
-    delete_all_keys_in_db_table("STATE_DB", XCVRD_GET_BER_RES_TABLE)
-    delete_all_keys_in_db_table("APPL_DB", XCVRD_GET_BER_CMD_ARG_TABLE)
+    delete_all_keys_in_db_table("APPL_DB", cmd_table_name)
+    delete_all_keys_in_db_table("STATE_DB", rsp_table_name)
+    if cmd_arg_table is not None:
+        delete_all_keys_in_db_table("APPL_DB", cmd_arg_table_name)
 
     return 0 
 
@@ -942,7 +947,7 @@ def berinfo(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "ber")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "ber")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -994,7 +999,7 @@ def eyeinfo(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "eye")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "eye")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1045,7 +1050,7 @@ def fecstatistics(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "fec_stats")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "fec_stats")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1096,7 +1101,7 @@ def pcsstatistics(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "pcs_stats")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "pcs_stats")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1145,7 +1150,7 @@ def debugdumpregisters(db, port, option, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 100, param_dict, "debug_dump")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 100, param_dict, "debug_dump")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1189,7 +1194,7 @@ def alivecablestatus(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "cable_alive")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", None, port, 10, None, "cable_alive")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1261,7 +1266,7 @@ def get_hwmode_mux_direction_port(db, port):
     if port is not None:
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RES", "XCVRD_SHOW_HWMODE_DIR_RSP", port, HWMODE_MUXDIRECTION_TIMEOUT, None, "probe")
+            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RES", "XCVRD_SHOW_HWMODE_DIR_RSP", None, port, HWMODE_MUXDIRECTION_TIMEOUT, None, "probe")
 
         result = get_result(port, res_dict, "muxdirection" , result, "XCVRD_SHOW_HWMODE_DIR_RES")
 
@@ -1480,7 +1485,7 @@ def switchmode(db, port):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, None, "probe")
+            "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", None, port, 1, None, "probe")
 
         body = []
         temp_list = []
@@ -1536,7 +1541,7 @@ def switchmode(db, port):
             res_dict[0] = CONFIG_FAIL
             res_dict[1] = "unknown"
             res_dict = update_and_get_response_for_xcvr_cmd(
-                "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, None, "probe")
+                "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", None, port, 1, None, "probe")
             port = platform_sfputil_helper.get_interface_alias(port, db)
             temp_list.append(port)
             temp_list.append(res_dict[1])
@@ -1721,7 +1726,7 @@ def version(db, port, active):
         mux_info_dict["version_self_next"] = "N/A"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "firmware_version", "status", "True", "XCVRD_SHOW_FW_CMD", None, "XCVRD_SHOW_FW_RSP", port, 20, None, "probe")
+            "firmware_version", "status", "True", "XCVRD_SHOW_FW_CMD", None, "XCVRD_SHOW_FW_RSP", None, port, 20, None, "probe")
 
         if res_dict[1] == "True":
             mux_info_dict = get_response_for_version(port, mux_info_dict)
@@ -1890,7 +1895,7 @@ def event_log(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "show_event", "status", "True", "XCVRD_EVENT_LOG_CMD", None, "XCVRD_EVENT_LOG_RSP", port, 1000, None, "probe")
+            "show_event", "status", "True", "XCVRD_EVENT_LOG_CMD", None, "XCVRD_EVENT_LOG_RSP", None, port, 1000, None, "probe")
 
         if res_dict[1] == "True":
             result = get_event_logs(port, res_dict, mux_info_dict)
@@ -1932,7 +1937,7 @@ def get_fec_anlt_speed(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_fec", "status", "True", "XCVRD_GET_FEC_CMD", None, "XCVRD_GET_FEC_RSP", port, 10, None, "probe")
+            "get_fec", "status", "True", "XCVRD_GET_FEC_CMD", None, "XCVRD_GET_FEC_RSP", None, port, 10, None, "probe")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_FEC_RES")
@@ -2271,7 +2276,6 @@ def muxdirection(db, port, json_output):
         if rc_exit == False:
             sys.exit(EXIT_FAIL)
 
-@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.argument('option', required=False, default=None)
@@ -2294,10 +2298,10 @@ def queueinfo(db, port, option, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 100, param_dict, "queue_info")
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, XCVRD_GET_BER_CMD_ARG_TABLE, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 100, param_dict, "queue_info")
 
         if res_dict[1] == "True":
-            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
 
 
         port = platform_sfputil_helper.get_interface_alias(port, db)
@@ -2313,7 +2317,6 @@ def queueinfo(db, port, option, json_output):
         sys.exit(CONFIG_FAIL)
 
 
-@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2342,10 +2345,10 @@ def health(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "health_check")
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, None, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 10, None, "health_check")
 
         if res_dict[1] == "True":
-            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
 
 
 
@@ -2372,7 +2375,6 @@ def health(db, port, json_output):
         click.echo("Did not get a valid Port for cable health status".format(port))
         sys.exit(CONFIG_FAIL)
 
-@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2398,10 +2400,10 @@ def resetcause(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "reset_cause")
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, None, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 10, None, "reset_cause")
 
         if res_dict[1] == "True":
-            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
 
 
 
@@ -2417,7 +2419,6 @@ def resetcause(db, port, json_output):
         click.echo("Did not get a valid Port for cable resetcause information".format(port))
         sys.exit(CONFIG_FAIL)
 
-@delete_all_keys_in_db_tables_helper
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
@@ -2437,10 +2438,10 @@ def operationtime(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "operation_time")
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, None, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 10, None, "operation_time")
 
         if res_dict[1] == "True":
-            result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
 
         
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2353,14 +2353,14 @@ def health(db, port, json_output):
 
         port = platform_sfputil_helper.get_interface_alias(port, db)
 
-        cable_health = result.get("health_check", None)
+        cable_health = result.get("cable_health", None)
 
         if cable_health == "False":
-            result["health_check"] = "Not Ok"
+            result["cable_health"] = "Not Ok"
         elif cable_health == "True":
-            result["health_check"] = "Ok"
+            result["cable_health"] = "Ok"
         else:
-            result["health_check"] = "Unknown"
+            result["cable_health"] = "Unknown"
 
             
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2328,6 +2328,7 @@ def health(db, port, json_output):
      - the FW is correctly loaded for SerDes by reading the appropriate register val
      - the Counters for UART are displaying healthy status 
        i.e Error Counters , retry Counters for UART or internal xfer protocols are below a threshold
+    """
 
     port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_tables_helper()

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -615,7 +615,6 @@ Ethernet0  server_ipv4  10.2.1.1        added     added
 
 
 show_muxcable_operationtime_expected_port_output="""\
-PORT       ATTR              OPERATION_TIME
 PORT       ATTR            OPERATION_TIME
 ---------  --------------  ----------------
 Ethernet0  operation_time  200:00
@@ -2590,7 +2589,7 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
-    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"cable_health": "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"health_check": "True"}))
     def test_show_mux_health(self):
         runner = CliRunner()
         db = Db()

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -636,7 +636,7 @@ Ethernet0  uart_stat2        1
 
 show_muxcable_resetcause_expected_port_output="""\
 PORT       ATTR         RESETCAUSE
----------  -----------  -------------
+---------  -----------  ------------
 Ethernet0  reset_cause  warm reset
 """
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -623,7 +623,7 @@ Ethernet0  operation_time               200
 show_muxcable_health_expected_port_output="""\
 PORT       ATTR          HEALTH
 ---------  ------------  --------
-Ethernet0  cable_health  True
+Ethernet0  cable_health  Ok
 """
 
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -647,6 +647,14 @@ show_muxcable_health_expected_port_output_json="""\
 }
 """
 
+
+
+show_muxcable_resetcause_expected_port_output_json="""\
+{
+    "reset_cause": "reboot by xyz"
+}
+"""
+
 class TestMuxcable(object):
     @classmethod
     def setup_class(cls):
@@ -2654,6 +2662,21 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["resetcause"],
                                ["Ethernet0"], obj=db)
         assert result.output == show_muxcable_resetcause_expected_port_output
+
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "reboot by xyz"}))
+    def test_show_mux_resetcause_json(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["resetcause"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_resetcause_expected_port_output_json
+
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -624,7 +624,7 @@ Ethernet0  operation_time  200:00
 show_muxcable_health_expected_port_output="""\
 PORT       ATTR          HEALTH
 ---------  ------------  --------
-Ethernet0  cable_health  Ok
+Ethernet0  health_check  Ok
 """
 
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -616,8 +616,9 @@ Ethernet0  server_ipv4  10.2.1.1        added     added
 
 show_muxcable_operationtime_expected_port_output="""\
 PORT       ATTR              OPERATION_TIME
+PORT       ATTR            OPERATION_TIME
 ---------  --------------  ----------------
-Ethernet0  operation_time               200
+Ethernet0  operation_time  200:00
 """
 
 show_muxcable_health_expected_port_output="""\

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -613,6 +613,37 @@ PORT       DEST_TYPE    DEST_ADDRESS    kernel    asic
 Ethernet0  server_ipv4  10.2.1.1        added     added
 """
 
+
+show_muxcable_operationtime_expected_port_output="""\
+PORT       ATTR              OPERATION_TIME
+---------  --------------  ----------------
+Ethernet0  operation_time               200
+"""
+
+show_muxcable_health_expected_port_output="""\
+PORT       ATTR          HEALTH
+---------  ------------  --------
+Ethernet0  cable_health  True
+"""
+
+
+show_muxcable_queueinfo_expected_port_output="""\
+PORT       ATTR          VALUE
+---------  ----------  -------
+Ethernet0  uart_stat1        2
+Ethernet0  uart_stat2        1
+"""
+
+show_muxcable_resetcause_expected_port_output="""\
+PORT       ATTR         RESETCAUSE
+---------  -----------  -------------
+Ethernet0  reset_cause  reboot by xyz
+"""
+
+
+
+
+
 class TestMuxcable(object):
     @classmethod
     def setup_class(cls):
@@ -2553,6 +2584,58 @@ class TestMuxcable(object):
                                ["Ethernet12", "--json"], obj=db)
         assert result.exit_code == 0
         assert result.output == show_muxcable_hwmode_muxdirection_active_expected_output_json
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"cable_health": "True"}))
+    def test_show_mux_health(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["health"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_health_expected_port_output
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"operation_time": "200"}))
+    def test_show_mux_operation_time(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["operationtime"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_operationtime_expected_port_output
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"uart_stat1": "2",
+                                                                          "uart_stat2": "1"}))
+    def test_show_mux_queue_info(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["queueinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_queueinfo_expected_port_output
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "reboot by xyz"}))
+    def test_show_mux_resetcause(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["resetcause"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_resetcause_expected_port_output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -637,7 +637,7 @@ Ethernet0  uart_stat2        1
 show_muxcable_resetcause_expected_port_output="""\
 PORT       ATTR         RESETCAUSE
 ---------  -----------  -------------
-Ethernet0  reset_cause  reboot by xyz
+Ethernet0  reset_cause  warm reset
 """
 
 
@@ -651,7 +651,7 @@ show_muxcable_health_expected_port_output_json="""\
 
 show_muxcable_resetcause_expected_port_output_json="""\
 {
-    "reset_cause": "reboot by xyz"
+    "reset_cause": "warm reset"
 }
 """
 
@@ -2654,7 +2654,7 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
-    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "reboot by xyz"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "1"}))
     def test_show_mux_resetcause(self):
         runner = CliRunner()
         db = Db()
@@ -2668,7 +2668,7 @@ class TestMuxcable(object):
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))
-    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "reboot by xyz"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "1"}))
     def test_show_mux_resetcause_json(self):
         runner = CliRunner()
         db = Db()

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -641,8 +641,11 @@ Ethernet0  reset_cause  reboot by xyz
 """
 
 
-
-
+show_muxcable_health_expected_port_output_json="""\
+{
+    "health_check": "Ok"
+}
+"""
 
 class TestMuxcable(object):
     @classmethod
@@ -2597,6 +2600,21 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["health"],
                                ["Ethernet0"], obj=db)
         assert result.output == show_muxcable_health_expected_port_output
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"health_check": "True"}))
+    def test_show_mux_health_json(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["health"],
+                               ["Ethernet0", "--json"], obj=db)
+        assert result.output == show_muxcable_health_expected_port_output_json
+
+
 
 
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -2674,7 +2674,7 @@ class TestMuxcable(object):
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["resetcause"],
-                               ["Ethernet0"], obj=db)
+                               ["Ethernet0", "--json"], obj=db)
         assert result.output == show_muxcable_resetcause_expected_port_output_json
 
 


### PR DESCRIPTION
This PR adds the support for adding some utility commands for muxacble
This includes commands for health, operationtime, queueinfo, resetcause
```
vdahiya@sonic:~$ show mux health Ethernet4 
PORT          ATTR               HEALTH
---------     ---------------   --------
Ethernet4     health_check       Ok
vdahiya@sonic:~$ show mux health Ethernet4 --json
{
    "health_check": "Ok"
}

vdahiya@sonic:~$ show mux operation Ethernet4 --json
{
    "operation_time": "22:22"
}
vdahiya@sonic:~$ show mux operation Ethernet4
PORT       ATTR              OPERATION_TIME
---------  --------------  ----------------
Ethernet4  operation_time                 22:22
vdahiya@sonic:~$ 

vdahiya@sonic:~$ show mux resetcause Ethernet4
PORT       ATTR           RESETCAUSE
---------  -----------  ------------
Ethernet4  reset_cause             0

vdahiya@sonic:~$ show mux resetcause Ethernet4 --json
{
    "reset_cause": "0"
}

vdahiya@sonic:~$ show mux queueinfo Ethernet4 --json
{
    "Remote": "{'VSC': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 0, 'node_size': 0}, 'UART1': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 209870, 'node_size': 1682183}, 'UART2': {'r_ptr': 13262, 'w_ptr': 3, 'total_count': 0, 'free_count': 0, 'buff_addr': 12, 'node_size': 0}}",
    "Local": "{'VSC': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 0, 'node_size': 0}, 'UART1': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 209870, 'node_size': 1682183}, 'UART2': {'r_ptr': 13262, 'w_ptr': 3, 'total_count': 0, 'free_count': 0, 'buff_addr': 12, 'node_size': 0}}"
}
```

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it
added changes for the requirement in show/muxcable.py. 

#### How to verify it
UT and running changes on a testbed
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

