### PR TITLE
YANG Validation for ConfigDB Updates: PORT_STORM_CONTROL, PORT_QOS_MAP, BUFFER_PROFILE, BUFFER_PG, BUFFER_QUEUE, BUFFER_POOL, FEATURE, DEFAULT_LOSSLESS_BUFFER_PARAMETER tables

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5972,7 +5972,6 @@ def over_subscribe_ratio(db, ratio):
         ctx.fail("Invalid over-subscribe-ratio value {}. It should be in range [0, {}]".format(ratio, port_number))
 
     default_lossless_param = config_db.get_table("DEFAULT_LOSSLESS_BUFFER_PARAMETER")
-    default_lossless_param = {"default_dynamic_th": "0"}
     first_item = True
     for k, v in default_lossless_param.items():
         if not first_item:

--- a/config/main.py
+++ b/config/main.py
@@ -697,17 +697,25 @@ def storm_control_set_entry(port_name, kbps, storm_type, namespace):
         return False
 
     #Validate kbps value
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     key = port_name + '|' + storm_type
     entry = config_db.get_entry('PORT_STORM_CONTROL', key)
 
     if len(entry) == 0:
-        config_db.set_entry('PORT_STORM_CONTROL', key, {'kbps':kbps})
+        try:
+            config_db.set_entry('PORT_STORM_CONTROL', key, {'kbps':kbps})
+        except ValueError as e:
+            ctx = click.get_current_context()
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         kbps_value = int(entry.get('kbps',0))
         if kbps_value != kbps:
-            config_db.mod_entry('PORT_STORM_CONTROL', key, {'kbps':kbps})
+            try:
+                config_db.mod_entry('PORT_STORM_CONTROL', key, {'kbps':kbps})
+            except ValueError as e:
+                ctx = click.get_current_context()
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     return True
 
@@ -717,7 +725,7 @@ def storm_control_delete_entry(port_name, storm_type):
     if storm_control_interface_validate(port_name) is False:
         return False
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     key = port_name + '|' + storm_type
     entry = config_db.get_entry('PORT_STORM_CONTROL', key)
@@ -726,7 +734,11 @@ def storm_control_delete_entry(port_name, storm_type):
         click.echo("%s storm-control not enabled on interface %s" %(storm_type, port_name))
         return False
     else:
-        config_db.set_entry('PORT_STORM_CONTROL', key, None)
+        try:
+            config_db.set_entry('PORT_STORM_CONTROL', key, None)
+        except JsonPatchConflict:
+            ctx = click.get_current_context()
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     return True
 
