### PR TITLE
Making 'show feature autorestart' more resilient to missing config

### DIFF
--- a/show/feature.py
+++ b/show/feature.py
@@ -156,11 +156,11 @@ def feature_autorestart(db, feature_name):
     feature_table = db.cfgdb.get_table('FEATURE')
     if feature_name:
         if feature_table and feature_name in feature_table:
-            body.append([feature_name, feature_table[feature_name]['auto_restart']])
+            body.append([feature_name, feature_table[ feature_name ].get('auto_restart', 'unknown')])
         else:
             click.echo("Can not find feature {}".format(feature_name))
             sys.exit(1)
     else:
         for name in natsorted(list(feature_table.keys())):
-            body.append([name, feature_table[name]['auto_restart']])
+            body.append([name, feature_table[ name ].get('auto_restart', 'unknown')])
     click.echo(tabulate(body, header))

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -130,6 +130,32 @@ teamd       enabled
 telemetry   enabled
 """
 
+show_feature_autorestart_missing_output="""\
+Feature     AutoRestart
+----------  --------------
+bar         unknown
+bgp         enabled
+database    always_enabled
+dhcp_relay  enabled
+lldp        enabled
+nat         enabled
+pmon        enabled
+radv        enabled
+restapi     enabled
+sflow       enabled
+snmp        enabled
+swss        enabled
+syncd       enabled
+teamd       enabled
+telemetry   enabled
+"""
+
+show_feature_autorestart_bar_missing_output="""\
+Feature    AutoRestart
+---------  -------------
+bar        unknown
+"""
+
 show_feature_bgp_autorestart_output="""\
 Feature    AutoRestart
 ---------  -------------
@@ -276,6 +302,25 @@ class TestFeature(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 1
+
+    def test_show_feature_autorestart_missing(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        dbconn = db.db
+        db.cfgdb.set_entry("FEATURE", "bar", { "state": "enabled" })
+        runner = CliRunner()
+
+        result = runner.invoke(show.cli.commands["feature"].commands["autorestart"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_autorestart_missing_output
+
+        result = runner.invoke(show.cli.commands["feature"].commands["autorestart"], ["bar"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_feature_autorestart_bar_missing_output
 
     def test_config_bgp_feature_state(self, get_cmd_module):
         (config, show) = get_cmd_module


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

- Fixed 'show feature autorestart' to handle features for which autorestart is not explicitly specified
- Added a testcase to test this scenario.

This addresses  https://github.com/sonic-net/sonic-utilities/issues/2587

#### How I did it

Modified show command logic to catch the case where feature autorestart is missing and report 'unknown'.

#### How to verify it

1. Running the show command
2. running the unit tests

#### Previous command output (if the output of a command-line utility has changed)

```
show feature autorestart
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/show/feature.py", line 165, in feature_autorestart
    body.append([name, feature_table[name]['auto_restart']])
 ```

#### New command output (if the output of a command-line utility has changed)

```
Feature    AutoRestart
---------  -------------
bar        unknown
```
