### PR TITLE
[fwutil] replace shell=True

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -236,7 +236,7 @@ class SquashFs(object):
     def get_current_image(self):
         cmd0 = ["sonic-installer", "list"]
         cmd1 = ["grep", 'Current: ']
-        cmd2 = ["cut", "-f2", "-d", ' ']
+        cmd2 = ["cut", "-f2", "-d "]
         output = check_output_pipe(cmd0, cmd1, cmd2)
 
         return output.rstrip(NEWLINE)
@@ -244,7 +244,7 @@ class SquashFs(object):
     def get_next_image(self):
         cmd0 = ["sonic-installer", "list"]
         cmd1 = ["grep", 'Next: ']
-        cmd2 = ["cut", "-f2", "-d", ' ']
+        cmd2 = ["cut", "-f2", "-d "]
         output = check_output_pipe(cmd0, cmd1, cmd2)
 
         return output.rstrip(NEWLINE)

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -23,6 +23,7 @@ try:
 
     from . import Platform
     from .log import LogHelper
+    from sonic_py_common.general import check_output_pipe
 except ImportError as e:
     raise ImportError("Required module not found: {}".format(str(e)))
 
@@ -233,14 +234,18 @@ class SquashFs(object):
         self.overlay_mountpoint = self.OVERLAY_MOUNTPOINT_TEMPLATE.format(image_stem)
 
     def get_current_image(self):
-        cmd = "sonic-installer list | grep 'Current: ' | cut -f2 -d' '"
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True, text=True)
+        cmd0 = ["sonic-installer", "list"]
+        cmd1 = ["grep", 'Current: ']
+        cmd2 = ["cut", "-f2", "-d", ' ']
+        output = check_output_pipe(cmd0, cmd1, cmd2)
 
         return output.rstrip(NEWLINE)
 
     def get_next_image(self):
-        cmd = "sonic-installer list | grep 'Next: ' | cut -f2 -d' '"
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True, text=True)
+        cmd0 = ["sonic-installer", "list"]
+        cmd1 = ["grep", 'Next: ']
+        cmd2 = ["cut", "-f2", "-d", ' ']
+        output = check_output_pipe(cmd0, cmd1, cmd2)
 
         return output.rstrip(NEWLINE)
 
@@ -252,37 +257,29 @@ class SquashFs(object):
             self.umount_next_image_fs()
 
         os.mkdir(self.fs_mountpoint)
-        cmd = "mount -t squashfs {} {}".format(
-            self.fs_path,
-            self.fs_mountpoint
-        )
-        subprocess.check_call(cmd, shell=True)
+        cmd = ["mount", "-t", "squashfs", self.fs_path, self.fs_mountpoint]
+        subprocess.check_call(cmd)
 
         if not (os.path.exists(self.fs_rw) and os.path.exists(self.fs_work)):
             return self.fs_mountpoint
 
         os.mkdir(self.overlay_mountpoint)
-        cmd = "mount -n -r -t overlay -o lowerdir={},upperdir={},workdir={} overlay {}".format(
-            self.fs_mountpoint,
-            self.fs_rw,
-            self.fs_work,
-            self.overlay_mountpoint
-        )
-        subprocess.check_call(cmd, shell=True)
+        cmd = ["mount", "-n", "-r", "-t", "overlay", "-o", "lowerdir={},upperdir={},workdir={}".format(self.fs_mountpoint, self.fs_rw, self.fs_work), "overlay", self.overlay_mountpoint]
+        subprocess.check_call(cmd)
 
         return self.overlay_mountpoint
 
     def umount_next_image_fs(self):
         if os.path.ismount(self.overlay_mountpoint):
-            cmd = "umount -rf {}".format(self.overlay_mountpoint)
-            subprocess.check_call(cmd, shell=True)
+            cmd = ["umount", "-rf", self.overlay_mountpoint]
+            subprocess.check_call(cmd)
 
         if os.path.exists(self.overlay_mountpoint):
             os.rmdir(self.overlay_mountpoint)
 
         if os.path.ismount(self.fs_mountpoint):
-            cmd = "umount -rf {}".format(self.fs_mountpoint)
-            subprocess.check_call(cmd, shell=True)
+            cmd = ["umount", "-rf", self.fs_mountpoint]
+            subprocess.check_call(cmd)
 
         if os.path.exists(self.fs_mountpoint):
             os.rmdir(self.fs_mountpoint)
@@ -875,13 +872,9 @@ class ComponentUpdateProvider(PlatformDataProvider):
             click.echo("{} firmware auto-update starting: {} with boot_type {}".format(component_path, firmware_path, boot))
             log_helper.log_fw_auto_update_start(component_path, firmware_path, boot)
             if os.path.isfile(utility) and os.access(utility, os.X_OK):
-                cmd = "{} -a {} {}".format(
-                    utility,
-                    firmware_path,
-                    boot
-                )
+                cmd = [utility, "-a", firmware_path, boot]
                 click.echo("firmware auto-update starting:utility cmd {}".format(cmd))
