### PR TITLE
[202012][show_bfd] add local discriminator in show bfd command

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1594,7 +1594,7 @@ def summary(db):
             key_values = key.split('|')
             values = db.db.get_all(db.db.STATE_DB, key)
             if "local_discriminator" not in values.keys():
-                values["local_discriminator"]="NA"
+                values["local_discriminator"] = "NA"
             bfd_body.append([key_values[3], key_values[2], key_values[1], values["state"], values["type"], values["local_addr"],
                                 values["tx_interval"], values["rx_interval"], values["multiplier"], values["multihop"], values["local_discriminator"]])
 
@@ -1625,7 +1625,7 @@ def peer(db, peer_ip):
             key_values = key.split(delimiter)
             values = db.db.get_all(db.db.STATE_DB, key)
             if "local_discriminator" not in values.keys():
-                values["local_discriminator"]="NA"
+                values["local_discriminator"] = "NA"
             bfd_body.append([key_values[3], key_values[2], key_values[1], values.get("state"), values.get("type"), values.get("local_addr"),
                                 values.get("tx_interval"), values.get("rx_interval"), values.get("multiplier"), values.get("multihop"), values.get("local_discriminator")])
 

--- a/show/main.py
+++ b/show/main.py
@@ -1582,7 +1582,7 @@ def bfd():
 def summary(db):
     """Show bfd session information"""
     bfd_headers = ["Peer Addr", "Interface", "Vrf", "State", "Type", "Local Addr",
-                "TX Interval", "RX Interval", "Multiplier", "Multihop"]
+                "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
 
     bfd_keys = db.db.keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*")
 
@@ -1593,8 +1593,10 @@ def summary(db):
         for key in bfd_keys:
             key_values = key.split('|')
             values = db.db.get_all(db.db.STATE_DB, key)
+            if "local_discriminator" not in values.keys():
+                values["local_discriminator"]="NA"
             bfd_body.append([key_values[3], key_values[2], key_values[1], values["state"], values["type"], values["local_addr"],
-                                values["tx_interval"], values["rx_interval"], values["multiplier"], values["multihop"]])
+                                values["tx_interval"], values["rx_interval"], values["multiplier"], values["multihop"], values["local_discriminator"]])
 
     click.echo(tabulate(bfd_body, bfd_headers))
 
@@ -1606,7 +1608,7 @@ def summary(db):
 def peer(db, peer_ip):
     """Show bfd session information for BFD peer"""
     bfd_headers = ["Peer Addr", "Interface", "Vrf", "State", "Type", "Local Addr",
-                "TX Interval", "RX Interval", "Multiplier", "Multihop"]
+                "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
 
     bfd_keys = db.db.keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*|{}".format(peer_ip))
     delimiter = db.db.get_db_separator(db.db.STATE_DB)
@@ -1622,8 +1624,10 @@ def peer(db, peer_ip):
         for key in bfd_keys:
             key_values = key.split(delimiter)
             values = db.db.get_all(db.db.STATE_DB, key)
+            if "local_discriminator" not in values.keys():
+                values["local_discriminator"]="NA"
             bfd_body.append([key_values[3], key_values[2], key_values[1], values.get("state"), values.get("type"), values.get("local_addr"),
-                                values.get("tx_interval"), values.get("rx_interval"), values.get("multiplier"), values.get("multihop")])
+                                values.get("tx_interval"), values.get("rx_interval"), values.get("multiplier"), values.get("multihop"), values.get("local_discriminator")])
 
     click.echo(tabulate(bfd_body, bfd_headers))
 

--- a/tests/show_bfd_test.py
+++ b/tests/show_bfd_test.py
@@ -29,7 +29,7 @@ class TestShowBfd(object):
                         "tx_interval" :"300", "rx_interval" : "500", "multiplier" : "3", "multihop": "true"})
         self.set_db_values(dbconnector, "BFD_SESSION_TABLE|default|Ethernet12|10.0.2.1",
                         {"state": "UP", "type": "async_active", "local_addr" : "10.0.0.1",
-                        "tx_interval" :"200", "rx_interval" : "600", "multiplier" : "3", "multihop": "false"})
+                        "tx_interval" :"200", "rx_interval" : "600", "multiplier" : "3", "multihop": "false", "local_discriminator": "88"})
         self.set_db_values(dbconnector, "BFD_SESSION_TABLE|default|default|2000::10:1",
                         {"state": "UP", "type": "async_active", "local_addr" : "2000::1",
                         "tx_interval" :"100", "rx_interval" : "700", "multiplier" : "3", "multihop": "false"})
