### PR TITLE
Add support for platform syncd pre shutdown plugin

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -79,11 +79,17 @@ function stop_sonic_services()
         if [[ ($NUM_ASIC -gt 1) ]]; then
             asic_num=0
             while [[ ($asic_num -lt $NUM_ASIC) ]]; do
+                PLATFORM_PRE_SHUTDOWN="/usr/share/sonic/device/$PLATFORM/plugins/syncd_pre_shutdown.sh"
+                [ -f $PLATFORM_PRE_SHUTDOWN ] && $PLATFORM_PRE_SHUTDOWN start $asic_num
+
                 debug "Stopping syncd$asic_num process..."
                 docker exec -i syncd$asic_num /usr/bin/syncd_request_shutdown --cold > /dev/null
                 ((asic_num = asic_num + 1))
             done
         else
+            PLATFORM_PRE_SHUTDOWN="/usr/share/sonic/device/$PLATFORM/plugins/syncd_pre_shutdown.sh"
+            [ -f $PLATFORM_PRE_SHUTDOWN ] && $PLATFORM_PRE_SHUTDOWN start
+
             debug "Stopping syncd process..."
             docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
         fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
#### Why I did it

Vendor platform may require running platform specific pre-shutdown routine before shutting down the syncd process which runs the SAI and vendor sdk instance.

#### How I did it
Added a platform script hook which will be executed if the plugin script is provided by the platform in device//plugins/

#### How to verify it
Add platform plugin script and run reboot

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

