### PR TITLE
Fix the `show interface counters` throwing exception on device with no external interfaces

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -333,13 +333,13 @@ class Portstat(object):
                               format_number_with_comma(data['tx_err']),
                               format_number_with_comma(data['tx_drop']),
                               format_number_with_comma(data['tx_ovr'])))
-
-        if use_json:
-            print(table_as_json(table, header))
-        else:
-            print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            if multi_asic.is_multi_asic() or device_info.is_chassis():
-                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+        if table:
+            if use_json:
+                print(table_as_json(table, header))
+            else:
+                print(tabulate(table, header, tablefmt='simple', stralign='right'))
+                if multi_asic.is_multi_asic() or device_info.is_chassis():
+                    print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
         """
@@ -551,13 +551,13 @@ class Portstat(object):
                               format_number_with_comma(cntr['tx_err']),
                               format_number_with_comma(cntr['tx_drop']),
                               format_number_with_comma(cntr['tx_ovr'])))
-
-        if use_json:
-            print(table_as_json(table, header))
-        else:
-            print(tabulate(table, header, tablefmt='simple', stralign='right'))
-            if multi_asic.is_multi_asic() or device_info.is_chassis():
-                print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+        if table:
+            if use_json:
+                print(table_as_json(table, header))
+            else:
+                print(tabulate(table, header, tablefmt='simple', stralign='right'))
+                if multi_asic.is_multi_asic() or device_info.is_chassis():
+                    print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():
     parser  = argparse.ArgumentParser(description='Display the ports state and counters',

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -338,7 +338,7 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic() or device_info.is_chassis():
+        if multi_asic.is_multi_asic() or device_info.is_chassis() and not use_json:
             print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
@@ -556,7 +556,7 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic() or device_info.is_chassis():
+        if multi_asic.is_multi_asic() or device_info.is_chassis() and not use_json:
             print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -338,8 +338,8 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-                if multi_asic.is_multi_asic() or device_info.is_chassis():
-                    print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+        if multi_asic.is_multi_asic() or device_info.is_chassis():
+            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
         """
@@ -556,8 +556,8 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-                if multi_asic.is_multi_asic() or device_info.is_chassis():
-                    print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+        if multi_asic.is_multi_asic() or device_info.is_chassis():
+            print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():
     parser  = argparse.ArgumentParser(description='Display the ports state and counters',


### PR DESCRIPTION
What/Why I did:


    Fix the `show interface counters` throwing exception
    issue where device do not have any external ports and all are internal links (ethernet or fabric) which is possible in chassis

```
show interface counters
Traceback (most recent call last):
  File "/usr/local/bin/portstat", line 643, in <module>
    main()
  File "/usr/local/bin/portstat", line 634, in main
    portstat.cnstat_print(cnstat_dict, ratestat_dict, intf_list, use_json, print_all, errors_only, rates_only, detail)
  File "/usr/local/bin/portstat", line 326, in cnstat_print
    print(tabulate(table, header, tablefmt='simple', stralign='right'))
  File "/usr/local/lib/python3.9/dist-packages/tabulate.py", line 1246, in tabulate
    list_of_lists, headers = _normalize_tabular_data(
  File "/usr/local/lib/python3.9/dist-packages/tabulate.py", line 932, in _normalize_tabular_data
    headers = list(map(_text_type,headers))
TypeError: 'NoneType' object is not iterable

```

How I verify:
Manual Veriifcation
