### PR TITLE
[POC] Import buffer config to Profile DB when load minigraph.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1743,15 +1743,20 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
     for namespace in namespace_list:
         if namespace is DEFAULT_NAMESPACE:
             config_db = ConfigDBConnector()
+            profile_db = ConfigDBConnector()
             cfggen_namespace_option = " "
             ns_cmd_prefix = ""
         else:
             config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+            profile_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
             cfggen_namespace_option = " -n {}".format(namespace)
             ns_cmd_prefix = "sudo ip netns exec {} ".format(namespace)
         config_db.connect()
+        profile_db.db_connect("PROFILE_DB")
         client = config_db.get_redis_client(config_db.CONFIG_DB)
         client.flushdb()
+        profile_db_client = profile_db.get_redis_client("PROFILE_DB")
+        profile_db_client.flushdb()
         if os.path.isfile('/etc/sonic/init_cfg.json'):
             command = "{} -H -m -j /etc/sonic/init_cfg.json {} --write-to-db".format(SONIC_CFGGEN_PATH, cfggen_namespace_option)
         else:
@@ -2710,6 +2715,16 @@ def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports):
                 )
                 # Apply the configurations only when both buffer and qos
                 # configuration files are present
+                clicommon.run_command(command, display_cmd=True)
+                
+                # write profile to profile-db
+                if not dry_run:
+                    from_db = "-d --write-to-db -P"
+                fname = "{}{}".format(dry_run, asic_id_suffix) if dry_run else "profile-db"
+                command = "{} {} {} -t {},{} -t {},{} -y {}".format(
+                    SONIC_CFGGEN_PATH, cmd_ns, from_db, buffer_template_file,
+                    fname, qos_template_file, fname, sonic_version_file
+                )
                 clicommon.run_command(command, display_cmd=True)
             else:
                 click.secho("QoS definition template not found at {}".format(
@@ -6070,6 +6085,7 @@ def remove_profile(db, profile):
             ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         ctx.fail("Profile {} doesn't exist".format(profile))
+        # TODO: mask profile_db profile.
 
 @buffer.group(cls=clicommon.AbbreviationGroup)
 @click.pass_context

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -51,6 +51,7 @@ class ConfigWrapper:
     def __init__(self, yang_dir = YANG_DIR):
         self.yang_dir = YANG_DIR
         self.sonic_yang_with_loaded_models = None
+        self.logger = genericUpdaterLogging.get_logger(title="Config Wrapper", print_all_to_console=True)
 
     def get_config_db_as_json(self):
         text = self._get_config_db_as_text()
@@ -137,6 +138,7 @@ class ConfigWrapper:
                 if not success:
                     return success, error
         except sonic_yang.SonicYangException as ex:
+            self.logger.log_notice("Validating config_db failed:{}".format(json.dumps(config_db_as_json)))
             return False, ex
 
         return True, None

--- a/tests/mock_tables/asic0/database_config.json
+++ b/tests/mock_tables/asic0/database_config.json
@@ -51,6 +51,11 @@
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
+        },
+        "PROFILE_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.1"

--- a/tests/mock_tables/asic1/database_config.json
+++ b/tests/mock_tables/asic1/database_config.json
@@ -51,6 +51,11 @@
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
+        },
+        "PROFILE_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.1"

--- a/tests/mock_tables/asic2/database_config.json
+++ b/tests/mock_tables/asic2/database_config.json
@@ -51,6 +51,11 @@
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
+        },
+        "PROFILE_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.1"

--- a/tests/mock_tables/database_config.json
+++ b/tests/mock_tables/database_config.json
@@ -56,6 +56,11 @@
             "id" : 12,
             "separator": "|",
             "instance" : "redis"
+        },
+        "PROFILE_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.1"


### PR DESCRIPTION
Import buffer config to Profile DB when load minigraph.

#### What I did
Import buffer config to Profile DB when load minigraph.

#### How I did it
Add new parameter to support write profile related tables to PROFILE_DB.

#### How to verify it
Pass all UT.
Add new UT to cover new code and scenario.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

