### PR TITLE
Revert "Convert IPv6 addresses to lowercase in apply-patch (#2299)"

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1362,20 +1362,6 @@ def apply_patch(ctx, patch_file_path, format, dry_run, ignore_non_yang_tables, i
             patch_as_json = json.loads(text)
             patch = jsonpatch.JsonPatch(patch_as_json)
 
-        # convert IPv6 addresses to lowercase
-        for patch_line in patch:
-            if 'remove' == patch_line['op']:
-                match = re.search(r"(?P<prefix>/INTERFACE/\w+\|)(?P<ipv6_address>([a-fA-F0-9]{0,4}[:~]|::){1,7}[a-fA-F0-9]{0,4})"
-                                    "(?P<suffix>.*)", str.format(patch_line['path']))
-                if match:
-                    prefix = match.group('prefix')
-                    ipv6_address_str = match.group('ipv6_address')
-                    suffix = match.group('suffix')
-                    ipv6_address_str = ipv6_address_str.lower()
-                    click.secho("converted ipv6 address to lowercase {} with prefix {} in value: {}"
-                                .format(ipv6_address_str, prefix, patch_line['path']))
-                    patch_line['path'] = prefix + ipv6_address_str + suffix
-
         config_format = ConfigFormat[format.upper()]
         GenericUpdater().apply_patch(patch, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_path)
 

--- a/tests/ip_config_input/patch_ipv6.test
+++ b/tests/ip_config_input/patch_ipv6.test
@@ -1,6 +1,0 @@
-[
-    {
-        "path": "/INTERFACE/Ethernet12|FC00::1~1126", 
-        "op": "remove"
-    }
-]

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -1,5 +1,3 @@
-import json
-import jsonpatch
 import os
 import traceback
 from unittest import mock
@@ -13,9 +11,6 @@ import show.main as show
 import config.validated_config_db_connector as validated_config_db_connector
 from utilities_common.db import Db
 import utilities_common.bgp_util as bgp_util
-
-test_path = os.path.dirname(os.path.abspath(__file__))
-ip_config_input_path = os.path.join(test_path, "ip_config_input")
 
 ERROR_MSG = "Error: IP address is not valid"
 
@@ -242,21 +237,6 @@ class TestConfigIP(object):
         print(result.exit_code, result.output)
         assert result.exit_code != 0
         assert ('Ethernet68', '3000::1/64') not in db.cfgdb.get_table('INTERFACE')
-
-    def test_remove_interface_case_sensitive_mock_ipv6_w_apply_patch(self):
-        runner = CliRunner()
-        any_patch_as_json = [{"op": "remove", "path": "/INTERFACE/Ethernet12|FC00::1~1126"}]
-        any_patch = jsonpatch.JsonPatch(any_patch_as_json)
-        any_patch_as_text = json.dumps(any_patch_as_json)
-        ipv6_patch_file = os.path.join(ip_config_input_path, 'patch_ipv6.test')
-
-        # config apply-patch patch
-        mock_generic_updater = mock.Mock()
-        with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
-            with mock.patch('builtins.open', mock.mock_open(read_data=any_patch_as_text)):
-                result = runner.invoke(config.config.commands["apply-patch"], [ipv6_patch_file], catch_exceptions=False)
-        print(result.exit_code, result.output)
-        assert "converted ipv6 address to lowercase fc00::1~1126 with prefix /INTERFACE/Ethernet12| in value: /INTERFACE/Ethernet12|FC00::1~1126" in result.output
 
     def test_intf_vrf_bind_unbind(self):
         runner = CliRunner()


### PR DESCRIPTION
This reverts commit 28b6ba5fc11f65abaf421c70159a605d233eda41.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
There are some issues when GCU tries to remove the interface IP in some tests, such as add rack test.

In the initial config, the INTERFACE's IPv6 was all loaded in uppercase by default.

    "INTERFACE": {
        "Ethernet68": {},
        "Ethernet68|10.0.0.34/31": {},
        "Ethernet68|FC00::45/126": {},
        "Ethernet72": {},
        "Ethernet72|10.0.0.36/31": {},
        "Ethernet72|FC00::49/126": {},
GCU will never be able to remove that IP because IPv6 was always translated to lowercase due to #2299 . It reported the error can't remove a non-existent object, thus making GCU fail.

#2299  is to deal with this issue: https://github.com/sonic-net/sonic-buildimage/issues/11622.

Although config CLI always translates uppercase to lowercase when adding an IP, the user can have two choices to remove that IP: One is to use config CLI to remove that IP no matter uppercase or lowercase. Another way is to use GCU. In order to use GCU, the user has to check the IP format saved in ConfigDB because GCU operation does differentiate between uppercase and lowercase.
#### What I did
Revert #2299 

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

