### PR TITLE
Fix the invalid variable issue when set-fips in uboot

### DIFF
--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -89,7 +89,8 @@ class UbootBootloader(OnieInstallerBootloader):
         cmdline = out.strip()
         cmdline = re.sub('^linuxargs=', '', cmdline)
         cmdline = re.sub(r' sonic_fips=[^\s]', '', cmdline) + " sonic_fips=" + fips
-        run_command('/usr/bin/fw_setenv linuxargs ' +  cmdline)
+        cmdline = '"' + cmdline + '"'
+        run_command('/usr/bin/fw_setenv linuxargs ' +  cmdline )
         click.echo('Done')
 
     def get_fips(self, image):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Reproduce the issue:
```
/home/admin# sonic-installer set-fips
Command: /usr/bin/fw_setenv linuxargs net.ifnames=0 loopfstype=squashfs loop=image-20220531.27/fs.squashfs systemd.unified_cgroup_hierarchy=0 varlog_size=4096 loglevel=4 sonic_fips=1
Error: illegal character '=' in variable name "loopfstype=squashfs"
```

##### Work item tracking
- Microsoft ADO **(number only)**: 22333116

#### How I did it
Add the double quotation marks when calling the command.

#### How to verify it
It works fine when calling the following command:
/usr/bin/fw_setenv linuxargs "net.ifnames=0 loopfstype=squashfs loop=image-20220531.27/fs.squashfs systemd.unified_cgroup_hierarchy=0 varlog_size=4096 loglevel=4 sonic_fips=1"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

