### PR TITLE
updated "show interfaces transceiver" command usage parameter in Command-Reference.md (pr2655 for 202205 CLI guide update)

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -994,9 +994,10 @@ This command displays information for all the interfaces for the transceiver req
   Port         Error Status
   -----------  --------------
   Ethernet100  OK
+  ``` 
   
   - Example (Display performance monitoring info of SFP transceiver connected to Ethernet100):
-  ```
+
   ```
   admin@sonic:~$ show interfaces transceiver pm Ethernet100
   Ethernet100:


### PR DESCRIPTION
updated pr2655 for 202205 CLI guide as the details from pr2655 was missed during the recovery of CLI guide for 202205 branch 

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

