### PR TITLE
[202205] Added a new option in show queue counters command to display voq stat…

### DIFF
--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -33,6 +33,7 @@ from utilities_common.cli import UserCache
 
 QueueStats = namedtuple("QueueStats", "queueindex, queuetype, totalpacket, totalbytes, droppacket, dropbytes")
 header = ['Port', 'TxQ', 'Counter/pkts', 'Counter/bytes', 'Drop/pkts', 'Drop/bytes']
+voq_header = ['Port', 'Voq', 'Counter/pkts', 'Counter/bytes', 'Drop/pkts', 'Drop/bytes']
 
 counter_bucket_dict = {
     'SAI_QUEUE_STAT_PACKETS': 2,
@@ -47,13 +48,17 @@ from utilities_common.netstat import ns_diff, STATUS_NA
 QUEUE_TYPE_MC = 'MC'
 QUEUE_TYPE_UC = 'UC'
 QUEUE_TYPE_ALL = 'ALL'
+QUEUE_TYPE_VOQ = 'VOQ'
 SAI_QUEUE_TYPE_MULTICAST = "SAI_QUEUE_TYPE_MULTICAST"
 SAI_QUEUE_TYPE_UNICAST = "SAI_QUEUE_TYPE_UNICAST"
+SAI_QUEUE_TYPE_UNICAST_VOQ = "SAI_QUEUE_TYPE_UNICAST_VOQ"
 SAI_QUEUE_TYPE_ALL = "SAI_QUEUE_TYPE_ALL"
 
 COUNTER_TABLE_PREFIX = "COUNTERS:"
 COUNTERS_PORT_NAME_MAP = "COUNTERS_PORT_NAME_MAP"
+COUNTERS_SYSTEM_PORT_NAME_MAP = "COUNTERS_SYSTEM_PORT_NAME_MAP"
 COUNTERS_QUEUE_NAME_MAP = "COUNTERS_QUEUE_NAME_MAP"
+COUNTERS_VOQ_NAME_MAP= "COUNTERS_VOQ_NAME_MAP"
 COUNTERS_QUEUE_TYPE_MAP = "COUNTERS_QUEUE_TYPE_MAP"
 COUNTERS_QUEUE_INDEX_MAP = "COUNTERS_QUEUE_INDEX_MAP"
 COUNTERS_QUEUE_PORT_MAP = "COUNTERS_QUEUE_PORT_MAP"
@@ -80,9 +85,10 @@ def build_json(port, cnstat):
 
 
 class Queuestat(object):
-    def __init__(self):
+    def __init__(self, voq=False):
         self.db = SonicV2Connector(use_unix_socket_path=False)
         self.db.connect(self.db.COUNTERS_DB)
+        self.voq = voq
 
         def get_queue_port(table_id):
             port_table_id = self.db.get(self.db.COUNTERS_DB, COUNTERS_QUEUE_PORT_MAP, table_id)
@@ -93,7 +99,11 @@ class Queuestat(object):
             return port_table_id
 
         # Get all ports
-        self.counter_port_name_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_PORT_NAME_MAP)
+        if voq:
+            self.counter_port_name_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_SYSTEM_PORT_NAME_MAP)
+        else:
+            self.counter_port_name_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_PORT_NAME_MAP)
+
         if self.counter_port_name_map is None:
             print("COUNTERS_PORT_NAME_MAP is empty!")
             sys.exit(1)
@@ -105,8 +115,13 @@ class Queuestat(object):
             self.port_queues_map[port] = {}
             self.port_name_map[self.counter_port_name_map[port]] = port
 
+        counter_queue_name_map = None
         # Get Queues for each port
-        counter_queue_name_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_QUEUE_NAME_MAP)
+        if voq:
+            counter_queue_name_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_VOQ_NAME_MAP)
+        else:
+            counter_queue_name_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_QUEUE_NAME_MAP)
+
         if counter_queue_name_map is None:
             print("COUNTERS_QUEUE_NAME_MAP is empty!")
             sys.exit(1)
@@ -140,6 +155,8 @@ class Queuestat(object):
                     return QUEUE_TYPE_MC
                 elif queue_type == SAI_QUEUE_TYPE_UNICAST:
                     return QUEUE_TYPE_UC
