### PR TITLE
Change db_migrator major version on master branch from version 3 to 4

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_3_0_6'
+        self.CURRENT_VERSION = 'version_4_0_0'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -747,10 +747,20 @@ class DBMigrator():
 
     def version_3_0_6(self):
         """
-        Current latest version. Nothing to do here.
+        Version 3_0_6
+        This is the latest version for 202211 branch
         """
 
         log.log_info('Handling version_3_0_6')
+        self.set_version('version_4_0_0')
+        return 'version_4_0_0'
+
+    def version_4_0_0(self):
+        """
+        Version 4_0_0.
+        This is the latest version for master branch
+        """
+        log.log_info('Handling version_4_0_0')
         return None
 
     def get_version(self):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Lock the major version on 202211 branch to version 3.

Start a new major version on master branch, with current version set to `version_4_0_0`.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

