### PR TITLE
[sonic_package_manager] replace shell=True

### DIFF
--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -5,7 +5,7 @@ import os
 import stat
 import subprocess
 from collections import defaultdict
-from typing import Dict, Type
+from typing import Dict, Type, List
 
 import jinja2 as jinja2
 from config.config_mgmt import ConfigMgmt
@@ -97,7 +97,7 @@ def remove_if_exists(path):
     log.info(f'removed {path}')
 
 
-def run_command(command: str):
+def run_command(command: List[str]):
     """ Run arbitrary bash command.
     Args:
         command: String command to execute as bash script
@@ -109,7 +109,6 @@ def run_command(command: str):
     log.debug(f'running command: {command}')
 
     proc = subprocess.Popen(command,
-                            shell=True,
                             executable='/bin/bash',
                             stdout=subprocess.PIPE)
     (_, _) = proc.communicate()
@@ -647,4 +646,4 @@ class ServiceCreator:
         """ Common operations executed after service is created/removed. """
 
         if not in_chroot():
-            run_command('systemctl daemon-reload')
+            run_command(['systemctl', 'daemon-reload'])

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import os
+import sys
 import stat
 import subprocess
 from collections import defaultdict
@@ -96,16 +97,19 @@ def remove_if_exists(path):
     os.remove(path)
     log.info(f'removed {path}')
 
+def is_list_of_strings(command):
+    return isinstance(command, list) and all(isinstance(item, str) for item in command)
 
 def run_command(command: List[str]):
     """ Run arbitrary bash command.
     Args:
-        command: String command to execute as bash script
+        command: List of Strings command to execute as bash script
     Raises:
         ServiceCreatorError: Raised when the command return code
                              is not 0.
     """
-
+    if not is_list_of_strings(command):
+        sys.exit("Input command should be a list of strings")
     log.debug(f'running command: {command}')
 
     proc = subprocess.Popen(command,

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -112,9 +112,7 @@ def run_command(command: List[str]):
         sys.exit("Input command should be a list of strings")
     log.debug(f'running command: {command}')
 
-    proc = subprocess.Popen(command,
-                            executable='/bin/bash',
-                            stdout=subprocess.PIPE)
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE)
     (_, _) = proc.communicate()
     if proc.returncode != 0:
         raise ServiceCreatorError(f'Failed to execute "{command}"')

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import copy
 from unittest.mock import Mock, MagicMock, call, patch
 
@@ -71,6 +72,13 @@ def test_is_list_of_strings():
 
     output = is_list_of_strings(['a', 'b', 1])
     assert output is False
+
+def test_run_command():
+    with pytest.raises(SystemExit) as e:
+        run_command('echo 1')
+
+    with pytest.raises(ServiceCreatorError) as e:
+        run_command([sys.executable, "-c", "import sys; sys.exit(6)"])
 
 @pytest.fixture()
 def service_creator(mock_feature_registry,

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -2,7 +2,7 @@
 
 import os
 import copy
-from unittest.mock import Mock, MagicMock, call
+from unittest.mock import Mock, MagicMock, call, patch
 
 import pytest
 
@@ -62,6 +62,15 @@ def manifest():
         ]
     })
 
+def test_is_list_of_strings():
+    output = is_list_of_strings(['a', 'b', 'c'])
+    assert output is True
+
+    output = is_list_of_strings('abc')
+    assert output is False
+
+    output = is_list_of_strings(['a', 'b', 1])
+    assert output is False
 
 @pytest.fixture()
 def service_creator(mock_feature_registry,
@@ -203,6 +212,11 @@ def test_service_creator_autocli(sonic_fs, manifest, mock_cli_gen,
         any_order=True
     )
 
+def test_service_creator_post_operation_hook(sonic_fs, manifest, mock_sonic_db, mock_config_mgmt, service_creator):
+    with patch('sonic_package_manager.service_creator.creator.run_command') as run_command:
+        with patch('sonic_package_manager.service_creator.creator.in_chroot', MagicMock(return_value=False)):
+            service_creator._post_operation_hook()
+            run_command.assert_called_with(['systemctl', 'daemon-reload'])
 
 def test_feature_registration(mock_sonic_db, manifest):
     mock_connector = Mock()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
#### How I did it
`subprocess()` - use `shell=False` instead, use list of strings Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
#### How to verify it
Pass UT
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

