### PR TITLE
[storm_control] CLI show error when trying to show the configuration with the specified interface

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -462,6 +462,7 @@ def storm_control(ctx, namespace, display):
             click.echo(tabulate(body, header, tablefmt="grid"))
 
 @storm_control.command('interface')
+@multi_asic_util.multi_asic_click_options
 @click.argument('interface', metavar='<interface>',required=True)
 def interface(interface, namespace, display):
     if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
storm_contro CLI show error when trying to show the configuration with the specified interface

```
admin@sonic:~$ show storm-control interface Ethernet0
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
TypeError: interface() missing 2 required positional arguments: 'namespace' and 'display' 
```

The interface() function of the show command is missing 2 required positional arguments: 'namespace' and 'display'.

#### How I did it
Added a default value for the arguments: 'namespace' and 'display

#### How to verify it
The CLI can display the storm_control setting of a given interface.
```
admin@sonic:~$ config interface storm-control add Ethernet0  broadcast 1000
admin@sonic:~$ show storm-control interface Ethernet0
+------------------+--------------+---------------+
| Interface Name   | Storm Type   |   Rate (kbps) |
+==================+==============+===============+
| Ethernet0        | broadcast    |          1000 |
+------------------+--------------+---------------+

admin@sonic:~$ config interface storm-control del Ethernet0 broadcast
admin@sonic:~$ show storm-control interface Ethernet0
admin@sonic:~$
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

