### PR TITLE
[acl-loader] Only add default deny rule when table is L3 or L3V6

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -678,6 +678,7 @@ class AclLoader(object):
     def deny_rule(self, table_name):
         """
         Create default deny rule in Config DB format
+        Only create default deny rule when table is [L3, L3V6, MIRROR, MIRRORV6]
         :param table_name: ACL table name to which rule belong
         :return: dict with Config DB schema
         """
@@ -689,6 +690,8 @@ class AclLoader(object):
             rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
         elif self.is_table_ipv4(table_name):
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
+        else:
+            return {}  # Don't add default deny rule if table is not [L3, L3V6, MIRROR, MIRRORV6]
         return rule_data
 
     def convert_rules(self):

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -354,6 +354,14 @@ class AclLoader(object):
         """
         return self.tables_db_info[tname]["type"].upper() == "L3"
 
+    def is_table_ipv4(self, tname):
+        """
+        Check if ACL table type is IPv4 (L3 or MIRROR)
+        :param tname: ACL table name
+        :return: True if table type is IPv4 else False
+        """
+        return self.tables_db_info[tname]["type"].upper() in ("L3", "MIRROR")
+
     def is_table_ipv6(self, tname):
         """
         Check if ACL table type is IPv6 (L3V6 or MIRRORV6)
@@ -679,7 +687,7 @@ class AclLoader(object):
         rule_props["PACKET_ACTION"] = "DROP"
         if self.is_table_ipv6(table_name):
             rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
-        else:
+        elif self.is_table_ipv4(table_name):
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
         return rule_data
 

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -354,14 +354,6 @@ class AclLoader(object):
         """
         return self.tables_db_info[tname]["type"].upper() == "L3"
 
-    def is_table_ipv4(self, tname):
-        """
-        Check if ACL table type is IPv4 (L3 or MIRROR)
-        :param tname: ACL table name
-        :return: True if table type is IPv4 else False
-        """
-        return self.tables_db_info[tname]["type"].upper() in ("L3", "MIRROR")
-
     def is_table_ipv6(self, tname):
         """
         Check if ACL table type is IPv6 (L3V6 or MIRRORV6)

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -678,7 +678,7 @@ class AclLoader(object):
     def deny_rule(self, table_name):
         """
         Create default deny rule in Config DB format
-        Only create default deny rule when table is [L3, L3V6, MIRROR, MIRRORV6]
+        Only create default deny rule when table is [L3, L3V6]
         :param table_name: ACL table name to which rule belong
         :return: dict with Config DB schema
         """
@@ -686,12 +686,12 @@ class AclLoader(object):
         rule_data = {(table_name, "DEFAULT_RULE"): rule_props}
         rule_props["PRIORITY"] = str(self.min_priority)
         rule_props["PACKET_ACTION"] = "DROP"
-        if self.is_table_ipv6(table_name):
+        if self.is_table_l3v6(table_name):
             rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
-        elif self.is_table_ipv4(table_name):
+        elif self.is_table_l3(table_name):
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
         else:
-            return {}  # Don't add default deny rule if table is not [L3, L3V6, MIRROR, MIRRORV6]
+            return {}  # Don't add default deny rule if table is not [L3, L3V6]
         return rule_data
 
     def convert_rules(self):
@@ -718,7 +718,7 @@ class AclLoader(object):
                 except AclLoaderException as ex:
                     error("Error processing rule %s: %s. Skipped." % (acl_entry_name, ex))
 
-            if not self.is_table_mirror(table_name) and not self.is_table_egress(table_name):
+            if not self.is_table_egress(table_name):
                 deep_update(self.rules_info, self.deny_rule(table_name))
 
     def full_update(self):

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -78,7 +78,7 @@
 						"name": "Sonic-SNMP_ACL"
 					}
 				},
