### PR TITLE
[GCU] Fix JsonPointerFilter bug

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -399,10 +399,10 @@ class JsonPointerFilter:
         if token == "*":
             matching_keys = config.keys()
         elif token.startswith("*|"):
-            suffix = token[2:]
+            suffix = token[1:]
             matching_keys = [key for key in config.keys() if key.endswith(suffix)]
         elif token.endswith("|*"):
-            prefix = token[:-2]
+            prefix = token[:-1]
             matching_keys = [key for key in config.keys() if key.startswith(prefix)]
         elif token in config:
             matching_keys = [token]

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -753,6 +753,41 @@ class TestMoveWrapper(unittest.TestCase):
         # Assert
         self.assertIs(self.any_diff, actual)
 
+class TestJsonPointerFilter(unittest.TestCase):
+    def test_get_paths__common_prefix__exact_match_returned(self):
+        config = {
+            "BUFFER_PG": {
+                "Ethernet1|0": {},
+                "Ethernet12|0": {},
+                "Ethernet120|0": {},  # 'Ethernet12' is a common prefix with the previous line
+            },
+        }
+
+        filter = ps.JsonPointerFilter([["BUFFER_PG", "Ethernet12|*"]], PathAddressing())
+
+        expected_paths = ["/BUFFER_PG/Ethernet12|0"]
+
+        actual_paths = list(filter.get_paths(config))
+
+        self.assertCountEqual(expected_paths, actual_paths)
+
+    def test_get_paths__common_suffix__exact_match_returned(self):
+        config = {
+            "QUEUE": {
+                "Ethernet1|0": {},
+                "Ethernet1|10": {},
+                "Ethernet1|110": {}, # 10 is a common suffix with the previous line
+            },
+        }
+
+        filter = ps.JsonPointerFilter([["QUEUE", "*|10"]], PathAddressing())
+
+        expected_paths = ["/QUEUE/Ethernet1|10"]
+
+        actual_paths = list(filter.get_paths(config))
+
+        self.assertCountEqual(expected_paths, actual_paths)
+
 class TestRequiredValueIdentifier(unittest.TestCase):
     def test_hard_coded_required_value_data(self):
         identifier = ps.RequiredValueIdentifier(PathAddressing())


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Refer to https://github.com/sonic-net/sonic-utilities/pull/2273
Before the fix, the prefix pattern `Ethernet12|*` would match `Ethernet124|0` and `Ethernet12|0`. 
The suffix pattern `*|10` would match `Ethernet1|10` and `Ethernet1|11110`.

#### What I did
Fix a bug of JsonPointerFilter in GCU that will make the wrong selection of candidates.
#### How I did it
Add the patch addressing '|' in the prefix and suffix filter to avoid wrong selection.
#### How to verify it
Add UT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