@@ -39,14 +39,14 @@ class TestShowBfd(object):
 
         expected_output = """\
 Total number of BFD sessions: 6
-Peer Addr              Interface    Vrf      State    Type          Local Addr               TX Interval    RX Interval    Multiplier  Multihop
----------------------  -----------  -------  -------  ------------  ---------------------  -------------  -------------  ------------  ----------
-100.251.7.1            default      default  Up       async_active  10.0.0.1                         300            500             3  true
-fddd:a101:a251::a10:1  default      default  Down     async_active  fddd:c101:a251::a10:2            300            500             3  true
-10.0.1.1               default      default  DOWN     async_active  10.0.0.1                         300            500             3  true
-10.0.2.1               Ethernet12   default  UP       async_active  10.0.0.1                         200            600             3  false
-2000::10:1             default      default  UP       async_active  2000::1                          100            700             3  false
-10.0.1.1               default      VrfRed   UP       async_active  10.0.0.1                         400            500             5  false
+Peer Addr              Interface    Vrf      State    Type          Local Addr               TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+---------------------  -----------  -------  -------  ------------  ---------------------  -------------  -------------  ------------  ----------  ---------------------
+100.251.7.1            default      default  Up       async_active  10.0.0.1                         300            500             3  true        NA
+fddd:a101:a251::a10:1  default      default  Down     async_active  fddd:c101:a251::a10:2            300            500             3  true        NA
+10.0.1.1               default      default  DOWN     async_active  10.0.0.1                         300            500             3  true        NA
+10.0.2.1               Ethernet12   default  UP       async_active  10.0.0.1                         200            600             3  false       88
+2000::10:1             default      default  UP       async_active  2000::1                          100            700             3  false       NA
+10.0.1.1               default      VrfRed   UP       async_active  10.0.0.1                         400            500             5  false       NA
 """
 
         result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
@@ -55,10 +55,10 @@ fddd:a101:a251::a10:1  default      default  Down     async_active  fddd:c101:a2
 
         expected_output = """\
 Total number of BFD sessions for peer IP 10.0.1.1: 2
-Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop
------------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------
-10.0.1.1     default      default  DOWN     async_active  10.0.0.1                300            500             3  true
-10.0.1.1     default      VrfRed   UP       async_active  10.0.0.1                400            500             5  false
+Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
+10.0.1.1     default      default  DOWN     async_active  10.0.0.1                300            500             3  true        NA
+10.0.1.1     default      VrfRed   UP       async_active  10.0.0.1                400            500             5  false       NA
 """
 
         result = runner.invoke(show.cli.commands['bfd'].commands['peer'], ['10.0.1.1'], obj=db)
@@ -67,9 +67,9 @@ Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Int
 
         expected_output = """\
 Total number of BFD sessions for peer IP 10.0.2.1: 1
-Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop
------------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------
-10.0.2.1     Ethernet12   default  UP       async_active  10.0.0.1                200            600             3  false
+Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
+10.0.2.1     Ethernet12   default  UP       async_active  10.0.0.1                200            600             3  false       88
 """
 
         result = runner.invoke(show.cli.commands['bfd'].commands['peer'], ['10.0.2.1'], obj=db)
@@ -91,10 +91,10 @@ No BFD sessions found for peer IP 10.0.3.1
 
         expected_output = """\
 Total number of BFD sessions: 2
-Peer Addr              Interface    Vrf      State    Type          Local Addr               TX Interval    RX Interval    Multiplier  Multihop
----------------------  -----------  -------  -------  ------------  ---------------------  -------------  -------------  ------------  ----------
-100.251.7.1            default      default  Up       async_active  10.0.0.1                         300            500             3  true
-fddd:a101:a251::a10:1  default      default  Down     async_active  fddd:c101:a251::a10:2            300            500             3  true
+Peer Addr              Interface    Vrf      State    Type          Local Addr               TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+---------------------  -----------  -------  -------  ------------  ---------------------  -------------  -------------  ------------  ----------  ---------------------
+100.251.7.1            default      default  Up       async_active  10.0.0.1                         300            500             3  true        NA
+fddd:a101:a251::a10:1  default      default  Down     async_active  fddd:c101:a251::a10:2            300            500             3  true        NA
 """
 
         result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)

