### PR TITLE
[202012][vlan] Remove add field of vlanid to DHCP_RELAY table while adding vlan

### DIFF
--- a/config/dhcp_relay.py
+++ b/config/dhcp_relay.py
@@ -24,11 +24,13 @@ def validate_ips(ctx, ips, ip_version):
             ctx.fail("{} is not IPv{} address".format(ip, ip_version))
 
 
-def get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str):
-    table = db.cfgdb.get_entry(table_name, vlan_name)
-    if len(table.keys()) == 0:
-        ctx.fail("{} doesn't exist".format(vlan_name))
+def get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str, check_is_exist=True):
+    if check_is_exist:
+        keys = db.cfgdb.get_keys(table_name)
+        if vlan_name not in keys:
+            ctx.fail("{} doesn't exist".format(vlan_name))
 
+    table = db.cfgdb.get_entry(table_name, vlan_name)
     dhcp_servers = table.get(dhcp_servers_str, [])
 
     return dhcp_servers, table
@@ -46,7 +48,9 @@ def add_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
     ctx = click.get_current_context()
     # Verify ip addresses are valid
     validate_ips(ctx, dhcp_relay_ips, ip_version)
-    dhcp_servers, table = get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str)
+    # It's unnecessary for DHCPv6 Relay to verify entry exist
+    check_config_exist = True if ip_version == 4 else False
+    dhcp_servers, table = get_dhcp_servers(db, vlan_name, ctx, table_name, dhcp_servers_str, check_config_exist)
     added_ips = []
 
     for dhcp_relay_ip in dhcp_relay_ips:
@@ -92,6 +96,9 @@ def del_dhcp_relay(vid, dhcp_relay_ips, db, ip_version):
         del table[dhcp_servers_str]
     else:
         table[dhcp_servers_str] = dhcp_servers
+
+    if ip_version == 6 and len(table.keys()) == 0:
+        table = None
 
     db.cfgdb.set_entry(table_name, vlan_name, table)
     click.echo("Removed DHCP relay address [{}] from {}".format(",".join(dhcp_relay_ips), vlan_name))

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -40,7 +40,7 @@ def add_vlan(db, vid):
     set_dhcp_relay_table('VLAN', db.cfgdb, vlan, {'vlanid': str(vid)})
 
     # set dhcpv6_relay table
-    set_dhcp_relay_table('DHCP_RELAY', db.cfgdb, vlan, {'vlanid': str(vid)})
+    set_dhcp_relay_table('DHCP_RELAY', db.cfgdb, vlan, None)
     # We need to restart dhcp_relay service after dhcpv6_relay config change
     dhcp_relay_util.handle_restart_dhcp_relay_service()
 

