### PR TITLE
[202012][dhcp-relay] Add support for dhcp_relay config cli

### DIFF
--- a/config/dhcp_relay.py
+++ b/config/dhcp_relay.py
@@ -1,0 +1,158 @@
+import click
+import ipaddress
+import utilities_common.cli as clicommon
+import utilities_common.dhcp_relay_util as dhcp_relay_util
+
+
+DHCP_RELAY_TABLE = "DHCP_RELAY"
+DHCPV6_SERVERS = "dhcpv6_servers"
+IPV6 = 6
+
+VLAN_TABLE = "VLAN"
+DHCPV4_SERVERS = "dhcp_servers"
+IPV4 = 4
+
+
+def validate_ips(ctx, ips, ip_version):
+    for ip in ips:
+        try:
+            ip_address = ipaddress.ip_address(ip)
+        except Exception:
+            ctx.fail("{} is invalid IP address".format(ip))
+
+        if ip_address.version != ip_version:
+            ctx.fail("{} is not IPv{} address".format(ip, ip_version))
+
+
+def get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str):
+    table = db.cfgdb.get_entry(table_name, vlan_name)
+    if len(table.keys()) == 0:
+        ctx.fail("{} doesn't exist".format(vlan_name))
+
+    dhcp_servers = table.get(dhcp_servers_str, [])
+
+    return dhcp_servers, table
+
+
+def add_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
+    table_name = DHCP_RELAY_TABLE if ip_version == 6 else VLAN_TABLE
+    dhcp_servers_str = DHCPV6_SERVERS if ip_version == 6 else DHCPV4_SERVERS
+    vlan_name = "Vlan{}".format(vid)
+    ctx = click.get_current_context()
+    # Verify ip addresses are valid
+    validate_ips(ctx, dhcp_relay_ips, ip_version)
+    dhcp_servers, table = get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str)
+    added_ips = []
+
+    for dhcp_relay_ip in dhcp_relay_ips:
+        # Verify ip addresses not duplicate in add list
+        if dhcp_relay_ip in added_ips:
+            ctx.fail("Error: Find duplicate DHCP relay ip {} in add list".format(dhcp_relay_ip))
+        # Verify ip addresses not exist in DB
+        if dhcp_relay_ip in dhcp_servers:
+            click.echo("{} is already a DHCP relay for {}".format(dhcp_relay_ip, vlan_name))
+            return
+
+        dhcp_servers.append(dhcp_relay_ip)
+        added_ips.append(dhcp_relay_ip)
+
+    table[dhcp_servers_str] = dhcp_servers
+
+    db.cfgdb.set_entry(table_name, vlan_name, table)
+    click.echo("Added DHCP relay address [{}] to {}".format(",".join(dhcp_relay_ips), vlan_name))
+    try:
+        dhcp_relay_util.restart_dhcp_relay_service()
+    except SystemExit as e:
+        ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+
+
+def del_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
+    table_name = DHCP_RELAY_TABLE if ip_version == 6 else VLAN_TABLE
+    dhcp_servers_str = DHCPV6_SERVERS if ip_version == 6 else DHCPV4_SERVERS
+    vlan_name = "Vlan{}".format(vid)
+    ctx = click.get_current_context()
+    # Verify ip addresses are valid
+    validate_ips(ctx, dhcp_relay_ips, ip_version)
+    dhcp_servers, table = get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str)
+    removed_ips = []
+
+    for dhcp_relay_ip in dhcp_relay_ips:
+        # Verify ip addresses not duplicate in del list
+        if dhcp_relay_ip in removed_ips:
+            ctx.fail("Error: Find duplicate DHCP relay ip {} in del list".format(dhcp_relay_ip))
+        # Remove dhcp servers if they exist in the DB
+        if dhcp_relay_ip not in dhcp_servers:
+            ctx.fail("{} is not a DHCP relay for {}".format(dhcp_relay_ip, vlan_name))
+
+        dhcp_servers.remove(dhcp_relay_ip)
+        removed_ips.append(dhcp_relay_ip)
+
+    if len(dhcp_servers) == 0:
+        del table[dhcp_servers_str]
+    else:
+        table[dhcp_servers_str] = dhcp_servers
+
+    db.cfgdb.set_entry(table_name, vlan_name, table)
+    click.echo("Removed DHCP relay address [{}] from {}".format(",".join(dhcp_relay_ips), vlan_name))
+    try:
+        dhcp_relay_util.restart_dhcp_relay_service()
+    except SystemExit as e:
+        ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+
+
+@click.group(cls=clicommon.AbbreviationGroup, name="dhcp_relay")
+def dhcp_relay():
+    """config DHCP_Relay information"""
+    pass
+
+
+@dhcp_relay.group(cls=clicommon.AbbreviationGroup, name="ipv6")
+def dhcp_relay_ipv6():
+    pass
+
+
+@dhcp_relay_ipv6.group(cls=clicommon.AbbreviationGroup, name="destination")
+def dhcp_relay_ipv6_destination():
+    pass
+
+
+@dhcp_relay_ipv6_destination.command("add")
+@click.argument("vid", metavar="<vid>", required=True, type=int)
+@click.argument("dhcp_relay_destinations", nargs=-1, required=True)
+@clicommon.pass_db
+def add_dhcp_relay_ipv6_destination(db, vid, dhcp_relay_destinations):
+    add_dhcp_relay(vid, dhcp_relay_destinations, db, IPV6)
+
+
+@dhcp_relay_ipv6_destination.command("del")
+@click.argument("vid", metavar="<vid>", required=True, type=int)
+@click.argument("dhcp_relay_destinations", nargs=-1, required=True)
+@clicommon.pass_db
+def del_dhcp_relay_ipv6_destination(db, vid, dhcp_relay_destinations):
+    del_dhcp_relay(vid, dhcp_relay_destinations, db, IPV6)
+
+
+@dhcp_relay.group(cls=clicommon.AbbreviationGroup, name="ipv4")
+def dhcp_relay_ipv4():
+    pass
+
+
+@dhcp_relay_ipv4.group(cls=clicommon.AbbreviationGroup, name="helper")
+def dhcp_relay_ipv4_helper():
+    pass
+
+
+@dhcp_relay_ipv4_helper.command("add")
+@click.argument("vid", metavar="<vid>", required=True, type=int)
+@click.argument("dhcp_relay_helpers", nargs=-1, required=True)
+@clicommon.pass_db
+def add_dhcp_relay_ipv4_helper(db, vid, dhcp_relay_helpers):
+    add_dhcp_relay(vid, dhcp_relay_helpers, db, IPV4)
+
+
+@dhcp_relay_ipv4_helper.command("del")
+@click.argument("vid", metavar="<vid>", required=True, type=int)
+@click.argument("dhcp_relay_helpers", nargs=-1, required=True)
+@clicommon.pass_db
+def del_dhcp_relay_ipv4_helper(db, vid, dhcp_relay_helpers):
+    del_dhcp_relay(vid, dhcp_relay_helpers, db, IPV4)

