### PR TITLE
[202211] Add support of secure warm-boot backport

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -618,12 +618,15 @@ fi
 if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
     load_aboot_secureboot_kernel
 else
-    # check if secure boot is enable in UEFI
-    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
-    if [ ${SECURE_UPGRADE_ENABLED} -eq 1 ]; then
-        load_kernel_secure
-    else
+    # check if secure boot is enable in UEFI 
+    CHECK_SECURE_UPGRADE_ENABLED=0
+    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
+    if [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]; then
+        debug "Loading kernel without secure boot"
         load_kernel
+    else
+        debug "Loading kernel with secure boot"
+        load_kernel_secure
     fi
 fi
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -182,7 +182,7 @@ function request_pre_shutdown()
 {
     if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_REBOOT_PRE_CHECK} ]; then
         debug "Requesting platform reboot pre-check ..."
-    	${DEVPATH}/${PLATFORM}/${PLATFORM_REBOOT_PRE_CHECK} ${REBOOT_TYPE} 
+    	${DEVPATH}/${PLATFORM}/${PLATFORM_REBOOT_PRE_CHECK} ${REBOOT_TYPE}
     fi
     debug "Requesting pre-shutdown ..."
     STATE=$(timeout 5s docker exec syncd /usr/bin/syncd_request_shutdown --pre &> /dev/null; if [[ $? == 124 ]]; then echo "timed out"; fi)
@@ -447,9 +447,20 @@ function load_aboot_secureboot_kernel() {
         swipath=$next_image kexec=true loadonly=true ENV_EXTRA_CMDLINE="$BOOT_OPTIONS" bash -
 }
 
+function invoke_kexec() {
+    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS" $@
+}
+
 function load_kernel() {
     # Load kernel into the memory
-    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
+    invoke_kexec -a
+}
+
+function load_kernel_secure() {
+    # Load kernel into the memory secure
+    # -s flag is for enforcing the new load kernel(vmlinuz) to be signed and verify.
+    # not using -a flag, this flag can fallback to an old kexec load that do not support Secure Boot verification
+    invoke_kexec -s
 }
 
 function unload_kernel()
@@ -607,7 +618,13 @@ fi
 if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
     load_aboot_secureboot_kernel
 else
-    load_kernel
+    # check if secure boot is enable in UEFI
+    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
+    if [ ${SECURE_UPGRADE_ENABLED} -eq 1 ]; then
+        load_kernel_secure
+    else
+        load_kernel
+    fi
 fi
 
 init_warm_reboot_states


### PR DESCRIPTION
Backport of https://github.com/sonic-net/sonic-utilities/pull/2532 and https://github.com/sonic-net/sonic-utilities/pull/2715
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support of secure warm-boot to SONiC.
Basically, warm-boot is supporting to load a new kernel without doing full/cold boot.
That is by loading a new kernel and exec with kexec Linux command. As a result of that, even when the Secure Boot feature is enabled, still a user or a malicious user can load an unsigned kernel, so to avoid that we added the support of the secure warm boot.
More Description about this feature can be found in the Secure Boot HLD: https://github.com/sonic-net/SONiC/pull/1028

#### How I did it
In general, Linux support it, so I enabled this support by doing the follow steps:

I added some special flags in Linux Kernel when user build the sonic-buildimage with secure boot feature enabled.
I added a flag "-s" to the kexec command
Note: more details in the HLD above.

#### How to verify it
Good flow:
manually just install with sonic-installed a new secure image (a SONiC image that was build with Secure Boot flag enabled)
after the secure image is installed, do:
warm-reboot
Check now that the new kernel is really loaded and switched.
Bad flow:
Do the same steps 1-2 as a good flow but with an insecure image (SONiC image that was built without setting Secure Boot enabled)
After the insecure image is installed, and triggered warm-boot you should get an error that the new unsigned kernel from the unsecured image was not loaded.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

NOTE:
PR of the Secure Boot [sonic-buildimage]: https://github.com/sonic-net/sonic-buildimage/pull/12692
PR of Secure Boot [sonic-linux-kernel]: https://github.com/sonic-net/sonic-linux-kernel/pull/316
