### PR TITLE
[202012]Revert "[config reload]: On dual ToR systems, cache ARP and FDB table…

### DIFF
--- a/tests/pgdropstat_test.py
+++ b/tests/pgdropstat_test.py
@@ -93,7 +93,7 @@ class TestPgDropstat(object):
         self.test_show_pg_drop_clear()
 
         # simulate 'config reload' to provoke counters recalculation (remove  backup from /tmp folder)
-        result = runner.invoke(config.config.commands["reload"], [ "--no_service_restart", "--disable_arp_cache",  "-y"])
+        result = runner.invoke(config.config.commands["reload"], [ "--no_service_restart", "-y"])
 
         print(result.exit_code)
         print(result.output)


### PR DESCRIPTION
…s (#1465)"

- This reverts commit 10de91d8c581cd0ed0e5ae79edeb05dfdda4f755.

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

