### PR TITLE
Add display support for serial field in show chassis modules status CLI

### DIFF
--- a/show/chassis_modules.py
+++ b/show/chassis_modules.py
@@ -12,6 +12,7 @@ CHASSIS_MODULE_INFO_DESC_FIELD = 'desc'
 CHASSIS_MODULE_INFO_SLOT_FIELD = 'slot'
 CHASSIS_MODULE_INFO_OPERSTATUS_FIELD = 'oper_status'
 CHASSIS_MODULE_INFO_ADMINSTATUS_FIELD = 'admin_status'
+CHASSIS_MODULE_INFO_SERIAL_FIELD = 'serial'
 
 CHASSIS_MIDPLANE_INFO_TABLE = 'CHASSIS_MIDPLANE_TABLE'
 CHASSIS_MIDPLANE_INFO_IP_FIELD = 'ip_address'
@@ -33,7 +34,7 @@ def modules():
 def status(db, chassis_module_name):
     """Show chassis-modules status"""
 
-    header = ['Name', 'Description', 'Physical-Slot', 'Oper-Status', 'Admin-Status']
+    header = ['Name', 'Description', 'Physical-Slot', 'Oper-Status', 'Admin-Status', 'Serial']
     chassis_cfg_table = db.cfgdb.get_table('CHASSIS_MODULE')
 
     state_db = SonicV2Connector(host="127.0.0.1")
@@ -59,13 +60,14 @@ def status(db, chassis_module_name):
         desc = data_dict[CHASSIS_MODULE_INFO_DESC_FIELD]
         slot = data_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]
         oper_status = data_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD]
+        serial = data_dict[CHASSIS_MODULE_INFO_SERIAL_FIELD]
 
         admin_status = 'up'
         config_data = chassis_cfg_table.get(key_list[1])
         if config_data is not None:
             admin_status = config_data.get(CHASSIS_MODULE_INFO_ADMINSTATUS_FIELD)
 
-        table.append((key_list[1], desc, slot, oper_status, admin_status))
+        table.append((key_list[1], desc, slot, oper_status, admin_status, serial))
 
     if table:
         click.echo(tabulate(table, header, tablefmt='simple', stralign='right'))

