### PR TITLE
[config] SNMP Service restart fix for consecutive configs

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3087,8 +3087,12 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
     config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', key, {})
 
     #Restarting the SNMP service will regenerate snmpd.conf and rerun snmpd
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+    try:
+        clicommon.run_command("systemctl reset-failed snmp.service", display_cmd=False)
+        clicommon.run_command("systemctl restart snmp.service", display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 @snmpagentaddress.command('del')
 @click.argument('agentip', metavar='<SNMP AGENT LISTENING IP Address>', required=True)
@@ -3106,8 +3110,12 @@ def del_snmp_agent_address(ctx, agentip, port, vrf):
         key = key+vrf
     config_db = ctx.obj['db']
     config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', key, None)
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+    try:
+        clicommon.run_command("systemctl reset-failed snmp.service", display_cmd=False)
+        clicommon.run_command("systemctl restart snmp.service", display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 @config.group(cls=clicommon.AbbreviationGroup)
 @click.pass_context
@@ -3137,8 +3145,12 @@ def modify_snmptrap_server(ctx, ver, serverip, port, vrf, comm):
     else:
         config_db.mod_entry('SNMP_TRAP_CONFIG', "v3TrapDest", {"DestIp": serverip, "DestPort": port, "vrf": vrf, "Community": comm})
 
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+    try:
+        clicommon.run_command("systemctl reset-failed snmp.service", display_cmd=False)
+        clicommon.run_command("systemctl restart snmp.service", display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 @snmptrap.command('del')
 @click.argument('ver', metavar='<SNMP Version>', type=click.Choice(['1', '2', '3']), required=True)
@@ -3153,8 +3165,13 @@ def delete_snmptrap_server(ctx, ver):
         config_db.mod_entry('SNMP_TRAP_CONFIG', "v2TrapDest", None)
     else:
         config_db.mod_entry('SNMP_TRAP_CONFIG', "v3TrapDest", None)
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+
+    try:
+        clicommon.run_command("systemctl reset-failed snmp.service", display_cmd=False)
+        clicommon.run_command("systemctl restart snmp.service", display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When SNMP Trap or agentaddress configurations are applied consecutively in a short interval, restart of SNMP process will fail with start-limit-hit error. Fixed this issue with reset-failed.

#### How I did it
To clear the start-limit error , execute reset-failed for SNMP service before restarting the process.

#### How to verify it
SNMP Trap or Agent address configurations can be done consecutively without start-limit-hit error.

#### Previous command output (if the output of a command-line utility has changed)
Command output is not affected.

#### New command output (if the output of a command-line utility has changed)

