### PR TITLE
[FIPS]: Enhance set-fips output

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -10537,7 +10537,7 @@ If the option --enable-fips or --disable-fips is not specified, the default beha
   ```
   admin@sonic:~$ sudo sonic-installer set-fips --enable-fips
   Done
-  Set FIPS for the image successfully
+  Enabled FIPS for the image successfully
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#software-installation-and-management)

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -653,7 +653,10 @@ def set_fips(image, enable_fips):
         echo_and_log('Error: Image does not exist', LOG_ERR)
         sys.exit(1)
     bootloader.set_fips(image, enable=enable_fips)
-    click.echo('Set FIPS for the image successfully')
+    if enable_fips:
+        click.echo('Enabled FIPS for the image successfully')
+    else:
+        click.echo('Disabled FIPS for the image successfully')
 
 # Get fips for image
 @sonic_installer.command('get-fips')

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -101,9 +101,9 @@ def test_set_fips(get_bootloader):
 
     # Test set-fips command options: --enable-fips/--disable-fips
     result = runner.invoke(sonic_installer.commands["set-fips"], [next_image, '--enable-fips'])
-    assert 'Set FIPS' in result.output
+    assert 'Enabled FIPS for the image successfully' in result.output
     result = runner.invoke(sonic_installer.commands["set-fips"], ['--disable-fips'])
-    assert 'Set FIPS' in result.output
+    assert 'Disabled FIPS for the image successfully' in result.output
 
     # Test command get-fips options
     result = runner.invoke(sonic_installer.commands["get-fips"])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

Signed-off-by: Muhammad Danish <danish.iqbal@xflowresearch.com>
#### What I did
- Show a better message for set-fips command.
#### How I did it

#### How to verify it
- Tested the wheel locally in SONiC to verify the output
#### Previous command output (if the output of a command-line utility has changed)
```
  admin@sonic:~$ sudo sonic-installer set-fips --enable-fips
  Done
  Set FIPS for the image successfully
  admin@sonic:~$ sudo sonic-installer set-fips --disable-fips
  Done
  Set FIPS for the image successfully
```
#### New command output (if the output of a command-line utility has changed)
```
  admin@sonic:~$ sudo sonic-installer set-fips --enable-fips
  Done
  Enabled FIPS for the image successfully
  admin@sonic:~$ sudo sonic-installer set-fips --disable-fips
  Done
  Disabled FIPS for the image successfully
```
