### PR TITLE
[202205] Fix validation of input of `config mirror_session add`

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2136,7 +2136,7 @@ def gather_session_info(session_info, policer, queue, src_port, direction):
     if policer:
         session_info['policer'] = policer
 
-    if queue:
+    if queue is not None:
         session_info['queue'] = queue
 
     if src_port:
@@ -2162,7 +2162,7 @@ def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer
             "ttl": ttl
             }
 
-    if gre_type:
+    if gre_type is not None:
         session_info['gre_type'] = gre_type
 
     session_info = gather_session_info(session_info, policer, queue, src_port, direction)

--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -85,7 +85,7 @@ def test_mirror_session_add():
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
 
         mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None)
-        
+
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["add"],
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63"])
@@ -137,7 +137,7 @@ def test_mirror_session_erspan_add():
             ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "65536", "100"])
     assert result.exit_code != 0
     assert ERR_MSG_GRE_TYPE_FAILURE in result.stdout
-    
+
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
             ["test_session", "1.1.1.1", "2.2.2.2", "6", "63", "abcd", "100"])
@@ -164,6 +164,12 @@ def test_mirror_session_erspan_add():
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0x1234", "100"])
 
         mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0x1234, 100, None, None, None)
+
+        result = runner.invoke(
+                config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
+
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None, None, None)
 
 
 def test_mirror_session_span_add():
@@ -258,9 +264,12 @@ def test_mirror_session_span_add():
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["span"].commands["add"],
                 ["test_session", "Ethernet8", "Ethernet4", "tx", "100"])
+
+        mocked.assert_called_with("test_session", "Ethernet8", "Ethernet4", "tx", 100, None)
+
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["span"].commands["add"],
-                ["test_session", "Ethernet0", "Ethernet4", "rx", "100"])
+                ["test_session", "Ethernet0", "Ethernet4", "rx", "0"])
 
-        mocked.assert_called_with("test_session", "Ethernet0", "Ethernet4", "rx", 100, None)
+        mocked.assert_called_with("test_session", "Ethernet0", "Ethernet4", "rx", 0, None)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to backport PR #2162 into `202205` branch.

`queue = 0` is not accepted by the validation of input because the follow check
https://github.com/Azure/sonic-utilities/blob/bce4694d3ad4454fc7181b99433457e76ab9e0a0/config/main.py#L2028-L2029

When addressing the issue, I saw similar issue in the logic of handling `gre_type`. The issue is also fixed.


#### How I did it
Change `if queue` to `if queue is not None`

#### How to verify it
Verified by UT
```
python setup.py test --addopts "tests/config_mirror_session_test.py -v" 
========================================================================================= test session starts =========================================================================================
collected 3 items                                                                                                                                                                                     

tests/config_mirror_session_test.py::test_mirror_session_add PASSED                                                                                                                             [ 33%]
tests/config_mirror_session_test.py::test_mirror_session_erspan_add PASSED                                                                                                                      [ 66%]
tests/config_mirror_session_test.py::test_mirror_session_span_add PASSED                                                                                                                        [100%]

========================================================================================== 3 passed in 0.96s ==========================================================================================
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)