### PR TITLE
[portstat CLI] don't print reminder if use json format

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -17,6 +17,7 @@ from collections import OrderedDict, namedtuple
 from natsort import natsorted
 from tabulate import tabulate
 from sonic_py_common import multi_asic
+from sonic_py_common import device_info
 
 # mock the redis for unit test purposes #
 try:
@@ -337,7 +338,7 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            if multi_asic.is_multi_asic():
+            if multi_asic.is_multi_asic() or device_info.is_chassis():
                 print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
@@ -555,7 +556,7 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            if multi_asic.is_multi_asic():
+            if multi_asic.is_multi_asic() or device_info.is_chassis():
                 print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -337,8 +337,8 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic(): 
-            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+            if multi_asic.is_multi_asic(): 
+                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
         """
@@ -555,8 +555,8 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic(): 
-            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+            if multi_asic.is_multi_asic(): 
+                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():
     parser  = argparse.ArgumentParser(description='Display the ports state and counters',

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -337,7 +337,8 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+            if multi_asic.is_multi_asic():
+                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
         """
@@ -554,7 +555,8 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+            if multi_asic.is_multi_asic():
+                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():
     parser  = argparse.ArgumentParser(description='Display the ports state and counters',

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -337,8 +337,7 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            if multi_asic.is_multi_asic(): 
-                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
         """
@@ -555,8 +554,7 @@ class Portstat(object):
             print(table_as_json(table, header))
         else:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            if multi_asic.is_multi_asic(): 
-                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():
     parser  = argparse.ArgumentParser(description='Display the ports state and counters',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
For this change: https://github.com/sonic-net/sonic-utilities/pull/2466
1. do not emit `string` format Reminder if use json format is required
because the json output would be expecting only json format and might do some parsing for json only.
e.g.
test_drop_counters.py does a json.load on output of `portstats -j`
https://github.com/sonic-net/sonic-mgmt/blob/cbd1d60b43dd7b02e2f8a7b1755f60203a5a1fde/tests/common/helpers/drop_counters/drop_counters.py#L52

3. print for both multi_asic and chassis duts
even single_asic duts don't have internal links, single-asic linecards have inbnd&recycle ports connect to other linecards or SUP
#### What I did
Print the reminder only when no `-j` option is given -- json format not required
#### How I did it
Move print of reminder to be only when not `use_json`
#### How to verify it
Before:
```
    def get_pkt_drops(duthost, cli_cmd, asic_index):
        """
        @summary: Parse output of "portstat" or "intfstat" commands and convert it to the dictionary.
        @param module: The AnsibleModule object
        @param cli_cmd: one of supported CLI commands - "portstat -j" or "intfstat -j"
        @return: Return dictionary of parsed counters
        """
        # Get namespace from asic_index.
        namespace = duthost.get_namespace_from_asic_id(asic_index)

        # Frame the correct cli command
        # the L2 commands need _SUFFIX and L3 commands need _PREFIX
        if cli_cmd == GET_L3_COUNTERS:
            CMD_PREFIX = NAMESPACE_PREFIX if (namespace is not None and duthost.is_multi_asic) else ''
            cli_cmd = CMD_PREFIX + cli_cmd
        elif cli_cmd == GET_L2_COUNTERS:
            CMD_SUFFIX = NAMESPACE_SUFFIX if (namespace is not None and duthost.is_multi_asic) else ''
            cli_cmd = cli_cmd + CMD_SUFFIX

        stdout = duthost.command(cli_cmd.format(namespace))
        stdout = stdout["stdout"]
        match = re.search("Last cached time was.*\n", stdout)
        if match:
            stdout = re.sub("Last cached time was.*\n", "", stdout)

        try:
            return json.loads(stdout)
        except Exception as err:
>           raise Exception("Failed to parse output of '{}', err={}".format(cli_cmd, str(err)))
E           Exception: Failed to parse output of 'portstat -j -n {} ', err=Extra data: line 274 column 1 - line 274 column 84 (char 6315 - 6398)
```

After:
```
------------------------------------------------------------------------------------------------ generated xml file: /var/src/sonic-mgmt-int/tests/logs/tr.xml -------------------------------------------------------------------------------------------------
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [26] /var/src/sonic-mgmt-int/tests/drop_packets/drop_packets.py:284: No vlan_members available
SKIPPED [6] drop_packets/drop_packets.py:889: This test failed intermittent due to known issue in sonic-mgmt, skip for now.
SKIPPED [6] /var/src/sonic-mgmt-int/tests/drop_packets/drop_packets.py:924: Test case requires explicit fanout support
SKIPPED [3] drop_packets/drop_packets.py: SONiC can't enable loop-back filter feature
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: BRCM does not drop SIP class E packets
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: BRCM does not drop DIP link local packets
SKIPPED [32] /var/src/sonic-mgmt-int/tests/drop_packets/drop_packets.py:284: No rif_members available
SKIPPED [1] /var/src/sonic-mgmt-int/tests/drop_packets/test_drop_counters.py:268: Test case requires explicit fanout support
SKIPPED [1] /var/src/sonic-mgmt-int/tests/drop_packets/drop_packets.py:492: Test case requires explicit fanout support
SKIPPED [1] /var/src/sonic-mgmt-int/tests/drop_packets/drop_packets.py:454: Test case requires explicit fanout support
SKIPPED [3] drop_packets/drop_packets.py: Not supported on Broadcom platforms
SKIPPED [1] /var/src/sonic-mgmt-int/tests/drop_packets/drop_packets.py:252: RIF interface is absent
SKIPPED [1] /var/src/sonic-mgmt-int/tests/common/helpers/assertions.py:13: BRCM does not drop SIP link local packets
ERROR drop_packets/test_drop_counters.py::test_acl_drop[port_channel_members-str-n3164-acs-2] - TypeError: 'NoneType' object has no attribute '__getitem__'
======================================================================================================= 18 passed, 83 skipped, 1 error in 871.70 seconds =======================================================================================================
```
Error is in acl_rules, unrelated to current change
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

