### PR TITLE
Update pcieutil error message on loading common pcie module

### DIFF
--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -119,6 +119,6 @@ def vlanintf_validator(old_config, upd_config, keys):
     for key in deleted_keys:
         iface, iface_ip = key
         rc = os.system(f"ip neigh flush dev {iface} {iface_ip}")
-        if not rc:
+        if rc:
             return False
     return True

--- a/pcieutil/main.py
+++ b/pcieutil/main.py
@@ -54,7 +54,7 @@ def load_platform_pcieutil():
         from sonic_platform.pcie import Pcie
         platform_pcieutil = Pcie(platform_path)
     except ImportError as e:
-        log.log_warning("Failed to load platform Pcie module. Error : {}, fallback to load Pcie common utility.".format(str(e)), True)
+        log.log_warning("Failed to load platform Pcie module. Warning : {}, fallback to load Pcie common utility.".format(str(e)))
         try:
             from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
             platform_pcieutil = PcieUtil(platform_path)

--- a/tests/pcieutil_test.py
+++ b/tests/pcieutil_test.py
@@ -3,6 +3,7 @@ import os
 from unittest import mock
 
 from click.testing import CliRunner
+from io import StringIO
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -201,13 +202,12 @@ class TestPcieUtil(object):
         result = runner.invoke(pcieutil.cli.commands["pcie-aer"].commands["correctable"], ["-d", "0:1.0"])
         assert result.output == pcieutil_pcie_aer_correctable_dev_output
 
-    def test_load_pcie_module_warning(self):
-        runner = CliRunner()
-        sys_path = sys.path
-        sys.path = ['']
-        result = runner.invoke(pcieutil.cli.commands["show"])
-        assert pcieutil_load_module_warning_msg not in result.output
-        sys.path = sys_path
+    def test_load_pcie_module_warning(self): 
+        stdout = sys.stdout
+        sys.stdout = result = StringIO()
+        pcieutil.load_platform_pcieutil()
+        sys.stdout = stdout
+        assert pcieutil_load_module_warning_msg not in result.get_value()
 
     @classmethod
     def teardown_class(cls):

--- a/tests/pcieutil_test.py
+++ b/tests/pcieutil_test.py
@@ -199,6 +199,11 @@ class TestPcieUtil(object):
         result = runner.invoke(pcieutil.cli.commands["pcie-aer"].commands["correctable"], ["-d", "0:1.0"])
         assert result.output == pcieutil_pcie_aer_correctable_dev_output
 
+    def test_load_pcie_module_warning(self):
+        runner = CliRunner()
+        result = runner.invoke(pcieutil.cli.commands["show"])
+        assert "Failed to load platform Pcie module. Warning : No module named 'sonic_platform.pcie', fallback to load Pcie common utility." not in result.output
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/tests/pcieutil_test.py
+++ b/tests/pcieutil_test.py
@@ -156,6 +156,8 @@ pcieutil_pcie_aer_correctable_dev_output = """\
 +---------------------+-----------+
 """
 
+pcieutil_load_module_warning_msg = "Failed to load platform Pcie module. Warning : No module named 'sonic_platform.pcie', fallback to load Pcie common utility."
+
 class TestPcieUtil(object):
     @classmethod
     def setup_class(cls):
@@ -201,8 +203,11 @@ class TestPcieUtil(object):
 
     def test_load_pcie_module_warning(self):
         runner = CliRunner()
+        sys_path = sys.path
+        sys.path = ['']
         result = runner.invoke(pcieutil.cli.commands["show"])
-        assert "Failed to load platform Pcie module. Warning : No module named 'sonic_platform.pcie', fallback to load Pcie common utility." not in result.output
+        assert pcieutil_load_module_warning_msg not in result.output
+        sys.path = sys_path
 
     @classmethod
     def teardown_class(cls):

--- a/tests/pcieutil_test.py
+++ b/tests/pcieutil_test.py
@@ -205,9 +205,12 @@ class TestPcieUtil(object):
     def test_load_pcie_module_warning(self): 
         stdout = sys.stdout
         sys.stdout = result = StringIO()
-        pcieutil.load_platform_pcieutil()
+        try:
+            pcieutil.load_platform_pcieutil()
+        except ImportError:
+            pass
         sys.stdout = stdout
-        assert pcieutil_load_module_warning_msg not in result.get_value()
+        assert pcieutil_load_module_warning_msg not in result.getvalue()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Currently, pcieutil will print the following message to console every time it is called if loading the common module:
root@sonic:/home/cisco# pcieutil show
Failed to load platform Pcie module. Error : No module named 'sonic_platform.pcie', fallback to load Pcie common utility.
==============================Display PCIe Device===============================

#### What I did
Update the error message to only be logged in syslog, rather than print to console.

#### How to verify it
Run any pcieutil command

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/cisco# pcieutil show
Failed to load platform Pcie module. Error : No module named 'sonic_platform.pcie', fallback to load Pcie common utility.
==============================Display PCIe Device===============================
......
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/cisco# pcieutil show
==============================Display PCIe Device===============================
.....
```
