### PR TITLE
[db_migrator] Add migration of FLEX_COUNTER_DELAY_STATUS during 1911->master upgrade + fast-reboot. Add UT.

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -650,6 +650,20 @@ class DBMigrator():
                 # Set new cable length values
                 self.configDB.set(self.configDB.CONFIG_DB, "CABLE_LENGTH|AZURE", intf, EDGEZONE_AGG_CABLE_LENGTH)
 
+    def migrate_config_db_flex_counter_delay_status(self):
+        """
+        Migrate "FLEX_COUNTER_TABLE|*": { "value": { "FLEX_COUNTER_DELAY_STATUS": "false" } }
+        Set FLEX_COUNTER_DELAY_STATUS true in case of fast-reboot
+        """
+
+        flex_counter_objects = self.configDB.get_keys('FLEX_COUNTER_TABLE')
+        for obj in flex_counter_objects:
+            flex_counter = self.configDB.get_entry('FLEX_COUNTER_TABLE', obj)
+            delay_status = flex_counter.get('FLEX_COUNTER_DELAY_STATUS')
+            if delay_status is None or delay_status == 'false':
+                flex_counter['FLEX_COUNTER_DELAY_STATUS'] = 'true'
+                self.configDB.mod_entry('FLEX_COUNTER_TABLE', obj, flex_counter)
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -948,9 +962,21 @@ class DBMigrator():
     def version_4_0_2(self):
         """
         Version 4_0_2.
-        This is the latest version for master branch
         """
         log.log_info('Handling version_4_0_2')
+
+        if self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system"):
+            self.migrate_config_db_flex_counter_delay_status()
+
+        self.set_version('version_4_0_3')
+        return 'version_4_0_3'
+
+    def version_4_0_3(self):
+        """
+        Version 4_0_3.
+        This is the latest version for master branch
+        """
+        log.log_info('Handling version_4_0_3')
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_expected.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_expected.json
@@ -1,0 +1,19 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_4_0_3"
+    },
+    "FLEX_COUNTER_TABLE|ACL": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|QUEUE": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|PG_WATERMARK": {
+        "FLEX_COUNTER_STATUS": "false",
+        "FLEX_COUNTER_DELAY_STATUS": "true"
+    }
+}

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_input.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_input.json
@@ -1,0 +1,18 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    },
+    "FLEX_COUNTER_TABLE|ACL": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|QUEUE": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "false",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|PG_WATERMARK": {
+        "FLEX_COUNTER_STATUS": "false"
+    }
+}

--- a/tests/db_migrator_input/state_db/fast_reboot_upgrade.json
+++ b/tests/db_migrator_input/state_db/fast_reboot_upgrade.json
@@ -1,0 +1,5 @@
+{
+	"FAST_REBOOT|system": {
+		"enable": "true"
+	}
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -623,3 +623,38 @@ class TestWarmUpgrade_T0_EdgeZoneAggregator(object):
 
         diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
         assert not diff
+
+
+class TestFastUpgrade_to_4_0_3(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+        cls.config_db_tables_to_verify = ['FLEX_COUNTER_TABLE']
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'fast_reboot_upgrade')
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+        dbconnector.dedicated_dbs['STATE_DB'] = None
+
+    def mock_dedicated_config_db(self, filename):
+        jsonfile = os.path.join(mock_db_path, 'config_db', filename)
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile
+        db = Db()
+        return db
+
+    def check_config_db(self, result, expected):
+        for table in self.config_db_tables_to_verify:
+            assert result.get_table(table) == expected.get_table(table)
+
+    def test_fast_reboot_upgrade_to_4_0_3(self):
+        db_before_migrate = 'cross_branch_upgrade_to_4_0_3_input'
+        db_after_migrate = 'cross_branch_upgrade_to_4_0_3_expected'
+        device_info.get_sonic_version_info = get_sonic_version_info_mlnx
+        db = self.mock_dedicated_config_db(db_before_migrate)
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        expected_db = self.mock_dedicated_config_db(db_after_migrate)
+        assert not self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add migration of `FLEX_COUNTER_DELAY_STATUS` attribute of config_db `FLEX_COUNTER_TABLE` during the `SONiC to SONiC upgrade + fast-reboot` from older versions `201911 -> master`.

This change is required for the `fast-reboot` procedure because without it the counters will be created during the init flow which will waste a lot of resources and cause data plane degradation of more than 30 seconds.

#### How I did it
Modify the `db_migrator.py`.

#### How to verify it
Add UT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

