### PR TITLE
YANG Validation for ConfigDB Updates: TACPLUS, TACPLUS_SERVER, AAA, VLAN_SUB_INTERFACE tables + decorated validated_mod_entry

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -20,7 +20,7 @@ def add_table_kv(table, entry, key, val):
     config_db.connect()
     try:
         config_db.mod_entry(table, entry, {key:val})
-    except Exception as e:
+    except ValueError as e:
         ctx = click.get_current_context()
         ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
@@ -34,7 +34,7 @@ def del_table_key(table, entry, key):
             del data[key]
         try:
             config_db.set_entry(table, entry, data)
-        except Exception as e:
+        except (ValueError, JsonPatchConflict) as e:
             ctx = click.get_current_context()
             ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -2,8 +2,11 @@ import click
 import ipaddress
 import re
 from swsscommon.swsscommon import ConfigDBConnector
+from .validated_config_db_connector import ValidatedConfigDBConnector
+from jsonpatch import JsonPatchConflict
 import utilities_common.cli as clicommon
 
+ADHOC_VALIDATION = True
 RADIUS_MAXSERVERS = 8
 RADIUS_PASSKEY_MAX_LEN = 65
 VALID_CHARS_MSG = "Valid chars are ASCII printable except SPACE, '#', and ','"
@@ -13,19 +16,27 @@ def is_secret(secret):
 
 
 def add_table_kv(table, entry, key, val):
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-    config_db.mod_entry(table, entry, {key:val})
+    try:
+        config_db.mod_entry(table, entry, {key:val})
+    except Exception as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 def del_table_key(table, entry, key):
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     data = config_db.get_entry(table, entry)
     if data:
         if key in data:
             del data[key]
-        config_db.set_entry(table, entry, data)
+        try:
+            config_db.set_entry(table, entry, data)
+        except Exception as e:
+            ctx = click.get_current_context()
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @click.group()
 def aaa():
