### PR TITLE
[generate_dump]: Enhance show techsupport for Marvell platform

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1158,6 +1158,67 @@ collect_mellanox_dfw_dumps() {
 }
 
 ###############################################################################
+# Runs a given marvellcmd command in all namesapces in case of multi ASIC platform
+# Globals:
+#  NUM_ASICS
+# Arguments:
+#  cmd: The command to run. Make sure that arguments with spaces have quotes
+#  filename: the filename to save the output as in $BASE/dump
+#  do_gzip: (OPTIONAL) true or false. Should the output be gzipped
+# Returns:
+#  None
+###############################################################################
+save_marvellcmd() {
+    trap 'handle_error $? $LINENO' ERR
+
+    mkdir -p $LOGDIR/sdkdump
+    local cmd="docker exec syncd mrvlcmd -c \"$1\""
+    save_cmd "$cmd" "sdkdump/$2"
+}
+
+###############################################################################
+# Collect Marvell specific information
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+collect_marvell() {
+    trap 'handle_error $? $LINENO' ERR
+
+    save_marvellcmd "show version" "CPSS_version"
+    save_marvellcmd "debug-mode;xps-api call xpsDataIntegrityDumpSerInfo all" "SER_table"
+    save_marvellcmd "show traffic cpu rx statistic device 0" "CPU_stat"
+    save_marvellcmd "show interfaces status all" "INTERFACE_config"
+    save_marvellcmd "show port monitor" "PORT_mirror"
+    save_marvellcmd "show vlan device 0" "VLAN_table"
+    save_marvellcmd "show ip route device 0" "IP_route"
+    save_marvellcmd "show ipv6 route device 0" "IPV6_route"
+    save_marvellcmd "show ip route_fdb device 0" "IP_forward_route"
+    save_marvellcmd "show ipv6 route_fdb device 0" "IPV6_forward_route"
+    save_marvellcmd "show ip next-hop device 0" "NH_table"
+    save_marvellcmd "show mac address-table device 0" "MAC_forward"
+    save_marvellcmd "show mac address-table count device 0" "MAC_count"
+    save_marvellcmd "show tail-drop-allocated buffers all" "Tail_drop"
+    save_marvellcmd "show policy device 0" "POLICER_table"
+    save_marvellcmd "show system policy-tcam utilization device 0" "Policy_count"
+    save_marvellcmd "show access-list device 0 pcl-id 0 format ingress_udb_30" "UDB30_acl"
+    save_marvellcmd "show access-list device 0 pcl-id 0 format ingress_udb_60" "UDB60_acl"
+    save_marvellcmd "debug-mode;show drop counters 0" "Drop_count"
+    save_marvellcmd "debug-mode;dump all registers" "REGISTER_table"
+    save_marvellcmd "debug-mode;dump all tables0" "HW_table_0"
+    save_marvellcmd "debug-mode;dump all tables1" "HW_table_1"
+    save_marvellcmd "debug-mode;dump all tables2" "HW_table_2"
+    save_marvellcmd "debug-mode;dump all tables3" "HW_table_3"
+    save_marvellcmd "debug-mode;dump all tables4" "HW_table_4"
+    save_marvellcmd "debug-mode;dump all tables5" "HW_table_5"
+    save_marvellcmd "debug-mode;dump all tables6" "HW_table_6"
+    save_marvellcmd "debug-mode;dump all tables7" "HW_table_7"
+}
+
+###############################################################################
 # Collect Broadcom specific information
 # Globals:
 #  None
@@ -1733,6 +1794,11 @@ main() {
     if [ "$asic" = "cisco-8000" ]; then
         collect_cisco_8000
     fi
+
+    if [ "$asic" = "marvell" ]; then
+        collect_marvell
+    fi
+
 
     # 2nd counter snapshot late. Need 2 snapshots to make sense of counters trend.
     save_counter_snapshot $asic 2


### PR DESCRIPTION
Change-Id: Ibb5b5a860833e8d7834a1d72756d070c61f2ab37

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support for marvell sdk commands in "show techsupport". 

#### How I did it
Modified the generate_dump script, to add marvell sdk commands under a proper platform check.

#### How to verify it
Verified the change by running "show techsupport" command and check all the newly added marvel sdk commands are collecting the correct information.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