--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -13,23 +13,23 @@ from utilities_common.db import Db
 from .utils import get_result_and_return_code
 
 show_linecard0_shutdown_output="""\
-LINE-CARD0 line-card 1 Empty down
+LINE-CARD0 line-card 1 Empty down LC1000101
 """
 
 show_linecard0_startup_output="""\
-LINE-CARD0 line-card 1 Empty up
+LINE-CARD0 line-card 1 Empty up LC1000101
 """
 header_lines = 2
 warning_lines = 0
 
 show_chassis_modules_output="""\
-        Name      Description    Physical-Slot    Oper-Status    Admin-Status
-------------  ---------------  ---------------  -------------  --------------
-FABRIC-CARD0      fabric-card               17         Online              up
-FABRIC-CARD1      fabric-card               18        Offline              up
-  LINE-CARD0        line-card                1          Empty              up
-  LINE-CARD1        line-card                2         Online            down
- SUPERVISOR0  supervisor-card               16         Online              up
+        Name      Description    Physical-Slot    Oper-Status    Admin-Status     Serial
+------------  ---------------  ---------------  -------------  --------------  ---------
+FABRIC-CARD0      fabric-card               17         Online              up  FC1000101
+FABRIC-CARD1      fabric-card               18        Offline              up  FC1000102
+  LINE-CARD0        line-card                1          Empty              up  LC1000101
+  LINE-CARD1        line-card                2         Online            down  LC1000102
+ SUPERVISOR0  supervisor-card               16         Online              up  RP1000101
 """
 
 show_chassis_midplane_output="""\

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -820,27 +820,32 @@
     "CHASSIS_MODULE_TABLE|SUPERVISOR0": {
         "desc": "supervisor-card",
         "oper_status": "Online",
-        "slot": "16"
+        "slot": "16",
+        "serial": "RP1000101"
     },
     "CHASSIS_MODULE_TABLE|LINE-CARD0": {
         "desc": "line-card",
         "oper_status": "Empty",
-        "slot": "1"
+        "slot": "1",
+        "serial": "LC1000101"
     },
     "CHASSIS_MODULE_TABLE|LINE-CARD1": {
         "desc": "line-card",
         "oper_status": "Online",
-        "slot": "2"
+        "slot": "2",
+        "serial": "LC1000102"
     },
     "CHASSIS_MODULE_TABLE|FABRIC-CARD0": {
         "desc": "fabric-card",
         "oper_status": "Online",
-        "slot": "17"
+        "slot": "17",
+        "serial": "FC1000101"
     },
     "CHASSIS_MODULE_TABLE|FABRIC-CARD1": {
         "desc": "fabric-card",
         "oper_status": "Offline",
-        "slot": "18"
+        "slot": "18",
+        "serial": "FC1000102"
     },
     "MUX_CABLE_TABLE|Ethernet32": {
         "state": "active"


### PR DESCRIPTION
#### What I did
Enhancement to the "show chassis modules status" CLI to add a new column added at the end to show each card's serial number

#### How I did it
- Store another field - serial in chassis module table for each card, which is be fetched and displayed through show command
- Dependent PR in sonic-platform-daemons to accommodate the storage of serial field to the database, both PRs <363> and <2858> need to go together and submodule versions need to be updated 
(https://github.com/amulyan7/sonic-platform-daemons/pull/1)

Microsoft ADO: https://dev.azure.com/msazure/One/_workitems/edit/17320021

#### How to verify it
Through the CLI: show chassis modules status
RP
```
root@sonic:/home/cisco# show chassis modules status
        Name                             Description    Physical-Slot    Oper-Status    Admin-Status       Serial
------------  --------------------------------------  ---------------  -------------  --------------  -----------
FABRIC-CARD0                        8808 Fabric Card               18         Online              up  FOC2201N3EM
FABRIC-CARD1  Cisco 8808  8-Slot Chassis Fabric Card               19         Online              up  FOC2220NXFA
FABRIC-CARD2                                     N/A               20          Empty              up          N/A
FABRIC-CARD3                                     N/A               21          Empty              up          N/A
FABRIC-CARD4                                     N/A               22          Empty              up          N/A
FABRIC-CARD5                                     N/A               23          Empty              up          N/A
FABRIC-CARD6                                     N/A               24          Empty              up          N/A
FABRIC-CARD7                                     N/A               25          Empty              up          N/A
  LINE-CARD0       8800-LC 48x100GE QSFP28 Line Card                2         Online              up  FOC2210N8U4
  LINE-CARD1    Cisco 8800 48x100GE QSFP28 Line Card                4         Online              up  FOC2211NKP3
  LINE-CARD2                                     N/A                6          Empty              up          N/A
  LINE-CARD3                                     N/A                8          Empty              up          N/A
  LINE-CARD4                                     N/A               10          Empty              up          N/A
  LINE-CARD5                                     N/A               12          Empty              up          N/A
  LINE-CARD6                                     N/A               14          Empty              up          N/A
  LINE-CARD7                                     N/A               16          Empty              up          N/A
 SUPERVISOR0       Cisco 8800 Route Processor - Open               30         Online              up  FOC2144N6W3
 SUPERVISOR1                                     N/A               31          Empty              up          N/A
 ```
LC
```
root@sonic:/home/cisco# show chassis modules status
       Name                        Description    Physical-Slot    Oper-Status    Admin-Status       Serial
-----------  ---------------------------------  ---------------  -------------  --------------  -----------
 LINE-CARD0  8800-LC 48x100GE QSFP28 Line Card                2         Online              up  FOC2210N8U4
SUPERVISOR0  Cisco 8800 Route Processor - Open               30         Online              up  FOC2144N6W3
```

Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)

