### PR TITLE
[generate_dump] [BCM] Dump only the relevant BCM commands for fabric cards

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1211,8 +1211,13 @@ collect_broadcom() {
     fi
 
     if [ "$bcm_family" == "broadcom-dnx" ]; then
-       switch_type=$(sonic-cfggen -d -v "DEVICE_METADATA['localhost']['switch_type']")
-       if [ $switch_type != "fabric" ]; then
+       supervisor=0
+       PLATFORM_ENV_CONF=/usr/share/sonic/device/${platform}/platform_env.conf
+       if [ -f "$PLATFORM_ENV_CONF" ]; then
+          source $PLATFORM_ENV_CONF
+       fi
+       if [[ x"$supervisor" != x"1" ]]; then
+
           save_bcmcmd_all_ns "\"l2 show\"" "l2.summary"
           save_bcmcmd_all_ns "\"field group list\"" "fpgroup.list.summary"
           total_fp_groups=34

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1211,39 +1211,42 @@ collect_broadcom() {
     fi
 
     if [ "$bcm_family" == "broadcom-dnx" ]; then
-       save_bcmcmd_all_ns "\"l2 show\"" "l2.summary"
-       save_bcmcmd_all_ns "\"field group list\"" "fpgroup.list.summary"
-       total_fp_groups=34
-       for (( fp_grp=0; fp_grp<$total_fp_groups; fp_grp++ ))
-       do
-         save_bcmcmd_all_ns "\"field group info group=$fp_grp\"" "fpgroup$fp_grp.info.summary"
-       done
-       save_bcmcmd_all_ns "\"dbal table dump table=IPV4_UNICAST_PRIVATE_LPM_FORWARD\"" "l3.ipv4.lpm.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=IPV6_UNICAST_PRIVATE_LPM_FORWARD\"" "l3.ipv6.lpm.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=IPV4_UNICAST_PRIVATE_HOST\"" "l3.ipv4.host.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=IPV6_UNICAST_PRIVATE_HOST\"" "l3.ipv6.host.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=SUPER_FEC_1ST_HIERARCHY\"" "l3.egress.fec.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=ECMP_TABLE\"" "ecmp.table.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=ECMP_GROUP_PROFILE_TABLE\"" "ecmp.group.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=ING_VSI_INFO_DB\"" "ing.vsi.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=L3_MY_MAC_DA_PREFIXES\"" "l3.mymac.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=INGRESS_VLAN_MEMBERSHIP\"" "ing.vlan.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=LOCAL_SBC_IN_LIF_MATCH_INFO_SW\"" "sbc.inlif.summary"
-       save_bcmcmd_all_ns "\"dbal table dump table=SNIF_COMMAND_TABLE\"" "snif.command.summary"
-       save_bcmcmd_all_ns "\"port mgmt dump full\"" "port.mgmt.summary"
-       save_bcmcmd_all_ns "\"tm lag\"" "tm.lag.summary"
-       save_bcmcmd_all_ns "\"pp info fec\"" "pp.fec.summary"
-       save_bcmcmd_all_ns "\"nif sts\"" "nif.sts.summary"
+       switch_type=$(sonic-cfggen -d -v "DEVICE_METADATA['localhost']['switch_type']")
+       if [ $switch_type != "fabric" ]; then
+          save_bcmcmd_all_ns "\"l2 show\"" "l2.summary"
+          save_bcmcmd_all_ns "\"field group list\"" "fpgroup.list.summary"
+          total_fp_groups=34
+          for (( fp_grp=0; fp_grp<$total_fp_groups; fp_grp++ ))
+          do
+            save_bcmcmd_all_ns "\"field group info group=$fp_grp\"" "fpgroup$fp_grp.info.summary"
+          done
+          save_bcmcmd_all_ns "\"dbal table dump table=IPV4_UNICAST_PRIVATE_LPM_FORWARD\"" "l3.ipv4.lpm.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=IPV6_UNICAST_PRIVATE_LPM_FORWARD\"" "l3.ipv6.lpm.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=IPV4_UNICAST_PRIVATE_HOST\"" "l3.ipv4.host.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=IPV6_UNICAST_PRIVATE_HOST\"" "l3.ipv6.host.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=SUPER_FEC_1ST_HIERARCHY\"" "l3.egress.fec.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=ECMP_TABLE\"" "ecmp.table.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=ECMP_GROUP_PROFILE_TABLE\"" "ecmp.group.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=ING_VSI_INFO_DB\"" "ing.vsi.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=L3_MY_MAC_DA_PREFIXES\"" "l3.mymac.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=INGRESS_VLAN_MEMBERSHIP\"" "ing.vlan.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=LOCAL_SBC_IN_LIF_MATCH_INFO_SW\"" "sbc.inlif.summary"
+          save_bcmcmd_all_ns "\"dbal table dump table=SNIF_COMMAND_TABLE\"" "snif.command.summary"
+          save_bcmcmd_all_ns "\"port mgmt dump full\"" "port.mgmt.summary"
+          save_bcmcmd_all_ns "\"tm lag\"" "tm.lag.summary"
+          save_bcmcmd_all_ns "\"pp info fec\"" "pp.fec.summary"
+          save_bcmcmd_all_ns "\"nif sts\"" "nif.sts.summary"
+          save_bcmcmd_all_ns "\"tm ing q map\"" "tm.ingress.qmap.summary"
+          save_bcmcmd_all_ns "\"tm ing vsq resources\"" "tm.ing.vsq.res.summary"
+          for group in {a..f}
+          do
+             save_bcmcmd_all_ns "\"tm ing vsq non g=$group\"" "tm.ing.vsq.non.group-$group.summary"
+          done
+       fi
        save_bcmcmd_all_ns "\"port pm info\"" "port.pm.summary"
        save_bcmcmd_all_ns "\"conf show\"" "conf.show.summary"
        save_bcmcmd_all_ns "\"show counters\"" "show.counters.summary"
        save_bcmcmd_all_ns "\"diag counter g\"" "diag.counter.summary"
-       save_bcmcmd_all_ns "\"tm ing q map\"" "tm.ingress.qmap.summary"
-       save_bcmcmd_all_ns "\"tm ing vsq resources\"" "tm.ing.vsq.res.summary"
-       for group in {a..f}
-       do
-          save_bcmcmd_all_ns "\"tm ing vsq non g=$group\"" "tm.ing.vsq.non.group-$group.summary"
-       done
        save_bcmcmd_all_ns "\"fabric connectivity\"" "fabric.connect.summary"
        save_bcmcmd_all_ns "\"port status\"" "port.status.summary"
     else


### PR DESCRIPTION

Signed-off-by: Sakthivadivu Saravanaraj <sakthivadivu.saravanaraj@nokia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When we run generate_dump script in SFM cards in a Broadcom chassis, the errors were printed in syslog for all the Broadcom commands which are not supported in fabric/Ramon cards. Added a check to dump all l2, l3, fp and tm commands only if the switch_type is non fabric card since these commands are not valid for fabric cards.

#### How I did it
 Get the switch_type from DEVICE_METADATA and check the switch_type before dumping these BCM commands. 

#### How to verify it
Ran generate_dump script in both voq  and fabric cards,  (1)verified that the fabric cards don't log the errors for the BCM commands (2) verified that the commands are dumped correctly in non-fabric dnx cards.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

