### PR TITLE
Restart the rsyslog after config hostname

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1939,6 +1939,10 @@ def hostname(new_hostname):
         ctx = click.get_current_context()
         ctx.fail("Failed to write new hostname to ConfigDB. Error: {}".format(e))
 
+    # Restart each rsyslog service
+    click.echo("Restarting rsyslog service ...")
+    clicommon.run_command("sudo systemctl restart rsyslog.service")
+    clicommon.run_command("for i in `docker ps -q`; do docker exec -it $i supervisorctl restart rsyslogd; done")
 
     click.echo('Please note loaded setting will be lost after system reboot. To'
                ' preserve setting, run `config save`.')


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Apply the new hostname into the system and syslog without reloading or rebooting.

#### How I did it

Restart the rsyslog process of the host and of each container after configuring new hostname.

#### How to verify it

Config new hostname with:
`sudo config hostname newhostname-test`
and check the /var/log/syslog to make sure the new hostname is applied.

#### Previous command output (if the output of a command-line utility has changed)

```
admin@my-test:/usr$ sudo config hostname newhostname-test
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
```

#### New command output (if the output of a command-line utility has changed)

```
admin@my-test:/usr$ sudo config hostname newhostname-test
Restarting rsyslog service ...
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
rsyslogd: stopped
rsyslogd: started
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
```