### PR TITLE
Remove the additional new line in the command show version

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1297,7 +1297,7 @@ def version(verbose):
     sys_date = datetime.now()
 
     click.echo("\nSONiC Software Version: SONiC.{}".format(version_info['build_version']))
-    click.echo("\nSONiC OS Version: {}".format(version_info['sonic_os_version']))
+    click.echo("SONiC OS Version: {}".format(version_info['sonic_os_version']))
     click.echo("Distribution: Debian {}".format(version_info['debian_version']))
     click.echo("Kernel: {}".format(version_info['kernel_version']))
     click.echo("Build commit: {}".format(version_info['commit_id']))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Remove the additional new line in the command show version, the new line character is no use.
```
SONiC Software Version: SONiC.master-14619.252155-d7c9d3b7d

SONiC OS Version: 11
Distribution: Debian 11.6
```
Change to:
```
SONiC Software Version: SONiC.master-14619.252155-d7c9d3b7d
SONiC OS Version: 11
Distribution: Debian 11.6
```
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

