### PR TITLE
Revert "[config reload]: On dual ToR systems, cache ARP and FDB table…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1082,38 +1082,6 @@ def update_sonic_environment():
             display_cmd=True
         )
 
-def cache_arp_entries():
-    success = True
-    cache_dir = '/host/config-reload'
-    click.echo('Caching ARP table to {}'.format(cache_dir))
-
-    if not os.path.exists(cache_dir):
-        os.mkdir(cache_dir)
-
-    arp_cache_cmd = '/usr/local/bin/fast-reboot-dump.py -t {}'.format(cache_dir)
-    cache_proc = subprocess.Popen(arp_cache_cmd, shell=True, text=True, stdout=subprocess.PIPE)
-    _, cache_err = cache_proc.communicate()
-    if cache_err:
-        click.echo("Could not cache ARP and FDB info prior to reloading")
-        success = False
-
-    if not cache_err:
-        fdb_cache_file = os.path.join(cache_dir, 'fdb.json')
-        arp_cache_file = os.path.join(cache_dir, 'arp.json')
-        fdb_filter_cmd = '/usr/local/bin/filter_fdb_entries -f {} -a {} -c /etc/sonic/configdb.json'.format(fdb_cache_file, arp_cache_file)
-        filter_proc = subprocess.Popen(fdb_filter_cmd, shell=True, text=True, stdout=subprocess.PIPE)
-        _, filter_err = filter_proc.communicate()
-        if filter_err:
-            click.echo("Could not filter FDB entries prior to reloading")
-            success = False
-
-    # If we are able to successfully cache ARP table info, signal SWSS to restore from our cache
-    # by creating /host/config-reload/needs-restore
-    if success:
-        restore_flag_file = os.path.join(cache_dir, 'needs-restore')
-        open(restore_flag_file, 'w').close()
-    return success
-
 def remove_router_interface_ip_address(config_db, interface_name, ipaddress_to_remove):
     table_name = get_interface_table_name(interface_name)
     keys = config_db.get_keys(table_name)
@@ -1520,12 +1488,11 @@ def list_checkpoints(ctx, verbose):
 @click.option('-y', '--yes', is_flag=True)
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')
 @click.option('-n', '--no_service_restart', default=False, is_flag=True, help='Do not restart docker services')
-@click.option('-d', '--disable_arp_cache', default=False, is_flag=True, help='Do not cache ARP table before reloading (applies to dual ToR systems only)')
 @click.option('-f', '--force', default=False, is_flag=True, help='Force config reload without system checks')
 @click.option('-t', '--file_format', default='config_db',type=click.Choice(['config_yang', 'config_db']),show_default=True,help='specify the file format')
 @click.argument('filename', required=False)
 @clicommon.pass_db
-def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cache, force, file_format):
+def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_format):
     """Clear current configuration and import a previous saved config DB dump file.
        <filename> : Names of configuration file(s) to load, separated by comma with no spaces in between
     """
@@ -1568,13 +1535,6 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, disable_arp_cach
         if len(cfg_files) != num_cfg_file:
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
-
-    # For dual ToR devices, cache ARP and FDB info
-    localhost_metadata = db.cfgdb.get_table('DEVICE_METADATA')['localhost']
-    cache_arp_table = not disable_arp_cache and 'subtype' in localhost_metadata and localhost_metadata['subtype'].lower() == 'dualtor'
-
-    if cache_arp_table:
-        cache_arp_entries()
 
     #Stop services before config push
     if not no_service_restart:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -224,7 +224,7 @@ class TestConfigReload(object):
             obj = {'config_db': db.cfgdb}
 
             # simulate 'config reload' to provoke load_sys_info option
-            result = runner.invoke(config.config.commands["reload"], ["-l", "-n", "-y", "--disable_arp_cache"], obj=obj)
+            result = runner.invoke(config.config.commands["reload"], ["-l", "-n", "-y"], obj=obj)
 
             print(result.exit_code)
             print(result.output)
@@ -498,7 +498,7 @@ class TestReloadConfig(object):
 
             result = runner.invoke(
                 config.config.commands["reload"],
-                [self.dummy_cfg_file, '-y', '-f', "--disable_arp_cache"])
+                [self.dummy_cfg_file, '-y', '-f'])
 
             print(result.exit_code)
             print(result.output)
@@ -515,7 +515,7 @@ class TestReloadConfig(object):
             (config, show) = get_cmd_module
 
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["reload"], [self.dummy_cfg_file, "-y", "--disable_arp_cache"])
+            result = runner.invoke(config.config.commands["reload"], [self.dummy_cfg_file, "-y"])
 
             print(result.exit_code)
             print(result.output)
@@ -540,7 +540,7 @@ class TestReloadConfig(object):
                             self.dummy_cfg_file)
             result = runner.invoke(
                 config.config.commands["reload"],
-                [cfg_files, '-y', '-f', "--disable_arp_cache"])
+                [cfg_files, '-y', '-f'])
 
             print(result.exit_code)
             print(result.output)
@@ -559,7 +559,7 @@ class TestReloadConfig(object):
             runner = CliRunner()
 
             result = runner.invoke(config.config.commands["reload"],
-                                    [self.dummy_cfg_file, "--disable_arp_cache", '-y', '-f', '-t', 'config_yang'])
+                                    [self.dummy_cfg_file, '-y', '-f', '-t', 'config_yang'])
 
             print(result.exit_code)
             print(result.output)


### PR DESCRIPTION
…s (#1465)"

This reverts commit 10de91d8c581cd0ed0e5ae79edeb05dfdda4f755.

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