--- a/config/main.py
+++ b/config/main.py
@@ -37,6 +37,7 @@ from . import muxcable
 from . import nat
 from . import vlan
 from . import vxlan
+from . import dhcp_relay
 from .config_mgmt import ConfigMgmtDPB
 
 # Using load_source to 'import /usr/local/bin/sonic-cfggen as sonic_cfggen'
@@ -1016,6 +1017,7 @@ config.add_command(muxcable.muxcable)
 config.add_command(nat.nat)
 config.add_command(vlan.vlan)
 config.add_command(vxlan.vxlan)
+config.add_command(dhcp_relay.dhcp_relay)
 
 @config.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -227,10 +227,7 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
 
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Added DHCP relay destination address {} to {}".format(dhcp_relay_destination_ip, vlan_name))
-    try:
-        dhcp_relay_util.restart_dhcp_relay_service()
-    except SystemExit as e:
-        ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+    dhcp_relay_util.handle_restart_dhcp_relay_service()
 
 @vlan_dhcp_relay.command('del')
 @click.argument('vid', metavar='<vid>', required=True, type=int)
@@ -271,7 +268,4 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
     
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination address {} from {}".format(dhcp_relay_destination_ip, vlan_name))
-    try:
-        dhcp_relay_util.restart_dhcp_relay_service()
-    except SystemExit as e:
-        ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
+    dhcp_relay_util.handle_restart_dhcp_relay_service()

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -1,6 +1,7 @@
 import click
 import ipaddress
 import utilities_common.cli as clicommon
+import utilities_common.dhcp_relay_util as dhcp_relay_util
 
 from time import sleep
 from .utils import log
