### PR TITLE
Update override_config_table for multi-asic platforms

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1923,7 +1923,7 @@ def override_config_table(db, input_config_db, dry_run):
             print(json.dumps(updated_config, sort_keys=True,
                              indent=4, cls=minigraph_encoder))
         else:
-            override_config_db(config_db, config_input)
+            override_config_db(ns, config_db, config_input)
 
 
 def validate_config_by_cm(cm, config_json, jname):
@@ -1944,7 +1944,7 @@ def update_config(current_config, config_input):
     return updated_config
 
 
-def override_config_db(config_db, config_input):
+def override_config_db(ns, config_db, config_input):
     namespace = "Host" if ns is DEFAULT_NAMESPACE else ns
     # Deserialized golden config to DB recognized format
     sonic_cfggen.FormatConverter.to_deserialized(config_input)


### PR DESCRIPTION
#### What I did
Update override_config_table for multi-asic platforms to apply the overriding config in golden_config_db.json to all namespaces in addition to the host namespace.

This will be removed later as we support the complete depreciation of minigraph and the golden_config_db.json file support the DB schema for multi-asic platforms. 

#### How I did it
Check the db client list which contains the db connector to DB in multiple namespaces and do yang validation and config override.

#### How to verify it
Validated with MACSEC_PROFILE present in the golden_config_db.json file and checked that the MACSEC_PROFILE gets added/updated in the config_db's for host as well as the namespaces.

```
admin@str2--lc1-1:~$ sudo config load_minigraph -y -o
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json   --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic0 --write-to-db
/usr/local/lib/python3.9/dist-packages/minigraph.py:796: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if voqinbandintfs:
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic1 --write-to-db
/usr/local/lib/python3.9/dist-packages/minigraph.py:796: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if voqinbandintfs:
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer --no-delay
Running command: /usr/local/bin/sonic-cfggen -n asic0 -d --write-to-db -t /usr/share/sonic/device/0/buffers.json.j2,config-db -t /usr/share/sonic/device/0/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -n asic1 -d --write-to-db -t /usr/share/sonic/device/1/buffers.json.j2,config-db -t /usr/share/sonic/device/1/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml
Running command: pfcwd start_default
Running command: config override-config-table /etc/sonic/golden_config_db.json
Working in Host namespace :
  - Removing configDB overriden table first ...
  - Overriding input config to configDB ...
  - Overriding completed. No service is restarted.
Working in asic0 namespace :
  - Removing configDB overriden table first ...
  - Overriding input config to configDB ...
  - Overriding completed. No service is restarted.
Working in asic1 namespace :
  - Removing configDB overriden table first ...
  - Overriding input config to configDB ...
  - Overriding completed. No service is restarted.
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
admin@str2--lc1-1:~$ sudo config save -y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
Running command: /usr/local/bin/sonic-cfggen -n asic0 -d --print-data > /etc/sonic/config_db0.json
Running command: /usr/local/bin/sonic-cfggen -n asic1 -d --print-data > /etc/sonic/config_db1.json
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

