### PR TITLE
[202205][Auto-Techsupport] Fix the coredump_gen_handler Exception when the History table is empty (#2265)

### DIFF
--- a/tests/coredump_gen_handler_test.py
+++ b/tests/coredump_gen_handler_test.py
@@ -450,3 +450,22 @@ class TestCoreDumpCreationEvent(unittest.TestCase):
             cls = cdump_mod.CriticalProcCoreDumpHandle("orchagent.12345.123.core.gz", "swss", redis_mock)
             cls.handle_core_dump_creation_event()
 
+    def test_auto_ts_empty_state_db(self):
+        """
+        Scenario: Check if the techsupport is called as expected even when the history table in empty
+                  and container cooloff is non-zero
+        """
+        db_wrap = Db()
+        redis_mock = db_wrap.db
+        set_auto_ts_cfg(redis_mock, state="enabled", since_cfg="2 days ago")
+        set_feature_table_cfg(redis_mock, state="enabled", rate_limit_interval="300")
+        with Patcher() as patcher:
+            def mock_cmd(cmd, env):
+                cmd_str = " ".join(cmd)
+                if "show techsupport" in cmd_str and cmd_str != TS_DEFAULT_CMD:
+                    assert False, "Expected TS_CMD: {}, Recieved: {}".format(TS_DEFAULT_CMD, cmd_str)
+                return 0, AUTO_TS_STDOUT, ""
+            ts_helper.subprocess_exec = mock_cmd
+            patcher.fs.create_file("/var/core/orchagent.12345.123.core.gz")
+            cls = cdump_mod.CriticalProcCoreDumpHandle("orchagent.12345.123.core.gz", "swss", redis_mock)
+            cls.handle_core_dump_creation_event()

--- a/utilities_common/auto_techsupport_helper.py
+++ b/utilities_common/auto_techsupport_helper.py
@@ -257,7 +257,7 @@ def get_ts_map(db):
     ts_map = {}
     ts_keys = db.keys(STATE_DB, TS_MAP+"*")
     if not ts_keys:
-        return
+        return ts_map
     for ts_key in ts_keys:
         data = db.get_all(STATE_DB, ts_key)
         if not data:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

BACKPORT OF: https://github.com/sonic-net/sonic-utilities/pull/2265

coredump_gen_handler script is throwing exception currently when the history table is empty.
```
root@r-lionfish-14:/home/admin# cat /tmp/coredump_gen_handler.log
Traceback (most recent call last):
  File "/usr/local/bin/coredump_gen_handler.py", line 82, in <module>
    main()
  File "/usr/local/bin/coredump_gen_handler.py", line 77, in main
    cls.handle_core_dump_creation_event()
  File "/usr/local/bin/coredump_gen_handler.py", line 60, in handle_core_dump_creation_event
    invoke_ts_command_rate_limited(self.db, EVENT_TYPE_CORE, {CORE_DUMP: self.core_name}, self.container)
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/auto_techsupport_helper.py", line 331, in invoke_ts_command_rate_limited
    cooloff_passed = verify_rate_limit_intervals(db, global_cooloff, container_cooloff, container)
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/auto_techsupport_helper.py", line 291, in verify_rate_limit_intervals
    if container_cooloff and container in ts_map:
TypeError: argument of type 'NoneType' is not iterable
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