-                rt_code = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True, text=True)
+                rt_code = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
                 rt_code = int(rt_code.strip())
             else:
                 rt_code = component.auto_update_firmware(firmware_path, boot)

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -13,13 +13,13 @@ class TestSquashFs(object):
     def test_get_current_image(self, mock_check_output_pipe):
         sqfs = fwutil_lib.SquashFs()
         sqfs.get_current_image()
-        mock_check_output_pipe.assert_called_with(['sonic-installer', 'list'], ['grep', 'Current: '], ['cut', '-f2', '-d',  ' '])
+        mock_check_output_pipe.assert_called_with(['sonic-installer', 'list'], ['grep', 'Current: '], ['cut', '-f2', '-d '])
 
     @patch('fwutil.lib.check_output_pipe')
     def test_get_next_image(self, mock_check_output_pipe):
         sqfs = fwutil_lib.SquashFs()
         sqfs.get_next_image()
-        mock_check_output_pipe.assert_called_with(['sonic-installer', 'list'], ['grep', 'Next: '], ['cut', '-f2', '-d',  ' '])
+        mock_check_output_pipe.assert_called_with(['sonic-installer', 'list'], ['grep', 'Next: '], ['cut', '-f2', '-d '])
 
     @patch("os.mkdir")
     @patch("os.path.exists", return_value=True)

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -1,0 +1,78 @@
+import sys
+import pytest
+from unittest.mock import call, patch, MagicMock
+
+sys.modules['sonic_platform.platform'] = MagicMock()
+import fwutil.lib as fwutil_lib
+
+class TestSquashFs(object):
+    def setup(self):
+        print('SETUP')
+
+    @patch('fwutil.lib.check_output_pipe')
+    def test_get_current_image(self, mock_check_output_pipe):
+        sqfs = fwutil_lib.SquashFs()
+        sqfs.get_current_image()
+        mock_check_output_pipe.assert_called_with(['sonic-installer', 'list'], ['grep', 'Current: '], ['cut', '-f2', '-d',  ' '])
+
+    @patch('fwutil.lib.check_output_pipe')
+    def test_get_next_image(self, mock_check_output_pipe):
+        sqfs = fwutil_lib.SquashFs()
+        sqfs.get_next_image()
+        mock_check_output_pipe.assert_called_with(['sonic-installer', 'list'], ['grep', 'Next: '], ['cut', '-f2', '-d',  ' '])
+
+    @patch("os.mkdir")
+    @patch("os.path.exists", return_value=True)
+    @patch("subprocess.check_call")
+    @patch("os.path.ismount", MagicMock(return_value=False))
+    @patch("fwutil.lib.SquashFs.next_image", MagicMock(return_value="SONiC-OS-123456"))
+    def test_mount_next_image_fs(self, mock_check_call, mock_exists, mock_mkdir):
+        image_stem = fwutil_lib.SquashFs.next_image()
+        sqfs = fwutil_lib.SquashFs()
+        sqfs.fs_path = "/host/image-{}/fs.squashfs".format(image_stem)
+        sqfs.fs_mountpoint = "/tmp/image-{}-fs".format(image_stem)
+        sqfs.overlay_mountpoint = "/tmp/image-{}-overlay".format(image_stem)
+
+        result = sqfs.mount_next_image_fs()
+
+        assert mock_mkdir.call_args_list == [
+            call(sqfs.fs_mountpoint),
+            call(sqfs.overlay_mountpoint)
+        ]
+
+        assert mock_check_call.call_args_list == [
+            call(["mount", "-t", "squashfs", sqfs.fs_path, sqfs.fs_mountpoint]),
+            call(["mount", "-n", "-r", "-t", "overlay", "-o", "lowerdir={},upperdir={},workdir={}".format(sqfs.fs_mountpoint, sqfs.fs_rw, sqfs.fs_work), "overlay", sqfs.overlay_mountpoint])
+        ]
+
+        assert mock_exists.call_args_list == [
+            call(sqfs.fs_rw),
+            call(sqfs.fs_work)
+        ]
+
+        assert result == sqfs.overlay_mountpoint
+
+    @patch("os.rmdir")
+    @patch("os.path.exists", return_value=True)
+    @patch("subprocess.check_call")
+    @patch("os.path.ismount", MagicMock(return_value=True))
+    @patch("fwutil.lib.SquashFs.next_image", MagicMock(return_value="SONiC-OS-123456"))
+    def test_unmount_next_image_fs(self, mock_check_call, mock_exists, mock_rmdir):
+        sqfs = fwutil_lib.SquashFs()
+        sqfs.fs_mountpoint = "/tmp/image-{}-fs".format("SONiC-OS-123456")
+        sqfs.overlay_mountpoint = "/tmp/image-{}-overlay".format("SONiC-OS-123456")
+
+        sqfs.umount_next_image_fs()
+
+        assert mock_check_call.call_args_list == [
+            call(["umount", "-rf", sqfs.overlay_mountpoint]),
+            call(["umount", "-rf", sqfs.fs_mountpoint])
+        ]
+
+        assert mock_rmdir.call_args_list == [
+            call(sqfs.overlay_mountpoint),
+            call(sqfs.fs_mountpoint)
+        ]
+
+    def teardown(self):
+        print('TEARDOWN')


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
#### How I did it
`subprocess()` - use `shell=False` instead, use list of strings Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
#### How to verify it
Pass UT
Manual test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

