### PR TITLE
[db_migrator] add required "protocol" field in ROUTE_TABLE

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -593,8 +593,6 @@ class DBMigrator():
             Upgrade from older branch to 202205 will require this 'weight' attr to be added explicitly
         2. 'protocol' attr in ROUTE introduced in 202305 onwards.
             WarmRestartHelper reconcile logic requires to have "protocol" field in the old dumped ROUTE_TABLE.
-            Since an empty value is invalid and we can't know which protocol routes have originated from from
-            the old dump we assume it is "bgp". Later fpmsyncd will correct this during reconciliation.
         """
         route_table = self.appDB.get_table("ROUTE_TABLE")
         for route_prefix, route_attr in route_table.items():
@@ -609,7 +607,7 @@ class DBMigrator():
                 self.appDB.set(self.appDB.APPL_DB, route_key, 'weight','')
 
             if 'protocol' not in route_attr:
-                self.appDB.set(self.appDB.APPL_DB, route_key, 'protocol', 'bgp')
+                self.appDB.set(self.appDB.APPL_DB, route_key, 'protocol', '')
 
     def update_edgezone_aggregator_config(self):
         """

--- a/tests/db_migrator_input/appl_db/routes_migrate_expected.json
+++ b/tests/db_migrator_input/appl_db/routes_migrate_expected.json
@@ -2,11 +2,13 @@
     "ROUTE_TABLE:192.168.104.0/25": {
         "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61,10.0.0.63",
         "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104",
-        "weight": ""
+        "weight": "",
+        "protocol": "bgp"
       },
     "ROUTE_TABLE:20c0:fe28:0:80::/64": {
-    "nexthop": "fc00::72,fc00::76,fc00::7a,fc00::7e",
-    "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104",
-    "weight": ""
+        "nexthop": "fc00::72,fc00::76,fc00::7a,fc00::7e",
+        "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104",
+        "weight": "",
+        "protocol": "bgp"
     }
 }

--- a/tests/db_migrator_input/appl_db/routes_migrate_expected.json
+++ b/tests/db_migrator_input/appl_db/routes_migrate_expected.json
@@ -3,12 +3,12 @@
         "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61,10.0.0.63",
         "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104",
         "weight": "",
-        "protocol": "bgp"
+        "protocol": ""
       },
     "ROUTE_TABLE:20c0:fe28:0:80::/64": {
         "nexthop": "fc00::72,fc00::76,fc00::7a,fc00::7e",
         "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104",
         "weight": "",
-        "protocol": "bgp"
+        "protocol": ""
     }
 }

--- a/tests/db_migrator_input/appl_db/routes_migrate_input.json
+++ b/tests/db_migrator_input/appl_db/routes_migrate_input.json
@@ -4,7 +4,7 @@
         "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104"
       },
     "ROUTE_TABLE:20c0:fe28:0:80::/64": {
-    "nexthop": "fc00::72,fc00::76,fc00::7a,fc00::7e",
-    "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104"
+        "nexthop": "fc00::72,fc00::76,fc00::7a,fc00::7e",
+        "ifname" : "PortChannel101,PortChannel102,PortChannel103,PortChannel104"
     }
 }

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -551,7 +551,7 @@ class Test_Migrate_Loopback(object):
             diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
             assert not diff
 
-class TestWarmUpgrade_without_route_weights(object):
+class TestWarmUpgrade_without_required_attributes(object):
     @classmethod
     def setup_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
@@ -562,7 +562,7 @@ class TestWarmUpgrade_without_route_weights(object):
         dbconnector.dedicated_dbs['CONFIG_DB'] = None
         dbconnector.dedicated_dbs['APPL_DB'] = None
 
-    def test_migrate_weights_for_nexthops(self):
+    def test_migrate_weights_protocol_for_nexthops(self):
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'routes_migrate_input')
         dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'routes_migrate_input')
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I added requires "protocol" field due to fpmsyncd reconcile logic (WarmRestartHelper class) requires old fvs keys to match new fvs.

#### How I did it

Add "protocol" field in db migration.

#### How to verify it

Upgrade from older branch to new image with supported FIB pending.

The field was added by https://github.com/sonic-net/sonic-swss/pull/2551.

Now, after reboot:

```
127.0.0.1:6379> hgetall ROUTE_TABLE:0.0.0.0/0
1) "weight"
2) "1,1,1,1,1,1,1,1"
3) "protocol"
4) "bgp"
5) "ifname"
6) "PortChannel102,PortChannel105,PortChannel108,PortChannel1011,PortChannel1014,PortChannel1017,PortChannel1020,PortChannel1023"
7) "nexthop"
8) "10.0.0.1,10.0.0.5,10.0.0.9,10.0.0.13,10.0.0.17,10.0.0.21,10.0.0.25,10.0.0.29"
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

