### PR TITLE
[vlan][dhcp_relay] Clear dhcpv6 relay counter while deleting vlan

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -1,6 +1,7 @@
 import click
 import utilities_common.cli as clicommon
 import utilities_common.dhcp_relay_util as dhcp_relay_util
+from swsscommon.swsscommon import SonicV2Connector
 
 from jsonpatch import JsonPatchConflict
 from time import sleep
@@ -65,6 +66,14 @@ def is_dhcpv6_relay_config_exist(db, vlan_name):
         return True
 
 
+def delete_state_db_entry(entry_name):
+    state_db = SonicV2Connector()
+    state_db.connect(state_db.STATE_DB)
+    exists = state_db.exists(state_db.STATE_DB, 'DHCPv6_COUNTER_TABLE|{}'.format(entry_name))
+    if exists:
+        state_db.delete(state_db.STATE_DB, 'DHCPv6_COUNTER_TABLE|{}'.format(entry_name))
+
+
 @vlan.command('del')
 @click.argument('vid', metavar='<vid>', required=True, type=int)
 @click.option('--no_restart_dhcp_relay', is_flag=True, type=click.BOOL, required=False, default=False,
@@ -108,6 +117,8 @@ def del_vlan(db, vid, no_restart_dhcp_relay):
 
     # set dhcpv4_relay table
     set_dhcp_relay_table('VLAN', config_db, vlan, None)
+
+    delete_state_db_entry(vlan)
 
     if not no_restart_dhcp_relay and is_dhcpv6_relay_config_exist(db, vlan):
         # set dhcpv6_relay table

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -391,10 +391,12 @@ class TestVlan(object):
             print(result.output)
             assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
+        with mock.patch("config.vlan.delete_state_db_entry") as delete_state_db_entry:
+            result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1000"], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            delete_state_db_entry.assert_called_once_with("Vlan1000")
 
         # show output
         result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [], obj=db)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix this issue: https://github.com/sonic-net/sonic-buildimage/issues/15047
Show dhcp_relay ipv6 counter will display vlan which has been deleted.

#### How I did it
Remove related info in state_db while deleting a vlan

#### How to verify it
1. Add unit test
```
tests/vlan_test.py::TestVlan::test_config_vlan_del_vlan PASSED           [ 74%]
```
2. Build utilities and run cmd to verify
```
admin@dut:~$ show dhcp_relay ipv6 counters
       Message Type    Vlan1000
-------------------  ----------
            Unknown           0
            Solicit           0
          Advertise           0
            Request           0
            Confirm           0
              Renew           0
             Rebind           0
              Reply           0
            Release           0
            Decline           0
        Reconfigure           0
Information-Request           0
      Relay-Forward           0
        Relay-Reply           0
          Malformed           0

       Message Type    Vlan1001
-------------------  ----------
            Unknown           0
            Solicit           0
          Advertise           0
            Request           0
            Confirm           0
              Renew           0
             Rebind           0
              Reply           0
            Release           0
            Decline           0
        Reconfigure           0
Information-Request           0
      Relay-Forward           0
        Relay-Reply           0
          Malformed           0

admin@dut:~$ show dhcp6relay_counters counts
       Message Type    Vlan1000
-------------------  ----------
            Unknown           0
            Solicit           0
          Advertise           0
            Request           0
            Confirm           0
              Renew           0
             Rebind           0
              Reply           0
            Release           0
            Decline           0
        Reconfigure           0
Information-Request           0
      Relay-Forward           0
        Relay-Reply           0
          Malformed           0

       Message Type    Vlan1001
-------------------  ----------
            Unknown           0
            Solicit           0
          Advertise           0
            Request           0
            Confirm           0
              Renew           0
             Rebind           0
              Reply           0
            Release           0
            Decline           0
        Reconfigure           0
Information-Request           0
      Relay-Forward           0
        Relay-Reply           0
          Malformed           0

admin@dut:~$ sudo config vlan del 1001
admin@dut:~$ show dhcp_relay ipv6 counters
       Message Type    Vlan1000
-------------------  ----------
            Unknown           0
            Solicit           0
          Advertise           0
            Request           0
            Confirm           0
              Renew           0
             Rebind           0
              Reply           0
            Release           0
            Decline           0
        Reconfigure           0
Information-Request           0
      Relay-Forward           0
        Relay-Reply           0
          Malformed           0

admin@dut:~$ show dhcp6relay_counters counts
       Message Type    Vlan1000
-------------------  ----------
            Unknown           0
            Solicit           0
          Advertise           0
            Request           0
            Confirm           0
              Renew           0
             Rebind           0
              Reply           0
            Release           0
            Decline           0
        Reconfigure           0
Information-Request           0
      Relay-Forward           0
        Relay-Reply           0
          Malformed           0

admin@dut:~$
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

