### PR TITLE
[muxcable][show] update `show mux tunnel-route` to separate ASIC and kernel into two columns

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -559,24 +559,31 @@ def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_a
         dest_address = mux_cfg_dict.get(name, None)
 
         if dest_address is not None:
-            route_keys = per_npu_appl_db[asic_id].keys(
+            kernel_route_keys = per_npu_appl_db[asic_id].keys(
                 per_npu_appl_db[asic_id].APPL_DB, 'TUNNEL_ROUTE_TABLE:*{}'.format(dest_address))
-            
-            if route_keys is not None and len(route_keys):
+            if_kernel_tunnel_route_programed = kernel_route_keys is not None and len(kernel_route_keys)
 
+            asic_route_keys = per_npu_asic_db[asic_id].keys(
+                per_npu_asic_db[asic_id].ASIC_DB, 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:*{}*'.format(dest_address))
+            if_asic_tunnel_route_programed = asic_route_keys is not None and len(asic_route_keys)
+
+            if if_kernel_tunnel_route_programed or if_asic_tunnel_route_programed:
                 port_tunnel_route["TUNNEL_ROUTE"][port] = port_tunnel_route["TUNNEL_ROUTE"].get(port, {})
                 port_tunnel_route["TUNNEL_ROUTE"][port][name] = {}
                 port_tunnel_route["TUNNEL_ROUTE"][port][name]['DEST'] = dest_address
 
-def create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_id, port):
+                port_tunnel_route["TUNNEL_ROUTE"][port][name]['kernel'] = if_kernel_tunnel_route_programed
+                port_tunnel_route["TUNNEL_ROUTE"][port][name]['asic'] = if_asic_tunnel_route_programed
 
-    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db,  asic_id, port)
+def create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port):
 
-def create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, asic_id, port):
+    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port)
+
+def create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port):
 
     port_tunnel_route = {}
     port_tunnel_route["TUNNEL_ROUTE"] = {}
-    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db,  asic_id, port)
+    get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port)
 
     for port, route in port_tunnel_route["TUNNEL_ROUTE"].items():
         for dest_name, values in route.items():
@@ -584,6 +591,8 @@ def create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, pe
             print_line.append(port)
             print_line.append(dest_name)
             print_line.append(values['DEST'])
+            print_line.append('added' if values['asic'] else '-')
+            print_line.append('added' if values['kernel'] else '-')
             print_data.append(print_line)
 
 @muxcable.command()
@@ -1904,6 +1913,7 @@ def tunnel_route(db, port, json_output):
     port = platform_sfputil_helper.get_interface_name(port, db)
 
     per_npu_appl_db = {}
+    per_npu_asic_db = {}
     per_npu_configdb = {}
     mux_tbl_keys = {}
 
@@ -1913,6 +1923,9 @@ def tunnel_route(db, port, json_output):
 
         per_npu_appl_db[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         per_npu_appl_db[asic_id].connect(per_npu_appl_db[asic_id].APPL_DB)
+
+        per_npu_asic_db[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        per_npu_asic_db[asic_id].connect(per_npu_asic_db[asic_id].ASIC_DB)
 
         per_npu_configdb[asic_id] = swsscommon.SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         per_npu_configdb[asic_id].connect(per_npu_configdb[asic_id].CONFIG_DB) 
@@ -1947,14 +1960,14 @@ def tunnel_route(db, port, json_output):
                 port_tunnel_route = {}
                 port_tunnel_route["TUNNEL_ROUTE"] = {}
 
-                create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_index, port)
+                create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_index, port)
 
                 click.echo("{}".format(json.dumps(port_tunnel_route, indent=4)))
 
             else:
                 print_data = []
 
-                create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, asic_index, port)
+                create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_index, port)
 
                 headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
 
@@ -1972,7 +1985,7 @@ def tunnel_route(db, port, json_output):
                 for key in natsorted(mux_tbl_keys[asic_id]):
                     port = key.split("|")[1]
 
-                    create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_id, port)
+                    create_json_dump_per_port_tunnel_route(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port)
             
             click.echo("{}".format(json.dumps(port_tunnel_route, indent=4)))
         else:
@@ -1983,7 +1996,7 @@ def tunnel_route(db, port, json_output):
                 for key in natsorted(mux_tbl_keys[asic_id]):
                     port = key.split("|")[1]
             
-                    create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, asic_id, port)
+                    create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port)
 
             headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -549,7 +549,7 @@ def create_json_dump_per_port_config(db, port_status_dict, per_npu_configdb, asi
     if soc_ipv4_value is not None:
         port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["soc_ipv4"] = soc_ipv4_value
 
-def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, asic_id, port):
+def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port):
 
     mux_cfg_dict = per_npu_configdb[asic_id].get_all(
     per_npu_configdb[asic_id].CONFIG_DB, 'MUX_CABLE|{}'.format(port))
