### PR TITLE
Transceiver eeprom dom CLI modification to show output from TRANSCEIVER_DOM_THRESHOLD table

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -391,6 +391,7 @@ class SFPShow(object):
                 if dump_dom:
                     sfp_type = sfp_info_dict['type']
                     dom_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_SENSOR|{}'.format(interface_name))
+                    dom_info_dict.update(state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_THRESHOLD|{}'.format(interface_name)))
                     dom_output = self.convert_dom_to_output_string(sfp_type, dom_info_dict)
                     output += dom_output
         else:

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -31,7 +31,9 @@
         "tx1power": "N/A",
         "tx2power": "N/A",
         "tx3power": "N/A",
-        "tx4power": "N/A",
+        "tx4power": "N/A"
+    },
+    "TRANSCEIVER_DOM_THRESHOLD|Ethernet0": {
         "rxpowerhighalarm": "3.4001",
         "rxpowerhighwarning": "2.4000",
         "rxpowerlowalarm": "-13.5067",

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -31,7 +31,9 @@
         "tx1power": "N/A",
         "tx2power": "N/A",
         "tx3power": "N/A",
-        "tx4power": "N/A",
+        "tx4power": "N/A"
+    },
+    "TRANSCEIVER_DOM_THRESHOLD|Ethernet64": {
         "rxpowerhighalarm": "3.4001",
         "rxpowerhighwarning": "2.4000",
         "rxpowerlowalarm": "-13.5067",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -49,7 +49,9 @@
         "tx1power": "N/A",
         "tx2power": "N/A",
         "tx3power": "N/A",
-        "tx4power": "N/A",
+        "tx4power": "N/A"
+    },
+    "TRANSCEIVER_DOM_THRESHOLD|Ethernet0": {
         "rxpowerhighalarm": "3.4001",
         "rxpowerhighwarning": "2.4000",
         "rxpowerlowalarm": "-13.5067",
@@ -111,7 +113,9 @@
         "tx5power": "1.175",
         "tx6power": "1.175",
         "tx7power": "1.175",
-        "tx8power": "1.175",
+        "tx8power": "1.175"
+    },
+    "TRANSCEIVER_DOM_THRESHOLD|Ethernet8": {
         "rxpowerhighalarm": "6.9999",
         "rxpowerhighwarning": "4.9999",
         "rxpowerlowalarm": "-11.9044",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is needed along with https://github.com/sonic-net/sonic-platform-daemons/pull/320 to continue supporting "show interface transceiver eeprom \<port\> -d" CLI since [PR#320](https://github.com/sonic-net/sonic-platform-daemons/pull/320) is separating DOM threshold related information in a separate table entry (TRANSCEIVER_DOM_THRESHOLD from TRANSCEIVER_DOM_SENSOR) in state DB.
The change with this PR will ensure that the CLI output remains unchanged until https://github.com/sonic-net/sonic-buildimage/issues/12911 is committed which will all together publish DOM threshold related information in a new CLI.

#### How I did it
dom_info_dict is now populated using information from both TRANSCEIVER_DOM_SENSOR as well as TRANSCEIVER_DOM_THRESHOLD.

#### How to verify it
Please refer to the enclosure attached to https://github.com/sonic-net/sonic-platform-daemons/pull/320

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Signed-off-by: Mihir Patel <patelmi@microsoft.com>