### PR TITLE
[show][multiasic]Fixed SONIC_CLI_IFACE_MODE=alias show ip|ipv6 route output in default mode issue

### DIFF
--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -367,21 +367,15 @@ def show_routes(args, namespace, display, verbose, ipver):
                 # Not ip address just ignore it
                 found_other_parms = 1
 
-    if multi_asic.is_multi_asic():
-        if not found_json and not found_other_parms:
-            arg_strg += "json"
+    # using the same format for both multiasic or non-multiasic
+    if not found_json and not found_other_parms:
+        arg_strg += "json"
 
     combined_route = {}
     for ns in ns_l:
         # Need to add "ns" to form bgpX so it is sent to the correct bgpX docker to handle the request
-        # If not MultiASIC, skip namespace argument
         cmd = "show {} route {}".format(ipver, arg_strg)
-        if multi_asic.is_multi_asic():
-            output = bgp_util.run_bgp_show_command(cmd, ns)
-        else:
-            output = bgp_util.run_bgp_show_command(cmd)
-            print("{}".format(output))
-            return
+        output = bgp_util.run_bgp_show_command(cmd, ns)
 
         # in case no output or something went wrong with user specified cmd argument(s) error it out
         # error from FRR always start with character "%"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,16 @@ def setup_single_bgp_instance(request):
     elif request.param == 'v6':
         bgp_mocked_json = os.path.join(
             test_path, 'mock_tables', 'ipv6_bgp_summary.json')
+    elif request.param == 'ip_route':
+        bgp_mocked_json = 'ip_route.json'
+    elif request.param == 'ip_specific_route': 
+        bgp_mocked_json = 'ip_specific_route.json'    
+    elif request.param == 'ipv6_specific_route':
+        bgp_mocked_json = 'ipv6_specific_route.json'
+    elif request.param == 'ipv6_route':
+        bgp_mocked_json = 'ipv6_route.json'
+    elif request.param == 'ip_special_route':
+        bgp_mocked_json = 'ip_special_route.json'    
     else:
         bgp_mocked_json = os.path.join(
             test_path, 'mock_tables', 'dummy.json')
@@ -187,23 +197,25 @@ def setup_single_bgp_instance(request):
     def mock_run_show_ip_route_commands(request):
         if request.param == 'ipv6_route_err':
             return show_ip_route_common.show_ipv6_route_err_expected_output
-        elif request.param == 'ip_route':
-            return show_ip_route_common.show_ip_route_expected_output
-        elif request.param == 'ip_specific_route':
-            return show_ip_route_common.show_specific_ip_route_expected_output
-        elif request.param == 'ip_special_route':
-            return show_ip_route_common.show_special_ip_route_expected_output
-        elif request.param == 'ipv6_route':
-            return show_ip_route_common.show_ipv6_route_expected_output
-        elif request.param == 'ipv6_specific_route':
-            return show_ip_route_common.show_ipv6_route_single_json_expected_output
         else:
             return ""
 
+    def mock_run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND):
+        bgp_mocked_json_file = os.path.join(
+            test_path, 'mock_tables', bgp_mocked_json)
+        if os.path.isfile(bgp_mocked_json_file):
+            with open(bgp_mocked_json_file) as json_data:
+                mock_frr_data = json_data.read()
+            return mock_frr_data
+        else:
+            return ""
 
