### PR TITLE
Fix non-zero status exit on non secure boot system

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -615,17 +615,13 @@ if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
 else
     # check if secure boot is enable in UEFI 
     CHECK_SECURE_UPGRADE_ENABLED=0
-    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled" || true) || CHECK_SECURE_UPGRADE_ENABLED=$?
+    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
     if [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]; then
-        error "CHECK_SECURE_UPGRADE_ENABLED failed"
+        debug "Loading kernel without secure boot"
+        load_kernel
     else
-        if [[ ${SECURE_UPGRADE_ENABLED} -eq 1 ]]; then
-            debug "Loading kernel with secure boot"
-            load_kernel_secure
-        else
-            debug "Loading kernel without secure boot"
-            load_kernel
-        fi
+        debug "Loading kernel with secure boot"
+        load_kernel_secure
     fi
 fi
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -614,11 +614,18 @@ if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
     load_aboot_secureboot_kernel
 else
     # check if secure boot is enable in UEFI 
-    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
-    if [ ${SECURE_UPGRADE_ENABLED} -eq 1 ]; then
-        load_kernel_secure
+    CHECK_SECURE_UPGRADE_ENABLED=0
+    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled" || true) || CHECK_SECURE_UPGRADE_ENABLED=$?
+    if [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]; then
+        error "CHECK_SECURE_UPGRADE_ENABLED failed"
     else
-        load_kernel
+        if [[ ${SECURE_UPGRADE_ENABLED} -eq 1 ]]; then
+            debug "Loading kernel with secure boot"
+            load_kernel_secure
+        else
+            debug "Loading kernel without secure boot"
+            load_kernel
+        fi
     fi
 fi
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Warm-reboot fails on kvm due to non-zero exit upon command 
`bootctl status 2>/dev/null | grep -c "Secure Boot: enabled"` 

#### How I did it
Added `|| true` to return 0 when previous command fails.
Added `CHECK_SECURE_UPGRADE_ENABLED` to check output of previous command
Added debug logs

#### How to verify it
Run warm-reboot on kvm and physical device when increased verbosity. Expects debug log to indicate secure/non secure boot. Successful warm reboot

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

