### PR TITLE
fix bug in multi_asic_namespace_validation_callback

### DIFF
--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -112,6 +112,11 @@ _multi_asic_click_options = [
 ]
 
 def multi_asic_namespace_validation_callback(ctx, param, value):
+    if param != 'namespace':
+        click.echo("this callback is only used for -n/--namespace option")
+        ctx.abort()
+    # if cli is "show run bgp -n asic0" on single-asic, value will be asic0, 
+    # we want to make sure no value for single-asic here
     if not multi_asic.is_multi_asic() and value:
         click.echo("-n/--namespace is not available for single asic")
         ctx.abort()

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -115,7 +115,7 @@ def multi_asic_namespace_validation_callback(ctx, param, value):
     if param != 'namespace':
         click.echo("this callback is only used for -n/--namespace option")
         ctx.abort()
-    # if cli is "show run bgp -n asic0" on single-asic, value will be asic0, 
+    # e.g. issue "show run bgp -n asic0" on single-asic, value will be asic0, should abort in this case
     # we want to make sure no value for single-asic here
     if not multi_asic.is_multi_asic() and value:
         click.echo("-n/--namespace is not available for single asic")

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -112,7 +112,7 @@ _multi_asic_click_options = [
 ]
 
 def multi_asic_namespace_validation_callback(ctx, param, value):
-    if not multi_asic.is_multi_asic:
+    if not multi_asic.is_multi_asic() and value:
         click.echo("-n/--namespace is not available for single asic")
         ctx.abort()
     return value


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
multi_asic.is_multi_asic is bug that returns True if function NOT exists, so the if condition will never enter, letting multi_asic_namespace_validation_callback to never work.

when changing to `multi_asic.is_multi_asic()`, for single-asic, we still need to ensure NO value passed inside this function.
e,g, `show run bgp -n asic0 ` on a single-asic is passing value `asic0` to this function, and we want to avoid that.


#### What I did

#### How I did it

#### How to verify it
Before:
```
    # admin@str2-7050cx3-acs-02:/usr$ show ip bgp neighbor -n asic0
    # -n/--namespace is not available for single asic
    # Aborted!
    # admin@str2-7050cx3-acs-02:/usr$ show ip bgp neighbor
    # -n/--namespace is not available for single asic
    # Aborted!
```
After:
```
admin@str2-7050cx3-acs-02:/usr$ show run bgp -n asic0
-n/--namespace is not available for single asic
Aborted!
admin@str2-7050cx3-acs-02:/usr$ 
admin@str2-7050cx3-acs-02:/usr$ 
admin@str2-7050cx3-acs-02:/usr$ 
admin@str2-7050cx3-acs-02:/usr$ show run bgp -n
Error: -n option requires an argument
admin@str2-7050cx3-acs-02:/usr$ 
admin@str2-7050cx3-acs-02:/usr$ 
admin@str2-7050cx3-acs-02:/usr$ show run bgp
Building configuration...

Current configuration:
!
frr version 8.2.2
frr defaults traditional
...
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

