### PR TITLE
[acl-loader] Support for ACL table type L3V4V6

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1520,7 +1520,7 @@ This command is used to create new ACL tables.
 
 - Parameters:
   - table_name: The name of the ACL table to create.
-  - table_type: The type of ACL table to create (e.g. "L3", "L3V6", "MIRROR")
+  - table_type: The type of ACL table to create (e.g. "L3", "L3V6", "L3V4V6", "MIRROR")
   - description: A description of the table for the user. (default is the table_name)
   - ports: A comma-separated list of ports/interfaces to add to the table. The behavior is as follows:
     - Physical ports will be bound as physical ports

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -316,6 +316,90 @@
 					"config": {
 						"name": "bmc_acl_northbound_v6"
 					}
+				},
+				"DATAACLV4V6": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"vlan-id": "369",
+										"ethertype": "ETHERTYPE_IPV4"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_TCP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								}
+							},
+							"2": {
+								"config": {
+									"sequence-id": 2
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"ethertype": "ETHERTYPE_IPV6"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "::1/128",
+										"destination-ip-address": "::1/128"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "1",
+										"code": "0"
+									}
+								}
+							},
+							"3": {
+								"config": {
+									"sequence-id": 3
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"ethertype": "ETHERTYPE_IPV6"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "::1/128",
+										"destination-ip-address": "::1/128"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "128"
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}

--- a/tests/acl_input/illegal_v4v6_rule_no_ethertype.json
+++ b/tests/acl_input/illegal_v4v6_rule_no_ethertype.json
@@ -1,0 +1,109 @@
+{
+	"acl": {
+		"acl-sets": {
+			"acl-set": {
+				"DATAACLV4V6": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_TCP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								}
+							},
+							"2": {
+								"config": {
+									"sequence-id": 2
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"ethertype": "ETHERTYPE_IPV6"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "::1/128",
+										"destination-ip-address": "::1/128"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "1",
+										"code": "0"
+									}
+								}
+							},
+							"3": {
+								"config": {
+									"sequence-id": 3
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "::1/128",
+										"destination-ip-address": "::1/128"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "1"
+									}
+								}
+							},
+							"4": {
+								"config": {
+									"sequence-id": 2
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"l2": {
+									"config": {
+										"ethertype": "ETHERTYPE_IPV4"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "IP_ICMP",
+										"source-ip-address": "20.0.0.2/32",
+										"destination-ip-address": "30.0.0.3/32"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "1",
+										"code": "0"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -21,7 +21,7 @@ class TestAclLoader(object):
 
     def test_valid(self):
         yang_acl = AclLoader.parse_acl_json(os.path.join(test_path, 'acl_input/acl1.json'))
-        assert len(yang_acl.acl.acl_sets.acl_set) == 8
+        assert len(yang_acl.acl.acl_sets.acl_set) == 9
 
     def test_invalid(self):
         with pytest.raises(AclLoaderException):
@@ -95,6 +95,42 @@ class TestAclLoader(object):
             "PRIORITY": "9997"
         }
 
+    def test_v4_rule_inv4v6_table(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("DATAACLV4V6", "RULE_1")]
+        assert acl_loader.rules_info[("DATAACLV4V6", "RULE_1")] == {
+            "VLAN_ID": 369,
+            "ETHER_TYPE": 2048,
+            "IP_PROTOCOL": 6,
+            "SRC_IP": "20.0.0.2/32",
+            "DST_IP": "30.0.0.3/32",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9999"
+        }
+
+    def test_v6_rule_inv4v6_table(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("DATAACLV4V6", "RULE_2")]
+        assert acl_loader.rules_info[("DATAACLV4V6", "RULE_2")] == {
+            "ETHER_TYPE": 34525,
+            "IP_PROTOCOL": 58,
+            "SRC_IPV6": "::1/128",
+            "DST_IPV6": "::1/128",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9998",
+            'ICMPV6_CODE': 0,
+            'ICMPV6_TYPE': 1
+        }
+
+    def test_rule_without_ethertype_inv4v6(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_v4v6_rule_no_ethertype.json'))
+        assert not acl_loader.rules_info.get(("DATAACLV4V6", "RULE_1"))
+        assert acl_loader.rules_info[("DATAACLV4V6", "RULE_2")]
+        assert not acl_loader.rules_info.get(("DATAACLV4V6", "RULE_3"))
+
     def test_icmp_translation(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
@@ -151,6 +187,12 @@ class TestAclLoader(object):
             'PACKET_ACTION': 'DROP',
             'IP_TYPE': 'IPV6ANY'
         }
+        assert acl_loader.rules_info[('DATAACLV4V6', 'DEFAULT_RULE')] == {
+            'PRIORITY': '1',
+            'PACKET_ACTION': 'DROP',
+            'IP_TYPE': 'IP'
+        }
+
         # Verify acl-loader doesn't add default deny rule to MIRROR
         assert ('EVERFLOW', 'DEFAULT_RULE') not in acl_loader.rules_info
         # Verify acl-loader doesn't add default deny rule to MIRRORV6

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -90,7 +90,7 @@ RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 15
+Total number of ACL Tables: 16
 Total number of ACL Rules: 21
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -556,6 +556,17 @@
         "type": "L3",
         "stage": "ingress"
     },
+  "ACL_TABLE|DATAACLV4V6": {
+    "expireat": 1602451533.237415,
+    "ttl": -0.001,
+    "type": "hash",
+    "value": {
+      "policy_desc": "DATAACLV4V6",
+      "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
+      "stage": "ingress",
+      "type": "L3V4V6"
+    }
+  },
     "ACL_TABLE|EVERFLOW": {
         "policy_desc": "EVERFLOW",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet100,Ethernet104,Ethernet92,Ethernet96,Ethernet84,Ethernet88,Ethernet76,Ethernet80,Ethernet108,Ethernet112,Ethernet64,Ethernet120,Ethernet116,Ethernet124,Ethernet72,Ethernet68",


### PR DESCRIPTION
Support a new ACL table type called L3V4V6.
This table supports both v4 and v6 Match types.
Added unit tests for this new ACL table type.

HLD: sonic-net/SONiC#1267

Signed-off-by: Ravi(Marvell) rck@innovium.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Support a new ACL table type called L3V4V6.

#### How I did it

- Added table L3V4V6. 
- Added checks that ethertype is provided for ACL rules in this table that have IP or ICMP or L4(TCP/UDP) match-fields.
- Enhanced convert_icmp() to decide ICMP_V6 vs ICMP by using the ether-type


#### How to verify it

- Added unit-tests to create both v4 and v6 rules in this new table.
- Verify that ICMP_CODE is translated to ICMPV6_CODE for rules with ether-type as IPv6.
- Extended the default_deny_rule testcase to have a drop rule with protocol as "IP". This will match both v4 and v6 packets.
- Added negative tests to skip rules that do not have ether-type in this ACL table type .

