### PR TITLE
[db_migrator] Fix migration of Loopback data: handle all Loopback interfaces

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -178,24 +178,33 @@ class DBMigrator():
         if self.appDB is None:
             return
 
-        data = self.appDB.keys(self.appDB.APPL_DB, "INTF_TABLE:*")
+        # Get Lo interface corresponding to IP(v4/v6) address from CONFIG_DB.
+        configdb_data = self.configDB.get_keys('LOOPBACK_INTERFACE')
+        lo_addr_to_int = dict()
+        for int_data in configdb_data:
+            if type(int_data) == tuple and len(int_data) > 1:
+                intf_name = int_data[0]
+                intf_addr = int_data[1]
+                lo_addr_to_int.update({intf_addr: intf_name})
 
-        if data is None:
+        lo_data = self.appDB.keys(self.appDB.APPL_DB, "INTF_TABLE:lo*")
+        if lo_data is None:
             return
+        for lo_row in lo_data:
+            # Example of lo_row: 'INTF_TABLE:lo:10.1.0.32/32'
+            # Example of lo_dict: {'family': 'IPv4', 'scope': 'global'}
+            lo_dict = self.appDB.get_all(self.appDB.APPL_DB, lo_row)
+            lo_addr = lo_row.split('INTF_TABLE:lo:')[1]
+            lo_name = lo_addr_to_int.get(lo_addr)
+            lo_table = "INTF_TABLE:" + lo_name + ":" + lo_addr
+            for key, value in lo_dict.items():
+                log.log_notice("Set table {} with field {} and value {}".format(
+                    lo_table, key, value))
+                self.appDB.set(self.appDB.APPL_DB, lo_table, key, value)
+            # delete the old row with name as 'lo' as new row has been added
+            self.appDB.delete(self.appDB.APPL_DB, lo_row)
 
         if_db = []
-        for key in data:
-            if_name = key.split(":")[1]
-            if if_name == "lo":
-                self.appDB.delete(self.appDB.APPL_DB, key)
-                key = key.replace(if_name, "Loopback0")
-                log.log_info('Migrating lo entry to ' + key)
-                self.appDB.set(self.appDB.APPL_DB, key, 'NULL', 'NULL')
-
-            if '/' not in key:
-                if_db.append(key.split(":")[1])
-                continue
-
         data = self.appDB.keys(self.appDB.APPL_DB, "INTF_TABLE:*")
         for key in data:
             if_name = key.split(":")[1]

--- a/tests/db_migrator_input/appl_db/loopback_interface_migrate_from_1_0_1_expected.json
+++ b/tests/db_migrator_input/appl_db/loopback_interface_migrate_from_1_0_1_expected.json
@@ -1,0 +1,20 @@
+{
+    "INTF_TABLE:Loopback0" : {"NULL": "NULL"},
+    "INTF_TABLE:Loopback0:10.1.0.32/32" : {
+        "scope": "global",
+        "family": "IPv4"
+    },
+    "INTF_TABLE:Loopback0:FC00:1::32/128" : {
+        "scope": "global",
+        "family": "IPv6"
+    },
+    "INTF_TABLE:Loopback1" : {"NULL": "NULL"},
+    "INTF_TABLE:Loopback1:10.20.8.199/32" : {
+        "scope": "global",
+        "family": "IPv4"
+    },
+    "INTF_TABLE:Loopback1:2001:506:28:500::1/128" : {
+        "scope": "global",
+        "family": "IPv6"
+    }
+}

--- a/tests/db_migrator_input/appl_db/loopback_interface_migrate_from_1_0_1_expected.json
+++ b/tests/db_migrator_input/appl_db/loopback_interface_migrate_from_1_0_1_expected.json
@@ -1,20 +1,8 @@
 {
     "INTF_TABLE:Loopback0" : {"NULL": "NULL"},
-    "INTF_TABLE:Loopback0:10.1.0.32/32" : {
-        "scope": "global",
-        "family": "IPv4"
-    },
-    "INTF_TABLE:Loopback0:FC00:1::32/128" : {
-        "scope": "global",
-        "family": "IPv6"
-    },
+    "INTF_TABLE:Loopback0:10.1.0.32/32" :  {"NULL": "NULL"},
+    "INTF_TABLE:Loopback0:FC00:1::32/128" : {"NULL": "NULL"},
     "INTF_TABLE:Loopback1" : {"NULL": "NULL"},
-    "INTF_TABLE:Loopback1:10.20.8.199/32" : {
-        "scope": "global",
-        "family": "IPv4"
-    },
-    "INTF_TABLE:Loopback1:2001:506:28:500::1/128" : {
-        "scope": "global",
-        "family": "IPv6"
-    }
+    "INTF_TABLE:Loopback1:10.20.8.199/32" :  {"NULL": "NULL"},
+    "INTF_TABLE:Loopback1:2001:506:28:500::1/128" :  {"NULL": "NULL"}
 }

--- a/tests/db_migrator_input/appl_db/loopback_interface_migrate_from_1_0_1_input.json
+++ b/tests/db_migrator_input/appl_db/loopback_interface_migrate_from_1_0_1_input.json
@@ -1,0 +1,18 @@
+{
+    "INTF_TABLE:lo:10.1.0.32/32" : {
+        "scope": "global",
+        "family": "IPv4"
+    },
+    "INTF_TABLE:lo:FC00:1::32/128" : {
+        "scope": "global",
+        "family": "IPv6"
+    },
+    "INTF_TABLE:lo:10.20.8.199/32" : {
+        "scope": "global",
+        "family": "IPv4"
+    },
+    "INTF_TABLE:lo:2001:506:28:500::1/128" : {
+        "scope": "global",
+        "family": "IPv6"
+    }
+}

