### PR TITLE
sonic-utilities: Update config reload() to verify formatting of an input file

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1182,7 +1182,6 @@ def validate_config_file(file):
                     fg='magenta')
         sys.exit(1)
 
-
 # This is our main entrypoint - the main 'config' command
 @click.group(cls=clicommon.AbbreviationGroup, context_settings=CONTEXT_SETTINGS)
 @click.pass_context
@@ -1605,10 +1604,6 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
         log.log_info("'reload' stopping services...")
         _stop_services()
 
-    # In Single ASIC platforms we have single DB service. In multi-ASIC platforms we have a global DB
-    # service running in the host + DB services running in each ASIC namespace created per ASIC.
-    # In the below logic, we get all namespaces in this platform and add an empty namespace ''
-    # denoting the current namespace which we are in ( the linux host )
     for file, namespace, file_exists in cfg_file_dict.values():
         if not file_exists:
             click.echo("The config file {} doesn't exist".format(file))

--- a/config/main.py
+++ b/config/main.py
@@ -1567,7 +1567,12 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             else:
                 file = DEFAULT_CONFIG_YANG_FILE
 
-        # Check the file is properly formatted before proceeding.  
+        # Check if the file exists before proceeding
+        # Instead of exiting, skip the current namespace and check the next one
+        if not os.path.exists(file):
+            continue
+
+        # Check the file is properly formatted before proceeding.
         try:
             # Load golden config json
             read_json_file(file)

--- a/config/main.py
+++ b/config/main.py
@@ -1547,6 +1547,15 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
         if len(cfg_files) != num_cfg_file:
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
+        
+        # Check if the file is properly formatted before proceeding.  
+        for file in cfg_files:
+            try:
+                config_input = read_json_file(file)
+            except Exception as e:
+                click.secho("Bad format: json file broken. {}".format(str(e)),
+                            fg='magenta')
+                sys.exit(1)
 
     #Stop services before config push
     if not no_service_restart:

--- a/config/main.py
+++ b/config/main.py
@@ -1551,7 +1551,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
         # Check if the file is properly formatted before proceeding.  
         for file in cfg_files:
             try:
-                config_input = read_json_file(file)
+                read_json_file(file)
             except Exception as e:
                 click.secho("Bad format: json file broken. {}".format(str(e)),
                             fg='magenta')

--- a/tests/config_reload_input/config_db_invalid.json
+++ b/tests/config_reload_input/config_db_invalid.json
@@ -1,0 +1,62 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "docker_routing_config_mode": "split",
+            "hostname": "sonic",
+            "hwsku": "Seastone-DX010-25-50",
+            "mac": "00:e0:ec:89:6e:48",
+            "platform": "x86_64-cel_seastone-r0",
+            "type": "ToRRouter"
+        }
+    }
+    "VLAN_MEMBER": {
+        "Vlan1000|Ethernet0": {
+            "tagging_mode": "untagged",
+        },
+        "Vlan1000|Ethernet4": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet8": {
+            "tagging_mode": "untagged"
+        }
+    },
+    "VLAN": {
+        "Vlan1000": {
+            "vlanid": "1000",
+            "dhcp_servers": [
+                "192.0.0.1",
+                "192.0.0.2",
+                "192.0.0.3",
+                "192.0.0.4"
+            ]
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "Eth1",
+            "lanes": "65, 66, 67, 68",
+            "description": "Ethernet0 100G link",
+            "speed": "100000"
+        },
+        "Ethernet4": {
+            "admin_status": "up",
+            "alias": "fortyGigE0/4",
+            "description": "Servers0:eth0",
+            "index": "1",
+            "lanes": "29,30,31,32",
+            "mtu": "9100",
+            "pfc_asym": "off",
+            "speed": "40000"
+        },
+        "Ethernet8": {
+            "admin_status": "up",
+            "alias": "fortyGigE0/8",
+            "description": "Servers1:eth0",
+            "index": "2",
+            "lanes": "33,34,35,36",
+            "mtu": "9100",
+            "pfc_asym": "off",
+            "speed": "40000"
+        }
+    }
+}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4,6 +4,7 @@ import os
 import traceback
 import json
 import jsonpatch
+import shutil
 import sys
 import unittest
 import ipaddress
@@ -88,6 +89,10 @@ Restarting SONiC target ...
 Reloading Monit configuration ...
 """
 
+RELOAD_CONFIG_DB_OUTPUT_INVALID = """\
+Bad format: json file broken. Expecting ',' delimiter: line 12 column 5 (char 321)
+"""
+
 RELOAD_YANG_CFG_OUTPUT = """\
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen  -Y /tmp/config.json  --write-to-db
@@ -102,6 +107,10 @@ Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  -n asic0  --w
 Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  -n asic1  --write-to-db
 Restarting SONiC target ...
 Reloading Monit configuration ...
+"""
+
+RELOAD_MASIC_CONFIG_DB_OUTPUT_INVALID = """\
+Bad format: json file broken. Expecting ',' delimiter: line 12 column 5 (char 321)
 """
 
 reload_config_with_sys_info_command_output="""\
