### PR TITLE
[GCU] fix rdma check failure

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -3,24 +3,8 @@ import re
 
 def rdma_config_update_validator():
     version_info = device_info.get_sonic_version_info()
-    build_version = version_info.get('build_version')
     asic_type = version_info.get('asic_type')
 
     if (asic_type != 'mellanox' and asic_type != 'broadcom' and asic_type != 'cisco-8000'):
         return False
-
-    version_substrings = build_version.split('.')
-    branch_version = None
-
-    for substring in version_substrings:
-        if substring.isdigit() and re.match(r'^\d{8}$', substring):
-            branch_version = substring
-            break
-
-    if branch_version is None:
-        return False
-
-    if asic_type == 'cisco-8000':
-        return branch_version >= "20201200"
-    else:
-        return branch_version >= "20181100"
+    return True


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`if substring.isdigit() and re.match(r'^\d{8}$', substring):` In this version check, it only applies to this pattern: 20220531.XXX. It will fail the master and other build check. For example, `master.261851-010dc3957` is a master build_version string. It will fail version validation and return failure.

My thought to remove the check is that GCU is only supported in 202205 and later. Either `branch_version >= "20201200"` or `branch_version >= "20181100"` is already satisfied.
#### How I did it
Remove redundant check in GCU RDMA validator
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

