### PR TITLE
[sonic-package-manager] Fix YANG validation failure on upgrade when

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -564,8 +564,11 @@ class PackageManager:
 
         # After all checks are passed we proceed to actual upgrade
 
+        feature_enabled = self.feature_registry.is_feature_enabled(old_feature)
+
         service_create_opts = {
             'register_feature': False,
+            'transient_disabled_state': feature_enabled,
         }
         service_remove_opts = {
             'deregister_feature': False,
@@ -578,8 +581,6 @@ class PackageManager:
 
                 source.install(new_package)
                 exits.callback(rollback(source.uninstall, new_package))
-
-                feature_enabled = self.feature_registry.is_feature_enabled(old_feature)
 
                 if feature_enabled:
                     self._stop_feature(old_package)


### PR DESCRIPTION
feature has constraints in YANG model on FEATURE table

In case feature's YANG model has a constraint on FEATURE table:

```
must "current() = \"disabled\" or /feature:sonic-feature/feature:FEATURE/feature:FEATURE_LIST[feature:name=\"Y\"]/feature:state = \"enabled\"" {
    error-message "X can only be set when is Y enabled";
}
```

it will fail to upgrade due to transient disablement of the feature by the upgrade process.

The upgrade process looks like this:
1. Disable feature via FEATURE table and wait for container to go down.
2. Remove all configuration files generated for this feature.
3. Create new configuration files for new docker image.
4. Merge new init_cfg from the new docker image and perform YANG validation.
5. Enable feature via FEATURE table.
6. Remove old docker image.

Since there is a transient enable/disable of the feature and YANG validation in the middle having the above constrains in YANG model would lead to an upgrade failure.

I attempt to fix this by letting the ServiceCreator know we undergo a transient disablement of the feature.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