@@ -227,10 +228,7 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Added DHCP relay destination address {} to {}".format(dhcp_relay_destination_ip, vlan_name))
     try:
-        click.echo("Restarting DHCP relay service...")
-        clicommon.run_command("systemctl stop dhcp_relay", display_cmd=False)
-        clicommon.run_command("systemctl reset-failed dhcp_relay", display_cmd=False)
-        clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
+        dhcp_relay_util.restart_dhcp_relay_service()
     except SystemExit as e:
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 
@@ -274,9 +272,6 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination address {} from {}".format(dhcp_relay_destination_ip, vlan_name))
     try:
-        click.echo("Restarting DHCP relay service...")
-        clicommon.run_command("systemctl stop dhcp_relay", display_cmd=False)
-        clicommon.run_command("systemctl reset-failed dhcp_relay", display_cmd=False)
-        clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
+        dhcp_relay_util.restart_dhcp_relay_service()
     except SystemExit as e:
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2249,6 +2249,74 @@ This command is used to delete a configured DHCP Relay Destination IP address fr
   Restarting DHCP relay service...
   ```
 
+**config dhcp_relay ipv4 helper add/del**
+
+This command is used to add or delete IPv4 DHCP Relay helper addresses to a VLAN. Note that more than one DHCP Relay helper addresses can be operated on a VLAN interface.
+
+- Usage:
+  ```
+  config dhcp_relay ipv4 helper (add | del) <vlan_id> <dhcp_helper_ips>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv4 helper add 1000 7.7.7.7
+  Added DHCP relay address [7.7.7.7] to Vlan1000
+  Restarting DHCP relay service...
+  ```
+
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv4 helper add 1000 7.7.7.7 1.1.1.1
+  Added DHCP relay address [7.7.7.7, 1.1.1.1] to Vlan1000
+  Restarting DHCP relay service...
+  ```
+
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv4 helper del 1000 7.7.7.7
+  Removed DHCP relay address [7.7.7.7] from Vlan1000
+  Restarting DHCP relay service...
+  ```
+
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv4 helper del 1000 7.7.7.7 1.1.1.1
+  Removed DHCP relay address [7.7.7.7, 1.1.1.1] from Vlan1000
+  Restarting DHCP relay service...
+  ```
+
+**config dhcp_relay ipv6 destination add/del**
+
+This command is used to add or del IPv6 DHCP Relay destination addresses to a VLAN. Note that more than one DHCP Relay Destination addresses can be operated on a VLAN interface.
+
+- Usage:
+  ```
+  config dhcp_relay ipv6 destination (add | del) <vlan_id> <dhcp_destination_ips>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv6 destination add 1000 fc02:2000::1
+  Added DHCP relay address [fc02:2000::1] to Vlan1000
+  Restarting DHCP relay service...
+  ```
+
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv6 destination add 1000 fc02:2000::1 fc02:2000::2
+  Added DHCP relay address [fc02:2000::1, fc02:2000::2] to Vlan1000
+  Restarting DHCP relay service...
+  ```
+
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv6 destination del 1000 fc02:2000::1
+  Removed DHCP relay address [fc02:2000::1] from Vlan1000
+  Restarting DHCP relay service...
+  ```
+
+  ```
+  admin@sonic:~$ sudo config dhcp_relay ipv6 destination del 1000 fc02:2000::1 fc02:2000::2
+  Removed DHCP relay address [fc02:2000::1, fc02:2000::2] from Vlan1000
+  Restarting DHCP relay service...
+  ```
+
 ### DHCPv6 Relay show commands
 
 This sub-section of commands is used to show the DHCPv6 Relay Destination IPv6 address for VLAN interfaces.

