### PR TITLE
[build] Fix dependency issue between responses and urllib3 package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -227,6 +227,7 @@ setup(
         'bcrypt==3.2.2',
         'click==7.0',
         'cryptography==3.3.2',
+        'urllib3>=2',
         'click-log>=0.3.2',
         'docker>=4.4.4',
         'docker-image-py>=0.1.10',

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,6 @@ setup(
         'bcrypt==3.2.2',
         'click==7.0',
         'cryptography==3.3.2',
-        'urllib3<2',
         'click-log>=0.3.2',
         'docker>=4.4.4',
         'docker-image-py>=0.1.10',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update urllib3 to V2.
#### How I did it
Some package depends on urllib3V2.
But urllib3 is pinned on V1 for docker 4.4.1 not support urllibV2.
Now docker is upgraded to V6. The issue didn't exist.
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

