### PR TITLE
Change show kube command default value of insecure key to True

### DIFF
--- a/show/kube.py
+++ b/show/kube.py
@@ -45,7 +45,7 @@ def config(db):
             # (<header name>, <field name>, <default val>)
             ("ip", "ip" "", False),
             ("port", "port", "6443"),
-            ("insecure", "insecure", "False"),
+            ("insecure", "insecure", "True"),
             ("disable","disable", "False")
             ]
 

--- a/tests/kube_test.py
+++ b/tests/kube_test.py
@@ -34,6 +34,18 @@ ip           port    insecure    disable
 10.3.157.24  7777    True        False
 """
 
+show_server_output_5="""\
+ip           port    insecure    disable
+-----------  ------  ----------  ---------
+10.10.10.11  6443    True        False
+"""
+
+show_server_output_6="""\
+ip           port    insecure    disable
+-----------  ------  ----------  ---------
+10.3.157.24  6443    True        False
+"""
+
 empty_server_status="""\
 Kubernetes server has no status info
 """
@@ -96,6 +108,20 @@ class TestKube(object):
         result = runner.invoke(config.config.commands["kubernetes"].commands["server"], ["ip", "10.10.10.11"], obj=db)
         self.__check_res(result, "set server IP when none", "")
 
+        result = runner.invoke(show.cli.commands["kubernetes"].commands["server"].commands["config"], [], obj=db)
+        self.__check_res(result, "config command default value", show_server_output_5)
+
+
+    def test_only_kube_server(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        db.cfgdb.delete_table("KUBERNETES_MASTER")
+        db.cfgdb.set_entry("KUBERNETES_MASTER", "SERVER", {"ip": "10.3.157.24"})
+
+        result = runner.invoke(show.cli.commands["kubernetes"].commands["server"].commands["config"], [], obj=db)
+        self.__check_res(result, "show command default value", show_server_output_6)
 
 
     def test_kube_server_status(self, get_cmd_module):


### PR DESCRIPTION
Signed-off-by: Yun Li <yunli1@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Change show kube command default value of insecure key to "True"
#### How I did it
Show kube command default value of insecure key should be "True"
#### How to verify it
Just execute "show kube server config" to see the output
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

