### PR TITLE
YANG Validation for MCLAG, NAT, MUXCABLE tables

### DIFF
--- a/config/console.py
+++ b/config/console.py
@@ -135,7 +135,7 @@ def upate_console_remote_device_name(db, linenum, devicename):
             data.pop(dataKey, None)
             try:
                 config_db.mod_entry(table, linenum, data)
-            except valueError as e:
+            except ValueError as e:
                 ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif isExistingSameDevice(config_db, devicename, table):
             ctx.fail("Given device name {} has been used. Please enter a valid device name or remove the existing one !!".format(devicename))

--- a/config/console.py
+++ b/config/console.py
@@ -1,6 +1,8 @@
 import click
+import jsonpatch
 import utilities_common.cli as clicommon
-
+from .validated_config_db_connector import ValidatedConfigDBConnector
+from jsonpatch import JsonPatchConflict
 #
 # 'console' group ('config console ...')
 #
@@ -16,14 +18,18 @@ def console():
 @clicommon.pass_db
 def enable_console_switch(db):
     """Enable console switch"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
     table = "CONSOLE_SWITCH"
     dataKey1 = 'console_mgmt'
     dataKey2 = 'enabled'
 
     data = { dataKey2 : "yes" }
-    config_db.mod_entry(table, dataKey1, data)
+    try:
+        config_db.mod_entry(table, dataKey1, data)
+    except ValueError as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'console disable' group ('config console disable')
@@ -32,14 +38,18 @@ def enable_console_switch(db):
 @clicommon.pass_db
 def disable_console_switch(db):
     """Disable console switch"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
     table = "CONSOLE_SWITCH"
     dataKey1 = 'console_mgmt'
     dataKey2 = 'enabled'
 
     data = { dataKey2 : "no" }
-    config_db.mod_entry(table, dataKey1, data)
+    try:
+        config_db.mod_entry(table, dataKey1, data)
+    except ValueError as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'console add' group ('config console add ...')
@@ -52,7 +62,7 @@ def disable_console_switch(db):
 @click.option('--devicename', '-d', metavar='<device_name>', required=False)
 def add_console_setting(db, linenum, baud, flowcontrol, devicename):
     """Add Console-realted configuration tasks"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
 
     table = "CONSOLE_PORT"
     dataKey1 = 'baud_rate'
@@ -72,7 +82,10 @@ def add_console_setting(db, linenum, baud, flowcontrol, devicename):
                 ctx.fail("Given device name {} has been used. Please enter a valid device name or remove the existing one !!".format(devicename))
             console_entry[dataKey3] = devicename
 
-        config_db.set_entry(table, linenum, console_entry)
+        try:
+            config_db.set_entry(table, linenum, console_entry)
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 #
@@ -83,15 +96,18 @@ def add_console_setting(db, linenum, baud, flowcontrol, devicename):
 @click.argument('linenum', metavar='<line_number>', required=True, type=click.IntRange(0, 65535))
 def remove_console_setting(db, linenum):
     """Remove Console-related configuration tasks"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
+    ctx = click.get_current_context()
 
     table = "CONSOLE_PORT"
 
     data = config_db.get_entry(table, linenum)
     if data:
-        config_db.mod_entry(table, linenum, None)
+        try:
+            config_db.set_entry(table, linenum, None)
+        except JsonPatchConflict as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
-        ctx = click.get_current_context()
         ctx.fail("Trying to delete console port setting, which is not present.")
 
 #
@@ -103,7 +119,7 @@ def remove_console_setting(db, linenum):
 @click.argument('devicename', metavar='<device_name>', required=False)
 def upate_console_remote_device_name(db, linenum, devicename):
     """Update remote device name for a console line"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
 
     table = "CONSOLE_PORT"
@@ -117,12 +133,18 @@ def upate_console_remote_device_name(db, linenum, devicename):
         elif not devicename:
             # remove configuration key from console setting if user not give a remote device name
             data.pop(dataKey, None)
-            config_db.mod_entry(table, linenum, data)
+            try:
+                config_db.mod_entry(table, linenum, data)
+            except valueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif isExistingSameDevice(config_db, devicename, table):
             ctx.fail("Given device name {} has been used. Please enter a valid device name or remove the existing one !!".format(devicename))
         else:
             data[dataKey] = devicename
-            config_db.mod_entry(table, linenum, data)
+            try:
+                config_db.mod_entry(table, linenum, data)
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         ctx.fail("Trying to update console port setting, which is not present.")
 
@@ -135,7 +157,7 @@ def upate_console_remote_device_name(db, linenum, devicename):
 @click.argument('baud', metavar='<baud>', required=True, type=click.INT)
 def update_console_baud(db, linenum, baud):
     """Update baud for a console line"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
 
     table = "CONSOLE_PORT"
@@ -149,7 +171,10 @@ def update_console_baud(db, linenum, baud):
             return
         else:
             data[dataKey] = baud
-            config_db.mod_entry(table, linenum, data)
+            try:
+                config_db.mod_entry(table, linenum, data)
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         ctx.fail("Trying to update console port setting, which is not present.")
 
