### PR TITLE
[201911][show] Add bgpraw to show run all

### DIFF
--- a/sonic-utilities-tests/show_test.py
+++ b/sonic-utilities-tests/show_test.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import show.main as show
+from click.testing import CliRunner
+import mock
+from mock import call, MagicMock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+
+class TestShowRunAllCommands(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_show_runningconfiguration_all_json_loads_failure(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "", 0
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert result.exit_code != 0
+
+    def test_show_runningconfiguration_all_get_cmd_ouput_failure(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "{}", 2
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert result.exit_code != 0
+
+    def test_show_runningconfiguration_all(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "{}", 0
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert mock_get_cmd_output.call_count == 2
+        assert mock_get_cmd_output.call_args_list == [
+            call(['sonic-cfggen', '-d', '--print-data']),
+            call(['rvtysh', '-c', 'show running-config'])]
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Backport https://github.com/sonic-net/sonic-utilities/pull/2537
Add bgpraw output to `show runningconfiguration all`
#### How I did it
Generate bgpraw output then append it to `show runnningconfiguration all`'s output
#### How to verify it
Unittest and manual test on 201911 image.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