@@ -591,8 +591,8 @@ def create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, pe
             print_line.append(port)
             print_line.append(dest_name)
             print_line.append(values['DEST'])
-            print_line.append('added' if values['asic'] else '-')
             print_line.append('added' if values['kernel'] else '-')
+            print_line.append('added' if values['asic'] else '-')
             print_data.append(print_line)
 
 @muxcable.command()
@@ -1969,7 +1969,7 @@ def tunnel_route(db, port, json_output):
 
                 create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_index, port)
 
-                headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
+                headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS', 'kernel', 'asic']
 
                 click.echo(tabulate(print_data, headers=headers))
         else:
@@ -1998,7 +1998,7 @@ def tunnel_route(db, port, json_output):
             
                     create_table_dump_per_port_tunnel_route(db, print_data, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port)
 
-            headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS']
+            headers = ['PORT', 'DEST_TYPE', 'DEST_ADDRESS', 'kernel', 'asic']
 
             click.echo(tabulate(print_data, headers=headers))
 

--- a/tests/mock_tables/asic_db.json
+++ b/tests/mock_tables/asic_db.json
@@ -19,5 +19,9 @@
      "VIDTORID":{
      		"oid:0xd00000000056d": "oid:0xd",
 		"oid:0x10000000004a4": "oid:0x1690000000001"
-     }
+     },
+     "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.2.1.1\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x300000000007c\"}": {
+        "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION": "SAI_PACKET_ACTION_FORWARD",
+        "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": "oid:0x40000000015d8"
+    }
 }

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -515,12 +515,16 @@ show_muxcable_tunnel_route_expected_output_json="""\
     "TUNNEL_ROUTE": {
         "Ethernet0": {
             "server_ipv4": {
-                "DEST": "10.2.1.1"
+                "DEST": "10.2.1.1",
+                "kernel": 1,
+                "asic": 1
             }
         },
         "Ethernet4": {
             "server_ipv4": {
-                "DEST": "10.3.1.1"
+                "DEST": "10.3.1.1",
+                "kernel": 1,
+                "asic": false
             }
         }
     }
@@ -528,10 +532,10 @@ show_muxcable_tunnel_route_expected_output_json="""\
 """
 
 show_muxcable_tunnel_route_expected_output="""\
-PORT       DEST_TYPE    DEST_ADDRESS
----------  -----------  --------------
-Ethernet0  server_ipv4  10.2.1.1
-Ethernet4  server_ipv4  10.3.1.1
+PORT       DEST_TYPE    DEST_ADDRESS    kernel    asic
+---------  -----------  --------------  --------  ------
+Ethernet0  server_ipv4  10.2.1.1        added     added
+Ethernet4  server_ipv4  10.3.1.1        added     -
 """
 
 show_muxcable_tunnel_route_expected_output_port_json="""\
@@ -539,7 +543,9 @@ show_muxcable_tunnel_route_expected_output_port_json="""\
     "TUNNEL_ROUTE": {
         "Ethernet0": {
             "server_ipv4": {
-                "DEST": "10.2.1.1"
+                "DEST": "10.2.1.1",
+                "kernel": 1,
+                "asic": 1
             }
         }
     }
@@ -547,9 +553,9 @@ show_muxcable_tunnel_route_expected_output_port_json="""\
 """
 
 show_muxcable_tunnel_route_expected_port_output="""\
-PORT       DEST_TYPE    DEST_ADDRESS
----------  -----------  --------------
-Ethernet0  server_ipv4  10.2.1.1
+PORT       DEST_TYPE    DEST_ADDRESS    kernel    asic
+---------  -----------  --------------  --------  ------
+Ethernet0  server_ipv4  10.2.1.1        added     added
 """
 
 class TestMuxcable(object):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

Stemming from https://github.com/sonic-net/sonic-swss/pull/2557. 

This PR is to update `show mux tunnel-route` command to show status of both ASIC and kernel tunnel routes.

sign-off: Jing Zhang zhangjing@microsoft.com 

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
Only check Kernel Route, if removing tunnel route for `server_ipv4` in kernel, it won't show in CMD output: 
```
zhangjing@********************:~$ show mux tunnel-route Ethernet4
PORT       DEST_TYPE    DEST_ADDRESS
---------  -----------  --------------------------------
Ethernet4  server_ipv6  2603:10b0:d11:8614::a32:9112/128
```
#### New command output (if the output of a command-line utility has changed)
Check both ASIC and APP DB for tunnel route status
```
zhangjing@********************:~$ show mux tunnel-route Ethernet4
PORT       DEST_TYPE    DEST_ADDRESS                      kernel    asic
---------  -----------  --------------------------------  --------  ------
Ethernet4  server_ipv4  10.50.145.18/32                   -         added
Ethernet4  server_ipv6  2603:10b0:d11:8614::a32:9112/128  added     added
```