### PR TITLE
Preserve copp tables through DB migration

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -868,6 +868,10 @@ class DBMigrator():
                 new_cfg = {**init_cfg, **curr_cfg}
                 self.configDB.set_entry(init_cfg_table, key, new_cfg)
 
+        # Avoiding copp table migration is platform specific at the moment as I understood this might cause issues for some
+        # vendors, probably Broadcom. This change can be checked with any specific vendor and if this works fine the platform
+        # condition can be modified and extend. If no vendor has an issue with not clearing copp tables the condition can be
+        # removed together with calling to migrate_copp_table function.
         if self.asic_type != "mellanox":
             self.migrate_copp_table()
         if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:            

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -868,7 +868,8 @@ class DBMigrator():
                 new_cfg = {**init_cfg, **curr_cfg}
                 self.configDB.set_entry(init_cfg_table, key, new_cfg)
 
-        self.migrate_copp_table()
+        if self.asic_type != "mellanox":
+            self.migrate_copp_table()
         if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:            
             self.migrate_mgmt_ports_on_s6100()
         else:


### PR DESCRIPTION
This PR should be merged together with https://github.com/sonic-net/sonic-swss/pull/2548 and is required to 202205 and 202211.
This PR implements [fastboot] Preserve CoPP table HLD to improve fastboot flow (https://github.com/sonic-net/SONiC/pull/1107).

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Preserve COPP table contents through DB migration. (Mellanox only)

#### How I did it
Skipped deleting of COPP tables in DB migrator.

#### How to verify it
Observe COPP table contents are preserved right after reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

