### PR TITLE
[show][muxcable] fix `show mux hwmode muxdirection` RC

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -1394,13 +1394,14 @@ def muxdirection(db, port, json_output):
                 headers = ['Port', 'Direction', 'Presence']
             click.echo(tabulate(body, headers=headers))
 
-        return rc
+        rc_exit = EXIT_SUCCESS if rc==0  else EXIT_FAIL
+        sys.exit(rc_exit)
 
     else:
 
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
-        rc_exit = True
+        rc_exit = EXIT_SUCCESS
         body = []
         active_active = False
         if json_output:
@@ -1449,8 +1450,9 @@ def muxdirection(db, port, json_output):
                     active_active = True
                 else:
                     rc = create_active_standby_mux_direction_result(body, port, db)
-                if rc != 0:
-                    rc_exit = False
+
+            if rc != 0:
+                rc_exit = EXIT_FAIL
 
 
 
@@ -1464,8 +1466,7 @@ def muxdirection(db, port, json_output):
                 headers = ['Port', 'Direction', 'Presence']
             click.echo(tabulate(body, headers=headers))
 
-        if rc_exit == False:
-            sys.exit(EXIT_FAIL)
+        sys.exit(rc_exit)
 
 
 @hwmode.command()
@@ -2140,7 +2141,7 @@ def get_grpc_cached_version_mux_direction_per_port(db, port):
     mux_info_dict = {}
     mux_info_full_dict = {}
     trans_info_full_dict = {}
-    mux_info_dict["rc"] = False
+    mux_info_dict["rc"] = 1
 
     # Getting all front asic namespace and correspding config and state DB connector
 
@@ -2182,7 +2183,7 @@ def get_grpc_cached_version_mux_direction_per_port(db, port):
 
     mux_info_dict["presence"] = presence
 
-    mux_info_dict["rc"] = True
+    mux_info_dict["rc"] = 0
 
     return mux_info_dict
 
@@ -2222,14 +2223,15 @@ def muxdirection(db, port, json_output):
             rc = create_active_active_mux_direction_result(body, port, db)
             click.echo(tabulate(body, headers=headers))
 
-        return rc
+        rc_exit = EXIT_SUCCESS if rc==0  else EXIT_FAIL
+        sys.exit(rc_exit)
 
     else:
 
 
         logical_port_list = platform_sfputil_helper.get_logical_list()
 
-        rc_exit = True
+        rc_exit = EXIT_SUCCESS
         body = []
         if json_output:
             result = {}
@@ -2266,8 +2268,8 @@ def muxdirection(db, port, json_output):
             else:
                 rc = create_active_active_mux_direction_result(body, port, db)
 
-            if rc != True:
-                rc_exit = False
+            if rc != 0:
+                rc_exit = EXIT_FAIL
 
         if json_output:
             click.echo("{}".format(json.dumps(result, indent=4)))
@@ -2276,8 +2278,7 @@ def muxdirection(db, port, json_output):
 
             click.echo(tabulate(body, headers=headers))
 
-        if rc_exit == False:
-            sys.exit(EXIT_FAIL)
+        sys.exit(rc_exit)
 
 @muxcable.command()
 @click.argument('port', metavar='<port_name>', required=True, default=None)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`show mux hwmode muxdirection` always has `rc==1`. 

Fixed the issue below:
* `get_grpc_cached_version_mux_direction_per_port` has reverted `TRUE/FALSE` return value compared to `get_hwmode_mux_direction_port`. The former is used to get results for `active-active` ports, the latter is used to get results for `active-standby` ports.
* Use `sys.exit()` instead of `return rc`. CLI rc is different from function return value. 
* Fixed `show mux grpc muxdirection` as well. 

sign-off: Jing Zhang 
 
#### How I did it

#### How to verify it
* Tested on DUTs to verify rc. Run commands for single port and all ports, with and without `--json`.
* Passed all UTs. 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