@@ -162,7 +187,7 @@ def update_console_baud(db, linenum, baud):
 @click.argument('linenum', metavar='<line_number>', required=True, type=click.IntRange(0, 65535))
 def update_console_flow_control(db, mode, linenum):
     """Update flow control setting for a console line"""
-    config_db = db.cfgdb
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
     ctx = click.get_current_context()
 
     table = "CONSOLE_PORT"
@@ -177,7 +202,10 @@ def update_console_flow_control(db, mode, linenum):
             return
         else:
             data[dataKey] = innerMode
-            config_db.mod_entry(table, linenum, data)
+            try:
+                config_db.mod_entry(table, linenum, data)
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         ctx.fail("Trying to update console port setting, which is not present.")
 

--- a/config/main.py
+++ b/config/main.py
@@ -4158,7 +4158,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
         raise click.Abort()
 
     # Get the config_db connector
-    config_db = ctx.obj['config_db']
+    config_db = ValidatedConfigDBConnector(ctx.obj['config_db'])
 
     target_brkout_mode = mode
 
@@ -4237,7 +4237,10 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
         if interface_name not in  brkout_cfg_keys:
             click.secho("[ERROR] {} is not present in 'BREAKOUT_CFG' Table!".format(interface_name), fg='red')
             raise click.Abort()
-        config_db.set_entry("BREAKOUT_CFG", interface_name, {'brkout_mode': target_brkout_mode})
+        try:
+            config_db.set_entry("BREAKOUT_CFG", interface_name, {'brkout_mode': target_brkout_mode})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         click.secho("Breakout process got successfully completed."
                     .format(interface_name), fg="cyan", underline=True)
         click.echo("Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.")
@@ -6358,15 +6361,18 @@ def ntp(ctx):
 @click.pass_context
 def add_ntp_server(ctx, ntp_ip_address):
     """ Add NTP server IP """
-    if not clicommon.is_ipaddress(ntp_ip_address):
+    if not clicommon.is_ipaddress(ntp_ip_address): 
         ctx.fail('Invalid ip address')
-    db = ctx.obj['db']
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
     ntp_servers = db.get_table("NTP_SERVER")
     if ntp_ip_address in ntp_servers:
         click.echo("NTP server {} is already configured".format(ntp_ip_address))
         return
     else:
-        db.set_entry('NTP_SERVER', ntp_ip_address, {'NULL': 'NULL'})
+        try:
+            db.set_entry('NTP_SERVER', ntp_ip_address, {'NULL': 'NULL'})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         click.echo("NTP server {} added to configuration".format(ntp_ip_address))
         try:
             click.echo("Restarting ntp-config service...")
@@ -6379,12 +6385,16 @@ def add_ntp_server(ctx, ntp_ip_address):
 @click.pass_context
 def del_ntp_server(ctx, ntp_ip_address):
     """ Delete NTP server IP """
-    if not clicommon.is_ipaddress(ntp_ip_address):
-        ctx.fail('Invalid IP address')
-    db = ctx.obj['db']
+    if ADHOC_VALIDATION:
+        if not clicommon.is_ipaddress(ntp_ip_address):
+            ctx.fail('Invalid IP address')
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
     ntp_servers = db.get_table("NTP_SERVER")
     if ntp_ip_address in ntp_servers:
-        db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
+        try:
+            db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
+        except JsonPatchConflict as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
     else:
         ctx.fail("NTP server {} is not configured.".format(ntp_ip_address))

--- a/config/mclag.py
+++ b/config/mclag.py
@@ -1,8 +1,12 @@
 
 import click
 from swsscommon.swsscommon import ConfigDBConnector
+from .validated_config_db_connector import ValidatedConfigDBConnector
 import ipaddress
-
+import jsonpatch
+from jsonpatch import JsonPatchConflict
+from jsonpointer import JsonPointerException
+ADHOC_VALIDATION = False
 CFG_PORTCHANNEL_PREFIX = "PortChannel"
 CFG_PORTCHANNEL_PREFIX_LEN = 11
 CFG_PORTCHANNEL_MAX_VAL = 9999
@@ -121,34 +125,41 @@ def mclag(ctx):
 @click.pass_context
 def add_mclag_domain(ctx, domain_id, source_ip_addr, peer_ip_addr, peer_ifname):
     """Add MCLAG Domain"""
+    if ADHOC_VALIDATION:
+        if not mclag_domain_id_valid(domain_id):
+            ctx.fail("{} invalid domain ID, valid range is 1 to 4095".format(domain_id))  
+        if not is_ipv4_addr_valid(source_ip_addr):
+            ctx.fail("{} invalid local ip address".format(source_ip_addr))
+        if not is_ipv4_addr_valid(peer_ip_addr):
+            ctx.fail("{} invalid peer ip address".format(peer_ip_addr))
 
