### PR TITLE
[show][muxcable] add some new commands health, reset-cause, queue_info support for muxcable 

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5206,6 +5206,154 @@ This command displays the eye info in mv(milli volts) of the port user provides 
         632      622
     ```
 
+
+**show muxcable health <port>**
+
+This command displays the hardware health of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current hadrware health of the cable as Ok, Not Ok, Unknown.
+
+- Usage:
+  ```
+  show muxcable health [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable health, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+-Ok means the cable is healthy
+
+in order to detemine whether the health of the cable is Ok
+the following are checked
+- the vendor name is correct able to be read
+- the FW is correctly loaded for SerDes by reading the appropriate register val
+- the Counters for UART are displaying healthy status 
+       i.e Error Counters , retry Counters for UART or internal xfer protocols are below a threshold
+
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable health Ethernet4
+      PORT       ATTR    HEALTH
+      ---------  ------  --------
+      Ethernet4  health  Ok
+    ```
+    ```
+      admin@sonic:~$ show muxcable health Ethernet4 --json
+    ```
+    ```json
+           {
+               "health": "Ok"
+           }
+
+    ```
+
+
+**show muxcable queueinfo <port>**
+
+This command displays the queue info of  the Y-cable which are connected to muxcable. The resultant table or json output will show the queue info in terms transactions for the UART stats in particular currently relevant to the MCU of the cable.
+
+- Usage:
+  ```
+  show muxcable queueinfo [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable queueinfo, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+the result will be displayed like this, each item in the dictionary shows the health of the attribute in the queue
+```
+"{'VSC': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 0, 'node_size': 0}, 'UART1': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 209870, 'node_size': 1682183}, 'UART2': {'r_ptr': 13262, 'w_ptr': 3, 'total_count': 0, 'free_count': 0, 'buff_addr': 12, 'node_size': 0}
+```
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable queueinfo Ethernet0
+      PORT       ATTR          VALUE
+      ---------  ----------  -------
+      Ethernet0  uart_stat1        2
+      Ethernet0  uart_stat2        1
+    ```
+    ```
+      admin@sonic:~$ show muxcable queueinfo Ethernet4 --json
+    ```
+    ```json
+           {
+               "uart_stat1": "2",
+               "uart_stat2": "1",
+                 
+           }
+    ```
+
+**show muxcable operationtime <port>**
+
+This command displays the operationtime of  the Y-cable which are connected to muxcable. The resultant table or json output will show the current operation time of the cable as `hh:mm:ss` format. Operation time means the time since the last time the reseated/reset of the cable is done, and the time would be in the format specified
+
+- Usage:
+  ```
+  show muxcable operationtime [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable operationtime, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable operationtime Ethernet4
+      PORT       ATTR            OPERATION_TIME
+      ---------  --------------  ----------------
+      Ethernet4  operation_time  00:22:22
+    ```
+    ```
+      admin@sonic:~$ show muxcable operationtime Ethernet4 --json
+    ```
+    ```json
+           {
+               "operation_time": "00:22:22"
+           }
+    ```
+
+**show muxcable resetcause <port>**
+
+This command displays the resetcause of  the Y-cable which are connected to muxcable. The resultant table or json output will show the most recent reset cause of the cable as string format.
+
+- Usage:
+  ```
+  show muxcable resetcause [OPTIONS] [PORT]
+  ```
+
+While displaying the muxcable resetcause, users need to provide the following fields
+
+- PORT     required - Port name should be a valid port
+- --json   optional - -- option to display the result in json format. By default output will be in tabular format.
+
+the reset cause only records NIC MCU reset status. The NIC MCU will automatically broadcast the reset cause status to each TORs, corresponding values returned
+display cold reset if the last reset is cold reset (ex. HW/SW reset, power reset the cable, or reboot the NIC server)
+display warm reset if the last reset is warm reset (ex. sudo config mux firmware activate....)
+the value is persistent, no clear on read
+
+- Example:
+    ```
+      admin@sonic:~$ show muxcable resetcause Ethernet4
+      PORT       ATTR           RESETCAUSE
+      ---------  -----------  ------------
+      Ethernet4  reset_cause    warm reset
+    ```
+    ```
+      admin@sonic:~$ show muxcable resetcause Ethernet4 --json
+    ```
+    ```json
+           {
+               "reset_cause": "warm reset"
+           }
+    ```
+
+
 ### Muxcable Config commands
 
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -34,6 +34,11 @@ STATUS_SUCCESSFUL = 0
 VENDOR_NAME = "Credo"
 VENDOR_MODEL_REGEX = re.compile(r"CAC\w{3}321P2P\w{2}MS")
 
+#define table names that interact with Cli
+XCVRD_GET_BER_CMD_TABLE = "XCVRD_GET_BER_CMD"
+XCVRD_GET_BER_RSP_TABLE = "XCVRD_GET_BER_RSP"
+XCVRD_GET_BER_RES_TABLE = "XCVRD_GET_BER_RES"
+XCVRD_GET_BER_CMD_ARG_TABLE = "XCVRD_GET_BER_CMD_ARG"
 
 def db_connect(db_name, namespace=EMPTY_NAMESPACE):
     return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, True, namespace)
@@ -260,9 +265,11 @@ def get_result(port, res_dict, cmd ,result, table_name):
     (status, fvp) = xcvrd_show_fw_res_tbl[asic_index].get(port)
     res_dir = dict(fvp)
 
+    delete_all_keys_in_db_table("STATE_DB", table_name)
+
     return res_dir
 
-def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, cmd_arg_table_name, rsp_table_name ,port, cmd_timeout_secs, param_dict= None, arg=None):
+def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_name, cmd_arg_table_name, rsp_table_name , res_table_name, port, cmd_timeout_secs, param_dict= None, arg=None):
 
     res_dict = {}
     state_db, appl_db = {}, {}
@@ -274,6 +281,8 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
     CMD_TIMEOUT_SECS = cmd_timeout_secs
 
     time_start = time.time()
+
+    delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_table_name, res_table_name)
 
     sel = swsscommon.Select()
     namespaces = multi_asic.get_front_end_namespaces()
@@ -389,9 +398,24 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
             firmware_rsp_tbl[asic_index]._del(port)
             break
 
-    delete_all_keys_in_db_table("STATE_DB", rsp_table_name)
+
+    delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_table_name, None)
 
     return res_dict
+
+
+def delete_all_keys_in_db_tables_helper(cmd_table_name, rsp_table_name, cmd_arg_table_name = None, res_table_name = None):
+
+    delete_all_keys_in_db_table("APPL_DB", cmd_table_name)
+    delete_all_keys_in_db_table("STATE_DB", rsp_table_name)
+    if cmd_arg_table_name is not None:
+        delete_all_keys_in_db_table("APPL_DB", cmd_arg_table_name)
+
+    if res_table_name is not None:
+        delete_all_keys_in_db_table("STATE_DB", res_table_name)
+
+    return 0 
+
 
 
 # 'muxcable' command ("show muxcable")
@@ -859,7 +883,7 @@ def berinfo(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "ber")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "ber")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -911,7 +935,7 @@ def eyeinfo(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "eye")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "eye")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -962,7 +986,7 @@ def fecstatistics(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "fec_stats")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "fec_stats")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1013,7 +1037,7 @@ def pcsstatistics(db, port, target, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 10, param_dict, "pcs_stats")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 10, param_dict, "pcs_stats")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1062,7 +1086,7 @@ def debugdumpregisters(db, port, option, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", port, 100, param_dict, "debug_dump")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", "XCVRD_GET_BER_CMD_ARG", "XCVRD_GET_BER_RSP", None, port, 100, param_dict, "debug_dump")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1106,7 +1130,7 @@ def alivecablestatus(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", port, 10, None, "cable_alive")
+            "get_ber", "status", "True", "XCVRD_GET_BER_CMD", None, "XCVRD_GET_BER_RSP", None, port, 10, None, "cable_alive")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_BER_RES")
@@ -1178,7 +1202,7 @@ def get_hwmode_mux_direction_port(db, port):
     if port is not None:
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RES", "XCVRD_SHOW_HWMODE_DIR_RSP", port, HWMODE_MUXDIRECTION_TIMEOUT, None, "probe")
+            "state", "state", "True", "XCVRD_SHOW_HWMODE_DIR_CMD", "XCVRD_SHOW_HWMODE_DIR_RES", "XCVRD_SHOW_HWMODE_DIR_RSP", None, port, HWMODE_MUXDIRECTION_TIMEOUT, None, "probe")
 
         result = get_result(port, res_dict, "muxdirection" , result, "XCVRD_SHOW_HWMODE_DIR_RES")
 
@@ -1308,7 +1332,7 @@ def switchmode(db, port):
         res_dict[0] = CONFIG_FAIL
         res_dict[1] = "unknown"
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, None, "probe")
+            "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", None, port, 1, None, "probe")
 
         body = []
         temp_list = []
@@ -1364,7 +1388,7 @@ def switchmode(db, port):
             res_dict[0] = CONFIG_FAIL
             res_dict[1] = "unknown"
             res_dict = update_and_get_response_for_xcvr_cmd(
-                "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", port, 1, None, "probe")
+                "state", "state", "True", "XCVRD_SHOW_HWMODE_SWMODE_CMD", None, "XCVRD_SHOW_HWMODE_SWMODE_RSP", None, port, 1, None, "probe")
             port = platform_sfputil_helper.get_interface_alias(port, db)
             temp_list.append(port)
             temp_list.append(res_dict[1])
@@ -1549,7 +1573,7 @@ def version(db, port, active):
         mux_info_dict["version_self_next"] = "N/A"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "firmware_version", "status", "True", "XCVRD_SHOW_FW_CMD", None, "XCVRD_SHOW_FW_RSP", port, 20, None, "probe")
+            "firmware_version", "status", "True", "XCVRD_SHOW_FW_CMD", None, "XCVRD_SHOW_FW_RSP", None, port, 20, None, "probe")
 
         if res_dict[1] == "True":
             mux_info_dict = get_response_for_version(port, mux_info_dict)
@@ -1718,7 +1742,7 @@ def event_log(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "show_event", "status", "True", "XCVRD_EVENT_LOG_CMD", None, "XCVRD_EVENT_LOG_RSP", port, 1000, None, "probe")
+            "show_event", "status", "True", "XCVRD_EVENT_LOG_CMD", None, "XCVRD_EVENT_LOG_RSP", None, port, 1000, None, "probe")
 
         if res_dict[1] == "True":
             result = get_event_logs(port, res_dict, mux_info_dict)
@@ -1760,7 +1784,7 @@ def get_fec_anlt_speed(db, port, json_output):
         res_dict[1] = "unknown"
 
         res_dict = update_and_get_response_for_xcvr_cmd(
-            "get_fec", "status", "True", "XCVRD_GET_FEC_CMD", None, "XCVRD_GET_FEC_RSP", port, 10, None, "probe")
+            "get_fec", "status", "True", "XCVRD_GET_FEC_CMD", None, "XCVRD_GET_FEC_RSP", None, port, 10, None, "probe")
 
         if res_dict[1] == "True":
             result = get_result(port, res_dict, "fec" , result, "XCVRD_GET_FEC_RES")
@@ -1947,3 +1971,198 @@ def tunnel_route(db, port, json_output):
             click.echo(tabulate(print_data, headers=headers))
 
     sys.exit(STATUS_SUCCESSFUL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.argument('option', required=False, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def queueinfo(db, port, option, json_output):
+    """Show muxcable queue info information, preagreed by vendors"""
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+        param_dict = {}
+        param_dict["option"] = option
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, XCVRD_GET_BER_CMD_ARG_TABLE, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 100, param_dict, "queue_info")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
+
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'VALUE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for queue info information".format(port))
+        sys.exit(CONFIG_FAIL)
+
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def health(db, port, json_output):
+    """Show muxcable health information as Ok or Not Ok"""
+
+    """
+    in order to detemine whether the health of the cable is Ok
+    the following are checked
+     - the vendor name is correct able to be read
+     - the FW is correctly loaded for SerDes by reading the appropriate register val
+     - the Counters for UART are displaying healthy status 
+       i.e Error Counters , retry Counters for UART or internal xfer protocols are below a threshold
+    """
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, None, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 10, None, "health_check")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
+
+
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        cable_health = result.get("health_check", None)
+
+        if cable_health == "False":
+            result["health_check"] = "Not Ok"
+        elif cable_health == "True":
+            result["health_check"] = "Ok"
+        else:
+            result["health_check"] = "Unknown"
+
+            
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'HEALTH']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for cable health status".format(port))
+        sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def resetcause(db, port, json_output):
+    """Show muxcable resetcause information """
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    """
+    the reset cause only records NIC MCU reset status. The NIC MCU will automatically broadcast the reset cause status to each TORs, corresponding values returned
+    return 0 if the last reset is cold reset (ex. HW/SW reset, power reset the cable, or reboot the NIC server)
+    return 1 if the last reset is warm reset (ex. sudo config mux firmware activate....)
+    the value is persistent, no clear on read
+    """
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, None, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 10, None, "reset_cause")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
+
+
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        reset_cause = result.get("reset_cause", None)
+
+        if reset_cause == "0":
+            result["reset_cause"] = "cold reset"
+        elif reset_cause == "1":
+            result["reset_cause"] = "warm reset"
+        else:
+            result["reset_cause"] = "Unknown"
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'RESETCAUSE']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for cable resetcause information".format(port))
+        sys.exit(CONFIG_FAIL)
+
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
+@clicommon.pass_db
+def operationtime(db, port, json_output):
+    """Show muxcable operation time hh:mm:ss forrmat"""
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+
+    if port is not None:
+
+        res_dict = {}
+        result = {}
+
+
+        res_dict[0] = CONFIG_FAIL
+        res_dict[1] = "unknown"
+
+        res_dict = update_and_get_response_for_xcvr_cmd(
+            "get_ber", "status", "True", XCVRD_GET_BER_CMD_TABLE, None, XCVRD_GET_BER_RSP_TABLE, XCVRD_GET_BER_RES_TABLE, port, 10, None, "operation_time")
+
+        if res_dict[1] == "True":
+            result = get_result(port, res_dict, "fec" , result, XCVRD_GET_BER_RES_TABLE)
+
+        
+
+        port = platform_sfputil_helper.get_interface_alias(port, db)
+
+        actual_time = result.get("operation_time", 0)
+        if actual_time is not None:
+            time = '{0:02.0f}:{1:02.0f}'.format(*divmod(int(actual_time) * 60, 60))
+            result['operation_time'] = time
+
+        if json_output:
+            click.echo("{}".format(json.dumps(result, indent=4)))
+        else:
+            headers = ['PORT', 'ATTR', 'OPERATION_TIME']
+            res = [[port]+[key] + [val] for key, val in result.items()]
+            click.echo(tabulate(res, headers=headers))
+    else:
+        click.echo("Did not get a valid Port for operation time".format(port))
+        sys.exit(CONFIG_FAIL)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -534,6 +534,48 @@ PORT       DEST_TYPE    DEST_ADDRESS
 Ethernet0  server_ipv4  10.2.1.1
 """
 
+
+show_muxcable_operationtime_expected_port_output="""\
+PORT       ATTR            OPERATION_TIME
+---------  --------------  ----------------
+Ethernet0  operation_time  200:00
+"""
+
+show_muxcable_health_expected_port_output="""\
+PORT       ATTR          HEALTH
+---------  ------------  --------
+Ethernet0  health_check  Ok
+"""
+
+
+show_muxcable_queueinfo_expected_port_output="""\
+PORT       ATTR          VALUE
+---------  ----------  -------
+Ethernet0  uart_stat1        2
+Ethernet0  uart_stat2        1
+"""
+
+show_muxcable_resetcause_expected_port_output="""\
+PORT       ATTR         RESETCAUSE
+---------  -----------  ------------
+Ethernet0  reset_cause  warm reset
+"""
+
+
+show_muxcable_health_expected_port_output_json="""\
+{
+    "health_check": "Ok"
+}
+"""
+
+
+
+show_muxcable_resetcause_expected_port_output_json="""\
+{
+    "reset_cause": "warm reset"
+}
+"""
+
 class TestMuxcable(object):
     @classmethod
     def setup_class(cls):
@@ -2333,6 +2375,88 @@ class TestMuxcable(object):
                                ["Ethernet0", "--json"], obj=db)
         assert result.exit_code == 0
         assert result.output == show_muxcable_tunnel_route_expected_output_port_json
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"health_check": "True"}))
+    def test_show_mux_health(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["health"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_health_expected_port_output
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"health_check": "True"}))
+    def test_show_mux_health_json(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["health"],
+                               ["Ethernet0", "--json"], obj=db)
+        assert result.output == show_muxcable_health_expected_port_output_json
+
+
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"operation_time": "200"}))
+    def test_show_mux_operation_time(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["operationtime"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_operationtime_expected_port_output
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"uart_stat1": "2",
+                                                                          "uart_stat2": "1"}))
+    def test_show_mux_queue_info(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["queueinfo"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_queueinfo_expected_port_output
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "1"}))
+    def test_show_mux_resetcause(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["resetcause"],
+                               ["Ethernet0"], obj=db)
+        assert result.output == show_muxcable_resetcause_expected_port_output
+
+
+
+    @mock.patch('show.muxcable.delete_all_keys_in_db_table', mock.MagicMock(return_value=0))
+    @mock.patch('show.muxcable.update_and_get_response_for_xcvr_cmd', mock.MagicMock(return_value={0: 0,
+                                                                                                      1: "True"}))
+    @mock.patch('show.muxcable.get_result', mock.MagicMock(return_value={"reset_cause": "1"}))
+    def test_show_mux_resetcause_json(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["muxcable"].commands["resetcause"],
+                               ["Ethernet0", "--json"], obj=db)
+        assert result.output == show_muxcable_resetcause_expected_port_output_json
+
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
raising this because cherry-pick failed for 202012
master branch PR https://github.com/sonic-net/sonic-utilities/pull/2414

This PR adds the support for adding some utility commands for muxacble This includes commands for health, operationtime, queueinfo, resetcause
```
vdahiya@sonic:~$ show mux health Ethernet4
PORT          ATTR               HEALTH
---------     ---------------   --------
Ethernet4     health_check       Ok
vdahiya@sonic:~$ show mux health Ethernet4 --json
{
    "health_check": "Ok"
}

vdahiya@sonic:~$ show mux operation Ethernet4 --json {
    "operation_time": "22:22"
}
vdahiya@sonic:~$ show mux operation Ethernet4
PORT       ATTR              OPERATION_TIME
---------  --------------  ----------------
Ethernet4  operation_time                 22:22
vdahiya@sonic:~$

vdahiya@sonic:~$ show mux resetcause Ethernet4
PORT       ATTR           RESETCAUSE
---------  -----------  ------------
Ethernet4  reset_cause             0

vdahiya@sonic:~$ show mux resetcause Ethernet4 --json {
    "reset_cause": "0"
}

vdahiya@sonic:~$ show mux queueinfo Ethernet4 --json {
    "Remote": "{'VSC': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 0, 'node_size': 0}, 'UART1': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 209870, 'node_size': 1682183}, 'UART2': {'r_ptr': 13262, 'w_ptr': 3, 'total_count': 0, 'free_count': 0, 'buff_addr': 12, 'node_size': 0}}",
    "Local": "{'VSC': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 0, 'node_size': 0}, 'UART1': {'r_ptr': 0, 'w_ptr': 0, 'total_count': 0, 'free_count': 0, 'buff_addr': 209870, 'node_size': 1682183}, 'UART2': {'r_ptr': 13262, 'w_ptr': 3, 'total_count': 0, 'free_count': 0, 'buff_addr': 12, 'node_size': 0}}"
}
```
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

