### PR TITLE
[202211] [cherry-pick] Add status for ACL_TABLE and ACL_RULE in STATE_DB

### DIFF
--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -46,6 +46,7 @@ RULE_7                                 DATAACL               9993  701          
 RULE_9                                 DATAACL               9991  901              900
 RULE_10                                DATAACL               9989  1001             1000
 DEFAULT_RULE                           DATAACL                  1  2                1
+RULE_1                                 DATAACL_5             9999  N/A              N/A
 RULE_NO_COUNTER                        DATAACL_NO_COUNTER    9995  N/A              N/A
 RULE_6                                 EVERFLOW              9994  601              600
 RULE_08                                EVERFLOW              9992  0                0
@@ -89,8 +90,8 @@ RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 11
-Total number of ACL Rules: 20
+Total number of ACL Tables: 12
+Total number of ACL Rules: 21
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------
@@ -136,6 +137,7 @@ RULE_7                                 DATAACL               9993  0            
 RULE_9                                 DATAACL               9991  0                0
 RULE_10                                DATAACL               9989  0                0
 DEFAULT_RULE                           DATAACL                  1  0                0
+RULE_1                                 DATAACL_5             9999  N/A              N/A
 RULE_NO_COUNTER                        DATAACL_NO_COUNTER    9995  N/A              N/A
 RULE_6                                 EVERFLOW              9994  0                0
 RULE_08                                EVERFLOW              9992  0                0
@@ -161,6 +163,7 @@ RULE_7                                 DATAACL               9993  0            
 RULE_9                                 DATAACL               9991  0                0
 RULE_10                                DATAACL               9989  0                0
 DEFAULT_RULE                           DATAACL                  1  0                0
+RULE_1                                 DATAACL_5             9999  N/A              N/A
 RULE_NO_COUNTER                        DATAACL_NO_COUNTER    9995  100              100
 RULE_6                                 EVERFLOW              9994  0                0
 RULE_08                                EVERFLOW              9992  0                0

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -246,5 +246,16 @@
         "holdtime": "10",
         "asn": "65200",
         "keepalive": "3"
+    },
+    "ACL_RULE|DATAACL_5|RULE_1": {
+        "IP_PROTOCOL": "126",
+        "PACKET_ACTION": "FORWARD",
+        "PRIORITY": "9999"
+    },
+    "ACL_TABLE|DATAACL_5": {
+        "policy_desc": "DATAACL_5",
+        "ports@": "Ethernet124",
+        "type": "L3",
+        "stage": "ingress"
     }
 }

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -286,5 +286,11 @@
         "STATUS": "up",
         "REMOTE_MOD": "0",
         "REMOTE_PORT": "93"
+    },
+    "ACL_TABLE_TABLE|DATAACL_5" : {
+        "status": "Active"
+    },
+    "ACL_RULE_TABLE|DATAACL_5|RULE_1" : {
+        "status": "Active"
     }
 }

--- a/tests/mock_tables/asic2/config_db.json
+++ b/tests/mock_tables/asic2/config_db.json
@@ -124,5 +124,16 @@
         "state": "disabled",
         "auto_restart": "disabled",
         "high_mem_alert": "disabled"
+    },
+    "ACL_RULE|DATAACL_5|RULE_1": {
+        "IP_PROTOCOL": "126",
+        "PACKET_ACTION": "FORWARD",
+        "PRIORITY": "9999"
+    },
+    "ACL_TABLE|DATAACL_5": {
+        "policy_desc": "DATAACL_5",
+        "ports@": "Ethernet124",
+        "type": "L3",
+        "stage": "ingress"
     }
 }

--- a/tests/mock_tables/asic2/state_db.json
+++ b/tests/mock_tables/asic2/state_db.json
@@ -207,5 +207,11 @@
         "speed_target": "50",
         "led_status": "green",
         "timestamp": "20200813 01:32:30"
+    },
+    "ACL_TABLE_TABLE|DATAACL_5" : {
+        "status": "Active"
+    },
+    "ACL_RULE_TABLE|DATAACL_5|RULE_1" : {
+        "status": "Active"
     }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -496,6 +496,11 @@
         "PACKET_ACTION": "FORWARD",
         "PRIORITY": "9995"
     },
+    "ACL_RULE|DATAACL_5|RULE_1": {
+        "IP_PROTOCOL": "126",
+        "PACKET_ACTION": "FORWARD",
+        "PRIORITY": "9999"
+    },
     "ACL_TABLE|NULL_ROUTE_V4": {
         "policy_desc": "DATAACL",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023",
@@ -532,6 +537,12 @@
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
         "type": "L3V6",
         "stage": "egress"
+    },
+    "ACL_TABLE|DATAACL_5": {
+        "policy_desc": "DATAACL_5",
+        "ports@": "Ethernet124",
+        "type": "L3",
+        "stage": "ingress"
     },
     "ACL_TABLE|EVERFLOW": {
         "policy_desc": "EVERFLOW",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1176,5 +1176,11 @@
     },
     "ADVERTISE_NETWORK_TABLE|fccc:a250:a251::a6:1/128": {
         "profile": ""
+    },
+    "ACL_TABLE_TABLE|DATAACL_5" : {
+        "status": "Active"
+    },
+    "ACL_RULE_TABLE|DATAACL_5|RULE_1" : {
+        "status": "Active"
     }
 }

