### PR TITLE
[syslog] Adjust runningconfiguration syslog command

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1686,7 +1686,7 @@ def syslog(verbose):
     header = ["Syslog Servers"]
     body = []
 
-    re_syslog = re.compile(r'^\*\.\* action\(.*target=\"{1}(.+?)\"{1}.*\)')
+    re_syslog = re.compile(r'^action\(type=\"omfwd\" Target=\"{1}(.+?)\"{1}.*\)')
 
     try:
         with open("/etc/rsyslog.conf") as syslog_file:

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -7,7 +7,7 @@ import show.main as show
 from unittest import mock
 from click.testing import CliRunner
 from utilities_common import constants
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import call, MagicMock, patch, mock_open
 
 EXPECTED_BASE_COMMAND = 'sudo '
 EXPECTED_BASE_COMMAND_LIST = ['sudo']
@@ -988,3 +988,27 @@ class TestShow(object):
     def teardown(self):
         print('TEAR DOWN')
 
+
+class TestShowRunningconfiguration(object):
+    @classmethod
+    def setup_class(cls):
+        print('SETUP')
+        os.environ['UTILITIES_UNIT_TESTING'] = '1'
+
+    @patch('show.main.run_command')
+    @patch('builtins.open', mock_open(
+        read_data=open('tests/syslog_input/rsyslog.conf').read()))
+    def test_rc_syslog(self, mock_rc):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            show.cli.commands['runningconfiguration'].commands['syslog'])
+        print(result.exit_code)
+        print(result.output)
+
+        assert result.exit_code == 0
+        assert '[1.1.1.1]' in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print('TEARDOWN')

--- a/tests/syslog_input/rsyslog.conf
+++ b/tests/syslog_input/rsyslog.conf
@@ -1,0 +1,77 @@
+###############################################################################
+# Managed by Ansible
+# file: ansible/roles/acs/templates/rsyslog.conf.j2
+###############################################################################
+#
+#  /etc/rsyslog.conf    Configuration file for rsyslog.
+#
+#                       For more information see
+#                       /usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
+
+
+#################
+#### MODULES ####
+#################
+
+$ModLoad imuxsock # provides support for local system logging
+$ModLoad imklog   # provides kernel logging support
+#$ModLoad immark  # provides --MARK-- message capability
+
+# provides UDP syslog reception
+$ModLoad imudp
+$UDPServerAddress 127.0.0.1  #bind to localhost before udp server run
+$UDPServerRun 514
+
+# provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
+#$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# Define a custom template
+$template SONiCFileFormat,"%timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$ActionFileDefaultTemplate SONiCFileFormat
+
+template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall time=\"%timereported\
+:::date-year%-%timereported:::date-month%-%timereported:::date-day% %timereported:::date-hour%:%timereported:::date-minute%:%timereported\
+:::date-second%\" fw=\"sonic\" pri=%syslogpriority% msg=\"%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\"\n")
+
+#Set remote syslog server
+*.notice
+action(type="omfwd" Target="1.1.1.1" Port="514" Protocol="udp" Device="eth0" Template="SONiCFileFormat")
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+#
+# Suppress duplicate messages and report "message repeated n times"
+#
+$RepeatedMsgReduction on
+
+###############
+#### RULES ####
+###############


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Adjust `show runningconfiguration syslog` command according to the new syslog configuration file

#### How I did it
Fix regex to match the target syslog server

#### How to verify it
Run the next command in sonic shell:
```
show runningconfiguration syslog
```

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A

