### PR TITLE
[config]Support multi-asic Golden Config override with fix

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -56,11 +56,7 @@ class ConfigMgmt():
             self.source = source
             self.allowTablesWithoutYang = allowTablesWithoutYang
             self.sonicYangOptions = sonicYangOptions
-            if configdb is None:
-                self.configdb = ConfigDBConnector()
-                self.configdb.connect()
-            else:
-                self.configdb = configdb
+            self.configdb = configdb
 
             # logging vars
             self.SYSLOG_IDENTIFIER = "ConfigMgmt"
@@ -201,7 +197,11 @@ class ConfigMgmt():
         self.sysLog(doPrint=True, msg='Reading data from Redis configDb')
         # Read from config DB on sonic switch
         data = dict()
-        configdb = self.configdb
+        if self.configdb is None:
+            configdb = ConfigDBConnector()
+            configdb.connect()
+        else:
+            configdb = self.configdb
         sonic_cfggen.deep_update(data, sonic_cfggen.FormatConverter.db_to_output(configdb.get_config()))
         self.configdbJsonIn = sonic_cfggen.FormatConverter.to_serialized(data)
         self.sysLog(syslog.LOG_DEBUG, 'Reading Input from ConfigDB {}'.\
@@ -221,7 +221,11 @@ class ConfigMgmt():
         '''
         self.sysLog(doPrint=True, msg='Writing in Config DB')
         data = dict()
-        configdb = self.configdb
+        if self.configdb is None:
+            configdb = ConfigDBConnector()
+            configdb.connect(False)
+        else:
+            configdb = self.configdb
         sonic_cfggen.deep_update(data, sonic_cfggen.FormatConverter.to_deserialized(jDiff))
         self.sysLog(msg="Write in DB: {}".format(data))
         configdb.mod_config(sonic_cfggen.FormatConverter.output_to_db(data))

--- a/config/main.py
+++ b/config/main.py
@@ -1858,7 +1858,11 @@ def override_config_table(db, input_config_db, dry_run):
         sonic_cfggen.FormatConverter.to_serialized(current_config)
 
         if multi_asic.is_multi_asic():
-            ns_config_input = config_input[ns]
+            # Golden Config will use "localhost" to represent host name
+            if ns == DEFAULT_NAMESPACE:
+                ns_config_input = config_input["localhost"]
+            else:
+                ns_config_input = config_input[ns]
         else:
             ns_config_input = config_input
         updated_config = update_config(current_config, ns_config_input)

--- a/config/main.py
+++ b/config/main.py
@@ -1849,36 +1849,41 @@ def override_config_table(db, input_config_db, dry_run):
                     fg='magenta')
         sys.exit(1)
 
-    config_db = db.cfgdb
+    cfgdb_clients = db.cfgdb_clients
 
-    # Read config from configDB
-    current_config = config_db.get_config()
-    # Serialize to the same format as json input
-    sonic_cfggen.FormatConverter.to_serialized(current_config)
+    for ns, config_db in cfgdb_clients.items():
+        # Read config from configDB
+        current_config = config_db.get_config()
+        # Serialize to the same format as json input
+        sonic_cfggen.FormatConverter.to_serialized(current_config)
 
-    updated_config = update_config(current_config, config_input)
+        if multi_asic.is_multi_asic():
+            ns_config_input = config_input[ns]
+        else:
+            ns_config_input = config_input
+        updated_config = update_config(current_config, ns_config_input)
 
-    yang_enabled = device_info.is_yang_config_validation_enabled(config_db)
-    if yang_enabled:
-        # The ConfigMgmt will load YANG and running
-        # config during initialization.
-        try:
-            cm = ConfigMgmt()
-            cm.validateConfigData()
-        except Exception as ex:
-            click.secho("Failed to validate running config. Error: {}".format(ex), fg="magenta")
-            sys.exit(1)
+        yang_enabled = device_info.is_yang_config_validation_enabled(config_db)
+        if yang_enabled:
+            # The ConfigMgmt will load YANG and running
+            # config during initialization.
+            try:
+                cm = ConfigMgmt(configdb=config_db)
+                cm.validateConfigData()
+            except Exception as ex:
+                click.secho("Failed to validate running config. Error: {}".format(ex), fg="magenta")
+                sys.exit(1)
 
-        # Validate input config
-        validate_config_by_cm(cm, config_input, "config_input")
-        # Validate updated whole config
-        validate_config_by_cm(cm, updated_config, "updated_config")
+            # Validate input config
+            validate_config_by_cm(cm, ns_config_input, "config_input")
+            # Validate updated whole config
+            validate_config_by_cm(cm, updated_config, "updated_config")
 
-    if dry_run:
-        print(json.dumps(updated_config, sort_keys=True,
-                         indent=4, cls=minigraph_encoder))
-    else:
-        override_config_db(config_db, config_input)
+        if dry_run:
+            print(json.dumps(updated_config, sort_keys=True,
+                             indent=4, cls=minigraph_encoder))
+        else:
+            override_config_db(config_db, ns_config_input)
 
 
 def validate_config_by_cm(cm, config_json, jname):

--- a/tests/config_override_input/multi_asic_dm_rm.json
+++ b/tests/config_override_input/multi_asic_dm_rm.json
@@ -1,0 +1,11 @@
+{
+    "": {
+        "DEVICE_METADATA": {}
+    },
+    "asic0": {
+        "DEVICE_METADATA": {}
+    },
+    "asic1": {
+        "DEVICE_METADATA": {}
+    }
+}

--- a/tests/config_override_input/multi_asic_dm_rm.json
+++ b/tests/config_override_input/multi_asic_dm_rm.json
@@ -1,5 +1,5 @@
 {
-    "": {
+    "localhost": {
         "DEVICE_METADATA": {}
     },
     "asic0": {

--- a/tests/config_override_input/multi_asic_macsec_ov.json
+++ b/tests/config_override_input/multi_asic_macsec_ov.json
@@ -1,0 +1,23 @@
+{
+    "": {
+        "MACSEC_PROFILE": {
+            "profile": {
+                "key": "value"
+            }
+        }
+    },
+    "asic0": {
+        "MACSEC_PROFILE": {
+            "profile": {
+                "key": "value"
+            }
+        }
+    },
+    "asic1": {
+        "MACSEC_PROFILE": {
+            "profile": {
+                "key": "value"
+            }
+        }
+    }
+}

--- a/tests/config_override_input/multi_asic_macsec_ov.json
+++ b/tests/config_override_input/multi_asic_macsec_ov.json
@@ -1,5 +1,5 @@
 {
-    "": {
+    "localhost": {
         "MACSEC_PROFILE": {
             "profile": {
                 "key": "value"

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -1,6 +1,7 @@
 import os
 import json
 import filecmp
+import importlib
 import config.main as config
 
 from click.testing import CliRunner
@@ -20,6 +21,8 @@ EMPTY_TABLE_REMOVAL = os.path.join(DATA_DIR, "empty_table_removal.json")
 RUNNING_CONFIG_YANG_FAILURE = os.path.join(DATA_DIR, "running_config_yang_failure.json")
 GOLDEN_INPUT_YANG_FAILURE = os.path.join(DATA_DIR, "golden_input_yang_failure.json")
 FINAL_CONFIG_YANG_FAILURE = os.path.join(DATA_DIR, "final_config_yang_failure.json")
+MULTI_ASIC_MACSEC_OV = os.path.join(DATA_DIR, "multi_asic_macsec_ov.json")
+MULTI_ASIC_DEVICE_METADATA_RM = os.path.join(DATA_DIR, "multi_asic_dm_rm.json")
 
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
@@ -173,7 +176,7 @@ class TestConfigOverride(object):
         def is_yang_config_validation_enabled_side_effect(filename):
             return True
 
-        def config_mgmt_side_effect():
+        def config_mgmt_side_effect(configdb):
             return config_mgmt.ConfigMgmt(source=CONFIG_DB_JSON_FILE)
 
         db = Db()
@@ -232,7 +235,7 @@ class TestConfigOverride(object):
         def read_json_file_side_effect(filename):
             return golden_config
 
-        def config_mgmt_side_effect():
+        def config_mgmt_side_effect(configdb):
             return config_mgmt.ConfigMgmt(source=CONFIG_DB_JSON_FILE)
 
         # ConfigMgmt will call ConfigDBConnector to load default config_db.json.
@@ -256,4 +259,74 @@ class TestConfigOverride(object):
     def teardown_class(cls):
         print("TEARDOWN")
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        return
+
+
+class TestConfigOverrideMultiasic(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        # change to multi asic config
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+        return
+
+    def test_macsec_override(self):
+        def read_json_file_side_effect(filename):
+            with open(MULTI_ASIC_MACSEC_OV, "r") as f:
+                macsec_profile = json.load(f)
+            return macsec_profile
+        db = Db()
+        cfgdb_clients = db.cfgdb_clients
+
+        # The profile_content was copied from MULTI_ASIC_MACSEC_OV, where all
+        # ns sharing the same content: {"profile": {"key": "value"}}
+        profile_content = {"profile": {"key": "value"}}
+
+        with mock.patch('config.main.read_json_file',
+                        mock.MagicMock(side_effect=read_json_file_side_effect)):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["override-config-table"],
+                                   ['golden_config_db.json'], obj=db)
+            assert result.exit_code == 0
+
+        for ns, config_db in cfgdb_clients.items():
+            assert config_db.get_config()['MACSEC_PROFILE'] == profile_content
+
+    def test_device_metadata_table_rm(self):
+        def read_json_file_side_effect(filename):
+            with open(MULTI_ASIC_DEVICE_METADATA_RM, "r") as f:
+                device_metadata = json.load(f)
+            return device_metadata
+        db = Db()
+        cfgdb_clients = db.cfgdb_clients
+
+        for ns, config_db in cfgdb_clients.items():
+            assert 'DEVICE_METADATA' in config_db.get_config()
+
+        with mock.patch('config.main.read_json_file',
+                        mock.MagicMock(side_effect=read_json_file_side_effect)):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["override-config-table"],
+                                   ['golden_config_db.json'], obj=db)
+            assert result.exit_code == 0
+
+        for ns, config_db in cfgdb_clients.items():
+            assert 'DEVICE_METADATA' not in config_db.get_config()
+
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+        # change back to single asic config
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_single_asic
+        importlib.reload(mock_single_asic)
+        dbconnector.load_namespace_config()
         return


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 17746282
#### What I did
Support multi-asic Golden Config Override with fix based on https://github.com/sonic-net/sonic-utilities/pull/2738
#### How I did it
Add ConfigMgmt support for ASIC validation. Modify override config cli to support multi-asic.
#### How to verify it
Unit test:
tests/config_override_test.py::TestConfigOverrideMultiasic::test_macsec_override PASSED [  8%]
tests/config_override_test.py::TestConfigOverrideMultiasic::test_device_metadata_table_rm PASSED [  8%]

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

