### PR TITLE
[202205][DBMigrator] Update db_migrator to support EdgeZoneAggregator Buffer Config for T0s

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -46,7 +46,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_3_0_7' # latest version for 202205 branch
+        self.CURRENT_VERSION = 'version_3_0_6'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -262,7 +262,6 @@ class DBMigrator():
         @append_item_method - a function which is called to append an item to the list of pending commit items
                               any update to buffer configuration will be pended and won't be applied until
                               all configuration is checked and aligns with the default one
-
         1. Buffer profiles for lossless PGs in BUFFER_PROFILE table will be removed
            if their names have the convention of pg_lossless_<speed>_<cable_length>_profile
            where the speed and cable_length belongs speed_list and cable_len_list respectively
@@ -346,7 +345,6 @@ class DBMigrator():
         '''
         This is the very first warm reboot of buffermgrd (dynamic) if the system reboot from old image by warm-reboot
         In this case steps need to be taken to get buffermgrd prepared (for warm reboot)
-
         During warm reboot, buffer tables should be installed in the first place.
         However, it isn't able to achieve that when system is warm-rebooted from an old image
         without dynamic buffer supported, because the buffer info wasn't in the APPL_DB in the old image.
@@ -354,7 +352,6 @@ class DBMigrator():
         During warm-reboot, db_migrator adjusts buffer info in CONFIG_DB by removing some fields
         according to requirement from dynamic buffer calculation.
         The buffer info before that adjustment needs to be copied to APPL_DB.
-
         1. set WARM_RESTART_TABLE|buffermgrd as {restore_count: 0}
         2. Copy the following tables from CONFIG_DB into APPL_DB in case of warm reboot
            The separator in fields that reference objects in other table needs to be updated from '|' to ':'
@@ -364,7 +361,6 @@ class DBMigrator():
            - BUFFER_QUEUE, separator updated for field 'profile
            - BUFFER_PORT_INGRESS_PROFILE_LIST, separator updated for field 'profile_list'
            - BUFFER_PORT_EGRESS_PROFILE_LIST, separator updated for field 'profile_list'
-
         '''
         warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
         mmu_size = self.stateDB.get(self.stateDB.STATE_DB, 'BUFFER_MAX_PARAM_TABLE|global', 'mmu_size')
@@ -797,19 +793,10 @@ class DBMigrator():
 
     def version_2_0_2(self):
         """
-        Version 2_0_2.
+        Version 2_0_2
+        This is the latest version for 202012 branch
         """
         log.log_info('Handling version_2_0_2')
-        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
-        self.update_edgezone_aggregator_config()
-        self.set_version('version_2_0_3')
-        return 'version_2_0_3'
-
-    def version_2_0_3(self):
-        """
-        Version 2_0_3. Latest version for 202012.
-        """
-        log.log_info('Handling version_2_0_3')
         self.set_version('version_3_0_0')
         return 'version_3_0_0'
 
@@ -895,19 +882,9 @@ class DBMigrator():
 
     def version_3_0_6(self):
         """
-        Version 3_0_6.
-        """
-        log.log_info('Handling version_3_0_6')
-        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
-        self.update_edgezone_aggregator_config()
-        self.set_version('version_3_0_7')
-        return 'version_3_0_7'
-
-    def version_3_0_7(self):
-        """
         Current latest version. Nothing to do here.
         """
-        log.log_info('Handling version_3_0_7')
+        log.log_info('Handling version_3_0_6')
         return None
 
     def get_version(self):
@@ -951,6 +928,9 @@ class DBMigrator():
             log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))
 
         self.migrate_route_table()
+
+        # Updating edgezone aggregator cable length config for T0 devices
+        self.update_edgezone_aggregator_config()
 
     def migrate(self):
         version = self.get_version()

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-input.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-input.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet8": "300m",
+        "Ethernet12": "300m",
+        "Ethernet16": "5m",
+        "Ethernet20": "5m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "40m",
+        "Ethernet4": "40m",
+        "Ethernet8": "40m",
+        "Ethernet12": "40m",
+        "Ethernet16": "5m",
+        "Ethernet20": "5m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_7"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
@@ -118,6 +118,6 @@
         "Ethernet20": "5m"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_7"
+        "VERSION": "version_3_0_6"
     }
 }

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-input.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-input.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet8": "300m",
+        "Ethernet12": "300m",
+        "Ethernet16": "300m",
+        "Ethernet20": "300m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet8": "300m",
+        "Ethernet12": "300m",
+        "Ethernet16": "300m",
+        "Ethernet20": "300m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_7"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
@@ -118,6 +118,6 @@
         "Ethernet20": "300m"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_7"
+        "VERSION": "version_3_0_6"
     }
 }

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -546,3 +546,41 @@ class TestWarmUpgrade_without_route_weights(object):
             expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
             diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
             assert not diff
+
+class TestWarmUpgrade_T0_EdgeZoneAggregator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+
+    def test_warm_upgrade_t0_edgezone_aggregator_diff_cable_length(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-output')
+        expected_db = Db()
+
+        resulting_table = dbmgtr.configDB.get_table('CABLE_LENGTH')
+        expected_table = expected_db.cfgdb.get_table('CABLE_LENGTH')
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff
+
+    def test_warm_upgrade_t0_edgezone_aggregator_same_cable_length(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-same-cable-input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-same-cable-output')
+        expected_db = Db()
+
+        resulting_table = dbmgtr.configDB.get_table('CABLE_LENGTH')
+        expected_table = expected_db.cfgdb.get_table('CABLE_LENGTH')
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Updated dbmigrator to support warm upgrade to new buffer config for EdgeZoneAggregator neighbors.

#### How I did it
Created a new version checkpoint for the change and made appropriate changes to the ConfigDB.

#### How to verify it
Unit tests pass and tested on lab device

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

