### PR TITLE
[202211][DBMigrator] Update db_migrator to support EdgeZoneAggregator Buffer Config for T0s

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -45,7 +45,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_4_0_2' # latest version for 202211 branch
+        self.CURRENT_VERSION = 'version_4_0_1'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -265,7 +265,6 @@ class DBMigrator():
         @append_item_method - a function which is called to append an item to the list of pending commit items
                               any update to buffer configuration will be pended and won't be applied until
                               all configuration is checked and aligns with the default one
-
         1. Buffer profiles for lossless PGs in BUFFER_PROFILE table will be removed
            if their names have the convention of pg_lossless_<speed>_<cable_length>_profile
            where the speed and cable_length belongs speed_list and cable_len_list respectively
@@ -349,7 +348,6 @@ class DBMigrator():
         '''
         This is the very first warm reboot of buffermgrd (dynamic) if the system reboot from old image by warm-reboot
         In this case steps need to be taken to get buffermgrd prepared (for warm reboot)
-
         During warm reboot, buffer tables should be installed in the first place.
         However, it isn't able to achieve that when system is warm-rebooted from an old image
         without dynamic buffer supported, because the buffer info wasn't in the APPL_DB in the old image.
@@ -357,7 +355,6 @@ class DBMigrator():
         During warm-reboot, db_migrator adjusts buffer info in CONFIG_DB by removing some fields
         according to requirement from dynamic buffer calculation.
         The buffer info before that adjustment needs to be copied to APPL_DB.
-
         1. set WARM_RESTART_TABLE|buffermgrd as {restore_count: 0}
         2. Copy the following tables from CONFIG_DB into APPL_DB in case of warm reboot
            The separator in fields that reference objects in other table needs to be updated from '|' to ':'
@@ -367,7 +364,6 @@ class DBMigrator():
            - BUFFER_QUEUE, separator updated for field 'profile
            - BUFFER_PORT_INGRESS_PROFILE_LIST, separator updated for field 'profile_list'
            - BUFFER_PORT_EGRESS_PROFILE_LIST, separator updated for field 'profile_list'
-
         '''
         warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
         mmu_size = self.stateDB.get(self.stateDB.STATE_DB, 'BUFFER_MAX_PARAM_TABLE|global', 'mmu_size')
@@ -783,19 +779,10 @@ class DBMigrator():
 
     def version_2_0_2(self):
         """
-        Version 2_0_2.
+        Version 2_0_2
+        This is the latest version for 202012 branch
         """
         log.log_info('Handling version_2_0_2')
-        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
-        self.update_edgezone_aggregator_config()
-        self.set_version('version_2_0_3')
-        return 'version_2_0_3'
-
-    def version_2_0_3(self):
-        """
-        Version 2_0_3. Latest version for 202012.
-        """
-        log.log_info('Handling version_2_0_3')
         self.set_version('version_3_0_0')
         return 'version_3_0_0'
 
@@ -892,19 +879,11 @@ class DBMigrator():
 
     def version_3_0_6(self):
         """
-        Version 3_0_6.
+        Version 3_0_6
+        This is the latest version for 202211 branch
         """
-        log.log_info('Handling version_3_0_6')
-        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
-        self.update_edgezone_aggregator_config()
-        self.set_version('version_3_0_7')
-        return 'version_3_0_7'
 
-    def version_3_0_7(self):
-        """
-        Version 3_0_7. Latest version for 202205.
-        """
-        log.log_info('Handling version_3_0_7')
+        log.log_info('Handling version_3_0_6')
         self.set_version('version_4_0_0')
         return 'version_4_0_0'
 
@@ -930,18 +909,9 @@ class DBMigrator():
     def version_4_0_1(self):
         """
         Version 4_0_1.
+        This is the latest version for master branch
         """
         log.log_info('Handling version_4_0_1')
