### PR TITLE
[202012][show] show logging CLI support for logs stored in tmpfs

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -916,14 +916,18 @@ def table(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def logging(process, lines, follow, verbose):
     """Show system log"""
+    if os.path.exists("/var/log.tmpfs"):
+        log_path = "/var/log.tmpfs"
+    else:
+        log_path = "/var/log"
     if follow:
-        cmd = "sudo tail -F /var/log/syslog"
+        cmd = "sudo tail -F {}/syslog".format(log_path)
         run_command(cmd, display_cmd=verbose)
     else:
-        if os.path.isfile("/var/log/syslog.1"):
-            cmd = "sudo cat /var/log/syslog.1 /var/log/syslog"
+        if os.path.isfile("{}/syslog.1".format(log_path)):
+            cmd = "sudo cat {}/syslog.1 {}/syslog".format(log_path, log_path)
         else:
-            cmd = "sudo cat /var/log/syslog"
+            cmd = "sudo cat {}/syslog".format(log_path)
 
         if process is not None:
             cmd += " | grep '{}'".format(process)

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -1,0 +1,70 @@
+import pytest
+import show.main as show
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+EXPECTED_BASE_COMMAND = 'sudo '
+
+@patch('show.main.run_command')
+@pytest.mark.parametrize(
+        "cli_arguments,expected",
+        [
+            ([], 'cat /var/log/syslog'),
+            (['xcvrd'], "cat /var/log/syslog | grep 'xcvrd'"),
+            (['-l', '10'], 'cat /var/log/syslog | tail -10'),
+            (['-f'], 'tail -F /var/log/syslog'),
+        ]
+)
+def test_show_logging_default(run_command, cli_arguments, expected):
+    runner = CliRunner()
+    result = runner.invoke(show.cli.commands["logging"], cli_arguments)
+    run_command.assert_called_with(EXPECTED_BASE_COMMAND + expected, display_cmd=False)
+
+@patch('show.main.run_command')
+@patch('os.path.isfile', MagicMock(return_value=True))
+@pytest.mark.parametrize(
+        "cli_arguments,expected",
+        [
+            ([], 'cat /var/log/syslog.1 /var/log/syslog'),
+            (['xcvrd'], "cat /var/log/syslog.1 /var/log/syslog | grep 'xcvrd'"),
+            (['-l', '10'], 'cat /var/log/syslog.1 /var/log/syslog | tail -10'),
+            (['-f'], 'tail -F /var/log/syslog'),
+        ]
+)
+def test_show_logging_syslog_1(run_command, cli_arguments, expected):
+    runner = CliRunner()
+    result = runner.invoke(show.cli.commands["logging"], cli_arguments)
+    run_command.assert_called_with(EXPECTED_BASE_COMMAND + expected, display_cmd=False)
+
+@patch('show.main.run_command')
+@patch('os.path.exists', MagicMock(return_value=True))
+@pytest.mark.parametrize(
+        "cli_arguments,expected",
+        [
+            ([], 'cat /var/log.tmpfs/syslog'),
+            (['xcvrd'], "cat /var/log.tmpfs/syslog | grep 'xcvrd'"),
+            (['-l', '10'], 'cat /var/log.tmpfs/syslog | tail -10'),
+            (['-f'], 'tail -F /var/log.tmpfs/syslog'),
+        ]
+)
+def test_show_logging_tmpfs(run_command, cli_arguments, expected):
+    runner = CliRunner()
+    result = runner.invoke(show.cli.commands["logging"], cli_arguments)
+    run_command.assert_called_with(EXPECTED_BASE_COMMAND + expected, display_cmd=False)
+
+@patch('show.main.run_command')
+@patch('os.path.isfile', MagicMock(return_value=True))
+@patch('os.path.exists', MagicMock(return_value=True))
+@pytest.mark.parametrize(
+        "cli_arguments,expected",
+        [
+            ([], 'cat /var/log.tmpfs/syslog.1 /var/log.tmpfs/syslog'),
+            (['xcvrd'], "cat /var/log.tmpfs/syslog.1 /var/log.tmpfs/syslog | grep 'xcvrd'"),
+            (['-l', '10'], 'cat /var/log.tmpfs/syslog.1 /var/log.tmpfs/syslog | tail -10'),
+            (['-f'], 'tail -F /var/log.tmpfs/syslog'),
+        ]
+)
+def test_show_logging_tmpfs_syslog_1(run_command, cli_arguments, expected):
+    runner = CliRunner()
+    result = runner.invoke(show.cli.commands["logging"], cli_arguments)
+    run_command.assert_called_with(EXPECTED_BASE_COMMAND + expected, display_cmd=False)


### PR DESCRIPTION
Signed-off-by: Mihir Patel <patelmi@microsoft.com>

Backport of #2641 

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Enabling "show logging" CLI to show logs from tmpfs if it exists.

#### How I did it
Added a check in the CLI handler to see if the path "/var/log.tmpfs" exists and display the logs from this directory if it exists. In case if the path doesn't exist, logs will be displayed from "/var/log"

#### How to verify it
Following tests were performed:
1.	"show logging" o/p when syslog resides in "/var/log"
2.	"show logging -f" o/p when syslog resides in "/var/log"
3.	"show logging" o/p when syslog resides in "/var/log.tmpfs"
4.	"show logging -f" o/p when syslog resides in "/var/log.tmpfs"

For detailed test results, please refer to [Unit-test_logging_cli.txt](https://github.com/sonic-net/sonic-utilities/files/10550147/Unit-test_logging_cli.txt)

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

