### PR TITLE
Fix issue: unconfigured PGs are displayed in watermarkstat

### DIFF
--- a/scripts/pg-drop
+++ b/scripts/pg-drop
@@ -117,22 +117,25 @@ class PgDropStat(object):
         self.header_list = ['Port']
         header_map = pg_drop_type["obj_map"]
 
-        max_idx = 0
-        min_idx = sys.maxsize
+        header_idx_set = set()
         for port in header_map.keys():
             for element in header_map[port].keys():
                 element_idx = int(element.split(':')[1])
-                if element_idx > max_idx:
-                    max_idx = element_idx
-                if min_idx > element_idx:
-                    min_idx = element_idx
+                header_idx_set.add(element_idx)
 
-        if min_idx == sys.maxsize:
+        if len(header_idx_set) == 0:
             print("Header info is not available!")
             sys.exit(1)
 
-        self.min_idx = min_idx
-        self.header_list += ["{}{}".format(pg_drop_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx + 1)]
+        header_idx_list = list(header_idx_set)
+        header_idx_list.sort()
+
+        self.header_idx_to_pos = {}
+        for i in header_idx_list:
+            self.header_idx_to_pos[i] = header_idx_list.index(i)
+
+        self.min_idx = header_idx_list[0]
+        self.header_list += ["{}{}".format(pg_drop_type["header_prefix"], idx) for idx in header_idx_list]
 
     def get_counters(self, table_prefix, port_obj, idx_func, counter_name):
         """
@@ -150,7 +153,7 @@ class PgDropStat(object):
             full_table_id = table_prefix + obj_id
             old_collected_data = port_drop_ckpt.get(name,{})[full_table_id] if len(port_drop_ckpt) > 0 else 0
             idx = int(idx_func(obj_id))
-            pos = idx - self.min_idx
+            pos = self.header_idx_to_pos[idx]
             counter_data = self.counters_db.get(self.counters_db.COUNTERS_DB, full_table_id, counter_name)
             if counter_data is None:
                 fields[pos] = STATUS_NA

--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -217,17 +217,13 @@ class Watermarkstat(object):
         self.header_list = ['Port']
         header_map = wm_type["obj_map"]
 
-        max_idx = 0
-        min_idx = sys.maxsize
+        header_idx_set = set()
         for port in header_map.keys():
             for element in header_map[port].keys():
                 element_idx = int(element.split(':')[1])
-                if element_idx > max_idx:
-                    max_idx = element_idx
-                if min_idx > element_idx:
-                    min_idx = element_idx
+                header_idx_set.add(element_idx)
 
-        if min_idx == sys.maxsize:
+        if len(header_idx_set) == 0:
             if counter_type != 'q_shared_multi':
                 print("Object map is empty!", file=sys.stderr)
                 sys.exit(1)
@@ -235,8 +231,15 @@ class Watermarkstat(object):
                 print("Object map from the COUNTERS_DB is empty because the multicast queues are not configured in the CONFIG_DB!")
                 sys.exit(0)
 
-        self.min_idx = min_idx
-        self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in range(self.min_idx, max_idx + 1)]
+        header_idx_list = list(header_idx_set)
+        header_idx_list.sort()
+
+        self.header_idx_to_pos = {}
+        for i in header_idx_list:
+            self.header_idx_to_pos[i] = header_idx_list.index(i)
+
+        self.min_idx = header_idx_list[0]
+        self.header_list += ["{}{}".format(wm_type["header_prefix"], idx) for idx in header_idx_list]
 
     def get_counters(self, table_prefix, port_obj, idx_func, watermark):
         """
@@ -252,7 +255,7 @@ class Watermarkstat(object):
         for name, obj_id in port_obj.items():
             full_table_id = table_prefix + obj_id
             idx = int(idx_func(obj_id))
-            pos = idx - self.min_idx
+            pos = self.header_idx_to_pos[idx]
             counter_data = self.counters_db.get(self.counters_db.COUNTERS_DB, full_table_id, watermark)
             if counter_data is None or counter_data == '':
                 fields[pos] = STATUS_NA


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix issue
All the PGs between minimal and maximal indexes are displayed regardless of whether they are configured.
Originally, watermark counters were enabled for all PGs, so there is no issue.
Now, watermark counters are enabled only for PGs with buffer configured, eg. if PG 0/2/3/4/6, is configured, PG 0-6 will be displayed, which is confusing by giving users a feeling that PG 7 is lost

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

Display valid PGs only

#### How to verify it

Manually test and unit test.

#### Previous command output (if the output of a command-line utility has changed)
```
       Port    PG0    PG1    PG2    PG3    PG4
-----------  -----  -----  -----  -----  -----
 Ethernet0      0      0      0      0      0
 Ethernet2      0      0      0      0      0
 Ethernet8      0      0      0      0      0
Ethernet10      0      0      0      0      0
Ethernet16      0      0      0      0      0
Ethernet18      0      0      0      0      0
Ethernet32      0      0      0      0      0
```

#### New command output (if the output of a command-line utility has changed)
`PG1` won't be displayed if it is not configured
```
       Port    PG0    PG3    PG4
-----------  -----  -----  -----
 Ethernet0      0      0      0
 Ethernet2      0      0      0
 Ethernet8      0      0      0
Ethernet10      0      0      0
Ethernet16      0      0      0
Ethernet18      0      0      0
Ethernet32      0      0      0
```
