### PR TITLE
Fix exception in adding mirror_session when `gre_type` is absent

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1143,6 +1143,8 @@ def validate_ipv4_address(ctx, param, ip_addr):
 def validate_gre_type(ctx, _, value):
     """A validator for validating input gre_type
     """
+    if value is None:
+        return None
     try:
         base = 10
         if value.lower().startswith('0x'):

--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -85,6 +85,12 @@ def test_mirror_session_add():
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
 
         mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None)
+        
+        result = runner.invoke(
+                config.config.commands["mirror_session"].commands["add"],
+                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63"])
+
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, None, None, None)
 
 
 def test_mirror_session_erspan_add():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to fix the exception in adding mirror session when `gre_type` is absent.
```
~$ sudo config mirror_session add session_1 25.25.25.25 10.1.1.1 8 100
Traceback (most recent call last):
  File "/usr/local/bin/config", line 8, in <module>
    sys.exit(config())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1135, in invoke
    sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 641, in make_context
    self.parse_args(ctx, args)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 940, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1476, in handle_parse_result
    value = invoke_param_callback(
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 96, in invoke_param_callback
    return callback(ctx, param, value)
  File "/usr/local/lib/python3.9/dist-packages/config/main.py", line 1069, in validate_gre_type
    if value.lower().startswith('0x'):
AttributeError: 'NoneType' object has no attribute 'lower'
```
#### How I did it
Add a check in `validate_gre_type`. If `gre_type` is absent, return `None` directly.
 
#### How to verify it
Verified by UT and running on a testbed.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

