### PR TITLE
[202205][timer.unit.j2] use wanted-by in timer unit

### DIFF
--- a/sonic-utilities-data/templates/timer.unit.j2
+++ b/sonic-utilities-data/templates/timer.unit.j2
@@ -13,3 +13,7 @@ Unit={{ manifest.service.name }}{% if multi_instance %}@%i{% endif %}.service
 
 [Install]
 WantedBy=timers.target sonic.target
+{%- for service in manifest.service["wanted-by"] %}
+WantedBy={{ service }}{% if multi_instance and service in multi_instance_services %}@%i{% endif %}.service
+{%- endfor %}
+


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I fixed the timer unit template to account "wanted-by" option in the manifest. In case service is delayed, "wanted-by" is applied to the timer unit that delays it.

#### How I did it

I updated timer.unit.j2 template

#### How to verify it

Make sure that "WantedBy" is rendered in the timer unit.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

