### PR TITLE
[warm/fast-reboot] Backup logs from tmpfs to disk during fast/warm shutdown

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -806,6 +806,17 @@ fi
 
 # Reboot: explicitly call Linux native reboot under sbin
 debug "Rebooting with ${REBOOT_METHOD} to ${NEXT_SONIC_IMAGE} ..."
+
+LOGS_ON_TMPFS=0
+df --output=fstype /var/log* | grep 'tmpfs' || LOGS_ON_TMPFS=$?
+if [[ LOGS_ON_TMPFS -eq 0 ]]; then
+    debug "Backup shutdown logs to /host/logs_before_reboot"
+    mkdir -p /host/logs_before_reboot || /bin/true
+    # maxdepth 2: find files within 2 nested directories (eg. /var/log/ and /var/log/swss/)
+    # mmin 30: find files written in past 30 minutes
+    find /var/log -maxdepth 2 -mmin -30 -type f | xargs -I {} cp {} /host/logs_before_reboot/ || /bin/true
+fi
+
 exec ${REBOOT_METHOD}
 
 # Should never reach here

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -808,7 +808,7 @@ fi
 debug "Rebooting with ${REBOOT_METHOD} to ${NEXT_SONIC_IMAGE} ..."
 
 LOGS_ON_TMPFS=0
-df --output=fstype /var/log* | grep 'tmpfs' || LOGS_ON_TMPFS=$?
+df --output=fstype /var/log* | grep -c 'tmpfs' || LOGS_ON_TMPFS=$?
 if [[ LOGS_ON_TMPFS -eq 0 ]]; then
     debug "Backup shutdown logs to /host/logs_before_reboot"
     mkdir -p /host/logs_before_reboot || /bin/true


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Goal: Preserve logs during TOR upgrades and shutdown

Need:

Below PRs moved logs from disk to tmpfs for specific hwskus.
Due to these changes, shutdown path logs are now lost.
The logs in shutdown path are crucial for debug purposes.

https://github.com/sonic-net/sonic-buildimage/pull/13805

https://github.com/sonic-net/sonic-buildimage/pull/13587

https://github.com/sonic-net/sonic-buildimage/pull/13587

#### How I did it

Check if logs are on tmpfs. If yes, backup logs from /var/log 

#### How to verify it
Verified on a physical device

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

