### PR TITLE
Add fabric_ns to the ns_list when display_option is DISPLAY_ALL.

### DIFF
--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -68,7 +68,8 @@ class MultiAsic(object):
                     ns_list = namespaces['front_ns']
             else:
                 if self.namespace_option not in namespaces['front_ns'] and \
-                        self.namespace_option not in namespaces['back_ns']:
+                        self.namespace_option not in namespaces['back_ns'] and \
+                        self.namespace_option not in namespaces['fabric_ns']:
                     raise ValueError(
                         'Unknown Namespace {}'.format(self.namespace_option))
                 ns_list = [self.namespace_option]

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -63,7 +63,7 @@ class MultiAsic(object):
             namespaces = multi_asic.get_all_namespaces()
             if self.namespace_option is None:
                 if self.get_display_option() == constants.DISPLAY_ALL:
-                    ns_list = namespaces['front_ns'] + namespaces['back_ns']
+                    ns_list = namespaces['front_ns'] + namespaces['back_ns'] + namespaces['fabric_ns']
                 else:
                     ns_list = namespaces['front_ns']
             else:


### PR DESCRIPTION
The get_ns_list_based_on_options function only gets front_ns and back_ns in current code. 
This change adds fabric_ns in the ns_list when display_option is DISPLAY_ALL. This enables the fabric related tests on voq chassis,  e.g  the change in https://github.com/sonic-net/sonic-mgmt/pull/6620/

 
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