-    if any ([request.param == 'ipv6_route_err', request.param == 'ip_route',\
+    if any ([request.param == 'ip_route',\
              request.param == 'ip_specific_route', request.param == 'ip_special_route',\
              request.param == 'ipv6_route', request.param == 'ipv6_specific_route']):
+        bgp_util.run_bgp_command = mock.MagicMock(
+            return_value=mock_run_bgp_command("",""))
+    elif request.param.startswith('ipv6_route_err'):
         bgp_util.run_bgp_command = mock.MagicMock(
             return_value=mock_run_show_ip_route_commands(request))
     elif request.param.startswith('bgp_v4_neighbor') or \

--- a/tests/ip_show_routes_multi_asic_test.py
+++ b/tests/ip_show_routes_multi_asic_test.py
@@ -166,6 +166,22 @@ class TestMultiAiscShowIpRouteDisplayAllCommands(object):
 
     @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
                              ['ipv6_route'], indirect=['setup_multi_asic_bgp_instance'])
+    def test_show_multi_asic_ipv6_route_all_namespace_alias(
+            self,
+            setup_ip_route_commands,
+            setup_multi_asic_bgp_instance):
+        show = setup_ip_route_commands
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(
+            show.cli.commands["ipv6"].commands["route"], ["-dfrontend"])
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_all_namesapce_alias_output
+
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
+                             ['ipv6_route'], indirect=['setup_multi_asic_bgp_instance'])
     def test_show_multi_asic_ipv6_route_single_namespace(
             self,
             setup_ip_route_commands,

--- a/tests/ip_show_routes_test.py
+++ b/tests/ip_show_routes_test.py
@@ -30,7 +30,7 @@ class TestShowIpRouteCommands(object):
             show.cli.commands["ip"].commands["route"], [])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ip_route_expected_output + "\n"
+        assert result.output == show_ip_route_common.show_ip_route_expected_output
 
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['ip_specific_route'], indirect=['setup_single_bgp_instance'])
@@ -44,7 +44,7 @@ class TestShowIpRouteCommands(object):
             show.cli.commands["ip"].commands["route"], ["192.168.0.1"])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_specific_ip_route_expected_output + "\n"
+        assert result.output == show_ip_route_common.show_specific_ip_route_expected_output
 
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['ip_special_route'], indirect=['setup_single_bgp_instance'])
@@ -58,7 +58,7 @@ class TestShowIpRouteCommands(object):
             show.cli.commands["ip"].commands["route"], [])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_special_ip_route_expected_output + "\n"
+        assert result.output == show_ip_route_common.show_special_ip_route_expected_output
 
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['ipv6_specific_route'], indirect=['setup_single_bgp_instance'])
@@ -72,7 +72,7 @@ class TestShowIpRouteCommands(object):
             show.cli.commands["ip"].commands["route"], ["20c0:a8c7:0:81::", "json"])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ipv6_route_single_json_expected_output + "\n"
+        assert result.output == show_ip_route_common.show_ipv6_route_single_json_expected_output
 
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['ipv6_route'], indirect=['setup_single_bgp_instance'])
@@ -86,7 +86,23 @@ class TestShowIpRouteCommands(object):
             show.cli.commands["ipv6"].commands["route"], [])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ipv6_route_expected_output + "\n"
+        assert result.output == show_ip_route_common.show_ipv6_route_expected_output
+
+    @pytest.mark.parametrize('setup_single_bgp_instance',
+                             ['ipv6_route'], indirect=['setup_single_bgp_instance'])
+    def test_show_ipv6_route_alias(
+            self,
+            setup_ip_route_commands,
+            setup_single_bgp_instance):
+        show = setup_ip_route_commands
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(
+            show.cli.commands["ipv6"].commands["route"], [])
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.show_ipv6_route_alias_expected_output
 
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['ipv6_route_err'], indirect=['setup_single_bgp_instance'])

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -38,6 +38,17 @@
         "speed": "40000",
         "asic_port_name": "Eth1-ASIC0"
     },
