### PR TITLE
[202205] 'portstat -j' avoid non json output for multi-asic/chassis duts

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -325,7 +325,7 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic() or device_info.is_chassis() and not use_json:
+        if (multi_asic.is_multi_asic() or device_info.is_chassis()) and not use_json:
             print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
     def cnstat_intf_diff_print(self, cnstat_new_dict, cnstat_old_dict, intf_list):
@@ -527,7 +527,7 @@ class Portstat(object):
                 print(table_as_json(table, header))
             else:
                 print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        if multi_asic.is_multi_asic() or device_info.is_chassis() and not use_json:
+        if (multi_asic.is_multi_asic() or device_info.is_chassis()) and not use_json:
             print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
 
 def main():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This is cherry pick of: https://github.com/sonic-net/sonic-utilities/pull/2874
ADO: https://msazure.visualstudio.com/One/_workitems/edit/24260584
fix issue: https://github.com/sonic-net/sonic-buildimage/issues/15439
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