--- a/tests/config_dhcp_relay_test.py
+++ b/tests/config_dhcp_relay_test.py
@@ -1,0 +1,259 @@
+import os
+import pytest
+
+import config.main as config
+from utilities_common.db import Db
+from unittest import mock
+from click.testing import CliRunner
+
+config_dhcp_relay_add_output = """\
+Added DHCP relay address [{}] to Vlan1000
+Restarting DHCP relay service...
+"""
+config_dhcp_relay_del_output = """\
+Removed DHCP relay address [{}] from Vlan1000
+Restarting DHCP relay service...
+"""
+expected_dhcp_relay_add_config_db_output = {
+    "ipv4": {
+        "dhcp_servers": [
+            "192.0.0.1", "192.0.0.2", "192.0.0.3", "192.0.0.4", "192.0.0.5"
+        ],
+        "dhcpv6_servers": [
+            "fc02:2000::1", "fc02:2000::2"
+        ],
+        "vlanid": "1000"
+    },
+    "ipv6": {
+        "dhcpv6_servers": [
+            "fc02:2000::1", "fc02:2000::2", "fc02:2000::3"
+        ]
+    }
+}
+expected_dhcp_relay_del_config_db_output = {
+    "ipv4": {
+        "dhcp_servers": [
+            "192.0.0.1", "192.0.0.2", "192.0.0.3", "192.0.0.4"
+        ],
+        "dhcpv6_servers": [
+            "fc02:2000::1", "fc02:2000::2"
+        ],
+        "vlanid": "1000"
+    },
+    "ipv6": {
+        "dhcpv6_servers": [
+            "fc02:2000::1", "fc02:2000::2"
+        ]
+    }
+}
+expected_dhcp_relay_add_multi_config_db_output = {
+    "ipv4": {
+        "dhcp_servers": [
+            "192.0.0.1", "192.0.0.2", "192.0.0.3", "192.0.0.4", "192.0.0.5", "192.0.0.6", "192.0.0.7"
+        ],
+        "dhcpv6_servers": [
+            "fc02:2000::1", "fc02:2000::2"
+        ],
+        "vlanid": "1000"
+    },
+    "ipv6": {
+        "dhcpv6_servers": [
+            "fc02:2000::1", "fc02:2000::2", "fc02:2000::3", "fc02:2000::4", "fc02:2000::5"
+        ]
+    }
+}
+
+IP_VER_TEST_PARAM_MAP = {
+    "ipv4": {
+        "command": "helper",
+        "ips": [
+            "192.0.0.5",
+            "192.0.0.6",
+            "192.0.0.7"
+        ],
+        "exist_ip": "192.0.0.1",
+        "nonexist_ip": "192.0.0.8",
+        "invalid_ip": "192.0.0",
+        "table": "VLAN"
+    },
+    "ipv6": {
+        "command": "destination",
+        "ips": [
+            "fc02:2000::3",
+            "fc02:2000::4",
+            "fc02:2000::5"
+        ],
+        "exist_ip": "fc02:2000::1",
+        "nonexist_ip": "fc02:2000::6",
+        "invalid_ip": "fc02:2000:",
+        "table": "DHCP_RELAY"
+    }
+}
+
+
+@pytest.fixture(scope="module", params=["ipv4", "ipv6"])
+def ip_version(request):
+    """
+    Parametrize Ip version
+    Args:
+        request: pytest request object
+    Returns:
+        Ip version needed for test case
+    """
+    return request.param
+
+
+@pytest.fixture(scope="module", params=["add", "del"])
+def op(request):
+    """
+    Parametrize operate tpye
+    Args:
+        request: pytest request object
+    Returns:
+        Operate tpye
+    """
+    return request.param
+
+
+class TestConfigDhcpRelay(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        print("SETUP")
+
+    def test_config_dhcp_relay_add_del_with_nonexist_vlanid(self, ip_version, op):
+        runner = CliRunner()
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1001", IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]])
+            print(result.exit_code)
+            print(result.stdout)
+            assert result.exit_code != 0
+            assert "Error: Vlan1001 doesn't exist" in result.output
+            assert mock_run_command.call_count == 0
+
+    def test_config_add_del_dhcp_relay_with_invalid_ip(self, ip_version, op):
+        runner = CliRunner()
+        invalid_ip = IP_VER_TEST_PARAM_MAP[ip_version]["invalid_ip"]
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1000", invalid_ip])
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code != 0
+            assert "Error: {} is invalid IP address".format(invalid_ip) in result.output
+            assert mock_run_command.call_count == 0
+
+    def test_config_add_dhcp_with_exist_ip(self, ip_version):
+        runner = CliRunner()
+        db = Db()
+        exist_ip = IP_VER_TEST_PARAM_MAP[ip_version]["exist_ip"]
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands["add"], ["1000", exist_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert "{} is already a DHCP relay for Vlan1000".format(exist_ip) in result.output
+            assert mock_run_command.call_count == 0
+
+    def test_config_del_nonexist_dhcp_relay(self, ip_version):
+        runner = CliRunner()
+        db = Db()
+        nonexist_ip = IP_VER_TEST_PARAM_MAP[ip_version]["nonexist_ip"]
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands["del"], ["1000", nonexist_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code != 0
+            assert "Error: {} is not a DHCP relay for Vlan1000".format(nonexist_ip) in result.output
+            assert mock_run_command.call_count == 0
+
+    def test_config_add_del_dhcp_relay(self, ip_version):
+        runner = CliRunner()
+        db = Db()
+        test_ip = IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]
+        config_db_table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            # add new dhcp relay
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands["add"], ["1000", test_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert result.output == config_dhcp_relay_add_output.format(test_ip)
+            assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
+                == expected_dhcp_relay_add_config_db_output[ip_version]
+            assert mock_run_command.call_count == 3
+
+        # del dhcp relay
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands["del"], ["1000", test_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert result.output == config_dhcp_relay_del_output.format(test_ip)
+            assert mock_run_command.call_count == 3
+            assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
+                == expected_dhcp_relay_del_config_db_output[ip_version]
+
+    def test_config_add_del_multiple_dhcp_relay(self, ip_version):
+        runner = CliRunner()
+        db = Db()
+        test_ips = IP_VER_TEST_PARAM_MAP[ip_version]["ips"]
+        config_db_table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            # add new dhcp relay
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands["add"], ["1000"] + test_ips, obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert result.output == config_dhcp_relay_add_output.format(",".join(test_ips))
+            assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
+                == expected_dhcp_relay_add_multi_config_db_output[ip_version]
+            assert mock_run_command.call_count == 3
+
+        # del dhcp relay
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands["del"], ["1000"] + test_ips, obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert result.output == config_dhcp_relay_del_output.format(",".join(test_ips))
+            assert mock_run_command.call_count == 3
+            assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
+                == expected_dhcp_relay_del_config_db_output[ip_version]
+
+    def test_config_add_del_duplicate_dhcp_relay(self, ip_version, op):
+        runner = CliRunner()
+        db = Db()
+        test_ip = IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0] if op == "add" \
+            else IP_VER_TEST_PARAM_MAP[ip_version]["exist_ip"]
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1000", test_ip, test_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code != 0
+            assert "Error: Find duplicate DHCP relay ip {} in {} list".format(test_ip, op) in result.output
+            assert mock_run_command.call_count == 0

--- a/utilities_common/dhcp_relay_util.py
+++ b/utilities_common/dhcp_relay_util.py
@@ -1,0 +1,12 @@
+import click
+import utilities_common.cli as clicommon
+
+
+def restart_dhcp_relay_service():
+    """
+    Restart dhcp_relay service
+    """
+    click.echo("Restarting DHCP relay service...")
+    clicommon.run_command("systemctl stop dhcp_relay", display_cmd=False)
+    clicommon.run_command("systemctl reset-failed dhcp_relay", display_cmd=False)
+    clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)

--- a/utilities_common/dhcp_relay_util.py
+++ b/utilities_common/dhcp_relay_util.py
@@ -12,13 +12,9 @@ def restart_dhcp_relay_service():
     clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
 
 
-def handle_restart_dhcp_relay_service(ignore_system_exit_error=False):
+def handle_restart_dhcp_relay_service():
     try:
         restart_dhcp_relay_service()
     except SystemExit as e:
         ctx = click.get_current_context()
-
-        if ignore_system_exit_error:
-            ctx.exit(0)
-
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))

