### PR TITLE
[202211][route_check] fix IPv6 address handling 

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -46,6 +46,7 @@ import time
 import signal
 import traceback
 
+from ipaddress import ip_network
 from swsscommon import swsscommon
 from utilities_common import chassis
 
@@ -141,7 +142,7 @@ def add_prefix(ip):
         ip = ip + PREFIX_SEPARATOR + "32"
     else:
         ip = ip + PREFIX_SEPARATOR + "128"
-    return ip
+    return str(ip_network(ip))
 
 
 def add_prefix_ifnot(ip):
@@ -150,7 +151,7 @@ def add_prefix_ifnot(ip):
     :param ip: IP to add prefix as string.
     :return ip with prefix
     """
-    return ip if ip.find(PREFIX_SEPARATOR) != -1 else add_prefix(ip)
+    return str(ip_network(ip)) if ip.find(PREFIX_SEPARATOR) != -1 else add_prefix(ip)
 
 
 def is_local(ip):

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -359,5 +359,23 @@ TEST_DATA = {
                 }
             }
         }
-    }
+    },
+    "10": {
+        DESCR: "basic good one with IPv6 address",
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            APPL_DB: {
+                ROUTE_TABLE: {
+                },
+                INTF_TABLE: {
+                    "PortChannel1013:2000:31:0:0::1/64": {},
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "2000:31::1/128" + RT_ENTRY_KEY_SUFFIX: {},
+                }
+            }
+        }
+    },
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

BACKPORT of https://github.com/sonic-net/sonic-utilities/pull/2722

#### What I did

In case user has configured an IPv6 address on an interface in CONFIG DB in non simplified form like 2000:31:0:0::1/64 it is present in a simplified form in ASIC_DB. This leads to route_check failure since it just compares strings.

#### How I did it

Convert prefix string using ip_network().

#### How to verify it

UT replicates the issue.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

