### PR TITLE
[Mellanox] Change severity to NOTICE in Mellanox buffer migrator when unable to fetch DEVICE_METADATA due to empty CONFIG_DB during initialization

### DIFF
--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -101,7 +101,7 @@ class MellanoxBufferMigrator():
             self.sku = device_data.get('hwsku')
             self.ready = True
         if not self.platform or not self.sku:
-            log.log_error("Trying to get DEVICE_METADATA from DB but doesn't exist, skip migration")
+            log.log_notice("Trying to get DEVICE_METADATA from DB but doesn't exist, skip migration")
             self.ready = False
 
         self.spc1_platforms = ["x86_64-mlnx_msn2010-r0", "x86_64-mlnx_msn2100-r0", "x86_64-mlnx_msn2410-r0", "x86_64-mlnx_msn2700-r0", "x86_64-mlnx_msn2740-r0"]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
It is expected that db_migrator is not able to fetch DEVICE_METADATA when it is invoked before the CONFIG_DB is initialized. In this case, we should not use ERROR to log the message since it's not an error.
Change the severity to NOTICE

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

Change the severity.

#### How to verify it

Manually test.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

