### PR TITLE
[Backport-202205][acl-loader] Only add default deny rule when table is L3 or L3V6 (#2796)

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -670,6 +670,7 @@ class AclLoader(object):
     def deny_rule(self, table_name):
         """
         Create default deny rule in Config DB format
+        Only create default deny rule when table is [L3, L3V6]
         :param table_name: ACL table name to which rule belong
         :return: dict with Config DB schema
         """
@@ -677,10 +678,12 @@ class AclLoader(object):
         rule_data = {(table_name, "DEFAULT_RULE"): rule_props}
         rule_props["PRIORITY"] = str(self.min_priority)
         rule_props["PACKET_ACTION"] = "DROP"
-        if self.is_table_ipv6(table_name):
+        if self.is_table_l3v6(table_name):
             rule_props["IP_TYPE"] = "IPV6ANY"  # ETHERTYPE is not supported for DATAACLV6
-        else:
+        elif self.is_table_l3(table_name):
             rule_props["ETHER_TYPE"] = str(self.ethertype_map["ETHERTYPE_IPV4"])
+        else:
+            return {}  # Don't add default deny rule if table is not [L3, L3V6]
         return rule_data
 
     def convert_rules(self):
@@ -707,7 +710,7 @@ class AclLoader(object):
                 except AclLoaderException as ex:
                     error("Error processing rule %s: %s. Skipped." % (acl_entry_name, ex))
 
-            if not self.is_table_mirror(table_name) and not self.is_table_egress(table_name):
+            if not self.is_table_egress(table_name):
                 deep_update(self.rules_info, self.deny_rule(table_name))
 
     def full_update(self):

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -259,6 +259,63 @@
 							}
 						}
 					}
+				},
+				"bmc_acl_northbound": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "0",
+										"source-ip-address": "172.17.0.200/30"
+									}
+								},
+								"input_interface": {
+									"interface_ref": {
+										"config": {
+											"interface": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45"
+										}
+									}
+								}
+							}
+						}
+					},
+					"config": {
+						"name": "bmc_acl_northbound"
+					}
+				},
+				"bmc_acl_northbound_v6": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "0",
+										"destination-ip-address": "fc02::/64"
+									}
+								}
+							}
+						}
+					},
+					"config": {
+						"name": "bmc_acl_northbound_v6"
+					}
 				}
 			}
 		}

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -90,7 +90,7 @@ RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 12
+Total number of ACL Tables: 15
 Total number of ACL Rules: 21
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -511,6 +511,18 @@
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023",
         "type": "L3V6"
     },
+    "ACL_TABLE|BMC_ACL_NORTHBOUND": {
+        "policy_desc": "BMC_ACL_NORTHBOUND",
+        "ports@": "Ethernet8,Ethernet0,Ethernet17,Ethernet16,Ethernet37,Ethernet4,Ethernet13,Ethernet45,Ethernet19,Ethernet24,Ethernet31,Ethernet30,Ethernet39,Ethernet40,Ethernet27,Ethernet43,Ethernet7,Ethernet3,Ethernet20,Ethernet6,Ethernet12,Ethernet34,Ethernet26,Ethernet11,Ethernet42,Ethernet5,Ethernet32,Ethernet36,Ethernet15,Ethernet33,Ethernet35,Ethernet9,Ethernet29,Ethernet21,Ethernet18,Ethernet38,Ethernet23,Ethernet41,Ethernet14,Ethernet2,Ethernet28,Ethernet22,Ethernet10,Ethernet25,Ethernet44,Ethernet1",
+        "stage": "ingress",
+        "type": "BMCDATA"
+    },
+    "ACL_TABLE|BMC_ACL_NORTHBOUND_V6": {
+        "policy_desc": "BMC_ACL_NORTHBOUND_V6",
+        "ports@": "Ethernet13,Ethernet3,Ethernet32,Ethernet33,Ethernet34,Ethernet8,Ethernet6,Ethernet44,Ethernet39,Ethernet18,Ethernet15,Ethernet1,Ethernet19,Ethernet7,Ethernet14,Ethernet43,Ethernet40,Ethernet27,Ethernet4,Ethernet36,Ethernet41,Ethernet10,Ethernet31,Ethernet5,Ethernet9,Ethernet12,Ethernet16,Ethernet25,Ethernet24,Ethernet17,Ethernet35,Ethernet11,Ethernet38,Ethernet42,Ethernet29,Ethernet20,Ethernet45,Ethernet26,Ethernet21,Ethernet37,Ethernet0,Ethernet28,Ethernet23,Ethernet22,Ethernet2,Ethernet30",
+        "stage": "ingress",
+        "type": "BMCDATAV6"
+    },
     "ACL_TABLE|DATAACL": {
         "policy_desc": "DATAACL",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
@@ -549,6 +561,12 @@
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet100,Ethernet104,Ethernet92,Ethernet96,Ethernet84,Ethernet88,Ethernet76,Ethernet80,Ethernet108,Ethernet112,Ethernet64,Ethernet120,Ethernet116,Ethernet124,Ethernet72,Ethernet68",
         "type": "MIRROR"
     },
