### PR TITLE
Issue#2583 : Fix for VXLAN tunnel port FDBs not displayed in 'show mac'

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -32,6 +32,9 @@ import sys
 import os
 import re
 
+#Option used to display only locally learnt mac(s)
+display_only_local = False
+
 # mock the redis for unit test purposes #
 try: # pragma: no cover
     if os.environ["UTILITIES_UNIT_TESTING"] == "1": 
@@ -120,6 +123,10 @@ class FdbShow(object):
                 else:
                     if_name = port_id
             else:
+                if display_only_local:
+                    #User requested option to display only the local mac address,
+                    #So skip logging this entry
+                    continue
                 if_name = endpoint_ip
 
             if 'vlan' in fdb:
@@ -209,6 +216,7 @@ class FdbShow(object):
         return True
 
 def main():
+    global display_only_local
     
     parser = argparse.ArgumentParser(description='Display ASIC FDB entries',
                                      formatter_class=argparse.RawTextHelpFormatter)
@@ -217,7 +225,10 @@ def main():
     parser.add_argument('-a', '--address', type=str, help='FDB display based on specific mac address', default=None)
     parser.add_argument('-t', '--type', type=str, help='FDB display of specific type of mac address', default=None)
     parser.add_argument('-c', '--count', action='store_true', help='FDB display count of mac address')
+    parser.add_argument('-l', '--local', action='store_true', help='Display only the locally learnt mac address')
     args = parser.parse_args()
+
+    display_only_local = args.local
 
     try:
         fdb = FdbShow()

--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -103,13 +103,25 @@ class FdbShow(object):
             br_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
             ent_type = ent["SAI_FDB_ENTRY_ATTR_TYPE"]
             fdb_type = ['Dynamic','Static'][ent_type == "SAI_FDB_ENTRY_TYPE_STATIC"]
-            if br_port_id not in self.if_br_oid_map:
-                continue
-            port_id = self.if_br_oid_map[br_port_id]
-            if port_id in self.if_oid_map:
-                if_name = self.if_oid_map[port_id]
+
+            #If we have VXLAN tunnel port FDBs try getting them
+            try:
+                endpoint_ip = ent["SAI_FDB_ENTRY_ATTR_ENDPOINT_IP"]
+            except:
+                endpoint_ip = None
+
+            #If endpoint_ip exists then use that as if_name
+            if not endpoint_ip:
+                if br_port_id not in self.if_br_oid_map:
+                    continue
+                port_id = self.if_br_oid_map[br_port_id]
+                if port_id in self.if_oid_map:
+                    if_name = self.if_oid_map[port_id]
+                else:
+                    if_name = port_id
             else:
-                if_name = port_id
+                if_name = endpoint_ip
+
             if 'vlan' in fdb:
                 vlan_id = fdb["vlan"]
             else:

--- a/show/main.py
+++ b/show/main.py
@@ -889,8 +889,9 @@ def pwm_headroom_pool():
 @click.option('-a', '--address')
 @click.option('-t', '--type')
 @click.option('-c', '--count', is_flag=True)
+@click.option('-l', '--local', is_flag=True)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def mac(ctx, vlan, port, address, type, count, verbose):
+def mac(ctx, vlan, port, address, type, count, local, verbose):
     """Show MAC (FDB) entries"""
 
     if ctx.invoked_subcommand is not None:
@@ -912,6 +913,9 @@ def mac(ctx, vlan, port, address, type, count, verbose):
 
     if count:
         cmd += " -c"
+
+    if local:
+        cmd += " -l"
 
     run_command(cmd, display_cmd=verbose)
 


### PR DESCRIPTION
#### What I did

The 'fdbshow' script did not have the logic to check and use 'SAI_FDB_ENTRY_ATTR_ENDPOINT_IP' which used for FDB entries learnt on tunnel port, it tried to look up 'br_port_id' from oid_map which was failing.
Added logic to use 'SAI_FDB_ENTRY_ATTR_ENDPOINT_IP' for vxlan tunnel entries and fallback to the port_id lookup for normal fdb thats leant on ports.
Tested with a combination of VXLAN tunnel and normal port macs.

#### How I did it

Added logic to logic to look for 'SAI_FDB_ENTRY_ATTR_ENDPOINT_IP' in the ASIC_DB entry and use it for 'if_name ' , if it doesnt exists then legacy code flow is maintained. 

#### How to verify it

https://github.com/sonic-net/sonic-utilities/issues/2583

Has been raised for this. 

'show mac' with VXLAN tunnel fdbs present. 

#### Previous command output (if the output of a command-line utility has changed)

root@sonic:~# show mac
  No.    Vlan  MacAddress         Port        Type
-----  ------  -----------------  ----------  -------
    1      77  0C:48:C6:C3:30:F8  Ethernet24  Dynamic
Total number of entries 1
root@sonic:~#


#### New command output (if the output of a command-line utility has changed)


root@sonic:~# show mac
  No.    Vlan  MacAddress         Port        Type
-----  ------  -----------------  ----------  -------
    1      30  72:E5:BE:90:A6:1C  1.1.1.1     Static
    2      30  F6:2C:C6:50:FF:F2  1.1.1.1     Static
    3      30  B2:14:7E:B4:05:3C  1.1.1.1     Static
    4      77  0C:48:C6:C3:30:F8  Ethernet24  Dynamic
Total number of entries 4
root@sonic:~#

