### PR TITLE
[202205][db_migrator] Add migration of FLEX_COUNTER_DELAY_STATUS during 1911->2205 upgrade + fast-reboot. Add UT.

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -636,6 +636,20 @@ class DBMigrator():
                 # Set new cable length values
                 self.configDB.set(self.configDB.CONFIG_DB, "CABLE_LENGTH|AZURE", intf, EDGEZONE_AGG_CABLE_LENGTH)
 
+    def migrate_config_db_flex_counter_delay_status(self):
+        """
+        Migrate "FLEX_COUNTER_TABLE|*": { "value": { "FLEX_COUNTER_DELAY_STATUS": "false" } }
+        Set FLEX_COUNTER_DELAY_STATUS true in case of fast-reboot
+        """
+
+        flex_counter_objects = self.configDB.get_keys('FLEX_COUNTER_TABLE')
+        for obj in flex_counter_objects:
+            flex_counter = self.configDB.get_entry('FLEX_COUNTER_TABLE', obj)
+            delay_status = flex_counter.get('FLEX_COUNTER_DELAY_STATUS')
+            if delay_status is None or delay_status == 'false':
+                flex_counter['FLEX_COUNTER_DELAY_STATUS'] = 'true'
+                self.configDB.mod_entry('FLEX_COUNTER_TABLE', obj, flex_counter)
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -885,9 +899,22 @@ class DBMigrator():
 
     def version_3_0_6(self):
         """
-        Current latest version. Nothing to do here.
+        Version 3_0_6
         """
         log.log_info('Handling version_3_0_6')
+
+        if self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system"):
+            self.migrate_config_db_flex_counter_delay_status()
+
+        self.set_version('version_3_0_7')
+        return 'version_3_0_7'
+
+    def version_3_0_7(self):
+        """
+        Version 3_0_7
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_3_0_7')
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_3_0_7_expected.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_3_0_7_expected.json
@@ -1,0 +1,19 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_7"
+    },
+    "FLEX_COUNTER_TABLE|ACL": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|QUEUE": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|PG_WATERMARK": {
+        "FLEX_COUNTER_STATUS": "false",
+        "FLEX_COUNTER_DELAY_STATUS": "true"
+    }
+}

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_3_0_7_input.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_3_0_7_input.json
@@ -1,0 +1,18 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    },
+    "FLEX_COUNTER_TABLE|ACL": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "true",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|QUEUE": {
+        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_DELAY_STATUS": "false",
+        "POLL_INTERVAL": "10000"
+    },
+    "FLEX_COUNTER_TABLE|PG_WATERMARK": {
+        "FLEX_COUNTER_STATUS": "false"
+    }
+}

--- a/tests/db_migrator_input/state_db/fast_reboot_upgrade.json
+++ b/tests/db_migrator_input/state_db/fast_reboot_upgrade.json
@@ -1,0 +1,5 @@
+{
+    "FAST_REBOOT|system": {
+        "enable": "true"
+    }
+}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add migration of `FLEX_COUNTER_DELAY_STATUS` attribute of config_db `FLEX_COUNTER_TABLE` during the `SONiC to SONiC upgrade + fast-reboot` from older versions `201911 -> 202205`.

This change is required for the `fast-reboot` procedure because without it the counters will be created during the init flow which will waste a lot of resources and cause data plane degradation of more than 30 seconds.

#### How I did it
Modify the `db_migrator.py`.

#### How to verify it
Add UT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

