### PR TITLE
Fix fast-reboot DB migration

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -875,7 +875,7 @@ class DBMigrator():
         # not using hash and won't work.
         # FAST_REBOOT table exists only if fast-reboot was triggered.
         keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT")
-        if keys is not None:
+        if not keys:
             enable_state = 'true'
         else:
             enable_state = 'false'

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -875,7 +875,7 @@ class DBMigrator():
         # not using hash and won't work.
         # FAST_REBOOT table exists only if fast-reboot was triggered.
         keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT")
-        if not keys:
+        if keys:
             enable_state = 'true'
         else:
             enable_state = 'false'

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -874,7 +874,7 @@ class DBMigrator():
         # reading FAST_REBOOT table can't be done with stateDB.get as it uses hget behind the scenes and the table structure is
         # not using hash and won't work.
         # FAST_REBOOT table exists only if fast-reboot was triggered.
-        keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT")
+        keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system")
         if keys:
             enable_state = 'true'
         else:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix DB migrator logic for migrating fast-reboot table, fixing https://github.com/sonic-net/sonic-utilities/pull/2621 db_migrator.

#### How I did it
Checking if fast-reboot table exists in DB.

#### How to verify it
Verified manually, migrating after fast-reboot and after cold/warm reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

