### PR TITLE
Input check for timeout in generate_dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2020,6 +2020,10 @@ while getopts ":xnvhzas:t:r:d" opt; do
             date --date="${SINCE_DATE}" &> /dev/null || abort "${EXT_INVALID_ARGUMENT}" "Invalid date expression passed: '${SINCE_DATE}'"
             ;;
         t)
+            if ! [[ ${OPTARG} =~ ^[0-9]+$ ]]; then
+                echo "Invalid timeout value: ${OPTARG}, Please enter a numeric value."
+                exit $EXT_GENERAL
+            fi
             TIMEOUT_MIN="${OPTARG}"
             ;;
         r)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added input check for argument "-t" in generate_dump script
#### How I did it
Made sure only integer values can be received for this argument
#### How to verify it
Call generate_dump -t with non-integer values
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

