### PR TITLE
YANG Validation for ConfigDB Updates: RADIUS_SERVER

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -498,15 +498,16 @@ radius.add_command(statistics)
 def add(address, retransmit, timeout, key, auth_type, auth_port, pri, use_mgmt_vrf, source_interface):
     """Specify a RADIUS server"""
 
-    if key:
-        if len(key) > RADIUS_PASSKEY_MAX_LEN:
-            click.echo('--key: Maximum of %d chars can be configured' % RADIUS_PASSKEY_MAX_LEN)
-            return
-        elif not is_secret(key):
-            click.echo('--key: ' + VALID_CHARS_MSG)
-            return
+    if ADHOC_VALIDATION:
+        if key:
+            if len(key) > RADIUS_PASSKEY_MAX_LEN:
+                click.echo('--key: Maximum of %d chars can be configured' % RADIUS_PASSKEY_MAX_LEN)
+                return
+            elif not is_secret(key):
+                click.echo('--key: ' + VALID_CHARS_MSG)
+                return
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     old_data = config_db.get_table('RADIUS_SERVER')
     if address in old_data :
@@ -529,16 +530,24 @@ def add(address, retransmit, timeout, key, auth_type, auth_port, pri, use_mgmt_v
             data['passkey'] = key
         if use_mgmt_vrf :
             data['vrf'] = "mgmt"
-        if source_interface :
-            if (source_interface.startswith("Ethernet") or \
-                source_interface.startswith("PortChannel") or \
-                source_interface.startswith("Vlan") or \
-                source_interface.startswith("Loopback") or \
-                source_interface == "eth0"):
+        if ADHOC_VALIDATION:
+            if source_interface :
+                if (source_interface.startswith("Ethernet") or \
+                    source_interface.startswith("PortChannel") or \
+                    source_interface.startswith("Vlan") or \
+                    source_interface.startswith("Loopback") or \
+                    source_interface == "eth0"):
+                    data['src_intf'] = source_interface
+                else:
+                    click.echo('Not supported interface name (valid interface name: Etherent<id>/PortChannel<id>/Vlan<id>/Loopback<id>/eth0)')
+        else:
+            if source_interface:
                 data['src_intf'] = source_interface
-            else:
-                click.echo('Not supported interface name (valid interface name: Etherent<id>/PortChannel<id>/Vlan<id>/Loopback<id>/eth0)')
-        config_db.set_entry('RADIUS_SERVER', address, data)
+        try:
+            config_db.set_entry('RADIUS_SERVER', address, data)
+        except ValueError as e:
+            ctx = click.get_current_context()
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 radius.add_command(add)
 
 
@@ -549,7 +558,11 @@ radius.add_command(add)
 def delete(address):
     """Delete a RADIUS server"""
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-    config_db.set_entry('RADIUS_SERVER', address, None)
+    try:
+        config_db.set_entry('RADIUS_SERVER', address, None)
+    except JsonPatchConflict as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 radius.add_command(delete)

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -4,6 +4,7 @@ import re
 from swsscommon.swsscommon import ConfigDBConnector
 from .validated_config_db_connector import ValidatedConfigDBConnector
 from jsonpatch import JsonPatchConflict
+from jsonpointer import JsonPointerException
 import utilities_common.cli as clicommon
 
 ADHOC_VALIDATION = True

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -562,7 +562,7 @@ def delete(address):
     config_db.connect()
     try:
         config_db.set_entry('RADIUS_SERVER', address, None)
-    except JsonPatchConflict as e:
+    except (JsonPointerException, JsonPatchConflict) as e:
         ctx = click.get_current_context()
         ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 radius.add_command(delete)

--- a/tests/radius_test.py
+++ b/tests/radius_test.py
@@ -8,6 +8,7 @@ from utilities_common.db import Db
 from mock import patch
 
 import config.main as config
+import config.aaa as aaa
 import show.main as show
 
 test_path = os.path.dirname(os.path.abspath(__file__))
@@ -197,10 +198,12 @@ class TestRadius(object):
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
     def test_config_radius_server_invalidkey_yang_validation(self):
-        config.ADHOC_VALIDATION = False
+        aaa.ADHOC_VALIDATION = False
         runner = CliRunner()
         result = runner.invoke(config.config.commands["radius"],\
                                ["add", "10.10.10.10", "-r", "1", "-t", "3",\
                                 "-k", "comma,invalid", "-s", "eth0"])
         print(result.output)
         assert "Invalid ConfigDB. Error" in result.output
+
+   

--- a/tests/radius_test.py
+++ b/tests/radius_test.py
@@ -2,10 +2,12 @@ import imp
 import os
 import sys
 import mock
+import jsonpatch
 
 from click.testing import CliRunner
 from utilities_common.db import Db
 from mock import patch
+from jsonpointer import JsonPointerException
 
 import config.main as config
 import config.aaa as aaa
@@ -206,4 +208,12 @@ class TestRadius(object):
         print(result.output)
         assert "Invalid ConfigDB. Error" in result.output
 
-   
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPointerException))
+    def test_config_radius_server_invalid_delete_yang_validation(self):
+        aaa.ADHOC_VALIDATION = False
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["radius"],\
+                               ["delete", "10.10.10.x"])
+        print(result.output)
+        assert "Invalid ConfigDB. Error" in result.output

--- a/tests/radius_test.py
+++ b/tests/radius_test.py
@@ -73,7 +73,6 @@ class TestRadius(object):
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
-        config.ADHOC_VALIDATION = True
         print("TEARDOWN")
 
     def test_show_radius_default(self):
@@ -205,5 +204,3 @@ class TestRadius(object):
                                 "-k", "comma,invalid", "-s", "eth0"])
         print(result.output)
         assert "Invalid ConfigDB. Error" in result.output
-
-   


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add YANG validation using GCU for writes to RADIUS_SERVER table in ConfigDB
#### How I did it
Using same method as https://github.com/sonic-net/sonic-utilities/pull/2190/files, extend to RADIUS table
#### How to verify it
verified testing on virtual switch CLI, unit tests

