### PR TITLE
fix precedence in portstat CLI

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -338,7 +338,7 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic() or device_info.is_chassis() and not use_json:
+        if (multi_asic.is_multi_asic() or device_info.is_chassis()) and not use_json:
             print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
@@ -556,7 +556,7 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic() or device_info.is_chassis() and not use_json:
+        if (multi_asic.is_multi_asic() or device_info.is_chassis()) and not use_json:
             print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -192,41 +192,6 @@ Ethernet-BP260        U        0  0.00 B/s      0.00%         0         0       
 Reminder: Please execute 'show interface counters -d all' to include internal links
 """
 
-multi_asic_external_intf_counters_use_json = """\
-{
-    "Ethernet0": {
-        "RX_BPS": "0.00 B/s",
-        "RX_DRP": "0",
-        "RX_ERR": "0",
-        "RX_OK": "0",
-        "RX_OVR": "N/A",
-        "RX_UTIL": "0.00%",
-        "STATE": "U",
-        "TX_BPS": "0.00 B/s",
-        "TX_DRP": "N/A",
-        "TX_ERR": "N/A",
-        "TX_OK": "0",
-        "TX_OVR": "N/A",
-        "TX_UTIL": "0.00%"
-    },
-    "Ethernet4": {
-        "RX_BPS": "0.00 B/s",
-        "RX_DRP": "0",
-        "RX_ERR": "0",
-        "RX_OK": "0",
-        "RX_OVR": "N/A",
-        "RX_UTIL": "0.00%",
-        "STATE": "U",
-        "TX_BPS": "0.00 B/s",
-        "TX_DRP": "N/A",
-        "TX_ERR": "N/A",
-        "TX_OK": "0",
-        "TX_OVR": "N/A",
-        "TX_UTIL": "0.00%"
-    }
-}
-"""
-
 intf_invalid_asic_error = """ValueError: Unknown Namespace asic99"""
 
 intf_counters_detailed = """\
@@ -554,13 +519,6 @@ class TestMultiAsicPortStat(object):
         print("result = {}".format(result))
         assert return_code == 0
         verify_after_clear(result, mutli_asic_intf_counters_after_clear)
-
-    def test_multi_asic_use_json(self):
-        return_code, result = get_result_and_return_code(['portstat', '-j'])
-        print("return_code: {}".format(return_code))
-        print("result = {}".format(result))
-        assert return_code == 0
-        assert result == multi_asic_external_intf_counters_use_json
 
     def test_multi_asic_invalid_asic(self):
         return_code, result = get_result_and_return_code(['portstat', '-n', 'asic99'])

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -192,6 +192,12 @@ Ethernet-BP260        U        0  0.00 B/s      0.00%         0         0       
 Reminder: Please execute 'show interface counters -d all' to include internal links
 """
 
+multi_asic_external_intf_counters_use_json = """\
+    IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
+---------  -------  -------  --------  ---------  --------  --------  --------  -------  --------  ---------  --------  --------  --------
+Ethernet0        U        8  0.00 B/s      0.00%        10       100       N/A       10  0.00 B/s      0.00%       N/A       N/A       N/A
+Ethernet4        U        4  0.00 B/s      0.00%         0     1,000       N/A       40  0.00 B/s      0.00%       N/A       N/A       N/A
+"""
 
 intf_invalid_asic_error = """ValueError: Unknown Namespace asic99"""
 
@@ -527,6 +533,13 @@ class TestMultiAsicPortStat(object):
         print("result = {}".format(result))
         assert return_code == 1
         assert result == intf_invalid_asic_error
+
+    def test_multi_asic_use_json(self):
+        return_code, result = get_result_and_return_code(['portstat', '-j'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 1
+        assert result == multi_asic_external_intf_counters_use_json
 
     @classmethod
     def teardown_class(cls):

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -527,19 +527,19 @@ class TestMultiAsicPortStat(object):
         assert return_code == 0
         verify_after_clear(result, mutli_asic_intf_counters_after_clear)
 
+    def test_multi_asic_use_json(self):
+        return_code, result = get_result_and_return_code(['portstat', '-j'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == multi_asic_external_intf_counters_use_json
+
     def test_multi_asic_invalid_asic(self):
         return_code, result = get_result_and_return_code(['portstat', '-n', 'asic99'])
         print("return_code: {}".format(return_code))
         print("result = {}".format(result))
         assert return_code == 1
         assert result == intf_invalid_asic_error
-
-    def test_multi_asic_use_json(self):
-        return_code, result = get_result_and_return_code(['portstat', '-j'])
-        print("return_code: {}".format(return_code))
-        print("result = {}".format(result))
-        assert return_code == 1
-        assert result == multi_asic_external_intf_counters_use_json
 
     @classmethod
     def teardown_class(cls):

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -193,10 +193,38 @@ Reminder: Please execute 'show interface counters -d all' to include internal li
 """
 
 multi_asic_external_intf_counters_use_json = """\
-    IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
----------  -------  -------  --------  ---------  --------  --------  --------  -------  --------  ---------  --------  --------  --------
-Ethernet0        U        8  0.00 B/s      0.00%        10       100       N/A       10  0.00 B/s      0.00%       N/A       N/A       N/A
-Ethernet4        U        4  0.00 B/s      0.00%         0     1,000       N/A       40  0.00 B/s      0.00%       N/A       N/A       N/A
+{
+    "Ethernet0": {
+        "RX_BPS": "0.00 B/s",
+        "RX_DRP": "0",
+        "RX_ERR": "0",
+        "RX_OK": "0",
+        "RX_OVR": "N/A",
+        "RX_UTIL": "0.00%",
+        "STATE": "U",
+        "TX_BPS": "0.00 B/s",
+        "TX_DRP": "N/A",
+        "TX_ERR": "N/A",
+        "TX_OK": "0",
+        "TX_OVR": "N/A",
+        "TX_UTIL": "0.00%"
+    },
+    "Ethernet4": {
+        "RX_BPS": "0.00 B/s",
+        "RX_DRP": "0",
+        "RX_ERR": "0",
+        "RX_OK": "0",
+        "RX_OVR": "N/A",
+        "RX_UTIL": "0.00%",
+        "STATE": "U",
+        "TX_BPS": "0.00 B/s",
+        "TX_DRP": "N/A",
+        "TX_ERR": "N/A",
+        "TX_OK": "0",
+        "TX_OVR": "N/A",
+        "TX_UTIL": "0.00%"
+    }
+}
 """
 
 intf_invalid_asic_error = """ValueError: Unknown Namespace asic99"""


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
'and' logic has higher precedence than 'or' logic. we want to make sure it's either chassis or multi-asic, and in both case, if 'use_json' option is not provided.

fix https://github.com/sonic-net/sonic-buildimage/issues/15439

#### What I did

#### How I did it

#### How to verify it
verified on a chassis linecard:
before:
Reminder: Please execute 'show interface counters -d all' to include internal links
is printed at end of 'portstat -j'

after: only json format is printed
```
...
        "TX_OK": "3,014",
        "TX_OVR": "0",
        "TX_UTIL": "0.00%"
    }
}
admin@str2-7804-lc5-1:~$ ```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

