### PR TITLE
Add "f" option for executing reboot force mode

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -171,7 +171,7 @@ function check_conflict_boot_in_fw_update()
 
 function parse_options()
 {
-    while getopts "h?v" opt; do
+    while getopts "h?vf" opt; do
         case ${opt} in
             h|\? )
                 show_help_and_exit


### PR DESCRIPTION
Allow reboot script to receive "f" option in order to execute "/sbin/reboot" in force mode (with "f" flag).

