### PR TITLE
[202205][dhcp_relay] Remove add field of vlanid to DHCP_RELAY table while adding vlan

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -44,7 +44,7 @@ def add_vlan(db, vid):
     set_dhcp_relay_table('VLAN', db.cfgdb, vlan, {'vlanid': str(vid)})
 
     # set dhcpv6_relay table
-    set_dhcp_relay_table('DHCP_RELAY', db.cfgdb, vlan, {'vlanid': str(vid)})
+    set_dhcp_relay_table('DHCP_RELAY', db.cfgdb, vlan, None)
     # We need to restart dhcp_relay service after dhcpv6_relay config change
     dhcp_relay_util.handle_restart_dhcp_relay_service()
 

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -19,9 +19,6 @@ IP_VERSION_PARAMS_MAP = {
         "table": "DHCP_RELAY"
     }
 }
-DHCP_RELAY_TABLE_ENTRY = {
-    "vlanid": "1001"
-}
 
 show_vlan_brief_output="""\
 +-----------+-----------------+-----------------+----------------+-------------+
@@ -610,7 +607,8 @@ class TestVlan(object):
         print(result.output)
         assert result.exit_code == 0
 
-        assert db.cfgdb.get_entry(IP_VERSION_PARAMS_MAP[ip_version]["table"], "Vlan1001") == DHCP_RELAY_TABLE_ENTRY
+        exp_output = {"vlanid": "1001"} if ip_version == "ipv4" else {}
+        assert db.cfgdb.get_entry(IP_VERSION_PARAMS_MAP[ip_version]["table"], "Vlan1001") == exp_output
 
         # del vlan 1001
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1001"], obj=db)


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Cherry-pick of this PR: https://github.com/sonic-net/sonic-utilities/pull/2678

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

