### PR TITLE
[route_check] incorrectly parsing complete ipv6 vnet info

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -436,7 +436,7 @@ def filter_out_vnet_routes(routes):
     vnet_routes = []
 
     for vnet_route_db_key in vnet_routes_db_keys:
-        vnet_route_attrs = vnet_route_db_key.split(':')
+        vnet_route_attrs = vnet_route_db_key.split(':', 1)
         vnet_name = vnet_route_attrs[0]
         vnet_route = vnet_route_attrs[1]
         vnet_routes.append(vnet_route)


### PR DESCRIPTION
**Description:**
In our lab environment, 
cisco sonic router will hit below error message from route_check
Apr 27 10:51:07.253041 str3-8101-02 ERR monit[519]: 'routeCheck' status failed (255) – 
Failure results: #012    "Unaccounted_ROUTE_ENTRY_TABLE_entries": #012       &quot;fddd:a150:a0::a66:1/128&quot;,#012        &quot;fddd:a150:a0::a67:1/128&quot;,#012       &quot;fddd:a150:a0::a71:1/128&quot;,#012        &quot;fddd:a150:a0::a78:1/128&quot;,#012        &quot;fddd:a150:a0::a80:1/128&quot;#012    
#012#012Failed. Look at reported mismatches above#012add: []#012del: []


**Steps to reproduce the issue:**
run the testcase "vxlan/test_vxlan_ecmp.py" on T1 testbed.
issue is reported from 4202:C48-MSFT: vxlan/test_vxlan_ecmp.py

**Describe the results you expected:**
testcase should not dump above route_check error msg.

**Additional information you deem important:**
the parser will only cut the chars before  :  regardless it is the IPv6 format.

For instance, 
route_check: "fddd:a150:a0::a21:1/128
Will be parsed as “fddd" ONLY
Vnet_v6_in_v4-0:  <fddd> :  a150:a0::a21:1/128"

the major task on route_check is to review whether
ASIC_DB and APPL_DB data are correct/to be synced as below.
we add the debug message on route_check and found.

cisco@dut-400g:/var/log$ zgrep -n route_check syslog*
syslog:12885:May  3 17:23:35.314610 dut-400g WARNING route_check.py: route_check_vnet_asic:[#012    "fddd:a150:a0::a21:1/128",#012    "fddd:a150:a0::a22:1/128",#012    "fddd:a150:a0::a23:1/128"#012]
syslog:12887:May  3 17:23:35.314771 dut-400g WARNING route_check.py: route_check_vnet_appl:[#012    **"fddd",#012    "fddd",#012    "fddd"#012**] **-> bug here**

syslog:12888:May  3 17:23:35.314806 dut-400g WARNING route_check.py:  route_check_vnet_extra:"fddd:a150:a0::a21:1/128"
syslog:12889:May  3 17:23:35.314838 dut-400g WARNING route_check.py:  route_check_vnet_extra:"fddd:a150:a0::a22:1/128"
syslog:12890:May  3 17:23:35.314869 dut-400g WARNING route_check.py:  route_check_vnet_extra:"fddd:a150:a0::a23:1/128"
syslog:12891:May  3 17:23:35.314904 dut-400g WARNING route_check.py:  route_check:[#012    "fddd:a150:a0::a21:1/128",#012    "fddd:a150:a0::a22:1/128",#012    "fddd:a150:a0::a23:1/128"#012]
syslog:12892:May  3 17:23:35.322969 dut-400g WARNING route_check.py: Failure results: {{#012    "Unaccounted_ROUTE_ENTRY_TABLE_entries”: 
[#012        "fddd:a150:a0::a21:1/128",#012        "fddd:a150:a0::a22:1/128",#012        "fddd:a150:a0::a23:1/128"#012    ]#012}}
syslog:12893:May  3 17:23:35.323036 dut-400g WARNING route_check.py: Failed. Look at reported mismatches above

all correct !!!
cisco@dut-400g:/var/log$ sonic-db-dump -n APPL_DB -y > /tmp/appldb.txt
cisco@dut-400g:/var/log$ sonic-db-dump -n ASIC_DB -y > /tmp/asicdb.txt
cisco@dut-400g:/var/log$ cat /tmp/appldb.txt | grep -n VNET
132824:  "VNET_ROUTE_TUNNEL_TABLE:Vnet_v6_in_v4-0:fddd:a150:a0::a21:1/128": {
132832:  "VNET_ROUTE_TUNNEL_TABLE:Vnet_v6_in_v4-0:fddd:a150:a0::a22:1/128": {
132840:  "VNET_ROUTE_TUNNEL_TABLE:Vnet_v6_in_v4-0:fddd:a150:a0::a23:1/128": {
132848:  "VNET_TABLE:Vnet_v6_in_v4-0": {
cisco@dut-400g:/var/log$ cat /tmp/asicdb.txt | grep -n fddd:a150:a0 
117125:  "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"fddd:a150:a0::a21:1/128\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}": {
117133:  "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"fddd:a150:a0::a22:1/128\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}": {
117141:  "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"fddd:a150:a0::a23:1/128\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}": {
cisco@dut-400g:/var/log$ date
Wed 03 May 2023 05:28:00 PM UTC


**solution:**
fix the parsing scheme on route check when APPL_DB refers IPv6 format.
