### PR TITLE
IP address validation is added for RADIUS CLIs

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -200,7 +200,9 @@ def is_ipaddress(val):
     if not val:
         return False
     try:
-        netaddr.IPAddress(str(val))
+        ip_addr = netaddr.IPAddress(str(val))
+        if ip_addr.is_loopback() or ip_addr.is_multicast() or ip_addr.is_reserved():
+            return False
     except netaddr.core.AddrFormatError:
         return False
     return True


### PR DESCRIPTION
Signed-off-by: Saravanan I [saravan@celestica.com](mailto:saravan@celestica.com)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Common IP address validation is improved to validate IP address in RADIUS config click commands
#### How I did it
Common IP address validation is invoked to validate RADIUS config click commands

#### How to verify it
Configure RADIUS click commands by invalid IP address like (reserved IP addresses, loopback IP addresses, multicast IP addresses). Observe that CLI throws error when user configures invalid IP addresses.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211