### PR TITLE
[GCU] Performance improvement by making patch sorting optional

### DIFF
--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -94,6 +94,7 @@ class ValidatedConfigDBConnector(object):
         config_format = ConfigFormat[format.upper()]
 
         try:
+            # Because all writes to ConfigDB through ValidatedConfigDBConnector are simple and don't require sorting, we set sort=False to skip sorting and improve performance
             GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None, sort=False)
         except EmptyTableError:
             self.validated_delete_table(table)

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -103,7 +103,7 @@ class ValidatedConfigDBConnector(object):
         format = ConfigFormat.CONFIGDB.name
         config_format = ConfigFormat[format.upper()]
         try:
-            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
+            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None, sort=False)
         except ValueError as e:
             logger = genericUpdaterLogging.get_logger(title="Patch Applier", print_all_to_console=True)
             logger.log_notice("Unable to remove entry, as doing so will result in invalid config. Error: {}".format(e))

--- a/config/validated_config_db_connector.py
+++ b/config/validated_config_db_connector.py
@@ -94,7 +94,7 @@ class ValidatedConfigDBConnector(object):
         config_format = ConfigFormat[format.upper()]
 
         try:
-            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None)
+            GenericUpdater().apply_patch(patch=gcu_patch, config_format=config_format, verbose=False, dry_run=False, ignore_non_yang_tables=False, ignore_paths=None, sort=False)
         except EmptyTableError:
             self.validated_delete_table(table)
 

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -526,7 +526,7 @@ class TestGenericUpdater(unittest.TestCase):
     def test_apply_patch__creates_applier_and_apply(self):
         # Arrange
         patch_applier = Mock()
-        patch_applier.apply.side_effect = create_side_effect_dict({(str(Files.SINGLE_OPERATION_SONIC_YANG_PATCH),): 0})
+        patch_applier.apply.side_effect = create_side_effect_dict({(str(Files.SINGLE_OPERATION_SONIC_YANG_PATCH), "True"): 0})
 
         factory = Mock()
         factory.create_patch_applier.side_effect = \
@@ -548,7 +548,7 @@ class TestGenericUpdater(unittest.TestCase):
                                     self.any_ignore_paths)
 
         # Assert
-        patch_applier.apply.assert_has_calls([call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH)])
+        patch_applier.apply.assert_has_calls([call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH, True)])
 
     def test_replace__creates_replacer_and_replace(self):
         # Arrange


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Make patch sorting optional. 

**Why:** In some cases, patch sorting is unnecessary, as the patch doesn't have dependencies on other tables, and the patch is already in an order that can directly be applied to ConfigDB. A specific example is when GCU is used for YANG validation of direct writes to ConfigDB via `set_entry` or `mod_entry`. In these scenarios, we can directly apply each element in the JsonPatch without need for additional sorting

This allows for a performance improvement of ~40%. 

Sample command to add portchannel including unnecessary patch sorting: 
```
admin@sonic:~$ sudo config portchannel add PortChannel09
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "add", "path": "/PORTCHANNEL/PortChannel09", "value": {}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel09", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating all JsonPatch operations are permitted on the specified fields
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Patch Applier: The patch was converted into 1 change:
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL/PortChannel09", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
Patch Applier: Applying 1 change in order:
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL/PortChannel09", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
[{"op": "add", "path": "/PORTCHANNEL/PortChannel09", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
**Elapsed time: 4.543376445770264**
```

Sample command to add portchannel without unnecessary patch sorting: 
```
admin@sonic:~$ sudo config portchannel add PortChannel06
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating all JsonPatch operations are permitted on the specified fields
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Converting patch to JsonChange.
Patch Applier: The patch was converted into 2 changes:
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
Patch Applier: Applying 2 changes in order:
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {}}]
[{"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
[{"op": "add", "path": "/PORTCHANNEL/PortChannel06", "value": {"admin_status": "up", "mtu": "9100", "lacp_key": "auto", "min_links": "1"}}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
**Elapsed time: 2.747215747833252**
```

#### How I did it
In ValidatedConfigDBConnector decorator code, set the sort=False flag, and read this value in GCU to determine whether patch sorting is necessary

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

