### PR TITLE
[sfputil] replace shell=True

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -906,11 +906,11 @@ def fetch_error_status_from_platform_api(port):
         "    errors=['{}:{}'.format(sfp.index, 'OK (Not implemented)') for sfp in sfp_list]\n" \
         "print(errors)\n"
 
-    get_error_status_command = "docker exec pmon python3 -c \"{}{}{}\"".format(
-        init_chassis_code, generate_sfp_list_code, get_error_status_code)
+    get_error_status_command = ["docker", "exec", "pmon", "python3", "-c", "{}{}{}".format(
+        init_chassis_code, generate_sfp_list_code, get_error_status_code)]
     # Fetch error status from pmon docker
     try:
-        output = subprocess.check_output(get_error_status_command, shell=True, universal_newlines=True)
+        output = subprocess.check_output(get_error_status_command, universal_newlines=True)
     except subprocess.CalledProcessError as e:
         click.Abort("Error! Unable to fetch error status for SPF modules. Error code = {}, error messages: {}".format(e.returncode, e.output))
         return None


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
#### How I did it
`subprocess()` - use `shell=False` instead, use list of strings Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
#### How to verify it
Pass UT
Manual test
```
admin@str-s6000-acs-12:~$ sudo sfputil show error-status -hw
Port         Error Status
-----------  --------------
Ethernet0
Ethernet4    OK
Ethernet8    OK
Ethernet12   OK
Ethernet16   OK
Ethernet20   OK
Ethernet24   OK
Ethernet28   OK
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

