### PR TITLE
[dualtor][202012] Send arp/ndp packets from vlan_mac if the device is dualtor

### DIFF
--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -13,6 +13,7 @@ import syslog
 import traceback
 import ipaddress
 from builtins import str #for unicode conversion in python2
+from swsscommon import swsscommon
 
 
 ARP_CHUNK = binascii.unhexlify('08060001080006040001') # defines a part of the packet for ARP Request
@@ -266,6 +267,11 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
     src_ifs = {map_mac_ip_per_vlan[vlan_name][dst_mac] for vlan_name, dst_mac, _ in neighbor_entries}
     src_mac_addrs = {src_if:get_iface_mac_addr(src_if) for src_if in src_ifs}
 
+    config_db = swsscommon.ConfigDBConnector()
+    config_db.connect()
+    device_metadata = config_db.get_table('DEVICE_METADATA')
+    subtype = device_metadata['localhost'].get('subtype', '')
+
     # open raw sockets for all required interfaces
     sockets = {}
     for src_if in src_ifs:
@@ -275,10 +281,17 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
     # send arp/ndp packets
     for vlan_name, dst_mac, dst_ip in neighbor_entries:
         src_if = map_mac_ip_per_vlan[vlan_name][dst_mac]
-        if ipaddress.ip_interface(str(dst_ip)).ip.version == 4:
-            send_arp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)
+        if subtype.lower() != 'dualtor':
+            # for non dualtor devices, src mac will be router_mac
+            src_mac = src_mac_addrs[src_if]
         else:
-            send_ndp(sockets[src_if], src_mac_addrs[src_if], src_ip_addrs[vlan_name], dst_mac, dst_ip)
+            # for dualtor devices, the src mac will be vlan_mac
+            src_mac = get_iface_mac_addr(vlan_name)
+
+        if ipaddress.ip_interface(str(dst_ip)).ip.version == 4:
+            send_arp(sockets[src_if], src_mac, src_ip_addrs[vlan_name], dst_mac, dst_ip)
+        else:
+            send_ndp(sockets[src_if], src_mac, src_ip_addrs[vlan_name], dst_mac, dst_ip)
 
     # close the raw sockets
     for s in sockets.values():

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -281,7 +281,7 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
     # send arp/ndp packets
     for vlan_name, dst_mac, dst_ip in neighbor_entries:
         src_if = map_mac_ip_per_vlan[vlan_name][dst_mac]
-        if subtype.lower() != 'dualtor':
+        if subtype and 'dualtor' in subtype.lower():
             # for non dualtor devices, src mac will be router_mac
             src_mac = src_mac_addrs[src_if]
         else:

--- a/scripts/fast-reboot-dump.py
+++ b/scripts/fast-reboot-dump.py
@@ -283,10 +283,10 @@ def send_garp_nd(neighbor_entries, map_mac_ip_per_vlan):
         src_if = map_mac_ip_per_vlan[vlan_name][dst_mac]
         if subtype and 'dualtor' in subtype.lower():
             # for non dualtor devices, src mac will be router_mac
-            src_mac = src_mac_addrs[src_if]
+            src_mac = get_iface_mac_addr(vlan_name)
         else:
             # for dualtor devices, the src mac will be vlan_mac
-            src_mac = get_iface_mac_addr(vlan_name)
+            src_mac = src_mac_addrs[src_if]
 
         if ipaddress.ip_interface(str(dst_ip)).ip.version == 4:
             send_arp(sockets[src_if], src_mac, src_ip_addrs[vlan_name], dst_mac, dst_ip)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

`fast-reboot-dump.pty` script collects fdb entries, will send out arp request for these fdb entries to keep them active longer.

However, the script sends these requests with switch mac.

Which has negative impacts on dualtor devices where the arp requests should come from vlan_mac, instead of router_mac


#### How I did it

Check the device subtype from metadata. If it is dualtor, use vlan_mac, otherwise use interface mac as the src address for ARP packets.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

