### PR TITLE
[202205][config]Support multi-asic Golden Config override with fix (#2825)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1777,36 +1777,45 @@ def override_config_table(db, input_config_db, dry_run):
                     fg='magenta')
         sys.exit(1)
 
-    config_db = db.cfgdb
+    cfgdb_clients = db.cfgdb_clients
 
-    # Read config from configDB
-    current_config = config_db.get_config()
-    # Serialize to the same format as json input
-    sonic_cfggen.FormatConverter.to_serialized(current_config)
+    for ns, config_db in cfgdb_clients.items():
+        # Read config from configDB
+        current_config = config_db.get_config()
+        # Serialize to the same format as json input
+        sonic_cfggen.FormatConverter.to_serialized(current_config)
 
-    updated_config = update_config(current_config, config_input)
+        if multi_asic.is_multi_asic():
+            # Golden Config will use "localhost" to represent host name
+            if ns == DEFAULT_NAMESPACE:
+                ns_config_input = config_input["localhost"]
+            else:
+                ns_config_input = config_input[ns]
+        else:
+            ns_config_input = config_input
+        updated_config = update_config(current_config, ns_config_input)
 
-    yang_enabled = device_info.is_yang_config_validation_enabled(config_db)
-    if yang_enabled:
-        # The ConfigMgmt will load YANG and running
-        # config during initialization.
-        try:
-            cm = ConfigMgmt()
-            cm.validateConfigData()
-        except Exception as ex:
-            click.secho("Failed to validate running config. Error: {}".format(ex), fg="magenta")
-            sys.exit(1)
+        yang_enabled = device_info.is_yang_config_validation_enabled(config_db)
+        if yang_enabled:
+            # The ConfigMgmt will load YANG and running
+            # config during initialization.
+            try:
+                cm = ConfigMgmt(configdb=config_db)
+                cm.validateConfigData()
+            except Exception as ex:
+                click.secho("Failed to validate running config. Error: {}".format(ex), fg="magenta")
+                sys.exit(1)
 
-        # Validate input config
-        validate_config_by_cm(cm, config_input, "config_input")
-        # Validate updated whole config
-        validate_config_by_cm(cm, updated_config, "updated_config")
+            # Validate input config
+            validate_config_by_cm(cm, ns_config_input, "config_input")
+            # Validate updated whole config
+            validate_config_by_cm(cm, updated_config, "updated_config")
 
-    if dry_run:
-        print(json.dumps(updated_config, sort_keys=True,
-                         indent=4, cls=minigraph_encoder))
-    else:
-        override_config_db(config_db, config_input)
+        if dry_run:
+            print(json.dumps(updated_config, sort_keys=True,
+                             indent=4, cls=minigraph_encoder))
+        else:
+            override_config_db(config_db, ns_config_input)
 
 
 def validate_config_by_cm(cm, config_json, jname):

--- a/tests/config_override_input/multi_asic_dm_rm.json
+++ b/tests/config_override_input/multi_asic_dm_rm.json
@@ -1,0 +1,11 @@
+{
+    "localhost": {
+        "DEVICE_METADATA": {}
+    },
+    "asic0": {
+        "DEVICE_METADATA": {}
+    },
+    "asic1": {
+        "DEVICE_METADATA": {}
+    }
+}

--- a/tests/config_override_input/multi_asic_macsec_ov.json
+++ b/tests/config_override_input/multi_asic_macsec_ov.json
@@ -1,0 +1,23 @@
+{
+    "localhost": {
+        "MACSEC_PROFILE": {
+            "profile": {
+                "key": "value"
+            }
+        }
+    },
+    "asic0": {
+        "MACSEC_PROFILE": {
+            "profile": {
+                "key": "value"
+            }
+        }
+    },
+    "asic1": {
+        "MACSEC_PROFILE": {
+            "profile": {
+                "key": "value"
+            }
+        }
+    }
+}

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -1,6 +1,7 @@
 import os
 import json
 import filecmp
+import importlib
 import config.main as config
 
 from click.testing import CliRunner
@@ -20,6 +21,8 @@ EMPTY_TABLE_REMOVAL = os.path.join(DATA_DIR, "empty_table_removal.json")
 RUNNING_CONFIG_YANG_FAILURE = os.path.join(DATA_DIR, "running_config_yang_failure.json")
 GOLDEN_INPUT_YANG_FAILURE = os.path.join(DATA_DIR, "golden_input_yang_failure.json")
 FINAL_CONFIG_YANG_FAILURE = os.path.join(DATA_DIR, "final_config_yang_failure.json")
