### PR TITLE
Work around unpopulated hwsku in db_migrator.py

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -890,7 +890,7 @@ class DBMigrator():
         # removed together with calling to migrate_copp_table function.
         if self.asic_type != "mellanox":
             self.migrate_copp_table()
-        if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:            
+        if self.asic_type == "broadcom" and self.hwsku and 'Force10-S6100' in self.hwsku:
             self.migrate_mgmt_ports_on_s6100()
         else:
             log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))


### PR DESCRIPTION
Handle the case where hwsku is None.
See sonic-net/sonic-buildimage#12083 and sonic-net/sonic-buildimage#11416

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
#### How I did it
`db_migrator.py` can fail on Arista devices if the hwsku field is not populated.
Check that the field is not None before trying to read the value.

#### How to verify it
Tested on Arista products, the error no longer occurs.