-        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
-        self.update_edgezone_aggregator_config()
-        self.set_version('version_4_0_2')
-        return 'version_4_0_2'
-
-    def version_4_0_2(self):
-        """
-        Version 4_0_2. Latest version for branch 202211.
-        """
-        log.log_info('Handling version_4_0_2')
         return None
 
     def get_version(self):
@@ -987,6 +957,9 @@ class DBMigrator():
             self.migrate_mgmt_ports_on_s6100()
         else:
             log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))
+
+        # Updating edgezone aggregator cable length config for T0 devices
+        self.update_edgezone_aggregator_config()
 
     def migrate(self):
         version = self.get_version()

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -45,7 +45,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_4_0_1'
+        self.CURRENT_VERSION = 'version_4_0_2' # latest version for 202211 branch
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -167,7 +167,7 @@ class DBMigrator():
             self.appDB.set(self.appDB.APPL_DB, 'PORT_TABLE:PortConfigDone', 'count', str(total_count))
             log.log_notice("Port count updated from {} to : {}".format(portCount, self.appDB.get(self.appDB.APPL_DB, 'PORT_TABLE:PortConfigDone', 'count')))
         return True
-        
+
     def migrate_intf_table(self):
         '''
         Migrate all data from existing INTF table in APP DB during warmboot with IP Prefix
@@ -572,12 +572,56 @@ class DBMigrator():
         dscp_to_tc_map_table_names = self.configDB.get_keys('DSCP_TO_TC_MAP')
         if len(dscp_to_tc_map_table_names) == 0:
             return
-        
+
         qos_maps = self.configDB.get_table('PORT_QOS_MAP')
         if 'global' not in qos_maps.keys():
             # We are unlikely to have more than 1 DSCP_TO_TC_MAP in previous versions
             self.configDB.set_entry('PORT_QOS_MAP', 'global', {"dscp_to_tc_map": dscp_to_tc_map_table_names[0]})
             log.log_info("Created entry for global DSCP_TO_TC_MAP {}".format(dscp_to_tc_map_table_names[0]))
+
+    def update_edgezone_aggregator_config(self):
+        """
+        Update cable length configuration in ConfigDB for T0 neighbor interfaces
+        connected to EdgeZone Aggregator devices, while resetting the port values to trigger a buffer change
+        1. Find a list of all interfaces connected to an EdgeZone Aggregator device.
+        2. If all the cable lengths are the same, do nothing and return.
+        3. If there are different cable lengths, update CABLE_LENGTH values for these interfaces with a constant value of 40m.
+        """
+        device_neighbor_metadata = self.configDB.get_table("DEVICE_NEIGHBOR_METADATA")
+        device_neighbors = self.configDB.get_table("DEVICE_NEIGHBOR")
+        cable_length = self.configDB.get_table("CABLE_LENGTH")
+        port_table = self.configDB.get_table("PORT")
+        edgezone_aggregator_devs = []
+        edgezone_aggregator_intfs = []
+        EDGEZONE_AGG_CABLE_LENGTH = "40m"
+        for k, v in device_neighbor_metadata.items():
+            if v.get("type") == "EdgeZoneAggregator":
+                    edgezone_aggregator_devs.append(k)
+
+        if len(edgezone_aggregator_devs) == 0:
+            return
+
+        for intf, intf_info in device_neighbors.items():
+            if intf_info.get("name") in edgezone_aggregator_devs:
+                edgezone_aggregator_intfs.append(intf)
+
+        cable_length_table = self.configDB.get_entry("CABLE_LENGTH", "AZURE")
+        first_cable_intf = next(iter(cable_length_table))
+        first_cable_length = cable_length_table[first_cable_intf]
+        index = 0
+
+        for intf, length in cable_length_table.items():
+            index += 1
+            if first_cable_length != length:
+                break
+            elif index == len(cable_length_table):
+                # All cable lengths are the same, nothing to modify
+                return
+
+        for intf, length in cable_length_table.items():
+            if intf in edgezone_aggregator_intfs:
+                # Set new cable length values
+                self.configDB.set(self.configDB.CONFIG_DB, "CABLE_LENGTH|AZURE", intf, EDGEZONE_AGG_CABLE_LENGTH)
 
     def version_unknown(self):
         """
@@ -739,10 +783,19 @@ class DBMigrator():
 
     def version_2_0_2(self):
         """
-        Version 2_0_2
-        This is the latest version for 202012 branch 
+        Version 2_0_2.
         """
         log.log_info('Handling version_2_0_2')
+        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
+        self.update_edgezone_aggregator_config()
+        self.set_version('version_2_0_3')
+        return 'version_2_0_3'
+
+    def version_2_0_3(self):
+        """
+        Version 2_0_3. Latest version for 202012.
+        """
+        log.log_info('Handling version_2_0_3')
         self.set_version('version_3_0_0')
         return 'version_3_0_0'
 
@@ -839,11 +892,19 @@ class DBMigrator():
 
     def version_3_0_6(self):
         """
-        Version 3_0_6
-        This is the latest version for 202211 branch
+        Version 3_0_6.
         """
-
         log.log_info('Handling version_3_0_6')
+        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
+        self.update_edgezone_aggregator_config()
+        self.set_version('version_3_0_7')
+        return 'version_3_0_7'
+
+    def version_3_0_7(self):
+        """
+        Version 3_0_7. Latest version for 202205.
+        """
+        log.log_info('Handling version_3_0_7')
         self.set_version('version_4_0_0')
         return 'version_4_0_0'
 
@@ -865,13 +926,22 @@ class DBMigrator():
         self.stateDB.set(self.stateDB.STATE_DB, 'FAST_RESTART_ENABLE_TABLE|system', 'enable', enable_state)
         self.set_version('version_4_0_1')
         return 'version_4_0_1'
-    
+
     def version_4_0_1(self):
         """
         Version 4_0_1.
-        This is the latest version for master branch
         """
         log.log_info('Handling version_4_0_1')
+        # Update cable length data and re-assign interface speed for T0 devices with interfaces connected to EdgeZone Aggregators
+        self.update_edgezone_aggregator_config()
+        self.set_version('version_4_0_2')
+        return 'version_4_0_2'
+
+    def version_4_0_2(self):
+        """
+        Version 4_0_2. Latest version for branch 202211.
+        """
+        log.log_info('Handling version_4_0_2')
         return None
 
     def get_version(self):
@@ -913,7 +983,7 @@ class DBMigrator():
         # removed together with calling to migrate_copp_table function.
         if self.asic_type != "mellanox":
             self.migrate_copp_table()
-        if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:            
+        if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:
             self.migrate_mgmt_ports_on_s6100()
         else:
             log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-input.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-input.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet8": "300m",
+        "Ethernet12": "300m",
+        "Ethernet16": "5m",
+        "Ethernet20": "5m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "40m",
+        "Ethernet4": "40m",
+        "Ethernet8": "40m",
+        "Ethernet12": "40m",
+        "Ethernet16": "5m",
+        "Ethernet20": "5m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_4_0_2"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-output.json
@@ -118,6 +118,6 @@
         "Ethernet20": "5m"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_4_0_2"
+        "VERSION": "version_4_0_1"
     }
 }

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-input.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-input.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet8": "300m",
+        "Ethernet12": "300m",
+        "Ethernet16": "300m",
+        "Ethernet20": "300m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
@@ -1,0 +1,123 @@
+{
+    "DEVICE_NEIGHBOR_METADATA|ARISTA01T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA02T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA03T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR_METADATA|ARISTA04T1": {
+        "hwsku": "Arista-VM",
+        "mgmt_addr": "10.64.247.200",
+        "type": "EdgeZoneAggregator"
+    },
+    "DEVICE_NEIGHBOR|Ethernet0": {
+        "name": "ARISTA01T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet4": {
+        "name": "ARISTA02T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet8": {
+        "name": "ARISTA03T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet12": {
+        "name": "ARISTA04T1",
+        "port": "Ethernet1"
+    },
+    "DEVICE_NEIGHBOR|Ethernet16": {
+        "name": "Servers1",
+        "port": "eth0"
+    },
+    "DEVICE_NEIGHBOR|Ethernet20": {
+        "name": "Servers2",
+        "port": "eth0"
+    },
+    "PORT|Ethernet0": {
+        "admin_status": "up",
+        "alias": "Ethernet1/1",
+        "description": "",
+        "index": "1",
+        "lanes": "77,78",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet4": {
+        "admin_status": "up",
+        "alias": "Ethernet2/1",
+        "description": "",
+        "index": "2",
+        "lanes": "79,80",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet8": {
+        "admin_status": "up",
+        "alias": "Ethernet3/1",
+        "description": "",
+        "index": "3",
+        "lanes": "81,82",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet12": {
+        "admin_status": "up",
+        "alias": "Ethernet4/1",
+        "description": "",
+        "index": "4",
+        "lanes": "83,84",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet16": {
+        "admin_status": "up",
+        "alias": "Ethernet5/1",
+        "description": "",
+        "index": "5",
+        "lanes": "85,86",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "PORT|Ethernet20": {
+        "admin_status": "up",
+        "alias": "Ethernet6/1",
+        "description": "",
+        "index": "6",
+        "lanes": "87,88",
+        "mtu": "9100",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "tpid": "0x8100"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet0": "300m",
+        "Ethernet4": "300m",
+        "Ethernet8": "300m",
+        "Ethernet12": "300m",
+        "Ethernet16": "300m",
+        "Ethernet20": "300m"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_4_0_2"
+    }
+}

--- a/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
+++ b/tests/db_migrator_input/config_db/sample-t0-edgezoneagg-config-same-cable-output.json
@@ -118,6 +118,6 @@
         "Ethernet20": "300m"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_4_0_2"
+        "VERSION": "version_4_0_1"
     }
 }

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -409,7 +409,7 @@ class TestGlobalDscpToTcMapMigrator(object):
         dbmgtr_mlnx.migrate()
         resulting_table = dbmgtr_mlnx.configDB.get_table('PORT_QOS_MAP')
         assert resulting_table == {}
-        
+
 class TestMoveLoggerTablesInWarmUpgrade(object):
     @classmethod
     def setup_class(cls):
@@ -468,11 +468,11 @@ class TestFastRebootTableModification(object):
         device_info.get_sonic_version_info = get_sonic_version_info_mlnx
         dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'fast_reboot_input')
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'empty-config-input')
-        
+
         import db_migrator
         dbmgtr = db_migrator.DBMigrator(None)
         dbmgtr.migrate()
-        
+
         dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'fast_reboot_expected')
         expected_db = SonicV2Connector(host='127.0.0.1')
         expected_db.connect(expected_db.STATE_DB)
@@ -550,3 +550,41 @@ class Test_Migrate_Loopback(object):
             expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
             diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
             assert not diff
+
+class TestWarmUpgrade_T0_EdgeZoneAggregator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+
+    def test_warm_upgrade_t0_edgezone_aggregator_diff_cable_length(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-output')
+        expected_db = Db()
+
+        resulting_table = dbmgtr.configDB.get_table('CABLE_LENGTH')
+        expected_table = expected_db.cfgdb.get_table('CABLE_LENGTH')
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff
+
+    def test_warm_upgrade_t0_edgezone_aggregator_same_cable_length(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-same-cable-input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'sample-t0-edgezoneagg-config-same-cable-output')
+        expected_db = Db()
+
+        resulting_table = dbmgtr.configDB.get_table('CABLE_LENGTH')
+        expected_table = expected_db.cfgdb.get_table('CABLE_LENGTH')
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Updated dbmigrator to support warm upgrade to new buffer config for EdgeZoneAggregator neighbors.

#### How I did it
Created a new version checkpoint for the change and made appropriate changes to the ConfigDB.

#### How to verify it
Unit tests pass and tested on lab device

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

