### PR TITLE
Revert "[config]config reload should generate sysinfo if missing (#2778)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1538,19 +1538,6 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("The config file {} doesn't exist".format(file))
             continue
 
-        if file_format == 'config_db':
-            file_input = read_json_file(file)
-
-            platform = file_input.get("DEVICE_METADATA", {}).\
-                get("localhost", {}).get("platform")
-            mac = file_input.get("DEVICE_METADATA", {}).\
-                get("localhost", {}).get("mac")
-
-            if not platform or not mac:
-                log.log_warning("Input file does't have platform or mac. platform: {}, mac: {}"
-                    .format(None if platform is None else platform, None if mac is None else mac))
-                load_sysinfo = True
-
         if load_sysinfo:
             try:
                 command = [SONIC_CFGGEN_PATH, "-j", file, '-v', "DEVICE_METADATA.localhost.hwsku"]

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -451,66 +451,9 @@ class TestReloadConfig(object):
         print("SETUP")
         import config.main
         importlib.reload(config.main)
-
-    def add_sysinfo_to_cfg_file(self):
-        with open(self.dummy_cfg_file, 'w') as f:
-            device_metadata = {
-                "DEVICE_METADATA": {
-                    "localhost": {
-                        "platform": "some_platform",
-                        "mac": "02:42:f0:7f:01:05"
-                    }
-                }
-            }
-            f.write(json.dumps(device_metadata))
-
-    def test_reload_config_invalid_input(self, get_cmd_module, setup_single_broadcom_asic):
-        open(self.dummy_cfg_file, 'w').close()
-        with mock.patch(
-                "utilities_common.cli.run_command",
-                mock.MagicMock(side_effect=mock_run_command_side_effect)
-        ) as mock_run_command:
-            (config, show) = get_cmd_module
-            runner = CliRunner()
-
-            result = runner.invoke(
-                config.config.commands["reload"],
-                [self.dummy_cfg_file, '-y', '-f'])
-
-            print(result.exit_code)
-            print(result.output)
-            traceback.print_tb(result.exc_info[2])
-            assert result.exit_code != 0
-
-    def test_reload_config_no_sysinfo(self, get_cmd_module, setup_single_broadcom_asic):
-        with open(self.dummy_cfg_file, 'w') as f:
-            device_metadata = {
-                "DEVICE_METADATA": {
-                    "localhost": {
-                        "hwsku": "some_hwsku"
-                    }
-                }
-            }
-            f.write(json.dumps(device_metadata))
-
-        with mock.patch(
-                "utilities_common.cli.run_command",
-                mock.MagicMock(side_effect=mock_run_command_side_effect)
-        ) as mock_run_command:
-            (config, show) = get_cmd_module
-            runner = CliRunner()
-
-            result = runner.invoke(
-                config.config.commands["reload"],
-                [self.dummy_cfg_file, '-y', '-f'])
-
-            print(result.exit_code)
-            print(result.output)
-            traceback.print_tb(result.exc_info[2])
-            assert result.exit_code == 0
+        open(cls.dummy_cfg_file, 'w').close()
 
     def test_reload_config(self, get_cmd_module, setup_single_broadcom_asic):
-        self.add_sysinfo_to_cfg_file()
         with mock.patch(
                 "utilities_common.cli.run_command",
                 mock.MagicMock(side_effect=mock_run_command_side_effect)
@@ -530,7 +473,6 @@ class TestReloadConfig(object):
                 == RELOAD_CONFIG_DB_OUTPUT
 
     def test_config_reload_disabled_service(self, get_cmd_module, setup_single_broadcom_asic):
-        self.add_sysinfo_to_cfg_file()
         with mock.patch(
                "utilities_common.cli.run_command",
                mock.MagicMock(side_effect=mock_run_command_side_effect_disabled_timer)
@@ -550,7 +492,6 @@ class TestReloadConfig(object):
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == reload_config_with_disabled_service_output
 
     def test_reload_config_masic(self, get_cmd_module, setup_multi_broadcom_masic):
-        self.add_sysinfo_to_cfg_file()
         with mock.patch(
                 "utilities_common.cli.run_command",
                 mock.MagicMock(side_effect=mock_run_command_side_effect)


### PR DESCRIPTION


This reverts commit 88ffb16721d6f867f71100bb14564120a456e07b.
It break config reload with stdin input.
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

