### PR TITLE
fix show interface neighbor expected empty issue

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -307,9 +307,9 @@ def expected(db, interfacename):
             body.append([interfacename,
                          device,
                          neighbor_dict[interfacename]['port'],
-                         neighbor_metadata_dict[device]['lo_addr'],
-                         neighbor_metadata_dict[device]['mgmt_addr'],
-                         neighbor_metadata_dict[device]['type']])
+                         neighbor_metadata_dict[device]['lo_addr'] if 'lo_addr' in neighbor_metadata_dict[device] else 'None',
+                         neighbor_metadata_dict[device]['mgmt_addr'] if 'mgmt_addr' in neighbor_metadata_dict[device] else 'None',
+                         neighbor_metadata_dict[device]['type'] if 'type' in neighbor_metadata_dict[device] else 'None'])
         except KeyError:
             click.echo("No neighbor information available for interface {}".format(interfacename))
             return
@@ -320,9 +320,9 @@ def expected(db, interfacename):
                 body.append([port,
                              device,
                              neighbor_dict[port]['port'],
-                             neighbor_metadata_dict[device]['lo_addr'],
-                             neighbor_metadata_dict[device]['mgmt_addr'],
-                             neighbor_metadata_dict[device]['type']])
+                             neighbor_metadata_dict[device]['lo_addr'] if 'lo_addr' in neighbor_metadata_dict[device] else 'None',
+                             neighbor_metadata_dict[device]['mgmt_addr'] if 'mgmt_addr' in neighbor_metadata_dict[device] else 'None',
+                             neighbor_metadata_dict[device]['type'] if 'type' in neighbor_metadata_dict[device] else 'None'])
             except KeyError:
                 pass
 


### PR DESCRIPTION
#### Why I did it
With the commit of https://github.com/sonic-net/sonic-buildimage/pull/11894.
device neighbor metadata in config_db.json changed a little bit when "lo_addr"/"mgmt_addr" are None.

![dfa09cf3-b9f5-4da1-b998-ff750ef6ab12](https://user-images.githubusercontent.com/111116206/197200767-cf538999-8cc4-4a93-808d-df7c239de71f.jpg)

CLI parse code for "show interface neighbor expected" is not strong enough to handle None case. 
It always assume 'lo_addr' and 'mgmt_addr' exists, and will finally cause KeyError, show command will not print the information. 

```
for port in natsorted(list(neighbor_dict.keys())):
            try:
                device = neighbor_dict[port]['name']
                body.append([port,
                             device,
                             neighbor_dict[port]['port'],
                             neighbor_metadata_dict[device]['lo_addr'],
                             neighbor_metadata_dict[device]['mgmt_addr'],
                             neighbor_metadata_dict[device]['type']])
            except KeyError:
                pass
```

#### How I did it
After discussion with team, we plan to keep current yang model change, but 
add fields check for 'lo_addr', "mgmt_addr", "type"before access it. 

#### How to verify it
"show interface neighbor expected" with fix image 

fixes #12301


