### PR TITLE
skip `cache_arp_entries` if there are active-active interfaces

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1572,7 +1572,9 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
     cache_arp_table = not disable_arp_cache and 'subtype' in localhost_metadata and localhost_metadata['subtype'].lower() == 'dualtor'
 
     if cache_arp_table:
-        cache_arp_entries()
+        mux_cable_config = db.cfgdb.get_table('MUX_CABLE')
+        if not any('cable_type' in mux_cable and mux_cable['cable_type']=='active-active' for mux_cable in mux_cable_config.values()):
+            cache_arp_entries()
 
     #Stop services before config push
     if not no_service_restart:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix issue detailed in https://github.com/sonic-net/sonic-platform-daemons/issues/291

sign-off: Jing Zhang zhangjing@microsoft.com
#### How I did it
Check if there is any interface configured to be active-active. 

#### How to verify it
1. Run `config reload` on active-standby topo dualtor, cache is created under `/host/config-reload/`
2. Run `config reload` on mixed topo dualtor, cache is not created under `/host/config-reload/`
3. Run `config reload` on mixed topo dualtor, peer's gRPC tcp session is no longer interrupted. 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