--- a/utilities_common/dhcp_relay_util.py
+++ b/utilities_common/dhcp_relay_util.py
@@ -12,9 +12,13 @@ def restart_dhcp_relay_service():
     clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
 
 
-def handle_restart_dhcp_relay_service():
+def handle_restart_dhcp_relay_service(ignore_system_exit_error=False):
     try:
         restart_dhcp_relay_service()
     except SystemExit as e:
         ctx = click.get_current_context()
+
+        if ignore_system_exit_error:
+            ctx.exit(0)
+
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))

--- a/utilities_common/dhcp_relay_util.py
+++ b/utilities_common/dhcp_relay_util.py
@@ -16,4 +16,5 @@ def handle_restart_dhcp_relay_service():
     try:
         restart_dhcp_relay_service()
     except SystemExit as e:
+        ctx = click.get_current_context()
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))

--- a/utilities_common/dhcp_relay_util.py
+++ b/utilities_common/dhcp_relay_util.py
@@ -10,3 +10,10 @@ def restart_dhcp_relay_service():
     clicommon.run_command("systemctl stop dhcp_relay", display_cmd=False)
     clicommon.run_command("systemctl reset-failed dhcp_relay", display_cmd=False)
     clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
+
+
+def handle_restart_dhcp_relay_service():
+    try:
+        restart_dhcp_relay_service()
+    except SystemExit as e:
+        ctx.fail("Restart service dhcp_relay failed with error {}".format(e))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did it
Currently the config cli of dhcpv4 is may cause confusion and config of dhcpv6 is missing.

