### PR TITLE
fixed bootloader method verify_image_sign to have dummy implementation…

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -579,11 +579,16 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
 
         # Calling verification script by default - signature will be checked if enabled in bios
         echo_and_log("Verifing image {} signature...".format(binary_image_version))
-        if not bootloader.verify_image_sign(image_path):
-            echo_and_log('Error: Failed verify image signature', LOG_ERR)
-            raise click.Abort()
-        else:
-            echo_and_log('Verification successful')
+        try:
+            if not bootloader.verify_image_sign(image_path):
+                echo_and_log('Error: Failed verify image signature', LOG_ERR)
+                raise click.Abort()
+            else:
+                echo_and_log('Verification successful')
+        except AttributeError:
+                echo_and_log("Skip Verifing image {} signature,".format(binary_image_version) +
+                             "method not implemented for the current bootloader type: {}".format(bootloader.__class__.__name__))
+                pass
 
         echo_and_log("Installing image {} and setting it as default...".format(binary_image_version))
         with SWAPAllocator(not skip_setup_swap, swap_mem_size, total_mem_threshold, available_mem_threshold):

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -586,9 +586,9 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
             else:
                 echo_and_log('Verification successful')
         except AttributeError:
-                echo_and_log("Skip Verifing image {} signature,".format(binary_image_version) +
-                             "method not implemented for the current bootloader type: {}".format(bootloader.__class__.__name__))
-                pass
+            echo_and_log("Skip Verifing image {} signature,".format(binary_image_version) +
+            " method not implemented for the current bootloader type: {}".format(bootloader.__class__.__name__))
+            pass
 
         echo_and_log("Installing image {} and setting it as default...".format(binary_image_version))
         with SWAPAllocator(not skip_setup_swap, swap_mem_size, total_mem_threshold, available_mem_threshold):

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -53,6 +53,13 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
     print(result.output)
 
     assert result.exit_code != 0
+    mock_bootloader_verify_image_sign_not_implemented = mock_bootloader
+    mock_bootloader_verify_image_sign_not_implemented.verify_image_sign = Mock(side_effect=AttributeError)
+    get_bootloader.return_value=mock_bootloader_verify_image_sign_not_implemented
+    result = runner.invoke(sonic_installer.commands["install"], [sonic_image_filename, "-y"])
+    print(result.output)
+
+    assert result.exit_code == 0
     # Assert bootloader install API was called
     mock_bootloader.install_image.assert_called_with(f"./{sonic_image_filename}")
     # Assert all below commands were called, so we ensure that

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -59,7 +59,7 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
     result = runner.invoke(sonic_installer.commands["install"], [sonic_image_filename, "-y"])
     print(result.output)
 
-    assert result.exit_code == 0
+    assert result.exit_code != 0
     # Assert bootloader install API was called
     mock_bootloader.install_image.assert_called_with(f"./{sonic_image_filename}")
     # Assert all below commands were called, so we ensure that
@@ -96,6 +96,11 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
         call(["umount", "-f", "-R", mounted_image_folder], raise_exception=False),
         call(["umount", "-r", "-f", mounted_image_folder], raise_exception=False),
         call(["rm", "-rf", mounted_image_folder], raise_exception=False),
+        call(['mkdir', '-p', mounted_image_folder]),
+        call(["mount", "-t", "squashfs", mounted_image_folder, mounted_image_folder]),
+        call(["sonic-cfggen", "-d", "-y", f"{mounted_image_folder}/etc/sonic/sonic_version.yml", "-t", f"{mounted_image_folder}/usr/share/sonic/templates/sonic-environment.j2"]),
+        call(["umount", "-r", "-f", mounted_image_folder], raise_exception=True),
+        call(["rm", "-rf", mounted_image_folder], raise_exception=True),
     ]
     assert run_command_or_raise.call_args_list == expected_call_list
 


### PR DESCRIPTION
…n in father class

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed bootloader issue in sonic-installer
#### How I did it
Added dummy implementation of verify_image_sign in bootloader.py
Added tests to check it's available
#### How to verify it
Run sonic-utilities tests and see that they pass
#### Previous command output (if the output of a command-line utility has changed)
NONE
#### New command output (if the output of a command-line utility has changed)
NONE
