### PR TITLE
[sonic_sku_create] remove shell=True, replace exit() with sys.exit()

### DIFF
--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -263,7 +263,7 @@ class SkuCreate(object):
             pattern = '^Ethernet([0-9]{1,})'
             m = re.match(pattern,key)
             if m is None:
-                print("Port Name ",port_name, " is not valid, Exiting...", file=sys.stderr) 
+                print("Port Name ", key, " is not valid, Exiting...", file=sys.stderr) 
                 sys.exit(1)
             port_idx = int(m.group(1))
 

--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -105,7 +105,7 @@ class SkuCreate(object):
         # Parsing XML sku definition file to extract Interface speed and InterfaceName(alias) <etp<#><a/b/c/d>|<Ethernet<#>/<#> to be used to analyze split configuration
         # Rest of the fields are used as placeholders for portconfig_dict [name,lanes,SPEED,ALIAS,index]
         try:
-            f = open(str(sku_def),"r")
+            f = open(str(sku_def), "r")
         except IOError:
             print("Couldn't open file: " + str(sku_def), file=sys.stderr)
             sys.exit(1)
@@ -769,8 +769,8 @@ def main(argv):
         if args.base:
             sku.base_sku_name = args.base
         else:
-            f=open(sku.default_sku_path + '/' + "default_sku","r")
-            sku.base_sku_name=f.read().split()[0]
+            f = open(sku.default_sku_path + '/' + "default_sku", "r")
+            sku.base_sku_name = f.read().split()[0]
 
         sku.base_sku_dir = sku.default_sku_path + '/' + sku.base_sku_name + '/'
         sku.base_file_path = sku.base_sku_dir + "port_config.ini"

--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -37,7 +37,7 @@ from collections import OrderedDict
 from tabulate import tabulate
 from lxml import etree as ET
 from lxml.etree import QName
-
+from sonic_py_common.general import check_output_pipe
 
 minigraph_ns = "Microsoft.Search.Autopilot.Evolution"
 minigraph_ns1 = "http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"
@@ -108,7 +108,7 @@ class SkuCreate(object):
             f = open(str(sku_def),"r")
         except IOError:
             print("Couldn't open file: " + str(sku_def), file=sys.stderr)
-            exit(1)
+            sys.exit(1)
         element = ET.parse(f)
  
         root = element.getroot()
@@ -184,7 +184,7 @@ class SkuCreate(object):
             int_port_speed = int(port_speed)
         else:
             print(port_str, "does not contain speed key, Exiting...", file=sys.stderr)
-            exit(1)
+            sys.exit(1)
         for i in range(1,self.base_lanes):
             curr_port_str = "Ethernet{:d}".format(port_idx+i)
             if curr_port_str in data['PORT']:
@@ -193,20 +193,20 @@ class SkuCreate(object):
                     curr_speed = curr_port_dict.get("speed")
                 else:
                     print(curr_port_str, "does not contain speed key, Exiting...", file=sys.stderr)
-                    exit(1)
+                    sys.exit(1)
                 if port_speed != curr_speed:
                     print(curr_port_str, "speed is different from that of ",port_str,", Exiting...", file=sys.stderr)
-                    exit(1)
+                    sys.exit(1)
                 if "alias" in curr_port_dict:
                     curr_alias = curr_port_dict.get("alias")
                 else:
                     print(curr_port_str, "does not contain alias key, Exiting...", file=sys.stderr)
-                    exit(1)
+                    sys.exit(1)
                 if "lanes" in curr_port_dict:
                     curr_lanes = curr_port_dict.get("lanes")
                 else:
                     print(curr_port_str, "does not contain lanes key, Exiting...", file=sys.stderr)
-                    exit(1)
+                    sys.exit(1)
                 port_bmp |= (1<<i)
                  
         for entry in self.bko_dict:
@@ -264,7 +264,7 @@ class SkuCreate(object):
             m = re.match(pattern,key)
             if m is None:
                 print("Port Name ",port_name, " is not valid, Exiting...", file=sys.stderr) 
-                exit(1)
+                sys.exit(1)
             port_idx = int(m.group(1))
 
             if port_idx%self.base_lanes == 0:
@@ -300,7 +300,7 @@ class SkuCreate(object):
         m = re.match(pattern,platform)
         if m is None:
             print("Platform Name ", platform, " is not valid, Exiting...", file=sys.stderr) 
-            exit(1)
+            sys.exit(1)
         self.platform = platform
 
        
