### PR TITLE
[GCU] Ignore bgpraw table in GCU operation

### DIFF
--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -76,7 +76,6 @@ class ChangeApplier:
     def __init__(self):
         self.config_db = get_config_db()
         self.backend_tables = [
-            "bgpraw",
             "BUFFER_PG",
             "BUFFER_PROFILE",
             "FLEX_COUNTER_TABLE"

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -54,7 +54,9 @@ class ConfigWrapper:
 
     def get_config_db_as_json(self):
         text = self._get_config_db_as_text()
-        return json.loads(text)
+        config_db_json = json.loads(text)
+        config_db_json.pop("bgpraw", None)
+        return config_db_json
 
     def _get_config_db_as_text(self):
         # TODO: Getting configs from CLI is very slow, need to get it from sonic-cffgen directly

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -57,8 +57,8 @@ class ConfigWrapper:
         return json.loads(text)
 
     def _get_config_db_as_text(self):
-        # Use sonic-cfggen to generate data only from CONFIG_DB
-        cmd = "sonic-cfggen -d --print-data"
+        # TODO: Getting configs from CLI is very slow, need to get it from sonic-cffgen directly
+        cmd = "show runningconfiguration all"
         result = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         text, err = result.communicate()
         return_code = result.returncode

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -57,8 +57,8 @@ class ConfigWrapper:
         return json.loads(text)
 
     def _get_config_db_as_text(self):
-        # TODO: Getting configs from CLI is very slow, need to get it from sonic-cffgen directly
-        cmd = "show runningconfiguration all"
+        # Use sonic-cfggen to generate data only from CONFIG_DB
+        cmd = "sonic-cfggen -d --print-data"
         result = subprocess.Popen(cmd, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         text, err = result.communicate()
         return_code = result.returncode

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -3,12 +3,24 @@ import json
 import jsonpatch
 import sonic_yang
 import unittest
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 from .gutest_helpers import create_side_effect_dict, Files
 import generic_config_updater.gu_common as gu_common
 
 class TestDryRunConfigWrapper(unittest.TestCase):
+    @patch('generic_config_updater.gu_common.subprocess.Popen')
+    def test_get_config_db_as_json(self, mock_popen):
+        config_wrapper = gu_common.DryRunConfigWrapper()
+        mock_proc = MagicMock()
+        mock_proc.communicate = MagicMock(
+            return_value=('{"PORT": {}, "bgpraw": ""}', None))
+        mock_proc.returncode = 0
+        mock_popen.return_value = mock_proc
+        actual = config_wrapper.get_config_db_as_json()
+        expected = {"PORT": {}}
+        self.assertDictEqual(actual, expected)
+
     def test_get_config_db_as_json__returns_imitated_config_db(self):
         # Arrange
         config_wrapper = gu_common.DryRunConfigWrapper(Files.CONFIG_DB_AS_JSON)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
After the previous fix https://github.com/sonic-net/sonic-utilities/pull/2623 , GCU still fails in the rollback operation. The `bgpraw` table should be discard in all GCU operation. 
Thus, I change `get_config_db_as_json` function to crop out "bgpraw" table.
#### How I did it
Pop "bgpraw" table if exists.
#### How to verify it
Unittest
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