--- a/tests/show_bfd_test.py
+++ b/tests/show_bfd_test.py
@@ -67,9 +67,9 @@ Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Int
 
         expected_output = """\
 Total number of BFD sessions for peer IP 10.0.2.1: 1
-Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
 -----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
-10.0.2.1     Ethernet12   default  UP       async_active  10.0.0.1                200            600             3  false       88
+10.0.2.1     Ethernet12   default  UP       async_active  10.0.0.1                200            600             3  false                          88
 """
 
         result = runner.invoke(show.cli.commands['bfd'].commands['peer'], ['10.0.2.1'], obj=db)


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
the pull request https://github.com/sonic-net/sonic-swss/pull/2587 added local_discriminator to state_db

In this pull request, local discriminator is added in the output of the following show commands :
```
show bfd summary
show bfd peer
```
the upcoming BFD debug CLI needs the local discriminator to specify BFD session.

#### How I did it
in show/main.py show bfd cli, read state db and show the value if there is local_discriminator field, and show "NA" if the field does not exist (backward compatible).

#### How to verify it
updated the test/show_bfd_test.py to test the local_discriminator field and show bfd cli output.
and also did manual test in a testbed (with modified bfdorch wich sonic-net/sonic-swss/pull/2587 diff ):
```
cisco@sonic:/var/tmp$ show bfd sum
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true        NA
cisco@sonic:/var/tmp$ show bfd peer 192.85.2.24
Total number of BFD sessions for peer IP 192.85.2.24: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true        NA
cisco@sonic:/var/tmp$ docker exec -i swss swssconfig /dev/stdin < bfd.cfg
cisco@sonic:/var/tmp$ show bfd peer 192.85.2.24
Total number of BFD sessions for peer IP 192.85.2.24: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true                            1
cisco@sonic:/var/tmp$ show bfd sum
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true                            1
```

#### Previous command output (if the output of a command-line utility has changed)
```
Peer Addr              Interface    Vrf      State    Type          Local Addr               TX Interval    RX Interval    Multiplier  Multihop
---------------------  -----------  -------  -------  ------------  ---------------------  -------------  -------------  ------------  ----------
100.251.7.1            default      default  Up       async_active  10.0.0.1                         300            500             3  true
fddd:a101:a251::a10:1  default      default  Down     async_active  fddd:c101:a251::a10:2            300            500             3  true
10.0.1.1               default      default  DOWN     async_active  10.0.0.1                         300            500             3  true
10.0.2.1               Ethernet12   default  UP       async_active  10.0.0.1                         200            600             3  false
2000::10:1             default      default  UP       async_active  2000::1                          100            700             3  false
10.0.1.1               default      VrfRed   UP       async_active  10.0.0.1                         400            500             5  false
```
#### New command output (if the output of a command-line utility has changed)
```
Peer Addr              Interface    Vrf      State    Type          Local Addr               TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
---------------------  -----------  -------  -------  ------------  ---------------------  -------------  -------------  ------------  ----------  ---------------------
100.251.7.1            default      default  Up       async_active  10.0.0.1                         300            500             3  true        NA
fddd:a101:a251::a10:1  default      default  Down     async_active  fddd:c101:a251::a10:2            300            500             3  true        NA
10.0.1.1               default      default  DOWN     async_active  10.0.0.1                         300            500             3  true        NA
10.0.2.1               Ethernet12   default  UP       async_active  10.0.0.1                         200            600             3  false       88
2000::10:1             default      default  UP       async_active  2000::1                          100            700             3  false       NA
10.0.1.1               default      VrfRed   UP       async_active  10.0.0.1                         400            500             5  false       NA
```
