### PR TITLE
[Bugfix] "show vnet routes all"

### DIFF
--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -329,8 +329,8 @@
         "endpoint_monitor":"100.251.7.1"
     },
     "VNET_ROUTE_TUNNEL_TABLE:Vnet_v6_in_v6-0:fddd:a156:a251::a6:1/128": {
-        "endpoint": "fddd:a100:a251::a10:1,fddd:a101:a251::a10:1",
-        "endpoint_monitor":"fddd:a100:a251::a10:1,fddd:a101:a251::a10:1"
+        "endpoint": "fddd:a100:a251::a10:1,fddd:a101:a251::a10:1,fddd:a102:a251::a10:1,fddd:a103:a251::a10:1",
+        "endpoint_monitor":"fddd:a100:a251::a10:1,fddd:a101:a251::a10:1,fddd:a102:a251::a10:1,fddd:a103:a251::a10:1"
     },
     "VNET_ROUTE_TUNNEL_TABLE:test_v4_in_v4-0:160.162.191.1/32": {
         "endpoint":"100.251.7.1",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1086,7 +1086,7 @@
         "state":"active"
     },
     "VNET_ROUTE_TUNNEL_TABLE|Vnet_v6_in_v6-0|fddd:a156:a251::a6:1/128": {
-        "active_endpoints":"fddd:a100:a251::a10:1,fddd:a101:a251::a10:1",
+        "active_endpoints":"fddd:a100:a251::a10:1,fddd:a101:a251::a10:1,fddd:a102:a251::a10:1,fddd:a103:a251::a10:1",
         "state":"active"
     },
     "BFD_SESSION_TABLE|default|default|100.251.7.1": {

--- a/tests/show_vnet_test.py
+++ b/tests/show_vnet_test.py
@@ -2,12 +2,56 @@ import os
 from click.testing import CliRunner
 from utilities_common.db import Db
 import show.main as show
+import show.vnet as vnet
 
 class TestShowVnetRoutesAll(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_Preety_print(self):
+        table =[]
+        row = ["Vnet_v6_in_v6-0", "fddd:a156:a251::a6:1/128"]
+        mac_addr = ""
+        vni = ""
+        state = "active"
+        epval = "fddd:a100:a251::a10:1,fddd:a101:a251::a10:1"
+
+        vnet.pretty_print(table, row, epval, mac_addr, vni, state)
+        expected_output = [['Vnet_v6_in_v6-0', 'fddd:a156:a251::a6:1/128', 'fddd:a100:a251::a10:1,fddd:a101:a251::a10:1', '', '', 'active']]
+        assert table == expected_output
+
+        table =[]
+        row = ["Vnet_v6_in_v6-0", "fddd:a156:a251::a6:1/128"]
+        epval = "fddd:a100:a251::a10:1,fddd:a101:a251::a10:1,fddd:a100:a251::a11:1,fddd:a100:a251::a12:1,fddd:a100:a251::a13:1"
+        vnet.pretty_print(table, row, epval, mac_addr, vni, state)
+        expected_output = [
+            ['Vnet_v6_in_v6-0', 'fddd:a156:a251::a6:1/128', 'fddd:a100:a251::a10:1,fddd:a101:a251::a10:1', '', '', 'active'],
+            ['',                '',                         'fddd:a100:a251::a11:1,fddd:a100:a251::a12:1', '', '', ''],
+            ['',                '',                         'fddd:a100:a251::a13:1',                       '', '', '']
+        ]
+        assert table == expected_output
+
+        table =[]
+        row = ["Vnet_v6_in_v6-0", "fddd:a156:a251::a6:1/128"]
+        epval = "192.168.1.1,192.168.1.2,192.168.1.3,192.168.1.4,192.168.1.5,192.168.1.6,192.168.1.7,192.168.1.8,192.168.1.9,192.168.1.10,192.168.1.11,192.168.1.12,192.168.1.13,192.168.1.14,192.168.1.15"
+        vnet.pretty_print(table, row, epval, mac_addr, vni, state)
+        expected_output =[
+            ['Vnet_v6_in_v6-0', 'fddd:a156:a251::a6:1/128', '192.168.1.1,192.168.1.2,192.168.1.3',    '', '', 'active'],
+            ['',                '',                         '192.168.1.4,192.168.1.5,192.168.1.6',    '', '', ''],
+            ['',                '',                         '192.168.1.7,192.168.1.8,192.168.1.9',    '', '', ''],
+            ['',                '',                         '192.168.1.10,192.168.1.11,192.168.1.12', '', '', ''],
+            ['',                '',                         '192.168.1.13,192.168.1.14,192.168.1.15', '', '', '']]
+        assert table == expected_output
+
+        table =[]
+        row = ["Vnet_v6_in_v6-0", "fddd:a156:a251::a6:1/128"]
+        epval = "192.168.1.1"
+        vnet.pretty_print(table, row, epval, mac_addr, vni, state)
+        expected_output =[
+            ['Vnet_v6_in_v6-0', 'fddd:a156:a251::a6:1/128', '192.168.1.1', '', '', 'active']]
+        assert table == expected_output
 
     def test_show_vnet_routes_all_basic(self):
         runner = CliRunner()
@@ -22,6 +66,7 @@ vnet name    prefix    nexthop    interface
 vnet name        prefix                    endpoint                                     mac address    vni    status
 ---------------  ------------------------  -------------------------------------------  -------------  -----  --------
 Vnet_v6_in_v6-0  fddd:a156:a251::a6:1/128  fddd:a100:a251::a10:1,fddd:a101:a251::a10:1                        active
+                                           fddd:a102:a251::a10:1,fddd:a103:a251::a10:1
 test_v4_in_v4-0  160.162.191.1/32          100.251.7.1                                                        active
 test_v4_in_v4-0  160.163.191.1/32          100.251.7.1                                                        active
 test_v4_in_v4-0  160.164.191.1/32          100.251.7.1

--- a/tests/show_vnet_vxlan_cli_test.py
+++ b/tests/show_vnet_vxlan_cli_test.py
@@ -9,31 +9,11 @@ import show.main as show
 
 #test_path = os.path.dirname(os.path.abspath(__file__))
 
-
-
 class TestShowVnet(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
-
-    def test_show_vnet_routes_all_basic(self):
-        runner = CliRunner()
-        db = Db()
-        result = runner.invoke(show.cli.commands['vnet'].commands['routes'].commands['all'], [], obj=db)
-        assert result.exit_code == 0
-        expected_output = """\
-vnet name    prefix    nexthop    interface
------------  --------  ---------  -----------
-
-vnet name        prefix                    endpoint                                     mac address    vni    status
----------------  ------------------------  -------------------------------------------  -------------  -----  --------
-Vnet_v6_in_v6-0  fddd:a156:a251::a6:1/128  fddd:a100:a251::a10:1,fddd:a101:a251::a10:1                        active
-test_v4_in_v4-0  160.162.191.1/32          100.251.7.1                                                        active
-test_v4_in_v4-0  160.163.191.1/32          100.251.7.1                                                        active
-test_v4_in_v4-0  160.164.191.1/32          100.251.7.1
-"""
-        assert result.output == expected_output
 
     def test_show_vnet_endpoint(self):
         runner = CliRunner()
@@ -45,6 +25,8 @@ Endpoint               Endpoint Monitor         prefix count  status
 ---------------------  ---------------------  --------------  --------
 fddd:a100:a251::a10:1  fddd:a100:a251::a10:1               1  Unknown
 fddd:a101:a251::a10:1  fddd:a101:a251::a10:1               1  Down
+fddd:a102:a251::a10:1  fddd:a102:a251::a10:1               1  Unknown
+fddd:a103:a251::a10:1  fddd:a103:a251::a10:1               1  Unknown
 100.251.7.1            100.251.7.1                         3  Up
 """
         assert result.output == expected_output


### PR DESCRIPTION
Signed-off-by: siqbal1486 <shahzad.iqbal@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
fixed the output to wrap up the list of endpoints  after a certian number has bene printed.
#### How I did it
added a function which limits the number of nexthops on each line to 2 for addresses longer than 16 characters and 3 for less than 16.
#### How to verify it
run show vnet routes all after adding a tunnel ecmp route with more than 3 endpoints.

#### Previous command output (if the output of a command-line utility has changed)
```
vnet name    prefix    nexthop    interface
-----------  --------  ---------  -----------
vnet name        prefix                    endpoint                                     mac address    vni    status
---------------  ------------------------  -------------------------------------------  -------------  -----  --------
Vnet_v6_in_v6-0  fddd:a156:a251::a6:1/128  fddd:a100:a251::a10:1,fddd:a101:a251::a10:1,fddd:a102:a251::a10:1,fddd:a103:a251::a10:1                        active
test_v4_in_v4-0  160.162.191.1/32          100.251.7.1                                                        active
test_v4_in_v4-0  160.163.191.1/32          100.251.7.1                                                        active
test_v4_in_v4-0  160.164.191.1/32          100.251.7.1
```

#### New command output (if the output of a command-line utility has changed)

```
 show vnet routes all
vnet name    prefix    nexthop    interface
-----------  --------  ---------  -----------
vnet name        prefix                    endpoint                                     mac address    vni    status
---------------  ------------------------  -------------------------------------------  -------------  -----  --------
Vnet_v6_in_v6-0  fddd:a156:a251::a6:1/128  fddd:a100:a251::a10:1,fddd:a101:a251::a10:1                        active
                                           fddd:a102:a251::a10:1,fddd:a103:a251::a10:1
test_v4_in_v4-0  160.162.191.1/32          100.251.7.1                                                        active
test_v4_in_v4-0  160.163.191.1/32          100.251.7.1                                                        active
test_v4_in_v4-0  160.164.191.1/32          100.251.7.1
```