### PR TITLE
Collect information for the issue #13791 asic_table.json is not rendered

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1108,6 +1108,8 @@ collect_mellanox() {
       echo "HW Mgmt dump script $HW_DUMP_FILE does not exist"
     fi
 
+    # Temporarily collect information for debugging the issue that asic_table.json not rendered
+    save_file "/usr/share/sonic/templates/asic_table.j2" dump false
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Collect information for issue [#13791](https://github.com/sonic-net/sonic-buildimage/issues/13791)
Besides redis server being temporarily inaccessible, another possible cause is that the template is not accessible.
So, copy the template into the dump folder in `show tech dump`

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