@@ -351,7 +351,7 @@ class SkuCreate(object):
                 idx += 1
             else:
                 print("port_config.ini file does not contain all fields, Exiting...", file=sys.stderr) 
-                exit(1)
+                sys.exit(1)
 
         f_in.close()
 
@@ -362,7 +362,7 @@ class SkuCreate(object):
         m = re.match(pattern,port_split)
         if m is None:
             print("Port split format ",port_split, " is not valid, Exiting...", file=sys.stderr) 
-            exit(1)
+            sys.exit(1)
         if port_split in self.bko_dict:
             step = self.bko_dict[port_split]["step"]
             speed = self.bko_dict[port_split]["speed"]
@@ -370,18 +370,18 @@ class SkuCreate(object):
             bko = self.bko_dict[port_split]["bko"]
         else:
             print("Port split ",port_split, " is undefined for this platform, Exiting...", file=sys.stderr) 
-            exit(1)
+            sys.exit(1)
 
         port_found = False
         pattern = '^Ethernet([0-9]{1,})'
         m = re.match(pattern,port_name)
         if m is None:
             print("Port Name ",port_name, " is not valid, Exiting...", file=sys.stderr) 
-            exit(1)
+            sys.exit(1)
         port_idx = int(m.group(1))
         if port_idx % base_lanes != 0:
             print(port_name, " is not base port, Exiting...", file=sys.stderr)
-            exit(1)
+            sys.exit(1)
 
         bak_file = ini_file + ".bak"
         shutil.copy(ini_file, bak_file)
@@ -528,7 +528,7 @@ class SkuCreate(object):
         shutil.copy(new_file,self.ini_file)
         if lanes_str_result is None:
             print("break_in_ini function returned empty lanes string, Exiting...", file=sys.stderr)
-            exit(1)
+            sys.exit(1)
         self.break_in_cfg(self.cfg_file,port_name,port_split,lanes_str_result)
 
     def _parse_interface_alias(self, alias):
@@ -573,7 +573,7 @@ class SkuCreate(object):
 
         except IOError:
             print("Could not open file "+ self.base_file_path, file=sys.stderr)
-            exit(1)
+            sys.exit(1)
 
     def set_lanes(self):
         #set lanes and index per interfaces based on split
@@ -590,7 +590,7 @@ class SkuCreate(object):
             lanes_count = len(lanes)
             if lanes_count % splt != 0:
                 print("Lanes(%s) could not be evenly splitted by %d." % (self.default_lanes_per_port[fp - 1], splt))
-                exit(1)
+                sys.exit(1)
 
             # split the lanes
             it = iter(lanes)
@@ -639,13 +639,13 @@ class SkuCreate(object):
         #create a port_config.ini file based on the sku definition 
         if not os.path.exists(self.new_sku_dir):
             print("Error - path:", self.new_sku_dir, " doesn't exist",file=sys.stderr)
-            exit(1)
+            sys.exit(1)
 
         try:
             f = open(self.new_sku_dir+"port_config.ini","w+")
         except IOError:
             print("Could not open file "+ self.new_sku_dir+"port_config.ini", file=sys.stderr)
-            exit(1)
+            sys.exit(1)
         header = PORTCONFIG_HEADER # ["name", "lanes", "alias", "index"]
         port_config = []
         for line in self.portconfig_dict.values():
@@ -670,7 +670,7 @@ class SkuCreate(object):
         # create a new SKU directory based on the base SKU
         if (os.path.exists(self.new_sku_dir)):
             print("SKU directory: "+self.new_sku_dir+ " already exists\n Please use -r flag to remove the SKU dir first", file=sys.stderr)
-            exit(1)
+            sys.exit(1)
         try:
             shutil.copytree(self.base_sku_dir, self.new_sku_dir)
         except OSError as e:
@@ -680,7 +680,7 @@ class SkuCreate(object):
         # remove SKU directory 
         if (self.new_sku_dir == self.base_sku_dir):
             print("Removing the base SKU" + self.new_sku_dir + " is not allowed", file=sys.stderr)
-            exit(1)
+            sys.exit(1)
         try:
             if not os.path.exists(self.new_sku_dir):
                 print("Trying to remove a SKU "+ self.new_sku_dir + " that doesn't exists, Ignoring -r command")
@@ -726,7 +726,7 @@ class SkuCreate(object):
                     raise  ValueError()
             except ValueError:
                 print("Error - Illegal split by 4 ", file=sys.stderr)