@@ -195,6 +204,7 @@ sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfg
 
 class TestConfigReload(object):
     dummy_cfg_file = os.path.join(os.sep, "tmp", "config.json")
+    dummy_cfg_file_contents = os.path.join(mock_db_path, "config_db.json")
 
     @classmethod
     def setup_class(cls):
@@ -206,7 +216,8 @@ class TestConfigReload(object):
 
         import config.main
         importlib.reload(config.main)
-        open(cls.dummy_cfg_file, 'w').close()
+        shutil.copyfile(cls.dummy_cfg_file_contents, cls.dummy_cfg_file)
+        open(cls.dummy_cfg_file, 'r').close()
 
     def test_config_reload(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
@@ -479,6 +490,8 @@ class TestLoadMinigraph(object):
 
 class TestReloadConfig(object):
     dummy_cfg_file = os.path.join(os.sep, "tmp", "config.json")
+    dummy_cfg_file_contents = os.path.join(mock_db_path, "config_db.json")
+    dummy_cfg_file_invalid = os.path.join(mock_db_path, "config_db_invalid.json")
 
     @classmethod
     def setup_class(cls):
@@ -486,7 +499,8 @@ class TestReloadConfig(object):
         print("SETUP")
         import config.main
         importlib.reload(config.main)
-        open(cls.dummy_cfg_file, 'w').close()
+        shutil.copyfile(cls.dummy_cfg_file_contents, cls.dummy_cfg_file)
+        open(cls.dummy_cfg_file, 'r').close()
 
     def test_reload_config(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
@@ -506,6 +520,25 @@ class TestReloadConfig(object):
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
                 == RELOAD_CONFIG_DB_OUTPUT
+
+    def test_reload_config_invalid_config_file(self, get_cmd_module, setup_single_broadcom_asic):
+        with mock.patch(
+                "utilities_common.cli.run_command",
+                mock.MagicMock(side_effect=mock_run_command_side_effect)
+        ) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+
+            result = runner.invoke(
+                config.config.commands["reload"],
+                [self.dummy_cfg_file_invalid, '-y', '-f', "--disable_arp_cache"])
+
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code == 1
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
+                == RELOAD_CONFIG_DB_OUTPUT_INVALID
 
     def test_config_reload_disabled_service(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
@@ -548,6 +581,29 @@ class TestReloadConfig(object):
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
                 == RELOAD_MASIC_CONFIG_DB_OUTPUT
+
+    def test_reload_config_masic_invalid(self, get_cmd_module, setup_multi_broadcom_masic):
+        with mock.patch(
+                "utilities_common.cli.run_command",
+                mock.MagicMock(side_effect=mock_run_command_side_effect)
+        ) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            # 3 config files: 1 for host and 2 for asic
+            cfg_files = "{},{},{}".format(
+                            self.dummy_cfg_file,
+                            self.dummy_cfg_file_invalid,
+                            self.dummy_cfg_file)
+            result = runner.invoke(
+                config.config.commands["reload"],
+                [cfg_files, '-y', '-f', "--disable_arp_cache"])
+
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code == 1
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
+                == RELOAD_MASIC_CONFIG_DB_OUTPUT_INVALID
 
     def test_reload_yang_config(self, get_cmd_module,
                                         setup_single_broadcom_asic):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -89,10 +89,11 @@ Restarting SONiC target ...
 Reloading Monit configuration ...
 """
 
-RELOAD_CONFIG_DB_OUTPUT_INVALID = """\
-Bad format: json file '/sonic/src/sonic-utilities/tests/config_reload_input/config_db_invalid.json' broken.
-Expecting ',' delimiter: line 12 column 5 (char 321)
-"""
+RELOAD_CONFIG_DB_OUTPUT_INVALID_MSG = """\
+Bad format: json file"""
+
+RELOAD_CONFIG_DB_OUTPUT_INVALID_ERROR = """\
+Expecting ',' delimiter: line 12 column 5 (char 321)"""
 
 RELOAD_YANG_CFG_OUTPUT = """\
 Stopping SONiC target ...
@@ -534,8 +535,10 @@ class TestReloadConfig(object):
             print(result.output)
             traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 1
-            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
-                == RELOAD_CONFIG_DB_OUTPUT_INVALID
+
+            output = "\n".join([l.rstrip() for l in result.output.split('\n')])
+            assert RELOAD_CONFIG_DB_OUTPUT_INVALID_MSG in output
+            assert RELOAD_CONFIG_DB_OUTPUT_INVALID_ERROR in output
 
     def test_config_reload_disabled_service(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
@@ -599,8 +602,10 @@ class TestReloadConfig(object):
             print(result.output)
             traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 1
-            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
-                == RELOAD_CONFIG_DB_OUTPUT_INVALID
+
+            output = "\n".join([l.rstrip() for l in result.output.split('\n')])
+            assert RELOAD_CONFIG_DB_OUTPUT_INVALID_MSG in output
+            assert RELOAD_CONFIG_DB_OUTPUT_INVALID_ERROR in output
 
     def test_reload_yang_config(self, get_cmd_module,
                                         setup_single_broadcom_asic):
@@ -637,8 +642,10 @@ class TestReloadConfig(object):
             print(result.output)
             traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 1
-            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
-                == RELOAD_CONFIG_DB_OUTPUT_INVALID
+
+            output = "\n".join([l.rstrip() for l in result.output.split('\n')])
+            assert RELOAD_CONFIG_DB_OUTPUT_INVALID_MSG in output
+            assert RELOAD_CONFIG_DB_OUTPUT_INVALID_ERROR in output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -90,7 +90,8 @@ Reloading Monit configuration ...
 """
 
 RELOAD_CONFIG_DB_OUTPUT_INVALID = """\
-Bad format: json file broken. Expecting ',' delimiter: line 12 column 5 (char 321)
+Bad format: json file '/sonic/src/sonic-utilities/tests/config_reload_input/config_db_invalid.json' broken.
+Expecting ',' delimiter: line 12 column 5 (char 321)
 """
 
 RELOAD_YANG_CFG_OUTPUT = """\
@@ -107,10 +108,6 @@ Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  -n asic0  --w
 Running command: /usr/local/bin/sonic-cfggen  -j /tmp/config.json  -n asic1  --write-to-db
 Restarting SONiC target ...
 Reloading Monit configuration ...
-"""
-
-RELOAD_MASIC_CONFIG_DB_OUTPUT_INVALID = """\
-Bad format: json file broken. Expecting ',' delimiter: line 12 column 5 (char 321)
 """
 
 reload_config_with_sys_info_command_output="""\
@@ -603,7 +600,7 @@ class TestReloadConfig(object):
             traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 1
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
-                == RELOAD_MASIC_CONFIG_DB_OUTPUT_INVALID
+                == RELOAD_CONFIG_DB_OUTPUT_INVALID
 
     def test_reload_yang_config(self, get_cmd_module,
                                         setup_single_broadcom_asic):
@@ -623,6 +620,25 @@ class TestReloadConfig(object):
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
                 == RELOAD_YANG_CFG_OUTPUT
+
+    def test_reload_yang_config_invalid(self, get_cmd_module,
+                                        setup_single_broadcom_asic):
+        with mock.patch(
+                "utilities_common.cli.run_command",
+                mock.MagicMock(side_effect=mock_run_command_side_effect)
+        ) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+
+            result = runner.invoke(config.config.commands["reload"],
+                                    [self.dummy_cfg_file_invalid, '-y', '-f', '-t', 'config_yang'])
+
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code == 1
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
+                == RELOAD_CONFIG_DB_OUTPUT_INVALID
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -531,7 +531,7 @@ class TestReloadConfig(object):
 
             result = runner.invoke(
                 config.config.commands["reload"],
-                [self.dummy_cfg_file_invalid, '-y', '-f', "--disable_arp_cache"])
+                [self.dummy_cfg_file_invalid, '-y', '-f'])
 
             print(result.exit_code)
             print(result.output)
@@ -596,7 +596,7 @@ class TestReloadConfig(object):
                             self.dummy_cfg_file)
             result = runner.invoke(
                 config.config.commands["reload"],
-                [cfg_files, '-y', '-f', "--disable_arp_cache"])
+                [cfg_files, '-y', '-f'])
 
             print(result.exit_code)
             print(result.output)


### PR DESCRIPTION
sonic-utilities: bugfix-9499
* Update config/main.py to verify if a config input file is properly formatted before writing it into confib_db
* Update tests/config_test.py to include test cases for invalid input file
* Add tests/config_reload_input/config_db_invalid.json as invalid input file used in tests/config_test.py

Signed-off-by: cchoate54@gmail.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Include a check to validate if all input files are properly formatted before trying to write them to config_db to resolve bug [9499 in sonic-buildimage](https://github.com/sonic-net/sonic-buildimage/issues/9499).

#### How I did it
Include a check to validate if all input files are properly formatted before trying to write them to config_db.

#### How to verify it
Run tests/config_test.py. 
With the change added in main.py, run 'config reload' with an inproperly formatted input file.

#### Previous command output (if the output of a command-line utility has changed)
crystalnet@ibr02:~$ sudo config reload conf_db.json                  
Clear current config and reload config in config_db from the file(s) conf_db.json ? [y/N]: y
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j conf_db.json  --write-to-db
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 452, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 322, in main
    _process_json(args, data)
  File "/usr/local/bin/sonic-cfggen", line 236, in _process_json
    deep_update(data, FormatConverter.to_deserialized(json.load(stream)))
  File "/usr/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 713 column 5 (char 21870)

*Then the terminal becomes unusable until the device is reloaded.
#### New command output (if the output of a command-line utility has changed)
crystalnet@ibr02:~$ sudo config reload conf_db.json 
Clear current config and reload config in config_db from the file(s) conf_db.json ? [y/N]: y
Bad format: json file broken. Expecting ',' delimiter: line 713 column 5 (char 21870)
