### PR TITLE
Revert "[warm-reboot] Use kexec_file_load instead of kexec_load when …

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -412,7 +412,7 @@ function load_aboot_secureboot_kernel() {
 
 function load_kernel() {
     # Load kernel into the memory
-    /sbin/kexec -a -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
+    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
 }
 
 function unload_kernel()


### PR DESCRIPTION
…available (#2608)"

This reverts commit 93c7d43de62721cfea1fbb678b5de71799e18461.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Revert using kexec_file_load only 202012 branch only. Kexec_file_load is causing warm-reboot failure on kvm

admin@vlab-01:~$ sudo warm-reboot -vvvv
Wed 10 May 2023 12:20:58 AM UTC Saving counters folder before warmboot...
kexec_file_load failed: Key was rejected by service
Wed 10 May 2023 12:21:00 AM UTC warm-reboot failure (255) cleanup ...
Wed 10 May 2023 12:21:01 AM UTC Cancel warm-reboot: code (0)



admin@vlab-01:~$ sudo /sbin/kexec -a -l  /host/image-202012-14937.266039-f379524f2/boot/vmlinuz-4.19.0-12-2-amd64 --initrd=/host/image-202012-14937.266039-f379524f2/boot/initrd.img-4.19.0-12-2-amd64 --append="BOOT_IMAGE=/image-202012-14937.266039-f379524f2/boot/vmlinuz-4.19.0-12-2-amd64 root=UUID=55f52500-e626-4865-ab33-54d72ca71c22 rw console=tty0 console=ttyS0,115200n8 quiet intel_idle.max_cstate=0 net.ifnames=0 biosdevname=0 loop=image-202012-14937.266039-f379524f2/fs.squashfs loopfstype=squashfs systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 SONIC_BOOT_TYPE=warm"
kexec_file_load failed: Key was rejected by service

#### How I did it
Revert using "-a" flag

#### How to verify it
Run warm-reboot on kvm without '-a' flag

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

