### PR TITLE
[show][muxcable] Catch port Value error exception (#2076)

### DIFF
--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -1168,7 +1168,18 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
                                ["Ethernet0"], obj=db)
         assert result.exit_code == 1
+        
+    @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
+    @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
+    @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
+    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
+    def test_show_muxcable_cableinfo_invalid_port(self):
+        runner = CliRunner()
+        db = Db()
 
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["abc"], obj=db)
+        assert result.exit_code == 1
 
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -384,6 +384,11 @@ Vendor    Model
 Credo     CACL1X321P2PA1M
 """
 
+expected_muxcable_cableinfo_invalid_port_output = """\
+Invalid port 'abc'
+ERR: Unable to get a port on muxcable port
+"""
+
 show_muxcable_hwmode_muxdirection_active_expected_output = """\
 Port        Direction    Presence
 ----------  -----------  ----------
@@ -1168,18 +1173,22 @@ class TestMuxcable(object):
         result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
                                ["Ethernet0"], obj=db)
         assert result.exit_code == 1
-        
+
     @mock.patch('sonic_y_cable.y_cable.get_part_number', mock.MagicMock(return_value=(False)))
     @mock.patch('sonic_y_cable.y_cable.get_vendor', mock.MagicMock(return_value=(False)))
     @mock.patch('show.muxcable.platform_sfputil', mock.MagicMock(return_value=1))
-    @mock.patch('utilities_common.platform_sfputil_helper.logical_port_name_to_physical_port_list', mock.MagicMock(return_value=[0]))
     def test_show_muxcable_cableinfo_invalid_port(self):
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.exit_code == 1
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["cableinfo"],
                                ["abc"], obj=db)
         assert result.exit_code == 1
+        assert result.output == expected_muxcable_cableinfo_invalid_port_output
 
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -53,14 +53,17 @@ def platform_sfputil_read_porttab_mappings():
 
 
 def logical_port_name_to_physical_port_list(port_name):
-    if port_name.startswith("Ethernet"):
-        if platform_sfputil.is_logical_port(port_name):
-            return platform_sfputil.get_logical_to_physical(port_name)
+    try:
+        if port_name.startswith("Ethernet"):
+            if platform_sfputil.is_logical_port(port_name):
+                return platform_sfputil.get_logical_to_physical(port_name)
         else:
-            click.echo("Invalid port '{}'".format(port_name))
-            return None
-    else:
-        return [int(port_name)]
+            return [int(port_name)]
+    except ValueError:
+        pass
+
+    click.echo("Invalid port '{}'".format(port_name))
+    return None
 
 
 def get_logical_list():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Catch the exception if a user passes in an invalid port name.

#### How I did it
Added a try/catch to catch the ValueError.

#### How to verify it
Run "show muxcable cableinfo [invalid port]".

#### Previous command output (if the output of a command-line utility has changed)
```
crystalnet@ibr01:~$ show muxcable cableinfo all
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/show/muxcable.py", line 626, in cableinfo
    physical_port_list = platform_sfputil_helper.logical_port_name_to_physical_port_list(port)
  File "/usr/local/lib/python3.7/dist-packages/utilities_common/platform_sfputil_helper.py", line 53, in logical_port_name_to_physical_port_list
    return [int(port_name)]
ValueError: invalid literal for int() with base 10: 'all'
crystalnet@ibr01:~$
```

#### New command output (if the output of a command-line utility has changed)
```
crystalnet@ibr01:~$ show muxcable cableinfo all
Invalid port 'all'
ERR: Unable to get a port on muxcable port
crystalnet@ibr01:~$ 
```
