### PR TITLE
Ignore bgpraw in GCU applier

### DIFF
--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -76,6 +76,7 @@ class ChangeApplier:
     def __init__(self):
         self.config_db = get_config_db()
         self.backend_tables = [
+            "bgpraw",
             "BUFFER_PG",
             "BUFFER_PROFILE",
             "FLEX_COUNTER_TABLE"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`show run all` output will include bgpraw for business needs. GCU ipv6 test will update BGP_NEIGHBOR table which caused `bgpraw` content change, which will make the `apply-patch` operation fail. The solution is to add `bgpraw` to ignored tables.
#### How I did it
Add new added `bgpraw` table to ignored backend table.
#### How to verify it
Existing Unit test and local E2E GCU test.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