--- a/tests/config_dhcp_relay_test.py
+++ b/tests/config_dhcp_relay_test.py
@@ -121,9 +121,25 @@ class TestConfigDhcpRelay(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "1"
         print("SETUP")
 
-    def test_config_dhcp_relay_add_del_with_nonexist_vlanid(self, ip_version, op):
+    def test_config_dhcp_relay_add_del_with_nonexist_vlanid_ipv4(self, op):
         runner = CliRunner()
 
+        ip_version = "ipv4"
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1001", IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]])
+            print(result.exit_code)
+            print(result.stdout)
+            assert result.exit_code != 0
+            assert "Error: Vlan1001 doesn't exist" in result.output
+            assert mock_run_command.call_count == 0
+
+    def test_config_dhcp_relay_del_with_nonexist_vlanid_ipv6(self):
+        runner = CliRunner()
+
+        op = "del"
+        ip_version = "ipv6"
         with mock.patch("utilities_common.cli.run_command") as mock_run_command:
             result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
                                    .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
@@ -257,3 +273,24 @@ class TestConfigDhcpRelay(object):
             assert result.exit_code != 0
             assert "Error: Find duplicate DHCP relay ip {} in {} list".format(test_ip, op) in result.output
             assert mock_run_command.call_count == 0
+
+    def test_config_add_dhcp_relay_ipv6_with_non_entry(self):
+        op = "add"
+        ip_version = "ipv6"
+        test_ip = IP_VER_TEST_PARAM_MAP[ip_version]["ips"][0]
+        runner = CliRunner()
+        db = Db()
+        table = IP_VER_TEST_PARAM_MAP[ip_version]["table"]
+        db.cfgdb.set_entry(table, "Vlan1000", None)
+        assert db.cfgdb.get_entry(table, "Vlan1000") == {}
+        assert len(db.cfgdb.get_keys(table)) == 0
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(config.config.commands["dhcp_relay"].commands[ip_version]
+                                   .commands[IP_VER_TEST_PARAM_MAP[ip_version]["command"]]
+                                   .commands[op], ["1000", test_ip], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry(table, "Vlan1000") == {"dhcpv6_servers": [test_ip]}
+            assert mock_run_command.call_count == 3

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -857,7 +857,8 @@ class TestVlan(object):
         print(result.output)
         assert result.exit_code == 0
 
-        assert db.cfgdb.get_entry(IP_VERSION_PARAMS_MAP[ip_version]["table"], "Vlan1001") == DHCP_RELAY_TABLE_ENTRY
+        exp_output = {"vlanid": "1001"} if ip_version == "ipv4" else {}
+        assert db.cfgdb.get_entry(IP_VERSION_PARAMS_MAP[ip_version]["table"], "Vlan1001") == exp_output
 
         # del vlan 1001
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1001"], obj=db)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove add field of vlanid to DHCP_RELAY table while add vlan which would cause conflict with yang model.

#### How I did it
Remove add field of vlanid to DHCP_RELAY table while add vlan

#### How to verify it
```
2023-02-16T02:09:35.8928219Z ============================= test session starts ==============================
2023-02-16T02:09:35.8933715Z platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
2023-02-16T02:09:35.8938378Z rootdir: /__w/1/s, inifile: pytest.ini
2023-02-16T02:09:35.8939079Z plugins: pyfakefs-5.1.0, cov-2.6.0
2023-02-16T02:09:40.5576217Z collected 961 items
2023-02-16T02:09:40.5615053Z 

2023-02-16T02:09:53.1351705Z tests/config_dhcp_relay_test.py ....................                     [ 10%]
2023-02-16T02:13:07.5436089Z tests/vlan_test.py ............................................          [ 97%]
2023-02-16T02:13:29.0043783Z 
2023-02-16T02:13:29.0045422Z ----------- coverage: platform linux, python 3.7.3-final-0 -----------
2023-02-16T02:13:29.0046195Z Name                                          Stmts   Miss  Cover
2023-02-16T02:13:29.0047090Z -----------------------------------------------------------------
2023-02-16T02:13:29.0055037Z config/dhcp_relay.py                            102      8    92%
2023-02-16T02:13:29.0060232Z config/vlan.py                                  180     14    92%
2023-02-16T02:13:29.0125331Z -----------------------------------------------------------------
2023-02-16T02:13:29.0125743Z TOTAL                                         23301   9713    58%
2023-02-16T02:13:29.0126195Z Coverage HTML written to dir htmlcov
2023-02-16T02:13:29.0126538Z Coverage XML written to file coverage.xml
2023-02-16T02:13:29.0126826Z 
2023-02-16T02:13:29.0126910Z 
2023-02-16T02:13:29.0127254Z ========================= 961 passed in 233.11 seconds =========================
```

```
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{}
admin@:~$ sudo config vlan add 2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{}
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::5
Added DHCP relay address [fc02:2000::5] to Vlan2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{'dhcpv6_servers@': 'fc02:2000::5'}
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::5
fc02:2000::5 is already a DHCP relay for Vlan2000
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::6
Added DHCP relay address [fc02:2000::6] to Vlan2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{'dhcpv6_servers@': 'fc02:2000::5,fc02:2000::6'}
admin@:~$ sudo config dhcp_relay ipv6 destination add 2000 fc02:2000::7 fc02:2000::8
Added DHCP relay address [fc02:2000::7,fc02:2000::8] to Vlan2000
Restarting DHCP relay service...
admin@:~$ sudo sonic-db-cli CONFIG_DB hgetall "DHCP_RELAY|Vlan2000"
{'dhcpv6_servers@': 'fc02:2000::5,fc02:2000::6,fc02:2000::7,fc02:2000::8'}
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

