### PR TITLE
[config] replace shell=True and replace exit() by sys.exit()

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -245,8 +245,8 @@ def _get_device_type():
     TODO: move to sonic-py-common
     """
 
-    command = "{} -m -v DEVICE_METADATA.localhost.type".format(SONIC_CFGGEN_PATH)
-    proc = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
+    command = [SONIC_CFGGEN_PATH, "-m", "-v", "DEVICE_METADATA.localhost.type"]
+    proc = subprocess.Popen(command, text=True, stdout=subprocess.PIPE)
     device_type, err = proc.communicate()
     if err:
         click.echo("Could not get the device type from minigraph, setting device type to Unknown")
@@ -847,7 +847,7 @@ def _get_disabled_services_list(config_db):
 
 def _stop_services():
     try:
-        subprocess.check_call("sudo monit status", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         click.echo("Disabling container monitoring ...")
         clicommon.run_command("sudo monit unmonitor container_checker")
     except subprocess.CalledProcessError as err:
@@ -887,7 +887,7 @@ def _restart_services():
     clicommon.run_command("sudo systemctl restart sonic.target")
 
     try:
-        subprocess.check_call("sudo monit status", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         click.echo("Enabling container monitoring ...")
         clicommon.run_command("sudo monit monitor container_checker")
     except subprocess.CalledProcessError as err:
@@ -1218,7 +1218,7 @@ def config(ctx):
     load_db_config()
 
     if os.geteuid() != 0:
-        exit("Root privileges are required for this operation")
+        sys.exit("Root privileges are required for this operation")
 
     ctx.obj = Db()
 
@@ -1603,8 +1603,8 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
 
         if load_sysinfo:
             try:
-                command = "{} -j {} -v DEVICE_METADATA.localhost.hwsku".format(SONIC_CFGGEN_PATH, file)
-                proc = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
+                command = [SONIC_CFGGEN_PATH, "-j", file, '-v', "DEVICE_METADATA.localhost.hwsku"]
+                proc = subprocess.Popen(command, text=True, stdout=subprocess.PIPE)
                 output, err = proc.communicate()
 
             except FileNotFoundError as e:
@@ -2904,7 +2904,7 @@ def warm_restart_enable(ctx, module):
     config_db = ctx.obj['db']
     feature_table = config_db.get_table('FEATURE')
     if module != 'system' and module not in feature_table:
-        exit('Feature {} is unknown'.format(module))
+        sys.exit('Feature {} is unknown'.format(module))
     prefix = ctx.obj['prefix']
     _hash = '{}{}'.format(prefix, module)
     state_db.set(state_db.STATE_DB, _hash, 'enable', 'true')
@@ -2918,7 +2918,7 @@ def warm_restart_enable(ctx, module):
     config_db = ctx.obj['db']
     feature_table = config_db.get_table('FEATURE')
     if module != 'system' and module not in feature_table:
-        exit('Feature {} is unknown'.format(module))
+        sys.exit('Feature {} is unknown'.format(module))
     prefix = ctx.obj['prefix']
     _hash = '{}{}'.format(prefix, module)
     state_db.set(state_db.STATE_DB, _hash, 'enable', 'false')
@@ -6152,10 +6152,10 @@ def firmware():
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def install(args):
     """Install platform firmware"""
-    cmd = "fwutil install {}".format(" ".join(args))
+    cmd = ["fwutil", "install"] + list(args)
 
     try:
-        subprocess.check_call(cmd, shell=True)
+        subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
 
@@ -6170,10 +6170,10 @@ def install(args):
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 def update(args):
     """Update platform firmware"""
-    cmd = "fwutil update {}".format(" ".join(args))
+    cmd = ["fwutil", "update"] + list(args)
 
     try:
-        subprocess.check_call(cmd, shell=True)
+        subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
 
@@ -6333,10 +6333,10 @@ def del_loopback(ctx, loopback_name):
 def ztp():
     """ Configure Zero Touch Provisioning """
     if os.path.isfile('/usr/bin/ztp') is False:
-        exit("ZTP feature unavailable in this image version")
+        sys.exit("ZTP feature unavailable in this image version")
 
     if os.geteuid() != 0:
-        exit("Root privileges are required for this operation")
+        sys.exit("Root privileges are required for this operation")
 
 @ztp.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
@@ -6447,7 +6447,7 @@ def enable(ctx):
         ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     try:
-        proc = subprocess.Popen("systemctl is-active sflow", shell=True, text=True, stdout=subprocess.PIPE)
+        proc = subprocess.Popen(['systemctl', 'is-active', 'sflow'], text=True, stdout=subprocess.PIPE)
         (out, err) = proc.communicate()
     except SystemExit as e:
         ctx.fail("Unable to check sflow status {}".format(e))

--- a/config/syslog.py
+++ b/config/syslog.py
@@ -31,13 +31,13 @@ log.set_min_log_priority_info()
 
 def exec_cmd(cmd):
     """ Execute shell command """
-    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
 
 def get_vrf_list():
     """ Get Linux VRF device list """
     vrf_list = []
-    vrf_data = json.loads(exec_cmd('ip --json vrf show'))
+    vrf_data = json.loads(exec_cmd(['ip', '--json', 'vrf', 'show']))
     for vrf_entry in vrf_data:
         vrf_name = vrf_entry.get('name', None)
         if vrf_name is not None:
@@ -51,7 +51,7 @@ def get_vrf_member_dict():
     vrf_list = get_vrf_list()
     for vrf_name in vrf_list:
         vrf_member_dict[vrf_name] = []
-        vrf_member_data = json.loads(exec_cmd('ip --json link show vrf {}'.format(vrf_name)))
+        vrf_member_data = json.loads(exec_cmd(['ip', '--json', 'link', 'show', 'vrf', vrf_name]))
         for vrf_member_entry in vrf_member_data:
             vrf_member_name = vrf_member_entry.get('ifname', None)
             if vrf_member_name is not None:
@@ -62,7 +62,7 @@ def get_vrf_member_dict():
 def get_ip_addr_dict():
     """ Get Linux interface to IPv4/IPv6 address list dict """
     ip_addr_dict = {}
-    ip_addr_data = json.loads(exec_cmd('ip --json address show'))
+    ip_addr_data = json.loads(exec_cmd(['ip', '--json', 'address', 'show']))
     for ip_addr_entry in ip_addr_data:
         link_name = ip_addr_entry.get('ifname', None)
         if link_name is not None:

--- a/tests/syslog_input/config_mock.py
+++ b/tests/syslog_input/config_mock.py
@@ -59,12 +59,12 @@ IP_ADDR_LIST = '''
 '''
 
 def exec_cmd_mock(cmd):
-    if cmd == 'ip --json vrf show':
+    if cmd == ['ip', '--json', 'vrf', 'show']:
         return VRF_LIST
-    elif cmd == 'ip --json link show vrf mgmt':
+    elif cmd == ['ip', '--json', 'link', 'show', 'vrf', 'mgmt']:
         return VRF_MGMT_MEMBERS
-    elif cmd == 'ip --json link show vrf Vrf-Data':
+    elif cmd == ['ip', '--json', 'link', 'show', 'vrf', 'Vrf-Data']:
         return VRF_DATA_MEMBERS
-    elif cmd == 'ip --json address show':
+    elif cmd == ['ip', '--json', 'address', 'show']:
         return IP_ADDR_LIST
     raise Exception("{}: unknown command: {}".format(__name__, cmd))


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
`sys.exit` is better than `exit`, considered good to use in production code.
Ref:
https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python
https://stackoverflow.com/questions/19747371/python-exit-commands-why-so-many-and-when-should-each-be-used
#### How I did it
`subprocess()` - use `shell=False` instead, use list of strings Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
Replace `exit()` by `sys.exit()`
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

