### PR TITLE
Show tech errors in cisco-8000 platform

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1231,7 +1231,9 @@ collect_cisco_8000() {
     if [ -d /usr/share/sonic/device/${platform} ]; then
         pushd /usr/share/sonic/device/${platform} > /dev/null
         for file in $(find . -path "./*plugin*" -prune -o -path "./*.xml" -prune -o -path "./*.yaml" -prune -o -print); do
-            save_file ${file} sai false
+            if [ -f ${file} ]; then
+                 save_file ${file} sai false
+            fi
         done
         popd > /dev/null
     else


### PR DESCRIPTION

### Motivation/issue:

While running showtech support in Cisco-8000 platform following errors are seen. This failure is happening
because non-file entries like  current directory "**.**"  and subdirectory  "**./Cisco-8102-C64**" are being 
saved as a file.

<pre>
mkdir: created directory '/var/dump/sonic_dump_mth64-m5-2_20221026_201933/sai'
cp: -r not specified; omitting directory '.'
handle_error $? $LINENO
ERR: RC:-1 observed on line 762
sonic_dump_mth64-m5-2_20221026_201933/sai/./
rm: cannot remove '/var/dump/sonic_dump_mth64-m5-2_20221026_201933/sai/.': Is a directory
handle_error $? $LINENO
ERR: RC:-1 observed on line 769
cp: -r not specified; omitting directory './Cisco-8102-C64'
handle_error $? $LINENO
ERR: RC:-1 observed on line 762
tar: sonic_dump_mth64-m5-2_20221026_201933/sai/Cisco-8102-C64: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
tar append operation failed. Aborting to prevent data loss
</pre>

### How it is fixed
 The script code is modified to skip non-file entries being saved in dump directory 

### Verification/test
    I have run the show tech fix in cisco-8000 platform and confirmed the aforementioned error messages are not seen.

