### PR TITLE
YANG Validation for ConfigDB Updates: WARM_RESTART, SFLOW_SESSION, SFLOW, VXLAN_TUNNEL, VXLAN_EVPN_NVO, VXLAN_TUNNEL_MAP, MGMT_VRF_CONFIG, CABLE_LENGTH, VRF tables

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5189,7 +5189,7 @@ def del_vrf(ctx, vrf_name):
     """Del vrf"""
     config_db = ValidatedConfigDBConnector(ctx.obj['config_db'])
     if not vrf_name.startswith("Vrf") and not (vrf_name == 'mgmt') and not (vrf_name == 'management'):
-        ctx.fail("'vrf_name' is not start with Vrf, mgmt or management!")
+        ctx.fail("'vrf_name' must begin with 'Vrf' or named 'mgmt'/'management' in case of ManagementVRF.")
     if len(vrf_name) > 15:
         ctx.fail("'vrf_name' is too long!")
     syslog_table = config_db.get_table("SYSLOG_SERVER")
@@ -5198,7 +5198,9 @@ def del_vrf(ctx, vrf_name):
         syslog_vrf = syslog_data.get("vrf")
         if syslog_vrf == syslog_vrf_dev:
             ctx.fail("Failed to remove VRF device: {} is in use by SYSLOG_SERVER|{}".format(syslog_vrf, syslog_entry))
-    if (vrf_name == 'mgmt' or vrf_name == 'management'):
+    if not is_vrf_exists(config_db, vrf_name):
+        ctx.fail("VRF {} does not exist!".format(vrf_name))
+    elif (vrf_name == 'mgmt' or vrf_name == 'management'):
         vrf_delete_management_vrf(config_db)
     else:
         del_interface_bind_to_vrf(config_db, vrf_name)

--- a/config/main.py
+++ b/config/main.py
@@ -2881,55 +2881,79 @@ def warm_restart_enable(ctx, module):
 @click.argument('seconds', metavar='<seconds>', required=True, type=int)
 @click.pass_context
 def warm_restart_neighsyncd_timer(ctx, seconds):
