### PR TITLE
[202205] Extend fast-reboot STATE_DB entry timer

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -519,7 +519,7 @@ case "$REBOOT_TYPE" in
         check_warm_restart_in_progress
         BOOT_TYPE_ARG=$REBOOT_TYPE
         trap clear_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
-        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180" &>/dev/null
+        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "1" "EX" "210" &>/dev/null
         config warm_restart enable system
         ;;
     "warm-reboot")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
This is a PR against 202205 based on the following PR: https://github.com/sonic-net/sonic-utilities/pull/2577
Due to an issue of fallback from to cold-boot when using upgrade with fast-reboot combined with FW upgrade a short term solution is to extend the timer.
An issue will be opened on this case with the full details, link will be added to the PR.
Long term solution of using fast-reboot finalizer replacing the timer is in work.

#### What I did
Extend the timer of STATE DB fast-reboot entry to 210 seconds.

#### How I did it
Modify the TTL of the entry set in STATE DB.

#### How to verify it
Verify the entry was preserved for 210 seconds.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