+MULTI_ASIC_MACSEC_OV = os.path.join(DATA_DIR, "multi_asic_macsec_ov.json")
+MULTI_ASIC_DEVICE_METADATA_RM = os.path.join(DATA_DIR, "multi_asic_dm_rm.json")
 
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
@@ -173,7 +176,7 @@ class TestConfigOverride(object):
         def is_yang_config_validation_enabled_side_effect(filename):
             return True
 
-        def config_mgmt_side_effect():
+        def config_mgmt_side_effect(configdb):
             return config_mgmt.ConfigMgmt(source=CONFIG_DB_JSON_FILE)
 
         db = Db()
@@ -232,7 +235,7 @@ class TestConfigOverride(object):
         def read_json_file_side_effect(filename):
             return golden_config
 
-        def config_mgmt_side_effect():
+        def config_mgmt_side_effect(configdb):
             return config_mgmt.ConfigMgmt(source=CONFIG_DB_JSON_FILE)
 
         # ConfigMgmt will call ConfigDBConnector to load default config_db.json.
@@ -256,4 +259,74 @@ class TestConfigOverride(object):
     def teardown_class(cls):
         print("TEARDOWN")
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        return
+
+
+class TestConfigOverrideMultiasic(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        # change to multi asic config
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+        return
+
+    def test_macsec_override(self):
+        def read_json_file_side_effect(filename):
+            with open(MULTI_ASIC_MACSEC_OV, "r") as f:
+                macsec_profile = json.load(f)
+            return macsec_profile
+        db = Db()
+        cfgdb_clients = db.cfgdb_clients
+
+        # The profile_content was copied from MULTI_ASIC_MACSEC_OV, where all
+        # ns sharing the same content: {"profile": {"key": "value"}}
+        profile_content = {"profile": {"key": "value"}}
+
+        with mock.patch('config.main.read_json_file',
+                        mock.MagicMock(side_effect=read_json_file_side_effect)):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["override-config-table"],
+                                   ['golden_config_db.json'], obj=db)
+            assert result.exit_code == 0
+
+        for ns, config_db in cfgdb_clients.items():
+            assert config_db.get_config()['MACSEC_PROFILE'] == profile_content
+
+    def test_device_metadata_table_rm(self):
+        def read_json_file_side_effect(filename):
+            with open(MULTI_ASIC_DEVICE_METADATA_RM, "r") as f:
+                device_metadata = json.load(f)
+            return device_metadata
+        db = Db()
+        cfgdb_clients = db.cfgdb_clients
+
+        for ns, config_db in cfgdb_clients.items():
+            assert 'DEVICE_METADATA' in config_db.get_config()
+
+        with mock.patch('config.main.read_json_file',
+                        mock.MagicMock(side_effect=read_json_file_side_effect)):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["override-config-table"],
+                                   ['golden_config_db.json'], obj=db)
+            assert result.exit_code == 0
+
+        for ns, config_db in cfgdb_clients.items():
+            assert 'DEVICE_METADATA' not in config_db.get_config()
+
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+        # change back to single asic config
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_single_asic
+        importlib.reload(mock_single_asic)
+        dbconnector.load_namespace_config()
         return


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 17746282
Cherry-pick conflict.
Backport #2825 and fix conflict.


Tested device:
```
admin@str-msn2700-01:~$ show ver

SONiC Software Version: SONiC.20220531.24
Distribution: Debian 11.6
Kernel: 5.10.0-18-2-amd64
Build commit: 262ec6a387
Build date: Tue Mar 28 19:56:42 UTC 2023
Built by: cloudtest@3d43ef1cc000000

Platform: x86_64-mlnx_msn2700-r0
HwSKU: Mellanox-SN2700
ASIC: mellanox
ASIC Count: 1
Serial Number: MT2020T04272
Model Number: MSN2700-CS2FO
Hardware Revision: A2
Uptime: 07:40:46 up 36 min,  3 users,  load average: 1.32, 1.31, 1.48
Date: Tue 06 Jun 2023 07:40:46
```
#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

