### PR TITLE
[dualtor][route_check] filter out `soc_ipv6` 

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -585,6 +585,9 @@ def get_soc_ips(config_db):
         if mux_entry.get("cable_type", "") == "active-active" and "soc_ipv4" in mux_entry:
             soc_ips.append(mux_entry["soc_ipv4"])
 
+            if "soc_ipv6" in mux_entry and mux_entry["soc_ipv6"]:
+                soc_ips.append(mux_entry["soc_ipv6"])
+
     return soc_ips
 
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -582,8 +582,9 @@ def get_soc_ips(config_db):
     mux_table = config_db.get_table('MUX_CABLE')
     soc_ips = []
     for _, mux_entry in mux_table.items():
-        if mux_entry.get("cable_type", "") == "active-active" and "soc_ipv4" in mux_entry:
-            soc_ips.append(mux_entry["soc_ipv4"])
+        if mux_entry.get("cable_type", "") == "active-active":
+            if "soc_ipv4" in mux_entry and mux_entry["soc_ipv4"]:
+                soc_ips.append(mux_entry["soc_ipv4"])
 
             if "soc_ipv6" in mux_entry and mux_entry["soc_ipv6"]:
                 soc_ips.append(mux_entry["soc_ipv6"])

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -342,6 +342,7 @@ TEST_DATA = {
                         "server_ipv4": "192.168.0.2/32",
                         "server_ipv6": "fc02:1000::2/128",
                         "soc_ipv4": "192.168.0.3/32",
+                        "soc_ipv6": "fc02:1000::3/128",
                         "state": "auto"
                     },
                 }
@@ -356,7 +357,8 @@ TEST_DATA = {
                 RT_ENTRY_TABLE: {
                     RT_ENTRY_KEY_PREFIX + "192.168.0.2/32" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "fc02:1000::2/128" + RT_ENTRY_KEY_SUFFIX: {},
-                    RT_ENTRY_KEY_PREFIX + "192.168.0.3/32" + RT_ENTRY_KEY_SUFFIX: {}
+                    RT_ENTRY_KEY_PREFIX + "192.168.0.3/32" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "fc02:1000::3/128" + RT_ENTRY_KEY_SUFFIX: {}
                 }
             }
         }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Skip `soc_ipv6` when comparing appl_db and asic_db route entries on `active-active` dualtor. Because it's creating false alarms when tunnel route is added for soc ips. The route is meant to be programmed in asic only. 

sign-off: Jing Zhang zhangjing@microsoft.com 
#### How I did it

#### How to verify it
Run the updated script on active-active dualtor devices. 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

