### PR TITLE
[Aboot] Add compatibility for drive in sonic-installer

### DIFF
--- a/tests/installer_bootloader_aboot_test.py
+++ b/tests/installer_bootloader_aboot_test.py
@@ -20,6 +20,7 @@ def test_swi_image_path():
                      f'{aboot.IMAGE_PREFIX}abcde/.sonic-boot.swi'
 
     bootloader = aboot.AbootBootloader()
+    bootloader._boot_config_read = Mock(return_value={'SWI': "flash:image-master.0-12345678/.sonic-boot.swi"})
 
     # Verify converted swi image path
     image_path = bootloader._swi_image_path(image_id)


### PR DESCRIPTION
Adds compatibility to the sonic-installer utility to work with drives on an arista switch.