-                exit(1)
+                sys.exit(1)
 
 
 def main(argv):
@@ -759,11 +759,11 @@ def main(argv):
             sku.default_sku_path = args.default_sku_path[0]
         else:
             try:
-                sku.platform = subprocess.check_output("sonic-cfggen -H -v DEVICE_METADATA.localhost.platform",shell=True, text=True) #self.metadata['platform']
+                sku.platform = subprocess.check_output(["sonic-cfggen", "-H", "-v", "DEVICE_METADATA.localhost.platform"], text=True) #self.metadata['platform']
                 sku.platform = sku.platform.rstrip()
             except KeyError:
                 print("Couldn't find platform info in CONFIG_DB DEVICE_METADATA", file=sys.stderr)
-                exit(1)
+                sys.exit(1)
             sku.default_sku_path = '/usr/share/sonic/device/' + sku.platform
 
         if args.base:
@@ -803,10 +803,10 @@ def main(argv):
                 sku.parse_platform_from_config_db_file(sku.cfg_file)
             else:
                 try:
-                    sku_name = subprocess.check_output("show platform summary | grep HwSKU ",shell=True).rstrip().split()[1] 
+                    sku_name = check_output_pipe(["show", "platform", "summary"], ["grep", "HwSKU"]).rstrip().split()[1]
                 except KeyError:
                     print("Couldn't find HwSku info in Platform summary", file=sys.stderr)
-                    exit(1)
+                    sys.exit(1)
                 sku.ini_file = sku.default_sku_path + "/" + sku_name + "/port_config.ini"
                 sku.cfg_file = "/etc/sonic/config_db.json"
 

--- a/tests/sku_create_input/2700_files/config_db_incorrect_platform.json
+++ b/tests/sku_create_input/2700_files/config_db_incorrect_platform.json
@@ -1,0 +1,12 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hwsku": "Mellanox-SN2700-C28D8", 
+            "hostname": "sonic", 
+            "platform": "x86_64-mlnx_2700-r0", 
+            "mac": "7c:fe:90:f8:06:80", 
+            "bgp_asn": "65100", 
+            "type": "LeafRouter"
+        }
+    }
+}

