### PR TITLE
test2

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -842,8 +842,10 @@ class AclLoader(object):
                                          val.get("monitor_port", ""), val.get("src_port", ""), val.get("direction", "").lower()])
 
         print("ERSPAN Sessions")
+        erspan_data = natsorted(erspan_data)
         print(tabulate.tabulate(erspan_data, headers=erspan_header, tablefmt="simple", missingval=""))
         print("\nSPAN Sessions")
+        span_data = natsorted(span_data)
         print(tabulate.tabulate(span_data, headers=span_header, tablefmt="simple", missingval=""))
 
     def show_policer(self, policer_name):

--- a/tests/mirror_input/config_db.json
+++ b/tests/mirror_input/config_db.json
@@ -1,0 +1,28 @@
+{
+    "MIRROR_SESSION": {
+        "session1": {
+            "direction": "BOTH",
+            "dst_port": "Ethernet30",
+            "src_port": "Ethernet40",
+            "type": "SPAN"
+        },
+        "session2": {
+            "direction": "BOTH",
+            "dst_port": "Ethernet7",
+            "src_port": "Ethernet8",
+            "type": "SPAN"
+        },
+        "session11": {
+            "direction": "RX",
+            "dst_port": "Ethernet9",
+            "src_port": "Ethernet10",
+            "type": "SPAN"
+        },
+        "session15": {
+            "direction": "TX",
+            "dst_port": "Ethernet2",
+            "src_port": "Ethernet3",
+            "type": "SPAN"
+        }
+    }
+}

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from click.testing import CliRunner
+from swsscommon.swsscommon import SonicV2Connector
+from utilities_common.db import Db
+
+from .utils import get_result_and_return_code
+
+import show.main as show
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+mock_db_path = os.path.join(test_path, "mirror_input")
+
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "acl_loader")
+
+class TestShowMirror(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        print(os.pathsep + scripts_path)
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_mirror_show(self):
+        from .mock_tables import dbconnector
+        jsonfile_config = os.path.join(mock_db_path, "config_db")
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
+        expected_output = """\
+ERSPAN Sessions
+Name    Status    SRC IP    DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
+------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------
+
+SPAN Sessions
+Name       Status    DST Port    SRC Port    Direction    Queue    Policer
+---------  --------  ----------  ----------  -----------  -------  ---------
+session1   active    Ethernet30  Ethernet40  both
+session2   active    Ethernet7   Ethernet8   both
+session11  active    Ethernet9   Ethernet10  rx
+session15  active    Ethernet2   Ethernet3   tx
+"""
+
+        return_code, result = get_result_and_return_code('main.py show session')
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        dbconnector.dedicated_dbs = {}
+        assert return_code == 0
+        assert result == expected_output
+

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -16,6 +16,7 @@ class TestShowMirror(object):
         aclloader.configdb.set_entry("MIRROR_SESSION", "session2", {"direction": "BOTH", "dst_port": "Ethernet7", "src_port": "Ethernet8", "type": "SPAN"})
         aclloader.configdb.set_entry("MIRROR_SESSION", "session11", {"direction": "RX", "dst_port": "Ethernet9", "src_port": "Ethernet10", "type": "SPAN"})
         aclloader.configdb.set_entry("MIRROR_SESSION", "session15", {"direction": "TX", "dst_port": "Ethernet2", "src_port": "Ethernet3", "type": "SPAN"})
+        aclloader.read_sessions_info()
         context = {
             "acl_loader": aclloader
         }

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -5,26 +5,18 @@ from swsscommon.swsscommon import SonicV2Connector
 from click.testing import CliRunner
 from utilities_common.db import Db
 
-import mock_tables.dbconnector
 import acl_loader.main as acl_loader_show
 from acl_loader import *
 from acl_loader.main import *
 
-test_path = os.path.dirname(os.path.abspath(__file__))
-mock_db_path = os.path.join(test_path, "mirror_input")
-
 class TestShowMirror(object):
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
-        os.environ["UTILITIES_UNIT_TESTING"] = "1"
-
     def test_mirror_show(self):
-        from .mock_tables import dbconnector
-        jsonfile_config = os.path.join(mock_db_path, "config_db")
-        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
         runner = CliRunner()
         aclloader = AclLoader()
+        aclloader.configdb.set_entry("MIRROR_SESSION", "session1", {"direction": "BOTH", "dst_port": "Ethernet30", "src_port": "Ethernet40", "type": "SPAN"})
+        aclloader.configdb.set_entry("MIRROR_SESSION", "session2", {"direction": "BOTH", "dst_port": "Ethernet7", "src_port": "Ethernet8", "type": "SPAN"})
+        aclloader.configdb.set_entry("MIRROR_SESSION", "session11", {"direction": "RX", "dst_port": "Ethernet9", "src_port": "Ethernet10", "type": "SPAN"})
+        aclloader.configdb.set_entry("MIRROR_SESSION", "session15", {"direction": "TX", "dst_port": "Ethernet2", "src_port": "Ethernet3", "type": "SPAN"})
         context = {
             "acl_loader": aclloader
         }
@@ -42,6 +34,5 @@ session11  active    Ethernet9   Ethernet10  rx
 session15  active    Ethernet2   Ethernet3   tx
 """
         result = runner.invoke(acl_loader_show.cli.commands['show'].commands['session'], [], obj=context)
-        dbconnector.dedicated_dbs = {}
         assert result.exit_code == 0
         assert result.output == expected_output

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -40,7 +40,7 @@ session11  active    Ethernet9   Ethernet10  rx
 session15  active    Ethernet2   Ethernet3   tx
 """
 
-        return_code, result = get_result_and_return_code('main.py show session')
+        return_code, result = get_result_and_return_code('python main.py show session')
         print("return_code: {}".format(return_code))
         print("result = {}".format(result))
         dbconnector.dedicated_dbs = {}

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -7,6 +7,8 @@ from utilities_common.db import Db
 
 import mock_tables.dbconnector
 import acl_loader.main as acl_loader_show
+from acl_loader import *
+from acl_loader.main import *
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 mock_db_path = os.path.join(test_path, "mirror_input")
@@ -22,6 +24,7 @@ class TestShowMirror(object):
         jsonfile_config = os.path.join(mock_db_path, "config_db")
         dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
         runner = CliRunner()
+        aclloader = AclLoader()
         context = {
             "acl_loader": aclloader
         }

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -40,7 +40,9 @@ session11  active    Ethernet9   Ethernet10  rx
 session15  active    Ethernet2   Ethernet3   tx
 """
 
-        return_code, result = get_result_and_return_code('python main.py show session')
+        cmd = 'python ' + os.path.join(scripts_path, 'main.py') + ' show session'
+        print cmd
+        return_code, result = get_result_and_return_code(cmd)
         print("return_code: {}".format(return_code))
         print("result = {}".format(result))
         dbconnector.dedicated_dbs = {}

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -36,7 +36,7 @@ session2   active    Ethernet7   Ethernet8   both
 session11  active    Ethernet9   Ethernet10  rx
 session15  active    Ethernet2   Ethernet3   tx
 """
-        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['session'], [], obj=db)
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['session'], [], obj=context)
         dbconnector.dedicated_dbs = {}
         assert result.exit_code == 0
         assert result.output == expected_output

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -38,6 +38,5 @@ session15  active    Ethernet2   Ethernet3   tx
 """
         result = runner.invoke(acl_loader_show.cli.commands['show'].commands['session'], [], obj=db)
         dbconnector.dedicated_dbs = {}
-        assert return_code == 0
-        assert result == expected_output
-
+        assert result.exit_code == 0
+        assert result.output == expected_output

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -36,7 +36,6 @@ session2   active    Ethernet7   Ethernet8   both
 session11  active    Ethernet9   Ethernet10  rx
 session15  active    Ethernet2   Ethernet3   tx
 """
