### PR TITLE
fix show techsupport error

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1352,14 +1352,14 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
     if global_timeout:
         cmd += " timeout --kill-after={}s -s SIGTERM --foreground {}m".format(COMMAND_TIMEOUT, global_timeout)
 
-    if allow_process_stop:
-        cmd += " -a"
-
     if silent:
         cmd += " generate_dump"
         click.echo("Techsupport is running with silent option. This command might take a long time.")
     else:
         cmd += " generate_dump -v"
+
+    if allow_process_stop:
+        cmd += " -a"
 
     if since:
         cmd += " -s '{}'".format(since)

--- a/tests/techsupport_test.py
+++ b/tests/techsupport_test.py
@@ -12,7 +12,7 @@ EXPECTED_BASE_COMMAND = 'sudo '
             ([], 'generate_dump -v -t 5'),
             (['--since', '2 days ago'], "generate_dump -v -s '2 days ago' -t 5"),
             (['-g', '50'], 'timeout --kill-after=300s -s SIGTERM --foreground 50m generate_dump -v -t 5'),
-            (['--allow-process-stop'], '-a generate_dump -v -t 5'),
+            (['--allow-process-stop'], 'generate_dump -v -a -t 5'),
             (['--silent'], 'generate_dump -t 5'),
             (['--debug-dump', '--redirect-stderr'], 'generate_dump -v -d -t 5 -r'),
         ]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modify the order of "--allow-process-stop" option, it belongs to 'generate_dump'.
#### How I did it
Option "--allow-process-stop" does not belongs to 'timeout'. change to 'generate_dump'.
#### How to verify it
show techsupport can use option "--allow-process-stop" without error.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

