### PR TITLE
[db_migrator] Add missing attribute 'weight' to route entries in APPL DB

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -899,6 +899,17 @@ class DBMigrator():
         else:
             log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))
 
+        route_table = self.appDB.get_table("ROUTE_TABLE")
+        for route_prefix, route_attr in route_table.items():
+            if 'weight' not in route_attr:
+                if type(route_prefix) == tuple:
+                    # IPv6 route_prefix is returned from db as tuple
+                    route_key = "ROUTE_TABLE:" + ":".join(route_prefix)
+                else:
+                    # IPv4 route_prefix is returned from db as str
+                    route_key = "ROUTE_TABLE:{}".format(route_prefix)
+                self.appDB.set(self.appDB.APPL_DB, route_key, 'weight','')
+
     def migrate(self):
         version = self.get_version()
         log.log_info('Upgrading from version ' + version)

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -579,7 +579,12 @@ class DBMigrator():
             self.configDB.set_entry('PORT_QOS_MAP', 'global', {"dscp_to_tc_map": dscp_to_tc_map_table_names[0]})
             log.log_info("Created entry for global DSCP_TO_TC_MAP {}".format(dscp_to_tc_map_table_names[0]))
 
-    def migrate_route_table_weights(self):
+    def migrate_route_table(self):
+        """
+        Handle route table migration. Migrations handled:
+        1. 'weight' attr in ROUTE object was introduced 202205 onwards.
+            Upgrade from older branch to 202205 will require this 'weight' attr to be added explicitly
+        """
         route_table = self.appDB.get_table("ROUTE_TABLE")
         for route_prefix, route_attr in route_table.items():
             if 'weight' not in route_attr:
@@ -911,7 +916,7 @@ class DBMigrator():
         else:
             log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))
 
-        self.migrate_route_table_weights()
+        self.migrate_route_table()
 
     def migrate(self):
         version = self.get_version()

--- a/tests/db_migrator_input/appl_db/routes_migrate_expected.json
+++ b/tests/db_migrator_input/appl_db/routes_migrate_expected.json
@@ -1,0 +1,12 @@
+{
+    "ROUTE_TABLE:192.168.104.0/25": {
+        "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61,10.0.0.63",
+        "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104",
+        "weight": ""
+      },
+    "ROUTE_TABLE:20c0:fe28:0:80::/64": {
+    "nexthop": "fc00::72,fc00::76,fc00::7a,fc00::7e",
+    "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104",
+    "weight": ""
+    }
+}

--- a/tests/db_migrator_input/appl_db/routes_migrate_input.json
+++ b/tests/db_migrator_input/appl_db/routes_migrate_input.json
@@ -1,0 +1,10 @@
+{
+    "ROUTE_TABLE:192.168.104.0/25": {
+        "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61,10.0.0.63",
+        "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104"
+      },
+    "ROUTE_TABLE:20c0:fe28:0:80::/64": {
+    "nexthop": "fc00::72,fc00::76,fc00::7a,fc00::7e",
+    "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104"
+    }
+}

--- a/tests/db_migrator_input/config_db/routes_migrate_input.json
+++ b/tests/db_migrator_input/config_db/routes_migrate_input.json
@@ -1,0 +1,7 @@
+{
+    "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback1|10.20.8.199/32" : {"NULL": "NULL"},
+    "LOOPBACK_INTERFACE|Loopback1|2001:506:28:500::1/128" : {"NULL": "NULL"},
+    "VERSIONS|DATABASE": {"VERSION": "version_1_0_1"}
+}

--- a/tests/db_migrator_input/config_db/routes_migrate_input.json
+++ b/tests/db_migrator_input/config_db/routes_migrate_input.json
@@ -1,7 +1,3 @@
 {
-    "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32" : {"NULL": "NULL"},
-    "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128" : {"NULL": "NULL"},
-    "LOOPBACK_INTERFACE|Loopback1|10.20.8.199/32" : {"NULL": "NULL"},
-    "LOOPBACK_INTERFACE|Loopback1|2001:506:28:500::1/128" : {"NULL": "NULL"},
     "VERSIONS|DATABASE": {"VERSION": "version_1_0_1"}
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/12625


#### How I did it

Check for missing attribute `weight` in APPLDB route entries. If found missing this attribute is added with empty value.

#### How to verify it
Verified on physical device. 201911 to 202205 upgrade worked fine.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