--- a/tests/sku_create_input/2700_files/config_db_invalid_portname.json
+++ b/tests/sku_create_input/2700_files/config_db_invalid_portname.json
@@ -1,0 +1,302 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hwsku": "Mellanox-SN2700-C28D8", 
+            "hostname": "sonic", 
+            "platform": "x86_64-mlnx_msn2700-r0", 
+            "mac": "7c:fe:90:f8:06:80", 
+            "bgp_asn": "65100", 
+            "type": "LeafRouter"
+        }
+    }, 
+    "PORT": {
+        "Ether8": {
+            "index": "3", 
+            "lanes": "8,9,10,11", 
+            "mtu": "9100", 
+            "alias": "etp3", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether0": {
+            "index": "1", 
+            "lanes": "0,1,2,3", 
+            "mtu": "9100", 
+            "alias": "etp1", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether4": {
+            "index": "2", 
+            "lanes": "4,5,6,7", 
+            "mtu": "9100", 
+            "alias": "etp2", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether108": {
+            "index": "28", 
+            "lanes": "108,109,110,111", 
+            "mtu": "9100", 
+            "alias": "etp28", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether100": {
+            "index": "26", 
+            "lanes": "100,101,102,103", 
+            "mtu": "9100", 
+            "alias": "etp26", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether104": {
+            "index": "27", 
+            "lanes": "104,105,106,107", 
+            "mtu": "9100", 
+            "alias": "etp27", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether68": {
+            "index": "18", 
+            "lanes": "68,69,70,71", 
+            "mtu": "9100", 
+            "alias": "etp18", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether126": {
+            "index": "32", 
+            "lanes": "126,127", 
+            "mtu": "9100", 
+            "alias": "etp32b", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether96": {
+            "index": "25", 
+            "lanes": "96,97,98,99", 
+            "mtu": "9100", 
+            "alias": "etp25", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether124": {
+            "index": "32", 
+            "lanes": "124,125", 
+            "mtu": "9100", 
+            "alias": "etp32a", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether122": {
+            "index": "31", 
+            "lanes": "122,123", 
+            "mtu": "9100", 
+            "alias": "etp31b", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether92": {
+            "index": "24", 
+            "lanes": "92,93,94,95", 
+            "mtu": "9100", 
+            "alias": "etp24", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether120": {
+            "index": "31", 
+            "lanes": "120,121", 
+            "mtu": "9100", 
+            "alias": "etp31a", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether52": {
+            "index": "14", 
+            "lanes": "52,53,54,55", 
+            "mtu": "9100", 
+            "alias": "etp14", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether56": {
+            "index": "15", 
+            "lanes": "56,57,58,59", 
+            "mtu": "9100", 
+            "alias": "etp15", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether76": {
+            "index": "20", 
+            "lanes": "76,77,78,79", 
+            "mtu": "9100", 
+            "alias": "etp20", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether72": {
+            "index": "19", 
+            "lanes": "72,73,74,75", 
+            "mtu": "9100", 
+            "alias": "etp19", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether64": {
+            "index": "17", 
+            "lanes": "64,65,66,67", 
+            "mtu": "9100", 
+            "alias": "etp17", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether32": {
+            "index": "9", 
+            "lanes": "32,33,34,35", 
+            "mtu": "9100", 
+            "alias": "etp9", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether16": {
+            "index": "5", 
+            "lanes": "16,17,18,19", 
+            "mtu": "9100", 
+            "alias": "etp5", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether36": {
+            "index": "10", 
+            "lanes": "36,37,38,39", 
+            "mtu": "9100", 
+            "alias": "etp10", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether12": {
+            "index": "4", 
+            "lanes": "12,13,14,15", 
+            "mtu": "9100", 
+            "alias": "etp4", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether88": {
+            "index": "23", 
+            "lanes": "88,89,90,91", 
+            "mtu": "9100", 
+            "alias": "etp23", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether118": {
+            "index": "30", 
+            "lanes": "118,119", 
+            "mtu": "9100", 
+            "alias": "etp30b", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether116": {
+            "index": "30", 
+            "lanes": "116,117", 
+            "mtu": "9100", 
+            "alias": "etp30a", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether114": {
+            "index": "29", 
+            "lanes": "114,115", 
+            "mtu": "9100", 
+            "alias": "etp29b", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether80": {
+            "index": "21", 
+            "lanes": "80,81,82,83", 
+            "mtu": "9100", 
+            "alias": "etp21", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether112": {
+            "index": "29", 
+            "lanes": "112,113", 
+            "mtu": "9100", 
+            "alias": "etp29a", 
+            "admin_status": "up", 
+            "speed": "50000"
+        }, 
+        "Ether84": {
+            "index": "22", 
+            "lanes": "84,85,86,87", 
+            "mtu": "9100", 
+            "alias": "etp22", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether48": {
+            "index": "13", 
+            "lanes": "48,49,50,51", 
+            "mtu": "9100", 
+            "alias": "etp13", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether44": {
+            "index": "12", 
+            "lanes": "44,45,46,47", 
+            "mtu": "9100", 
+            "alias": "etp12", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether40": {
+            "index": "11", 
+            "lanes": "40,41,42,43", 
+            "mtu": "9100", 
+            "alias": "etp11", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether28": {
+            "index": "8", 
+            "lanes": "28,29,30,31", 
+            "mtu": "9100", 
+            "alias": "etp8", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether60": {
+            "index": "16", 
+            "lanes": "60,61,62,63", 
+            "mtu": "9100", 
+            "alias": "etp16", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether20": {
+            "index": "6", 
+            "lanes": "20,21,22,23", 
+            "mtu": "9100", 
+            "alias": "etp6", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }, 
+        "Ether24": {
+            "index": "7", 
+            "lanes": "24,25,26,27", 
+            "mtu": "9100", 
+            "alias": "etp7", 
+            "admin_status": "up", 
+            "speed": "100000"
+        }
+    }
+}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`subprocess()` - when using with `shell=True` is dangerous. Using subprocess function without a static string can lead to command injection.
`sys.exit` is better than `exit`, considered good to use in production code.
Ref:
https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python
https://stackoverflow.com/questions/19747371/python-exit-commands-why-so-many-and-when-should-each-be-used
#### How I did it
`subprocess()` - use `shell=False` instead, use list of strings Ref: [https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation](https://semgrep.dev/docs/cheat-sheets/python-command-injection/#mitigation)
Replace `exit()` by `sys.exit()`
#### How to verify it
Add UT
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