#### How I did it
Add dhcp_relay config cli and test cases.
```
config dhcp_relay ipv4 helper (add | del) <vlan_id> <helper_ip_list>
config dhcp_relay ipv6 destination (add | del) <vlan_id> <destination_ip_list>
```

#### How to verify it
1. Verify by unitest, all passed
```
2023-01-31T17:13:39.5310534Z ----------- coverage: platform linux, python 3.7.3-final-0 -----------
2023-01-31T17:13:39.5311171Z Name                                          Stmts   Miss  Cover
2023-01-31T17:13:39.5311934Z -----------------------------------------------------------------
2023-01-31T17:13:39.5318510Z config/dhcp_relay.py                            101     11    89%
2023-01-31T17:13:39.5375220Z utilities_common/dhcp_relay_util.py               7      0   100%
2023-01-31T17:13:39.5378676Z -----------------------------------------------------------------
2023-01-31T17:13:39.5379423Z Coverage HTML written to dir htmlcov
2023-01-31T17:13:39.5379772Z Coverage XML written to file coverage.xml
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
```
2. Build sonic-utilities and install in DUT and run cli, test cli
```
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv6 destination add 1000 fc02:2000::6    
Added DHCP relay address [fc02:2000::6] to Vlan1000
Restarting DHCP relay service...
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv6 destination add 1000 fc02:2000::7 fc02:2000::8
Added DHCP relay address [fc02:2000::7,fc02:2000::8] to Vlan1000
Restarting DHCP relay service...
admin@str-e1031-acs-3:~$ show dhcprelay_helper ipv6                                                
--------  ------------
Vlan1000  fc02:2000::1
          fc02:2000::2
          fc02:2000::3
          fc02:2000::4
          fc02:2000::6
          fc02:2000::7
          fc02:2000::8
--------  ------------
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv6 destination del 1000 fc02:2000::6   
Removed DHCP relay address [fc02:2000::6] from Vlan1000
Restarting DHCP relay service...
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv6 destination del 1000 fc02:2000::7 fc02:2000::8   
Removed DHCP relay address [fc02:2000::7,fc02:2000::8] from Vlan1000
Restarting DHCP relay service...
admin@str-e1031-acs-3:~$ show dhcprelay_helper ipv6                                                
--------  ------------
Vlan1000  fc02:2000::1
          fc02:2000::2
          fc02:2000::3
          fc02:2000::4
--------  ------------
```

```
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv4 helper add 1000 192.0.0.49
Added DHCP relay address [192.0.0.49] to Vlan1000
Restarting DHCP relay service...
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv4 helper add 1000 192.0.0.50 192.0.0.51
Added DHCP relay address [192.0.0.50,192.0.0.51] to Vlan1000
Restarting DHCP relay service...
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv4 helper del 1000 192.0.0.49   
Removed DHCP relay address [192.0.0.49] from Vlan1000
Restarting DHCP relay service...
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv4 helper del 1000 192.0.0.49
Usage: config dhcp_relay ipv4 helper del [OPTIONS] <vid> DHCP_RELAY_HELPERS...
Try "config dhcp_relay ipv4 helper del -h" for help. Error: 192.0.0.49 is not a DHCP relay for Vlan1000
admin@str-e1031-acs-3:~$ sudo config dhcp_relay ipv4 helper del 1000 192.0.0.50 192.0.0.51   
Removed DHCP relay address [192.0.0.50,192.0.0.51] from Vlan1000
Restarting DHCP relay service...
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

