### PR TITLE
[dhcp_relay] Remove add field of vlanid to DHCP_RELAY table while add vlan

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -47,7 +47,7 @@ def add_vlan(db, vid):
     set_dhcp_relay_table('VLAN', config_db, vlan, {'vlanid': str(vid)})
 
     # set dhcpv6_relay table
-    set_dhcp_relay_table('DHCP_RELAY', config_db, vlan, {'vlanid': str(vid)})
+    set_dhcp_relay_table('DHCP_RELAY', config_db, vlan, None)
     # We need to restart dhcp_relay service after dhcpv6_relay config change
     dhcp_relay_util.handle_restart_dhcp_relay_service()
 

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -19,9 +19,6 @@ IP_VERSION_PARAMS_MAP = {
         "table": "DHCP_RELAY"
     }
 }
-DHCP_RELAY_TABLE_ENTRY = {
-    "vlanid": "1001"
-}
 
 show_vlan_brief_output="""\
 +-----------+-----------------+-----------------+----------------+-------------+
@@ -610,7 +607,8 @@ class TestVlan(object):
         print(result.output)
         assert result.exit_code == 0
 
-        assert db.cfgdb.get_entry(IP_VERSION_PARAMS_MAP[ip_version]["table"], "Vlan1001") == DHCP_RELAY_TABLE_ENTRY
+        exp_output = {"vlanid": "1001"} if ip_version == "ipv4" else {}
+        assert db.cfgdb.get_entry(IP_VERSION_PARAMS_MAP[ip_version]["table"], "Vlan1001") == exp_output
 
         # del vlan 1001
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1001"], obj=db)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove add field of vlanid to DHCP_RELAY table while add vlan which would cause conflict with yang model.

#### How I did it
Remove add field of vlanid to DHCP_RELAY table while add vlan

#### How to verify it
```
2023-02-15T14:25:22.1711670Z ============================= test session starts ==============================
2023-02-15T14:25:22.1712734Z platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0 -- /usr/bin/python3
2023-02-15T14:25:22.1713066Z cachedir: .pytest_cache
2023-02-15T14:25:22.1713331Z rootdir: /__w/1/s, configfile: pytest.ini
2023-02-15T14:25:22.1713766Z plugins: pyfakefs-5.1.0, cov-2.10.1
2023-02-15T14:25:32.4827379Z collecting ... collected 2183 items
2023-02-15T14:25:32.4827959Z 

2023-02-15T14:33:42.4732391Z tests/vlan_test.py::TestVlan::test_show_vlan PASSED                      [ 72%]
2023-02-15T14:33:42.5487151Z tests/vlan_test.py::TestVlan::test_show_vlan_brief PASSED                [ 72%]
2023-02-15T14:33:42.6208159Z tests/vlan_test.py::TestVlan::test_show_vlan_brief_verbose PASSED        [ 72%]
2023-02-15T14:33:42.6935191Z tests/vlan_test.py::TestVlan::test_show_vlan_brief_in_alias_mode PASSED  [ 72%]
2023-02-15T14:33:42.7599133Z tests/vlan_test.py::TestVlan::test_show_vlan_brief_explicit_proxy_arp_disable PASSED [ 72%]
2023-02-15T14:33:42.8288658Z tests/vlan_test.py::TestVlan::test_show_vlan_config PASSED               [ 72%]
2023-02-15T14:33:42.8981508Z tests/vlan_test.py::TestVlan::test_show_vlan_config_in_alias_mode PASSED [ 72%]
2023-02-15T14:33:42.9657090Z tests/vlan_test.py::TestVlan::test_config_vlan_add_vlan_with_invalid_vlanid PASSED [ 72%]
2023-02-15T14:33:43.0323397Z tests/vlan_test.py::TestVlan::test_config_vlan_add_vlan_with_exist_vlanid PASSED [ 72%]
2023-02-15T14:33:43.1001843Z tests/vlan_test.py::TestVlan::test_config_vlan_del_vlan_with_invalid_vlanid PASSED [ 72%]
2023-02-15T14:33:43.1679844Z tests/vlan_test.py::TestVlan::test_config_vlan_del_vlan_with_nonexist_vlanid PASSED [ 72%]
2023-02-15T14:33:43.2352835Z tests/vlan_test.py::TestVlan::test_config_vlan_add_member_with_invalid_vlanid PASSED [ 72%]
2023-02-15T14:33:43.3036569Z tests/vlan_test.py::TestVlan::test_config_vlan_add_member_with_nonexist_vlanid PASSED [ 72%]
2023-02-15T14:33:43.3718630Z tests/vlan_test.py::TestVlan::test_config_vlan_add_exist_port_member PASSED [ 72%]
2023-02-15T14:33:43.4404763Z tests/vlan_test.py::TestVlan::test_config_vlan_add_nonexist_port_member PASSED [ 72%]
2023-02-15T14:33:43.5092691Z tests/vlan_test.py::TestVlan::test_config_vlan_add_nonexist_portchannel_member PASSED [ 72%]
2023-02-15T14:33:43.5836137Z tests/vlan_test.py::TestVlan::test_config_vlan_add_portchannel_member PASSED [ 72%]
2023-02-15T14:33:43.6528121Z tests/vlan_test.py::TestVlan::test_config_vlan_add_rif_portchannel_member PASSED [ 72%]
2023-02-15T14:33:43.7229411Z tests/vlan_test.py::TestVlan::test_config_vlan_with_vxlanmap_del_vlan PASSED [ 72%]
2023-02-15T14:33:43.8258984Z tests/vlan_test.py::TestVlan::test_config_vlan_del_vlan PASSED           [ 72%]
2023-02-15T14:33:44.4965583Z tests/vlan_test.py::TestVlan::test_config_vlan_del_nonexist_vlan_member PASSED [ 72%]
2023-02-15T14:33:44.4966319Z tests/vlan_test.py::TestVlan::test_config_add_del_vlan_and_vlan_member PASSED [ 72%]
2023-02-15T14:33:44.4966867Z tests/vlan_test.py::TestVlan::test_config_add_del_vlan_and_vlan_member_in_alias_mode PASSED [ 73%]
2023-02-15T14:33:44.4967434Z tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_with_nonexist_vlan_intf_table PASSED [ 73%]
2023-02-15T14:33:44.4968083Z tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_with_nonexist_vlan_intf PASSED [ 73%]
2023-02-15T14:33:44.4968624Z tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_enable PASSED   [ 73%]
2023-02-15T14:33:44.4969390Z tests/vlan_test.py::TestVlan::test_config_vlan_proxy_arp_disable PASSED  [ 73%]
2023-02-15T14:33:44.4988671Z tests/vlan_test.py::TestVlan::test_config_2_untagged_vlan_on_same_interface PASSED [ 73%]
2023-02-15T14:33:44.5666099Z tests/vlan_test.py::TestVlan::test_config_set_router_port_on_member_interface PASSED [ 73%]
2023-02-15T14:33:44.6360696Z tests/vlan_test.py::TestVlan::test_config_vlan_add_member_of_portchannel PASSED [ 73%]
2023-02-15T14:33:44.7055475Z tests/vlan_test.py::TestVlan::test_config_add_del_vlan_dhcp_relay[ipv4] PASSED [ 73%]
2023-02-15T14:33:44.7751427Z tests/vlan_test.py::TestVlan::test_config_add_del_vlan_dhcp_relay[ipv6] PASSED [ 73%]
2023-02-15T14:33:44.8455055Z tests/vlan_test.py::TestVlan::test_config_add_exist_vlan_dhcp_relay[ipv6] PASSED [ 73%]
2023-02-15T14:33:45.0804031Z tests/vnet_route_check_test.py::TestVnetRouteCheck::test_vnet_route_check PASSED [ 73%]



2023-02-15T14:35:30.9629795Z ----------- coverage: platform linux, python 3.9.2-final-0 -----------
2023-02-15T14:35:30.9630243Z Name                                                Stmts   Miss Branch BrPart  Cover
2023-02-15T14:35:30.9630753Z -------------------------------------------------------------------------------------
2023-02-15T14:35:30.9641334Z config/vlan.py                                        154     15     68     11    88%
2023-02-15T14:35:30.9708556Z -------------------------------------------------------------------------------------
2023-02-15T14:35:30.9708886Z TOTAL                                               39739  11403  14108   2030    68%
2023-02-15T14:35:30.9709176Z Coverage HTML written to dir htmlcov
2023-02-15T14:35:30.9709441Z Coverage XML written to file coverage.xml
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

