### PR TITLE
Show tech save file to skip non-file entries in cisco-8000 platform (…

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -956,7 +956,9 @@ collect_cisco_8000() {
     if [ -d /usr/share/sonic/device/${platform} ]; then
         pushd /usr/share/sonic/device/${platform} > /dev/null
         for file in $(find . -path "./*plugin*" -prune -o -path "./*.xml" -prune -o -path "./*.yaml" -prune -o -print); do
-            save_file ${file} sai false
+            if [ -f ${file} ]; then
+                 save_file ${file} sai false
+            fi
         done
         popd > /dev/null
     else


### PR DESCRIPTION
…#2507)

Motivation/issue:
While running showtech support in Cisco-8000 platform following errors are seen. This failure is happening because non-file entries like current directory "." and subdirectory "./Cisco-8102-C64" are being saved as a file.
How it is fixed
The script code is modified to skip non-file entries being saved in dump directory

Verification/test
I have run the show tech fix in cisco-8000 platform and confirmed the aforementioned error messages are not seen.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