+                elif queue_type == SAI_QUEUE_TYPE_UNICAST_VOQ:
+                    return QUEUE_TYPE_VOQ
                 elif queue_type == SAI_QUEUE_TYPE_ALL:
                     return QUEUE_TYPE_ALL
                 else:
@@ -190,7 +207,8 @@ class Queuestat(object):
             json_output[port].update(build_json(port, table))
             return json_output
         else:
-            print(tabulate(table, header, tablefmt='simple', stralign='right'))
+            hdr = voq_header if self.voq else header
+            print(tabulate(table, hdr, tablefmt='simple', stralign='right'))
             print()
 
     def cnstat_diff_print(self, port, cnstat_new_dict, cnstat_old_dict, json_opt):
@@ -225,7 +243,8 @@ class Queuestat(object):
             json_output[port].update(build_json(port, table))
             return json_output
         else:
-            print(tabulate(table, header, tablefmt='simple', stralign='right'))
+            hdr = voq_header if self.voq else header
+            print(tabulate(table, hdr, tablefmt='simple', stralign='right'))
             print()
 
     def get_print_all_stat(self, json_opt):
@@ -325,11 +344,13 @@ Examples:
     parser.add_argument('-d', '--delete', action='store_true', help='Delete saved stats')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     parser.add_argument('-j', '--json_opt', action='store_true', help='Print in JSON format')
+    parser.add_argument('-V', '--voq', action='store_true', help='display voq stats')
     args = parser.parse_args()
 
     save_fresh_stats = args.clear
     delete_stats = args.delete
     json_opt = args.json_opt
+    voq = args.voq
 
     port_to_show_stats = args.port
 
@@ -341,7 +362,7 @@ Examples:
     if delete_stats:
         cache.remove()
 
-    queuestat = Queuestat()
+    queuestat = Queuestat( voq )
 
     if save_fresh_stats:
         queuestat.save_fresh_stats()

--- a/show/main.py
+++ b/show/main.py
@@ -547,7 +547,8 @@ def queue():
 @click.argument('interfacename', required=False)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--json', is_flag=True, help="JSON output")
-def counters(interfacename, verbose, json):
+@click.option('--voq', is_flag=True, help="VOQ counters")
+def counters(interfacename, verbose, json, voq):
     """Show queue counters"""
 
     cmd = "queuestat"
@@ -561,6 +562,9 @@ def counters(interfacename, verbose, json):
 
     if json:
         cmd += " -j"
+
+    if voq:
+        cmd += " -V"
 
     run_command(cmd, display_cmd=verbose)
 

--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -398,6 +398,150 @@
         "SAI_QUEUE_STAT_PACKETS": "20",
         "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES": "81"
     },
