### PR TITLE
Modify the error message of configuring duplicate syslog to have a consistent message between versions.

### DIFF
--- a/config/syslog.py
+++ b/config/syslog.py
@@ -177,14 +177,10 @@ def server_validator(ctx, db, ip_addr, is_exist=True):
     """
     if is_exist:
         if not is_exist_in_db(db, str(SYSLOG_TABLE_CDB), str(ip_addr)):
-            raise click.UsageError("Invalid value for {}: {} is not a valid syslog server".format(
-                get_param_hint(ctx, "server_ip_address"), ip_addr), ctx
-            )
+            raise click.UsageError("Syslog server {} is not configured.".format(str(ip_addr)))
     else:
         if is_exist_in_db(db, str(SYSLOG_TABLE_CDB), str(ip_addr)):
-            raise click.UsageError("Invalid value for {}: {} is a valid syslog server".format(
-                get_param_hint(ctx, "server_ip_address"), ip_addr), ctx
-            )
+            raise click.UsageError("Syslog server {} is already configured.".format(str(ip_addr)))
 
 
 def ip_addr_validator(ctx, param, value):


### PR DESCRIPTION
Modify the error message of configuring duplicate syslog to have a consistent message between versions.

#### What I did
Modify the error message of configuring duplicate syslog to have a consistent message between versions.

#### How I did it
The error message of configuring duplicate syslog is ambiguous to user, so modify it to make it have clearer meaning.

#### How to verify it
Modify the code and check the error message, also build the sonic-utilities python wheel to make sure all unit test cases will pass.

The error message after modification:
```
admin@sonic:~$ sudo config syslog add 20.1.1.12
Running command: systemctl reset-failed rsyslog-config rsyslog
Running command: systemctl restart rsyslog-config
admin@sonic:~$
admin@sonic:~$ sudo config syslog add 20.1.1.12
Usage: config syslog add [OPTIONS] SERVER_IP_ADDRESS

Error: Syslog server 20.1.1.12 is already configured.  <---------------- modified error message.
```