### PR TITLE
[storyteller] add link prober state change to story teller

### DIFF
--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -20,6 +20,7 @@ regex_dict = {
                 'lag'       : r'link becomes\|addLag\|PortChannel.*oper state',
                 'reboot'    : r'BOOT\|rc.local\|old_config\|minigraph.xml\|Rebooting\|reboot\|executeOperationsOnAsic\|getAsicView\|dumpVidToAsicOperatioId\|neighbor_adv\|Pausing\|shutdown\|warm',
                 'service'   : r'Starting\|Stopping\|Started\|Stopped',
+                'linkprober': r'Received link prober event, new state'
              }
 
 
@@ -86,7 +87,7 @@ def main():
 
     parser.add_argument('-l', '--log', help='log file prefix, e.g. syslog; default: syslog',
                         type=str, required=False, default='syslog')
-    parser.add_argument('-c', '--category', help='Categories: bgp, crash, interface, lag, reboot, service Specify multiple categories as c1,c2,c3; default: reboot',
+    parser.add_argument('-c', '--category', help='Categories: bgp, crash, interface, lag, reboot, service, linkprober Specify multiple categories as c1,c2,c3; default: reboot',
                         type=str, required=False, default='reboot')
     parser.add_argument('-p', '--logpath', help='log file path, e.g. /var/log; default: /var/log',
                         type=str, required=False, default='/var/log')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add `linkprober` category to story teller. It will reflect dualtor heartbeat events. 

sign-off: Jing Zhang zhangjing@microsoft.com 

#### How I did it

#### How to verify it
Tested on dualtor device, was able to grep link prober state change events. 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

