### PR TITLE
Added platform plugin support in load_minigraph (#2808)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1683,6 +1683,17 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
             raise click.Abort()
         override_config_by(golden_config_path)
 
+    # Invoke platform script if available before starting the services
+    platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs()
+    platform_mg_plugin = platform_path + '/plugins/platform_mg_post_check'
+    if os.path.isfile(platform_mg_plugin):
+        click.echo("Running Platform plugin ............!")
+        proc = subprocess.Popen([platform_mg_plugin], text=True, stdout=subprocess.PIPE)
+        proc.communicate()
+        if proc.returncode != 0:
+            click.echo("Platform plugin failed! retruncode {}".format(proc.returncode))
+            raise click.Abort()
+
     # We first run "systemctl reset-failed" to remove the "failed"
     # status from all services before we attempt to restart them
     if not no_service_restart:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -32,12 +32,27 @@ os.environ["PATH"] += os.pathsep + scripts_path
 # Config Reload input Path
 mock_db_path = os.path.join(test_path, "config_reload_input")
 
+# Load minigraph input Path
+load_minigraph_input_path = os.path.join(test_path, "load_minigraph_input")
+load_minigraph_platform_path = os.path.join(load_minigraph_input_path, "platform")
+load_minigraph_platform_false_path = os.path.join(load_minigraph_input_path, "platform_false")
 
 load_minigraph_command_output="""\
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
 Running command: config qos reload --no-dynamic-buffer --no-delay
 Running command: pfcwd start_default
+Restarting SONiC target ...
+Reloading Monit configuration ...
+Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
+"""
+
+load_minigraph_platform_plugin_command_output="""\
+Stopping SONiC target ...
+Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
+Running command: config qos reload --no-dynamic-buffer --no-delay
+Running command: pfcwd start_default
+Running Platform plugin ............!
 Restarting SONiC target ...
 Reloading Monit configuration ...
 Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
@@ -261,6 +276,7 @@ class TestLoadMinigraph(object):
         import config.main
         importlib.reload(config.main)
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
             (config, show) = get_cmd_module
@@ -277,6 +293,35 @@ class TestLoadMinigraph(object):
             mock_run_command.assert_any_call('systemctl reset-failed snmp')
             assert mock_run_command.call_count == 11
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_path, None)))
+    def test_load_minigraph_platform_plugin(self, get_cmd_module, setup_single_broadcom_asic):
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code == 0
+            assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_platform_plugin_command_output
+            # Verify "systemctl reset-failed" is called for services under sonic.target
+            mock_run_command.assert_any_call('systemctl reset-failed swss')
+            assert mock_run_command.call_count == 8
+
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_false_path, None)))
+    def test_load_minigraph_platform_plugin_fail(self, get_cmd_module, setup_single_broadcom_asic):
+        print(load_minigraph_platform_false_path)
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["-y"])
+            print(result.exit_code)
+            print(result.output)
+            traceback.print_tb(result.exc_info[2])
+            assert result.exit_code != 0
+            assert "Platform plugin failed" in result.output
+
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_port_config_bad_format(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
             "utilities_common.cli.run_command",
@@ -291,6 +336,7 @@ class TestLoadMinigraph(object):
             port_config = [{}]
             self.check_port_config(None, config, port_config, "Failed to load port_config.json, Error: Bad format: PORT table not exists")
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_port_config_inconsistent_port(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
             "utilities_common.cli.run_command",
@@ -302,6 +348,7 @@ class TestLoadMinigraph(object):
             port_config = [{"PORT": {"Eth1": {"admin_status": "up"}}}]
             self.check_port_config(db, config, port_config, "Failed to load port_config.json, Error: Port Eth1 is not defined in current device")
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_port_config(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(
             "utilities_common.cli.run_command",
@@ -319,6 +366,7 @@ class TestLoadMinigraph(object):
             port_config = [{"PORT": {"Ethernet0": {"admin_status": "up"}}}]
             self.check_port_config(db, config, port_config, "config interface startup Ethernet0")
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def check_port_config(self, db, config, port_config, expected_output):
         def read_json_file_side_effect(filename):
             return port_config
@@ -333,6 +381,7 @@ class TestLoadMinigraph(object):
                 assert result.exit_code == 0
                 assert expected_output in result.output
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_non_exist_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
@@ -344,6 +393,7 @@ class TestLoadMinigraph(object):
             assert result.exit_code != 0
             assert "Cannot find 'non_exist.json'" in result.output
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_specified_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
@@ -355,6 +405,7 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert "config override-config-table golden_config.json" in result.output
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_default_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
@@ -366,6 +417,7 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_traffic_shift_away(self, get_cmd_module):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
             (config, show) = get_cmd_module
@@ -377,6 +429,7 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert "TSA" in result.output
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_traffic_shift_away_with_golden_config(self, get_cmd_module):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
             def is_file_side_effect(filename):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -306,7 +306,7 @@ class TestLoadMinigraph(object):
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_platform_plugin_command_output
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call('systemctl reset-failed swss')
-            assert mock_run_command.call_count == 8
+            assert mock_run_command.call_count == 11
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_false_path, None)))
     def test_load_minigraph_platform_plugin_fail(self, get_cmd_module, setup_single_broadcom_asic):

--- a/tests/load_minigraph_input/platform/plugins/platform_mg_post_check
+++ b/tests/load_minigraph_input/platform/plugins/platform_mg_post_check
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Do Nothing!"
+exit 0

--- a/tests/load_minigraph_input/platform_false/plugins/platform_mg_post_check
+++ b/tests/load_minigraph_input/platform_false/plugins/platform_mg_post_check
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Do Nothing!"
+exit 1


### PR DESCRIPTION
Double commit (#2808 )

Signed-off-by: anamehra anamehra@cisco.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added platform plugin hook to execute platform script after minigraph config is loaded in config db and before starting the services.

#### Why I did it
For the phy-based platforms, changing the port speed via minigraoh, e.g. 400G to 100G, also requires gearbox/phy config files to be modified in hwsku directory. Current gearbox config change is not supported by config db or minigraph and that causes a mismatch in speed configuration between config db and gearbox config. To handle this scenario, a platform plugin is added which could do the gearbox config modifications as required based on the minigraph config.

#### How I did it
Call platform plugin script, if present, before starting the services

#### How to verify it
Add a platform plugin script, platform_mg_post_check  in <platform>/plugins dir
Call config load_minigraph and validate if the script is invoked.
The following message is printed if the plugin script is present:
Running Platform plugin ............!

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)