### PR TITLE
[muxcable][config] add CLI support for mux mode detach

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -280,7 +280,7 @@ def update_configdb_pck_loss_data(config_db, port, val):
 
 # 'muxcable' command ("config muxcable mode <port|all> active|auto")
 @muxcable.command()
-@click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "auto", "manual", "standby"]))
+@click.argument('state', metavar='<operation_status>', required=True, type=click.Choice(["active", "auto", "manual", "standby", "detach"]))
 @click.argument('port', metavar='<port_name>', required=True, default=None)
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL)
 @clicommon.pass_db


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support for `config mux mode detach`. Stemming from https://github.com/sonic-net/sonic-linkmgrd/pull/79

sign-off: Jing Zhang zhangjing@microsoft.com

#### How I did it
Add `detach` to the choice list. 

#### How to verify it
* Existing unit test. 
* Tested on DUT
```
admin@svcstr-7050-acs-1:~$ sudo config mux mode detach Ethernet12
port        state
----------  -------
Ethernet12  OK
```
After config change, shutdown peer's link, self side got peer link prober unknown event but didn't toggle peer's mux state as it's in `Detached` mode. 
```
Oct  5 23:47:03.510501 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:524 handlePeerStateChange: Ethernet12: Received peer link prober event, new state: PeerUnknown
```

A `auto` mode interface would toggle: 
```
Oct  5 23:46:21.472932 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:524 handlePeerStateChange: Ethernet8: Received peer link prober event, new state: PeerUnknown
Oct  5 23:46:21.473244 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:909 switchPeerMuxState: Ethernet8: Switching peer MUX state to 'Standby'
Oct  5 23:46:21.552629 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:323 handlePeerMuxStateNotification: Ethernet8: state db mux state: Standby
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

