### PR TITLE
[sonic-package-manager] add support for multiple CLI plugin files

### DIFF
--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -76,6 +76,26 @@ class ManifestSchema:
             return value
 
     @dataclass
+    class ListMarshaller(Marshaller):
+        """ Returns a list. In case input is of other type it returns a list containing that single value. """
+
+        type: type
+
+        def marshal(self, value):
+            if isinstance(value, list):
+                for item in value:
+                    if not isinstance(item, self.type):
+                        raise ManifestError(f'{value} has items not of type {self.type.__name__}')
+                return value
+            elif isinstance(value, self.type):
+                return [value]
+            else:
+                raise ManifestError(f'{value} is not of type {self.type.__name__}')
+
+        def unmarshal(self, value):
+            return value
+
+    @dataclass
     class ManifestNode(Marshaller, ABC):
         """
         Base class for any manifest object.
@@ -207,9 +227,9 @@ class ManifestSchema:
         ])),
         ManifestRoot('cli', [
             ManifestField('mandatory', DefaultMarshaller(bool), False),
-            ManifestField('show', DefaultMarshaller(str), ''),
-            ManifestField('config', DefaultMarshaller(str), ''),
-            ManifestField('clear', DefaultMarshaller(str), ''),
+            ManifestField('show', ListMarshaller(str), []),
+            ManifestField('config', ListMarshaller(str), []),
+            ManifestField('clear', ListMarshaller(str), []),
             ManifestField('auto-generate-show', DefaultMarshaller(bool), False),
             ManifestField('auto-generate-config', DefaultMarshaller(bool), False),
         ])

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 import re
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 import pytest
 
+import sonic_package_manager
 from sonic_package_manager.errors import *
 from sonic_package_manager.version import Version
 
@@ -161,9 +162,25 @@ def test_installation_base_os_constraint_satisfied(package_manager, fake_metadat
 def test_installation_cli_plugin(package_manager, fake_metadata_resolver, anything):
     manifest = fake_metadata_resolver.metadata_store['Azure/docker-test']['1.6.0']['manifest']
     manifest['cli']= {'show': '/cli/plugin.py'}
-    package_manager._install_cli_plugins = Mock()
-    package_manager.install('test-package')
-    package_manager._install_cli_plugins.assert_called_once_with(anything)
+    with patch('sonic_package_manager.manager.get_cli_plugin_directory') as get_dir_mock:
+        get_dir_mock.return_value = '/'
+        package_manager.install('test-package')
+        package_manager.docker.extract.assert_called_once_with(anything, '/cli/plugin.py', '/test-package_0.py')
+
+
+def test_installation_multiple_cli_plugin(package_manager, fake_metadata_resolver, anything):
+    manifest = fake_metadata_resolver.metadata_store['Azure/docker-test']['1.6.0']['manifest']
+    manifest['cli']= {'show': ['/cli/plugin.py', '/cli/plugin2.py']}
+    with patch('sonic_package_manager.manager.get_cli_plugin_directory') as get_dir_mock:
+        get_dir_mock.return_value = '/'
+        package_manager.install('test-package')
+        package_manager.docker.extract.assert_has_calls(
+            [
+                call(anything, '/cli/plugin.py', '/test-package_0.py'),
+                call(anything, '/cli/plugin2.py', '/test-package_1.py'),
+            ],
+            any_order=True,
+        )
 
 
 def test_installation_cli_plugin_skipped(package_manager, fake_metadata_resolver, anything):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Use case for some application extensions we develop is to have multiple features as part of a single container. Therefore we want to have ability to install multiple CLI plugins from a single extension.

#### How I did it

Allowed to specify few CLI plugins in the manifest.

#### How to verify it

Build extension with multiple CLI plugins and install. Verified all plugins are installed.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