+    "PORT|Ethernet16": {
+        "lanes": "17,18,19,20",
+        "description": "ARISTA01T2:Ethernet3/3/1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "Ethernet1/5",
+        "admin_status": "up",
+        "role": "Ext",
+        "speed": "40000",
+        "asic_port_name": "Eth1-ASIC0"
+    },
     "PORT|Ethernet-BP0" : {
         "lanes": "93,94,95,96",
         "description": "ASIC1:Eth0-ASIC1",

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -323,6 +323,162 @@ C *fe80::/64 is directly connected, Loopback0, 1d11h34m
 C>*fe80::/64 is directly connected, eth0, 1d11h34m
 """
 
+show_ipv6_route_alias_expected_output = """\
+Codes: K - kernel route, C - connected, S - static, R - RIP,
+       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
+       F - PBR, f - OpenFabric,
+       > - selected route, * - FIB route, q - queued route, r - rejected route
+
+B>*::/0 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *            via fc00::6, PortChannel0005, 1d11h34m
+K *::/0 [210/0] via fd00::1, eth0, 1d11h34m
+B>*2064:100::1/128 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+B>*2064:100::3/128 [20/0] via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                      via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                          via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:10::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:11::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:20::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:21::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:30::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:31::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:40::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:41::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:50::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:51::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:60::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:61::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:70::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:71::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:80::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:81::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:90::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:91::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:a0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:a1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:b0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:b1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:c0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:c1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:d0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:d1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:e0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:e1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:f0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a800:0:f1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                      via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                          via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:10::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:11::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:20::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:21::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:30::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:31::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:40::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:41::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:50::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:51::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:60::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:61::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:70::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:71::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:80::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:81::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:90::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:91::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:a0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:a1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:b0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:b1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:c0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:c1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:d0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:d1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:e0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:e1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:f0::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+B>*20c0:a801:0:f1::/64 [20/0] via fc00::2, PortChannel0002, 1d11h34m
+  *                           via fc00::6, PortChannel0005, 1d11h34m
+C>*2603:10e2:400::/128 is directly connected, Loopback4096, 1d11h34m
+C>*fc00::/126 is directly connected, PortChannel0002, 1d11h34m
+C>*fc00::4/126 is directly connected, PortChannel0005, 1d11h34m
+C>*fc00:1::32/128 is directly connected, Loopback0, 1d11h34m
+C>*fd00::/80 is directly connected, eth0, 1d11h34m
+C *fe80::/64 is directly connected, PortChannel0002, 1d11h34m
+C *fe80::/64 is directly connected, PortChannel0005, 1d11h34m
+C *fe80::/64 is directly connected, etp6, 1d11h34m
+C *fe80::/64 is directly connected, etp5, 1d11h34m
+C *fe80::/64 is directly connected, etp2, 1d11h34m
+C *fe80::/64 is directly connected, etp1, 1d11h34m
+C *fe80::/64 is directly connected, Loopback4096, 1d11h34m
+C *fe80::/64 is directly connected, Loopback0, 1d11h34m
+C>*fe80::/64 is directly connected, eth0, 1d11h34m
+"""
+
 #
 # MULTI ASIC TEST SECTION
 #
@@ -553,6 +709,52 @@ C *fe80::/64 is directly connected, Ethernet20, 2d22h00m
 C *fe80::/64 is directly connected, PortChannel0005, 2d22h00m
 C *fe80::/64 is directly connected, PortChannel1016, 2d22h02m
 C *fe80::/64 is directly connected, Ethernet24, 2d22h02m
+"""
+
+show_ipv6_route_multi_asic_all_namesapce_alias_output = """\
+Codes: K - kernel route, C - connected, S - static, R - RIP,
+       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
+       F - PBR, f - OpenFabric,
+       > - selected route, * - FIB route, q - queued route, r - rejected route
+
+K *::/0 [210/0] via fd00::1, eth0, 2d22h00m
+B>*::/0 [20/0] via fc00::6, PortChannel0005, 2d22h00m
+  *            via fc00::2, PortChannel0002, 2d22h00m
+  *            via fc00::2, PortChannel1015, 2d22h00m
+  *            via fc00::6, PortChannel1016, 2d22h00m
+B>*2064:100::1/128 [20/0] via fc00::2, PortChannel0002, 2d22h00m
+  *                       via fc00::2, PortChannel1015, 2d22h00m
+B>*2064:100::3/128 [20/0] via fc00::6, PortChannel0005, 2d22h00m
+  *                       via fc00::6, PortChannel1016, 2d22h00m
+B>*20c0:a800:0:1::/64 [20/0] via fc00::6, PortChannel0005, 2d22h00m
+  *                          via fc00::2, PortChannel0002, 2d22h00m
+  *                          via fc00::2, PortChannel1015, 2d22h00m
+  *                          via fc00::6, PortChannel1016, 2d22h00m
+B>*20c0:a800:0:10::/64 [20/0] via fc00::6, PortChannel0005, 2d22h00m
+  *                           via fc00::2, PortChannel0002, 2d22h00m
+  *                           via fc00::2, PortChannel1015, 2d22h00m
+  *                           via fc00::6, PortChannel1016, 2d22h00m
+B>*20c0:a800:0:11::/64 [20/0] via fc00::6, PortChannel0002, 2d22h00m
+  *                           via fc00::6, PortChannel1015, 2d22h00m
+B>*20c0:a800:0:20::/64 [20/0] via fc00::2, PortChannel0002, 2d22h00m
+  *                           via fc00::2, PortChannel1015, 2d22h00m
+B>*20c0:a800:0:21::/64 [20/0] via fc00::2, PortChannel0002, 2d22h00m
+  *                           via fc00::2, PortChannel1015, 2d22h00m
+C>*2603:10e2:400::/128 is directly connected, Loopback4096, 2d22h00m
+C>*2603:10e2:400::2/128 is directly connected, Loopback4096, 2d22h02m
+C>*fc00::4/126 is directly connected, PortChannel0005, 2d22h00m
+C>*fc00::4/126 is directly connected, PortChannel1016, 2d22h02m
+C>*fc00:1::32/128 is directly connected, Loopback0, 2d22h00m
+C>*fd00::/80 is directly connected, eth0, 2d22h00m
+C>*fe80::/64 is directly connected, eth0, 2d22h00m
+C *fe80::/64 is directly connected, Loopback0, 2d22h00m
+C *fe80::/64 is directly connected, Loopback4096, 2d22h00m
+C *fe80::/64 is directly connected, Ethernet1/5, 2d22h00m
+C *fe80::/64 is directly connected, Ethernet1/6, 2d22h00m
+C *fe80::/64 is directly connected, PortChannel0005, 2d22h00m
+C *fe80::/64 is directly connected, PortChannel1016, 2d22h02m
+C *fe80::/64 is directly connected, Ethernet1/7, 2d22h02m
 """
 
 show_ipv6_route_multi_asic_single_namesapce_output = """\

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -193,7 +193,24 @@ def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, vtysh
     return output
 
 def run_bgp_show_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE):
-    return run_bgp_command(vtysh_cmd, bgp_namespace, constants.RVTYSH_COMMAND)
+    output = run_bgp_command(vtysh_cmd, bgp_namespace, constants.RVTYSH_COMMAND)
+    # handle the the alias mode in the following code
+    if output is not None:
+        if clicommon.get_interface_naming_mode() == "alias" and re.search("show ip|ipv6 route", vtysh_cmd):
+            iface_alias_converter = clicommon.InterfaceAliasConverter()
+            route_info =json.loads(output)
+            for route, info in route_info.items():
+                for i in range(0, len(info)):
+                    if 'nexthops' in info[i]:
+                        for j in range(0, len(info[i]['nexthops'])):
+                            intf_name = ""
+                            if 'interfaceName' in info[i]['nexthops'][j]:
+                                intf_name  = info[i]['nexthops'][j]['interfaceName']
+                                alias = iface_alias_converter.name_to_alias(intf_name)
+                                if alias is not None:
+                                    info[i]['nexthops'][j]['interfaceName'] = alias 
+            output= json.dumps(route_info)
+    return output
 
 def get_bgp_summary_from_all_bgp_instances(af, namespace, display):
 

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -529,7 +529,9 @@ def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False
 
     # No conversion needed for intfutil commands as it already displays
     # both SONiC interface name and alias name for all interfaces.
-    if get_interface_naming_mode() == "alias" and not command.startswith("intfutil"):
+    # IP route table cannot be handled in function run_command_in_alias_mode since it is in JSON format 
+    # with a list for next hops 
+    if get_interface_naming_mode() == "alias" and not command.startswith("intfutil") and not re.search("show ip|ipv6 route", command):
         run_command_in_alias_mode(command)
         sys.exit(0)
 


### PR DESCRIPTION
#### What I did
There are many issues with the "SONIC_CLI_IFACE_MODE=aliasshow ip/ipv6 route [json]" commands on both single asic platform and multiasic platform
- Doesn't show the interface alias on single asic platform
- Display the route info twice either in Json format or default format on the single asic platform
- Doesn't show the interface alias on multiasic platform
- Display the route info in the Json format even if Json is not specified in the CLI command 

Resolves# https://github.com/sonic-net/sonic-buildimage/issues/8498

This PR is required by 202205 branch

#### How I did it
- In the current show_routes() function, the internal command to get the route for single asic platform is formatted to "vtysh show ip/ipv6 route" while it is formatted to "vtysh  show ip/ipv6 route json".   This commit changes to use the same command "vtysh show ip/ipv6 route json" for both single asic platform and multiasic platform.
 - With the same format (in Json) output, add logic to run_bgp_show_command() to convert the Interface name to alias if SONIC_CLI_IFACE_MODE=alias for both show ip/ipv4 route command 
 - Add code to skip the function  run_command_in_alias_mode() for "show ip/ipv6 route" command since it is not applicable to show the route table info.
 - Modify and clean up the show_routes() function to use the same code path to display route info for both none-multasic and multiasic platform.   
- Add unit test cases: test_show_ipv6_route_alias() and test show_multi_asic_ipv6_route_all_namespace_alias() 
#### How to verify it
1) execute show command "SONIC_CLI_IFACE_MODE=alias show ip route", it will display the route info in the default format with the interface name
2) verify the port interface name is displayed the alias instead of the port name 
```
admin@sonic:~$ SONIC_CLI_IFACE_MODE=alias show ip route 0.0.0.0/0
Routing entry for 0.0.0.0/0
  Known via "bgp", distance 20, metric 0, best
  Last update 01:24:03 ago
  * 10.0.0.11, via Ethernet-IB0 onlink
  * 10.0.0.11 (recursive)
  * 10.0.0.7, via Ethernet-IB0 onlink
  * 10.0.0.7 (recursive)
  * 10.0.0.5, via Ethernet1/18
  * 10.0.0.1, via PortChannel102
  * 10.0.0.1 (recursive)
  * 10.0.0.1, via Ethernet-IB1 onlink
  * 10.0.0.5 (recursive)
  * 10.0.0.5, via Ethernet-IB1 onlink
  * 10.0.0.7, via PortChannel106
  * 10.0.0.11, via Ethernet1/36
```
2) Also exec the "show ipv6 command" to verify the ipv6 route info is displayed in the correct format with the alias name.
```
admin@sonic:~$ SONIC_CLI_IFACE_MODE=alias show ipv6 route  ::0/0
Routing entry for ::/0
  Known via "kernel", distance 210, metric 0
  Last update 21:31:04 ago
  * fd00::1, via eth0

Routing entry for ::/0
  Known via "bgp", distance 20, metric 0, best
  Last update 01:27:15 ago
  * fc00::16, via Ethernet-IB0 onlink
  * fc00::16 (recursive)
  * fc00::e, via Ethernet-IB0 onlink
  * fc00::e (recursive)
  * fc00::a, via Ethernet1/18
  * fc00::2, via PortChannel102
  * fc00::2 (recursive)
  * fc00::2, via Ethernet-IB1 onlink
  * fc00::a (recursive)
  * fc00::a, via Ethernet-IB1 onlink
  * fc00::e, via PortChannel106
  * fc00::16, via Ethernet1/36
```

The following command have been run to against these changes. They all work as expected:
```
------------------- Multiasic ip/ipv6 route ---------------------
show ip route 
SONIC_CLI_IFACE_MODE=alias show ip route 
show ip route json
SONIC_CLI_IFACE_MODE=alias show ip route json

show ip route -n asic0
SONIC_CLI_IFACE_MODE=alias show ip route -n asic0 
show ip route json -n asic0
SONIC_CLI_IFACE_MODE=alias show ip route json -n asic0 

show ip route -d all
SONIC_CLI_IFACE_MODE=alias show ip route -d all
show ip route json -d all
SONIC_CLI_IFACE_MODE=alias show ip route json -d all

show ip route -d frontend
SONIC_CLI_IFACE_MODE=alias show ip route -d frontend
show ip route json -d frontend
SONIC_CLI_IFACE_MODE=alias show ip route json -d frontend

show ip route 192.217.192.128
SONIC_CLI_IFACE_MODE=alias show ip route 192.217.192.128
show ip route 192.217.192.128 json
SONIC_CLI_IFACE_MODE=alias show ip route 192.217.192.128 json

show ip route 192.217.192.128 -d all
SONIC_CLI_IFACE_MODE=alias show ip route 192.217.192.128 -d all
show ip route 192.217.192.128 json -d all
SONIC_CLI_IFACE_MODE=alias show ip route 192.217.192.128 json -d all

show ip route 192.217.192.128 -d frontend
SONIC_CLI_IFACE_MODE=alias show ip route 192.217.192.128 -d frontend
show ip route 192.217.192.128 json -d frontend
SONIC_CLI_IFACE_MODE=alias show ip route 192.217.192.128 json -d frontend

show ipv6 route 
SONIC_CLI_IFACE_MODE=alias show ipv6 route 
show ipv6 route json
SONIC_CLI_IFACE_MODE=alias show ipv6 route json

show ipv6 route -d all
SONIC_CLI_IFACE_MODE=alias show ipv6 route -d all
show ipv6 route json -d all
SONIC_CLI_IFACE_MODE=alias show ip route json -d all

show ipv6 route -d frontend
SONIC_CLI_IFACE_MODE=alias show ipv6 route -d frontend
show ipv6 route json -d frontend
SONIC_CLI_IFACE_MODE=alias show ipv6 route json -d frontend

show ipv6 route fe80::
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64
show ipv6 route  fe80::/64 json
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 json

show ipv6 route fe80::/64 -d all 
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 -d all 
show ipv6 route  fe80::/64 json -d all  
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 json -d all 

show ipv6 route fe80::/64 -d frontend  
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 -d frontend  
show ipv6 route  fe80::/64 json -d frontend  
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 json -d frontend   

================  Non-multiasic ip/ route =======================
show ip route
SONIC_CLI_IFACE_MODE=alias show ip route
show ip route json
SONIC_CLI_IFACE_MODE=alias show ip route json

show ip route -d all
SONIC_CLI_IFACE_MODE=alias show ip route -d all
show ip route json -d all 
SONIC_CLI_IFACE_MODE=alias show ip route json -d all 

show ip route 10.1.0.32
SONIC_CLI_IFACE_MODE=alias show ip route 10.1.0.32
show ip route 192.217.192.128 json
SONIC_CLI_IFACE_MODE=alias show ip route 10.1.0.32 json

show ip route 10.1.0.32 -d all
SONIC_CLI_IFACE_MODE=alias show ip route 10.1.0.32  -d all
show ip route 10.1.0.32 json -d all
SONIC_CLI_IFACE_MODE=alias show ip route 10.1.0.32  json -d all


show ip route 10.1.0.32 -d frontend
SONIC_CLI_IFACE_MODE=alias show ip route 10.1.0.32  -d frontend
show ip route 10.1.0.32 json -d frontend
SONIC_CLI_IFACE_MODE=alias show ip route 10.1.0.32  json -d frontend

show ipv6 route 
SONIC_CLI_IFACE_MODE=alias show ipv6 route 
show ipv6 route json
SONIC_CLI_IFACE_MODE=alias show ipv6 route json

show ipv6 route -d all
SONIC_CLI_IFACE_MODE=alias show ipv6 route -d all
show ipv6 route json -d all
SONIC_CLI_IFACE_MODE=alias show ip route json -d all

show ipv6 route -d frontend
SONIC_CLI_IFACE_MODE=alias show ipv6 route -d frontend
show ipv6 route json -d frontend
SONIC_CLI_IFACE_MODE=alias show ipv6 route json -d frontend

show ipv6 route fe80::
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64
show ipv6 route  fe80::/64 json
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 json

show ipv6 route fe80::/64 -d all 
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 -d all 
show ipv6 route  fe80::/64 json -d all  
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 json -d all 

show ipv6 route fe80::/64 -d frontend  
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 -d frontend  
show ipv6 route  fe80::/64 json -d frontend  
SONIC_CLI_IFACE_MODE=alias show ipv6 route fe80::/64 json -d frontend   
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

