### PR TITLE
[config]: Dynamically start and stop ndppd

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -116,12 +116,12 @@ def del_vlan(db, vid, no_restart_dhcp_relay):
         if is_dhcp_relay_running():
             dhcp_relay_util.handle_restart_dhcp_relay_service()
     
-    vlans = config_db.get_keys('VLAN')
+    vlans = db.cfgdb.get_keys('VLAN')
     if not vlans:
-        click.echo("No VLANs remaining, stopping ndppd service")
         docker_exec_cmd = "docker exec -i swss {}"
         _, rc = clicommon.run_command(docker_exec_cmd.format("supervisorctl status ndppd"), ignore_error=True, return_cmd=True)
         if rc == 0:
+            click.echo("No VLANs remaining, stopping ndppd service")
             clicommon.run_command(docker_exec_cmd.format("supervisorctl stop ndppd"), ignore_error=True, return_cmd=True)
             clicommon.run_command(docker_exec_cmd.format("rm -f /etc/supervisor/conf.d/ndppd.conf"), ignore_error=True, return_cmd=True)
             clicommon.run_command(docker_exec_cmd.format("supervisorctl update"), return_cmd=True)

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -124,7 +124,7 @@ def del_vlan(db, vid, no_restart_dhcp_relay):
         if rc == 0:
             clicommon.run_command(docker_exec_cmd.format("supervisorctl stop ndppd"), ignore_error=True, return_cmd=True)
             clicommon.run_command(docker_exec_cmd.format("rm -f /etc/supervisor/conf.d/ndppd.conf"), ignore_error=True, return_cmd=True)
-            clicommon.run_command(docker_exec_cmd.format("supervisorctl update"), ignore_error=True, return_cmd=True)
+            clicommon.run_command(docker_exec_cmd.format("supervisorctl update"), return_cmd=True)
 
 
 def restart_ndppd():
@@ -146,11 +146,12 @@ def restart_ndppd():
 
     if rc != 0:
         clicommon.run_command(docker_exec_cmd.format(ndppd_conf_copy_cmd))
-        clicommon.run_command(docker_exec_cmd.format(supervisor_update_cmd))
+        clicommon.run_command(docker_exec_cmd.format(supervisor_update_cmd), return_cmd=True)
 
-    clicommon.run_command(docker_exec_cmd.format(ndppd_config_gen_cmd), display_cmd=True)
+    click.echo("Starting ndppd service")
+    clicommon.run_command(docker_exec_cmd.format(ndppd_config_gen_cmd))
     sleep(3)
-    clicommon.run_command(docker_exec_cmd.format(ndppd_restart_cmd), display_cmd=True, return_cmd=True)
+    clicommon.run_command(docker_exec_cmd.format(ndppd_restart_cmd), return_cmd=True)
 
 
 @vlan.command('proxy_arp')

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -115,11 +115,24 @@ def del_vlan(db, vid, no_restart_dhcp_relay):
         # We need to restart dhcp_relay service after dhcpv6_relay config change
         if is_dhcp_relay_running():
             dhcp_relay_util.handle_restart_dhcp_relay_service()
+    
+    vlans = config_db.get_keys('VLAN')
+    if not vlans:
+        click.echo("No VLANs remaining, stopping ndppd service")
+        docker_exec_cmd = "docker exec -i swss {}"
+        _, rc = clicommon.run_command(docker_exec_cmd.format("supervisorctl status ndppd"), ignore_error=True, return_cmd=True)
+        if rc == 0:
+            clicommon.run_command(docker_exec_cmd.format("supervisorctl stop ndppd"), ignore_error=True, return_cmd=True)
+            clicommon.run_command(docker_exec_cmd.format("rm -f /etc/supervisor/conf.d/ndppd.conf"), ignore_error=True, return_cmd=True)
+            clicommon.run_command(docker_exec_cmd.format("supervisorctl update"), ignore_error=True, return_cmd=True)
 
 
 def restart_ndppd():
     verify_swss_running_cmd = "docker container inspect -f '{{.State.Status}}' swss"
     docker_exec_cmd = "docker exec -i swss {}"
+    ndppd_status_cmd= "supervisorctl status ndppd"
+    ndppd_conf_copy_cmd = "cp /usr/share/sonic/templates/ndppd.conf /etc/supervisor/conf.d/"
+    supervisor_update_cmd = "supervisorctl update"
     ndppd_config_gen_cmd = "sonic-cfggen -d -t /usr/share/sonic/templates/ndppd.conf.j2,/etc/ndppd.conf"
     ndppd_restart_cmd = "supervisorctl restart ndppd"
 
@@ -129,9 +142,15 @@ def restart_ndppd():
         click.echo(click.style('SWSS container is not running, changes will take effect the next time the SWSS container starts', fg='red'),)
         return
 
+    _, rc = clicommon.run_command(docker_exec_cmd.format(ndppd_status_cmd), ignore_error=True, return_cmd=True)
+
+    if rc != 0:
+        clicommon.run_command(docker_exec_cmd.format(ndppd_conf_copy_cmd))
+        clicommon.run_command(docker_exec_cmd.format(supervisor_update_cmd))
+
     clicommon.run_command(docker_exec_cmd.format(ndppd_config_gen_cmd), display_cmd=True)
     sleep(3)
-    clicommon.run_command(docker_exec_cmd.format(ndppd_restart_cmd), display_cmd=True)
+    clicommon.run_command(docker_exec_cmd.format(ndppd_restart_cmd), display_cmd=True, return_cmd=True)
 
 
 @vlan.command('proxy_arp')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fixes https://github.com/sonic-net/sonic-buildimage/issues/14231

#### What I did
- When enabling proxy_arp for a VLAN, configure and start the ndppd service if it isn't already running
- When removing the last VLAN, stop the ndppd service

#### How I did it
Check `supervisorctl status ndppd` to determine if ndppd needs to be started or stopped

#### How to verify it
- Load a config on a device that does not have any VLANs
- Create a vlan and enable proxy_arp:
```
sudo config vlan add 10
sudo config interface ip add Vlan10 4.0.0.2/24
sudo config vlan proxy_arp 10 enabled
```
- Verify that the commands succeed and ndppd is running:
```
admin@sonic:~$ docker exec -it swss supervisorctl status ndppd
ndppd                            RUNNING   pid 1744, uptime 0:00:03
```

- Remove the vlan:
```
sudo config interface ip remove Vlan10 4.0.0.2/24
sudo config vlan del 10
```
- Verify that the commands succeed and ndppd is no longer configured:
```
admin@sonic:~$ docker exec -it swss supervisorctl status ndppd
ndppd: ERROR (no such process)
```
#### Previous command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo config vlan proxy_arp 10 enabled
Proxy ARP setting saved to ConfigDB
Running command: docker exec -i swss sonic-cfggen -d -t /usr/share/sonic/templates/ndppd.conf.j2,/etc/ndppd.conf
Running command: docker exec -i swss supervisorctl restart ndppd
ndppd: stopped
ndppd: started
```
```
admin@sonic:~$ sudo config vlan del 10
```

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo config vlan proxy_arp 10 enabled
Proxy ARP setting saved to ConfigDB
Starting ndppd service
```
```
admin@sonic:~$ sudo config vlan del 10
No VLANs remaining, stopping ndppd service
```