+    "ACL_TABLE|EVERFLOWV6": {
+        "policy_desc": "EVERFLOWV6",
+        "ports@": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47",
+        "type": "MIRRORV6",
+        "stage": "ingress"
+    },
     "ACL_TABLE|EVERFLOW_EGRESS": {
         "policy_desc": "EGRESS EVERFLOW",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet100,Ethernet104,Ethernet92,Ethernet96,Ethernet84,Ethernet88,Ethernet76,Ethernet80,Ethernet108,Ethernet112,Ethernet64,Ethernet120,Ethernet116,Ethernet124,Ethernet72,Ethernet68",
@@ -564,6 +582,16 @@
         "policy_desc": "SSH_ONLY",
         "services@": "SSH",
         "type": "CTRLPLANE"
+    },
+    "ACL_TABLE_TYPE|BMCDATA": {
+        "ACTIONS": "PACKET_ACTION,COUNTER",
+        "BIND_POINTS": "PORT",
+        "MATCHES": "SRC_IP,DST_IP,ETHER_TYPE,IP_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
+    },
+    "ACL_TABLE_TYPE|BMCDATAV6": {
+        "ACTIONS": "PACKET_ACTION,COUNTER",
+        "BIND_POINTS": "PORT",
+        "MATCHES": "SRC_IPV6,DST_IPV6,ETHER_TYPE,IP_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
     },
     "VLAN|Vlan1000": {
         "dhcp_servers@": "192.0.0.1,192.0.0.2,192.0.0.3,192.0.0.4",


### PR DESCRIPTION
Backport #2796 to 202205 branch.

**What I did**
1. Update acl-loader to only add default deny rule when table is L3 or L3V6.
2. Update unittest to cover it.

**How I did it**

Update function deny_rule and return {} if table is not L3 or L3V6.

**How to verify it**
1. Update unittest and run all testcases to verify.
2. Built the package and installed on DUT to verify.

Unittest results on 202205 branch:
```
tests/acl_loader_test.py::TestAclLoader::test_acl_empty PASSED                                                                [  0%]
tests/acl_loader_test.py::TestAclLoader::test_valid PASSED                                                                    [  0%]
tests/acl_loader_test.py::TestAclLoader::test_invalid PASSED                                                                  [  0%]
tests/acl_loader_test.py::TestAclLoader::test_validate_mirror_action PASSED                                                   [  1%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_translation PASSED                                                      [  1%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_lower_bound PASSED                                                      [  1%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_upper_bound PASSED                                                      [  1%]
tests/acl_loader_test.py::TestAclLoader::test_vlan_id_not_a_number PASSED                                                     [  1%]
tests/acl_loader_test.py::TestAclLoader::test_ethertype_translation PASSED                                                    [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_translation PASSED                                                         [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmpv6_translation PASSED                                                       [  1%]
tests/acl_loader_test.py::TestAclLoader::test_ingress_default_deny_rule PASSED                                                [  1%]
tests/acl_loader_test.py::TestAclLoader::test_egress_no_default_deny_rule PASSED                                              [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_type_lower_bound PASSED                                                    [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_type_upper_bound PASSED                                                    [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_type_not_a_number PASSED                                                   [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_code_lower_bound PASSED                                                    [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_code_upper_bound PASSED                                                    [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_code_not_a_number PASSED                                                   [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_fields_with_non_icmp_protocol PASSED                                       [  1%]
tests/acl_loader_test.py::TestAclLoader::test_icmp_fields_with_non_tcp_protocol PASSED                                        [  1%]
tests/acl_loader_test.py::TestAclLoader::test_incremental_update PASSED                                                       [  1%]

----------- coverage: platform linux, python 3.9.2-final-0 -----------
Name                                                   Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------------------------------
acl_loader/__init__.py                                     0      0      0      0   100%
acl_loader/main.py                                       638    167    284     49    69%
...
----------------------------------------------------------------------------------------
TOTAL                                                  38668  11513  13845   1937    67%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

====================================================== short test summary info ======================================================
FAILED tests/disk_check_test.py::TestDiskCheck::test_readonly - assert 1 == 0
FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts - AssertionError: assert ('    IFACE    STATE    RX_ERR    RX...
FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts_with_group - AssertionError: assert ('\n'\n '          DEVICE...
FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts_with_type - AssertionError: assert ('    IFACE    STATE    RX...
================================ 4 failed, 2044 passed, 3 skipped, 19 warnings in 508.01s (0:08:28) =================================
```

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:


#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
-->