-    if not mclag_domain_id_valid(domain_id):
-        ctx.fail("{} invalid domain ID, valid range is 1 to 4095".format(domain_id))  
-    if not is_ipv4_addr_valid(source_ip_addr):
-        ctx.fail("{} invalid local ip address".format(source_ip_addr))
-    if not is_ipv4_addr_valid(peer_ip_addr):
-        ctx.fail("{} invalid peer ip address".format(peer_ip_addr))
-
-    db = ctx.obj['db']
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
     fvs = {}
     fvs['source_ip'] = str(source_ip_addr)
     fvs['peer_ip'] = str(peer_ip_addr)
-    if peer_ifname is not None:
-        if (peer_ifname.startswith("Ethernet") is False) and (peer_ifname.startswith("PortChannel") is False):
-            ctx.fail("peer interface is invalid, should be Ethernet interface or portChannel !!")
-        if (peer_ifname.startswith("Ethernet") is True) and (check_if_interface_is_valid(db, peer_ifname) is False):
-            ctx.fail("peer Ethernet interface name is invalid. it is not present in port table of configDb!!")
-        if (peer_ifname.startswith("PortChannel")) and (is_portchannel_name_valid(peer_ifname) is False):
-            ctx.fail("peer PortChannel interface name is invalid !!")
-        fvs['peer_link'] = str(peer_ifname)
+    if ADHOC_VALIDATION:
+        if peer_ifname is not None:
+            if (peer_ifname.startswith("Ethernet") is False) and (peer_ifname.startswith("PortChannel") is False):
+                ctx.fail("peer interface is invalid, should be Ethernet interface or portChannel !!")
+            if (peer_ifname.startswith("Ethernet") is True) and (check_if_interface_is_valid(db, peer_ifname) is False):
+                ctx.fail("peer Ethernet interface name is invalid. it is not present in port table of configDb!!")
+            if (peer_ifname.startswith("PortChannel")) and (is_portchannel_name_valid(peer_ifname) is False):
+                ctx.fail("peer PortChannel interface name is invalid !!")
+    fvs['peer_link'] = str(peer_ifname)
     mclag_domain_keys = db.get_table('MCLAG_DOMAIN').keys()
     if len(mclag_domain_keys) == 0:
-        db.set_entry('MCLAG_DOMAIN', domain_id, fvs)
+        try:
+            db.set_entry('MCLAG_DOMAIN', domain_id, fvs)
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         if domain_id in mclag_domain_keys:
-            db.mod_entry('MCLAG_DOMAIN', domain_id, fvs)
-        else: 
-            ctx.fail("only one mclag Domain can be configured. Already one domain {} configured ".format(mclag_domain_keys[0]))  
+            try:
+                db.mod_entry('MCLAG_DOMAIN', domain_id, fvs)
+            except ValueError as e:
+                ctx.Fail("Invalid ConfigDB. Error: {}".format(e))
+        else:
+            ctx.fail("only one mclag Domain can be configured. Already one domain {} configured ".format(list(mclag_domain_keys)[0]))
 
 
 #mclag domain delete
@@ -158,15 +169,17 @@ def add_mclag_domain(ctx, domain_id, source_ip_addr, peer_ip_addr, peer_ifname):
 @click.pass_context
 def del_mclag_domain(ctx, domain_id):
     """Delete MCLAG Domain"""
+    
+    if ADHOC_VALIDATION:
+        if not mclag_domain_id_valid(domain_id):
+            ctx.fail("{} invalid domain ID, valid range is 1 to 4095".format(domain_id))  
 
-    if not mclag_domain_id_valid(domain_id):
-        ctx.fail("{} invalid domain ID, valid range is 1 to 4095".format(domain_id))  
-
-    db = ctx.obj['db']
-    entry = db.get_entry('MCLAG_DOMAIN', domain_id)
-    if entry is None:
-        ctx.fail("MCLAG Domain {} not configured ".format(domain_id))  
-        return
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        entry = db.get_entry('MCLAG_DOMAIN', domain_id)
+        if entry is None:
+            ctx.fail("MCLAG Domain {} not configured ".format(domain_id))  
+            return
 
     click.echo("MCLAG Domain delete takes care of deleting all associated MCLAG Interfaces")
 
@@ -175,11 +188,17 @@ def del_mclag_domain(ctx, domain_id):
 
     #delete associated mclag interfaces
     for iface_domain_id, iface_name in interface_table_keys:
-        if (int(iface_domain_id) == domain_id): 
-            db.set_entry('MCLAG_INTERFACE', (iface_domain_id, iface_name), None )
+        if (int(iface_domain_id) == domain_id):
+            try:
+                db.set_entry('MCLAG_INTERFACE', (iface_domain_id, iface_name), None )
+            except (JsonPointerException, JsonPatchConflict) as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     
     #delete mclag domain
-    db.set_entry('MCLAG_DOMAIN', domain_id, None)
+    try:
+        db.set_entry('MCLAG_DOMAIN', domain_id, None)
+    except (JsonPointerException, JsonPatchConflict) as e:
+        ctx.fail("Invalid ConfigDB. Error: MCLAG_DOMAIN {} failed to be deleted".format(domain_id))
 
 
 #keepalive timeout config
