### PR TITLE
[show] Add bgpraw to show run all

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1385,7 +1385,7 @@ def all(verbose):
     """Show full running configuration"""
     cmd = "sonic-cfggen -d --print-data"
     output = json.loads(run_command(cmd, display_cmd=verbose, return_cmd=True))
-    if not multi_asic.is_multi_asic():
+    if 'bgpraw' in output or not multi_asic.is_multi_asic():
         bgpraw_cmd = "sudo {} -c 'show running-config'".format(constants.RVTYSH_COMMAND)
         bgpraw = run_command(bgpraw_cmd, display_cmd=verbose, return_cmd=True)
         output['bgpraw'] = bgpraw

--- a/show/main.py
+++ b/show/main.py
@@ -130,7 +130,7 @@ def run_command(command, display_cmd=False, return_cmd=False):
         sys.exit(rc)
 
 def get_cmd_output(cmd):
-    proc = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
     stdout, stderr = proc.communicate()
     if proc.returncode != 0:
         click.echo("Command failed '{}': {}".format(cmd, stderr))
@@ -1391,7 +1391,7 @@ def runningconfiguration():
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def all(verbose):
     """Show full running configuration"""
-    cmd = "sonic-cfggen -d --print-data"
+    cmd = ['sonic-cfggen', '-d', '--print-data']
     stdout = get_cmd_output(cmd)
 
     try:
@@ -1401,7 +1401,7 @@ def all(verbose):
         raise click.Abort()
 
     if 'bgpraw' in output or not multi_asic.is_multi_asic():
-        bgpraw_cmd = "{} -c 'show running-config'".format(constants.RVTYSH_COMMAND)
+        bgpraw_cmd = [constants.RVTYSH_COMMAND, '-c', 'show running-config']
         bgpraw = get_cmd_output(bgpraw_cmd)
         output['bgpraw'] = bgpraw
     click.echo(json.dumps(output, indent=4))

--- a/show/main.py
+++ b/show/main.py
@@ -19,6 +19,7 @@ from utilities_common.db import Db
 from datetime import datetime
 import utilities_common.constants as constants
 from utilities_common.general import load_db_config
+from json.decoder import JSONDecodeError
 
 # mock the redis for unit test purposes #
 try:
@@ -131,11 +132,7 @@ def run_command(command, display_cmd=False, return_cmd=False):
 
 def get_cmd_output(cmd):
     proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
-    stdout, stderr = proc.communicate()
-    if proc.returncode != 0:
-        click.echo("Command failed '{}': {}".format(cmd, stderr))
-        raise click.Abort()
-    return stdout
+    return proc.communicate()[0]
 
 # Lazy global class instance for SONiC interface name to alias conversion
 iface_alias_converter = lazy_object_proxy.Proxy(lambda: clicommon.InterfaceAliasConverter())
@@ -1396,7 +1393,7 @@ def all(verbose):
 
     try:
         output = json.loads(stdout)
-    except Exception as e:
+    except JSONDecodeError as e:
         click.echo("Failed to load output '{}':{}".format(cmd, e))
         raise click.Abort()
 

--- a/show/main.py
+++ b/show/main.py
@@ -1385,9 +1385,10 @@ def all(verbose):
     """Show full running configuration"""
     cmd = "sonic-cfggen -d --print-data"
     output = json.loads(run_command(cmd, display_cmd=verbose, return_cmd=True))
-    bgpraw_cmd = "vtysh -c 'show running-config'"
-    bgpraw = run_command(bgpraw_cmd, display_cmd=verbose, return_cmd=True)
-    output['bgpraw'] = bgpraw
+    if not multi_asic.is_multi_asic():
+        bgpraw_cmd = "vtysh -c 'show running-config'"
+        bgpraw = run_command(bgpraw_cmd, display_cmd=verbose, return_cmd=True)
+        output['bgpraw'] = bgpraw
     click.echo(json.dumps(output, indent=4))
 
 

