### PR TITLE
[drop counters] Fix CLI script for unconfigured PGs

### DIFF
--- a/scripts/pg-drop
+++ b/scripts/pg-drop
@@ -116,16 +116,23 @@ class PgDropStat(object):
 
         self.header_list = ['Port']
         header_map = pg_drop_type["obj_map"]
-        single_key = list(header_map.keys())[0]
-        header_len = len(header_map[single_key])
-        min_idx = sys.maxsize
 
-        for name, counter_oid in header_map[single_key].items():
-            curr_idx = int(pg_drop_type["idx_func"](counter_oid))
-            min_idx = min(min_idx, curr_idx)
+        max_idx = 0
+        min_idx = sys.maxsize
+        for port in header_map.keys():
+            for element in header_map[port].keys():
+                element_idx = int(element.split(':')[1])
+                if element_idx > max_idx:
+                    max_idx = element_idx
+                if min_idx > element_idx:
+                    min_idx = element_idx
+
+        if min_idx == sys.maxsize:
+            print("Header info is not available!")
+            sys.exit(1)
 
         self.min_idx = min_idx
-        self.header_list += ["{}{}".format(pg_drop_type["header_prefix"], idx) for idx in range(self.min_idx, self.min_idx + header_len)]
+        self.header_list += ["{}{}".format(pg_drop_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx + 1)]
 
     def get_counters(self, table_prefix, port_obj, idx_func, counter_name):
         """


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Since PG counters are created only if they are configured in the switch, it is not enough to relay only on the first entry in the DB when building the output table of watermarkstat script.
We need to go over all configured counters, check what is the max configured and build the table accordingly.

#### How I did it
Iterate all configured PG buffers for all ports and find the max index.
Build the output table according to the max index.

#### How to verify it
Run test "pgdropstat_test.py" including this PR and observe it passes.

#### Previous command output (if the output of a command-line utility has changed)

- N/A

#### New command output (if the output of a command-line utility has changed)

- N/A