-        aclloader = AclLoader()
         result = runner.invoke(acl_loader_show.cli.commands['show'].commands['session'], [], obj=db)
         dbconnector.dedicated_dbs = {}
         assert return_code == 0

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -41,7 +41,6 @@ session15  active    Ethernet2   Ethernet3   tx
 """
 
         cmd = 'python ' + os.path.join(scripts_path, 'main.py') + ' show session'
-        print cmd
         return_code, result = get_result_and_return_code(cmd)
         print("return_code: {}".format(return_code))
         print("result = {}".format(result))

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -1,31 +1,28 @@
 import os
 import sys
-from click.testing import CliRunner
+import imp
 from swsscommon.swsscommon import SonicV2Connector
+from click.testing import CliRunner
 from utilities_common.db import Db
 
-from .utils import get_result_and_return_code
-
-import show.main as show
+import mock_tables.dbconnector
+import acl_loader.main as acl_loader_show
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 mock_db_path = os.path.join(test_path, "mirror_input")
-
-modules_path = os.path.dirname(test_path)
-scripts_path = os.path.join(modules_path, "acl_loader")
 
 class TestShowMirror(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
-        os.environ["PATH"] += os.pathsep + scripts_path
-        print(os.pathsep + scripts_path)
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 
     def test_mirror_show(self):
         from .mock_tables import dbconnector
         jsonfile_config = os.path.join(mock_db_path, "config_db")
         dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
+        runner = CliRunner()
+        db = Db()
         expected_output = """\
 ERSPAN Sessions
 Name    Status    SRC IP    DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