@@ -4486,7 +4498,7 @@ def buffer_objects_map_check_legality(ctx, db, interface_name, input_map, is_new
 
 
 def update_buffer_object(db, interface_name, object_map, override_profile, is_pg, add=True):
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
 
     # Check whether port is legal
@@ -4516,16 +4528,22 @@ def update_buffer_object(db, interface_name, object_map, override_profile, is_pg
         if is_pg:
             if not 'xoff' in profile_dict.keys() and 'size' in profile_dict.keys():
                 ctx.fail("Profile {} doesn't exist or isn't a lossless profile".format(override_profile))
-        config_db.set_entry(buffer_table, (interface_name, object_map), {"profile": override_profile})
+        try:
+            config_db.set_entry(buffer_table, (interface_name, object_map), {"profile": override_profile})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
-        config_db.set_entry(buffer_table, (interface_name, object_map), {"profile": "NULL"})
+        try:
+            config_db.set_entry(buffer_table, (interface_name, object_map), {"profile": "NULL"})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     if is_pg:
         adjust_pfc_enable(ctx, db, interface_name, object_map, True)
 
 
 def remove_buffer_object_on_port(db, interface_name, buffer_object_map, is_pg=True):
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
 
     # Check whether port is legal
@@ -4546,7 +4564,10 @@ def remove_buffer_object_on_port(db, interface_name, buffer_object_map, is_pg=Tr
                     ctx.fail("Lossy PG {} can't be removed".format(buffer_object_map))
                 else:
                     continue
-            config_db.set_entry(buffer_table, (interface_name, existing_buffer_object), None)
+            try:
+                config_db.set_entry(buffer_table, (interface_name, existing_buffer_object), None)
+            except JsonPatchConflict as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
             if is_pg:
                 adjust_pfc_enable(ctx, db, interface_name, buffer_object_map, False)
             removed = True
@@ -4559,7 +4580,7 @@ def remove_buffer_object_on_port(db, interface_name, buffer_object_map, is_pg=Tr
 
 
 def adjust_pfc_enable(ctx, db, interface_name, pg_map, add):
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
     # Fetch the original pfc_enable
     qosmap = config_db.get_entry("PORT_QOS_MAP", interface_name)
@@ -4592,7 +4613,10 @@ def adjust_pfc_enable(ctx, db, interface_name, pg_map, add):
         ctx.fail("Try to add empty priorities")
 
     qosmap["pfc_enable"] = pfc_enable[:-1]
-    config_db.set_entry("PORT_QOS_MAP", interface_name, qosmap)
+    try:
+        config_db.set_entry("PORT_QOS_MAP", interface_name, qosmap)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 #
@@ -5827,6 +5851,7 @@ def _is_shared_headroom_pool_enabled(ctx, config_db):
 
 
 def update_profile(ctx, config_db, profile_name, xon, xoff, size, dynamic_th, pool, profile_entry = None):
+    config_db = ValidatedConfigDBConnector(config_db)
     params = {}
     if profile_entry:
         params = profile_entry
@@ -5898,14 +5923,17 @@ def update_profile(ctx, config_db, profile_name, xon, xoff, size, dynamic_th, po
             else:
                 ctx.fail("No dynamic_th defined in DEFAULT_LOSSLESS_BUFFER_PARAMETER")
 
-    config_db.set_entry("BUFFER_PROFILE", (profile_name), params)
+    try:
+        config_db.set_entry("BUFFER_PROFILE", (profile_name), params)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @profile.command('remove')
 @click.argument('profile', metavar='<profile>', required=True)
 @clicommon.pass_db
 def remove_profile(db, profile):
     """Delete a buffer profile"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
 
     existing_pgs = config_db.get_table("BUFFER_PG")
@@ -5917,7 +5945,10 @@ def remove_profile(db, profile):
 
     entry = config_db.get_entry("BUFFER_PROFILE", profile)
     if entry:
-        config_db.set_entry("BUFFER_PROFILE", profile, None)
+        try:
+            config_db.set_entry("BUFFER_PROFILE", profile, None)
+        except JsonPatchConflict as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         ctx.fail("Profile {} doesn't exist".format(profile))
 
@@ -5933,7 +5964,7 @@ def shared_headroom_pool(ctx):
 @clicommon.pass_db
 def over_subscribe_ratio(db, ratio):
     """Configure over subscribe ratio"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
 
     port_number = len(config_db.get_table('PORT'))
@@ -5941,6 +5972,7 @@ def over_subscribe_ratio(db, ratio):
         ctx.fail("Invalid over-subscribe-ratio value {}. It should be in range [0, {}]".format(ratio, port_number))
 
     default_lossless_param = config_db.get_table("DEFAULT_LOSSLESS_BUFFER_PARAMETER")
+    default_lossless_param = {"default_dynamic_th": "0"}
     first_item = True
     for k, v in default_lossless_param.items():
         if not first_item:
@@ -5953,7 +5985,10 @@ def over_subscribe_ratio(db, ratio):
         else:
             v["over_subscribe_ratio"] = ratio
 
-        config_db.set_entry("DEFAULT_LOSSLESS_BUFFER_PARAMETER", k, v)
+        try:
+            config_db.set_entry("DEFAULT_LOSSLESS_BUFFER_PARAMETER", k, v)
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 @shared_headroom_pool.command()
@@ -5961,7 +5996,7 @@ def over_subscribe_ratio(db, ratio):
 @clicommon.pass_db
 def size(db, size):
     """Configure shared headroom pool size"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     state_db = db.db
     ctx = click.get_current_context()
 
@@ -5980,7 +6015,10 @@ def size(db, size):
     else:
         ingress_lossless_pool["xoff"] = size
 
-    config_db.set_entry("BUFFER_POOL", "ingress_lossless_pool", ingress_lossless_pool)
+    try:
+        config_db.set_entry("BUFFER_POOL", "ingress_lossless_pool", ingress_lossless_pool)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 #

--- a/config/main.py
+++ b/config/main.py
@@ -736,7 +736,7 @@ def storm_control_delete_entry(port_name, storm_type):
     else:
         try:
             config_db.set_entry('PORT_STORM_CONTROL', key, None)
-        except JsonPatchConflict:
+        except JsonPatchConflict as e:
             ctx = click.get_current_context()
             ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -53,7 +53,10 @@ class ValidatedConfigDBConnector(object):
 
         """Add patch element to create ConfigDB path if necessary, as GCU is unable to add to a nonexistent path"""
         if op == "add" and not self.get_entry(table, key):
-            path = JsonPointer.from_parts([table, key]).path
+            if type(key) == tuple: 
+                path = JsonPointer.from_parts([table, '|'.join(key)]).path
+            else:
+                path = JsonPointer.from_parts([table, key]).path 
             gcu_json = {"op": "{}".format(op),
                         "path": "{}".format(path),
                         "value": {}}
@@ -106,7 +109,9 @@ class ValidatedConfigDBConnector(object):
             logger.log_notice("Unable to remove entry, as doing so will result in invalid config. Error: {}".format(e))
 
     def validated_mod_entry(self, table, key, value):
-        if value is not None:
+        if isinstance(value, dict) and len(value) == 1 and list(value.values())[0] == "":
+            op = "remove"        
+        elif value is not None:
             op = "add"
         else:
             op = "remove"
@@ -115,7 +120,9 @@ class ValidatedConfigDBConnector(object):
         self.apply_patch(gcu_patch, table)
 
     def validated_set_entry(self, table, key, value):
-        if value is not None:
+        if isinstance(value, dict) and len(value) == 1 and list(value.values())[0] == "":
+            op = "remove"        
+        elif value is not None:
             op = "add"
         else:
             op = "remove"

--- a/tests/buffer_test.py
+++ b/tests/buffer_test.py
@@ -2,10 +2,13 @@ import os
 import sys
 import pytest
 import mock
+import jsonpatch
 from importlib import reload
 from click.testing import CliRunner
 from unittest import TestCase
 from swsscommon.swsscommon import ConfigDBConnector
+from mock import patch
+from jsonpatch import JsonPatchConflict
 
 from .mock_tables import dbconnector
 
@@ -14,6 +17,7 @@ import config.main as config
 from utilities_common.db import Db
 
 from .buffer_input.buffer_test_vectors import *
+from config.validated_config_db_connector import ValidatedConfigDBConnector
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -28,6 +32,15 @@ class TestBuffer(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
         print("SETUP")
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    def test_config_buffer_profile_headroom_yang(self):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["buffer"].commands["profile"].commands["add"],
+                               ["testprofile", "--dynamic_th", "3", "--xon", "18432", "--xoff", "32768"], obj=db)
+        assert "Invalid ConfigDB. Error" in result.output
+    
     def test_config_buffer_profile_headroom(self):
         runner = CliRunner()
         db = Db()
@@ -286,7 +299,34 @@ class TestInterfaceBuffer(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
         from .mock_tables import dbconnector
         dbconnector.dedicated_dbs = {}
+    
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    def test_config_int_buffer_pg_lossless_add_yang(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["add"],
+                                   ["Ethernet0", "5"], obj=db)
+        assert "Invalid ConfigDB. Error" in result.output
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
+    def test_config_int_buffer_pg_lossless_remove(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        # Remove non-exist entry
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["buffer"].commands["priority-group"].
+                                   commands["lossless"].commands["remove"],
+                                   ["Ethernet0", "5"], obj=db)
+            print(result.exit_code, result.output)
+            assert "Invalidi ConfigDB. Error" in result.output
+    
     def test_config_int_buffer_pg_lossless_add(self, get_cmd_module):
         (config, show) = get_cmd_module
         runner = CliRunner()

--- a/tests/buffer_test.py
+++ b/tests/buffer_test.py
@@ -131,6 +131,16 @@ class TestBuffer(object):
         assert result.exit_code != 0
         assert "Multiple entries are found in DEFAULT_LOSSLESS_BUFFER_PARAMETER while no dynamic_th specified" in result.output
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    def test_config_shp_size_negative_yang(self):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["buffer"].commands["shared-headroom-pool"].commands["size"],
+                               ["200000"])
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
     def test_config_shp_size_negative(self):
         runner = CliRunner()
         result = runner.invoke(config.config.commands["buffer"].commands["shared-headroom-pool"].commands["size"],

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -3,11 +3,14 @@ import pytest
 
 from unittest import mock
 from contextlib import ExitStack
+from mock import patch
 
 from click.testing import CliRunner
 
 from utilities_common.db import Db
 from swsscommon import swsscommon
+
+import config.validated_config_db_connector as validated_config_db_connector
 
 show_feature_status_output="""\
 Feature     State           AutoRestart     SetOwner
@@ -305,6 +308,17 @@ class TestFeature(object):
         print(result.output)
         assert result.exit_code == rc
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(retur_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_config_snmp_feature_owner_yang(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands["owner"], ["snmp", "local"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
     def test_config_snmp_feature_owner(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
@@ -360,6 +374,17 @@ class TestFeature(object):
         assert result.exit_code == 0
         assert result.output == show_feature_bgp_disabled_autorestart_output
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_config_database_feature_state_yang(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands["state"], ["bgp", "disabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
     def test_config_database_feature_state(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
@@ -378,6 +403,17 @@ class TestFeature(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_feature_database_always_enabled_state_output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(retur_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_config_bgp_feature_autorestart_yang(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["feature"].commands["autorestart"], ["bgp", "enabled"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
 
     def test_config_database_feature_autorestart(self, get_cmd_module):
         (config, show) = get_cmd_module

--- a/tests/storm_control_test.py
+++ b/tests/storm_control_test.py
@@ -1,11 +1,16 @@
 import os
 import traceback
+import mock
+import jsonpatch
 
 from click.testing import CliRunner
+from mock import patch
+from jsonpatch import JsonPatchConflict
 
 import config.main as config
 import show.main as show
 from utilities_common.db import Db
+import config.validated_config_db_connector as validated_config_db_connector
 
 class TestStormControl(object):
     @classmethod
@@ -33,6 +38,32 @@ class TestStormControl(object):
         print (result.output)
         assert result.exit_code == 0
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value=""))
+    def test_add_umcast_storm_yang_empty_entry(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["interface"].commands["storm-control"].commands["add"], ["Ethernet0", "unknown-multicast", "10000"], obj = obj)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value={'kbps': '1000'}))
+    def test_add_umcast_storm_yang_empty_entry(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["interface"].commands["storm-control"].commands["add"], ["Ethernet0", "unknown-multicast", "10000"], obj = obj)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+    
     def test_add_umcast_storm(self):
         runner = CliRunner()
         db = Db()
@@ -43,6 +74,18 @@ class TestStormControl(object):
         print (result.output)
         assert result.exit_code == 0
 
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
+    def test_del_broadcast_storm_yang(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["interface"].commands["storm-control"].commands["del"], ["Ethernet0", "broadcast"], obj = obj)
+        print (result.exit_code)
+        print (result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
     def test_del_broadcast_storm(self):
         runner = CliRunner()
         db = Db()
@@ -52,7 +95,7 @@ class TestStormControl(object):
         print (result.exit_code)
         print (result.output)
         assert result.exit_code == 0
-
+    
     def test_del_uucast_storm(self):
         runner = CliRunner()
         db = Db()

--- a/tests/storm_control_test.py
+++ b/tests/storm_control_test.py
@@ -49,12 +49,12 @@ class TestStormControl(object):
         result = runner.invoke(config.config.commands["interface"].commands["storm-control"].commands["add"], ["Ethernet0", "unknown-multicast", "10000"], obj = obj)
         print(result.exit_code)
         print(result.output)
-        assert "Invalid ConfigDB. Error" in result.output
+        assert "Invalid ConfigDB. Error1" in result.output
 
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value={'kbps': '1000'}))
-    def test_add_umcast_storm_yang_empty_entry(self):
+    def test_add_umcast_storm_yang_non_empty_entry(self):
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}

--- a/tests/storm_control_test.py
+++ b/tests/storm_control_test.py
@@ -49,7 +49,7 @@ class TestStormControl(object):
         result = runner.invoke(config.config.commands["interface"].commands["storm-control"].commands["add"], ["Ethernet0", "unknown-multicast", "10000"], obj = obj)
         print(result.exit_code)
         print(result.output)
-        assert "Invalid ConfigDB. Error1" in result.output
+        assert "Invalid ConfigDB. Error" in result.output
 
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
-Add YANG validation using GCU for writes to PORT_STORM_CONTROL, PORT_QOS_MAP, BUFFER_PROFILE, BUFFER_PG, BUFFER_QUEUE, BUFFER_POOL, FEATURE, DEFAULT_LOSSLESS_BUFFER_PARAMETER tables  in ConfigDB

#### How I did it
Using same method as https://github.com/sonic-net/sonic-utilities/pull/2190/files, extend to PORT_STORM_CONTROL, PORT_QOS_MAP, BUFFER_PROFILE, BUFFER_PG, BUFFER_QUEUE, BUFFER_POOL, FEATURE, DEFAULT_LOSSLESS_BUFFER_PARAMETER tables
#### How to verify it
Verified testing CLI on virtual switch

