### PR TITLE
[armhf][sonic-installer] [cherry-pick to branch 202012] Fix the issue of sonic-installer list after set-default and cleanup (#2479)

### DIFF
--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -38,7 +38,7 @@ class UbootBootloader(OnieInstallerBootloader):
         proc = subprocess.Popen("/usr/bin/fw_printenv -n boot_next", shell=True, text=True, stdout=subprocess.PIPE)
         (out, _) = proc.communicate()
         image = out.rstrip()
-        if "sonic_image_2" in image:
+        if "sonic_image_2" in image and len(images) == 2:
             next_image_index = 1
         else:
             next_image_index = 0


### PR DESCRIPTION
What I did
sonic-installer list will throw a exception when install images as the following step

(onie-nos-install ) Install first image A
(sonic-installer) Install Image B and not reboot it (sonic-installer) set default to back to Image A
sudo sonic-installer cleanup
At this time, executing sonic-installer list will throw exception

How I did it
Modify the get_next_image() in uboot.py to check and return index 1 when the images list contains two elements. This PR should work with sonic-net/sonic-buildimage#12609

This PR is needed by branch 202012 and 2022o5

Signed-off-by: mlok <marty.lok@nokia.com>
(cherry picked from commit d1ca2cdda0cdc1402b88d53816576486e2e8107f)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Cherry-pick PR https://github.com/sonic-net/sonic-utilities/pull/2479 from master branch to 202012 branch 

#### How I did it
Cherry-pick https://github.com/sonic-net/sonic-utilities/pull/2479

#### How to verify it
Modify the get_next_image() in uboot.py to check and return index 1 when the images list contains two elements. This PR should work with sonic-net/sonic-buildimage#12609

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

