### PR TITLE
Add begin logs to config reload/config minigraph/warm-reboot/fast-reboot

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1549,7 +1549,8 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
     if not yes:
         click.confirm(message, abort=True)
 
-    log.log_info("'reload' executing...")
+    argv_str = ' '.join(['config', *sys.argv[1:]])
+    log.log_notice(f"'reload' executing with command: {argv_str}")
 
     num_asic = multi_asic.get_num_asics()
     cfg_files = []
@@ -1569,7 +1570,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
 
     #Stop services before config push
     if not no_service_restart:
-        log.log_info("'reload' stopping services...")
+        log.log_notice("'reload' stopping services...")
         _stop_services()
 
     # In Single ASIC platforms we have single DB service. In multi-ASIC platforms we have a global DB
@@ -1678,7 +1679,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
     # status from all services before we attempt to restart them
     if not no_service_restart:
         _reset_failed_services()
-        log.log_info("'reload' restarting services...")
+        log.log_notice("'reload' restarting services...")
         _restart_services()
 
 @config.command("load_mgmt_config")
@@ -1725,11 +1726,12 @@ def load_mgmt_config(filename):
 @clicommon.pass_db
 def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, golden_config_path):
     """Reconfigure based on minigraph."""
-    log.log_info("'load_minigraph' executing...")
+    argv_str = ' '.join(['config', *sys.argv[1:]])
+    log.log_notice(f"'load_minigraph' executing with command: {argv_str}")
 
     #Stop services before config push
     if not no_service_restart:
-        log.log_info("'load_minigraph' stopping services...")
+        log.log_notice("'load_minigraph' stopping services...")
         _stop_services()
 
     # For Single Asic platform the namespace list has the empty string
@@ -1815,7 +1817,7 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
     if not no_service_restart:
         _reset_failed_services()
         #FIXME: After config DB daemon is implemented, we'll no longer need to restart every service.
-        log.log_info("'load_minigraph' restarting services...")
+        log.log_notice("'load_minigraph' restarting services...")
         _restart_services()
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -522,6 +522,7 @@ then
     exit "${EXIT_FAILURE}"
 fi
 
+debug "Starting $REBOOT_TYPE"
 
 # re-run the script in background mode with detaching from the terminal session
 if [[ x"${DETACH}" == x"yes" && x"${ALREADY_DETACHED}" == x"" ]]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add more logs for config reload/config minigraph/warm-reboot/fast/reboot to identify in the log (notice level) what was the command executed which could cause a service affect.

#### How I did it

Add more logs for config reload/config minigraph/warm-reboot/fast/reboot. 

#### How to verify it

Manual test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

