### PR TITLE
[GCU] Prohibit removal of PFC_WD POLL_INTERVAL field

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -2,6 +2,9 @@ import click
 import ipaddress
 import re
 from swsscommon.swsscommon import ConfigDBConnector
+from .validated_config_db_connector import ValidatedConfigDBConnector
+from jsonpatch import JsonPatchConflict
+from jsonpointer import JsonPointerException
 import utilities_common.cli as clicommon
 
 RADIUS_MAXSERVERS = 8
@@ -477,15 +480,16 @@ radius.add_command(statistics)
 def add(address, retransmit, timeout, key, auth_type, auth_port, pri, use_mgmt_vrf, source_interface):
     """Specify a RADIUS server"""
 
-    if key:
-        if len(key) > RADIUS_PASSKEY_MAX_LEN:
-            click.echo('--key: Maximum of %d chars can be configured' % RADIUS_PASSKEY_MAX_LEN)
-            return
-        elif not is_secret(key):
-            click.echo('--key: ' + VALID_CHARS_MSG)
-            return
+    if ADHOC_VALIDATION:
+        if key:
+            if len(key) > RADIUS_PASSKEY_MAX_LEN:
+                click.echo('--key: Maximum of %d chars can be configured' % RADIUS_PASSKEY_MAX_LEN)
+                return
+            elif not is_secret(key):
+                click.echo('--key: ' + VALID_CHARS_MSG)
+                return
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     old_data = config_db.get_table('RADIUS_SERVER')
     if address in old_data :
@@ -508,16 +512,24 @@ def add(address, retransmit, timeout, key, auth_type, auth_port, pri, use_mgmt_v
             data['passkey'] = key
         if use_mgmt_vrf :
             data['vrf'] = "mgmt"
-        if source_interface :
-            if (source_interface.startswith("Ethernet") or \
-                source_interface.startswith("PortChannel") or \
-                source_interface.startswith("Vlan") or \
-                source_interface.startswith("Loopback") or \
-                source_interface == "eth0"):
+        if ADHOC_VALIDATION:
+            if source_interface :
+                if (source_interface.startswith("Ethernet") or \
+                    source_interface.startswith("PortChannel") or \
+                    source_interface.startswith("Vlan") or \
+                    source_interface.startswith("Loopback") or \
+                    source_interface == "eth0"):
+                    data['src_intf'] = source_interface
+                else:
+                    click.echo('Not supported interface name (valid interface name: Etherent<id>/PortChannel<id>/Vlan<id>/Loopback<id>/eth0)')
+        else:
+            if source_interface:
                 data['src_intf'] = source_interface
-            else:
-                click.echo('Not supported interface name (valid interface name: Etherent<id>/PortChannel<id>/Vlan<id>/Loopback<id>/eth0)')
-        config_db.set_entry('RADIUS_SERVER', address, data)
+        try:
+            config_db.set_entry('RADIUS_SERVER', address, data)
+        except ValueError as e:
+            ctx = click.get_current_context()
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 radius.add_command(add)
 
 
@@ -528,7 +540,11 @@ radius.add_command(add)
 def delete(address):
     """Delete a RADIUS server"""
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
-    config_db.set_entry('RADIUS_SERVER', address, None)
+    try:
+        config_db.set_entry('RADIUS_SERVER', address, None)
+    except (JsonPointerException, JsonPatchConflict) as e:
+        ctx = click.get_current_context()
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 radius.add_command(delete)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
-Add new infrastructure to GCU for validation of moves that YANG models are unable to capture
-Prohibit deletion of PFC_WD POLL_INTERVAL field

#### How I did it
- Ensure JSON Diff does not have POLL_INTERVAL deletion
- If diff reflects request for POLL_INTERVAL deletion, raise an Exception and do not allow patch application to go through

#### How to verify it
Attempt to delete POLL_INTERVAL field using GCU

Please note that this is different than the create-only extension, which is described here: https://github.com/sonic-net/SONiC/blob/master/doc/config-generic-update-rollback/Json_Patch_Ordering_using_YANG_Models_Design.md#313-using-yang-models-to-host-flags-for-move-validation
create-only is programmed as a MoveValidator in GCU, but that is different than the use case necessary for this PR. We don't want to validate each intermediate move to get to the final state, as is done by MoveValidators- we just need to validate the initial request. Additionally, MoveValidators continue searching for a different move that is 'valid' if it finds one invalid - possibly by deleting the parent and then readding other children. This is not the behavior we desire. We only need a check of the initial request (reflected in Json diff).  

#### Previous command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ sudo config apply-patch patch.json
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating all JsonPatch operations are permitted on the specified fields
Patch Applier: Validating target config does not have empty tables, since they do not show up in ConfigDb.
Patch Applier: Sorting patch updates.
Patch Applier: The patch was sorted into 1 change:
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Applying 1 change in order:
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Verifying patch updates are reflected on ConfigDB.
Patch Applier: Patch application completed.
Patch applied successfully.
```
#### New command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ sudo config apply-patch patch.json
Patch Applier: Patch application starting.
Patch Applier: Patch: [{"op": "remove", "path": "/PFC_WD/GLOBAL/POLL_INTERVAL"}]
Patch Applier: Getting current config db.
Patch Applier: Simulating the target full config after applying the patch.
Patch Applier: Validating all JsonPatch operations are permitted on the specified fields
Failed to apply patch
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Given patch operation is invalid. Operation: remove is illegal on field: /PFC_WD/GLOBAL/POLL_INTERVAL
```
