### PR TITLE
[muxcable][config] Add support to enable/disable ceasing to be an advertisement interface when `radv` service is stopped

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -370,7 +370,7 @@ def mode(db, state, port, json_output):
         sys.exit(CONFIG_SUCCESSFUL)
 
 
-# 'muxcable' command ("config muxcable kill radv <enable|disable> ")
+# 'muxcable' command ("config muxcable kill-radv <enable|disable> ")
 @muxcable.command(short_help="Kill radv service when it is meant to be stopped, so no good-bye packet is sent for ceasing To Be an Advertising Interface")
 @click.argument('knob', metavar='<feature_knob>', required=True, type=click.Choice(["enable", "disable"]))
 @clicommon.pass_db

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -370,6 +370,22 @@ def mode(db, state, port, json_output):
         sys.exit(CONFIG_SUCCESSFUL)
 
 
+# 'muxcable' command ("config muxcable kill radv <enable|disable> ")
+@muxcable.command(short_help="Kill radv service when it is meant to be stopped, so no good-bye packet is sent for ceasing To Be an Advertising Interface")
+@click.argument('knob', metavar='<feature_knob>', required=True, type=click.Choice(["enable", "disable"]))
+@clicommon.pass_db
+def kill_radv(db, knob):
+    """config muxcable kill radv"""
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+
+        mux_lmgrd_cfg_tbl = config_db.get_table("MUX_LINKMGR")
+        config_db.mod_entry("MUX_LINKMGR", "SERVICE_MGMT", {"kill_radv": "True" if knob == "enable" else "False"})
+
+
  #'muxcable' command ("config muxcable packetloss reset <port|all>")
 @muxcable.command()
 @click.argument('action', metavar='<action_name>', required=True, type=click.Choice(["reset"]))

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -959,6 +959,15 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
+    def test_config_muxcable_kill_radv_enable(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["muxcable"].commands["kill-radv"], ["enable"], obj=db)
+
+        assert result.exit_code == 0
+        assert result.output == ""
+
     @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
     @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
                                                                                                       1: "active"}))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

This PR is to add CLI support to enable or disable the feature to send out a good-bye packet when `radv` service is stopped on `active-active` dualtor devices. 

sign-off: Jing Zhang zhangjing@microsoft.com 
#### How to verify 
UT added: 
```
tests/muxcable_test.py::TestMuxcable::test_config_muxcable_kill_radv_enable PASSED    [ 47%]
```
#### New command output (if the output of a command-line utility has changed)
```
admin@svcstr-7050-acs-1:~$ sudo config mux kill-radv enable 
admin@svcstr-7050-acs-1:~$ redis-cli -n 4 hgetall "MUX_LINKMGR|SERVICE_MGMT"
1) "kill_radv"
2) "True"
admin@svcstr-7050-acs-1:~$ sudo config mux kill-radv disable 
admin@svcstr-7050-acs-1:~$ redis-cli -n 4 hgetall "MUX_LINKMGR|SERVICE_MGMT"
1) "kill_radv"
2) "False"
```