-				"sonic-everflow": {
+				"everflow": {
 					"acl-entries": {
 						"acl-entry": {
 							"1": {
@@ -258,6 +258,63 @@
 								}
 							}
 						}
+					}
+				},
+				"bmc_acl_northbound": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "DROP"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "0",
+										"source-ip-address": "172.17.0.200/30"
+									}
+								},
+								"input_interface": {
+									"interface_ref": {
+										"config": {
+											"interface": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45"
+										}
+									}
+								}
+							}
+						}
+					},
+					"config": {
+						"name": "bmc_acl_northbound"
+					}
+				},
+				"bmc_acl_northbound_v6": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "DROP"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "0",
+										"destination-ip-address": "fc02::/64"
+									}
+								}
+							}
+						}
+					},
+					"config": {
+						"name": "bmc_acl_northbound_v6"
 					}
 				}
 			}

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -78,7 +78,7 @@
 						"name": "Sonic-SNMP_ACL"
 					}
 				},
-				"everflow": {
+				"sonic-everflow": {
 					"acl-entries": {
 						"acl-entry": {
 							"1": {
@@ -269,7 +269,7 @@
 								},
 								"actions": {
 									"config": {
-										"forwarding-action": "DROP"
+										"forwarding-action": "ACCEPT"
 									}
 								},
 								"ip": {
@@ -301,7 +301,7 @@
 								},
 								"actions": {
 									"config": {
-										"forwarding-action": "DROP"
+										"forwarding-action": "ACCEPT"
 									}
 								},
 								"ip": {

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -151,9 +151,9 @@ class TestAclLoader(object):
             'PACKET_ACTION': 'DROP',
             'IP_TYPE': 'IPV6ANY'
         }
-        # Verify MIRROR doesn't add default deny rule correctly
+        # Verify acl-loader doesn't add default deny rule to MIRROR
         assert ('EVERFLOW', 'DEFAULT_RULE') not in acl_loader.rules_info
-        # Verify MIRRORV6 can add default deny rule correctly
+        # Verify acl-loader doesn't add default deny rule to MIRRORV6
         assert ('EVERFLOWV6', 'DEFAULT_RULE') not in acl_loader.rules_info
         # Verify acl-loader doesn't add default deny rule to custom ACL table types
         assert ('BMC_ACL_NORTHBOUND', 'DEFAULT_RULE') not in acl_loader.rules_info

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -21,7 +21,7 @@ class TestAclLoader(object):
 
     def test_valid(self):
         yang_acl = AclLoader.parse_acl_json(os.path.join(test_path, 'acl_input/acl1.json'))
-        assert len(yang_acl.acl.acl_sets.acl_set) == 6
+        assert len(yang_acl.acl.acl_sets.acl_set) == 8
 
     def test_invalid(self):
         with pytest.raises(AclLoaderException):
@@ -135,6 +135,8 @@ class TestAclLoader(object):
         }
 
     def test_ingress_default_deny_rule(self, acl_loader):
+        acl_loader.set_mirror_stage("ingress")
+        acl_loader.get_session_name = mock.MagicMock(return_value="everflow_session_mock")
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
         # Verify L3 can add default deny rule correctly
@@ -149,21 +151,13 @@ class TestAclLoader(object):
             'PACKET_ACTION': 'DROP',
             'IP_TYPE': 'IPV6ANY'
         }
-        # Verify MIRROR can add default deny rule correctly
-        assert acl_loader.rules_info[('EVERFLOW', 'DEFAULT_RULE')] == {
-            'PRIORITY': '1',
-            'PACKET_ACTION': 'DROP',
-            'ETHER_TYPE': '2048'
-        }
+        # Verify MIRROR doesn't add default deny rule correctly
+        assert ('EVERFLOW', 'DEFAULT_RULE') not in acl_loader.rules_info
         # Verify MIRRORV6 can add default deny rule correctly
-        assert acl_loader.rules_info[('EVERFLOWV6', 'DEFAULT_RULE')] == {
-            'PRIORITY': '1',
-            'PACKET_ACTION': 'DROP',
-            'IP_TYPE': 'IPV6ANY'
-        }
+        assert ('EVERFLOWV6', 'DEFAULT_RULE') not in acl_loader.rules_info
         # Verify acl-loader doesn't add default deny rule to custom ACL table types
-        assert acl_loader.rules_info[('BMC_ACL_NORTHBOUND', 'DEFAULT_RULE')] == {}
-        assert acl_loader.rules_info[('BMC_ACL_NORTHBOUND_V6', 'DEFAULT_RULE')] == {}
+        assert ('BMC_ACL_NORTHBOUND', 'DEFAULT_RULE') not in acl_loader.rules_info
+        assert ('BMC_ACL_NORTHBOUND_V6', 'DEFAULT_RULE') not in acl_loader.rules_info
 
     def test_egress_no_default_deny_rule(self, acl_loader):
         acl_loader.rules_info = {}

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -137,17 +137,31 @@ class TestAclLoader(object):
     def test_ingress_default_deny_rule(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
-        print(acl_loader.rules_info)
+        # Verify L3 can add default deny rule correctly
         assert acl_loader.rules_info[('DATAACL', 'DEFAULT_RULE')] == {
             'PRIORITY': '1',
             'PACKET_ACTION': 'DROP',
             'ETHER_TYPE': '2048'
         }
+        # Verify L3V6 can add default deny rule correctly
         assert acl_loader.rules_info[('DATAACL_2', 'DEFAULT_RULE')] == {
             'PRIORITY': '1',
             'PACKET_ACTION': 'DROP',
             'IP_TYPE': 'IPV6ANY'
         }
+        # Verify MIRROR can add default deny rule correctly
+        assert acl_loader.rules_info[('EVERFLOW', 'DEFAULT_RULE')] == {
+            'PRIORITY': '1',
+            'PACKET_ACTION': 'DROP',
+            'ETHER_TYPE': '2048'
+        }
+        # Verify MIRRORV6 can add default deny rule correctly
+        assert acl_loader.rules_info[('EVERFLOWV6', 'DEFAULT_RULE')] == {
+            'PRIORITY': '1',
+            'PACKET_ACTION': 'DROP',
+            'IP_TYPE': 'IPV6ANY'
+        }
+        # Verify acl-loader doesn't add default deny rule to custom ACL table types
         assert acl_loader.rules_info[('BMC_ACL_NORTHBOUND', 'DEFAULT_RULE')] == {}
         assert acl_loader.rules_info[('BMC_ACL_NORTHBOUND_V6', 'DEFAULT_RULE')] == {}
 

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -148,6 +148,8 @@ class TestAclLoader(object):
             'PACKET_ACTION': 'DROP',
             'IP_TYPE': 'IPV6ANY'
         }
+        assert acl_loader.rules_info[('BMC_ACL_NORTHBOUND', 'DEFAULT_RULE')] == {}
+        assert acl_loader.rules_info[('BMC_ACL_NORTHBOUND_V6', 'DEFAULT_RULE')] == {}
 
     def test_egress_no_default_deny_rule(self, acl_loader):
         acl_loader.rules_info = {}

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -91,7 +91,7 @@ RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
 Total number of ACL Tables: 15
-Total number of ACL Rules: 23
+Total number of ACL Rules: 21
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -90,8 +90,8 @@ RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 12
-Total number of ACL Rules: 21
+Total number of ACL Tables: 15
+Total number of ACL Rules: 23
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
 -----------  ------------  ------  ---------------  -------------

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -561,6 +561,12 @@
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet100,Ethernet104,Ethernet92,Ethernet96,Ethernet84,Ethernet88,Ethernet76,Ethernet80,Ethernet108,Ethernet112,Ethernet64,Ethernet120,Ethernet116,Ethernet124,Ethernet72,Ethernet68",
         "type": "MIRROR"
     },
+    "ACL_TABLE|EVERFLOWV6": {
+        "policy_desc": "EVERFLOWV6",
+        "ports@": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47",
+        "type": "MIRRORV6",
+        "stage": "ingress"
+    },
     "ACL_TABLE|EVERFLOW_EGRESS": {
         "policy_desc": "EGRESS EVERFLOW",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet100,Ethernet104,Ethernet92,Ethernet96,Ethernet84,Ethernet88,Ethernet76,Ethernet80,Ethernet108,Ethernet112,Ethernet64,Ethernet120,Ethernet116,Ethernet124,Ethernet72,Ethernet68",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -511,6 +511,18 @@
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023",
         "type": "L3V6"
     },
+    "ACL_TABLE|BMC_ACL_NORTHBOUND": {
+        "policy_desc": "BMC_ACL_NORTHBOUND",
+        "ports@": "Ethernet8,Ethernet0,Ethernet17,Ethernet16,Ethernet37,Ethernet4,Ethernet13,Ethernet45,Ethernet19,Ethernet24,Ethernet31,Ethernet30,Ethernet39,Ethernet40,Ethernet27,Ethernet43,Ethernet7,Ethernet3,Ethernet20,Ethernet6,Ethernet12,Ethernet34,Ethernet26,Ethernet11,Ethernet42,Ethernet5,Ethernet32,Ethernet36,Ethernet15,Ethernet33,Ethernet35,Ethernet9,Ethernet29,Ethernet21,Ethernet18,Ethernet38,Ethernet23,Ethernet41,Ethernet14,Ethernet2,Ethernet28,Ethernet22,Ethernet10,Ethernet25,Ethernet44,Ethernet1",
+        "stage": "ingress",
+        "type": "BMCDATA"
+    },
+    "ACL_TABLE|BMC_ACL_NORTHBOUND_V6": {
+        "policy_desc": "BMC_ACL_NORTHBOUND_V6",
+        "ports@": "Ethernet13,Ethernet3,Ethernet32,Ethernet33,Ethernet34,Ethernet8,Ethernet6,Ethernet44,Ethernet39,Ethernet18,Ethernet15,Ethernet1,Ethernet19,Ethernet7,Ethernet14,Ethernet43,Ethernet40,Ethernet27,Ethernet4,Ethernet36,Ethernet41,Ethernet10,Ethernet31,Ethernet5,Ethernet9,Ethernet12,Ethernet16,Ethernet25,Ethernet24,Ethernet17,Ethernet35,Ethernet11,Ethernet38,Ethernet42,Ethernet29,Ethernet20,Ethernet45,Ethernet26,Ethernet21,Ethernet37,Ethernet0,Ethernet28,Ethernet23,Ethernet22,Ethernet2,Ethernet30",
+        "stage": "ingress",
+        "type": "BMCDATAV6"
+    },
     "ACL_TABLE|DATAACL": {
         "policy_desc": "DATAACL",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
@@ -564,6 +576,16 @@
         "policy_desc": "SSH_ONLY",
         "services@": "SSH",
         "type": "CTRLPLANE"
+    },
+    "ACL_TABLE_TYPE|BMCDATA": {
+        "ACTIONS": "PACKET_ACTION,COUNTER",
+        "BIND_POINTS": "PORT",
+        "MATCHES": "SRC_IP,DST_IP,ETHER_TYPE,IP_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
+    },
+    "ACL_TABLE_TYPE|BMCDATAV6": {
+        "ACTIONS": "PACKET_ACTION,COUNTER",
+        "BIND_POINTS": "PORT",
+        "MATCHES": "SRC_IPV6,DST_IPV6,ETHER_TYPE,IP_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
     },
     "PBH_TABLE|pbh_table1": {
         "description": "NVGRE",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

1. Update `acl-loader` to only add default deny rule when table is L3 or L3V6.
2. Update unittest to cover it.

#### How I did it

Update function `deny_rule` and return `{}` if table is not L3 or L3V6.

#### How to verify it

1. Update unittest and run all testcases to verify:

  ```
  ----------- coverage: platform linux, python 3.9.2-final-0 -----------
  Name                                                   Stmts   Miss Branch BrPart  Cover
  ----------------------------------------------------------------------------------------
  acl_loader/__init__.py                                     0      0      0      0   100%
  acl_loader/main.py                                       640    152    284     50    71%  ...
  =================================================================== short test summary info ====================================================================
  FAILED tests/disk_check_test.py::TestDiskCheck::test_readonly - assert 1 == 0
  FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts - AssertionError: assert ('    IFACE    STATE    RX_ERR    RX_DROPS    TX_ERR    TX_DROP...
  FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts_with_group - AssertionError: assert ('\n'\n '          DEVICE    SWITCH_DROPS\n'\n '----...
  FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts_with_type - AssertionError: assert ('    IFACE    STATE    RX_ERR    RX_DROPS    DEBUG_0...
  ============================================== 4 failed, 2300 passed, 3 skipped, 16 warnings in 672.50s (0:11:12) ==============================================
  ```

2. Built the package and installed on DUT to verify.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

