### PR TITLE
[202012] avoid printing error if no neighbors are present

### DIFF
--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -91,6 +91,13 @@ Try "summary --help" for help.
 Error: bgp summary from bgp container not in json format
 """
 
+show_error_no_v6_neighbor = """\
+No IPv6 neighbor is configured
+"""
+
+show_error_no_v4_neighbor = """\
+No IPv4 neighbor is configured
+"""
 
 class TestBgpCommands(object):
     @classmethod
@@ -139,3 +146,31 @@ class TestBgpCommands(object):
         print("{}".format(result.output))
         assert result.exit_code == 2
         assert result.output == show_error_invalid_json
+
+    @pytest.mark.parametrize('setup_single_bgp_instance',
+                             ['show_bgp_summary_no_neigh'], indirect=['setup_single_bgp_instance'])
+    def test_bgp_summary_no_v4_neigh(
+            self,
+            setup_bgp_commands,
+            setup_single_bgp_instance):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ipv6"].commands["bgp"].commands["summary"], [])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_error_no_v6_neighbor
+
+    @pytest.mark.parametrize('setup_single_bgp_instance',
+                             ['show_bgp_summary_no_neigh'], indirect=['setup_single_bgp_instance'])
+    def test_bgp_summary_no_v6_neigh(
+            self,
+            setup_bgp_commands,
+            setup_single_bgp_instance):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["bgp"].commands["summary"], [])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_error_no_v4_neighbor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,9 @@ def setup_single_bgp_instance(request):
         bgp_mocked_json = os.path.join(
             test_path, 'mock_tables', 'dummy.json')
 
+    def mock_show_bgp_summary_no_neigh(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND):
+        return "{}"
+    
     def mock_run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND):
         if os.path.isfile(bgp_mocked_json):
             with open(bgp_mocked_json) as json_data:
@@ -148,6 +151,9 @@ def setup_single_bgp_instance(request):
              request.param == 'ipv6_route', request.param == 'ipv6_specific_route']):
         bgp_util.run_bgp_command = mock.MagicMock(
             return_value=mock_run_show_ip_route_commands(request))
+    elif request.param == "show_bgp_summary_no_neigh":
+        bgp_util.run_bgp_command = mock.MagicMock(
+            return_value=mock_show_bgp_summary_no_neigh("", ""))
     else:
         bgp_util.run_bgp_command = mock.MagicMock(
             return_value=mock_run_bgp_command("", ""))

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -186,8 +186,10 @@ def get_bgp_summary_from_all_bgp_instances(af, namespace, display):
         except ValueError:
             ctx.fail("bgp summary from bgp container not in json format")
 
+        # exit cli command without printing the error message
         if key not in cmd_output_json:
-            ctx.fail("bgp summary from bgp container in invalid format")
+            click.echo("No IP{} neighbor is configured".format(af))
+            exit()
 
         device.current_namespace = ns
 


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix #2492. port #2502  in 202012 branch

#### How I did it
Use `click.echo` and `exit` instead of `ctx.fail` in cli handler when no neighbor information is returned from bgp container.

#### How to verify it
Test on target and add UT
new output when no neighbors are present
```
admin@vlab-01:~$ show version

SONiC Software Version: SONiC.202012.202057-b111cecf0
Distribution: Debian 10.13
Kernel: 4.19.0-12-2-amd64
Build commit: b111cecf0
Build date: Thu Jan 12 12:18:18 UTC 2023
Built by: AzDevOps@vmss-soni000AO0

Platform: x86_64-kvm_x86_64-r0
HwSKU: Force10-S6000
ASIC: vs
ASIC Count: 1
Serial Number: 000000
Uptime: 00:04:12 up  2:26,  1 user,  load average: 0.30, 0.21, 0.19

Docker images:
REPOSITORY                    TAG                       IMAGE ID            SIZE
docker-sonic-mgmt-framework   202012.202057-b111cecf0   5794cb357e98        688MB
docker-sonic-mgmt-framework   latest                    5794cb357e98        688MB
docker-sonic-telemetry        202012.202057-b111cecf0   41410937da23        452MB
docker-sonic-telemetry        latest                    41410937da23        452MB
docker-sflow                  202012.202057-b111cecf0   5652fd0ec085        375MB
docker-sflow                  latest                    5652fd0ec085        375MB
docker-teamd                  202012.202057-b111cecf0   0d8ec0fe02a6        374MB
docker-teamd                  latest                    0d8ec0fe02a6        374MB
docker-orchagent              202012.202057-b111cecf0   adbe5e3b4d3e        392MB
docker-orchagent              latest                    adbe5e3b4d3e        392MB
docker-fpm-frr                202012.202057-b111cecf0   c616d6c60a64        392MB
docker-fpm-frr                latest                    c616d6c60a64        392MB
docker-nat                    202012.202057-b111cecf0   fe2fe5a96166        376MB
docker-nat                    latest                    fe2fe5a96166        376MB
docker-gbsyncd-vs             202012.202057-b111cecf0   814a42269647        369MB
docker-gbsyncd-vs             latest                    814a42269647        369MB
docker-snmp                   202012.202057-b111cecf0   79def75c20b5        405MB
docker-snmp                   latest                    79def75c20b5        405MB
docker-platform-monitor       202012.202057-b111cecf0   868b11d10a59        544MB
docker-platform-monitor       latest                    868b11d10a59        544MB
docker-syncd-vs               202012.202057-b111cecf0   86c0ad53fbda        369MB
docker-syncd-vs               latest                    86c0ad53fbda        369MB
docker-router-advertiser      202012.202057-b111cecf0   35a37b25ccb9        362MB
docker-router-advertiser      latest                    35a37b25ccb9        362MB
docker-lldp                   202012.202057-b111cecf0   3d3a9a84668d        402MB
docker-lldp                   latest                    3d3a9a84668d        402MB
docker-database               202012.202057-b111cecf0   90137c4b5362        362MB
docker-database               latest                    90137c4b5362        362MB
docker-dhcp-relay             202012.202057-b111cecf0   586c47d3a09a        375MB
docker-dhcp-relay             latest                    586c47d3a09a        375MB
docker-mux                    202012.202057-b111cecf0   d6f54ccb76cf        415MB
docker-mux                    latest                    d6f54ccb76cf        415MB

admin@vlab-01:~$ show ipv6 bgp summary
No IPv6 neighbor is configured
admin@vlab-01:~$ 
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

