### PR TITLE
Add support of secure warm-boot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -608,15 +608,17 @@ if [[ "$sonic_asic_type" == "mellanox" ]]; then
     fi
 fi
 
-# check if secure boot is enable in UEFI 
-SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
 
 if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
     load_aboot_secureboot_kernel
-elif [ ${SECURE_UPGRADE_ENABLED} -eq 1 ]; then
-    load_kernel_secure
 else
-    load_kernel
+    # check if secure boot is enable in UEFI 
+    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
+    if [ ${SECURE_UPGRADE_ENABLED} -eq 1 ]; then
+        load_kernel_secure
+    else
+        load_kernel
+    fi
 fi
 
 init_warm_reboot_states

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -447,6 +447,13 @@ function load_kernel() {
     /sbin/kexec -a -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
 }
 
+function load_kernel_secure() {
+    # Load kernel into the memory secure
+    # -s flag is for enforcing the new load kernel(vmlinuz) to be signed and verify.
+    # not using -a flag, this flag can fallback to an old kexec load that do not support Secure Boot verification
+    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS" -s
+}
+
 function unload_kernel()
 {
     # Unload the previously loaded kernel if any loaded
@@ -597,9 +604,13 @@ if [[ "$sonic_asic_type" == "mellanox" ]]; then
     fi
 fi
 
+# check if secure boot is enable in UEFI 
+SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
 
 if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
     load_aboot_secureboot_kernel
+elif [ ${SECURE_UPGRADE_ENABLED} -eq 1 ]; then
+    load_kernel_secure
 else
     load_kernel
 fi

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -442,16 +442,20 @@ function load_aboot_secureboot_kernel() {
         swipath=$next_image kexec=true loadonly=true ENV_EXTRA_CMDLINE="$BOOT_OPTIONS" bash -
 }
 
+function invoke_kexec() {
+    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS" $@
+}
+
 function load_kernel() {
     # Load kernel into the memory
-    /sbin/kexec -a -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
+    invoke_kexec -a 
 }
 
 function load_kernel_secure() {
     # Load kernel into the memory secure
     # -s flag is for enforcing the new load kernel(vmlinuz) to be signed and verify.
     # not using -a flag, this flag can fallback to an old kexec load that do not support Secure Boot verification
-    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS" -s
+    invoke_kexec -s
 }
 
 function unload_kernel()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support of secure warm-boot to SONiC. 
Basically, warm-boot is supporting to load a new kernel without doing full/cold boot.
That is by loading a new kernel and exec with kexec Linux command. As a result of that, even when the Secure Boot feature is enabled, still a user or a malicious user can load an unsigned kernel, so to avoid that we added the support of the secure warm boot.
More Description about this feature can be found in the Secure Boot HLD: https://github.com/sonic-net/SONiC/pull/1028

#### How I did it
In general, Linux support it, so I enabled this support by doing the follow steps:
1. I added some special flags in Linux Kernel when user build the sonic-buildimage with secure boot feature enabled.
2. I added a flag "-s" to the kexec command
Note: more details in the HLD above.
#### How to verify it
- Good flow
1. manually just install with sonic-installed a new secure image (a SONiC image that was build with Secure Boot flag enabled)
2. after the secure image is installed, do:
`warm-reboot`
3. Check now that the new kernel is really loaded and switched.
- Bad flow:
1. Do the same steps 1-2 as a good flow but with an insecure image (SONiC image that was built without setting Secure Boot enabled)
2. After the insecure image is installed, and triggered warm-boot you should get an error that the new unsigned kernel from the unsecured image was not loaded.

Automation test - TBD

#### Previous command output (if the output of a command-line utility has changed)
no changed
#### New command output (if the output of a command-line utility has changed)
no changed

NOTE:
PR of the Secure Boot [sonic-buildimage]: https://github.com/sonic-net/sonic-buildimage/pull/12692
PR of Secure Boot [sonic-linux-kernel]: https://github.com/sonic-net/sonic-linux-kernel/pull/298
This is an old paper: https://lwn.net/Articles/603116/
but explaining why it's critical to add this support.