### PR TITLE
Remove timer from FAST_REBOOT STATE_DB entry and use finalizer

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -46,7 +46,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_3_0_5'
+        self.CURRENT_VERSION = 'version_3_0_6'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -806,9 +806,28 @@ class DBMigrator():
 
     def version_3_0_5(self):
         """
-        Current latest version. Nothing to do here.
+        Version 3_0_5
         """
         log.log_info('Handling version_3_0_5')
+        # Update state-db fast-reboot entry to enable if set to enable fast-reboot finalizer when using upgrade with fast-reboot
+        # since upgrading from previous version FAST_REBOOT table will be deleted when the timer will expire.
+        # reading FAST_REBOOT table can't be done with stateDB.get as it uses hget behind the scenes and the table structure is
+        # not using hash and won't work.
+        # FAST_REBOOT table exists only if fast-reboot was triggered.
+        keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT")
+        if keys is not None:
+            enable_state = 'true'
+        else:
+            enable_state = 'false'
+        self.stateDB.set(self.stateDB.STATE_DB, 'FAST_RESTART_ENABLE_TABLE|system', 'enable', enable_state)
+        self.set_version('version_3_0_6')
+        return 'version_3_0_6'
+    
+    def version_3_0_6(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_3_0_6')
         return None
 
     def get_version(self):

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -143,7 +143,7 @@ function clear_boot()
 
     #clear_fast_boot
     if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
-        sonic-db-cli STATE_DB DEL "FAST_REBOOT|system" &>/dev/null || /bin/true
+        sonic-db-cli STATE_DB HSET "FAST_RESTART_ENABLE_TABLE|system" "enable" "false" &>/dev/null || /bin/true
     fi
 }
 
@@ -260,7 +260,7 @@ function backup_database()
                                           and not string.match(k, 'WARM_RESTART_ENABLE_TABLE|') \
                                           and not string.match(k, 'VXLAN_TUNNEL_TABLE|') \
                                           and not string.match(k, 'BUFFER_MAX_PARAM_TABLE|') \
-                                          and not string.match(k, 'FAST_REBOOT|') then
+                                          and not string.match(k, 'FAST_RESTART_ENABLE_TABLE|') then
                 redis.call('del', k)
             end
         end
@@ -519,7 +519,7 @@ case "$REBOOT_TYPE" in
         check_warm_restart_in_progress
         BOOT_TYPE_ARG=$REBOOT_TYPE
         trap clear_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
-        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "1" "EX" "210" &>/dev/null
+        sonic-db-cli STATE_DB HSET "FAST_RESTART_ENABLE_TABLE|system" "enable" "true" &>/dev/null
         config warm_restart enable system
         ;;
     "warm-reboot")

--- a/sonic-utilities-data/templates/service_mgmt.sh.j2
+++ b/sonic-utilities-data/templates/service_mgmt.sh.j2
@@ -51,7 +51,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
@@ -2044,6 +2044,6 @@
         "admin_status": "up"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_5"
+        "VERSION": "version_3_0_3"
     }
 }


### PR DESCRIPTION
This should come along with sonic-buildimage PR  implementing fast-reboot finalizing logic in finalize-warmboot script and other submodules PRs utilizing the change.

This PR should come along with the following PRs as well:


This set of PRs solves the issue https://github.com/sonic-net/sonic-buildimage/issues/13251

What I did
Remove the timer used to clear fast-reboot entry from state-db, instead it will be cleared by fast-reboot finalize function implemented inside finalize-warmboot script (which will be invoked since fast-reboot is using warm-reboot infrastructure).

As well instead of having "1" as the value for fast-reboot entry in state-db and deleting it when done it is now modified to set enable/disable according to the context.

As well all scripts reading this entry should be modified to the new value options.

How I did it
Removed the timer usage in the fast-reboot script and adding fast-reboot finalize logic to warm-reboot in the linked PR.
Use "enable: true/false" instead of "1" as the entry value.

How to verify it
Run fast-reboot and check that the state-db entry for fast-reboot is being deleted after finalizing fast-reboot and not by an expiring timer.

Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)