@@ -39,11 +36,8 @@ session2   active    Ethernet7   Ethernet8   both
 session11  active    Ethernet9   Ethernet10  rx
 session15  active    Ethernet2   Ethernet3   tx
 """
-
-        cmd = 'python ' + os.path.join(scripts_path, 'main.py') + ' show session'
-        return_code, result = get_result_and_return_code(cmd)
-        print("return_code: {}".format(return_code))
-        print("result = {}".format(result))
+        aclloader = AclLoader()
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['session'], [], obj=db)
         dbconnector.dedicated_dbs = {}
         assert return_code == 0
         assert result == expected_output

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import imp
 from swsscommon.swsscommon import SonicV2Connector
 from click.testing import CliRunner
 from utilities_common.db import Db
@@ -32,6 +31,7 @@ session1   active    Ethernet30  Ethernet40  both
 session2   active    Ethernet7   Ethernet8   both
 session11  active    Ethernet9   Ethernet10  rx
 session15  active    Ethernet2   Ethernet3   tx
+
 """
         result = runner.invoke(acl_loader_show.cli.commands['show'].commands['session'], [], obj=context)
         assert result.exit_code == 0

--- a/tests/show_mirror_test.py
+++ b/tests/show_mirror_test.py
@@ -22,7 +22,9 @@ class TestShowMirror(object):
         jsonfile_config = os.path.join(mock_db_path, "config_db")
         dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
         runner = CliRunner()
-        db = Db()
+        context = {
+            "acl_loader": aclloader
+        }
         expected_output = """\
 ERSPAN Sessions
 Name    Status    SRC IP    DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix display disorder problem of show mirror_session

The problem is as follows, the span session and erspan session are not sorted in the name column(Take SPAN as an example, ERSPAN is similar)：
```
root@sonic:/home/admin# show mirror_session 
ERSPAN Sessions
Name    Status    SRC IP    DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------

SPAN Sessions
Name       Status    DST Port    SRC Port    Direction    Queue    Policer
---------  --------  ----------  ----------  -----------  -------  ---------
session1   active    Ethernet30  Ethernet40  both
session11  active    Ethernet9   Ethernet10  rx
session15  active    Ethernet2   Ethernet3   tx
session2   active    Ethernet7   Ethernet8   both
root@sonic:/home/admin# 
```

#### How I did it
Sort the name column with natsorted

#### How to verify it
use “show mirror_session”

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show mirror_session 
ERSPAN Sessions
Name    Status    SRC IP    DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------

SPAN Sessions
Name       Status    DST Port    SRC Port    Direction    Queue    Policer
---------  --------  ----------  ----------  -----------  -------  ---------
session1   active    Ethernet30  Ethernet40  both
session11  active    Ethernet9   Ethernet10  rx
session15  active    Ethernet2   Ethernet3   tx
session2   active    Ethernet7   Ethernet8   both
root@sonic:/home/admin# 
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show mirror_session 
ERSPAN Sessions
Name    Status    SRC IP    DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------

SPAN Sessions
Name       Status    DST Port    SRC Port    Direction    Queue    Policer
---------  --------  ----------  ----------  -----------  -------  ---------
session1   active    Ethernet30  Ethernet40  both
session2   active    Ethernet7   Ethernet8   both
session11  active    Ethernet9   Ethernet10  rx
session15  active    Ethernet2   Ethernet3   tx
```