### PR TITLE
sonic-utilities: CLICK support  added to restart certain services after config load

### DIFF
--- a/tests/config_load_input/config_db.json
+++ b/tests/config_load_input/config_db.json
@@ -1,0 +1,39 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "docker_routing_config_mode": "split",
+            "hostname": "sonic",
+            "hwsku": "Seastone-DX010-25-50",
+            "mac": "00:e0:ec:89:6e:48",
+            "platform": "x86_64-cel_seastone-r0",
+            "type": "ToRRouter"
+        }
+    },
+    "VLAN_MEMBER": {
+        "Vlan1000|Ethernet0": {
+            "tagging_mode": "untagged"
+        }
+    },
+    "VLAN": {
+        "Vlan1000": {
+            "vlanid": "1000",
+            "dhcp_servers": [
+                "192.0.0.1",
+                "192.0.0.2",
+                "192.0.0.3",
+                "192.0.0.4"
+            ]
+        }
+    },
+    "NTP_SERVER": {
+        "8.8.8.8": {}
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "Eth1",
+            "lanes": "65, 66, 67, 68",
+            "description": "Ethernet0 10g link",
+            "speed": "100000"
+        }
+    }
+}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -35,6 +35,8 @@ os.environ["PATH"] += os.pathsep + scripts_path
 # Config Reload input Path
 mock_db_path = os.path.join(test_path, "config_reload_input")
 
+# Config Reload input Path
+mock_db_path_for_load = os.path.join(test_path, "config_load_input")
 
 load_minigraph_command_output="""\
 Stopping SONiC target ...
@@ -685,6 +687,36 @@ class TestReloadConfig(object):
         os.remove(cls.dummy_cfg_file)
         print("TEARDOWN")
 
+class TestLoadConfig(object):
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        print("SETUP")
+        import config.main
+        importlib.reload(config.main)
+
+    def test_load_config(self, get_cmd_module, setup_single_broadcom_asic):
+        with mock.patch(
+                "utilities_common.cli.run_command",
+                mock.MagicMock(side_effect=mock_run_command_side_effect)
+        ) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            cfg_file = os.path.join(mock_db_path_for_load, "config_db.json")
+
+            result = runner.invoke(
+                config.config.commands["load"],
+                [cfg_file, '-y'])
+
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        print("TEARDOWN")
 
 class TestConfigCbf(object):
     @classmethod


### PR DESCRIPTION
Certain features (like NTP,SNMP) requires restarting of the related services after doing config load. 

Signed-off-by: Saravanan I <saravan@celestica.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Certain features (like NTP,SNMP) requires restarting of the related services after doing config load.  After doing config load, some of the features (like ntp,snmp) doesn't work. Only after doing explicit restarting of services, this features work. Added the common capability to restart services in background after doing config load.

#### How I did it
Restart the services (SNMP,NTP) in the background when user executes the config load (click command) when the SNMP/NTP related configuration found in config_db json file.  Otherwise those services will not be restarted.

#### How to verify it
Have NTP,SNMP configurations in a config_db.json file. Load the configuration file using config load CLI. Verify that NTP,SNMP features work seamless without requiring any explicit reload of the related services. - PASS

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
