### PR TITLE
[202205] Flush RESTAPI db in fast-reboot shutdown path

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -726,6 +726,11 @@ for service in ${SERVICES_TO_STOP}; do
             sonic-db-cli FLEX_COUNTER_DB FLUSHDB > /dev/null
         fi
 
+        if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
+            # Flush RESTAP_DB in fast-reboot to avoid stale status
+            sonic-db-cli RESTAPI_DB FLUSHDB > /dev/null
+        fi
+        
         # TODO: backup_database preserves FDB_TABLE
         # need to cleanup as well for fastfast boot case
         backup_database

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -727,10 +727,10 @@ for service in ${SERVICES_TO_STOP}; do
         fi
 
         if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
-            # Flush RESTAP_DB in fast-reboot to avoid stale status
+            # Flush RESTAPI_DB in fast-reboot to avoid stale status
             sonic-db-cli RESTAPI_DB FLUSHDB > /dev/null
         fi
-        
+
         # TODO: backup_database preserves FDB_TABLE
         # need to cleanup as well for fastfast boot case
         backup_database


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
**This PR is to backport change #2917 into `202205` branch.**

The PR is to flush `RESTAPI_DB` in the fast-reboot shutdown path.
After PR https://github.com/sonic-net/sonic-utilities/pull/2365, the table is not cleared because the `WARM_RESTART_ENABLE_TABLE|system` is set to `true`.
So below code in `swss.sh` doesn't do the db flush.
https://github.com/sonic-net/sonic-buildimage/blob/bdef73ea963064cdc9fbebb63ac381440c0fafd6/files/scripts/swss.sh#L168C1-L181C7
```
if [[ x"$WARM_BOOT" != x"true" ]]; then
        debug "Flushing APP, ASIC, COUNTER, CONFIG, and partial STATE databases ..."
        $SONIC_DB_CLI APPL_DB FLUSHDB
        $SONIC_DB_CLI ASIC_DB FLUSHDB
        $SONIC_DB_CLI COUNTERS_DB FLUSHDB
        $SONIC_DB_CLI FLEX_COUNTER_DB FLUSHDB
        $SONIC_DB_CLI GB_ASIC_DB FLUSHDB
        $SONIC_DB_CLI GB_COUNTERS_DB FLUSHDB
        $SONIC_DB_CLI RESTAPI_DB FLUSHDB
        clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*', 'FG_ROUTE_TABLE*', 'BUFFER_POOL*', 'BUFFER_PROFILE*', 'MUX_CABLE_TABLE*', 'ADVERTISE_NETWORK_TABLE*', 'VXLAN_TUNNEL_TABLE*', 'VNET_ROUTE*', 'MACSEC_PORT_TABLE*', 'MACSEC_INGRESS_SA_TABLE*', 'MACSEC_EGRESS_SA_TABLE*', 'MACSEC_INGRESS_SC_TABLE*', 'MACSEC_EGRESS_SC_TABLE*', 'VRF_OBJECT_TABLE*', 'VNET_MONITOR_TABLE*', 'BFD_SESSION_TABLE*'"
        $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
        rm -rf /tmp/cache
    fi
```

#### How I did it
Flush  `RESTAPI_DB` in the fast-reboot shutdown path.

#### How to verify it
We have a sonic-mgmt test case `restapi/test_restapi.py::test_check_reset_status`  to cover the feature.
The test can pass after this change.


#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A
