### PR TITLE
[queuestat CLI] Enable queuestat to get counters with missing data

### DIFF
--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -182,7 +182,7 @@ class Queuestat(object):
             for counter_name, pos in counter_bucket_dict.items():
                 full_table_id = COUNTER_TABLE_PREFIX + table_id
                 counter_data =  self.db.get(self.db.COUNTERS_DB, full_table_id, counter_name)
-                if counter_data is None:
+                if counter_data is None or counter_data == '':
                     fields[pos] = STATUS_NA
                 elif fields[pos] != STATUS_NA:
                     fields[pos] = str(int(counter_data))


### PR DESCRIPTION
If self.db.get returns an empty string due to missing fields in countersDB, queuestat will crash instead of setting STATUS_NA.

Fixed this problem by checking if counter_data == ''

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