--- a/show/main.py
+++ b/show/main.py
@@ -1386,7 +1386,7 @@ def all(verbose):
     cmd = "sonic-cfggen -d --print-data"
     output = json.loads(run_command(cmd, display_cmd=verbose, return_cmd=True))
     if not multi_asic.is_multi_asic():
-        bgpraw_cmd = "vtysh -c 'show running-config'"
+        bgpraw_cmd = "sudo {} -c 'show running-config'".format(constants.RVTYSH_COMMAND)
         bgpraw = run_command(bgpraw_cmd, display_cmd=verbose, return_cmd=True)
         output['bgpraw'] = bgpraw
     click.echo(json.dumps(output, indent=4))

--- a/show/main.py
+++ b/show/main.py
@@ -1384,7 +1384,11 @@ def runningconfiguration():
 def all(verbose):
     """Show full running configuration"""
     cmd = "sonic-cfggen -d --print-data"
-    run_command(cmd, display_cmd=verbose)
+    output = json.loads(run_command(cmd, display_cmd=verbose, return_cmd=True))
+    bgpraw_cmd = "vtysh -c 'show running-config'"
+    bgpraw = run_command(bgpraw_cmd, display_cmd=verbose, return_cmd=True)
+    output['bgpraw'] = bgpraw
+    click.echo(json.dumps(output, indent=4))
 
 
 # 'acl' subcommand ("show runningconfiguration acl")

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -10,29 +10,6 @@ modules_path = os.path.dirname(test_path)
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
-class TestCommonFunc(object):
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
-        os.environ["UTILITIES_UNIT_TESTING"] = "1"
-
-    def test_get_cmd_output(self):
-        with mock.patch('show.main.subprocess.Popen',
-                mock.MagicMock()) as mock_popen:
-            mock_proc = MagicMock()
-            mock_proc.communicate = MagicMock(return_value=(None, None))
-            mock_proc.returncode = 1
-            mock_popen.return_value = mock_proc
-            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
-        assert result.exit_code != 0
-        assert "Aborted" in result.output
-
-    @classmethod
-    def teardown_class(cls):
-        print("TEARDOWN")
-        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
-        os.environ["UTILITIES_UNIT_TESTING"] = "0"
-
 
 class TestShowRunAllCommands(object):
     @classmethod

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -3,12 +3,36 @@ import sys
 import show.main as show
 from click.testing import CliRunner
 from unittest import mock