@@ -260,16 +279,20 @@ def mclag_member(ctx):
 @click.pass_context
 def add_mclag_member(ctx, domain_id, portchannel_names):
     """Add member MCLAG interfaces from MCLAG Domain"""
-    db = ctx.obj['db']
-    entry = db.get_entry('MCLAG_DOMAIN', domain_id)
-    if len(entry) == 0:
-        ctx.fail("MCLAG Domain " + domain_id + " not configured, configure mclag domain first")
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    if ADHOC_VALIDATION:
+        entry = db.get_entry('MCLAG_DOMAIN', domain_id)
+        if len(entry) == 0:
+            ctx.fail("MCLAG Domain " + domain_id + " not configured, configure mclag domain first")
 
     portchannel_list = portchannel_names.split(",")
     for portchannel_name in portchannel_list:
         if is_portchannel_name_valid(portchannel_name) != True:
             ctx.fail("{} is invalid!, name should have prefix '{}' and suffix '{}'" .format(portchannel_name, CFG_PORTCHANNEL_PREFIX, CFG_PORTCHANNEL_NO))
-        db.set_entry('MCLAG_INTERFACE', (domain_id, portchannel_name), {'if_type':"PortChannel"} )
+        try:
+            db.set_entry('MCLAG_INTERFACE', (domain_id, portchannel_name), {'if_type':"PortChannel"} )
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @mclag_member.command('del')
 @click.argument('domain_id', metavar='<domain_id>', required=True)
@@ -277,13 +300,17 @@ def add_mclag_member(ctx, domain_id, portchannel_names):
 @click.pass_context
 def del_mclag_member(ctx, domain_id, portchannel_names):
     """Delete member MCLAG interfaces from MCLAG Domain"""
-    db = ctx.obj['db']
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
     #split comma seperated portchannel names
     portchannel_list = portchannel_names.split(",")
     for portchannel_name in portchannel_list:
-        if is_portchannel_name_valid(portchannel_name) != True:
-            ctx.fail("{} is invalid!, name should have prefix '{}' and suffix '{}'" .format(portchannel_name, CFG_PORTCHANNEL_PREFIX, CFG_PORTCHANNEL_NO))
-        db.set_entry('MCLAG_INTERFACE', (domain_id, portchannel_name), None )
+        if ADHOC_VALIDATION:
+            if is_portchannel_name_valid(portchannel_name) != True:
+                ctx.fail("{} is invalid!, name should have prefix '{}' and suffix '{}'" .format(portchannel_name, CFG_PORTCHANNEL_PREFIX, CFG_PORTCHANNEL_NO))
+        try:
+            db.set_entry('MCLAG_INTERFACE', (domain_id, portchannel_name), None )
+        except (JsonPatchConflict, JsonPointerException) as e:
+            ctx.fail("Failed to delete mclag member {} from mclag domain {}".format(portchannel_name, domain_id))
 
 #mclag unique ip config
 @mclag.group('unique-ip')
@@ -297,7 +324,7 @@ def mclag_unique_ip(ctx):
 @click.pass_context
 def add_mclag_unique_ip(ctx, interface_names):
     """Add Unique IP on MCLAG Vlan interface"""
-    db = ctx.obj['db']
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
     mclag_domain_keys = db.get_table('MCLAG_DOMAIN').keys()
     if len(mclag_domain_keys) == 0:
         ctx.fail("MCLAG not configured. MCLAG should be configured.")
@@ -318,14 +345,17 @@ def add_mclag_unique_ip(ctx, interface_names):
                 (intf_name, ip) = k
                 if intf_name == interface_name and ip != 0:
                     ctx.fail("%s is configured with IP %s, remove the IP configuration and reconfigure after enabling unique IP configuration."%(str(intf_name), str(ip)))
-        db.set_entry('MCLAG_UNIQUE_IP', (interface_name), {'unique_ip':"enable"} )
+        try:
+            db.set_entry('MCLAG_UNIQUE_IP', (interface_name), {'unique_ip':"enable"} )
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 @mclag_unique_ip.command('del')
 @click.argument('interface_names', metavar='<interface_names>', required=True)
 @click.pass_context
 def del_mclag_unique_ip(ctx, interface_names):
     """Delete Unique IP from MCLAG Vlan interface"""
-    db = ctx.obj['db']
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
     #split comma seperated interface names
     interface_list = interface_names.split(",")
     for interface_name in interface_list:
@@ -341,7 +371,10 @@ def del_mclag_unique_ip(ctx, interface_names):
                 (intf_name, ip) = k
                 if intf_name == interface_name and ip != 0:
                     ctx.fail("%s is configured with IP %s, remove the IP configuration and reconfigure after disabling unique IP configuration."%(str(intf_name), str(ip)))
-        db.set_entry('MCLAG_UNIQUE_IP', (interface_name), None )
+        try:
+            db.set_entry('MCLAG_UNIQUE_IP', (interface_name), None )
+        except (JsonPatchConflict, JsonPointerException) as e:
+            ctx.fail("Failed to delete mclag unique IP from Vlan interface {}".format(interface_name))
 
 #######
 

