### PR TITLE
[Clock] Implement clock CLI

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -543,6 +543,62 @@ This command displays the current date and time configured on the system
   Mon Mar 25 20:25:16 UTC 2019
   ```
 
+**config clock date**
+	
+This command will set the date-time of the systetm, given strings with date-time format <YYYY-MM-DD> <HH:MM:SS>
+
+- Usage:
+  ```
+  config clock date <YYYY-MM-DD> <HH:MM:SS>
+  ```
+
+- Parameters:
+  - _date_: valid date in format YYYY-MM-DD
+  - _time_: valid time in format HH:MM:SS
+
+- Example:
+  ```
+  admin@sonic:~$ config clock date 2023-04-10 13:54:36
+  ```
+
+**config clock timezone**
+	
+This command will set the timezone of the systetm, given a string of a valid timezone.
+
+- Usage:
+  ```
+  config clock timezone <timezone>
+  ```
+
+- Parameters:
+  - _timezone_: valid timezone to be configured
+	
+	
+- Example:
+  ```
+  admin@sonic:~$ config clock timezone Africa/Accra
+
+	
+**show clock timezones**
+
+This command Will display list of all valid timezones to be configured.
+
+- Usage:
+  ```
+  show clock timezones
+  ```
+
+- Example:
+  ```
+  root@host:~$ show clock timezones
+  Africa/Abidjan
+  Africa/Accra
+  Africa/Addis_Ababa
+  Africa/Algiers
+  Africa/Asmara
+  ...
+  ```
+
 **show boot**
 
 This command displays the current OS image, the image to be loaded on next reboot, and lists all the available images installed on the device

--- a/show/main.py
+++ b/show/main.py
@@ -1771,13 +1771,32 @@ def uptime(verbose):
     cmd = ['uptime', '-p']
     run_command(cmd, display_cmd=verbose)
 
-@cli.command()
-@click.option('--verbose', is_flag=True, help="Enable verbose output")
-def clock(verbose):
-    """Show date and time"""
-    cmd = ["date"]
-    run_command(cmd, display_cmd=verbose)
 
+#
+# 'clock' command group ("show clock ...")
+#
+@cli.group('clock', invoke_without_command=True)
+@click.pass_context
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def clock(ctx, verbose):
+    """Show date and time"""
+    # If invoking subcomand, no need to do anything
+    if ctx.invoked_subcommand is not None:
+        return
+
+    run_command(['date'], display_cmd=verbose)
+
+
+@clock.command()
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def timezones(verbose):
+    """List of available timezones"""
+    run_command(['timedatectl', 'list-timezones'], display_cmd=verbose)
+
+
+#
+# 'system-memory' command ("show system-memory")
+#
 @cli.command('system-memory')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def system_memory(verbose):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2363,3 +2363,65 @@ class TestConfigInterface(object):
     def teardown(self):
         print("TEARDOWN")
 
+
+class TestConfigClock(object):
+    timezone_test_val = ['Europe/Kyiv', 'Asia/Israel', 'UTC']
+
+    @classmethod
+    def setup_class(cls):
+        print('SETUP')
+        import config.main
+        importlib.reload(config.main)
+
+    @patch('config.main.get_tzs', mock.Mock(return_value=timezone_test_val))
+    def test_timezone_good(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['timezone'],
+            ['UTC'], obj=obj)
+
+        assert result.exit_code == 0
+
+    @patch('config.main.get_tzs', mock.Mock(return_value=timezone_test_val))
+    def test_timezone_bad(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['timezone'],
+            ['Atlantis'], obj=obj)
+
+        assert result.exit_code != 0
+        assert 'Timezone Atlantis does not conform format' in result.output
+
+    @patch('utilities_common.cli.run_command',
+           mock.MagicMock(side_effect=mock_run_command_side_effect))
+    def test_date_good(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['date'],
+            ['2020-10-10', '10:20:30'], obj=obj)
+
+        assert result.exit_code == 0
+
+    @patch('utilities_common.cli.run_command',
+           mock.MagicMock(side_effect=mock_run_command_side_effect))
+    def test_date_bad(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['date'],
+            ['20-10-10', '60:70:80'], obj=obj)
+
+        assert result.exit_code != 0
+        assert 'Date 20-10-10 does not conform format' in result.output
+        assert 'Time 60:70:80 does not conform format' in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print('TEARDOWN')

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -927,6 +927,15 @@ class TestShow(object):
         mock_run_command.assert_called_with(['date'], display_cmd=True)
 
     @patch('show.main.run_command')
+    def test_show_timezone(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['clock'].commands['timezones'], ['--verbose'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['timedatectl', 'list-timezones'], display_cmd=True)
+
+    @patch('show.main.run_command')
     def test_show_system_memory(self, mock_run_command):
         runner = CliRunner()
         result = runner.invoke(show.cli.commands['system-memory'], ['--verbose'])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
hld [#1219](https://github.com/sonic-net/SONiC/pull/1219)
closes [#1171](https://github.com/sonic-net/SONiC/issues/1171)

#### What I did
* Add command to configure date and time
* Add command to configure timezone
* Add command to show timezones

#### How to verify it
Show clock and timezones:
```
show clock
show clock timezones
```
Set date and time and verify:
```
sudo config clock date-time <date> <time>
show clock
```
Set timezone and verify:
```
sudo config clock timezone <timezone>
show clock
```

#### Previous command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show clock
Sat 10 Oct 2020 01:02:20 AM HDT
```
#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show clock
Sat 10 Oct 2020 01:02:20 AM HDT
```
```
admin@sonic:~$ show clock timezones
Africa/Abidjan
Africa/Accra
### More data here ##
Pacific/Wallis
UTC
Etc/UTC
```
```
admin@sonic:~$ sudo config clock timezone Europe/Ki # <TAB><TAB>
Europe/Kiev   Europe/Kirov
admin@sonic:~$ sudo config clock timezone Europe/Kiev
admin@sonic:~$ sudo config clock timezone Europe/Kie
Timezone Europe/Kie does not conform format
```
```
admin@sonic:~$ sudo config clock date 2020-10-11 1:2:4
admin@sonic:~$ sudo config clock date 20-40-50 60:70:80
Date 20-40-50 does not conform format YYYY-MM-DD
Time 60:70:80 does not conform format HH:MM:SS
```