### PR TITLE
[DPB] Enhance the code to shutdown interface before delete ports

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -369,6 +369,31 @@ class ConfigMgmtDPB(ConfigMgmt):
 
         return True
 
+    def _verifyPortShutdown(self, db, ports, timeout):
+        self.sysLog(doPrint=True, msg="Verify Port shutdown from State DB, Wait...")
+
+        db.connect(db.STATE_DB)
+        for waitTime in range(timeout):
+            retry = False
+            for intf in ports:
+                _hash = "PORT_TABLE|{}".format(intf)
+                port_status = db.get(db.STATE_DB, _hash, "admin_status")
+                if port_status != 'down':
+                    retry = True
+                    continue
+            if retry:
+                tsleep(1)
+            else:
+                break
+
+        if waitTime + 1 == timeout:
+            for intf in ports:
+                _hash = "PORT_TABLE|{}".format(intf)
+                port_status = db.get(db.STATE_DB, _hash, "admin_status")
+                if port_status != 'down':
+                    self.sysLog(syslog.LOG_CRIT, "Fail to shutdown port {}".format(intf))
+
+
     def _verifyAsicDB(self, db, ports, portMap, timeout):
         '''
         Verify in the Asic DB that port are deleted, Keep on trying till timeout
@@ -448,6 +473,7 @@ class ConfigMgmtDPB(ConfigMgmt):
             # -- verify Asic DB for port deletion,
             # -- then update addition of ports in config DB.
             self._shutdownIntf(delPorts)
+            self._verifyPortShutdown(dataBase, delPorts, MAX_WAIT)
             self.writeConfigDB(delConfigToLoad)
             # Verify in Asic DB,
             self._verifyAsicDB(db=dataBase, ports=delPorts, portMap=if_name_map, \
@@ -594,9 +620,14 @@ class ConfigMgmtDPB(ConfigMgmt):
         Returns:
             void
         """
+        configdb = ConfigDBConnector()
+        configdb.connect(False)
         shutDownConf = dict(); shutDownConf["PORT"] = dict()
         for intf in ports:
-            shutDownConf["PORT"][intf] = {"admin_status": "down"}
+            port_entry = configdb.get_entry('PORT', intf)
+            port_status = port_entry.get("admin_status")
+            if port_status == "up":
+                shutDownConf["PORT"][intf] = {"admin_status": "down"}
         self.sysLog(msg='shutdown Interfaces: {}'.format(shutDownConf))
 
         if len(shutDownConf["PORT"]):

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -188,8 +188,10 @@ class TestConfigMgmt(TestCase):
             args = args[0]
         assert "PORT" in args
 
-        # {"admin_status": "down"} should be set for all ports in dPorts
-        assert len(args["PORT"]) == len(dPorts)
+        # {"admin_status": "down"} should be set for Ethernet8
+        # The admin_status of Ethernet8 is 'up'.
+        # Only need to shutdown Ethernet8
+        assert len(args["PORT"]) == 1
         # each port should have {"admin_status": "down"}
         for port in args["PORT"].keys():
             assert args["PORT"][port]['admin_status'] == 'down'

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -229,6 +229,7 @@ class TestConfigMgmt(TestCase):
         # mock funcs
         cmdpb.writeConfigDB = mock.MagicMock(return_value=True)
         cmdpb._verifyAsicDB = mock.MagicMock(return_value=True)
+        cmdpb._verifyPortShutdown = mock.MagicMock(return_value=True)
         from .mock_tables import dbconnector
         return cmdpb
 

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -23,6 +23,7 @@
         "brkout_mode": "1x100G[40G]"
     },
     "PORT|Ethernet0": {
+        "admin_status": "up",
         "alias": "etp1",
         "description": "etp1",
         "index": "0",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Make sure the port shutdown is done before delete the port.

#### How I did it
Check the admin status on the ports to be deleted. 
If the port admin status is up, do shutdown ports. 
If the port admin status is down, do nothing.
Wait until the admin status of the ports to be removed on state DB has changed to down.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


Signed-off-by: chiourung_huang chiourung_huang@edge-core.com
