### PR TITLE
[202205][show] Add bgpraw to show run all

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -10,7 +10,7 @@ import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 from importlib import reload
 from natsort import natsorted
-from sonic_py_common import device_info
+from sonic_py_common import device_info, multi_asic
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import util_base
@@ -18,6 +18,7 @@ from utilities_common.db import Db
 from datetime import datetime
 import utilities_common.constants as constants
 from utilities_common.general import load_db_config
+from json.decoder import JSONDecodeError
 
 # mock the redis for unit test purposes #
 try:
@@ -126,6 +127,10 @@ def run_command(command, display_cmd=False, return_cmd=False):
     rc = proc.poll()
     if rc != 0:
         sys.exit(rc)
+
+def get_cmd_output(cmd):
+    proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
+    return proc.communicate()[0], proc.returncode
 
 # Lazy global class instance for SONiC interface name to alias conversion
 iface_alias_converter = lazy_object_proxy.Proxy(lambda: clicommon.InterfaceAliasConverter())
@@ -1229,8 +1234,25 @@ def runningconfiguration():
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def all(verbose):
     """Show full running configuration"""
-    cmd = "sonic-cfggen -d --print-data"
-    run_command(cmd, display_cmd=verbose)
+    cmd = ['sonic-cfggen', '-d', '--print-data']
+    stdout, rc = get_cmd_output(cmd)
+    if rc:
+        click.echo("Failed to get cmd output '{}':rc {}".format(cmd, rc))
+        raise click.Abort()
+
+    try:
+        output = json.loads(stdout)
+    except JSONDecodeError as e:
+        click.echo("Failed to load output '{}':{}".format(cmd, e))
+        raise click.Abort()
+
+    if not multi_asic.is_multi_asic():
+        bgpraw_cmd = [constants.RVTYSH_COMMAND, '-c', 'show running-config']
+        bgpraw, rc = get_cmd_output(bgpraw_cmd)
+        if rc:
+            bgpraw = ""
+        output['bgpraw'] = bgpraw
+    click.echo(json.dumps(output, indent=4))
 
 
 # 'acl' subcommand ("show runningconfiguration acl")

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import show.main as show
+from click.testing import CliRunner
+from unittest import mock
+from unittest.mock import call, MagicMock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+
+class TestShowRunAllCommands(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_show_runningconfiguration_all_json_loads_failure(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "", 0
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert result.exit_code != 0
+
+    def test_show_runningconfiguration_all_get_cmd_ouput_failure(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "{}", 2
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert result.exit_code != 0
+
+    def test_show_runningconfiguration_all(self):
+        def get_cmd_output_side_effect(*args, **kwargs):
+            return "{}", 0
+        with mock.patch('show.main.get_cmd_output',
+                mock.MagicMock(side_effect=get_cmd_output_side_effect)) as mock_get_cmd_output:
+            result = CliRunner().invoke(show.cli.commands['runningconfiguration'].commands['all'], [])
+        assert mock_get_cmd_output.call_count == 2
+        assert mock_get_cmd_output.call_args_list == [
+            call(['sonic-cfggen', '-d', '--print-data']),
+            call(['rvtysh', '-c', 'show running-config'])]
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
https://github.com/sonic-net/sonic-utilities/pull/2537
202205 branch doesn't have `from sonic_py_common import multi_asic`, which results in test failure and build error.
The only difference between this PR and original PR is just one line of import.
#### How I did it

#### How to verify it
Tested locally on 202205 build and pass the build process.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

