### PR TITLE
[VXLAN]Fixing traceback in show remotemac when mac moves during command execution

### DIFF
--- a/show/vxlan.py
+++ b/show/vxlan.py
@@ -308,7 +308,7 @@ def remotemac(remote_vtep_ip, count):
             if vxlan_table is None:
              continue
             rmtip = vxlan_table.get('remote_vtep')
-            if remote_vtep_ip != 'all' and rmtip != remote_vtep_ip or rmtip == None:
+            if remote_vtep_ip != 'all' and rmtip != remote_vtep_ip or rmtip is None:
                continue
             if count is None:
                body.append([vlan, mac, rmtip, vxlan_table['vni'], vxlan_table['type']])

--- a/show/vxlan.py
+++ b/show/vxlan.py
@@ -98,14 +98,14 @@ def interface():
           vtepname = key1.pop();
           if 'src_ip' in vxlan_table[key]:
             vtep_sip = vxlan_table[key]['src_ip']
-          if vtep_sip is not '0.0.0.0':
+          if vtep_sip != '0.0.0.0':
              output = '\tVTEP Name : ' + vtepname + ', SIP  : ' + vxlan_table[key]['src_ip']
           else:
              output = '\tVTEP Name : ' + vtepname
 
           click.echo(output)
 
-    if vtep_sip is not '0.0.0.0':
+    if vtep_sip != '0.0.0.0':
        vxlan_table = config_db.get_table('VXLAN_EVPN_NVO')
        vxlan_keys = vxlan_table.keys()
        if vxlan_keys is not None:
@@ -307,8 +307,8 @@ def remotemac(remote_vtep_ip, count):
             vxlan_table = db.get_all(db.APPL_DB, key);
             if vxlan_table is None:
              continue
-            rmtip = vxlan_table['remote_vtep']
-            if remote_vtep_ip != 'all' and rmtip != remote_vtep_ip:
+            rmtip = vxlan_table.get('remote_vtep')
+            if remote_vtep_ip != 'all' and rmtip != remote_vtep_ip or rmtip == None:
                continue
             if count is None:
                body.append([vlan, mac, rmtip, vxlan_table['vni'], vxlan_table['type']])

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -290,6 +290,16 @@
     "VXLAN_REMOTE_VNI_TABLE:Vlan200:25.25.25.27": {
         "vni": "200"
     },
+    "VXLAN_FDB_TABLE:Vlan200:00:02:00:00:47:e2": {
+        "remote_vtep": "2.2.2.2",
+        "type": "dynamic",
+        "vni": "200"
+    },
+    "VXLAN_FDB_TABLE:Vlan200:00:02:00:00:47:e3": {
+        "remote_vtep": "2.2.2.3",
+        "type": "dynamic",
+        "vni": "200"
+    },
     "MUX_CABLE_TABLE:Ethernet32": {
         "state": "active"
     },

--- a/tests/vxlan_test.py
+++ b/tests/vxlan_test.py
@@ -112,6 +112,38 @@ Total count : 1
 
 """
 
+show_vxlan_remotemac_all_output="""\
++---------+-------------------+--------------+-------+---------+
+| VLAN    | MAC               | RemoteVTEP   |   VNI | Type    |
++=========+===================+==============+=======+=========+
+| Vlan200 | 00:02:00:00:47:e2 | 2.2.2.2      |   200 | dynamic |
++---------+-------------------+--------------+-------+---------+
+| Vlan200 | 00:02:00:00:47:e3 | 2.2.2.3      |   200 | dynamic |
++---------+-------------------+--------------+-------+---------+
+Total count : 2
+
+"""
+
+show_vxlan_remotemac_specific_output="""\
++---------+-------------------+--------------+-------+---------+
+| VLAN    | MAC               | RemoteVTEP   |   VNI | Type    |
++=========+===================+==============+=======+=========+
+| Vlan200 | 00:02:00:00:47:e2 | 2.2.2.2      |   200 | dynamic |
++---------+-------------------+--------------+-------+---------+
+Total count : 1
+
+"""
+
+show_vxlan_remotemac_cnt_output="""\
+Total count : 2
+
+"""
+
+show_vxlan_remotemac_specific_cnt_output="""\
+Total count : 1
+
+"""
+
 class TestVxlan(object):
     @classmethod
     def setup_class(cls):
@@ -214,6 +246,38 @@ class TestVxlan(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_vxlan_remotevni_specific_cnt_output
+
+    def test_show_vxlan_remotemac(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["vxlan"].commands["remotemac"], ["all"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_vxlan_remotemac_all_output
+
+    def test_show_vxlan_remotemac_specific(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["vxlan"].commands["remotemac"], ["2.2.2.2"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_vxlan_remotemac_specific_output
+
+    def test_show_vxlan_remotemac_cnt(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["vxlan"].commands["remotemac"], ["all", "count"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_vxlan_remotemac_cnt_output
+
+    def test_show_vxlan_remotemac_specific_cnt(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["vxlan"].commands["remotemac"], ["2.2.2.2", "count"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_vxlan_remotemac_specific_cnt_output
 
     def test_config_vxlan_add(self):
         runner = CliRunner()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
During the execution of show vxlan remotemac command, if a mac moves after the key is fetched but not the table fields, there will be the below traceback

```
show vxlan remotemac 2.2.2.2 
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/show/vxlan.py", line 310, in remotemac
    rmtip = vxlan_table['remote_vtep']
KeyError: 'remote_vtep'
```
This is because the entry would have got removed before the CLI fetches the table.

#### How I did it
Used get API to fetch table rather than indexing directly which resulted in traceback. Additionally fixed Python 3.8 SyntaxWarning.

show vxlan remotemac all
/usr/local/lib/python3.9/dist-packages/show/vxlan.py:101: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if vtep_sip is not '0.0.0.0':
/usr/local/lib/python3.9/dist-packages/show/vxlan.py:108: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if vtep_sip is not '0.0.0.0':


#### How to verify it
Perform mac move during show command execution and verify there is no traceback.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