--- a/config/nat.py
+++ b/config/nat.py
@@ -1,8 +1,14 @@
 import ipaddress
 
 import click
+import jsonpatch
+import jsonpointer
+from jsonpatch import JsonPatchConflict
+from jsonpointer import JsonPointerException
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
+from .validated_config_db_connector import ValidatedConfigDBConnector
 
+ADHOC_VALIDATION = True
 
 def is_valid_ipv4_address(address):
     """Check if the given ipv4 address is valid"""
@@ -243,15 +249,15 @@ def static():
 @click.option('-twice_nat_id', metavar='<twice_nat_id>', required=False, type=click.IntRange(1, 9999), help="Set the twice nat id")
 def add_basic(ctx, global_ip, local_ip, nat_type, twice_nat_id):
     """Add Static NAT-related configutation"""
+    if ADHOC_VALIDATION:
+        # Verify the ip address format 
+        if is_valid_ipv4_address(local_ip) is False:
+            ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip)) 
 
-    # Verify the ip address format 
-    if is_valid_ipv4_address(local_ip) is False:
-        ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip)) 
-
-    if is_valid_ipv4_address(global_ip) is False:
-        ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
+        if is_valid_ipv4_address(global_ip) is False:
+            ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
    
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     entryFound = False
@@ -304,13 +310,25 @@ def add_basic(ctx, global_ip, local_ip, nat_type, twice_nat_id):
                 ctx.fail("Same Twice nat id is not allowed for more than 2 entries!!")
 
         if nat_type is not None and twice_nat_id is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: nat_type, dataKey3: twice_nat_id}) 
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: nat_type, dataKey3: twice_nat_id})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif nat_type is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: nat_type})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: nat_type})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif twice_nat_id is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey3: twice_nat_id})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey3: twice_nat_id})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         else:
-            config_db.set_entry(table, key, {dataKey1: local_ip})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat add static tcp' command ('config nat add static tcp <global-ip> <global-port> <local-ip> <local-port>')
@@ -325,15 +343,15 @@ def add_basic(ctx, global_ip, local_ip, nat_type, twice_nat_id):
 @click.option('-twice_nat_id', metavar='<twice_nat_id>', required=False, type=click.IntRange(1, 9999), help="Set the twice nat id")
 def add_tcp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_nat_id):
     """Add Static TCP Protocol NAPT-related configutation"""
+    if ADHOC_VALIDATION: 
+        # Verify the ip address format 
+        if is_valid_ipv4_address(local_ip) is False:
+            ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
 
-    # Verify the ip address format 
-    if is_valid_ipv4_address(local_ip) is False:
-        ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
+        if is_valid_ipv4_address(global_ip) is False:
+            ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
 
-    if is_valid_ipv4_address(global_ip) is False:
-        ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
-
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     
     entryFound = False
@@ -384,13 +402,25 @@ def add_tcp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_n
                 ctx.fail("Same Twice nat id is not allowed for more than 2 entries!!")
 
         if nat_type is not None and twice_nat_id is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type, dataKey4: twice_nat_id})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type, dataKey4: twice_nat_id})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif nat_type is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif twice_nat_id is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey4: twice_nat_id})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey4: twice_nat_id})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         else:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat add static udp' command ('config nat add static udp <global-ip> <global-port> <local-ip> <local-port>')
@@ -405,15 +435,16 @@ def add_tcp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_n
 @click.option('-twice_nat_id', metavar='<twice_nat_id>', required=False, type=click.IntRange(1, 9999), help="Set the twice nat id")
 def add_udp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_nat_id):
     """Add Static UDP Protocol NAPT-related configutation"""
+    
+    if ADHOC_VALIDATION:
+        # Verify the ip address format 
+        if is_valid_ipv4_address(local_ip) is False:
+            ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
 
-    # Verify the ip address format 
-    if is_valid_ipv4_address(local_ip) is False:
-        ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
+        if is_valid_ipv4_address(global_ip) is False:
+            ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
 
-    if is_valid_ipv4_address(global_ip) is False:
-        ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
-
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     entryFound = False
@@ -464,13 +495,25 @@ def add_udp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_n
                 ctx.fail("Same Twice nat id is not allowed for more than 2 entries!!")
 
         if nat_type is not None and twice_nat_id is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type, dataKey4: twice_nat_id})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type, dataKey4: twice_nat_id})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif nat_type is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey3: nat_type})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         elif twice_nat_id is not None:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey4: twice_nat_id})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port, dataKey4: twice_nat_id})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         else:
-            config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port})
+            try:
+                config_db.set_entry(table, key, {dataKey1: local_ip, dataKey2: local_port})
+            except ValueError as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat remove static' group ('config nat remove static ...')
@@ -489,15 +532,16 @@ def static():
 @click.argument('local_ip', metavar='<local_ip>', required=True)
 def remove_basic(ctx, global_ip, local_ip):
     """Remove Static NAT-related configutation"""
+    
+    if ADHOC_VALIDATION:
+        # Verify the ip address format 
+        if is_valid_ipv4_address(local_ip) is False:
+            ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
 
