### PR TITLE
Fixed techsupport failure in generate_dump 'show bgp neighbors'

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -459,13 +459,12 @@ save_bgp_neighbor() {
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local asic_id=${1:-""}
     local ns=$(get_vtysh_namespace $asic_id)
-
-    neighbor_list_v4=$(${timeout_cmd} vtysh $ns -c "show ip bgp neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}')
+    neighbor_list_v4=$(${timeout_cmd} vtysh $ns -c "show ip bgp neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}' | awk /\\./)
     for word in $neighbor_list_v4; do
         save_cmd "vtysh $ns -c \"show ip bgp neighbors $word advertised-routes\"" "ip.bgp.neighbor.$word.adv$asic_id"
         save_cmd "vtysh $ns -c \"show ip bgp neighbors $word routes\"" "ip.bgp.neighbor.$word.rcv$asic_id"
     done
-    neighbor_list_v6=$(vtysh $ns -c "show bgp ipv6 neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}' | fgrep ':')
+    neighbor_list_v6=$(vtysh $ns -c "show bgp ipv6 neighbors" | grep "BGP neighbor is" | awk -F '[, ]' '{print $4}' | awk /:/)
     for word in $neighbor_list_v6; do
         save_cmd "vtysh $ns -c \"show bgp ipv6 neighbors $word advertised-routes\"" "ipv6.bgp.neighbor.$word.adv$asic_id"
         save_cmd "vtysh $ns -c \"show bgp ipv6 neighbors $word routes\"" "ipv6.bgp.neighbor.$word.rcv$asic_id"


### PR DESCRIPTION

#### What I did
Resolved Techsupport failure upon generate_dump (techsupport gives rc = 1) execution for 'show bgp ipv6 neighbors' and 'show ip bgp neighbors' cli.

#### How I did it
fgrep returned non 0 RC in case bgp neighbors are not configured or link down/config abscent on peer etc. This results in script failure. So, I replaced fgrep with awk. This returns rc = 0 even when we dont have any results in filter.
In case of ipv4 (show ip bgp neighbors), it is observed that cli also gives v6 peers. Consequently neighbor_list_v4 has v4 and v6 peers. This generates 2 sets of files in techsupport (1 set for v4 and other for v6). however v6 neighbors do not have routes and are empty files. So I added extra filtering here using awk and neighbor_list_v4 will only have v4 neighbors.
How to verify it
case 1 : setup having route. Verified my script does not result any errors by rc checking.
I also checked techsuppport dump and observed no non 0 rc and no files with empty routes.
case 2 : setup not having neigbor/routes. Ensured rc is always 0.

#### How to verify it
show techsupport -r --since '5 minute ago' -> echo $? gives 1

#### Previous command output (if the output of a command-line utility has changed)
show techsupport -r --since '5 minute ago' -> echo $? gives 0

#### New command output (if the output of a command-line utility has changed)

