### PR TITLE
revert unit test tests/test_clear_tag

### DIFF
--- a/tests/intfstat_test.py
+++ b/tests/intfstat_test.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import traceback
-import subprocess
 import show.main as show
 import clear.main as clear
 
@@ -211,28 +210,6 @@ class TestIntfstat(object):
         for i, interface in enumerate(interfaces):
             assert interface in result_lines[i+2]
         os.environ["SONIC_CLI_IFACE_MODE"] = "default"
-
-    def test_clear_tag(self):
-        cmd0 = ["intfstat", "-c"]
-        subprocess.Popen(cmd0, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-
-        cmd1 = ["intfstat", "-c", '-t', 'test']
-        subprocess.Popen(cmd1, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-        cmd2 = ["intfstat", '-t', 'test']
-        p2 = subprocess.Popen(cmd2, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-        output2 = p2.communicate()[0]
-        print(output2)
-        assert show_interfaces_counters_rif_clear in output2
-
-        cmd3 = ["intfstat", "-c", '-t', 'test']
-        subprocess.Popen(cmd3, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-        cmd4 = ["intfstat", '-t', 'test']
-        p4 = subprocess.Popen(cmd4, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-        output4 = p4.communicate()[0]
-        print(output4)
-        assert show_interfaces_counters_rif_clear in output4
-
-        show.run_command(["intfstat", "-D"])
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Revert test case due to frequent failure in azp introduced in PR https://github.com/sonic-net/sonic-utilities/pull/2849
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

