### PR TITLE
[202111][db_migrator] Add migration of FLEX_COUNTER_DELAY_STATUS during 1911->2111 upgrade + fast-reboot. Add UT.

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_2_0_4'
+        self.CURRENT_VERSION = 'version_2_0_5'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_2_0_5_expected.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_2_0_5_expected.json
@@ -1,0 +1,19 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_2_0_5"
+    },
+    "FLEX_COUNTER_TABLE|ACL": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|QUEUE": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|PG_WATERMARK": {
+        "FLEX_COUNTER_STATUS": "false",
+        "FLEX_COUNTER_DELAY_STATUS": "true"
+    }
+}

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_2_0_5_input.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_2_0_5_input.json
@@ -1,0 +1,18 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    },
+    "FLEX_COUNTER_TABLE|ACL": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|QUEUE": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "false",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|PG_WATERMARK": {
+        "FLEX_COUNTER_STATUS": "false"
+    }
+}

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
@@ -2043,6 +2043,6 @@
         "admin_status": "up"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_2_0_4"
+        "VERSION": "version_2_0_5"
     }
 }

--- a/tests/db_migrator_input/state_db/fast_reboot_upgrade.json
+++ b/tests/db_migrator_input/state_db/fast_reboot_upgrade.json
@@ -1,0 +1,5 @@
+{
+	"FAST_REBOOT|system": {
+		"enable": "true"
+	}
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -383,3 +383,4 @@ class TestFastUpgrade_to_2_0_5(object):
         dbmgtr.migrate()
         expected_db = self.mock_dedicated_config_db(db_after_migrate)
         assert not self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)
+        assert dbmgtr.CURRENT_VERSION == expected_db.cfgdb.get_entry('VERSIONS', 'DATABASE')['VERSION']

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -348,3 +348,38 @@ class TestQosDBFieldValueReferenceRemoveMigrator(object):
         self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)
         self.check_appl_db(dbmgtr.appDB, expected_appl_db)
         self.clear_dedicated_mock_dbs()
+
+
+class TestFastUpgrade_to_2_0_5(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+        cls.config_db_tables_to_verify = ['FLEX_COUNTER_TABLE']
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'fast_reboot_upgrade')
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+        dbconnector.dedicated_dbs['STATE_DB'] = None
+
+    def mock_dedicated_config_db(self, filename):
+        jsonfile = os.path.join(mock_db_path, 'config_db', filename)
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile
+        db = Db()
+        return db
+
+    def check_config_db(self, result, expected):
+        for table in self.config_db_tables_to_verify:
+            assert result.get_table(table) == expected.get_table(table)
+
+    def test_fast_reboot_upgrade_to_2_0_5(self):
+        db_before_migrate = 'cross_branch_upgrade_to_2_0_5_input'
+        db_after_migrate = 'cross_branch_upgrade_to_2_0_5_expected'
+        device_info.get_sonic_version_info = get_sonic_version_info_mlnx
+        db = self.mock_dedicated_config_db(db_before_migrate)
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        expected_db = self.mock_dedicated_config_db(db_after_migrate)
+        assert not self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add migration of `FLEX_COUNTER_DELAY_STATUS` attribute of config_db `FLEX_COUNTER_TABLE` during the `SONiC to SONiC upgrade + fast-reboot` from older versions `201911 -> 202111`.

This change is required for the `fast-reboot` procedure because without it the counters will be created during the init flow which will waste a lot of resources and cause data plane degradation of more than 30 seconds.

#### How I did it
Modify the `db_migrator.py`.

#### How to verify it
Add UT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

