### PR TITLE
[202205] Preserve copp tables through DB migration

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -827,7 +827,8 @@ class DBMigrator():
                 new_cfg = {**init_cfg, **curr_cfg}
                 self.configDB.set_entry(init_cfg_table, key, new_cfg)
 
-        self.migrate_copp_table()
+        if self.asic_type != "mellanox":
+            self.migrate_copp_table()
         if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:            
             self.migrate_mgmt_ports_on_s6100()
         else:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
This PR implements [fastboot] Preserve CoPP table HLD to improve fastboot flow (https://github.com/sonic-net/SONiC/pull/1107).
It is PR against 202205 of the following PR: https://github.com/sonic-net/sonic-utilities/pull/2524

#### What I did

Preserve COPP table contents through DB migration. (Mellanox only)

#### How I did it

Skipped deleting of COPP tables in DB migrator

#### How to verify it

Observe COPP table contents are preserved right after reboot

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