+    "COUNTERS:oid:0x15000000000657": {
+        "SAI_QUEUE_STAT_BYTES": "30",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "74",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "56",
+        "SAI_QUEUE_STAT_PACKETS": "68"
+    },
+    "COUNTERS:oid:0x15000000000658": {
+        "SAI_QUEUE_STAT_BYTES": "43",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "1",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "39",
+        "SAI_QUEUE_STAT_PACKETS": "60"
+    },
+    "COUNTERS:oid:0x15000000000659": {
+        "SAI_QUEUE_STAT_BYTES": "7",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "21",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "39",
+        "SAI_QUEUE_STAT_PACKETS": "82"
+    },
+    "COUNTERS:oid:0x1500000000065a": {
+        "SAI_QUEUE_STAT_BYTES": "59",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "94",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "12",
+        "SAI_QUEUE_STAT_PACKETS": "11"
+    },
+    "COUNTERS:oid:0x1500000000065b": {
+        "SAI_QUEUE_STAT_BYTES": "62",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "40",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "35",
+        "SAI_QUEUE_STAT_PACKETS": "36"
+    },
+    "COUNTERS:oid:0x1500000000065c": {
+        "SAI_QUEUE_STAT_BYTES": "91",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "88",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "2",
+        "SAI_QUEUE_STAT_PACKETS": "49"
+    },
+    "COUNTERS:oid:0x1500000000065d": {
+        "SAI_QUEUE_STAT_BYTES": "17",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "74",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "94",
+        "SAI_QUEUE_STAT_PACKETS": "33"
+    },
+    "COUNTERS:oid:0x1500000000065e": {
+        "SAI_QUEUE_STAT_BYTES": "71",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "33",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "95",
+        "SAI_QUEUE_STAT_PACKETS": "40"
+    },
+    "COUNTERS:oid:0x15000000000667": {
+        "SAI_QUEUE_STAT_BYTES": "8",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "78",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "93",
+        "SAI_QUEUE_STAT_PACKETS": "54"
+    },
+    "COUNTERS:oid:0x15000000000668": {
+        "SAI_QUEUE_STAT_BYTES": "96",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "9",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "74",
+        "SAI_QUEUE_STAT_PACKETS": "83"
+    },
+    "COUNTERS:oid:0x15000000000669": {
+        "SAI_QUEUE_STAT_BYTES": "60",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "31",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "61",
+        "SAI_QUEUE_STAT_PACKETS": "15"
+    },
+    "COUNTERS:oid:0x1500000000066a": {
+        "SAI_QUEUE_STAT_BYTES": "52",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "94",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "82",
+        "SAI_QUEUE_STAT_PACKETS": "45"
+    },
+    "COUNTERS:oid:0x1500000000066b": {
+        "SAI_QUEUE_STAT_BYTES": "88",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "52",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "89",
+        "SAI_QUEUE_STAT_PACKETS": "55"
+    },
+    "COUNTERS:oid:0x1500000000066c": {
+        "SAI_QUEUE_STAT_BYTES": "70",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "79",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "95",
+        "SAI_QUEUE_STAT_PACKETS": "14"
+    },
+    "COUNTERS:oid:0x1500000000066d": {
+        "SAI_QUEUE_STAT_BYTES": "60",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "81",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "66",
+        "SAI_QUEUE_STAT_PACKETS": "68"
+    },
+    "COUNTERS:oid:0x1500000000066e": {
+        "SAI_QUEUE_STAT_BYTES": "4",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "76",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "48",
+        "SAI_QUEUE_STAT_PACKETS": "63"
+    },
+    "COUNTERS:oid:0x15000000000677": {
+        "SAI_QUEUE_STAT_BYTES": "73",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "74",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "77",
+        "SAI_QUEUE_STAT_PACKETS": "41"
+    },
+    "COUNTERS:oid:0x15000000000678": {
+        "SAI_QUEUE_STAT_BYTES": "21",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "54",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "56",
+        "SAI_QUEUE_STAT_PACKETS": "60"
+    },
+    "COUNTERS:oid:0x15000000000679": {
+        "SAI_QUEUE_STAT_BYTES": "31",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "39",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "12",
+        "SAI_QUEUE_STAT_PACKETS": "57"
+    },
+    "COUNTERS:oid:0x1500000000067a": {
+        "SAI_QUEUE_STAT_BYTES": "96",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "98",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "70",
+        "SAI_QUEUE_STAT_PACKETS": "41"
+    },
+    "COUNTERS:oid:0x1500000000067b": {
+        "SAI_QUEUE_STAT_BYTES": "49",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "36",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "63",
+        "SAI_QUEUE_STAT_PACKETS": "18"
+    },
+    "COUNTERS:oid:0x1500000000067c": {
+        "SAI_QUEUE_STAT_BYTES": "90",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "15",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "3",
+        "SAI_QUEUE_STAT_PACKETS": "99"
+    },
+    "COUNTERS:oid:0x1500000000067d": {
+        "SAI_QUEUE_STAT_BYTES": "84",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "94",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "82",
+        "SAI_QUEUE_STAT_PACKETS": "8"
+    },
+    "COUNTERS:oid:0x1500000000067e": {
+        "SAI_QUEUE_STAT_BYTES": "15",
+        "SAI_QUEUE_STAT_DROPPED_BYTES": "92",
+        "SAI_QUEUE_STAT_DROPPED_PACKETS": "75",
+        "SAI_QUEUE_STAT_PACKETS": "83"
+    },
     "COUNTERS:oid:0x60000000005a3": {
             "SAI_ROUTER_INTERFACE_STAT_IN_ERROR_OCTETS": "0",
             "SAI_ROUTER_INTERFACE_STAT_IN_ERROR_PACKETS": "0",
@@ -904,7 +1048,40 @@
     "COUNTERS:oid:0x1a0000000003a6" : {
         "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS" : "107"
     },
+    
+    "COUNTERS_SYSTEM_PORT_NAME_MAP": {
+        "Ethernet0": "oid:0x1000000000042",
+        "Ethernet4": "oid:0x1000000000043",
+        "Ethernet8": "oid:0x1000000000044"
+    },
 
+    "COUNTERS_VOQ_NAME_MAP": {
+        "Ethernet0:0": "oid:0x15000000000657",
+        "Ethernet0:1": "oid:0x15000000000658",
+        "Ethernet0:2": "oid:0x15000000000659",
+        "Ethernet0:3": "oid:0x1500000000065a",
+        "Ethernet0:4": "oid:0x1500000000065b",
+        "Ethernet0:5": "oid:0x1500000000065c",
+        "Ethernet0:6": "oid:0x1500000000065d",
+        "Ethernet0:7": "oid:0x1500000000065e",
+        "Ethernet4:0": "oid:0x15000000000667",
+        "Ethernet4:1": "oid:0x15000000000668",
+        "Ethernet4:2": "oid:0x15000000000669",
+        "Ethernet4:3": "oid:0x1500000000066a",
+        "Ethernet4:4": "oid:0x1500000000066b",
+        "Ethernet4:5": "oid:0x1500000000066c",
+        "Ethernet4:6": "oid:0x1500000000066d",
+        "Ethernet4:7": "oid:0x1500000000066e",
+        "Ethernet8:0": "oid:0x15000000000677",
+        "Ethernet8:1": "oid:0x15000000000678",
+        "Ethernet8:2": "oid:0x15000000000679",
+        "Ethernet8:3": "oid:0x1500000000067a",
+        "Ethernet8:4": "oid:0x1500000000067b",
+        "Ethernet8:5": "oid:0x1500000000067c",
+        "Ethernet8:6": "oid:0x1500000000067d",
+        "Ethernet8:7": "oid:0x1500000000067e"
+    },
+  
     "COUNTERS_PORT_NAME_MAP": {
         "Ethernet0": "oid:0x1000000000012",
         "Ethernet4": "oid:0x1000000000013",
@@ -1155,8 +1332,33 @@
         "oid:0x150000000003c3": "oid:0x1000000000014",
         "oid:0x150000000003c4": "oid:0x1000000000014",
         "oid:0x150000000003c5": "oid:0x1000000000014",
-        "oid:0x150000000003c6": "oid:0x1000000000014"
+        "oid:0x150000000003c6": "oid:0x1000000000014",
+        "oid:0x15000000000657": "oid:0x1000000000042",
+        "oid:0x15000000000658": "oid:0x1000000000042",
+        "oid:0x15000000000659": "oid:0x1000000000042",
+        "oid:0x1500000000065a": "oid:0x1000000000042",
+        "oid:0x1500000000065b": "oid:0x1000000000042",
+        "oid:0x1500000000065c": "oid:0x1000000000042",
+        "oid:0x1500000000065d": "oid:0x1000000000042",
+        "oid:0x1500000000065e": "oid:0x1000000000042",
+        "oid:0x15000000000667": "oid:0x1000000000043",
+        "oid:0x15000000000668": "oid:0x1000000000043",
+        "oid:0x15000000000669": "oid:0x1000000000043",
+        "oid:0x1500000000066a": "oid:0x1000000000043",
+        "oid:0x1500000000066b": "oid:0x1000000000043",
+        "oid:0x1500000000066c": "oid:0x1000000000043",
+        "oid:0x1500000000066d": "oid:0x1000000000043",
+        "oid:0x1500000000066e": "oid:0x1000000000043",
+        "oid:0x15000000000677": "oid:0x1000000000044",
+        "oid:0x15000000000678": "oid:0x1000000000044",
+        "oid:0x15000000000679": "oid:0x1000000000044",
+        "oid:0x1500000000067a": "oid:0x1000000000044",
+        "oid:0x1500000000067b": "oid:0x1000000000044",
+        "oid:0x1500000000067c": "oid:0x1000000000044",
+        "oid:0x1500000000067d": "oid:0x1000000000044",
+        "oid:0x1500000000067e": "oid:0x1000000000044"
     },
+
     "COUNTERS_PG_INDEX_MAP": {
         "oid:0x1a00000000034f": "0",
         "oid:0x1a000000000350": "1",
@@ -1273,7 +1475,31 @@
         "oid:0x150000000003c3": "26",
         "oid:0x150000000003c4": "27",
         "oid:0x150000000003c5": "28",
-        "oid:0x150000000003c6": "29"
+        "oid:0x150000000003c6": "29",
+        "oid:0x15000000000657":  "0",
+        "oid:0x15000000000658":  "1",
+        "oid:0x15000000000659":  "2",
+        "oid:0x1500000000065a":  "3",
+        "oid:0x1500000000065b":  "4",
+        "oid:0x1500000000065c":  "5",
+        "oid:0x1500000000065d":  "6",
+        "oid:0x1500000000065e":  "7",
+        "oid:0x15000000000667":  "0",
+        "oid:0x15000000000668":  "1",
+        "oid:0x15000000000669":  "2",
+        "oid:0x1500000000066a":  "3",
+        "oid:0x1500000000066b":  "4",
+        "oid:0x1500000000066c":  "5",
+        "oid:0x1500000000066d":  "6",
+        "oid:0x1500000000066e":  "7",
+        "oid:0x15000000000677":  "0",
+        "oid:0x15000000000678":  "1",
+        "oid:0x15000000000679":  "2",
+        "oid:0x1500000000067a":  "3",
+        "oid:0x1500000000067b":  "4",
+        "oid:0x1500000000067c":  "5",
+        "oid:0x1500000000067d":  "6",
+        "oid:0x1500000000067e":  "7"
     },
     "COUNTERS_QUEUE_TYPE_MAP": {
         "oid:0x15000000000357": "SAI_QUEUE_TYPE_UNICAST",
@@ -1365,7 +1591,31 @@
         "oid:0x150000000003c3": "SAI_QUEUE_TYPE_ALL",
         "oid:0x150000000003c4": "SAI_QUEUE_TYPE_ALL",
         "oid:0x150000000003c5": "SAI_QUEUE_TYPE_ALL",
-        "oid:0x150000000003c6": "SAI_QUEUE_TYPE_ALL"
+        "oid:0x150000000003c6": "SAI_QUEUE_TYPE_ALL",
+        "oid:0x15000000000657": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000658": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000659": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000065a": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000065b": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000065c": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000065d": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000065e": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000667": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000668": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000669": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000066a": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000066b": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000066c": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000066d": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000066e": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000677": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000678": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x15000000000679": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000067a": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000067b": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000067c": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000067d": "SAI_QUEUE_TYPE_UNICAST_VOQ",
+        "oid:0x1500000000067e": "SAI_QUEUE_TYPE_UNICAST_VOQ"
     },
     "COUNTERS_DEBUG_NAME_PORT_STAT_MAP": {
         "DEBUG_0": "SAI_PORT_STAT_IN_DROP_REASON_RANGE_BASE",

--- a/tests/queue_counter_test.py
+++ b/tests/queue_counter_test.py
@@ -895,6 +895,263 @@ show_queue_counters_port_json = """\
   }
 }"""
 
+show_queue_voq_counters = """\
+     Port    Voq    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
+---------  -----  --------------  ---------------  -----------  ------------
+Ethernet0   VOQ0              68               30           56            74
+Ethernet0   VOQ1              60               43           39             1
+Ethernet0   VOQ2              82                7           39            21
+Ethernet0   VOQ3              11               59           12            94
+Ethernet0   VOQ4              36               62           35            40
+Ethernet0   VOQ5              49               91            2            88
+Ethernet0   VOQ6              33               17           94            74
+Ethernet0   VOQ7              40               71           95            33
+
+     Port    Voq    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
+---------  -----  --------------  ---------------  -----------  ------------
+Ethernet4   VOQ0              54                8           93            78
+Ethernet4   VOQ1              83               96           74             9
+Ethernet4   VOQ2              15               60           61            31
+Ethernet4   VOQ3              45               52           82            94
+Ethernet4   VOQ4              55               88           89            52
+Ethernet4   VOQ5              14               70           95            79
+Ethernet4   VOQ6              68               60           66            81
+Ethernet4   VOQ7              63                4           48            76
+
+     Port    Voq    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
+---------  -----  --------------  ---------------  -----------  ------------
+Ethernet8   VOQ0              41               73           77            74
+Ethernet8   VOQ1              60               21           56            54
+Ethernet8   VOQ2              57               31           12            39
+Ethernet8   VOQ3              41               96           70            98
+Ethernet8   VOQ4              18               49           63            36
+Ethernet8   VOQ5              99               90            3            15
+Ethernet8   VOQ6               8               84           82            94
+Ethernet8   VOQ7              83               15           75            92
+
+"""
+
+show_queue_port_voq_counters = """\
+     Port    Voq    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
+---------  -----  --------------  ---------------  -----------  ------------
+Ethernet0   VOQ0              68               30           56            74
+Ethernet0   VOQ1              60               43           39             1
+Ethernet0   VOQ2              82                7           39            21
+Ethernet0   VOQ3              11               59           12            94
+Ethernet0   VOQ4              36               62           35            40
+Ethernet0   VOQ5              49               91            2            88
+Ethernet0   VOQ6              33               17           94            74
+Ethernet0   VOQ7              40               71           95            33
+
+"""
+
+show_queue_voq_counters_json = """\
+{
+  "Ethernet0": {
+    "VOQ0": {
+      "dropbytes": "74",
+      "droppacket": "56",
+      "totalbytes": "30",
+      "totalpacket": "68"
+    },
+    "VOQ1": {
+      "dropbytes": "1",
+      "droppacket": "39",
+      "totalbytes": "43",
+      "totalpacket": "60"
+    },
+    "VOQ2": {
+      "dropbytes": "21",
+      "droppacket": "39",
+      "totalbytes": "7",
+      "totalpacket": "82"
+    },
+    "VOQ3": {
+      "dropbytes": "94",
+      "droppacket": "12",
+      "totalbytes": "59",
+      "totalpacket": "11"
+    },
+    "VOQ4": {
+      "dropbytes": "40",
+      "droppacket": "35",
+      "totalbytes": "62",
+      "totalpacket": "36"
+    },
+    "VOQ5": {
+      "dropbytes": "88",
+      "droppacket": "2",
+      "totalbytes": "91",
+      "totalpacket": "49"
+    },
+    "VOQ6": {
+      "dropbytes": "74",
+      "droppacket": "94",
+      "totalbytes": "17",
+      "totalpacket": "33"
+    },
+    "VOQ7": {
+      "dropbytes": "33",
+      "droppacket": "95",
+      "totalbytes": "71",
+      "totalpacket": "40"
+    }
+  },
+  "Ethernet4": {
+    "VOQ0": {
+      "dropbytes": "78",
+      "droppacket": "93",
+      "totalbytes": "8",
+      "totalpacket": "54"
+    },
+    "VOQ1": {
+      "dropbytes": "9",
+      "droppacket": "74",
+      "totalbytes": "96",
+      "totalpacket": "83"
+    },
+    "VOQ2": {
+      "dropbytes": "31",
+      "droppacket": "61",
+      "totalbytes": "60",
+      "totalpacket": "15"
+    },
+    "VOQ3": {
+      "dropbytes": "94",
+      "droppacket": "82",
+      "totalbytes": "52",
+      "totalpacket": "45"
+    },
+    "VOQ4": {
+      "dropbytes": "52",
+      "droppacket": "89",
+      "totalbytes": "88",
+      "totalpacket": "55"
+    },
+    "VOQ5": {
+      "dropbytes": "79",
+      "droppacket": "95",
+      "totalbytes": "70",
+      "totalpacket": "14"
+    },
+    "VOQ6": {
+      "dropbytes": "81",
+      "droppacket": "66",
+      "totalbytes": "60",
+      "totalpacket": "68"
+    },
+    "VOQ7": {
+      "dropbytes": "76",
+      "droppacket": "48",
+      "totalbytes": "4",
+      "totalpacket": "63"
+    }
+  },
+  "Ethernet8": {
+    "VOQ0": {
+      "dropbytes": "74",
+      "droppacket": "77",
+      "totalbytes": "73",
+      "totalpacket": "41"
+    },
+    "VOQ1": {
+      "dropbytes": "54",
+      "droppacket": "56",
+      "totalbytes": "21",
+      "totalpacket": "60"
+    },
+    "VOQ2": {
+      "dropbytes": "39",
+      "droppacket": "12",
+      "totalbytes": "31",
+      "totalpacket": "57"
+    },
+    "VOQ3": {
+      "dropbytes": "98",
+      "droppacket": "70",
+      "totalbytes": "96",
+      "totalpacket": "41"
+    },
+    "VOQ4": {
+      "dropbytes": "36",
+      "droppacket": "63",
+      "totalbytes": "49",
+      "totalpacket": "18"
+    },
+    "VOQ5": {
+      "dropbytes": "15",
+      "droppacket": "3",
+      "totalbytes": "90",
+      "totalpacket": "99"
+    },
+    "VOQ6": {
+      "dropbytes": "94",
+      "droppacket": "82",
+      "totalbytes": "84",
+      "totalpacket": "8"
+    },
+    "VOQ7": {
+      "dropbytes": "92",
+      "droppacket": "75",
+      "totalbytes": "15",
+      "totalpacket": "83"
+    }
+  }
+}"""
+
+show_queue_port_voq_counters_json = """\
+{
+  "Ethernet0": {
+    "VOQ0": {
+      "dropbytes": "74",
+      "droppacket": "56",
+      "totalbytes": "30",
+      "totalpacket": "68"
+    },
+    "VOQ1": {
+      "dropbytes": "1",
+      "droppacket": "39",
+      "totalbytes": "43",
+      "totalpacket": "60"
+    },
+    "VOQ2": {
+      "dropbytes": "21",
+      "droppacket": "39",
+      "totalbytes": "7",
+      "totalpacket": "82"
+    },
+    "VOQ3": {
+      "dropbytes": "94",
+      "droppacket": "12",
+      "totalbytes": "59",
+      "totalpacket": "11"
+    },
+    "VOQ4": {
+      "dropbytes": "40",
+      "droppacket": "35",
+      "totalbytes": "62",
+      "totalpacket": "36"
+    },
+    "VOQ5": {
+      "dropbytes": "88",
+      "droppacket": "2",
+      "totalbytes": "91",
+      "totalpacket": "49"
+    },
+    "VOQ6": {
+      "dropbytes": "74",
+      "droppacket": "94",
+      "totalbytes": "17",
+      "totalpacket": "33"
+    },
+    "VOQ7": {
+      "dropbytes": "33",
+      "droppacket": "95",
+      "totalbytes": "71",
+      "totalpacket": "40"
+    }
+  }
+}"""
 
 class TestQueue(object):
     @classmethod
@@ -952,6 +1209,58 @@ class TestQueue(object):
         for _, v in json_output.items():
             del v["time"]
         assert json_dump(json_output) == show_queue_counters_port_json 
+
+    def test_queue_voq_counters(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["queue"].commands["counters"],
+            ["--voq"]
+        )
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_queue_voq_counters
+
+    def test_queue_port_voq_counters(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["queue"].commands["counters"],
+            ["Ethernet0 --voq"]
+        )
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_queue_port_voq_counters
+
+    def test_queue_voq_counters_json(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["queue"].commands["counters"],
+            ["--voq", "--json"]
+        )
+        assert result.exit_code == 0
+        print(result.output)
+        json_output = json.loads(result.output)
+
+        # remove "time" from the output
+        for _, v in json_output.items():
+            del v["time"]
+        print(json_dump(json_output))
+        print(show_queue_voq_counters_json)
+        assert json_dump(json_output) == show_queue_voq_counters_json
+
+    def test_queue_voq_counters_port_json(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["queue"].commands["counters"],
+            ["Ethernet0", "--voq", "--json"]
+        )
+        assert result.exit_code == 0
+        print(result.output)
+        json_output = json.loads(result.output)
+
+        # remove "time" from the output
+        for _, v in json_output.items():
+            del v["time"]
+        assert json_dump(json_output) == show_queue_port_voq_counters_json
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
 Added a new option in show queue counters command to display voq statistics.

* Enhanced queue stat to add an option to display voq statistics. When voq option is given look at COUNTERS_SYSTEM_PORT_NAME_MAP and COUNTERS_VOQ_NAME_MAP to derive the queue information to lookup. Added a modified header for voq statistics.

* Added a unit test for the new voq option.