### PR TITLE
[GCU] Prohibit removal of PFC_WD POLL_INTERVAL field

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -47,6 +47,10 @@ class PatchApplier:
         # Generate target config
         self.logger.log_notice("Simulating the target full config after applying the patch.")
         target_config = self.patch_wrapper.simulate_patch(patch, old_config)
+        
+        # Validate all JsonPatch operations on specified fields
+        self.logger.log_notice("Validating all JsonPatch operations are permitted on the specified fields")
+        self.config_wrapper.validate_field_operation(old_config, target_config)
 
         # Validate target config does not have empty tables since they do not show up in ConfigDb
         self.logger.log_notice("Validating target config does not have empty tables, " \

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -149,7 +149,7 @@ class ConfigWrapper:
         # illegal_operations_to_fields_map['remove'] yields a list of fields for which `remove` is an illegal operation 
         illegal_operations_to_fields_map = {'add':[],
                                             'replace': [],
-                                            'remove': ['/PFC_WD/GLOBAL/POLL_INTERVAL']}
+                                            'remove': ['/PFC_WD/GLOBAL/POLL_INTERVAL', '/PFC_WD/GLOBAL']}
         for operation, field_list in illegal_operations_to_fields_map.items():
             for field in field_list:
                 if any(op['op'] == operation and field in op['path'] for op in patch):

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -152,7 +152,7 @@ class ConfigWrapper:
                                             'remove': ['/PFC_WD/GLOBAL/POLL_INTERVAL', '/PFC_WD/GLOBAL']}
         for operation, field_list in illegal_operations_to_fields_map.items():
             for field in field_list:
-                if any(op['op'] == operation and field in op['path'] for op in patch):
+                if any(op['op'] == operation and field == op['path'] for op in patch):
                     raise IllegalPatchOperationError("Given patch operation is invalid. Operation: {} is illegal on field: {}".format(operation, field))
 
     def validate_lanes(self, config_db):

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -16,6 +16,9 @@ SYSLOG_IDENTIFIER = "GenericConfigUpdater"
 class GenericConfigUpdaterError(Exception):
     pass
 
+class IllegalPatchOperationError(ValueError):
+    pass
+
 class EmptyTableError(ValueError):
     pass
 
@@ -135,6 +138,22 @@ class ConfigWrapper:
             return False, ex
 
         return True, None
+
+    def validate_field_operation(self, old_config, target_config):
+        """
+        Some fields in ConfigDB are restricted and may not allow third-party addition, replacement, or removal. 
+        Because YANG only validates state and not transitions, this method helps to JsonPatch operations/transitions for the specified fields. 
+        """
+        patch = jsonpatch.JsonPatch.from_diff(old_config, target_config)
+        
+        # illegal_operations_to_fields_map['remove'] yields a list of fields for which `remove` is an illegal operation 
+        illegal_operations_to_fields_map = {'add':[],
+                                            'replace': [],
+                                            'remove': ['/PFC_WD/GLOBAL/POLL_INTERVAL']}
+        for operation, field_list in illegal_operations_to_fields_map.items():
+            for field in field_list:
+                if any(op['op'] == operation and field in op['path'] for op in patch):
+                    raise IllegalPatchOperationError("Given patch operation is invalid. Operation: {} is illegal on field: {}".format(operation, field))
 
     def validate_lanes(self, config_db):
         if "PORT" not in config_db:

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -57,6 +57,18 @@ class TestConfigWrapper(unittest.TestCase):
         self.config_wrapper_mock = gu_common.ConfigWrapper()
         self.config_wrapper_mock.get_config_db_as_json=MagicMock(return_value=Files.CONFIG_DB_AS_JSON)
 
+    def test_validate_field_operation_legal(self):
+        old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
+        target_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "40"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+    
+    def test_validate_field_operation_illegal(self):
+        old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": 60}}}
+        target_config = {"PFC_WD": {"GLOBAL": {}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
+
     def test_ctor__default_values_set(self):
         config_wrapper = gu_common.ConfigWrapper()
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
-Add new infrastructure to GCU for validation of moves that YANG models are unable to capture
-Prohibit deletion of PFC_WD POLL_INTERVAL field

#### How I did it
- Ensure JSON Diff does not have POLL_INTERVAL deletion
- If diff reflects request for POLL_INTERVAL deletion, raise an Exception and do not allow patch application to go through

#### How to verify it
Attempt to delete POLL_INTERVAL field using GCU

Please note that this is different than the create-only extension, which is described here: https://github.com/sonic-net/SONiC/blob/master/doc/config-generic-update-rollback/Json_Patch_Ordering_using_YANG_Models_Design.md#313-using-yang-models-to-host-flags-for-move-validation
create-only is programmed as a MoveValidator in GCU, but that is different than the use case necessary for this PR. We don't want to validate each intermediate move to get to the final state, as is done by MoveValidators- we just need to validate the initial request. Additionally, MoveValidators continue searching for a different move that is 'valid' if it finds one invalid - possibly by deleting the parent and then readding other children. This is not the behavior we desire. We only need a check of the initial request (reflected in Json diff).  

#### Previous command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ sudo config apply-patch patch.json
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating all JsonPatch operations are permitted on the specified fields
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Patch Applier: The patch was sorted into 1 change:
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Applying 1 change in order:
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.
```
#### New command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ sudo config apply-patch patch.json
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating all JsonPatch operations are permitted on the specified fields
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Given patch operation is invalid. Operation: remove is illegal on field: /PFC_WD/GLOBAL/POLL_INTERVAL
```