-    # Verify the ip address format 
-    if is_valid_ipv4_address(local_ip) is False:
-        ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
+        if is_valid_ipv4_address(global_ip) is False:
+            ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
 
-    if is_valid_ipv4_address(global_ip) is False:
-        ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
-
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     entryFound = False
@@ -508,8 +552,11 @@ def remove_basic(ctx, global_ip, local_ip):
     data = config_db.get_entry(table, key)
     if data:
         if data[dataKey] == local_ip:
-            config_db.set_entry(table, key, None)
-            entryFound = True
+            try:
+                config_db.set_entry(table, key, None)
+                entryFound = True
+            except (JsonPatchConflict, JsonPointerExceptiOn) as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     if entryFound is False:
         click.echo("Trying to delete static nat entry, which is not present.")
@@ -526,15 +573,16 @@ def remove_basic(ctx, global_ip, local_ip):
 @click.argument('local_port', metavar='<local_port>', type=click.IntRange(1, 65535), required=True)
 def remove_tcp(ctx, global_ip, global_port, local_ip, local_port):
     """Remove Static TCP Protocol NAPT-related configutation"""
+    
+    if ADHOC_VALIDATION:
+        # Verify the ip address format 
+        if is_valid_ipv4_address(local_ip) is False:
+            ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
 
-    # Verify the ip address format 
-    if is_valid_ipv4_address(local_ip) is False:
-        ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
+        if is_valid_ipv4_address(global_ip) is False:
+            ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
 
-    if is_valid_ipv4_address(global_ip) is False:
-        ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
-
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     entryFound = False
@@ -544,8 +592,11 @@ def remove_tcp(ctx, global_ip, global_port, local_ip, local_port):
     data = config_db.get_entry(table, key)
     if data:
         if data['local_ip'] == local_ip and data['local_port'] == str(local_port):
-            config_db.set_entry(table, key, None)
-            entryFound = True
+            try:
+                config_db.set_entry(table, key, None)
+                entryFound = True
+            except (JsonPatchConflict, JsonPointerException) as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     if entryFound is False:
         click.echo("Trying to delete static napt entry, which is not present.")
@@ -561,15 +612,16 @@ def remove_tcp(ctx, global_ip, global_port, local_ip, local_port):
 @click.argument('local_port', metavar='<local_port>', type=click.IntRange(1, 65535), required=True)
 def remove_udp(ctx, global_ip, global_port, local_ip, local_port):
     """Remove Static UDP Protocol NAPT-related configutation"""
+    
+    if ADHOC_VALIDATION:
+        # Verify the ip address format 
+        if is_valid_ipv4_address(local_ip) is False:
+            ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
 
-    # Verify the ip address format 
-    if is_valid_ipv4_address(local_ip) is False:
-        ctx.fail("Given local ip address {} is invalid. Please enter a valid local ip address !!".format(local_ip))
+        if is_valid_ipv4_address(global_ip) is False:
+            ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
 
-    if is_valid_ipv4_address(global_ip) is False:
-        ctx.fail("Given global ip address {} is invalid. Please enter a valid global ip address !!".format(global_ip))
-
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     entryFound = False
@@ -581,8 +633,11 @@ def remove_udp(ctx, global_ip, global_port, local_ip, local_port):
     data = config_db.get_entry(table, key)
     if data:
         if data[dataKey1] == local_ip and data[dataKey2] == str(local_port):
-            config_db.set_entry(table, key, None)
-            entryFound = True
+            try:
+                config_db.set_entry(table, key, None)
+                entryFound = True
+            except (JsonPatchConflict, JsonPointerException) as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     if entryFound is False:
         click.echo("Trying to delete static napt entry, which is not present.")
@@ -595,7 +650,7 @@ def remove_udp(ctx, global_ip, global_port, local_ip, local_port):
 def remove_static_all(ctx):
     """Remove all Static related configutation"""
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     tables = ['STATIC_NAT', 'STATIC_NAPT']
@@ -604,7 +659,10 @@ def remove_static_all(ctx):
         table_dict = config_db.get_table(table_name)
         if table_dict:
             for table_key_name in table_dict:
-                config_db.set_entry(table_name, table_key_name, None)
+                try:
+                    config_db.set_entry(table_name, table_key_name, None)
+                except (JsonPatchConflict, JsonPointerException) as e:
+                    ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat add pool' command ('config nat add pool <pool_name> <global_ip> <global_port_range>')
@@ -664,7 +722,7 @@ def add_pool(ctx, pool_name, global_ip_range, global_port_range):
     else:
         global_port_range = "NULL"
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     entryFound = False
@@ -711,10 +769,13 @@ def add_pool(ctx, pool_name, global_ip_range, global_port_range):
                     ctx.fail("Given Ip address entry is overlapping with existing Static NAT entry !!")
 
     if entryFound == False:
