### PR TITLE
[show] Added alias interface mode support for 'show interfaces counters ...' command

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -533,6 +533,7 @@ def counters(ctx, verbose, period, interface, printall, namespace, display):
         if period is not None:
             cmd += " -p {}".format(period)
         if interface is not None:
+            interface = try_convert_interfacename_from_alias(ctx, interface)
             cmd += " -i {}".format(interface)
         else:
             cmd += " -s {}".format(display)
@@ -598,10 +599,13 @@ def rates(verbose, period, namespace, display):
 def rif(interface, period, verbose):
     """Show interface counters"""
 
+    ctx = click.get_current_context()
+
     cmd = "intfstat"
     if period is not None:
         cmd += " -p {}".format(period)
     if interface is not None:
+        interface = try_convert_interfacename_from_alias(ctx, interface)
         cmd += " -i {}".format(interface)
 
     clicommon.run_command(cmd, display_cmd=verbose)
@@ -614,10 +618,13 @@ def rif(interface, period, verbose):
 def detailed(interface, period, verbose):
     """Show interface counters detailed"""
 
+    ctx = click.get_current_context()
+
     cmd = "portstat -l"
     if period is not None:
         cmd += " -p {}".format(period)
     if interface is not None:
+        interface = try_convert_interfacename_from_alias(ctx, interface)
         cmd += " -i {}".format(interface)
 
     clicommon.run_command(cmd, display_cmd=verbose)


### PR DESCRIPTION
Fixes #2464

Signed-off-by: Julian Chang - TW <julianc@supermicro.com.tw>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This change fixed "show interfaces counters xxx" output nothing when naming mode is alias. 

#### How I did it
Convert the alias name into interface name for "show interfaces counters -u xxx", "show interfaces counters detailed xxx" and "show interfaces counters rif xxx" subcommands.

#### How to verify it
1. Set interface naming mode to alias.
2. Logout/Login.
3. Verify "show interfaces counters -i Eth1".
4. Verify "show interfaces counters rif Eth1".
5. Verify "show interfaces counters detailed Eth1".
6. Set interface naming mode to default.
7. Logout/Login
8. Repeat step 3~5.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

