### PR TITLE
[show][muxcable] add support for show mux firmware version all

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 import json
 import sys

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -110,7 +110,7 @@ def get_per_port_firmware(port):
     namespaces = multi_asic.get_front_end_namespaces()
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
-        state_db[asic_id] = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        state_db[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         state_db[asic_id].connect(state_db[asic_id].STATE_DB)
 
     if platform_sfputil is not None:

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1745,7 +1745,7 @@ def metrics(db, port, json_output):
 def event_log(db, port, json_output):
     """Show muxcable event log <port>"""
 
-    click.confirm(('Muxcable at port {} will retreive cable logs from MCU, Caution: approx wait time could be ~2 minutes Continue?'.format(port), abort=True)
+    click.confirm(('Muxcable at port {} will retreive cable logs from MCU, Caution: approx wait time could be ~2 minutes Continue?'.format(port)), abort=True)
     port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_EVENT_LOG_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -131,8 +131,14 @@ def get_per_port_firmware(port):
 
     res_dir = dict(fvp)
     mux_info_dict["version_nic_active"] = res_dir.get("version_nic_active", None)
+    mux_info_dict["version_nic_inactive"] = res_dir.get("version_nic_inactive", None)
+    mux_info_dict["version_nic_next"] = res_dir.get("version_nic_next", None)
     mux_info_dict["version_peer_active"] = res_dir.get("version_peer_active", None)
+    mux_info_dict["version_peer_inactive"] = res_dir.get("version_peer_inactive", None)
+    mux_info_dict["version_peer_next"] = res_dir.get("version_peer_next", None)
     mux_info_dict["version_self_active"] = res_dir.get("version_self_active", None)
+    mux_info_dict["version_self_inactive"] = res_dir.get("version_self_inactive", None)
+    mux_info_dict["version_self_next"] = res_dir.get("version_self_next", None)
 
     return mux_info_dict
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import sys
 import time
@@ -1744,7 +1746,7 @@ def metrics(db, port, json_output):
 def event_log(db, port, json_output):
     """Show muxcable event log <port>"""
 
-    click.confirm(('Muxcable at port {} will retreive cable logs from MCU, approx time could be ~2 minutes wait time Continue?'.format(port), abort=True)
+    click.confirm(('Muxcable at port {} will retreive cable logs from MCU, Caution: approx wait time could be ~2 minutes Continue?'.format(port), abort=True)
     port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_EVENT_LOG_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1608,7 +1608,7 @@ def version(db, port, active):
         else:
             click.echo("{}".format(json.dumps(mux_info_dict, indent=4)))
 
-   elif port == "all" and port is not None:
+    elif port == "all" and port is not None:
 
         logical_port_list = platform_sfputil_helper.get_logical_list()
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1606,7 +1606,6 @@ def version(db, port, active):
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
         rc_exit = True
-        print_data = []
 
         for port in logical_port_list:
 
@@ -1638,22 +1637,28 @@ def version(db, port, active):
 
             port = platform_sfputil_helper.get_interface_alias(port, db)
             
-            mux_info = get_per_port_firmware(port)
-            if not isinstance(mux_info, dict):
-                mux_info = {}
+            mux_info_dict = get_per_port_firmware(port)
+            if not isinstance(mux_info_dict, dict):
+                mux_info_dict = {}
+                rc_exit = False
+             
+            mux_info = {}
+            mux_info_active_dict = {}
+            if active is True:
+                for key in mux_info_dict:
+                    if key.endswith("_active"):
+                        mux_info_active_dict[key] = mux_info_dict[key]
+                mux_info[port] = mux_info_active_dict
+                click.echo("{}".format(json.dumps(mux_info, indent=4)))
+            else:
+                mux_info[port] = mux_info_dict
+                click.echo("{}".format(json.dumps(mux_info, indent=4)))
             
-            for key, val in mux_info.items():
-                print_port_data = []
-                port = platform_sfputil_helper.get_interface_alias(port, db)
-                print_port_data.append(port)
-                print_port_data.append(key)
-                print_port_data.append(val)
-                print_data.append(print_port_data)
+            if rc_exit == False:
+                sys.exit(EXIT_FAIL)
 
-        headers = ['PORT', 'SIDE', 'VERSION']
-        click.echo(tabulate(print_data, headers=headers))
+        sys.exit(CONFIG_SUCCESSFUL)
 
-        sys.exit(CONFIG_SUCCESSFUL) 
     else:
         port_name = platform_sfputil_helper.get_interface_name(port, db)
         click.echo("Did not get a valid Port for mux firmware version".format(port_name))

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -102,7 +102,6 @@ def check_port_in_mux_cable_table(port):
 def get_per_port_firmware(port):
 
     state_db = {}
-    muxcable_info_tbl = {}
     mux_info_dict = {}
     mux_info_full_dict = {}
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -104,6 +104,7 @@ def get_per_port_firmware(port):
     state_db = {}
     muxcable_info_tbl = {}
     mux_info_dict = {}
+    mux_info_full_dict = {}
 
     # Getting all front asic namespace and correspding config and state DB connector
 
@@ -111,8 +112,7 @@ def get_per_port_firmware(port):
     for namespace in namespaces:
         asic_id = multi_asic.get_asic_index_from_namespace(namespace)
         state_db[asic_id] = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
-        state_db[asic_id].connect(statedb[asic_id].STATE_DB)
-        muxcable_info_tbl[asic_id] = swsscommon.Table(state_db[asic_id], "MUX_CABLE_INFO")
+        state_db[asic_id].connect(state_db[asic_id].STATE_DB)
 
     if platform_sfputil is not None:
         asic_index = platform_sfputil_helper.get_asic_id_for_logical_port(port)
@@ -127,10 +127,11 @@ def get_per_port_firmware(port):
             return False
 
 
-    muxcable_grpc_dict[asic_index] = per_npu_statedb[asic_index].get_all(
-        per_npu_statedb[asic_index].STATE_DB, 'MUX_CABLE_INFO|{}'.format(port))
+    mux_info_full_dict[asic_index] = state_db[asic_index].get_all(
+        state_db[asic_index].STATE_DB, 'MUX_CABLE_INFO|{}'.format(port))
 
-    res_dir = muxcable_grpc_dict
+    res_dir = {}
+    res_dir = mux_info_full_dict[asic_index]
     mux_info_dict["version_nic_active"] = res_dir.get("version_nic_active", None)
     mux_info_dict["version_nic_inactive"] = res_dir.get("version_nic_inactive", None)
     mux_info_dict["version_nic_next"] = res_dir.get("version_nic_next", None)

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -365,6 +365,30 @@
         "Name": "CRC-32",
         "Value": "0xAC518FB3"
     },
+    "MUX_CABLE_INFO|Ethernet0": {
+        "version_peer_next": "0.1MS",
+        "version_peer_active": "0.1MS",
+        "version_peer_inactive": "0.1MS",
+        "version_nic_next": "0.1MS",
+        "version_nic_active": "0.1MS",
+        "version_nic_inactive": "0.1MS",
+        "version_self_next": "0.1MS",
+        "version_self_active": "0.1MS",
+        "version_self_inactive": "0.1MS",
+        "Value": "AABB"
+    },
+    "MUX_CABLE_INFO|Ethernet12": {
+        "version_peer_next": "0.1MS",
+        "version_peer_active": "0.1MS",
+        "version_peer_inactive": "0.1MS",
+        "version_nic_next": "0.1MS",
+        "version_nic_active": "0.1MS",
+        "version_nic_inactive": "0.1MS",
+        "version_self_next": "0.1MS",
+        "version_self_active": "0.1MS",
+        "version_self_inactive": "0.1MS",
+        "Value": "AABB"
+    },
     "SWITCH_CAPABILITY|switch": {
         "MIRROR": "true",
         "MIRRORV6": "true",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -366,15 +366,15 @@
         "Value": "0xAC518FB3"
     },
     "MUX_CABLE_INFO|Ethernet0": {
-        "version_peer_next": "0.1MS",
-        "version_peer_active": "0.1MS",
-        "version_peer_inactive": "0.1MS",
-        "version_nic_next": "0.1MS",
-        "version_nic_active": "0.1MS",
-        "version_nic_inactive": "0.1MS",
-        "version_self_next": "0.1MS",
-        "version_self_active": "0.1MS",
-        "version_self_inactive": "0.1MS",
+        "version_peer_next": "0.2MS",
+        "version_peer_active": "0.2MS",
+        "version_peer_inactive": "0.2MS",
+        "version_nic_next": "0.2MS",
+        "version_nic_active": "0.2MS",
+        "version_nic_inactive": "0.2MS",
+        "version_self_next": "0.2MS",
+        "version_self_active": "0.2MS",
+        "version_self_inactive": "0.2MS",
         "Value": "AABB"
     },
     "MUX_CABLE_INFO|Ethernet12": {

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -438,6 +438,17 @@ show_muxcable_firmware_version_all_expected_output = """\
 }
 """
 
+show_muxcable_firmware_version_all_active_expected_output = """\
+{
+    "Ethernet12": {
+        "version_nic_active": "0.1MS",
+        "version_peer_active": "0.1MS",
+        "version_self_active": "0.1MS"
+    }
+}
+"""
+
+
 
 show_muxcable_firmware_version_active_expected_output = """\
 {
@@ -1467,6 +1478,26 @@ class TestMuxcable(object):
         f.write(result.output)
         assert result.output == show_muxcable_firmware_version_all_expected_output
 
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_firmware_version_all_active(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "all", "--active"], obj=db)
+        assert result.exit_code == 0
+        f = open("newfile", "w")
+        f.write(result.output)
+        assert result.output == show_muxcable_firmware_version_all_active_expected_output
 
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -1446,6 +1446,26 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
                                "all"], obj=db)
         assert result.exit_code == 0
+        assert result.output == show_muxcable_firmware_version_expected_output
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=1))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_firmware_version_all_bad_asic_index(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "all"], obj=db)
+        assert result.exit_code == 1 
+
 
     @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -1436,9 +1436,10 @@ class TestMuxcable(object):
     @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
     @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
     @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
-    def test_show_muxcable_firmware_version(self):
+    def test_show_muxcable_firmware_version_all(self):
         runner = CliRunner()
         db = Db()
 

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -422,6 +422,23 @@ show_muxcable_firmware_version_expected_output = """\
 }
 """
 
+show_muxcable_firmware_version_all_expected_output = """\
+{
+    "Ethernet12": {
+        "version_nic_active": "0.1MS",
+        "version_nic_inactive": "0.1MS",
+        "version_nic_next": "0.1MS",
+        "version_peer_active": "0.1MS",
+        "version_peer_inactive": "0.1MS",
+        "version_peer_next": "0.1MS",
+        "version_self_active": "0.1MS",
+        "version_self_inactive": "0.1MS",
+        "version_self_next": "0.1MS"
+    }
+}
+"""
+
+
 show_muxcable_firmware_version_active_expected_output = """\
 {
     "version_self_active": "0.6MS",
@@ -1446,7 +1463,9 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
                                "all"], obj=db)
         assert result.exit_code == 0
-        assert result.output == show_muxcable_firmware_version_expected_output
+        f = open("newfile", "w")
+        f.write(result.output)
+        assert result.output == show_muxcable_firmware_version_all_expected_output
 
 
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -980,6 +980,7 @@ class TestMuxcable(object):
         assert result.exit_code == 0
 
 
+    @mock.patch('click.confirm', mock.MagicMock(return_value=("y")))
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "True"}))

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -1429,6 +1429,23 @@ class TestMuxcable(object):
         assert result.exit_code == 0
         assert result.output == show_muxcable_firmware_version_expected_output
 
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_logical_list', mock.MagicMock(return_value=["Ethernet0", "Ethernet12"]))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.get_physical_to_logical', mock.MagicMock(return_value={0: ["Ethernet12", "Ethernet0"]}))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_firmware_version(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["firmware"].commands["version"], [
+                               "all"], obj=db)
+        assert result.exit_code == 0
+
     @mock.patch('config.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('config.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "sucess"}))