-        config_db.set_entry(table, key, {dataKey1: global_ip_range, dataKey2 : global_port_range})
+        try:
+            config_db.set_entry(table, key, {dataKey1: global_ip_range, dataKey2 : global_port_range})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
-# 'nat add binding' command ('config nat add binding <binding_name> <pool_name> <acl_name>')
+# 'nat add binding' command ('config nat add binding <ninding_name> <pool_name> <acl_name>')
 #
 @add.command('binding')
 @click.pass_context
@@ -740,7 +801,7 @@ def add_binding(ctx, binding_name, pool_name, acl_name, nat_type, twice_nat_id):
     if len(binding_name) > 32:
         ctx.fail("Invalid binding name. Maximum allowed binding name is 32 characters !!")
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     data = config_db.get_entry(table, key)
@@ -773,7 +834,10 @@ def add_binding(ctx, binding_name, pool_name, acl_name, nat_type, twice_nat_id):
             if count > 1:
                 ctx.fail("Same Twice nat id is not allowed for more than 2 entries!!")
 
-        config_db.set_entry(table, key, {dataKey1: acl_name, dataKey2: pool_name, dataKey3: nat_type, dataKey4: twice_nat_id})
+        try:
+            config_db.set_entry(table, key, {dataKey1: acl_name, dataKey2: pool_name, dataKey3: nat_type, dataKey4: twice_nat_id})
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat remove pool' command ('config nat remove pool <pool_name>')
@@ -791,7 +855,7 @@ def remove_pool(ctx, pool_name):
     if len(pool_name) > 32:
         ctx.fail("Invalid pool name. Maximum allowed pool name is 32 characters !!")
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     data = config_db.get_entry(table, key)
@@ -808,7 +872,10 @@ def remove_pool(ctx, pool_name):
                 break
 
     if entryFound == False:
-        config_db.set_entry(table, key, None)
+        try:
+            config_db.set_entry(table, key, None)
+        except (JsonPatchConflict, JsonPointerException) as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat remove pools' command ('config nat remove pools')
@@ -818,7 +885,7 @@ def remove_pool(ctx, pool_name):
 def remove_pools(ctx):
     """Remove all Pools for Dynamic configutation"""
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     entryFound = False
@@ -835,8 +902,11 @@ def remove_pools(ctx):
                     entryFound = True
                     break
 
-            if entryFound == False: 
-                config_db.set_entry(pool_table_name, pool_key_name, None)
+            if entryFound == False:
+                try:
+                    config_db.set_entry(pool_table_name, pool_key_name, None)
+                except (JsonPatchConflict, JsonPointerException) as e:
+                    ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat remove binding' command ('config nat remove binding <binding_name>')
@@ -854,7 +924,7 @@ def remove_binding(ctx, binding_name):
     if len(binding_name) > 32:
         ctx.fail("Invalid binding name. Maximum allowed binding name is 32 characters !!")
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     data = config_db.get_entry(table, key)
@@ -863,7 +933,10 @@ def remove_binding(ctx, binding_name):
         entryFound = True
 
     if entryFound == False:
-        config_db.set_entry(table, key, None)
+        try:
+            config_db.set_entry(table, key, None)
+        except (JsonPatchConflict, JsonPointerException) as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat remove bindings' command ('config nat remove bindings')
@@ -873,14 +946,17 @@ def remove_binding(ctx, binding_name):
 def remove_bindings(ctx):
     """Remove all Bindings for Dynamic configutation"""
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigBConnector(ConfigDBConnector())
     config_db.connect()
 
     binding_table_name = 'NAT_BINDINGS'
     binding_dict = config_db.get_table(binding_table_name)
     if binding_dict:
         for binding_key_name in binding_dict:
-            config_db.set_entry(binding_table_name, binding_key_name, None)
+            try:
+                config_db.set_entry(binding_table_name, binding_key_name, None)
+            except (JsonPatchConflict, JsonPointerException) as e:
+                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat add interface' command ('config nat add interface <interface_name> -nat_zone <zone-value>')
@@ -892,7 +968,7 @@ def remove_bindings(ctx):
 def add_interface(ctx, interface_name, nat_zone):
     """Add interface related nat configuration"""
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     if nat_interface_name_is_valid(interface_name) is False:
@@ -912,7 +988,10 @@ def add_interface(ctx, interface_name, nat_zone):
     if not interface_table_dict or interface_name not in interface_table_dict:
         ctx.fail("Interface table is not present. Please configure ip-address on {} and apply the nat zone !!".format(interface_name))
 
-    config_db.mod_entry(interface_table_type, interface_name, {"nat_zone": nat_zone})
+    try:
+        config_db.mod_entry(interface_table_type, interface_name, {"nat_zone": nat_zone})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat remove interface' command ('config nat remove interface <interface_name>')
@@ -922,7 +1001,7 @@ def add_interface(ctx, interface_name, nat_zone):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 def remove_interface(ctx, interface_name):
     """Remove interface related NAT configuration"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     if nat_interface_name_is_valid(interface_name) is False:
@@ -942,7 +1021,10 @@ def remove_interface(ctx, interface_name):
     if not interface_table_dict or interface_name not in interface_table_dict:
         ctx.fail("Interface table is not present. Ignoring the nat zone configuration")
 
-    config_db.mod_entry(interface_table_type, interface_name, {"nat_zone": "0"})
+    try:
+        config_db.mod_entry(interface_table_type, interface_name, {"nat_zone": "0"})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat remove interfaces' command ('config nat remove interfaces')
@@ -951,7 +1033,7 @@ def remove_interface(ctx, interface_name):
 @click.pass_context
 def remove_interfaces(ctx):
     """Remove all interface related NAT configuration"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
     tables = ['INTERFACE', 'PORTCHANNEL_INTERFACE', 'VLAN_INTERFACE', 'LOOPBACK_INTERFACE']
