### PR TITLE
[202205] check for vxlan mapping before removing vlan 

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -60,6 +60,10 @@ def del_vlan(db, vid):
     
     if keys:
         ctx.fail("VLAN ID {} can not be removed. First remove all members assigned to this VLAN.".format(vid))
+    vxlan_table = db.cfgdb.get_table('VXLAN_TUNNEL_MAP')
+    for vxmap_key, vxmap_data in vxlan_table.items():
+        if vxmap_data['vlan'] == 'Vlan{}'.format(vid):
+            ctx.fail("vlan: {} can not be removed. First remove vxlan mapping '{}' assigned to VLAN".format(vid, '|'.join(vxmap_key)) )
         
     db.cfgdb.set_entry('VLAN', 'Vlan{}'.format(vid), None)
 

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -311,6 +311,30 @@ class TestVlan(object):
         assert result.exit_code != 0
         assert "Error: PortChannel0001 is a router interface!" in result.output
 
+    def test_config_vlan_with_vxlanmap_del_vlan(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        # create vlan
+        result = runner.invoke(config.config.commands["vlan"].commands["add"], ["1027"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        # create vxlan map
+        result = runner.invoke(config.config.commands["vxlan"].commands["map"].commands["add"], ["vtep1", "1027", "11027"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        # attempt to del vlan with vxlan map, should fail
+        result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1027"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: vlan: 1027 can not be removed. First remove vxlan mapping" in result.output
+
     def test_config_vlan_del_vlan(self):
         runner = CliRunner()
         db = Db()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Backporting https://github.com/sonic-net/sonic-utilities/pull/2388 to 202205
check for vxlan mapping before removing vlan


#### How I did it
added a check similar to vlan member above


#### How to verify it
attempt to delete a vlan that has a vxlan mapping in place

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