--- a/tests/db_migrator_input/config_db/loopback_interface_migrate_from_1_0_1_expected.json
+++ b/tests/db_migrator_input/config_db/loopback_interface_migrate_from_1_0_1_expected.json
@@ -1,0 +1,8 @@
+{
+    "LOOPBACK_INTERFACE|Loopback0" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback1" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback1|10.20.8.199/32" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback1|2001:506:28:500::1/128" : {"NULL": "NULL"}
+}

--- a/tests/db_migrator_input/config_db/loopback_interface_migrate_from_1_0_1_input.json
+++ b/tests/db_migrator_input/config_db/loopback_interface_migrate_from_1_0_1_input.json
@@ -1,0 +1,7 @@
+{
+    "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback1|10.20.8.199/32" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback1|2001:506:28:500::1/128" : {"NULL": "NULL"},
+    "VERSIONS|DATABASE": {"VERSION": "version_1_0_1"}
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -476,3 +476,45 @@ class TestWarmUpgrade_to_2_0_2(object):
             expected_table = expected_db.cfgdb.get_table(table)
             diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
             assert not diff
+
+class Test_Migrate_Loopback(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+        dbconnector.dedicated_dbs['APPL_DB'] = None
+
+    def test_migrate_loopback_int(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'loopback_interface_migrate_from_1_0_1_input')
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'loopback_interface_migrate_from_1_0_1_input')
+
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'loopback_interface_migrate_from_1_0_1_expected')
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'loopback_interface_migrate_from_1_0_1_expected')
+        expected_db = Db()
+
+        # verify migrated configDB
+        resulting_table = dbmgtr.configDB.get_table("LOOPBACK_INTERFACE")
+        expected_table = expected_db.cfgdb.get_table("LOOPBACK_INTERFACE")
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff
+
+        # verify migrated appDB
+        expected_appl_db = SonicV2Connector(host='127.0.0.1')
+        expected_appl_db.connect(expected_appl_db.APPL_DB)
+        expected_keys = expected_appl_db.keys(expected_appl_db.APPL_DB, "INTF_TABLE:*")
+        expected_keys.sort()
+        resulting_keys = dbmgtr.appDB.keys(dbmgtr.appDB.APPL_DB, "INTF_TABLE:*")
+        resulting_keys.sort()
+        assert expected_keys == resulting_keys
+        for key in expected_keys:
+            resulting_keys = dbmgtr.appDB.get_all(dbmgtr.appDB.APPL_DB, key)
+            expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
+            diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
+            assert not diff


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix the issue where cross branch upgrades (base DB version 1_0_1) lead to a OA crash due to a duplicate IP2ME route being added when there are more than one Loopback interfaces.


The issue happens as in current implementation `lo` is hardcoded to be replaced as `Loopback0`.
When the base image's APP DB has more than one IP assigned to `lo` interface, upon migration, all the IPs are assinged to same loopback `Loopback0`. This is incorrect, as in newer images different IPs are assinged to distinct Loopback interfaces.


Eg. If the base image APP DB contains:
```
{
    "INTF_TABLE:lo:10.1.0.32/32" : {
        "scope": "global",
        "family": "IPv4"
    },
    "INTF_TABLE:lo:10.20.8.199/32" : {
        "scope": "global",
        "family": "IPv4"
    }
}
```

In current implementation, this will be INCORRECTLY migrated as:
```
{
    "INTF_TABLE:Loopback0" : {"NULL": "NULL"},
    "INTF_TABLE:Loopback0:10.1.0.32/32" : {
        "scope": "global",
        "family": "IPv4"
    },
    "INTF_TABLE:Loopback0:10.20.8.199/32" : {
        "scope": "global",
        "family": "IPv4"
    }
}
```

The expected migration would look like:
```
{
    "INTF_TABLE:Loopback0" : {"NULL": "NULL"},
    "INTF_TABLE:Loopback0:10.1.0.32/32" : {
        "scope": "global",
        "family": "IPv4"
    },
    "INTF_TABLE:Loopback1" : {"NULL": "NULL"},
    "INTF_TABLE:Loopback1:10.20.8.199/32" : {
        "scope": "global",
        "family": "IPv4"
    },
}
```

#### How I did it

Use source-of-truth data from CONFIG_DB to assign IPs (v4 and v6) to different Loopback interfaces, and add new entries into APPL_DB.
New entries for new loopback interfaces are created accordingly, and the field/values are also copied into new entries.

#### How to verify it
Verified on a physical testbed that this change fixes the OA crash issue.
Also added a unit test to catch this issue in PR tests.

New log from migration:
```
Dec 15 00:34:30.011565 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback0:FC00:1::32/128 with field family and value IPv6
Dec 15 00:34:30.011773 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback0:FC00:1::32/128 with field scope and value global

Dec 15 00:34:30.011880 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback1:2001:506:28:500::1/128 with field family and value IPv6
Dec 15 00:34:30.011991 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback1:2001:506:28:500::1/128 with field scope and value global

Dec 15 00:34:30.012089 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback0:10.1.0.32/32 with field family and value IPv4
Dec 15 00:34:30.012177 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback0:10.1.0.32/32 with field scope and value global

Dec 15 00:34:30.012280 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback1:10.20.8.199/32 with field family and value IPv4
Dec 15 00:34:30.012385 str-7260cx3-acs-1 NOTICE db_migrator: Set table INTF_TABLE:Loopback1:10.20.8.199/32 with field scope and value global
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

