### PR TITLE
[armhf][sonic-installer] Fix the issue of sonic-installer list after set-default and cleanup

### DIFF
--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -40,7 +40,7 @@ class UbootBootloader(OnieInstallerBootloader):
         proc = subprocess.Popen("/usr/bin/fw_printenv -n boot_next", shell=True, text=True, stdout=subprocess.PIPE)
         (out, _) = proc.communicate()
         image = out.rstrip()
-        if "sonic_image_2" in image:
+        if "sonic_image_2" in image and len(images) == 2:
             next_image_index = 1
         else:
             next_image_index = 0

--- a/tests/installer_bootloader_uboot_test.py
+++ b/tests/installer_bootloader_uboot_test.py
@@ -37,6 +37,37 @@ def test_remove_image(run_command_patch):
 
 @patch("sonic_installer.bootloader.uboot.subprocess.Popen")
 @patch("sonic_installer.bootloader.uboot.run_command")
+def test_get_next_image(run_command_patch, popen_patch):
+    class MockProc():
+        commandline = "boot_next"
+        def communicate(self):
+            return MockProc.commandline, None
+
+    def mock_run_command(cmd):
+        # Remove leading string "/usr/bin/fw_setenv boot_next " -- the 29 characters
+        MockProc.commandline = cmd[29:]
+
+    # Constants
+    intstalled_images = [
+        f'{uboot.IMAGE_PREFIX}expeliarmus-{uboot.IMAGE_PREFIX}abcde',
+        f'{uboot.IMAGE_PREFIX}expeliarmus-abcde',
+    ]
+    
+    run_command_patch.side_effect = mock_run_command
+    popen_patch.return_value = MockProc()
+
+    bootloader = uboot.UbootBootloader()
+    bootloader.get_installed_images = Mock(return_value=intstalled_images)
+
+    bootloader.set_default_image(intstalled_images[1])
+    
+    # Verify get_next_image was executed with image path
+    next_image=bootloader.get_next_image()
+
+    assert next_image == intstalled_images[1]
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+@patch("sonic_installer.bootloader.uboot.run_command")
 def test_set_fips_uboot(run_command_patch, popen_patch):
     class MockProc():
         commandline = "linuxargs"


### PR DESCRIPTION
#### What I did
sonic-installer list will throw a exception when install images as the following step

(onie-nos-install ) Install first image A
(sonic-installer) Install Image B and not reboot it
(sonic-installer) set default to back to Image A
sudo sonic-installer cleanup
At this time, executing sonic-installer list will throw exception

#### How I did it
Modify the get_next_image() in uboot.py to check and return index 1 when the images list contains two elements.
This PR should work with https://github.com/sonic-net/sonic-buildimage/pull/12609

This PR is needed by branch 202012 and 2022o5

#### How to verify it
Using the following test case to verify it
Case 1:
   1) (onie-nos-install ) Install first image A (SONiC-OS-202012.0-dirty-20221104.031351)
   2) (sonic-installer) Install Image B (SONiC-OS-202205.0-dirty-20221104.050857) and not reboot it 
   3) (sonic-installer) set default to back to Image A
   4) sudo sonic-installer cleanup
   5) execute sonic-installer list, it should list image A as expected
```
admin@sonic:~$ sudo sonic-installer list
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONiC-OS-202012.0-dirty-20221104.031351
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
```
           
Case 2:
   6) sonic-installer install an image C (SONIC-OS-202205.0-dirty-20221104.050348)
   7) sonic-installer list. It should lis image as expected
```
admin@sonic:~$ sudo sonic-installer list
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 3:
8) reboot the system.
9) sonic-installer list 
```
admin@sonic:~$ sudo sonic-installer list
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 4
   10) sonic-installer install the image A.
   11) it should be indicated that the image has been installed and just set to default.
```
admin@ixs-7215-pizza9:~$ sudo sonic-installer install /tmp/sonic-marvell-armhf.bin
New image will be installed, continue? [y/N]: y
Image SONiC-OS-202012.0-dirty-20221104.031351 is already installed. Setting it as default...
Command: /usr/bin/fw_setenv boot_next "run sonic_image_2"

Command: sync;sync;sync

Command: sleep 3

Done
```
case 5:
  12 execute sonic-installer list
```
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next: SONiC-OS-202012.0-dirty-20221104.031351
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 6:
 13) reboot the device
 14) and sonic-installer list
```
admin@sonic:~$ sudo sonic-installer list
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONiC-OS-202012.0-dirty-20221104.031351
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 7:
  15) sonic-installer set-default to image C (SONIC-OS-202205.0-dirty-20221104.050348)
  16) sonic-installer list 
```
Current: SONiC-OS-202012.0-dirty-20221104.031351
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 8:
    17) reboot the device 
    18)  sonic-installer list
```
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next: SONIC-OS-202205.0-dirty-20221104.050348
Available: 
SONiC-OS-202012.0-dirty-20221104.031351
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 9: 
 19) install image B (SONiC-OS-202205.0-dirty-20221104.050857)
 20) sonic-installer list
```
Current: SONIC-OS-202205.0-dirty-20221104.050348
Next:  SONiC-OS-202205.0-dirty-20221104.050857
Available: 
SONiC-OS-202205.0-dirty-20221104.050857
SONIC-OS-202205.0-dirty-20221104.050348
```
Case 10:
 21) reboot the device
22) sonic-installer list
```
Current: SONiC-OS-202205.0-dirty-20221104.050857
Next:  SONiC-OS-202205.0-dirty-20221104.050857
Available: 
SONiC-OS-202205.0-dirty-20221104.050857
SONIC-OS-202205.0-dirty-20221104.050348
```



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