@@ -246,11 +257,12 @@ default.add_command(passkey)
 @click.option('-m', '--use-mgmt-vrf', help="Management vrf, default is no vrf", is_flag=True)
 def add(address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
     """Specify a TACACS+ server"""
-    if not clicommon.is_ipaddress(address):
-        click.echo('Invalid ip address')
-        return
+    if ADHOC_VALIDATION:
+        if not clicommon.is_ipaddress(address):
+            click.echo('Invalid ip address') # TODO: MISSING CONSTRAINT IN YANG MODEL
+            return
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     old_data = config_db.get_entry('TACPLUS_SERVER', address)
     if old_data != {}:
@@ -268,7 +280,11 @@ def add(address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
             data['passkey'] = key
         if use_mgmt_vrf :
             data['vrf'] = "mgmt"
-        config_db.set_entry('TACPLUS_SERVER', address, data)
+        try:
+            config_db.set_entry('TACPLUS_SERVER', address, data)
+        except ValueError as e:
+            ctx = click.get_current_context()
+            ctx.fail("Invalid ip address. Error: {}".format(e))
 tacacs.add_command(add)
 
 
@@ -278,13 +294,18 @@ tacacs.add_command(add)
 @click.argument('address', metavar='<ip_address>')
 def delete(address):
     """Delete a TACACS+ server"""
-    if not clicommon.is_ipaddress(address):
-        click.echo('Invalid ip address')
-        return
+    if ADHOC_VALIDATION:
+        if not clicommon.is_ipaddress(address):
+            click.echo('Invalid ip address')
+            return
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-    config_db.set_entry('TACPLUS_SERVER', address, None)
+    try:
+        config_db.set_entry('TACPLUS_SERVER', address, None)
+    except JsonPatchConflict as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ip address. Error: {}".format(e))
 tacacs.add_command(delete)
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -1971,14 +1971,10 @@ def override_config_db(config_db, config_input):
 def hostname(new_hostname):
     """Change device hostname without impacting the traffic."""
 
-    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
+    config_db = ConfigDBConnector()
     config_db.connect()
-    try:
-        config_db.mod_entry(swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, 'localhost',
-                            {'hostname': new_hostname})
-    except Exception as e:
-        ctx = click.get_current_context()
-        ctx.fail("Failed to write new hostname to ConfigDB. Error: {}".format(e))
+    config_db.mod_entry(swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, 'localhost',
+                        {'hostname': new_hostname})
 
     click.echo('Please note loaded setting will be lost after system reboot. To'
                ' preserve setting, run `config save`.')
@@ -1997,22 +1993,16 @@ def synchronous_mode(sync_mode):
             2. systemctl restart swss
     """
 
-    if ADHOC_VALIDATION:
-        if sync_mode != 'enable' and sync_mode != 'disable':
-            raise click.BadParameter("Error: Invalid argument %s, expect either enable or disable" % sync_mode)
-    
-    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
-    config_db.connect()
-    try:
+    if sync_mode == 'enable' or sync_mode == 'disable':
+        config_db = ConfigDBConnector()
+        config_db.connect()
         config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"synchronous_mode" : sync_mode})
-    except Exception as e:
-        ctx = click.get_current_context()
-        ctx.fail("Error: Invalid argument %s, expect either enable or disable" % sync_mode)
-    
-    click.echo("""Wrote %s synchronous mode into CONFIG_DB, swss restart required to apply the configuration: \n
-        Option 1. config save -y \n
-                  config reload -y \n
-        Option 2. systemctl restart swss""" % sync_mode)
+        click.echo("""Wrote %s synchronous mode into CONFIG_DB, swss restart required to apply the configuration: \n
+    Option 1. config save -y \n
+              config reload -y \n
+    Option 2. systemctl restart swss""" % sync_mode)
+    else:
+        raise click.BadParameter("Error: Invalid argument %s, expect either enable or disable" % sync_mode)
 
 #
 # 'yang_config_validation' command ('config yang_config_validation ...')
@@ -2021,21 +2011,13 @@ def synchronous_mode(sync_mode):
 @click.argument('yang_config_validation', metavar='<enable|disable>', required=True)
 def yang_config_validation(yang_config_validation):
     # Enable or disable YANG validation on updates to ConfigDB
-
-    if ADHOC_VALIDATION:
-        if yang_config_validation != 'enable' and yang_config_validation != 'disable':
-            raise click.BadParameter("Error: Invalid argument %s, expect either enable or disable" % yang_config_validation)
-
-    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
-    config_db.connect()
-    try:
+    if yang_config_validation == 'enable' or yang_config_validation == 'disable':
+        config_db = ConfigDBConnector()
+        config_db.connect()
         config_db.mod_entry('DEVICE_METADATA', 'localhost', {"yang_config_validation": yang_config_validation})
-    except Exception as e:
-        ctx = click.get_current_context()
-        print(e)
-        ctx.fail("Error: Invalid argument %s, expect either enable or disable" % yang_config_validation)
-
-    click.echo("""Wrote %s yang config validation into CONFIG_DB""" % yang_config_validation)
+        click.echo("""Wrote %s yang config validation into CONFIG_DB""" % yang_config_validation)
+    else:
+        raise click.BadParameter("Error: Invalid argument %s, expect either enable or disable" % yang_config_validation)
 
 #
 # 'portchannel' group ('config portchannel ...')

--- a/config/main.py
+++ b/config/main.py
@@ -6796,73 +6796,82 @@ def is_subintf_shortname(intf):
 @click.argument('vid', metavar='<vid>', required=False, type=click.IntRange(1,4094))
 @click.pass_context
 def add_subinterface(ctx, subinterface_name, vid):
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
     sub_intf_sep_idx = subinterface_name.find(VLAN_SUB_INTERFACE_SEPARATOR)
-    if sub_intf_sep_idx == -1:
-        ctx.fail("{} is invalid vlan subinterface".format(subinterface_name))
-
     interface_alias = subinterface_name[:sub_intf_sep_idx]
-    if interface_alias is None:
-        ctx.fail("{} invalid subinterface".format(interface_alias))
+    if ADHOC_VALIDATION:
+        if sub_intf_sep_idx == -1:
+            ctx.fail("{} is invalid vlan subinterface".format(subinterface_name))
 
-    if interface_alias.startswith("Po") is True:
-        intf_table_name = CFG_PORTCHANNEL_PREFIX
-    elif interface_alias.startswith("Eth") is True:
-        intf_table_name = 'PORT'
+        if interface_alias is None:
+            ctx.fail("{} invalid subinterface".format(interface_alias))
 
-    config_db = ctx.obj['db']
-    port_dict = config_db.get_table(intf_table_name)
-    parent_intf = get_intf_longname(interface_alias)
-    if interface_alias is not None:
-        if not port_dict:
-            ctx.fail("{} parent interface not found. {} table none".format(interface_alias, intf_table_name))
-        if parent_intf not in port_dict.keys():
-            ctx.fail("{} parent interface not found".format(subinterface_name))
+        if interface_alias.startswith("Po") is True:
+            intf_table_name = CFG_PORTCHANNEL_PREFIX
+        elif interface_alias.startswith("Eth") is True:
+            intf_table_name = 'PORT'
+        else:
+            ctx.fail("{} is invalid vlan subinterface".format(subinterface_name))
 
-    # Validate if parent is portchannel member
-    portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
-    if interface_is_in_portchannel(portchannel_member_table, parent_intf):
-        ctx.fail("{} is configured as a member of portchannel. Cannot configure subinterface"
-                .format(parent_intf))
+        port_dict = config_db.get_table(intf_table_name)
+        parent_intf = get_intf_longname(interface_alias)
+        if interface_alias is not None:
+            if not port_dict:
+                ctx.fail("{} parent interface not found. {} table none".format(interface_alias, intf_table_name))
+            if parent_intf not in port_dict.keys():
+                ctx.fail("{} parent interface not found".format(subinterface_name))
 
-    # Validate if parent is vlan member
-    vlan_member_table = config_db.get_table('VLAN_MEMBER')
-    if interface_is_in_vlan(vlan_member_table, parent_intf):
-        ctx.fail("{} is configured as a member of vlan. Cannot configure subinterface"
-                .format(parent_intf))
+        # Validate if parent is portchannel member
+        portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+        if interface_is_in_portchannel(portchannel_member_table, parent_intf): # TODO: MISSING CONSTRAINT IN YANG MODEL
+            ctx.fail("{} is configured as a member of portchannel. Cannot configure subinterface"
+                    .format(parent_intf))
 
-    sub_intfs = [k for k,v in config_db.get_table('VLAN_SUB_INTERFACE').items() if type(k) != tuple]
-    if subinterface_name in sub_intfs:
-        ctx.fail("{} already exists".format(subinterface_name))
+        # Validate if parent is vlan member
+        vlan_member_table = config_db.get_table('VLAN_MEMBER')
+        if interface_is_in_vlan(vlan_member_table, parent_intf): # TODO: MISSING CONSTRAINT IN YANG MODEL
+            ctx.fail("{} is configured as a member of vlan. Cannot configure subinterface"
+                    .format(parent_intf))
+
+        sub_intfs = [k for k,v in config_db.get_table('VLAN_SUB_INTERFACE').items() if type(k) != tuple]
+        if subinterface_name in sub_intfs:
+            ctx.fail("{} already exists".format(subinterface_name)) # TODO: MISSING CONSTRAINT IN YANG MODEL
+
+        if subintf_vlan_check(config_db, get_intf_longname(interface_alias), vid) is True:
+            ctx.fail("Vlan {} encap already configured on other subinterface on {}".format(vid, interface_alias)) # TODO: MISSING CONSTRAINT IN YANG MODEL
+
+        if vid is None and is_subintf_shortname(subinterface_name):
+            ctx.fail("{} Encap vlan is mandatory or short name subinterfaces".format(subinterface_name)) # TODO: MISSING CONSTRAINT IN YANG MODEL
 
     subintf_dict = {}
     if vid is not None:
         subintf_dict.update({"vlan" : vid})
-    elif is_subintf_shortname(subinterface_name):
-        ctx.fail("{} Encap vlan is mandatory for short name subinterfaces".format(subinterface_name))
-
-    if subintf_vlan_check(config_db, get_intf_longname(interface_alias), vid) is True:
-        ctx.fail("Vlan {} encap already configured on other subinterface on {}".format(vid, interface_alias))
-
     subintf_dict.update({"admin_status" : "up"})
-    config_db.set_entry('VLAN_SUB_INTERFACE', subinterface_name, subintf_dict)
+    
+    try:
+        config_db.set_entry('VLAN_SUB_INTERFACE', subinterface_name, subintf_dict)
+    except ValueError as e:
+        ctx.fail("Invalid vlan subinterface. Error: {}".format(e))
 
 @subinterface.command('del')
 @click.argument('subinterface_name', metavar='<subinterface_name>', required=True)
 @click.pass_context
 def del_subinterface(ctx, subinterface_name):
-    sub_intf_sep_idx = subinterface_name.find(VLAN_SUB_INTERFACE_SEPARATOR)
-    if sub_intf_sep_idx == -1:
-        ctx.fail("{} is invalid vlan subinterface".format(subinterface_name))
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
 
-    config_db = ctx.obj['db']
-    #subinterface_name = subintf_get_shortname(subinterface_name)
-    if interface_name_is_valid(config_db, subinterface_name) is False:
-        ctx.fail("{} is invalid ".format(subinterface_name))
+    if ADHOC_VALIDATION:
+        sub_intf_sep_idx = subinterface_name.find(VLAN_SUB_INTERFACE_SEPARATOR)
+        if sub_intf_sep_idx == -1:
+            ctx.fail("{} is invalid vlan subinterface".format(subinterface_name))
 
-    subintf_config_db = config_db.get_table('VLAN_SUB_INTERFACE')
-    sub_intfs = [k for k,v in subintf_config_db.items() if type(k) != tuple]
-    if subinterface_name not in sub_intfs:
-        ctx.fail("{} does not exists".format(subinterface_name))
+        #subinterface_name = subintf_get_shortname(subinterface_name)
+        if interface_name_is_valid(config_db, subinterface_name) is False:
+            ctx.fail("{} is invalid ".format(subinterface_name))
+
+        subintf_config_db = config_db.get_table('VLAN_SUB_INTERFACE')
+        sub_intfs = [k for k,v in subintf_config_db.items() if type(k) != tuple]
+        if subinterface_name not in sub_intfs:
+            ctx.fail("{} does not exists".format(subinterface_name))
 
     ips = {}
     ips = [ k[1] for k in config_db.get_table('VLAN_SUB_INTERFACE') if type(k) == tuple and k[0] == subinterface_name ]
@@ -6878,7 +6887,10 @@ def del_subinterface(ctx, subinterface_name):
     for ip in ips:
         config_db.set_entry('INTERFACE', (subinterface_name, ip), None)
 
-    config_db.set_entry('VLAN_SUB_INTERFACE', subinterface_name, None)
+    try:
+        config_db.set_entry('VLAN_SUB_INTERFACE', subinterface_name, None)
+    except JsonPatchConflict as e:
+        ctx.fail("{} is invalid vlan subinterface. Error: {}".format(subinterface_name, e))
 
 if __name__ == '__main__':
     config()

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -122,4 +122,4 @@ class ValidatedConfigDBConnector(object):
             op = "remove"
 
         gcu_patch = self.create_gcu_patch(op, table, key, value)
-        self.apply_patch(gcu_patch)
+        self.apply_patch(gcu_patch, table)

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -5,7 +5,6 @@ from jsonpointer import JsonPointer
 from sonic_py_common import device_info
 from generic_config_updater.generic_updater import GenericUpdater, ConfigFormat
 from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogging
-from swsscommon.swsscommon import ConfigDBConnector
 
 class ValidatedConfigDBConnector(object):
     

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -93,7 +93,6 @@ class ValidatedConfigDBConnector(object):
 
         try:
             GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
-            return True
         except EmptyTableError:
             self.validated_delete_table(table)
 
@@ -114,7 +113,7 @@ class ValidatedConfigDBConnector(object):
             op = "remove"
 
         gcu_patch = self.create_gcu_patch(op, table, key, value, mod_entry=True)
-        return self.apply_patch(gcu_patch, table)
+        self.apply_patch(gcu_patch, table)
 
     def validated_set_entry(self, table, key, value):
         if value is not None:
@@ -123,4 +122,4 @@ class ValidatedConfigDBConnector(object):
             op = "remove"
 
         gcu_patch = self.create_gcu_patch(op, table, key, value)
-        return self.apply_patch(gcu_patch, table)
+        self.apply_patch(gcu_patch, table)

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -5,6 +5,7 @@ from jsonpointer import JsonPointer
 from sonic_py_common import device_info
 from generic_config_updater.generic_updater import GenericUpdater, ConfigFormat
 from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogging
+from swsscommon.swsscommon import ConfigDBConnector
 
 class ValidatedConfigDBConnector(object):
     

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -93,6 +93,7 @@ class ValidatedConfigDBConnector(object):
 
         try:
             GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
+            return True
         except EmptyTableError:
             self.validated_delete_table(table)
 
@@ -113,7 +114,7 @@ class ValidatedConfigDBConnector(object):
             op = "remove"
 
         gcu_patch = self.create_gcu_patch(op, table, key, value, mod_entry=True)
-        self.apply_patch(gcu_patch, table)
+        return self.apply_patch(gcu_patch, table)
 
     def validated_set_entry(self, table, key, value):
         if value is not None:
@@ -122,4 +123,4 @@ class ValidatedConfigDBConnector(object):
             op = "remove"
 
         gcu_patch = self.create_gcu_patch(op, table, key, value)
-        self.apply_patch(gcu_patch, table)
+        return self.apply_patch(gcu_patch, table)

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -5,7 +5,6 @@ from jsonpointer import JsonPointer
 from sonic_py_common import device_info
 from generic_config_updater.generic_updater import GenericUpdater, ConfigFormat
 from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogging
-from swsscommon.swsscommon import ConfigDBConnector
 
 class ValidatedConfigDBConnector(object):
     
@@ -40,7 +39,7 @@ class ValidatedConfigDBConnector(object):
         if value == {"NULL" : "NULL"}:
             value = {}
         else:
-            value = self.stringify_value()
+            value = self.stringify_value(value)
         return path, value
 
     def create_gcu_patch(self, op, table, key=None, value=None, mod_entry=False):

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -87,7 +87,7 @@ class ValidatedConfigDBConnector(object):
         gcu_patch = jsonpatch.JsonPatch(gcu_json_input)
         return gcu_patch
 
-    def apply_patch(self, gcu_patch):
+    def apply_patch(self, gcu_patch, table):
         format = ConfigFormat.CONFIGDB.name
         config_format = ConfigFormat[format.upper()]
 
@@ -113,7 +113,7 @@ class ValidatedConfigDBConnector(object):
             op = "remove"
 
         gcu_patch = self.create_gcu_patch(op, table, key, value, mod_entry=True)
-        self.apply_patch(gcu_patch)
+        self.apply_patch(gcu_patch, table)
 
     def validated_set_entry(self, table, key, value):
         if value is not None:

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -1,9 +1,11 @@
 import jsonpatch
+import copy
 from jsonpointer import JsonPointer
 
 from sonic_py_common import device_info
 from generic_config_updater.generic_updater import GenericUpdater, ConfigFormat
 from generic_config_updater.gu_common import EmptyTableError, genericUpdaterLogging
+from swsscommon.swsscommon import ConfigDBConnector
 
 class ValidatedConfigDBConnector(object):
     
@@ -17,32 +19,78 @@ class ValidatedConfigDBConnector(object):
                 return self.validated_set_entry
             if name == "delete_table":
                 return self.validated_delete_table
+            if name == "mod_entry":
+                return self.validated_mod_entry
         return self.connector.__getattribute__(name)
 
     def make_path_value_jsonpatch_compatible(self, table, key, value):
+        def stringify_value():
+            nonlocal value
+            if isinstance(value, dict):
+                value = {str(k):str(v) for k, v in value.items()}
+            else:
+                value = str(value)
         if type(key) == tuple:
             path = JsonPointer.from_parts([table, '|'.join(key)]).path
+        elif type(key) == list:
+            path = JsonPointer.from_parts([table, *key]).path
         else:
             path = JsonPointer.from_parts([table, key]).path
         if value == {"NULL" : "NULL"}:
             value = {}
+        else:
+            stringify_value()
         return path, value
 
-    def create_gcu_patch(self, op, table, key=None, value=None):
-        if key:
-            path, value = self.make_path_value_jsonpatch_compatible(table, key, value)
-        else: 
-            path = "/{}".format(table)
-
+    def create_gcu_patch(self, op, table, key=None, value=None, mod_entry=False):
         gcu_json_input = []
-        gcu_json = {"op": "{}".format(op),
-                    "path": "{}".format(path)}
-        if op == "add":
-            gcu_json["value"] = value
+        if op == "add" and not self.get_table(table):
+            gcu_json = {"op": "{}".format(op),
+                        "path": "/{}".format(table),
+                        "value": {}}
+            gcu_json_input.append(gcu_json)
 
-        gcu_json_input.append(gcu_json)
+        if op == "add" and not self.get_entry(table, key):
+            path = JsonPointer.from_parts([table, key]).path
+            gcu_json = {"op": "{}".format(op),
+                        "path": "{}".format(path),
+                        "value": {}}
+            gcu_json_input.append(gcu_json)
+         
+        def add_patch_entry():
+            if key: 
+                patch_path, patch_value = self.make_path_value_jsonpatch_compatible(table, key, value)
+            else:  
+                patch_path = "/{}".format(table)
+      
+            gcu_json = {"op": "{}".format(op),
+                        "path": "{}".format(patch_path)}
+            if op == "add":
+                gcu_json["value"] = patch_value
+
+            gcu_json_input.append(gcu_json)
+        
+        if mod_entry:
+            key_start = key
+            value_copy = copy.deepcopy(value)
+            for key_end, cleaned_value in value_copy.items():
+                key = [key_start, key_end]
+                value = cleaned_value
+                add_patch_entry()
+        else:
+            add_patch_entry()
+
         gcu_patch = jsonpatch.JsonPatch(gcu_json_input)
         return gcu_patch
+
+    def apply_patch(self, gcu_patch):
+        format = ConfigFormat.CONFIGDB.name
+        config_format = ConfigFormat[format.upper()]
+
+        try:
+            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
+        except EmptyTableError:
+            self.validated_delete_table(table)
 
     def validated_delete_table(self, table):
         gcu_patch = self.create_gcu_patch("remove", table)
@@ -54,17 +102,20 @@ class ValidatedConfigDBConnector(object):
             logger = genericUpdaterLogging.get_logger(title="Patch Applier", print_all_to_console=True)
             logger.log_notice("Unable to remove entry, as doing so will result in invalid config. Error: {}".format(e))
 
+    def validated_mod_entry(self, table, key, value):
+        if value is not None:
+            op = "add"
+        else:
+            op = "remove"
+
+        gcu_patch = self.create_gcu_patch(op, table, key, value, mod_entry=True)
+        self.apply_patch(gcu_patch)
+
     def validated_set_entry(self, table, key, value):
         if value is not None:
             op = "add"
         else:
             op = "remove"
-    
-        gcu_patch = self.create_gcu_patch(op, table, key, value)
-        format = ConfigFormat.CONFIGDB.name
-        config_format = ConfigFormat[format.upper()]
 
-        try:
-            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
-        except EmptyTableError:
-            self.validated_delete_table(table)
+        gcu_patch = self.create_gcu_patch(op, table, key, value)
+        self.apply_patch(gcu_patch)

--- a/tests/aaa_test.py
+++ b/tests/aaa_test.py
@@ -294,7 +294,17 @@ class TestAaa(object):
 
         result = runner.invoke(config.config.commands["tacacs"].commands["delete"], ["10.10.10.10"], obj=obj)
         print(result.exit_code)
-        print(result.output)
         assert result.exit_code != 0
-        assert "Invalid ip address. Error:" in result.output
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value={}))
+    def test_config_aaa_tacacs_add_yang_validation(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["tacacs"].commands["add"], ["10.10.10.10"], obj=obj)
+        print(result.exit_code)
+        assert result.exit_code != 0

--- a/tests/aaa_test.py
+++ b/tests/aaa_test.py
@@ -4,8 +4,12 @@ import sys
 
 from click.testing import CliRunner
 from utilities_common.db import Db
+from jsonpatch import JsonPatchConflict
+from unittest import mock
+from mock import patch
 
 import config.main as config
+import config.validated_config_db_connector as validated_config_db_connector
 import show.main as show
 
 test_path = os.path.dirname(os.path.abspath(__file__))
@@ -279,4 +283,18 @@ class TestAaa(object):
         result = runner.invoke(show.cli.commands["aaa"], [], obj=db)
         assert result.exit_code == 0
         assert result.output == show_aaa_disable_accounting_output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
+    def test_config_aaa_tacacs_delete_yang_validation(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["tacacs"].commands["delete"], ["10.10.10.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid ip address. Error:" in result.output
 

--- a/tests/aaa_test.py
+++ b/tests/aaa_test.py
@@ -294,17 +294,7 @@ class TestAaa(object):
 
         result = runner.invoke(config.config.commands["tacacs"].commands["delete"], ["10.10.10.10"], obj=obj)
         print(result.exit_code)
+        print(result.output)
         assert result.exit_code != 0
+        assert "Invalid ip address. Error:" in result.output
 
-    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
-    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
-    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value={}))
-    def test_config_aaa_tacacs_add_yang_validation(self):
-        config.ADHOC_VALIDATION = True
-        runner = CliRunner()
-        db = Db()
-        obj = {'db':db.cfgdb}
-
-        result = runner.invoke(config.config.commands["tacacs"].commands["add"], ["10.10.10.10"], obj=obj)
-        print(result.exit_code)
-        assert result.exit_code != 0

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -42,5 +42,7 @@ class TestValidatedConfigDBConnector(TestCase):
 
     def test_create_gcu_patch(self):
         expected_gcu_patch = jsonpatch.JsonPatch([{"op": "add", "path": "/PORTCHANNEL/PortChannel01", "value": "test"}])
-        created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(ValidatedConfigDBConnector(ConfigDBConnector()), "add", "PORTCHANNEL", "PortChannel01", "test")
-        assert expected_gcu_patch == created_gcu_patch
+        with mock.patch('validated_config_db_connector.ConfigDBConnector.get_table', return_value=True):
+            with mock.patch('validated_config_db_connector.ConfigDBConnector.get_entry', return_value=True):
+                created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(ValidatedConfigDBConnector(ConfigDBConnector()), "add", "PORTCHANNEL", "PortChannel01", "test")
+                assert expected_gcu_patch == created_gcu_patch

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -18,6 +18,9 @@ from utilities_common.db import Db
 SAMPLE_TABLE = 'VLAN'
 SAMPLE_KEY = 'Vlan1000'
 SAMPLE_VALUE_EMPTY = None
+SAMPLE_VALUE = 'test'
+SAMPLE_VALUE_DICT = {'sample_field_key': 'sample_field_value'}
+SAMPLE_PATCH = [{"op": "add", "path": "/VLAN", "value": "sample value"}]
 
 
 class TestValidatedConfigDBConnector(TestCase):
@@ -33,6 +36,12 @@ class TestValidatedConfigDBConnector(TestCase):
             remove_entry_success = validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry(mock.Mock(), SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
             assert not remove_entry_success
 
+    def test_validated_mod_entry(self):
+        mock_generic_updater = mock.Mock()
+        with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
+            successful_application = validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry(mock.Mock(), SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_DICT)
+            assert successful_application
+
     def test_validated_delete_table_invalid_delete(self):
         mock_generic_updater = mock.Mock()
         mock_generic_updater.apply_patch = mock.Mock(side_effect=ValueError)
@@ -41,8 +50,16 @@ class TestValidatedConfigDBConnector(TestCase):
             assert not delete_table_success
 
     def test_create_gcu_patch(self):
-        expected_gcu_patch = jsonpatch.JsonPatch([{"op": "add", "path": "/PORTCHANNEL/PortChannel01", "value": "test"}])
-        with mock.patch('validated_config_db_connector.ConfigDBConnector.get_table', return_value=True):
-            with mock.patch('validated_config_db_connector.ConfigDBConnector.get_entry', return_value=True):
-                created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(ValidatedConfigDBConnector(ConfigDBConnector()), "add", "PORTCHANNEL", "PortChannel01", "test")
+        expected_gcu_patch = jsonpatch.JsonPatch([{"op": "add", "path": "/PORTCHANNEL", "value": {}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel01", "value": {}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel01", "value": "test"}])
+        with mock.patch('validated_config_db_connector.ConfigDBConnector.get_table', return_value=False):
+            with mock.patch('validated_config_db_connector.ConfigDBConnector.get_entry', return_value=False):
+                created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(ValidatedConfigDBConnector(ConfigDBConnector()), "add", "PORTCHANNEL", "PortChannel01", SAMPLE_VALUE)
                 assert expected_gcu_patch == created_gcu_patch
+
+    def test_apply_patch(self):
+        mock_generic_updater = mock.Mock()
+        mock_generic_updater.apply_patch = mock.Mock(side_effect=EmptyTableError)
+        with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
+            with mock.patch('validated_config_db_connector.ValidatedConfigDBConnector.validated_delete_table', return_value=True):
+                apply_patch_success = validated_config_db_connector.ValidatedConfigDBConnector.apply_patch(mock.Mock(), SAMPLE_PATCH, SAMPLE_TABLE)
+                assert not apply_patch_success

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -56,18 +56,20 @@ class TestValidatedConfigDBConnector(TestCase):
                 assert False, "Exception {} thrown unexpectedly".format(ex)
 
     def test_create_gcu_patch_set_entry(self):
+        mock_validated_config_db_connector = ValidatedConfigDBConnector(ConfigDBConnector())
+        mock_validated_config_db_connector.get_entry = mock.Mock(return_value=False)
+        mock_validated_config_db_connector.get_table = mock.Mock(return_value=False)
         expected_gcu_patch = jsonpatch.JsonPatch([{"op": "add", "path": "/PORTCHANNEL", "value": {}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel01", "value": {}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel01", "value": "test"}])
-        with mock.patch('validated_config_db_connector.ConfigDBConnector.get_table', return_value=False):
-            with mock.patch('validated_config_db_connector.ConfigDBConnector.get_entry', return_value=False):
-                created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(ValidatedConfigDBConnector(ConfigDBConnector()), "add", "PORTCHANNEL", "PortChannel01", SAMPLE_VALUE)
-                assert expected_gcu_patch == created_gcu_patch
+        created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(mock_validated_config_db_connector, "add", "PORTCHANNEL", "PortChannel01", SAMPLE_VALUE)
+        assert expected_gcu_patch == created_gcu_patch
 
     def test_create_gcu_patch_mod_entry(self):
+        mock_validated_config_db_connector = ValidatedConfigDBConnector(ConfigDBConnector())
+        mock_validated_config_db_connector.get_entry = mock.Mock(return_value=True)
+        mock_validated_config_db_connector.get_table = mock.Mock(return_value=True)
         expected_gcu_patch = jsonpatch.JsonPatch([{"op": "add", "path": "/PORTCHANNEL/PortChannel01/test_key", "value": "test_value"}])
-        with mock.patch('validated_config_db_connector.ConfigDBConnector.get_table', return_value=True):
-            with mock.patch('validated_config_db_connector.ConfigDBConnector.get_entry', return_value=True):
-                created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(ValidatedConfigDBConnector(ConfigDBConnector()), "add", "PORTCHANNEL", "PortChannel01", {"test_key": "test_value"}, mod_entry=True)
-                assert expected_gcu_patch == created_gcu_patch
+        created_gcu_patch = validated_config_db_connector.ValidatedConfigDBConnector.create_gcu_patch(mock_validated_config_db_connector, "add", "PORTCHANNEL", "PortChannel01", {"test_key": "test_value"}, mod_entry=True)
+        assert expected_gcu_patch == created_gcu_patch
 
     def test_apply_patch(self):
         mock_generic_updater = mock.Mock()

--- a/tests/validated_config_db_connector_test.py
+++ b/tests/validated_config_db_connector_test.py
@@ -34,7 +34,7 @@ class TestValidatedConfigDBConnector(TestCase):
         mock_generic_updater.apply_patch = mock.Mock(side_effect=EmptyTableError)
         with mock.patch('validated_config_db_connector.GenericUpdater', return_value=mock_generic_updater):
             remove_entry_success = validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry(mock.Mock(), SAMPLE_TABLE, SAMPLE_KEY, SAMPLE_VALUE_EMPTY)
-            assert not remove_entry_success
+            assert remove_entry_success
 
     def test_validated_mod_entry(self):
         mock_generic_updater = mock.Mock()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
-Add YANG validation using GCU for writes to TACPLUS, TACPLUS_SERVER, AAA, VLAN_SUB_INTERFACE  in ConfigDB
-decorate mod_entry with validated_mod_entry to include YANG validation 
-process all values in GCU JsonPatch, convert to string

#### How I did it
Using same method as https://github.com/sonic-net/sonic-utilities/pull/2190/files, extend to TACPLUS, TACPLUS_SERVER, AAA, VLAN_SUB_INTERFACE use cases
#### How to verify it
Verified testing CLI on virtual switch