--- a/tests/show_acl_test.py
+++ b/tests/show_acl_test.py
@@ -1,0 +1,95 @@
+import os
+import pytest
+from click.testing import CliRunner
+
+import acl_loader.main as acl_loader_show
+from acl_loader import *
+from acl_loader.main import *
+from importlib import reload
+
+root_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(root_path)
+scripts_path = os.path.join(modules_path, "scripts")
+
+
+@pytest.fixture()
+def setup_teardown_single_asic():
+    os.environ["PATH"] += os.pathsep + scripts_path
+    os.environ["UTILITIES_UNIT_TESTING"] = "2"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+    yield
+    os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
+
+@pytest.fixture(scope="class")
+def setup_teardown_multi_asic():
+    os.environ["PATH"] += os.pathsep + scripts_path
+    os.environ["UTILITIES_UNIT_TESTING"] = "2"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+    from .mock_tables import mock_multi_asic_3_asics
+    reload(mock_multi_asic_3_asics)
+    from .mock_tables import dbconnector
+    dbconnector.load_namespace_config()
+    yield
+    os.environ["UTILITIES_UNIT_TESTING"] = "0"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+    from .mock_tables import mock_single_asic
+    reload(mock_single_asic)
+
+
+class TestShowACLSingleASIC(object):
+    def test_show_acl_table(self, setup_teardown_single_asic):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['table'], ['DATAACL_5'], obj=context)
+        assert result.exit_code == 0
+        # We only care about the third line, which contains the 'Active'
+        result_top = result.output.split('\n')[2]
+        expected_output = "DATAACL_5  L3      Ethernet124  DATAACL_5      ingress  Active"
+        assert result_top == expected_output
+
+    def test_show_acl_rule(self, setup_teardown_single_asic):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['rule'], ['DATAACL_5'], obj=context)
+        assert result.exit_code == 0
+        # We only care about the third line, which contains the 'Active'
+        result_top = result.output.split('\n')[2]
+        expected_output = "DATAACL_5  RULE_1        9999  FORWARD   IP_PROTOCOL: 126  Active"
+        assert result_top == expected_output
+
+
+class TestShowACLMultiASIC(object):
+    def test_show_acl_table(self, setup_teardown_multi_asic):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['table'], ['DATAACL_5'], obj=context)
+        assert result.exit_code == 0
+        # We only care about the third line, which contains the 'Active'
+        result_top = result.output.split('\n')[2]
+        expected_output = "DATAACL_5  L3      Ethernet124  DATAACL_5      ingress  {'asic0': 'Active', 'asic2': 'Active'}"
+        assert result_top == expected_output
+
+    def test_show_acl_rule(self, setup_teardown_multi_asic):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['rule'], ['DATAACL_5'], obj=context)
+        assert result.exit_code == 0
+        # We only care about the third line, which contains the 'Active'
+        result_top = result.output.split('\n')[2]
+        expected_output = "DATAACL_5  RULE_1        9999  FORWARD   IP_PROTOCOL: 126  {'asic0': 'Active', 'asic2': 'Active'}"
+        assert result_top == expected_output
+        
+        


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to backport changes in PR #2667 into `202211` branch.
HLD https://github.com/sonic-net/SONiC/pull/1261
This PR is to enhance `show acl table` and `show acl rule` commands.
Currently, `show acl table` and `show acl rule` commands read ACL table/rule configuration from `CONFIG_DB` directly. We don't know whether the ACL table or rule is created successfully.
We improved `swss` to write the status of ACL table/rule into a `STATE_DB` table. In this PR, the show command is enhanced to read the status from `STATE_DB` table.
#### How I did it
1. Introduce two tables in `STATE_DB`
2. `orchgent` writes the status to `STATE_DB`
3. show commands read the status from `STATE_DB`.

#### How to verify it
Verified by copying the new script to a testbed, and check the output.

#### Previous command output (if the output of a command-line utility has changed)
```
$ show acl table DATAACL
Name     Type    Binding      Description    Stage     
-------  ------  -----------  -------------  -------   
DATAACL  L3      Ethernet0    DATAACL        ingress   
                 Ethernet4
                 Ethernet8
                 Ethernet12
```
```
show acl rule
Table    Rule          Priority    Action    Match               
-------  ------------  ----------  --------  ------------------- 
DATAACL  RULE_1        9999        DROP      DST_IP: 9.5.9.3/32  
                                             ETHER_TYPE: 2048
DATAACL  RULE_2        9998        FORWARD   DST_IP: 10.2.1.2/32 
                                             ETHER_TYPE: 2048
                                             IP_PROTOCOL: 6
                                             L4_DST_PORT: 22
```
#### New command output (if the output of a command-line utility has changed)
```
$ show acl table DATAACL
Name     Type    Binding      Description    Stage      Status
-------  ------  -----------  -------------  -------    -------
DATAACL  L3      Ethernet0    DATAACL        ingress    Active
                 Ethernet4
                 Ethernet8
                 Ethernet12
```
```
show acl rule
Table    Rule          Priority    Action    Match                Status
-------  ------------  ----------  --------  -------------------  --------
DATAACL  RULE_1        9999        DROP      DST_IP: 9.5.9.3/32   Active
                                             ETHER_TYPE: 2048
DATAACL  RULE_2        9998        FORWARD   DST_IP: 10.2.1.2/32  Active
                                             ETHER_TYPE: 2048
                                             IP_PROTOCOL: 6
                                             L4_DST_PORT: 22
```

