### PR TITLE
[202012][dhcp-relay] Fix dhcp6relay counter issue (#2866)

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -106,14 +106,13 @@ def del_vlan(db, vid, no_restart_dhcp_relay):
     # set dhcpv4_relay table
     set_dhcp_relay_table('VLAN', db.cfgdb, vlan, None)
 
-    delete_state_db_entry(vlan)
-
     if not no_restart_dhcp_relay and is_dhcpv6_relay_config_exist(db, vlan):
         # set dhcpv6_relay table
         set_dhcp_relay_table('DHCP_RELAY', db.cfgdb, vlan, None)
         # We need to restart dhcp_relay service after dhcpv6_relay config change
         if is_dhcp_relay_running():
             dhcp_relay_util.handle_restart_dhcp_relay_service()
+    delete_state_db_entry(vlan)
 
 
 def restart_ndppd():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did
Manually cherry-pick and resolve conflict of this PR: https://github.com/sonic-net/sonic-utilities/pull/2866.
While deleting a Vlan, clear dhcpv6_relay counter info state_db before dhcp_relay container restart would cause that counter info still exist in state_db, which is incorrect.
Microsoft ADO number: 24211173

#### How I did it
Clear counter info in state_db after container restart.

#### How to verify it
Previous ut and build image to verify.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

