### PR TITLE
[show][muxcable] increase timeout for displaying HW_STATUS

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -20,7 +20,7 @@ platform_sfputil = None
 
 REDIS_TIMEOUT_MSECS = 0
 SELECT_TIMEOUT = 1000
-HWMODE_MUXDIRECTION_TIMEOUT = 0.1
+HWMODE_MUXDIRECTION_TIMEOUT = 0.5
 
 # The empty namespace refers to linux host namespace.
 EMPTY_NAMESPACE = ''


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did


probe mux direction not always return success.

Sample output of: while [ 1 ]; do date; show mux hwmode muxdirection; show mux status; sleep 1; done
```
Mon 27 Feb 2023 03:12:25 PM UTC
Port         Direction    Presence
-----------  -----------  ----------
Ethernet16   unknown      True

PORT         STATUS    HEALTH    HWSTATUS      LAST_SWITCHOVER_TIME
-----------  --------  --------  ------------  ---------------------------
Ethernet16   standby   healthy   inconsistent  2023-Feb-25 07:55:18.269177
```

If we increase the timeout to 0.5 secs to get the values back from ycabled, this will remove the inconsistency issue, and display the consistent values, because while telemetry is going on, the time to get actual mux value takes significantly longer than 0.1 seconds. 
```
PORT         STATUS    HEALTH    HWSTATUS      LAST_SWITCHOVER_TIME
-----------  --------  --------  ------------  ---------------------------
Ethernet16   standby   healthy   consistent  2023-Feb-25 07:55:18.269177
```

#### How I did it

#### How to verify it
Manually run changes on setup
worst-case CLI return time could be 16 seconds for 32 ports. on avg each port is 200 mSec if telemetry is going, but on average show command will return in < 1 sec for all 32 ports. 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

