### PR TITLE
Fix JSONDecodeError for intfstat

### DIFF
--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -308,7 +308,7 @@ def main():
                         general_data = json.load(open(cnstat_fqn_general_file, 'r'))
                         for key, val in cnstat_dict.items():
                             general_data[key] = val
-                        json.dump(general_data, open(cnstat_fqn_general_file, 'w'))
+                        json.dump(general_data, open(cnstat_fqn_general_file, 'w'), default=json_serial)
                     except IOError as e:
                         sys.exit(e.errno)
             # Add the information also to tag specific file
@@ -316,7 +316,7 @@ def main():
                 data = json.load(open(cnstat_fqn_file, 'r'))
                 for key, val in cnstat_dict.items():
                     data[key] = val
-                json.dump(data, open(cnstat_fqn_file, 'w'))
+                json.dump(data, open(cnstat_fqn_file, 'w'), default=json_serial)
             else:
                 json.dump(cnstat_dict, open(cnstat_fqn_file, 'w'), default=json_serial)
         except IOError as e:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix #14089.

PR https://github.com/sonic-net/sonic-utilities/pull/2636 introduced the following error if I run `intfstat -c` twice.
The first run is fine, because there is no intfstat tmp file, but the  twice run will save new data into same tmp file again, this time, it calls `json.dump(data, open(cnstat_fqn_file, 'w'))` and throws traceback. 


```
admin@str2-7050cx3-acs-01:~$ intfstat -c                    
Cleared counters
admin@str2-7050cx3-acs-01:~$ intfstat -c
Traceback (most recent call last):
  File "/usr/local/bin/intfstat", line 376, in <module>
    main()
  File "/usr/local/bin/intfstat", line 324, in main
    json.dump(data, open(cnstat_fqn_file, 'w'))
  File "/usr/lib/python3.9/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/usr/lib/python3.9/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.9/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/usr/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

#### How I did it
 The default value for the default parameter is None.
Should use json_serial as default format.

#### How to verify it
run `intfstat -c` twice

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

