### PR TITLE
Fix port breakout issue

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4102,11 +4102,6 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     click.secho("\nAfter running Logic to limit the impact", fg="cyan", underline=True)
     matched_items = [intf for intf in del_intf_dict if intf in add_intf_dict and del_intf_dict[intf] == add_intf_dict[intf]]
 
-    # Remove the interface which remains unchanged from both del_intf_dict and add_intf_dict
-    for item in matched_items:
-        del_intf_dict.pop(item)
-        add_intf_dict.pop(item)
-
     # validate all del_ports before calling breakOutPort
     for intf in del_intf_dict.keys():
         if not interface_name_is_valid(config_db, intf):


### PR DESCRIPTION
#### What I did
Fix https://github.com/sonic-net/sonic-buildimage/issues/9663
#### How I did it
Removed the logic which stopped port deletion when DPB is done  
#### How to verify it 
    root@sonic:~# config interface breakout Ethernet0 "1x100G(4)" -y -f 
    Running Breakout Mode : 1x400G
    Target Breakout Mode : 1x100G(4)
    
    Ports to be deleted :
     {
        "Ethernet0": "400000"
    }
    Ports to be added :
     {
        "Ethernet0": "100000"
    }
    
    After running Logic to limit the impact
    
    Final list of ports to be deleted :
     {
        "Ethernet0": "400000"
    }
    Final list of ports to be added :
     {
        "Ethernet0": "100000"
    }
    Breakout process got successfully completed.
    Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
    root@sonic:~#
    root@sonic:~#
    root@sonic:~# config save -y
    Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
    root@sonic:~# config interface breakout Ethernet0 "4x100G[50G]" -y -f
    
    Running Breakout Mode : 1x100G(4)
    Target Breakout Mode : 4x100G[50G]
    
    Ports to be deleted :
     {
        "Ethernet0": "100000"
    }
    Ports to be added :
     {
        "Ethernet0": "100000",
        "Ethernet2": "100000",
        "Ethernet4": "100000",
        "Ethernet6": "100000"
    }
    
    After running Logic to limit the impact
    
    Final list of ports to be deleted :
     {
        "Ethernet0": "100000"
    }
    Final list of ports to be added :
     {
        "Ethernet0": "100000",
        "Ethernet2": "100000",
        "Ethernet4": "100000",
        "Ethernet6": "100000"
    }
    Breakout process got successfully completed.
    Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
    root@sonic:~# config save -y
    Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
    root@sonic:~# show interface status
      Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
    -----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------------------------  ----------
      Ethernet0                            33,34     100G   9100    N/A    etp1a  routed    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
      Ethernet2                            35,36     100G   9100    N/A    etp1b  routed    down     down                                              N/A         N/A
      Ethernet4                            37,38     100G   9100    N/A    etp1c  routed    down     down                                              N/A         N/A
      Ethernet6                            39,40     100G   9100    N/A    etp1d  routed    down     down                                              N/A         N/A
