### PR TITLE
Fixed admin state config CLI for Backport interfaces

### DIFF
--- a/utilities_common/intf_filter.py
+++ b/utilities_common/intf_filter.py
@@ -2,6 +2,7 @@
 
 SONIC_PORT_NAME_PREFIX = "Ethernet"
 SONIC_LAG_NAME_PREFIX = "PortChannel"
+SONIC_BACK_PORT_NAME_PREFIX = "Ethernet-BP"
 
 def parse_interface_in_filter(intf_filter):
     intf_fs = []
@@ -11,7 +12,19 @@ def parse_interface_in_filter(intf_filter):
 
     fs = intf_filter.split(',')
     for x in fs:
-        if '-' in x:
+        if x.startswith(SONIC_BACK_PORT_NAME_PREFIX):
+            intf = SONIC_BACK_PORT_NAME_PREFIX
+            x = x.split(intf)[1]
+            if '-' in x:
+                start = x.split('-')[0]
+                end = x.split('-')[1]
+                if not start.isdigit() or not end.isdigit():
+                    continue
+                for i in range(int(start), int(end)+1):
+                    intf_fs.append(intf+str(i))
+            else:
+                intf_fs.append(intf+x)
+        elif '-' in x:
             # handle range
             if not x.startswith(SONIC_PORT_NAME_PREFIX) and not x.startswith(SONIC_LAG_NAME_PREFIX):
                 continue
@@ -40,4 +53,3 @@ def interface_in_filter(intf, filter):
         return True
 
     return False
-


### PR DESCRIPTION
    Added Backport handling in parse interface logic

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed admin state config CLI for Backport interfaces
Fixes https://github.com/sonic-net/sonic-buildimage/issues/13057

#### How I did it
Added backport interface handling in parse interface logic

#### How to verify it
Run 'config interface -n asic<> shut/start ' command
Use show interface status -d all to check the status

without fix:
```
root@sfd-vt2-lc2:/home/cisco# show int st -d all -n asic0 | grep Ethernet-BP204
 Ethernet-BP204            2324,2325     100G   9100     rs  Eth364-ASIC0           routed    down     down              N/A         off
root@sfd-vt2-lc2:/home/cisco# config interface -n asic0 startup  Ethernet-BP204
root@sfd-vt2-lc2:/home/cisco# show int st -d all -n asic0 | grep Ethernet-BP204
 Ethernet-BP204            2324,2325     100G   9100     rs  Eth364-ASIC0           routed    down     down              N/A         off
```

with fix:
```
root@sfd-vt2-lc0:/home/cisco# show int st -d all -n asic0 | grep Ethernet-BP204
 Ethernet-BP204            2324,2325     100G   9100     rs  Eth364-ASIC0           routed    down     down              N/A         off
root@sfd-vt2-lc0:/home/cisco# config interface -n asic0 startup  Ethernet-BP204
root@sfd-vt2-lc0:/home/cisco# show int st -d all -n asic0 | grep Ethernet-BP204
 Ethernet-BP204            2324,2325     100G   9100     rs  Eth364-ASIC0           routed    down       up              N/A         off
root@sfd-vt2-lc0:/home/cisco# config interface -n asic0 shutdown  Ethernet-BP204
root@sfd-vt2-lc0:/home/cisco# show int st -d all -n asic0 | grep Ethernet-BP204
 Ethernet-BP204            2324,2325     100G   9100     rs  Eth364-ASIC0           routed    down     down              N/A         off
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

