### PR TITLE
[GCU] protect loopback0 from deletion

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -153,9 +153,14 @@ class ConfigWrapper:
         patch = jsonpatch.JsonPatch.from_diff(old_config, target_config)
         
         # illegal_operations_to_fields_map['remove'] yields a list of fields for which `remove` is an illegal operation 
-        illegal_operations_to_fields_map = {'add':[],
-                                            'replace': [],
-                                            'remove': ['/PFC_WD/GLOBAL/POLL_INTERVAL', '/PFC_WD/GLOBAL']}
+        illegal_operations_to_fields_map = {
+            'add':[],
+            'replace': [],
+            'remove': [
+                '/PFC_WD/GLOBAL/POLL_INTERVAL',
+                '/PFC_WD/GLOBAL',
+                '/LOOPBACK_INTERFACE/Loopback0']
+        }
         for operation, field_list in illegal_operations_to_fields_map.items():
             for field in field_list:
                 if any(op['op'] == operation and field == op['path'] for op in patch):

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -77,7 +77,25 @@ class TestConfigWrapper(unittest.TestCase):
         target_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "40"}}}
         config_wrapper = gu_common.ConfigWrapper()
         config_wrapper.validate_field_operation(old_config, target_config)
-        
+
+    def test_validate_field_operation_legal__rm_loopback1(self):
+        old_config = {
+            "LOOPBACK_INTERFACE": {
+                "Loopback0": {},
+                "Loopback0|10.1.0.32/32": {},
+                "Loopback1": {},
+                "Loopback1|10.1.0.33/32": {}
+            }
+        }
+        target_config = {
+            "LOOPBACK_INTERFACE": {
+                "Loopback0": {},
+                "Loopback0|10.1.0.32/32": {}
+            }
+        }
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
         target_config = {"PFC_WD": {"GLOBAL": {}}}
@@ -88,6 +106,24 @@ class TestConfigWrapper(unittest.TestCase):
     def test_validate_field_modification_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
         target_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "80"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
+
+    def test_validate_field_operation_illegal__rm_loopback0(self):
+        old_config = {
+            "LOOPBACK_INTERFACE": {
+                "Loopback0": {},
+                "Loopback0|10.1.0.32/32": {},
+                "Loopback1": {},
+                "Loopback1|10.1.0.33/32": {}
+            }
+        }
+        target_config = {
+            "LOOPBACK_INTERFACE": {
+                "Loopback1": {},
+                "Loopback1|10.1.0.33/32": {}
+            }
+        }
         config_wrapper = gu_common.ConfigWrapper()
         self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
 


### PR DESCRIPTION
Fix conflict and backport (#2638) to 202205.
What I did
Refer to sonic-net/sonic-buildimage#11171, protect loopback0 from deletion

How I did it
Add patch checker to fail the validation when remove loopback0

How to verify it
Unit test

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

