### PR TITLE
[202205] [ci] Use regular build of swsscommon

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ stages:
         source: specific
         project: build
         pipeline: 9
-        artifact: sonic-swss-common.bullseye.amd64
+        artifact: sonic-swss-common
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/$(sourceBranch)'
       displayName: "Download sonic swss common deb packages"


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

The 202205 branch of sonic-swss-common doesn't have a package built on Bullseye; it's only built for Buster. However, it also doesn't have any dependency on Boost, which suggests it is probably installable on Bullseye.

Therefore, just use the Buster build of swsscommon on Bullseye.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