-    db = ctx.obj['db']
-    if seconds not in range(1, 9999):
-        ctx.fail("neighsyncd warm restart timer must be in range 1-9999")
-    db.mod_entry('WARM_RESTART', 'swss', {'neighsyncd_timer': seconds})
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        if seconds not in range(1, 9999):
+            ctx.fail("neighsyncd warm restart timer must be in range 1-9999")
+    try:
+        db.mod_entry('WARM_RESTART', 'swss', {'neighsyncd_timer': seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @warm_restart.command('bgp_timer')
 @click.argument('seconds', metavar='<seconds>', required=True, type=int)
 @click.pass_context
 def warm_restart_bgp_timer(ctx, seconds):
-    db = ctx.obj['db']
-    if seconds not in range(1, 3600):
-        ctx.fail("bgp warm restart timer must be in range 1-3600")
-    db.mod_entry('WARM_RESTART', 'bgp', {'bgp_timer': seconds})
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        if seconds not in range(1, 3600):
+            ctx.fail("bgp warm restart timer must be in range 1-3600")
+    try:
+        db.mod_entry('WARM_RESTART', 'bgp', {'bgp_timer': seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @warm_restart.command('teamsyncd_timer')
 @click.argument('seconds', metavar='<seconds>', required=True, type=int)
 @click.pass_context
 def warm_restart_teamsyncd_timer(ctx, seconds):
-    db = ctx.obj['db']
-    if seconds not in range(1, 3600):
-        ctx.fail("teamsyncd warm restart timer must be in range 1-3600")
-    db.mod_entry('WARM_RESTART', 'teamd', {'teamsyncd_timer': seconds})
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        if seconds not in range(1, 3600):
+            ctx.fail("teamsyncd warm restart timer must be in range 1-3600")
+    try:
+        db.mod_entry('WARM_RESTART', 'teamd', {'teamsyncd_timer': seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @warm_restart.command('bgp_eoiu')
 @click.argument('enable', metavar='<enable>', default='true', required=False, type=click.Choice(["true", "false"]))
 @click.pass_context
 def warm_restart_bgp_eoiu(ctx, enable):
-    db = ctx.obj['db']
-    db.mod_entry('WARM_RESTART', 'bgp', {'bgp_eoiu': enable})
-
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    try:
+        db.mod_entry('WARM_RESTART', 'bgp', {'bgp_eoiu': enable})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 def vrf_add_management_vrf(config_db):
     """Enable management vrf in config DB"""
 
+    config_db = ValidatedConfigDBConnector(config_db)
     entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
     if entry and entry['mgmtVrfEnabled'] == 'true' :
         click.echo("ManagementVRF is already Enabled.")
         return None
-    config_db.mod_entry('MGMT_VRF_CONFIG', "vrf_global", {"mgmtVrfEnabled": "true"})
+    try:
+        config_db.mod_entry('MGMT_VRF_CONFIG', "vrf_global", {"mgmtVrfEnabled": "true"})
+    except ValueError as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 def vrf_delete_management_vrf(config_db):
     """Disable management vrf in config DB"""
 
+    config_db = ValidatedConfigDBConnector(config_db)
     entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
     if not entry or entry['mgmtVrfEnabled'] == 'false' :
         click.echo("ManagementVRF is already Disabled.")
         return None
-    config_db.mod_entry('MGMT_VRF_CONFIG', "vrf_global", {"mgmtVrfEnabled": "false"})
+    try:
+        config_db.mod_entry('MGMT_VRF_CONFIG', "vrf_global", {"mgmtVrfEnabled": "false"})
+    except ValueError as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 @config.group(cls=clicommon.AbbreviationGroup)
@@ -4707,26 +4731,30 @@ def remove_queue(db, interface_name, queue_map):
 @click.pass_context
 def cable_length(ctx, interface_name, length):
     """Set interface cable length"""
-    config_db = ctx.obj["config_db"]
+    config_db = ValidatedConfigDBConnector(ctx.obj["config_db"])
 
     if not is_dynamic_buffer_enabled(config_db):
         ctx.fail("This command can only be supported on a system with dynamic buffer enabled")
+    
+    if ADHOC_VALIDATION:
+        # Check whether port is legal
+        ports = config_db.get_entry("PORT", interface_name)
+        if not ports:
+            ctx.fail("Port {} doesn't exist".format(interface_name))
 
-    # Check whether port is legal
-    ports = config_db.get_entry("PORT", interface_name)
-    if not ports:
-        ctx.fail("Port {} doesn't exist".format(interface_name))
-
-    try:
-        assert "m" == length[-1]
-    except Exception:
-        ctx.fail("Invalid cable length. Should be in format <num>m, like 300m".format(cable_length))
+        try:
+            assert "m" == length[-1]
+        except Exception:
+            ctx.fail("Invalid cable length. Should be in format <num>m, like 300m".format(cable_length))
 
     keys = config_db.get_keys("CABLE_LENGTH")
 
     cable_length_set = {}
     cable_length_set[interface_name] = length
-    config_db.mod_entry("CABLE_LENGTH", keys[0], cable_length_set)
+    try:
+        config_db.mod_entry("CABLE_LENGTH", keys[0], cable_length_set)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'transceiver' subgroup ('config interface transceiver ...')
@@ -5151,7 +5179,10 @@ def add_vrf(ctx, vrf_name):
     if (vrf_name == 'mgmt' or vrf_name == 'management'):
         vrf_add_management_vrf(config_db)
     else:
-        config_db.set_entry('VRF', vrf_name, {"NULL": "NULL"})
+        try:
+            config_db.set_entry('VRF', vrf_name, {"NULL": "NULL"})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vrf.command('del')
 @click.argument('vrf_name', metavar='<vrf_name>', required=True)
@@ -5173,7 +5204,10 @@ def del_vrf(ctx, vrf_name):
         vrf_delete_management_vrf(config_db)
     else:
         del_interface_bind_to_vrf(config_db, vrf_name)
-        config_db.set_entry('VRF', vrf_name, None)
+        try:
+            config_db.set_entry('VRF', vrf_name, None)
+        except JsonPatchConflict as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         click.echo("VRF {} deleted and all associated IP addresses removed.".format(vrf_name))
 
 @vrf.command('add_vrf_vni_map')
@@ -6273,7 +6307,7 @@ def sflow(ctx):
 @click.pass_context
 def enable(ctx):
     """Enable sFlow"""
-    config_db = ctx.obj['db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
     sflow_tbl = config_db.get_table('SFLOW')
 
     if not sflow_tbl:
@@ -6281,7 +6315,10 @@ def enable(ctx):
     else:
         sflow_tbl['global']['admin_state'] = 'up'
 
-    config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    try:
+        config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     try:
         proc = subprocess.Popen("systemctl is-active sflow", shell=True, text=True, stdout=subprocess.PIPE)
@@ -6301,7 +6338,7 @@ def enable(ctx):
 @click.pass_context
 def disable(ctx):
     """Disable sFlow"""
-    config_db = ctx.obj['db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
     sflow_tbl = config_db.get_table('SFLOW')
 
     if not sflow_tbl:
@@ -6309,7 +6346,10 @@ def disable(ctx):
     else:
         sflow_tbl['global']['admin_state'] = 'down'
 
-    config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    try:
+        config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'sflow' command ('config sflow polling-interval ...')
@@ -6320,17 +6360,21 @@ def disable(ctx):
 @click.pass_context
 def polling_int(ctx, interval):
     """Set polling-interval for counter-sampling (0 to disable)"""
-    if interval not in range(5, 301) and interval != 0:
-        click.echo("Polling interval must be between 5-300 (0 to disable)")
+    if ADHOC_VALIDATION:
+        if interval not in range(5, 301) and interval != 0:
+            click.echo("Polling interval must be between 5-300 (0 to disable)")
 
-    config_db = ctx.obj['db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
     sflow_tbl = config_db.get_table('SFLOW')
 
     if not sflow_tbl:
         sflow_tbl = {'global': {'admin_state': 'down'}}
 
     sflow_tbl['global']['polling_interval'] = interval
-    config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    try:
+        config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 def is_valid_sample_rate(rate):
     return rate.isdigit() and int(rate) in range(256, 8388608 + 1)
@@ -6352,18 +6396,25 @@ def interface(ctx):
 @click.argument('ifname', metavar='<interface_name>', required=True, type=str)
 @click.pass_context
 def enable(ctx, ifname):
-    config_db = ctx.obj['db']
-    if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
-        click.echo("Invalid interface name")
-        return
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
+            click.echo("Invalid interface name")
+            return
 
     intf_dict = config_db.get_table('SFLOW_SESSION')
 
     if intf_dict and ifname in intf_dict:
         intf_dict[ifname]['admin_state'] = 'up'
-        config_db.mod_entry('SFLOW_SESSION', ifname, intf_dict[ifname])
+        try:
+            config_db.mod_entry('SFLOW_SESSION', ifname, intf_dict[ifname])
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
-        config_db.mod_entry('SFLOW_SESSION', ifname, {'admin_state': 'up'})
+        try:
+            config_db.mod_entry('SFLOW_SESSION', ifname, {'admin_state': 'up'})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'sflow' command ('config sflow interface disable  ...')
@@ -6372,19 +6423,26 @@ def enable(ctx, ifname):
 @click.argument('ifname', metavar='<interface_name>', required=True, type=str)
 @click.pass_context
 def disable(ctx, ifname):
-    config_db = ctx.obj['db']
-    if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
-        click.echo("Invalid interface name")
-        return
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
+            click.echo("Invalid interface name")
+            return
 
     intf_dict = config_db.get_table('SFLOW_SESSION')
 
     if intf_dict and ifname in intf_dict:
         intf_dict[ifname]['admin_state'] = 'down'
-        config_db.mod_entry('SFLOW_SESSION', ifname, intf_dict[ifname])
+        try:
+            config_db.mod_entry('SFLOW_SESSION', ifname, intf_dict[ifname])
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
-        config_db.mod_entry('SFLOW_SESSION', ifname,
-                            {'admin_state': 'down'})
+        try:
+            config_db.mod_entry('SFLOW_SESSION', ifname,
+                                {'admin_state': 'down'})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'sflow' command ('config sflow interface sample-rate  ...')
@@ -6394,13 +6452,14 @@ def disable(ctx, ifname):
 @click.argument('rate', metavar='<sample_rate>', required=True, type=str)
 @click.pass_context
 def sample_rate(ctx, ifname, rate):
-    config_db = ctx.obj['db']
-    if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
-        click.echo('Invalid interface name')
-        return
-    if not is_valid_sample_rate(rate) and rate != 'default':
-        click.echo('Error: Sample rate must be between 256 and 8388608 or default')
-        return
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        if not interface_name_is_valid(config_db, ifname) and ifname != 'all':
+            click.echo('Invalid interface name')
+            return
+        if not is_valid_sample_rate(rate) and rate != 'default':
+            click.echo('Error: Sample rate must be between 256 and 8388608 or default')
+            return
 
     sess_dict = config_db.get_table('SFLOW_SESSION')
 
@@ -6409,13 +6468,22 @@ def sample_rate(ctx, ifname, rate):
             if 'sample_rate' not in sess_dict[ifname]:
                 return
             del sess_dict[ifname]['sample_rate']
-            config_db.set_entry('SFLOW_SESSION', ifname, sess_dict[ifname])
+            try:
+                config_db.set_entry('SFLOW_SESSION', ifname, sess_dict[ifname])
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
             return
         sess_dict[ifname]['sample_rate'] = rate
-        config_db.mod_entry('SFLOW_SESSION', ifname, sess_dict[ifname])
+        try:
+            config_db.mod_entry('SFLOW_SESSION', ifname, sess_dict[ifname])
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         if rate != 'default':
-            config_db.mod_entry('SFLOW_SESSION', ifname, {'sample_rate': rate})
+            try:
+                config_db.mod_entry('SFLOW_SESSION', ifname, {'sample_rate': rate})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 #
@@ -6510,11 +6578,12 @@ def agent_id(ctx):
 @click.pass_context
 def add(ctx, ifname):
     """Add sFlow agent information"""
-    if ifname not in netifaces.interfaces():
-        click.echo("Invalid interface name")
-        return
+    if ADHOC_VALIDATION:
+        if ifname not in netifaces.interfaces():
+            click.echo("Invalid interface name")
+            return
 
-    config_db = ctx.obj['db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
     sflow_tbl = config_db.get_table('SFLOW')
 
     if not sflow_tbl:
@@ -6525,7 +6594,10 @@ def add(ctx, ifname):
         return
 
     sflow_tbl['global']['agent_id'] = ifname
-    config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    try:
+        config_db.mod_entry('SFLOW', 'global', sflow_tbl['global'])
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'sflow' command ('config sflow agent-id del')
@@ -6534,7 +6606,7 @@ def add(ctx, ifname):
 @click.pass_context
 def delete(ctx):
     """Delete sFlow agent information"""
-    config_db = ctx.obj['db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['db'])
     sflow_tbl = config_db.get_table('SFLOW')
 
     if not sflow_tbl:
@@ -6545,7 +6617,10 @@ def delete(ctx):
         return
 
     sflow_tbl['global'].pop('agent_id')
-    config_db.set_entry('SFLOW', 'global', sflow_tbl['global'])
+    try:
+        config_db.set_entry('SFLOW', 'global', sflow_tbl['global'])
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # set ipv6 link local mode on a given interface

--- a/config/main.py
+++ b/config/main.py
@@ -2929,7 +2929,6 @@ def warm_restart_bgp_eoiu(ctx, enable):
 def vrf_add_management_vrf(config_db):
     """Enable management vrf in config DB"""
 
-    config_db = ValidatedConfigDBConnector(config_db)
     entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
     if entry and entry['mgmtVrfEnabled'] == 'true' :
         click.echo("ManagementVRF is already Enabled.")
@@ -2944,7 +2943,6 @@ def vrf_add_management_vrf(config_db):
 def vrf_delete_management_vrf(config_db):
     """Disable management vrf in config DB"""
 
-    config_db = ValidatedConfigDBConnector(config_db)
     entry = config_db.get_entry('MGMT_VRF_CONFIG', "vrf_global")
     if not entry or entry['mgmtVrfEnabled'] == 'false' :
         click.echo("ManagementVRF is already Disabled.")

--- a/config/main.py
+++ b/config/main.py
@@ -5171,7 +5171,7 @@ def vrf(ctx):
 @click.pass_context
 def add_vrf(ctx, vrf_name):
     """Add vrf"""
-    config_db = ctx.obj['config_db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['config_db'])
     if not vrf_name.startswith("Vrf") and not (vrf_name == 'mgmt') and not (vrf_name == 'management'):
         ctx.fail("'vrf_name' is not start with Vrf, mgmt or management!")
     if len(vrf_name) > 15:
@@ -5189,7 +5189,7 @@ def add_vrf(ctx, vrf_name):
 @click.pass_context
 def del_vrf(ctx, vrf_name):
     """Del vrf"""
-    config_db = ctx.obj['config_db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['config_db'])
     if not vrf_name.startswith("Vrf") and not (vrf_name == 'mgmt') and not (vrf_name == 'management'):
         ctx.fail("'vrf_name' is not start with Vrf, mgmt or management!")
     if len(vrf_name) > 15:

--- a/config/vxlan.py
+++ b/config/vxlan.py
@@ -1,6 +1,5 @@
 import click
 import utilities_common.cli as clicommon
-import jsonpatch
 
 from jsonpatch import JsonPatchConflict
 from .validated_config_db_connector import ValidatedConfigDBConnector

--- a/config/vxlan.py
+++ b/config/vxlan.py
@@ -93,7 +93,7 @@ def vxlan_evpn_nvo():
 def add_vxlan_evpn_nvo(db, nvo_name, vxlan_name):
     """Add NVO"""
     ctx = click.get_current_context()
-    config_db = validatedConfigDBConnector(db.cfgdb)
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     vxlan_keys = db.cfgdb.get_keys("VXLAN_EVPN_NVO|*")
     if not vxlan_keys:
       vxlan_count = 0

--- a/config/vxlan.py
+++ b/config/vxlan.py
@@ -1,6 +1,11 @@
 import click
 import utilities_common.cli as clicommon
+import jsonpatch
 
+from jsonpatch import JsonPatchConflict
+from .validated_config_db_connector import ValidatedConfigDBConnector
+
+ADHOC_VALIDATION = True
 #
 # 'vxlan' group ('config vxlan ...')
 #
@@ -15,9 +20,11 @@ def vxlan():
 def add_vxlan(db, vxlan_name, src_ip):
     """Add VXLAN"""
     ctx = click.get_current_context()
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
-    if not clicommon.is_ipaddress(src_ip):
-        ctx.fail("{} invalid src ip address".format(src_ip))  
+    if ADHOC_VALIDATION:
+        if not clicommon.is_ipaddress(src_ip):
+            ctx.fail("{} invalid src ip address".format(src_ip))  
 
     vxlan_keys = db.cfgdb.get_keys('VXLAN_TUNNEL')
     if not vxlan_keys:
@@ -29,7 +36,10 @@ def add_vxlan(db, vxlan_name, src_ip):
         ctx.fail("VTEP already configured.")  
 
     fvs = {'src_ip': src_ip}
-    db.cfgdb.set_entry('VXLAN_TUNNEL', vxlan_name, fvs)
+    try:
+        config_db.set_entry('VXLAN_TUNNEL', vxlan_name, fvs)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vxlan.command('del')
 @click.argument('vxlan_name', metavar='<vxlan_name>', required=True)
@@ -37,6 +47,7 @@ def add_vxlan(db, vxlan_name, src_ip):
 def del_vxlan(db, vxlan_name):
     """Del VXLAN"""
     ctx = click.get_current_context()
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
     vxlan_keys = db.cfgdb.get_keys('VXLAN_TUNNEL')
     if vxlan_name not in vxlan_keys:
@@ -66,7 +77,10 @@ def del_vxlan(db, vxlan_name):
         if ('vxlan_tunnel' in vnet_table[vnet_key] and vnet_table[vnet_key]['vxlan_tunnel'] == vxlan_name):
             ctx.fail("Please delete all VNET configuration referencing the tunnel " + vxlan_name)
 
-    db.cfgdb.set_entry('VXLAN_TUNNEL', vxlan_name, None)
+    try:
+        config_db.set_entry('VXLAN_TUNNEL', vxlan_name, None)
+    except JsonPatchConflict as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vxlan.group('evpn_nvo')
 def vxlan_evpn_nvo():
@@ -79,6 +93,7 @@ def vxlan_evpn_nvo():
 def add_vxlan_evpn_nvo(db, nvo_name, vxlan_name):
     """Add NVO"""
     ctx = click.get_current_context()
+    config_db = validatedConfigDBConnector(db.cfgdb)
     vxlan_keys = db.cfgdb.get_keys("VXLAN_EVPN_NVO|*")
     if not vxlan_keys:
       vxlan_count = 0
@@ -92,7 +107,10 @@ def add_vxlan_evpn_nvo(db, nvo_name, vxlan_name):
         ctx.fail("VTEP {} not configured".format(vxlan_name))
 
     fvs = {'source_vtep': vxlan_name}
-    db.cfgdb.set_entry('VXLAN_EVPN_NVO', nvo_name, fvs)
+    try:
+        config_db.set_entry('VXLAN_EVPN_NVO', nvo_name, fvs)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vxlan_evpn_nvo.command('del')
 @click.argument('nvo_name', metavar='<nvo_name>', required=True)
@@ -100,6 +118,7 @@ def add_vxlan_evpn_nvo(db, nvo_name, vxlan_name):
 def del_vxlan_evpn_nvo(db, nvo_name):
     """Del NVO"""
     ctx = click.get_current_context()
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     vxlan_keys = db.cfgdb.get_keys('VXLAN_TUNNEL_MAP')
     if not vxlan_keys:
       vxlan_count = 0
@@ -107,8 +126,11 @@ def del_vxlan_evpn_nvo(db, nvo_name):
       vxlan_count = len(vxlan_keys)
 
     if(vxlan_count > 0):
-        ctx.fail("Please delete all VLAN VNI mappings.")  
-    db.cfgdb.set_entry('VXLAN_EVPN_NVO', nvo_name, None)
+        ctx.fail("Please delete all VLAN VNI mappings.")
+    try:
+        config_db.set_entry('VXLAN_EVPN_NVO', nvo_name, None)
+    except JsonPatchConflict as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vxlan.group('map')
 def vxlan_map():
@@ -122,6 +144,7 @@ def vxlan_map():
 def add_vxlan_map(db, vxlan_name, vlan, vni):
     """Add VLAN-VNI map entry"""
     ctx = click.get_current_context()
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
     if not vlan.isdigit():
         ctx.fail("Invalid vlan {}. Only valid vlan is accepted".format(vni))
@@ -152,7 +175,10 @@ def add_vxlan_map(db, vxlan_name, vlan, vni):
     fvs = {'vni': vni,
            'vlan' : vlan_name}
     mapname = vxlan_name + '|' + 'map_' + vni + '_' + vlan_name
-    db.cfgdb.set_entry('VXLAN_TUNNEL_MAP', mapname, fvs)
+    try:
+        config_db.set_entry('VXLAN_TUNNEL_MAP', mapname, fvs)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vxlan_map.command('del')
 @click.argument('vxlan_name', metavar='<vxlan_name>', required=True)
@@ -162,6 +188,7 @@ def add_vxlan_map(db, vxlan_name, vlan, vni):
 def del_vxlan_map(db, vxlan_name, vlan, vni):
     """Del VLAN-VNI map entry"""
     ctx = click.get_current_context()
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
     if not vlan.isdigit():
         ctx.fail("Invalid vlan {}. Only valid vlan is accepted".format(vni))
@@ -189,7 +216,10 @@ def del_vxlan_map(db, vxlan_name, vlan, vni):
     mapname = vxlan_name + '|' + 'map_' + vni + '_' + vlan
     db.cfgdb.set_entry('VXLAN_TUNNEL_MAP', mapname, None)
     mapname = vxlan_name + '|' + 'map_' + vni + '_Vlan' + vlan
-    db.cfgdb.set_entry('VXLAN_TUNNEL_MAP', mapname, None)
+    try:
+        config_db.set_entry('VXLAN_TUNNEL_MAP', mapname, None)
+    except JsonPatchConflict as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vxlan.group('map_range')
 def vxlan_map_range():
@@ -203,6 +233,7 @@ def vxlan_map_range():
 @clicommon.pass_db
 def add_vxlan_map_range(db, vxlan_name, vlan_start, vlan_end, vni_start):
     """Add Range of vlan-vni mappings"""
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
     if clicommon.is_vlanid_in_range(vlan_start) is False:
         ctx.fail(" Invalid Vlan Id , Valid Range : 1 to 4094 ")
@@ -244,7 +275,10 @@ def add_vxlan_map_range(db, vxlan_name, vlan_start, vlan_end, vni_start):
        fvs = {'vni': vni_name,
               'vlan' : vlan_name}
        mapname = vxlan_name + '|' + 'map_' + vni_name + '_' + vlan_name
-       db.cfgdb.set_entry('VXLAN_TUNNEL_MAP', mapname, fvs)
+       try:
+           config_db.set_entry('VXLAN_TUNNEL_MAP', mapname, fvs)
+       except ValueError as e:
+           ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @vxlan_map_range.command('del')
 @click.argument('vxlan_name', metavar='<vxlan_name>', required=True)
@@ -255,6 +289,7 @@ def add_vxlan_map_range(db, vxlan_name, vlan_start, vlan_end, vni_start):
 def del_vxlan_map_range(db, vxlan_name, vlan_start, vlan_end, vni_start):
     """Del Range of vlan-vni mappings"""
     ctx = click.get_current_context()
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     if clicommon.is_vlanid_in_range(vlan_start) is False:
         ctx.fail(" Invalid Vlan Id , Valid Range : 1 to 4094 ")
     if clicommon.is_vlanid_in_range(vlan_end) is False:
@@ -279,5 +314,8 @@ def del_vxlan_map_range(db, vxlan_name, vlan_start, vlan_end, vni_start):
            continue
 
        mapname = vxlan_name + '|' + 'map_' + vni_name + '_' + vlan_name
-       db.cfgdb.set_entry('VXLAN_TUNNEL_MAP', mapname, None)
+       try:
+           config_db.set_entry('VXLAN_TUNNEL_MAP', mapname, None)
+       except JsonPatchConflict as e:
+           ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1640,7 +1640,7 @@ class TestConfigWarmRestart(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     def test_warm_restart_neighsyncd_timer_yang_validation(self):
-        config.ADHOC_VALIDATION = True
+        config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
@@ -1650,7 +1650,13 @@ class TestConfigWarmRestart(object):
         print(result.output)
         assert result.exit_code != 0
         assert "Invalid ConfigDB. Error" in result.output
-
+    
+    def test_warm_restart_neighsyncd_timer(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+        
         result = runner.invoke(config.config.commands["warm_restart"].commands["neighsyncd_timer"], ["0"], obj=obj)
         print(result.exit_code)
         print(result.output)
@@ -1660,7 +1666,7 @@ class TestConfigWarmRestart(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     def test_warm_restart_bgp_timer_yang_validation(self):
-        config.ADHOC_VALIDATION = True
+        config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
@@ -1670,6 +1676,12 @@ class TestConfigWarmRestart(object):
         print(result.output)
         assert result.exit_code != 0
         assert "Invalid ConfigDB. Error" in result.output
+    
+    def test_warm_restart_bgp_timer(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["bgp_timer"], ["0"], obj=obj)
         print(result.exit_code)
@@ -1680,7 +1692,7 @@ class TestConfigWarmRestart(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     def test_warm_restart_teamsyncd_timer_yang_validation(self):
-        config.ADHOC_VALIDATION = True
+        config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
@@ -1691,6 +1703,12 @@ class TestConfigWarmRestart(object):
         assert result.exit_code != 0
         assert "Invalid ConfigDB. Error" in result.output
 
+    def test_warm_restart_teamsyncd_timer(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
         result = runner.invoke(config.config.commands["warm_restart"].commands["teamsyncd_timer"], ["0"], obj=obj)
         print(result.exit_code)
         print(result.output)
@@ -1700,7 +1718,7 @@ class TestConfigWarmRestart(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     def test_warm_restart_bgp_eoiu_yang_validation(self):
-        config.ADHOC_VALIDATION = True
+        config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1723,11 +1723,9 @@ class TestConfigCableLength(object):
         import config.main
         importlib.reload(config.main)
 
-    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.main.is_dynamic_buffer_enabled", mock.Mock(return_value=True))
-    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value=False))
-    def test_add_cablelength_with_invalid_name_valid_length_yang_validation(self):
+    def test_add_cablelength_with_nonexistent_name_valid_length(self):
         config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
@@ -1756,11 +1754,9 @@ class TestConfigCableLength(object):
         assert result.exit_code != 0
         assert "Invalid ConfigDB. Error" in result.output
     
-    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
-    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
     @patch("config.main.is_dynamic_buffer_enabled", mock.Mock(return_value=True))
-    def test_add_cablelength_with_invalid_name_invalid_length_yang_validation(self):
+    def test_add_cablelength_with_invalid_name_invalid_length(self):
         config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
@@ -1771,7 +1767,6 @@ class TestConfigCableLength(object):
         print(result.output)
         assert result.exit_code != 0
         assert "Invalid cable length" in result.output
-
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1651,6 +1651,12 @@ class TestConfigWarmRestart(object):
         assert result.exit_code != 0
         assert "Invalid ConfigDB. Error" in result.output
 
+        result = runner.invoke(config.config.commands["warm_restart"].commands["neighsyncd_timer"], ["0"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "neighsyncd warm restart timer must be in range 1-9999" in result.output
+    
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     def test_warm_restart_bgp_timer_yang_validation(self):
@@ -1665,6 +1671,12 @@ class TestConfigWarmRestart(object):
         assert result.exit_code != 0
         assert "Invalid ConfigDB. Error" in result.output
 
+        result = runner.invoke(config.config.commands["warm_restart"].commands["bgp_timer"], ["0"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "bgp warm restart timer must be in range 1-3600" in result.output
+    
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     def test_warm_restart_teamsyncd_timer_yang_validation(self):
@@ -1679,6 +1691,12 @@ class TestConfigWarmRestart(object):
         assert result.exit_code != 0
         assert "Invalid ConfigDB. Error" in result.output
 
+        result = runner.invoke(config.config.commands["warm_restart"].commands["teamsyncd_timer"], ["0"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "teamsyncd warm restart timer must be in range 1-3600" in result.output
+    
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     def test_warm_restart_bgp_eoiu_yang_validation(self):
@@ -1706,13 +1724,14 @@ class TestConfigCableLength(object):
         importlib.reload(config.main)
 
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.main.is_dynamic_buffer_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
-    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value=None))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value=False))
     def test_add_cablelength_with_invalid_name_valid_length_yang_validation(self):
         config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db':db.cfgdb}
 
         result = runner.invoke(config.config.commands["interface"].commands["cable-length"], ["Ethernet0","40m"], obj=obj)
         print(result.exit_code)
@@ -1723,28 +1742,36 @@ class TestConfigCableLength(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
-    def test_add_cablelength_with_invalid_name_valid_length_yang_validation(self):
-        config.ADHOC_VALIDATION = True
-        runner = CliRunner()
-        db = Db()
-        obj = {'db':db.cfgdb}
-
-        result = runner.invoke(config.config.commands["interface"].commands["cable-length"], ["Ethernet0","40x"], obj=obj)
-        print(result.exit_code)
-        assert result.exit_code != 0
-
-    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
-    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
-    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
+    @patch("config.main.is_dynamic_buffer_enabled", mock.Mock(return_value=True))
+    @patch("config.main.ConfigDBConnector.get_keys", mock.Mock(return_value=["sample_key"]))
     def test_add_cablelength_invalid_yang_validation(self):
-        config.ADHOC_VALIDATION = True
+        config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db':db.cfgdb}
 
         result = runner.invoke(config.config.commands["interface"].commands["cable-length"], ["Ethernet0","40"], obj=obj)
         print(result.exit_code)
+        print(result.output)
         assert result.exit_code != 0
+        assert "Invalid ConfigDB. Error" in result.output
+    
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
+    @patch("config.main.is_dynamic_buffer_enabled", mock.Mock(return_value=True))
+    def test_add_cablelength_with_invalid_name_invalid_length_yang_validation(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["interface"].commands["cable-length"], ["Ethernet0","40x"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid cable length" in result.output
+
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1698,6 +1698,62 @@ class TestConfigWarmRestart(object):
         print("TEARDOWN")
 
 
+class TestConfigCableLength(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        import config.main
+        importlib.reload(config.main)
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value=None))
+    def test_add_loopback_with_invalid_name_valid_length_yang_validation(self):
+        config.ADHOC_VALIDATION = TRUE
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["interface"].commands["cable_length"], ["Ethernet0","40m"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Port Ethernet0 doesn't exist" in result.output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
+    def test_add_loopback_with_invalid_name_valid_length_yang_validation(self):
+        config.ADHOC_VALIDATION = TRUE
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["interface"].commands["cable_length"], ["Ethernet0","40x"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid cable length" in result.output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
+    def test_add_loopback_invalid_yang_validation(self):
+        config.ADHOC_VALIDATION = TRUE
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["interface"].commands["cable_length"], ["Ethernet0","40x"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output 
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+
+
 class TestConfigLoopback(object):
     @classmethod
     def setup_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1714,7 +1714,7 @@ class TestConfigCableLength(object):
         db = Db()
         obj = {'db':db.cfgdb}
 
-        result = runner.invoke(config.config.commands["interface"].commands["cable_length"], ["Ethernet0","40m"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["cable-length"], ["Ethernet0","40m"], obj=obj)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code != 0
@@ -1724,16 +1724,14 @@ class TestConfigCableLength(object):
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
     def test_add_cablelength_with_invalid_name_valid_length_yang_validation(self):
-        config.ADHOC_VALIDATION = TRUE
+        config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
 
-        result = runner.invoke(config.config.commands["interface"].commands["cable_length"], ["Ethernet0","40x"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["cable-length"], ["Ethernet0","40x"], obj=obj)
         print(result.exit_code)
-        print(result.output)
         assert result.exit_code != 0
-        assert "Invalid cable length" in result.output
 
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
@@ -1744,10 +1742,9 @@ class TestConfigCableLength(object):
         db = Db()
         obj = {'db':db.cfgdb}
 
-        result = runner.invoke(config.config.commands["interface"].commands["cable_length"], ["Ethernet0","40x"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["cable-length"], ["Ethernet0","40"], obj=obj)
         print(result.exit_code)
-        print(result.output)
-        assert "Invalid ConfigDB. Error" in result.output 
+        assert result.exit_code != 0
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1630,6 +1630,74 @@ class TestConfigHostname(object):
         print("TEARDOWN")
 
 
+class TestConfigWarmRestart(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        import config.main
+        importlib.reload(config.main)
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_warm_restart_neighsyncd_timer_yang_validation(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["warm_restart"].commands["neighsyncd_timer"], ["2000"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid ConfigDB. Error" in result.output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_warm_restart_bgp_timer_yang_validation(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["warm_restart"].commands["bgp_timer"], ["2000"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid ConfigDB. Error" in result.output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_warm_restart_teamsyncd_timer_yang_validation(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["warm_restart"].commands["teamsyncd_timer"], ["2000"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid ConfigDB. Error" in result.output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_warm_restart_bgp_eoiu_yang_validation(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["warm_restart"].commands["bgp_eoiu"], ["true"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid ConfigDB. Error" in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+
+
 class TestConfigLoopback(object):
     @classmethod
     def setup_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1708,8 +1708,8 @@ class TestConfigCableLength(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value=None))
-    def test_add_loopback_with_invalid_name_valid_length_yang_validation(self):
-        config.ADHOC_VALIDATION = TRUE
+    def test_add_cablelength_with_invalid_name_valid_length_yang_validation(self):
+        config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
@@ -1723,7 +1723,7 @@ class TestConfigCableLength(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
-    def test_add_loopback_with_invalid_name_valid_length_yang_validation(self):
+    def test_add_cablelength_with_invalid_name_valid_length_yang_validation(self):
         config.ADHOC_VALIDATION = TRUE
         runner = CliRunner()
         db = Db()
@@ -1738,8 +1738,8 @@ class TestConfigCableLength(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Port Info"))
-    def test_add_loopback_invalid_yang_validation(self):
-        config.ADHOC_VALIDATION = TRUE
+    def test_add_cablelength_invalid_yang_validation(self):
+        config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -296,6 +296,7 @@ class TestConfigIP(object):
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.main.is_vrf_exists", mock.Mock(return_value=True))
     @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value={"mgmtVrfEnabled": "true"}))
     def test_del_vrf_invalid_configdb_yang_validation(self):
         runner = CliRunner()

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -6,6 +6,7 @@ from unittest import mock
 from mock import patch
 
 from click.testing import CliRunner
+from jsonpatch import JsonPatchConflict
 
 import config.main as config
 import show.main as show
@@ -271,21 +272,48 @@ class TestConfigIP(object):
         print(result.exit_code, result.output)
         assert result.exit_code == 0
 
-    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(return_value=True))
-    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(side_effect=ValueError))
-    def test_intf_unknown_vrf_bind_yang_validation(self):
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value={"mgmtVrfEnabled": "false"}))
+    def test_add_vrf_invalid_configdb_yang_validation(self):
         runner = CliRunner()
         db = Db()
         obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
         
         result = runner.invoke(config.config.commands["vrf"].commands["add"], ["mgmt"], obj=obj)
         print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
         assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["vrf"].commands["add"], ["Vrf01"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+        assert result.exit_code != 0
+    
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value={"mgmtVrfEnabled": "true"}))
+    def test_del_vrf_invalid_configdb_yang_validation(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb, 'namespace':db.db.namespace}
 
         result = runner.invoke(config.config.commands["vrf"].commands["del"], ["mgmt"], obj=obj)
         print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
         assert result.exit_code != 0 
 
+        result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf01"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+        assert result.exit_code != 0
+    
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -68,7 +68,7 @@ class TestShowSflow(object):
         runner = CliRunner()
         obj = {'db':db.cfgdb}
 
-        result = runner.invoke(config.config.commands["sflow"].commands["disable"], [], obj=obj)
+        result = runner.invoke(config.config.commands["sflow"].commands["enable"], [], obj=obj)
         print(result.exit_code, result.output)
         assert "Invalid ConfigDB. Error" in result.output
 

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -5,9 +5,11 @@ from unittest import mock
 
 from click.testing import CliRunner
 from utilities_common.db import Db
+from mock import patch
 
 import show.main as show
 import config.main as config
+import config.validated_config_db_connector as validated_config_db_connector
 
 config.asic_type = mock.MagicMock(return_value = "broadcom")
 
@@ -58,6 +60,21 @@ class TestShowSflow(object):
         print(result.exit_code, result.output)
         assert result.exit_code == 0
         assert result.output == show_sflow_intf_output
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_config_sflow_disable_enable_yang_validation(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        result = runner.invoke(config.config.commands["sflow"].commands["disable"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
+        result = runner.invoke(config.config.commands["sflow"].commands["disable"], [], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Invalid ConfigDB. Error" in result.output
 
     def test_config_sflow_disable_enable(self):
         # config sflow <enable|disable>
@@ -176,11 +193,31 @@ class TestShowSflow(object):
         assert result.output == show_sflow_output
 
         return
+    
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_config_sflow_polling_interval_yang_validation(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+
+        config.ADHOC_VALIDATION = False
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["polling-interval"], ["500"], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Invalid ConfigDB. Error" in result.output
 
     def test_config_sflow_polling_interval(self):
         db = Db()
         runner = CliRunner()
         obj = {'db':db.cfgdb}
+        config.ADHOC_VALIDATION = True
+
+        # set to 500 out of range
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["polling-interval"], ["500"], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Polling interval must be between 5-300" in result.output
 
         # set to 20
         result = runner.invoke(config.config.commands["sflow"].
@@ -208,10 +245,38 @@ class TestShowSflow(object):
 
         return
 
+    @patch("config.main.ConfigDBConnector.get_table", mock.Mock(return_value={'Ethernet1': {'admin_state': 'sample_state'}}))
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_config_sflow_existing_intf_enable_yang_validation(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+        config.ADHOC_VALIDATION = False
+
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["interface"].commands["enable"], ["Ethernet1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+    
+    @patch("config.main.ConfigDBConnector.get_table", mock.Mock(return_value=None))
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry", mock.Mock(side_effect=ValueError))
+    def test_config_sflow_nonexistent_intf_enable_yang_validation(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'db':db.cfgdb}
+ 
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["interface"].commands["enable"], ["Ethernet1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
     def test_config_sflow_intf_enable_disable(self):
         db = Db()
         runner = CliRunner()
         obj = {'db':db.cfgdb}
+        config.ADHOC_VALIDATION = True
 
         # mock interface_name_is_valid
         config.interface_name_is_valid = mock.MagicMock(return_value = True)
@@ -236,6 +301,17 @@ class TestShowSflow(object):
         # verify in configDb
         sflowSession = db.cfgdb.get_table('SFLOW_SESSION')
         assert sflowSession["Ethernet1"]["admin_state"] == "down"
+
+        config.interface_name_is_valid = mock.MagicMock(return_value = False)
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["interface"].commands["enable"], ["Ethernetx"], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Invalid interface name" in result.output
+
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["interface"].commands["disable"], ["Ethernetx"], obj=obj)
+        print(result.exit_code, result.output)
+        assert "Invalid interface name" in result.output
 
         return
 

--- a/tests/vxlan_test.py
+++ b/tests/vxlan_test.py
@@ -3,8 +3,11 @@ import traceback
 from unittest import mock
 
 from click.testing import CliRunner
+from mock import patch
+from jsonpatch import JsonPatchConflict
 
 import config.main as config
+import config.validated_config_db_connector as validated_config_db_connector
 import show.main as show
 from utilities_common.db import Db
 from .mock_tables import dbconnector
@@ -214,6 +217,34 @@ class TestVxlan(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_vxlan_remotevni_specific_cnt_output
+    
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.main.ConfigDBConnector.get_entry", mock.Mock(return_value="Vlan Data"))
+    @patch("config.main.ConfigDBConnector.get_table", mock.Mock(return_value={'sample_key': 'sample_value'}))
+    def test_config_vxlan_add_yang_validation(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["map_range"].commands["del"], ["vtep1", "100", "102", "100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["map_range"].commands["add"], ["vtep1", "100", "102", "100"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
+    def test_config_vxlan_add_yang_validation_json_error(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["map"].commands["del"], ["vtep1", "200", "200"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
 
     def test_config_vxlan_add(self):
         runner = CliRunner()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
-Add YANG validation using GCU for writes to WARM_RESTART, SFLOW_SESSION, SFLOW, VXLAN_TUNNEL, VXLAN_EVPN_NVO, VXLAN_TUNNEL_MAP, MGMT_VRF_CONFIG, CABLE_LENGTH, VRF tables  in ConfigDB

#### How I did it
Using same method as https://github.com/sonic-net/sonic-utilities/pull/2190/files, extend to WARM_RESTART, SFLOW_SESSION, SFLOW, VXLAN_TUNNEL, VXLAN_EVPN_NVO, VXLAN_TUNNEL_MAP, MGMT_VRF_CONFIG, CABLE_LENGTH, VRF tables use cases
#### How to verify it
Verified testing CLI on virtual switch

