### PR TITLE
[config]Generate sysinfo in single asic

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1906,10 +1906,10 @@ def override_config_table(db, input_config_db, dry_run):
                 ns_config_input = config_input["localhost"]
             else:
                 ns_config_input = config_input[ns]
-            # Generate sysinfo if missing in ns_config_input
-            generate_sysinfo(current_config, ns_config_input, ns)
         else:
             ns_config_input = config_input
+        # Generate sysinfo if missing in ns_config_input
+        generate_sysinfo(current_config, ns_config_input, ns)
         updated_config = update_config(current_config, ns_config_input)
 
         yang_enabled = device_info.is_yang_config_validation_enabled(config_db)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 17921518
#### What I did
It is a bug introduced from https://github.com/sonic-net/sonic-utilities/pull/2836. Need to generate sysinfo for single asic.
#### How I did it
Reuse the mac and platform in existing device runnning config and generate that if missing.
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

