### PR TITLE
Add support nat zone setting for VLAN sub interfaces.

### DIFF
--- a/config/nat.py
+++ b/config/nat.py
@@ -34,7 +34,9 @@ def nat_interface_name_is_valid(interface_name):
     config_db = ConfigDBConnector()
     config_db.connect()
 
-    if interface_name.startswith("Ethernet"):
+    if interface_name.startswith("Ethernet") and '.' in interface_name:
+        interface_dict = config_db.get_table('VLAN_SUB_INTERFACE')
+    elif interface_name.startswith("Ethernet"):
         interface_dict = config_db.get_table('PORT')
     elif interface_name.startswith("PortChannel"):
         interface_dict = config_db.get_table('PORTCHANNEL')
@@ -898,7 +900,9 @@ def add_interface(ctx, interface_name, nat_zone):
     if nat_interface_name_is_valid(interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a  valid interface name!!")
 
-    if interface_name.startswith("Ethernet"):
+    if interface_name.startswith("Ethernet") and '.' in interface_name:
+        interface_table_type = "VLAN_SUB_INTERFACE"
+    elif interface_name.startswith("Ethernet"):
         interface_table_type = "INTERFACE"
     elif interface_name.startswith("PortChannel"):
         interface_table_type = "PORTCHANNEL_INTERFACE"
@@ -928,7 +932,9 @@ def remove_interface(ctx, interface_name):
     if nat_interface_name_is_valid(interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a  valid interface name!!")
 
-    if interface_name.startswith("Ethernet"):
+    if interface_name.startswith("Ethernet") and '.' in interface_name:
+        interface_table_type = "VLAN_SUB_INTERFACE"
+    elif interface_name.startswith("Ethernet"):
         interface_table_type = "INTERFACE"
     elif interface_name.startswith("PortChannel"):
         interface_table_type = "PORTCHANNEL_INTERFACE"
@@ -954,7 +960,7 @@ def remove_interfaces(ctx):
     config_db = ConfigDBConnector()
     config_db.connect()
 
-    tables = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE', 'LOOPBACK_INTERFACE']
+    tables = ['INTERFACE', 'VLAN_SUB_INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE', 'LOOPBACK_INTERFACE']
     nat_config = {"nat_zone": "0"}
 
     for table_name in tables:

--- a/scripts/natconfig
+++ b/scripts/natconfig
@@ -202,7 +202,7 @@ class NatConfig(object):
         """
             Fetch NAT zone config from CONFIG DB.
         """
-        interfaces = ['INTERFACE', 'VLAN_INTERFACE', 'PORTCHANNEL_INTERFACE', 'LOOPBACK_INTERFACE'] 
+        interfaces = ['INTERFACE', 'VLAN_SUB_INTERFACE', 'VLAN_INTERFACE', 'PORTCHANNEL_INTERFACE', 'LOOPBACK_INTERFACE']
 
         self.nat_zone_data = []
 


### PR DESCRIPTION
Signed-off-by: Masaru OKI <masaru.oki@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support VLAN sub interfaces (e.g. Ethernet0.100) for 'config nat add interface'.

#### How I did it
VLAN sub interface configuration is checked in interface name validation.

#### How to verify it

```
# on nat enabled images
sudo config interface ip add Ethernet0.100 192.168.0.1/24
sudo config nat add interface -nat_zone 0 Ethernet0.100
```

#### Previous command output (if the output of a command-line utility has changed)

```
Usage: config nat add interface [OPTIONS] <interface_name>
Try "config nat add interface -h" for help.

Error: Interface name is invalid. Please enter a  valid interface name!!
```

#### New command output (if the output of a command-line utility has changed)

empty output