### PR TITLE
[202012] Check for adding default vlan attempt added (#2075)

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -25,6 +25,10 @@ def add_vlan(db, vid):
         ctx.fail("Invalid VLAN ID {} (1-4094)".format(vid))
 
     vlan = 'Vlan{}'.format(vid)
+    
+    if vid == 1:
+        ctx.fail("{} is default VLAN".format(vlan))
+    
     if clicommon.check_if_vlanid_exist(db.cfgdb, vlan):
         ctx.fail("{} already exists".format(vlan))
 


### PR DESCRIPTION
fixing https://github.com/sonic-net/sonic-buildimage/issues/9946
*CLI throws an error specifying the user that Vlan 1 is default VLAN. Fix Orchagent crash.

Signed-off-by: Julian Chang - TW <julianc@supermicro.com.tw>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
BACKPORT OF: #2075 
#### How I did it

#### How to verify it
config vlan add 1
CLI throws an error specifying the user that Vlan 1 is default VLAN. Orchagent doesn't crash.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

