### PR TITLE
Update main.py to support portchannel active or passive mode

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2068,8 +2068,9 @@ def portchannel(db, ctx, namespace):
 @click.option('--fast-rate', default='false',
               type=click.Choice(['true', 'false'],
                                 case_sensitive=False))
+@click.option('--active', default='true')
 @click.pass_context
-def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
+def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate, active):
     """Add port channel"""
     
     fvs = {
@@ -2077,12 +2078,15 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
         'mtu': '9100',
         'lacp_key': 'auto',
         'fast_rate': fast_rate.lower(),
+        'active' : 'true'
     }
 
     if min_links != 0:
         fvs['min_links'] = str(min_links)
     if fallback != 'false':
         fvs['fallback'] = 'true'
+    if active != 'true':
+        fvs['active'] = 'false'
     
     db = ValidatedConfigDBConnector(ctx.obj['db'])
     if ADHOC_VALIDATION:

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -217,11 +217,6 @@ def ipaddress_type(val):
 
     return ip_version.version
 
-def is_ipv4addr_loopback(ipaddr):
-    if ipaddress.ip_network("127.0.0.0/8", False).overlaps(ipaddress.ip_network(ipaddr, False)):
-        return True
-    return False
-
 def is_ip_prefix_in_key(key):
     '''
     Function to check if IP address is present in the key. If it

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -217,6 +217,11 @@ def ipaddress_type(val):
 
     return ip_version.version
 
+def is_ipv4addr_loopback(ipaddr):
+    if ipaddress.ip_network("127.0.0.0/8", False).overlaps(ipaddress.ip_network(ipaddr, False)):
+        return True
+    return False
+
 def is_ip_prefix_in_key(key):
     '''
     Function to check if IP address is present in the key. If it


### PR DESCRIPTION
add active parameter to set portchannel active or passive mode

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
support active or passive mode when add a portchannel
#### How I did it
support active parameter when add a portchannel
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

