### PR TITLE
[db_migrator] Set correct CURRENT_VERSION, extend UT

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -47,7 +47,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_4_0_2'
+        self.CURRENT_VERSION = 'version_4_0_3'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -675,3 +675,4 @@ class TestFastUpgrade_to_4_0_3(object):
         dbmgtr.migrate()
         expected_db = self.mock_dedicated_config_db(db_after_migrate)
         assert not self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)
+        assert dbmgtr.CURRENT_VERSION == expected_db.cfgdb.get_entry('VERSIONS', 'DATABASE')['VERSION']


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Set the correct value for the `db_migrator` class variable `CURRENT_VERSION`, because if the new DB version was introduced the `CURRENT_VERSION` variable should have the newest version value.

#### How I did it
Edit the `db_migrator.py`.

#### How to verify it
Extend existing UT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

