### PR TITLE
[system-health] Fix issue: show system-health CLI crashes

### DIFF
--- a/show/system_health.py
+++ b/show/system_health.py
@@ -7,7 +7,7 @@ import utilities_common.cli as clicommon
 
 
 def get_system_health_status():
-    if os.environ["UTILITIES_UNIT_TESTING"] == "1":
+    if os.environ.get("UTILITIES_UNIT_TESTING") == "1":
         modules_path = os.path.join(os.path.dirname(__file__), "..")
         sys.path.insert(0, modules_path)
         from tests.system_health_test import MockerManager


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix issue: show system-health CLI crashes

```
root@switch:/home/admin# show system-health summary 
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/show/system_health.py", line 113, in summary
    _, chassis, stat = get_system_health_status()
  File "/usr/local/lib/python3.9/dist-packages/show/system_health.py", line 10, in get_system_health_status
    if os.environ["UTILITIES_UNIT_TESTING"] == "1":
  File "/usr/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'UTILITIES_UNIT_TESTING'
```

#### How I did it

Use dict.get instead of `[]` operator.

#### How to verify it

Manual test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

