### PR TITLE
[db_migrator] Remove import of swsssdk as it is not supported in master

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -8,7 +8,6 @@ import traceback
 import re
 
 from sonic_py_common import device_info, logger
-from swsssdk import ConfigDBConnector, SonicDBConfig
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
 from db_migrator_constants import RESTAPI, TELEMETRY, CONSOLE_SWITCH
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/12955

The cherrypick changes (from 202012 to master) made as part of https://github.com/sonic-net/sonic-utilities/pull/2515
broke the master branch `db_migrator`. The issue is due to an import of `swsssdk` which is no longer available in master image.


#### How I did it
Removed the import statement that came due to cherrypick.


#### How to verify it

Checked on physical device running master image

Without fix:
```
root@str2-acs-12:~# db_migrator.py
Traceback (most recent call last):
  File "/usr/local/bin/db_migrator.py", line 11, in <module>
    from swsssdk import ConfigDBConnector, SonicDBConfig
ModuleNotFoundError: No module named 'swsssdk'
root@str2-acs-12:~# 
```

With fix:
```
root@str2-acs-12:~# db_migrator.py     
version_4_0_0
root@str2-acs-12:~# 
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

