### PR TITLE
sonic-utilities : Added support for L2_TABLE_TYPE in acl-loader

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -314,6 +314,14 @@ class AclLoader(object):
         """
         return self.tables_db_info[tname]["type"].upper() == "L3"
 
+    def is_table_l2(self, tname):
+        """
+        Check if ACL table type is L2
+        :param tname: ACL table name
+        :return: True if table type is L2 else False
+        """
+        return self.tables_db_info[tname]["type"].upper() == "L2"
+
     def is_table_ipv6(self, tname):
         """
         Check if ACL table type is IPv6 (L3V6 or MIRRORV6)
@@ -456,6 +464,15 @@ class AclLoader(object):
 
             rule_props["VLAN_ID"] = vlan_id
 
+        if rule.l2.config.source_mac:
+            source_mac = rule.l2.config.source_mac
+            source_mac_mask = rule.l2.config.source_mac_mask
+            rule_props["SRC_MAC"] = source_mac + "/" + source_mac_mask
+        if rule.l2.config.destination_mac:
+            destination_mac = rule.l2.config.destination_mac
+            destination_mac_mask = rule.l2.config.destination_mac_mask
+            rule_props["DST_MAC"] = destination_mac + "/" + destination_mac_mask
+ 
         return rule_props
 
     def convert_ip(self, table_name, rule_idx, rule):
@@ -639,6 +656,8 @@ class AclLoader(object):
         rule_props["PACKET_ACTION"] = "DROP"
         if self.is_table_ipv6(table_name):
             rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
+        elif self.is_table_l2(table_name):
+            rule_props["IP_TYPE"] = "ANY"
         else:
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
         return rule_data


### PR DESCRIPTION
* For L2 table type, modified the default rule to match any ip type
* Added support for handling src-mac,dst-mac fields

Signed-off-by: arthig <arthig@celestica.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added L2 table type support in acl-loader utility.


#### How I did it
ACL supports only L3 and L3V6 table type. There is no support for matching L2 table type.
From CLICK, provided support for L2 table type.

The changes in this commit are:
*  for the default rule which matches any ip type for L2 table rule
*  for identifying table type as L2
*  for parsing src-mac/dst-mac and passing it as "src-mac/mask" and "dst-mac/mask" respectively.
Related pull requests
https://github.com/sonic-net/sonic-swss/pull/2540
https://github.com/sonic-net/sonic-mgmt-common/pull/65


#### How to verify it
1. Create L2 Table from CLICK
   "config acl add table -s ingress -p <table_name> L2"
2. Add rules using openconfig json format for supported fields "config acl update full/incremental <file.json>"
"source-mac": "00:00:00:11:11:12",
"source-mac-mask": "00:00:00:ff:ff:ff",
"destination-mac": "00:00:00:11:11:13",
"destination-mac-mask": "00:00:00:ff:ff:ff",
"ethertype": "ETHERTYPE_ARP"

3. Validate commands "show acl table"
4. Validate commands and fields in "show acl rule"
5. Validate commands "aclshow -a" /* Ensured that the counters are hitting the relevant rule */
All the rules are added for each field and combinations as well. and each field tested with traffic in Broadcom based platform.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
show acl rule
L2_TABLE  RULE_1  1           FORWARD   DST_MAC: 00:00:00:22:22:22/00:00:00:ff:ff:ff
                                                                ETHER_TYPE: 0x0800
                                                                SRC_MAC: 00:00:00:11:11:11/00:00:00:ff:ff:ff

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205