-from unittest.mock import call
+from unittest.mock import call, MagicMock
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
+
+class TestCommonFunc(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_get_cmd_output(self):
+        with mock.patch('show.main.subprocess.Popen',
+                mock.MagicMock()) as mock_popen:
+            mock_proc = MagicMock()
+            mock_proc.communicate = MagicMock(return_value=(None, None))
+            mock_proc.returncode = 1
+            mock_popen.return_value = mock_proc
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert result.exit_code != 0
+        assert "Aborted" in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
 
 class TestShowRunAllCommands(object):
     @classmethod

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -19,7 +19,15 @@ class TestShowRunAllCommands(object):
 
     def test_show_runningconfiguration_all_json_loads_failure(self):
         def get_cmd_output_side_effect(*args, **kwargs):
-            return ""
+            return "", 0
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert result.exit_code != 0
+
+    def test_show_runningconfiguration_all_get_cmd_ouput_failure(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "{}", 2
         with mock.patch('show.main.get_cmd_output',
                 mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
             result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
@@ -27,7 +35,7 @@ class TestShowRunAllCommands(object):
 
     def test_show_runningconfiguration_all(self):
         def get_cmd_output_side_effect(*args, **kwargs):
-            return "{}"
+            return "{}", 0
         with mock.patch('show.main.get_cmd_output',
                 mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
             result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -56,8 +56,8 @@ class TestShowRunAllCommands(object):
             result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
         assert mock_get_cmd_output.call_count == 2
         assert mock_get_cmd_output.call_args_list == [
-            call('sonic-cfggen -d --print-data'),
-            call("rvtysh -c 'show running-config'")]
+            call(['sonic-cfggen', '-d', '--print-data']),
+            call(['rvtysh', '-c', 'show running-config'])]
 
     @classmethod
     def teardown_class(cls):

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -16,16 +16,24 @@ class TestShowRunAllCommands(object):
         print("SETUP")
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 
-    def test_show_runningconfiguration_all(self):
-        def run_command_side_effect(*args, **kwargs):
-            return "{}"
-        with mock.patch('show.main.run_command',
-                mock.MagicMock(side_effect=run_command_side_effect)) as mock_run_command:
+    def test_show_runningconfiguration_all_json_loads_failure(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return ""
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
             result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
-        assert mock_run_command.call_count == 2
-        assert mock_run_command.call_args_list == [
-            call('sonic-cfggen -d --print-data', display_cmd=False, return_cmd=True),
-            call("sudo rvtysh -c 'show running-config'", display_cmd=False, return_cmd=True)]
+        assert result.exit_code != 0
+
+    def test_show_runningconfiguration_all(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "{}"
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert mock_get_cmd_output.call_count == 2
+        assert mock_get_cmd_output.call_args_list == [
+            call('sonic-cfggen -d --print-data'),
+            call("rvtysh -c 'show running-config'")]
 
     @classmethod
     def teardown_class(cls):

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import show.main as show
+from click.testing import CliRunner
+from unittest import mock
+from unittest.mock import call
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+class TestShowRunAllCommands(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_show_runningconfiguration_all(self):
+        def run_command_side_effect(*args, **kwargs):
+            return "{}"
+        with mock.patch('show.main.run_command',
+                mock.MagicMock(side_effect=run_command_side_effect)) as mock_run_command:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert mock_run_command.call_count == 2
+        assert mock_run_command.call_args_list == [
+            call('sonic-cfggen -d --print-data', display_cmd=False, return_cmd=True),
+            call("sudo rvtysh -c 'show running-config'", display_cmd=False, return_cmd=True)]
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add bgpraw output to `show runningconfiguration all`
```
Requirements:
1. current `show runningconfig` will print all the ConfigDB in a json format, we need to add a new key-value into the json output "bgpraw" with a long string value
2. The long string value should be the output of `vtysh -c "show run"`. It is normally multiline string, may include special characters like \". Need to make sure the escaping properly
3. We do not need to insert the key-value into ConfigDB is not existing there
4. If ConfigDB already has the key-value, we do not need to override it by vtysh command output
5. Not break multi-asic use
```
#### How I did it
Generate bgpraw output then append it to `show runnningconfiguration all`'s output
#### How to verify it
Mannual test
#### Previous command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ show run all
{
    "ACL_TABLE": {
......
    "WRED_PROFILE": {
        "AZURE_LOSSLESS": {
            "ecn": "ecn_all",
            "green_drop_probability": "5",
            "green_max_threshold": "2097152",
            "green_min_threshold": "1048576",
            "red_drop_probability": "5",
            "red_max_threshold": "2097152",
            "red_min_threshold": "1048576",
            "wred_green_enable": "true",
            "wred_red_enable": "true",
            "wred_yellow_enable": "true",
            "yellow_drop_probability": "5",
            "yellow_max_threshold": "2097152",
            "yellow_min_threshold": "1048576"
        }
    }
}
```
#### New command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ show run all
{
    "ACL_TABLE": {
......
    "WRED_PROFILE": {
        "AZURE_LOSSLESS": {
            "ecn": "ecn_all",
            "green_drop_probability": "5",
            "green_max_threshold": "2097152",
            "green_min_threshold": "1048576",
            "red_drop_probability": "5",
            "red_max_threshold": "2097152",
            "red_min_threshold": "1048576",
            "wred_green_enable": "true",
            "wred_red_enable": "true",
            "wred_yellow_enable": "true",
            "yellow_drop_probability": "5",
            "yellow_max_threshold": "2097152",
            "yellow_min_threshold": "1048576"
        }
    },
    "bgpraw": "Building configuration...\n\nCurrent configuration......end\n"
}
```
