### PR TITLE
Add "f" option for executing reboot force mode

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -121,6 +121,7 @@ function show_help_and_exit()
     echo " "
     echo "    Available options:"
     echo "        -h, -? : getting this help"
+    echo "        -f     : execute reboot force"
 
     exit 0
 }
@@ -171,7 +172,7 @@ function check_conflict_boot_in_fw_update()
 
 function parse_options()
 {
-    while getopts "h?v" opt; do
+    while getopts "h?vf" opt; do
         case ${opt} in
             h|\? )
                 show_help_and_exit


### PR DESCRIPTION
**Why I did it**
The vendor platform reboot, which is called from the reboot script, supports force mode, and for now there is no option to execute it via the reboot script, so this change will enable it.

**What I did**
Add an "f" option in reboot_script for executing reboot force mode.
Add this option to help command as well.

**How to verify it**
Execute the reboot script with "-f" and see that the vendor platform reboot executes the force mode indeed.



