### PR TITLE
[db-migrator] Fix hwsku match for 6100 and add errors when hwsku is None

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -76,9 +76,12 @@ class DBMigrator():
             self.loglevelDB.connect(self.loglevelDB.LOGLEVEL_DB)
 
         version_info = device_info.get_sonic_version_info()
-        asic_type = version_info.get('asic_type')
-        self.asic_type = asic_type
+        self.asic_type = version_info.get('asic_type')
+        if not self.asic_type:
+            log.log_error("ASIC type information not obtained. DB migration will not be reliable")
         self.hwsku = device_info.get_hwsku()
+        if not self.hwsku:
+            log.log_error("HWSKU information not obtained. DB migration will not be reliable")
 
         if asic_type == "mellanox":
             from mellanox_buffer_migrator import MellanoxBufferMigrator
@@ -989,7 +992,7 @@ class DBMigrator():
         # removed together with calling to migrate_copp_table function.
         if self.asic_type != "mellanox":
             self.migrate_copp_table()
-        if self.asic_type == "broadcom" and 'Force10-S6100' in self.hwsku:
+        if self.asic_type == "broadcom" and 'Force10-S6100' in str(self.hwsku):
             self.migrate_mgmt_ports_on_s6100()
         else:
             log.log_notice("Asic Type: {}, Hwsku: {}".format(self.asic_type, self.hwsku))

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -83,7 +83,7 @@ class DBMigrator():
         if not self.hwsku:
             log.log_error("HWSKU information not obtained. DB migration will not be reliable")
 
-        if asic_type == "mellanox":
+        if self.asic_type == "mellanox":
             from mellanox_buffer_migrator import MellanoxBufferMigrator
             self.mellanox_buffer_migrator = MellanoxBufferMigrator(self.configDB, self.appDB, self.stateDB)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

MSFT ADO: 17972494

Fix errors in db migration when hwsku is not detected.
This PR is adds a better-error-handling fix for the issue that is fixed by: https://github.com/sonic-net/sonic-buildimage/pull/14933

```
May  2 20:35:04 sonic database.sh[649]: Creating new database container
May  2 20:35:04 sonic database.sh[663]: 99e8edba01ed0c7581f0d61dd2fa78374fa4f23e636a957004dd03a6f68eea86
May  2 20:35:04 sonic root: Starting database service...
May  2 20:35:06 sonic database.sh[690]: database
May  2 20:35:10 sonic database.sh[926]: True

May  2 20:35:10 sonic database.sh[928]:   File "/usr/local/bin/db_migrator.py", line 714, in common_migration_ops
May  2 20:35:10 sonic database.sh[928]:   File "/usr/local/bin/db_migrator.py", line 741, in migrate
May  2 20:35:10 sonic database.sh[928]:   File "/usr/local/bin/db_migrator.py", line 782, in main
May  2 20:35:10 sonic database.sh[928]: Traceback (most recent call last):
May  2 20:35:10 sonic database.sh[928]: TypeError: argument of type 'NoneType' is not iterable
May  2 20:35:10 sonic database.sh[928]: argument of type 'NoneType' is not iterable
May  2 20:35:10 sonic database.sh[928]: optional arguments:
May  2 20:35:10 sonic database.sh[928]: usage: db_migrator.py [-h] [-o operation migrate, set_version, get_version]
May  2 20:35:10 sonic db_migrator: :- operator(): DB '{APPL_DB}' is empty with pattern 'COPP_TABLE:*'!
May  2 20:35:10 sonic db_migrator: :- operator(): DB '{APPL_DB}' is empty with pattern 'INTF_TABLE:*'!
May  2 20:35:10 sonic db_migrator: :- operator(): Key 'BUFFER_MAX_PARAM_TABLE|global' field 'mmu_size' unavailable in database 'STATE_DB'
May  2 20:35:10 sonic db_migrator: :- operator(): Key 'WARM_RESTART_ENABLE_TABLE|system' field 'enable' unavailable in database 'STATE_DB'
May  2 20:35:10 sonic db_migrator: Caught exception: argument of type 'NoneType' is not iterable

May  2 20:35:11 sonic config-setup[935]: Copying SONiC configuration minigraph.xml ...
May  2 20:35:11 sonic config-setup[935]: Reloading minigraph...
May  2 20:35:11 sonic config-setup[935]: Use minigraph.xml from old system...

May  2 20:35:11 sonic root: Started database service...
```

#### How I did it

Convert hwsku's type to `str` before checking substring.
Add error logs when hwsku and asic type information is not obtained.

#### How to verify it
Tested on a physical device
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

