### PR TITLE
Work "show ip fib" with vrf.

### DIFF
--- a/scripts/fibshow
+++ b/scripts/fibshow
@@ -97,8 +97,8 @@ class FibBase(object):
         for fib in self.fib_entry_list:
             prefix = fib[0]
 
-            if 'VRF' in fib[0]:
-                vrf = re.match(r"VRF-(.*)",fib[0].split(":")[0]).group(1)
+            if 'Vrf' in fib[0]:
+                vrf = re.match(r"Vrf(.*)",fib[0].split(":")[0]).group(1)
                 prefix = fib[0].split(":")[1]
             else:
                 vrf = ""

--- a/tests/fibshow_input/appl_db.json
+++ b/tests/fibshow_input/appl_db.json
@@ -11,7 +11,7 @@
     "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61,10.0.0.63",
     "ifname" : ""
   },
-  "ROUTE_TABLE:VRF-Red:192.168.112.128/25": {
+  "ROUTE_TABLE:VrfRed:192.168.112.128/25": {
     "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61,10.0.0.63",
     "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104"
   },


### PR DESCRIPTION
VRF name format in APPL_DB is "Vrf*", not "VRF-*".

Signed-off-by: Masaru OKI <masaru.oki@gmail.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Work `show ip fib` with vrf correctly.

#### How I did it

Correct VRF name format in fibshow.

#### How to verify it

1. add vrf
2. add route in vrf
3. `show ip fib`

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

