### PR TITLE
Skip saidump for Spine Router as this can take more than 5 sec (#2637)

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1518,6 +1518,7 @@ main() {
     save_cmd "show reboot-cause" reboot.cause
 
     local asic="$(/usr/local/bin/sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)"
+    local device_type=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' type`
     # 1st counter snapshot early. Need 2 snapshots to make sense of counters trend.
     save_counter_snapshot $asic 1
 
@@ -1594,7 +1595,9 @@ main() {
         done
     fi
 
-    save_saidump
+    if [[ "$device_type" != "SpineRouter" ]]; then
+        save_saidump
+    fi
 
     if [[ "$asic" = "mellanox" ]]; then
         collect_mellanox


### PR DESCRIPTION
To address sonic-net/sonic-buildimage#13561 skip saidump on T2 platforms for time-being.

#### What I did
Cherry-pick https://github.com/sonic-net/sonic-utilities/pull/2637 to 202205

