### PR TITLE
avoid printing error if no neighbors are present

### DIFF
--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -97,8 +97,12 @@ Try "summary --help" for help.
 Error: bgp summary from bgp container not in json format
 """
 
-show_error_no_neighbor = """\
-% No BGP neighbors found in VRF default
+show_error_no_v6_neighbor = """\
+% No IPv6 neighbor is configured
+"""
+
+show_error_no_v4_neighbor = """\
+% No IPv4 neighbor is configured
 """
 
 show_bgp_summary_v4_chassis = """\
@@ -324,10 +328,9 @@ class TestBgpCommands(object):
         assert result.exit_code == 0
         assert result.output == show_bgp_summary_v4_all_chassis
 
-
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['show_bgp_summary_no_neigh'], indirect=['setup_single_bgp_instance'])
-    def test_bgp_summary_no_neigh(
+    def test_bgp_summary_no_v4_neigh(
             self,
             setup_bgp_commands,
             setup_single_bgp_instance):
@@ -337,4 +340,18 @@ class TestBgpCommands(object):
             show.cli.commands["ipv6"].commands["bgp"].commands["summary"], [])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_error_no_neighbor
+        assert result.output == show_error_no_v6_neighbor
+
+    @pytest.mark.parametrize('setup_single_bgp_instance',
+                             ['show_bgp_summary_no_neigh'], indirect=['setup_single_bgp_instance'])
+    def test_bgp_summary_no_v6_neigh(
+            self,
+            setup_bgp_commands,
+            setup_single_bgp_instance):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["bgp"].commands["summary"], [])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_error_no_v4_neighbor

--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -98,11 +98,11 @@ Error: bgp summary from bgp container not in json format
 """
 
 show_error_no_v6_neighbor = """\
-% No IPv6 neighbor is configured
+No IPv6 neighbor is configured
 """
 
 show_error_no_v4_neighbor = """\
-% No IPv4 neighbor is configured
+No IPv4 neighbor is configured
 """
 
 show_bgp_summary_v4_chassis = """\

--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -97,6 +97,10 @@ Try "summary --help" for help.
 Error: bgp summary from bgp container not in json format
 """
 
+show_error_no_neighbor = """\
+% No BGP neighbors found in VRF default
+"""
+
 show_bgp_summary_v4_chassis = """\
 
 IPv4 Unicast Summary:
@@ -319,3 +323,18 @@ class TestBgpCommands(object):
         print("{}".format(result.output))
         assert result.exit_code == 0
         assert result.output == show_bgp_summary_v4_all_chassis
+
+
+    @pytest.mark.parametrize('setup_single_bgp_instance',
+                             ['show_bgp_summary_no_neigh'], indirect=['setup_single_bgp_instance'])
+    def test_bgp_summary_no_neigh(
+            self,
+            setup_bgp_commands,
+            setup_single_bgp_instance):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ipv6"].commands["bgp"].commands["summary"], [])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_error_no_neighbor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,9 @@ def setup_single_bgp_instance(request):
         bgp_mocked_json = os.path.join(
             test_path, 'mock_tables', 'dummy.json')
 
+    def mock_show_bgp_summary_no_neigh(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND):
+        return "{}"
+
     def mock_show_bgp_summary(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND):
         if os.path.isfile(bgp_mocked_json):
             with open(bgp_mocked_json) as json_data:
@@ -217,6 +220,9 @@ def setup_single_bgp_instance(request):
     elif request.param == 'ip_route_for_int_ip':
         _old_run_bgp_command = bgp_util.run_bgp_command
         bgp_util.run_bgp_command = mock_run_bgp_command_for_static
+    elif request.param == "show_bgp_summary_no_neigh":
+        bgp_util.run_bgp_command = mock.MagicMock(
+            return_value=mock_show_bgp_summary_no_neigh("", ""))
     else:
         bgp_util.run_bgp_command = mock.MagicMock(
             return_value=mock_show_bgp_summary("", ""))

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -215,8 +215,10 @@ def get_bgp_summary_from_all_bgp_instances(af, namespace, display):
         except ValueError:
             ctx.fail("bgp summary from bgp container not in json format")
 
+        # exit cli command without printing the error message
         if key not in cmd_output_json:
-            ctx.fail("bgp summary from bgp container in invalid format")
+            click.echo("% No BGP neighbors found in VRF default")
+            exit()
 
         device.current_namespace = ns
 

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -217,7 +217,7 @@ def get_bgp_summary_from_all_bgp_instances(af, namespace, display):
 
         # exit cli command without printing the error message
         if key not in cmd_output_json:
-            click.echo("% No BGP neighbors found in VRF default")
+            click.echo("% No IP{} neighbor is configured".format(af))
             exit()
 
         device.current_namespace = ns

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -217,7 +217,7 @@ def get_bgp_summary_from_all_bgp_instances(af, namespace, display):
 
         # exit cli command without printing the error message
         if key not in cmd_output_json:
-            click.echo("% No IP{} neighbor is configured".format(af))
+            click.echo("No IP{} neighbor is configured".format(af))
             exit()
 
         device.current_namespace = ns


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes #2492 

#### How I did it
Use `click.echo` and `exit` instead of `ctx.fail` in cli handler when no neighbor information is returned from bgp container.

#### How to verify it
Test on target and add UT
new output when no neighbors are present
```
admin@sonic:~$ show ipv6 bgp summary
% No BGP neighbors found in VRF default
admin@sonic:~$
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

