### PR TITLE
Improve `route_check` to better handle duplicate updates

### DIFF
--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -35,38 +35,24 @@ def set_test_case_data(ctdata):
     subscribers_returned = {}
 
 
-def recursive_update(d, t):
-    assert (type(t) is dict)
-    for k in t.keys():
-        if type(t[k]) is not dict:
-            d.update(t)
-            return
-
-        if k not in d:
-            d[k] = {}
-        recursive_update(d[k], t[k])
-
-
 class Table:
 
     def __init__(self, db, tbl):
         self.db = db
         self.tbl = tbl
-        self.data = copy.deepcopy(self.get_val(current_test_data[PRE], [db, tbl]))
+        self.data = self.get_val(current_test_data[PRE], [db, tbl])
         # print("Table:init: db={} tbl={} data={}".format(db, tbl, json.dumps(self.data, indent=4)))
 
 
     def update(self):
-        t = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
-            [self.db, self.tbl, OP_SET]))
-        drop = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
-                        [self.db, self.tbl, OP_DEL]))
-        if t:
-            recursive_update(self.data, t)
+        add = self.get_val(current_test_data.get(UPD, {}), [self.db, self.tbl, OP_SET])
+        drop = self.get_val(current_test_data.get(UPD, {}), [self.db, self.tbl, OP_DEL])
 
-        for k in drop:
+        # update existing table content
+        for k, _ in drop:
             self.data.pop(k, None)
-        return (list(t.keys()), list(drop.keys()))
+        self.data.update(add)
+        return ([_[0] for _ in add], [_[0] for _ in drop])
 
 
     def get_val(self, d, keys):

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -86,12 +86,12 @@ TEST_DATA = {
         UPD: {
             ASIC_DB: {
                 RT_ENTRY_TABLE: {
-                    OP_SET: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                    },
-                    OP_DEL: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + RT_ENTRY_KEY_SUFFIX: {}
-                    }
+                    OP_SET: [
+                        (RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX, {}),
+                    ],
+                    OP_DEL: [
+                        (RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + RT_ENTRY_KEY_SUFFIX, {}),
+                    ]
                 }
             }
         }
@@ -480,4 +480,44 @@ TEST_DATA = {
             }
         }
     },
+    "11": {
+        DESCR: "dualtor duplicate updates",
+        ARGS: "route_check -m DEBUG -i 1",
+        RET: 0,
+        PRE: {
+            APPL_DB: {
+                ROUTE_TABLE: {
+                    "0.0.0.0/0" : { "ifname": "portchannel0" },
+                    "20.20.196.12/31" : { "ifname": "portchannel0" },
+                    "20.20.196.20/31" : { "ifname": "portchannel0" },
+                    "10.10.196.30/31" : { "ifname": "lo" }
+                },
+                INTF_TABLE: {
+                    "PortChannel1013:10.10.196.24/31": {},
+                    "PortChannel1023:2603:10b0:503:df4::5d/126": {}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {},
+                }
+            }
+        },
+        UPD: {
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    OP_SET: [
+                        (RT_ENTRY_KEY_PREFIX + "20.20.196.12/31" + RT_ENTRY_KEY_SUFFIX, {}),
+                        (RT_ENTRY_KEY_PREFIX + "20.20.196.12/31" + RT_ENTRY_KEY_SUFFIX, {}),
+                        (RT_ENTRY_KEY_PREFIX + "20.20.196.20/31" + RT_ENTRY_KEY_SUFFIX, {}),
+                        (RT_ENTRY_KEY_PREFIX + "20.20.196.20/31" + RT_ENTRY_KEY_SUFFIX, {}),
+                    ],
+                    OP_DEL: [
+                    ]
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Reason for this PR is that there could be multiple route set updates from ASIC_DB when the mux toggles to standby. This PR aims to improve `route_check` to handle this situation.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How I did it
Few updates:
1. Replace `diff_sorted_lists` with `diff_lists`, which is better in handling duplicate entries and executed faster.
2. Remove redundant sort.
3. Add UT to cover duplicate updates.

#### How to verify it
UT and verify on dualtor environment

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