@@ -964,7 +1046,10 @@ def remove_interfaces(ctx):
                 if isinstance(table_key_name, str) is False:
                     continue
 
-                config_db.set_entry(table_name, table_key_name, nat_config)
+                try:
+                    config_db.set_entry(table_name, table_key_name, nat_config)
+                except ValueError as e:
+                    ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat feature' group ('config nat feature ')
@@ -982,9 +1067,12 @@ def feature():
 def enable(ctx):
     """Enbale the NAT feature """
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"admin_mode": "enabled"})
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"admin_mode": "enabled"})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat feature disable' command ('config nat feature disable>')
@@ -993,9 +1081,12 @@ def enable(ctx):
 @click.pass_context
 def disable(ctx):
     """Disable the NAT feature """
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"admin_mode": "disabled"})
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"admin_mode": "disabled"})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat set timeout' command ('config nat set timeout <seconds>')
@@ -1005,10 +1096,13 @@ def disable(ctx):
 @click.argument('seconds', metavar='<timeout in range of 300 to 432000 seconds>', type=click.IntRange(300, 432000), required=True)
 def timeout(ctx, seconds):
     """Set NAT timeout configuration"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_timeout": seconds})
+    
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_timeout": seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat set tcp-timeout' command ('config nat set tcp-timeout <seconds>')
@@ -1018,10 +1112,13 @@ def timeout(ctx, seconds):
 @click.argument('seconds', metavar='<timeout in range of 300 to 432000 seconds>', type=click.IntRange(300, 432000), required=True)
 def tcp_timeout(ctx, seconds):
     """Set NAT TCP timeout configuration"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_tcp_timeout": seconds})
+    
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_tcp_timeout": seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat set udp-timeout' command ('config nat set udp-timeout <seconds>')
@@ -1031,10 +1128,13 @@ def tcp_timeout(ctx, seconds):
 @click.argument('seconds', metavar='<timeout in range of 120 to 600 seconds>', type=click.IntRange(120, 600), required=True)
 def udp_timeout(ctx, seconds):
     """Set NAT UDP timeout configuration"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
 
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_udp_timeout": seconds})
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_udp_timeout": seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat reset timeout' command ('config nat reset timeout')
@@ -1043,11 +1143,14 @@ def udp_timeout(ctx, seconds):
 @click.pass_context
 def timeout(ctx):
     """Reset NAT timeout configuration to default value (600 seconds)"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     seconds = 600
-
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_timeout": seconds})
+    
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_timeout": seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat reset tcp-timeout' command ('config nat reset tcp-timeout')
@@ -1056,11 +1159,14 @@ def timeout(ctx):
 @click.pass_context
 def tcp_timeout(ctx):
     """Reset NAT TCP timeout configuration to default value (86400 seconds)"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     seconds = 86400
-
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_tcp_timeout": seconds})
+    
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_tcp_timeout": seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'nat reset udp-timeout' command ('config nat reset udp-timeout')
@@ -1069,8 +1175,11 @@ def tcp_timeout(ctx):
 @click.pass_context
 def udp_timeout(ctx):
     """Reset NAT UDP timeout configuration to default value (300 seconds)"""
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     seconds = 300
-
-    config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_udp_timeout": seconds})
+    
+    try:
+        config_db.mod_entry("NAT_GLOBAL", "Values", {"nat_udp_timeout": seconds})
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))

--- a/tests/mclag_test.py
+++ b/tests/mclag_test.py
@@ -87,6 +87,7 @@ class TestMclag(object):
         return False
 
     def test_add_mclag_with_invalid_src_ip(self):
+        config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}

--- a/tests/mclag_test.py
+++ b/tests/mclag_test.py
@@ -4,6 +4,7 @@ import traceback
 from click.testing import CliRunner
 
 import config.main as config
+import config.mclag as mclag
 import show.main as show
 from utilities_common.db import Db
 
@@ -87,7 +88,7 @@ class TestMclag(object):
         return False
 
     def test_add_mclag_with_invalid_src_ip(self):
-        config.ADHOC_VALIDATION = True
+        mclag.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add YANG validation using GCU for writes to MCLAG, NAT, MUXCABLE tables tables in ConfigDB
#### How I did it
Using same method as https://github.com/sonic-net/sonic-utilities/pull/2190/files, extend to  MCLAG, NAT, MUXCABLE tables
#### How to verify it
verified testing on virtual switch CLA

