### PR TITLE
[Mgmt] Fix show mgmt-interface address CLI for DHCP

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -510,9 +510,16 @@ def address ():
 
     # Fetching data from config_db for MGMT_INTERFACE
     mgmt_ip_data = config_db.get_table('MGMT_INTERFACE')
-    for key in natsorted(list(mgmt_ip_data.keys())):
-        click.echo("Management IP address = {0}".format(key[1]))
-        click.echo("Management Network Default Gateway = {0}".format(mgmt_ip_data[key]['gwaddr']))
+    if len(mgmt_ip_data) != 0:
+        for key in natsorted(list(mgmt_ip_data.keys())):
+            click.echo("Management IP address = {0}".format(key[1]))
+            if 'gwaddr' in mgmt_ip_data[key]:
+                click.echo("Management Network Default Gateway = {0}".format(mgmt_ip_data[key]['gwaddr']))
+    else:
+        cmd = "sudo ipintutil -a ipv4 | grep eth0 | grep -oP '(\d+(\.\d+){3}\/\d+)'"
+        mgmt_ip = clicommon.run_command(cmd,return_cmd=True)
+        if len(mgmt_ip) > 0:
+            click.echo("Management IP address = {0}".format(mgmt_ip.strip()))
 
 #
 # 'snmpagentaddress' group ("show snmpagentaddress ...")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
show management_interface address CLI doesn't display management address configured via DHCP.

#### How I did it
For DHCP Management IP , Get the IP details from kernel via ipintutil

#### How to verify it
The DHCP IP of eth0 will be displayed in show management_interface address output.


#### Previous command output (if the output of a command-line utility has changed)

```
Without Fix :
root@sonic:~#  show management_interface address
root@sonic:~#
```

#### New command output (if the output of a command-line utility has changed)
```
With Fix :
root@sonic:~#  show management_interface address
Management IP address = 10.208.140.130/24
root@sonic:~#
```