### PR DESCRIPTION
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

This PR adds support for show mux firmware version all as well as adds a click confirmation to process event-log
This PR also fixes a permission issue for executing the show mux packetloss command.

$show mux firmware version all
```
{
    "Ethernet116": {
        "version_nic_active": "1.0MV",
        "version_nic_inactive": "0.9MS",
        "version_nic_next": "1.0MV",
        "version_peer_active": "1.0MV",
        "version_peer_inactive": "0.9MS",
        "version_peer_next": "1.0MV",
        "version_self_active": "1.0MV",
        "version_self_inactive": "0.9MS",
        "version_self_next": "1.0MV"
    }
}
{
    "Ethernet120": {
        "version_nic_active": "1.0MV",
        "version_nic_inactive": "0.9MS",
        "version_nic_next": "1.0MV",
        "version_peer_active": "1.0MV",
        "version_peer_inactive": "0.9MS",
        "version_peer_next": "1.0MV",
        "version_self_active": "1.0MV",
        "version_self_inactive": "0.9MS",
        "version_self_next": "1.0MV"
    }
}
```

$ show mux firmware version all --active
```
{
    "Ethernet116": {
        "version_nic_active": "1.0MV",
        "version_peer_active": "1.0MV",
        "version_self_active": "1.0MV"
    }
}
{
    "Ethernet120": {
        "version_nic_active": "1.0MV",
        "version_peer_active": "1.0MV",
        "version_self_active": "1.0MV"
    }
}
```

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it
UT and deploying changes on testbed
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

