### PR TITLE
Add "show fabric reachability" command.

### DIFF
--- a/scripts/fabricstat
+++ b/scripts/fabricstat
@@ -178,6 +178,33 @@ class FabricQueueStat(FabricStat):
         print(tabulate(table, queuestat_header, tablefmt='simple', stralign='right'))
         print()
 
+class FabricReachability(FabricStat):
+    def reachability_print(self):
+        # Connect to database
+        self.db = multi_asic.connect_to_all_dbs_for_ns(self.namespace)
+        # Get the set of all fabric port keys
+        port_keys = self.db.keys(self.db.STATE_DB, FABRIC_PORT_STATUS_TABLE_PREFIX + '*')
+        # Create a new dictionary. The key values are the local port values
+        # in integer format. Only ports that have remote port data are added.
+        # Only ports that are "up" will be connected to a remote peer.
+        port_dict = {}
+        for port_key in port_keys:
+           port_data = self.db.get_all(self.db.STATE_DB, port_key)
+           if "REMOTE_PORT" in port_data:
+              port_number = int(port_key.replace("FABRIC_PORT_TABLE|PORT", ""))
+              port_dict.update({port_number: port_data})
+        # Create ordered table of port data
+        header = ["Local Link", "Remote Module", "Remote Link", "Status"]
+        body = []
+        for port_number in sorted(port_dict.keys()):
+              port_data = port_dict[port_number]
+              body.append((port_number, port_data["REMOTE_MOD"], \
+                           port_data["REMOTE_PORT"], port_data["STATUS"]))
+        if self.namespace:
+           print(f"\n{self.namespace}")
+        print(tabulate(body, header, tablefmt='simple', stralign='right'))
+        return
+
 def main():
     parser  = argparse.ArgumentParser(description='Display the fabric port state and counters',
                                       formatter_class=argparse.RawTextHelpFormatter,
@@ -191,16 +218,25 @@ Examples:
 """)
 
     parser.add_argument('-q','--queue', action='store_true', help='Display fabric queue stat, otherwise port stat')
+    parser.add_argument('-r','--reachability', action='store_true', help='Display reachability, otherwise port stat')
     parser.add_argument('-n','--namespace', default=None, help='Display fabric ports counters for specific namespace')
     parser.add_argument('-e', '--errors', action='store_true', help='Display errors')
 
     args = parser.parse_args()
     queue = args.queue
+    reachability = args.reachability
     namespace = args.namespace
     errors_only = args.errors
 
     def nsStat(ns, errors_only):
-        stat = FabricQueueStat(ns) if queue else FabricPortStat(ns)
+        if queue:
+           stat = FabricQueueStat(ns)
+        elif reachability:
+           stat = FabricReachability(ns)
+           stat.reachability_print()
+           return
+        else:
+           stat = FabricPortStat(ns)
         cnstat_dict = stat.get_cnstat_dict()
         stat.cnstat_print(cnstat_dict, errors_only)
 

--- a/show/fabric.py
+++ b/show/fabric.py
@@ -13,6 +13,18 @@ def counters():
     """Show fabric port counters"""
     pass
 
+@fabric.group(invoke_without_command=True)
+@multi_asic_util.multi_asic_click_option_namespace
+@click.option('-e', '--errors', is_flag=True)
+def reachability(namespace, errors):
+    """Show fabric reachability"""
+    cmd = "fabricstat -r"
+    if namespace is not None:
+        cmd += " -n {}".format(namespace)
+    if errors:
+        cmd += " -e"
+    clicommon.run_command(cmd)
+
 @counters.command()
 @multi_asic_util.multi_asic_click_option_namespace
 @click.option('-e', '--errors', is_flag=True)

--- a/tests/fabricstat_test.py
+++ b/tests/fabricstat_test.py
@@ -90,6 +90,36 @@ multi_asic_fabric_counters_queue_asic0 = """\
 
 """
 
+multi_asic_fabric_reachability = """\
+
+asic0
+  Local Link    Remote Module    Remote Link    Status
+------------  ---------------  -------------  --------
+           0                0             79        up
+           2                0             94        up
+           4                0             85        up
+           6                0             84        up
+           7                0             93        up
+
+asic1
+  Local Link    Remote Module    Remote Link    Status
+------------  ---------------  -------------  --------
+           0                0             69        up
+           4                0             75        up
+"""
+
+multi_asic_fabric_reachability_asic0 = """\
+
+asic0
+  Local Link    Remote Module    Remote Link    Status
+------------  ---------------  -------------  --------
+           0                0             79        up
+           2                0             94        up
+           4                0             85        up
+           6                0             84        up
+           7                0             93        up
+"""
+
 class TestMultiAsicFabricStat(object):
     @classmethod
     def setup_class(cls):
@@ -132,6 +162,20 @@ class TestMultiAsicFabricStat(object):
         print("result = {}".format(result))
         assert return_code == 0
         assert result == multi_asic_fabric_counters_queue_asic0
+
+    def test_multi_show_fabric_reachability(self):
+        return_code, result = get_result_and_return_code('fabricstat -r')
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == multi_asic_fabric_reachability
+
+    def test_multi_show_fabric_reachability_asic(self):
+        return_code, result = get_result_and_return_code('fabricstat -r -n asic0')
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == multi_asic_fabric_reachability_asic0
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added "show fabric reachability" command. 

The output of this command :

```# show fabric reachability
  Local Link    Remote Module    Remote Link    Status
------------  ---------------  -------------  --------
           0              304            171        up
           1              304            156        up
           2              304            147        up

```

Added test for the change at tests/fabricstat_test.py. The test is at https://github.com/sonic-net/sonic-mgmt/pull/6620/ 

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

