### PR TITLE
[202205][db_migrator] Set docker_routing_config_mode to the value obtained from minigraph parser

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -616,6 +616,21 @@ class DBMigrator():
                     route_key = "ROUTE_TABLE:{}".format(route_prefix)
                 self.appDB.set(self.appDB.APPL_DB, route_key, 'weight','')
 
+    def migrate_routing_config_mode(self):
+        # DEVICE_METADATA - synchronous_mode entry
+        if not self.minigraph_data or 'DEVICE_METADATA' not in self.minigraph_data:
+            return
+        device_metadata_old = self.configDB.get_entry('DEVICE_METADATA', 'localhost')
+        device_metadata_new = self.minigraph_data['DEVICE_METADATA']['localhost']
+        # overwrite the routing-config-mode as per minigraph parser
+        # Criteria for update:
+        # if config mode is missing in base OS or if base and target modes are not same
+        #  Eg. in 201811 mode is "unified", and in newer branches mode is "separated" 
+        if ('docker_routing_config_mode' not in device_metadata_old and 'docker_routing_config_mode' in device_metadata_new) or \
+        (device_metadata_old.get('docker_routing_config_mode') != device_metadata_new.get('docker_routing_config_mode')):
+            device_metadata_old['docker_routing_config_mode'] = device_metadata_new.get('docker_routing_config_mode')
+            self.configDB.set_entry('DEVICE_METADATA', 'localhost', device_metadata_old)
+
     def update_edgezone_aggregator_config(self):
         """
         Update cable length configuration in ConfigDB for T0 neighbor interfaces
@@ -985,6 +1000,8 @@ class DBMigrator():
 
         # Updating edgezone aggregator cable length config for T0 devices
         self.update_edgezone_aggregator_config()
+        # update FRR config mode based on minigraph parser on target image
+        self.migrate_routing_config_mode()
 
     def migrate(self):
         version = self.get_version()

--- a/tests/db_migrator_input/config_db/acs-msn2700-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/acs-msn2700-t0-version_3_0_0.json
@@ -681,7 +681,7 @@
     "DEVICE_METADATA|localhost": {
         "hwsku": "ACS-MSN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",

--- a/tests/db_migrator_input/config_db/acs-msn2700-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/acs-msn2700-t0-version_3_0_3.json
@@ -681,7 +681,7 @@
     "DEVICE_METADATA|localhost": {
         "hwsku": "ACS-MSN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",

--- a/tests/db_migrator_input/config_db/acs-msn2700-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/acs-msn2700-t1-version_3_0_0.json
@@ -762,7 +762,7 @@
         "bgp_asn": "65100",
         "buffer_model": "dynamic",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "LOSSLESS_TRAFFIC_PATTERN|AZURE": {
         "small_packet_percentage": "100",

--- a/tests/db_migrator_input/config_db/acs-msn2700-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/acs-msn2700-t1-version_3_0_3.json
@@ -761,7 +761,7 @@
         "bgp_asn": "65100",
         "buffer_model": "dynamic",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "LOSSLESS_TRAFFIC_PATTERN|AZURE": {

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_version_2_0_2_expected.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_version_2_0_2_expected.json
@@ -22,5 +22,8 @@
         },
     "CONSOLE_SWITCH|console_mgmt": {
             "enabled": "no"
-        }
+        },
+    "DEVICE_METADATA|localhost": {
+        "docker_routing_config_mode": "separated"
+    }
 }

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_version_2_0_2_input.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_version_2_0_2_input.json
@@ -1,3 +1,6 @@
 {
+    "DEVICE_METADATA|localhost": {
+        "docker_routing_config_mode": "unified"
+    }
 }
 

--- a/tests/db_migrator_input/config_db/empty-config-expected.json
+++ b/tests/db_migrator_input/config_db/empty-config-expected.json
@@ -3,6 +3,7 @@
         "VERSION": "version_3_0_3"
     },
     "DEVICE_METADATA|localhost": {
-        "synchronous_mode": "enable"
+        "synchronous_mode": "enable",
+        "docker_routing_config_mode": "separated"
     }
 }

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t0-version_3_0_0.json
@@ -735,7 +735,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t0-version_3_0_3.json
@@ -734,7 +734,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_3_0_0.json
@@ -828,7 +828,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-single-pool-t1-version_3_0_3.json
@@ -827,7 +827,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t0-version_3_0_0.json
@@ -740,7 +740,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t0-version_3_0_3.json
@@ -739,7 +739,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_3_0_0.json
@@ -833,7 +833,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-c28d8-t1-version_3_0_3.json
@@ -832,7 +832,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t0-version_3_0_0.json
@@ -735,7 +735,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t0-version_3_0_3.json
@@ -734,7 +734,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable" 
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t1-version_3_0_0.json
@@ -828,7 +828,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d40c8s8-t1-version_3_0_3.json
@@ -827,7 +827,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t0-version_3_0_0.json
@@ -735,7 +735,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t0-version_3_0_3.json
@@ -734,7 +734,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_3_0_0.json
@@ -828,7 +828,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-single-pool-t1-version_3_0_3.json
@@ -827,7 +827,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t0-version_3_0_0.json
@@ -740,7 +740,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t0-version_3_0_3.json
@@ -739,7 +739,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_3_0_0.json
@@ -833,7 +833,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-d48c8-t1-version_3_0_3.json
@@ -832,7 +832,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t0-version_3_0_0.json
@@ -726,7 +726,7 @@
     "DEVICE_METADATA|localhost": {
         "hwsku": "Mellanox-SN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t0-version_3_0_3.json
@@ -726,7 +726,7 @@
     "DEVICE_METADATA|localhost": {
         "hwsku": "Mellanox-SN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_3_0_0.json
@@ -828,7 +828,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-single-pool-t1-version_3_0_3.json
@@ -827,7 +827,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-t0-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-t0-version_3_0_0.json
@@ -740,7 +740,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-t0-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-t0-version_3_0_3.json
@@ -739,7 +739,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_3_0_0.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_3_0_0.json
@@ -833,7 +833,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_3_0_3.json
+++ b/tests/db_migrator_input/config_db/mellanox-sn2700-t1-version_3_0_3.json
@@ -832,7 +832,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "synchronous_mode": "enable"
     },
     "PORT|Ethernet0": {

--- a/tests/db_migrator_input/config_db/non-default-config-expected.json
+++ b/tests/db_migrator_input/config_db/non-default-config-expected.json
@@ -754,7 +754,7 @@
     "DEVICE_METADATA|localhost": {
         "hwsku": "ACS-MSN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",

--- a/tests/db_migrator_input/config_db/non-default-config-input.json
+++ b/tests/db_migrator_input/config_db/non-default-config-input.json
@@ -730,7 +730,7 @@
     "DEVICE_METADATA|localhost": {
         "hwsku": "ACS-MSN2700",
         "default_bgp_status": "up",
-        "docker_routing_config_mode": "unified",
+        "docker_routing_config_mode": "separated",
         "hostname": "sonic",
         "platform": "x86_64-mlnx_msn2700-r0",
         "mac": "00:01:02:03:04:00",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-expected.json
@@ -207,7 +207,7 @@
         "bgp_asn": "65100",
         "buffer_model": "dynamic",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-input.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-input.json
@@ -123,7 +123,7 @@
         "bgp_asn": "65100",
         "buffer_model": "dynamic",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-expected.json
@@ -203,7 +203,7 @@
         "bgp_asn": "65100",
         "buffer_model": "dynamic",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-input.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-input.json
@@ -119,7 +119,7 @@
         "bgp_asn": "65100",
         "buffer_model": "dynamic",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-double-pools-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-double-pools-expected.json
@@ -266,7 +266,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-double-pools-input.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-double-pools-input.json
@@ -158,7 +158,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-single-pool-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-single-pool-expected.json
@@ -261,7 +261,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-single-pool-input.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-traditional-single-pool-input.json
@@ -158,7 +158,7 @@
         "bgp_asn": "65100",
         "buffer_model": "traditional",
         "deployment_id": "1",
-        "docker_routing_config_mode": "unified"
+        "docker_routing_config_mode": "separated"
     },
     "PORT|Ethernet0": {
         "lanes": "0,1,2,3",

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -469,6 +469,13 @@ class TestWarmUpgrade_to_2_0_2(object):
             diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
             assert not diff
 
+        target_routing_mode_result = dbmgtr.configDB.get_table("DEVICE_METADATA")['localhost']['docker_routing_config_mode']
+        target_routing_mode_expected = expected_db.cfgdb.get_table("DEVICE_METADATA")['localhost']['docker_routing_config_mode']
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert target_routing_mode_result == target_routing_mode_expected,\
+            "After migration: {}. Expected after migration: {}".format(
+                target_routing_mode_result, target_routing_mode_expected)
+
     def test_warm_upgrade__without_mg_to_2_0_2(self):
         dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'cross_branch_upgrade_to_version_2_0_2_input')
         import db_migrator


### PR DESCRIPTION
Cherry pick of #2890

MSFT ADO: 24419953

This is to fix a bug where warm upgrade from old image (eg. 20181130) to new image (eg. 202012) does not update docker_routing_config_mode to the new config expected the target OS.

For eg., in 201811 DEVICE_METADATA.localhost.docker_routing_config_mode is set to unified. After upgrade to 202012 the value is not changed. However, the expectation in newer images is that the value is separated.

The move from unified to separated was done as part of an old change: sonic-net/sonic-buildimage#2961

However, migration logic was not updated since then. Because of this miss, cross-branch warm-upgrade from 201811 to 2020212 to 202305 to latest will always keep the setting as unified.

How I did it
Added a common migration logic: update docker_routing_config_mode to the value from minigraph parser.

How to verify it
Added a new unit test. Updated old unit tests.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

