### PR TITLE
bugfix[2024] vnet route check exit code fix.

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -393,8 +393,8 @@ def main():
         rc = RC_ERR
         print_message(syslog.LOG_ERR, json.dumps(res, indent=4))
         print_message(syslog.LOG_ERR, 'Vnet Route Mismatch reported')
-
-    return rc, res
+        return rc, res
+    return rc
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes https://github.com/sonic-net/sonic-utilities/issues/2424
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed the return value for vnet route check if vxlan tunnel is present but no route mismatch is happening.
#### How I did it
return 0 of there is no route diff
#### How to verify it
add a vxlan tunnel without routes and run the script. it should return 0.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

