### PR TITLE
[chassis] rexec enhancements 

### DIFF
--- a/rcli/linecard.py
+++ b/rcli/linecard.py
@@ -44,9 +44,8 @@ class Linecard:
         connection.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
             connection.connect(self.ip, username=self.username, password=self.password)
-        except paramiko.ssh_exception.NoValidConnectionsError as e:
+        except:
             connection = None
-            click.echo(e)
         return connection
 
     def _get_password(self):

--- a/rcli/rshell.py
+++ b/rcli/rshell.py
@@ -10,28 +10,32 @@ from rcli import utils as rcli_utils
 
 @click.command()
 @click.argument('linecard_name', type=str, autocompletion=rcli_utils.get_all_linecards)
-def cli(linecard_name):
+@click.option('-u', '--username', type=str, default=None, help="Username for login")
+def cli(linecard_name, username):
     """
     Open interactive shell for one linecard
-    
+
     :param linecard_name: The name of the linecard to connect to
     """
     if not device_info.is_chassis():
         click.echo("This commmand is only supported Chassis")
         sys.exit(1)
 
-    username = os.getlogin()
+    if not username:
+        username = os.getlogin()
     password = rcli_utils.get_password(username)
-    
+
     try:
-        lc =Linecard(linecard_name, username, password)
-        if lc.connection:
-            click.echo("Connecting to {}".format(lc.linecard_name))
-            # If connection was created, connection exists. Otherwise, user will see an error message.
-            lc.start_shell()
+        linecard = Linecard(linecard_name, username, password)
+        if linecard.connection:
+            click.echo(f"Connecting to {linecard.linecard_name}")
+            # If connection was created, connection exists.
+            # Otherwise, user will see an error message.
+            linecard.start_shell()
             click.echo("Connection Closed")
     except paramiko.ssh_exception.AuthenticationException:
-        click.echo("Login failed on '{}' with username '{}'".format(linecard_name, lc.username))
+        click.echo(
+            f"Login failed on '{linecard.linecard_name}' with username '{linecard.username}'")
 
 
 if __name__=="__main__":

--- a/rcli/utils.py
+++ b/rcli/utils.py
@@ -31,24 +31,21 @@ def connect_state_db():
     return state_db
 
 
-
 def get_linecard_module_name_from_hostname(linecard_name: str):
-    
-    chassis_state_db = connect_to_chassis_state_db()
 
+    chassis_state_db = connect_to_chassis_state_db()
     keys = chassis_state_db.keys(chassis_state_db.CHASSIS_STATE_DB , '{}|{}'.format(CHASSIS_MODULE_HOSTNAME_TABLE, '*'))
     for key in keys:
         module_name = key.split('|')[1]
         hostname = chassis_state_db.get(chassis_state_db.CHASSIS_STATE_DB, key, CHASSIS_MODULE_HOSTNAME)
         if hostname.replace('-', '').lower() == linecard_name.replace('-', '').lower():
-             return module_name
- 
+            return module_name
+
     return None
-       
+
 def get_linecard_ip(linecard_name: str):
     """
     Given a linecard name, lookup its IP address in the midplane table
-    
     :param linecard_name: The name of the linecard you want to connect to
     :type linecard_name: str
     :return: IP address of the linecard
@@ -62,7 +59,7 @@ def get_linecard_ip(linecard_name: str):
     if module_name is None:
         module_name = linecard_name
     module_ip, module_access = get_module_ip_and_access_from_state_db(module_name)
-    
+
     if not module_ip:
         click.echo('Linecard {} not found'.format(linecard_name))
         return None
@@ -70,8 +67,6 @@ def get_linecard_ip(linecard_name: str):
     if module_access != 'True':
         click.echo('Linecard {} not accessible'.format(linecard_name))
         return None
-  
-    
     return module_ip
 
 def get_module_ip_and_access_from_state_db(module_name):
@@ -80,10 +75,10 @@ def get_module_ip_and_access_from_state_db(module_name):
         state_db.STATE_DB, '{}|{}'.format(CHASSIS_MIDPLANE_INFO_TABLE,module_name ))
     if data_dict is None:
         return None, None
-    
+
     linecard_ip = data_dict.get(CHASSIS_MIDPLANE_INFO_IP_FIELD, None)
     access = data_dict.get(CHASSIS_MIDPLANE_INFO_ACCESS_FIELD, None)
-    
+
     return linecard_ip, access
 
 
@@ -91,7 +86,7 @@ def get_all_linecards(ctx, args, incomplete) -> list:
     """
     Return a list of all accessible linecard names. This function is used to 
     autocomplete linecard names in the CLI.
-    
+
     :param ctx: The Click context object that is passed to the command function
     :param args: The arguments passed to the Click command
     :param incomplete: The string that the user has typed so far
@@ -100,10 +95,9 @@ def get_all_linecards(ctx, args, incomplete) -> list:
     # Adapted from `show chassis modules midplane-status` command logic:
     # https://github.com/sonic-net/sonic-utilities/blob/master/show/chassis_modules.py
 
- 
     chassis_state_db = connect_to_chassis_state_db()
     state_db = connect_state_db()
-    
+
     linecards = []
     keys = state_db.keys(state_db.STATE_DB,'{}|*'.format(CHASSIS_MIDPLANE_INFO_TABLE))
     for key in keys:
@@ -115,17 +109,17 @@ def get_all_linecards(ctx, args, incomplete) -> list:
         linecard_ip, access = get_module_ip_and_access_from_state_db(module_name)
         if linecard_ip is None:
             continue
-        
-        if access != "True" :
+
+        if access != "True":
             continue
-        
+
         # get the hostname for this module
         hostname = chassis_state_db.get(chassis_state_db.CHASSIS_STATE_DB, '{}|{}'.format(CHASSIS_MODULE_HOSTNAME_TABLE, module_name), CHASSIS_MODULE_HOSTNAME)
         if hostname:
             linecards.append(hostname)
         else:
             linecards.append(module_name)
-    
+
     # Return a list of all matched linecards
     return [lc for lc in linecards if incomplete in lc]
 
@@ -133,15 +127,15 @@ def get_all_linecards(ctx, args, incomplete) -> list:
 def get_password(username=None):
     """
     Prompts the user for a password, and returns the password
-    
+
     :param username: The username that we want to get the password for
     :type username: str
     :return: The password for the username.
     """
 
     if username is None:
-        username =os.getlogin()
-        
+        username = os.getlogin()
+
     return getpass(
         "Password for username '{}': ".format(username),
         # Pass in click stdout stream - this is similar to using click.echo

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -1,7 +1,7 @@
 import os
 from click.testing import CliRunner
 import paramiko
-from rcli import rexec 
+from rcli import rexec
 from rcli import rshell
 from rcli import linecard
 from rcli import utils as rcli_utils
@@ -23,12 +23,15 @@ REXEC_HELP = '''Usage: cli [OPTIONS] LINECARD_NAMES...
 
   :param linecard_names: A list of linecard names to execute the command on,
   use `all` to execute on all linecards. :param command: The command to
-  execute on the linecard(s)
+  execute on the linecard(s) :param username: The username to use to login to
+  the linecard(s)
 
 Options:
-  -c, --command TEXT  [required]
-  --help              Show this message and exit.
+  -c, --command TEXT   [required]
+  -u, --username TEXT  Username for login
+  --help               Show this message and exit.
 '''
+
 
 def mock_exec_command():
 
@@ -36,10 +39,12 @@ def mock_exec_command():
     mock_stderr = BytesIO()
     return '', mock_stdout, None
 
+
 def mock_exec_error_cmd():
     mock_stdout = BytesIO()
     mock_stderr = BytesIO(b"""Command not found""")
     return '', mock_stdout, mock_stderr
+
 
 def mock_connection_channel():
     c = mock.MagicMock(return_value="channel")
@@ -48,23 +53,27 @@ def mock_connection_channel():
     c.recv = mock.MagicMock(side_effect=['abcd', ''])
     return c
 
+
 def mock_connection_channel_with_timeout():
     c = mock.MagicMock(return_value="channel")
     c.get_pty = mock.MagicMock(return_value='')
     c.invoke_shell = mock.MagicMock()
-    c.recv = mock.MagicMock(side_effect=['abcd', socket.timeout(10, 'timeout')])
+    c.recv = mock.MagicMock(
+        side_effect=['abcd', socket.timeout(10, 'timeout')])
     return c
+
 
 def mock_paramiko_connection(channel):
     # Create a mock to return for connection.
     conn = mock.MagicMock()
-    #create a mock return for transport
-    t = mock.MagicMock()   
+    # create a mock return for transport
+    t = mock.MagicMock()
     t.open_session = mock.MagicMock(return_value=channel)
     conn.get_transport = mock.MagicMock(return_value=t)
     conn.connect = mock.MagicMock()
     conn.close = mock.MagicMock()
     return conn
+
 
 class TestRemoteExec(object):
     @classmethod
@@ -72,13 +81,13 @@ class TestRemoteExec(object):
         print("SETUP")
         from .mock_tables import dbconnector
         dbconnector.load_database_config()
-   
+
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
-    #@mock.patch.object(linecard.Linecard, '_get_password', mock.MagicMock(return_value='dummmy'))
+    # @mock.patch.object(linecard.Linecard, '_get_password', mock.MagicMock(return_value='dummmy'))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value = mock_exec_command()))
+    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_command()))
     def test_rexec_with_module_name(self):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD0"
@@ -86,12 +95,12 @@ class TestRemoteExec(object):
         print(result.output)
         assert result.exit_code == 0, result.output
         assert "hello world" in result.output
-        
+
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value = mock_exec_command()))
+    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_command()))
     def test_rexec_with_hostname(self):
         runner = CliRunner()
         LINECARD_NAME = "sonic-lc1"
@@ -99,12 +108,12 @@ class TestRemoteExec(object):
         print(result.output)
         assert result.exit_code == 0, result.output
         assert "hello world" in result.output
-        
+
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value = mock_exec_error_cmd()))
+    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_error_cmd()))
     def test_rexec_error_with_module_name(self):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD0"
@@ -112,24 +121,26 @@ class TestRemoteExec(object):
         print(result.output)
         assert result.exit_code == 0, result.output
         assert "Command not found" in result.output
-        
+
     def test_rexec_error(self):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD0"
-        result = runner.invoke(rexec.cli, [LINECARD_NAME, "-c", "show version"])
+        result = runner.invoke(
+            rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 1, result.output
         assert "This commmand is only supported Chassis" in result.output
-      
+
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value = "hello world"))      
+    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_all(self):
         runner = CliRunner()
         LINECARD_NAME = "all"
-        result = runner.invoke(rexec.cli, [LINECARD_NAME, "-c", "show version"])
+        result = runner.invoke(
+            rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert MULTI_LC_REXEC_OUTPUT == result.output
@@ -138,55 +149,70 @@ class TestRemoteExec(object):
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value = "hello world"))      
+    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_invalid_lc(self):
         runner = CliRunner()
         LINECARD_NAME = "sonic-lc-3"
-        result = runner.invoke(rexec.cli, [LINECARD_NAME, "-c", "show version"])
+        result = runner.invoke(
+            rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 1, result.output
         assert "Linecard sonic-lc-3 not found\n" == result.output
 
-
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value = "hello world"))      
+    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_unreachable_lc(self):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD1"
-        result = runner.invoke(rexec.cli, [LINECARD_NAME, "-c", "show version"])
+        result = runner.invoke(
+            rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 1, result.output
-        assert "Linecard LINE-CARD1 not accessible\n" == result.output          
+        assert "Linecard LINE-CARD1 not accessible\n" == result.output
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value = "hello world"))      
+    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_help(self):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD1"
         result = runner.invoke(rexec.cli, ["--help"])
         print(result.output)
         assert result.exit_code == 0, result.output
-        assert REXEC_HELP == result.output          
-  
+        assert REXEC_HELP == result.output
+
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock(side_effect=paramiko.ssh_exception.NoValidConnectionsError({('192.168.0.1',
-    22): "None" })))
-    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value = "hello world"))      
+                                                                                                                                  22): "None"})))
+    @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_exception(self):
         runner = CliRunner()
         LINECARD_NAME = "sonic-lc1"
-        result = runner.invoke(rexec.cli, [LINECARD_NAME, "-c", "show version"])
+        result = runner.invoke(
+            rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
-        assert result.exit_code == 0, result.output
-        assert "[Errno None] Unable to connect to port 22 on 192.168.0.1\n" == result.output      
+        assert result.exit_code == 1, result.output
+        assert "Failed to connect to sonic-lc1 with username admin\n" == result.output
+
+    @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
+    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock(side_effect=paramiko.ssh_exception.NoValidConnectionsError({('192.168.0.1',
+                                                                                                                                  22): "None"})))
+    def test_rexec_with_user_param(self):
+        runner = CliRunner()
+        LINECARD_NAME = "all"
+        result = runner.invoke(
+            rexec.cli, [LINECARD_NAME, "-c", "show version", "-u", "testuser"])
+        print(result.output)
+        assert result.exit_code == 1, result.output
+        assert "Failed to connect to sonic-lc1 with username testuser\n" == result.output
 
 
 class TestRemoteCLI(object):
@@ -195,7 +221,7 @@ class TestRemoteCLI(object):
         print("SETUP")
         from .mock_tables import dbconnector
         dbconnector.load_database_config()
-   
+
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
@@ -206,14 +232,13 @@ class TestRemoteCLI(object):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD0"
         channel = mock_connection_channel()
-        
+
         with mock.patch('paramiko.SSHClient', mock.MagicMock(return_value=mock_paramiko_connection(channel))), \
-        mock.patch('select.select', mock.MagicMock(return_value=([channel], [], []))):
+                mock.patch('select.select', mock.MagicMock(return_value=([channel], [], []))):
             result = runner.invoke(rshell.cli, [LINECARD_NAME])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert "abcd" in result.output
-
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
@@ -225,13 +250,13 @@ class TestRemoteCLI(object):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD0"
         channel = mock_connection_channel()
-        
+
         with mock.patch('paramiko.SSHClient', mock.MagicMock(return_value=mock_paramiko_connection(channel))), \
-        mock.patch('select.select', mock.MagicMock(side_effect=[([], [], []), ([channel], [], []),([channel], [], [])])):
+                mock.patch('select.select', mock.MagicMock(side_effect=[([], [], []), ([channel], [], []), ([channel], [], [])])):
             result = runner.invoke(rshell.cli, [LINECARD_NAME])
         print(result.output)
         assert result.exit_code == 0, result.output
-        assert "Connecting to LINE-CARD0" in result.output    
+        assert "Connecting to LINE-CARD0" in result.output
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
@@ -243,7 +268,7 @@ class TestRemoteCLI(object):
         runner = CliRunner()
         LINECARD_NAME = "LINE-CARD0"
         channel = mock_connection_channel_with_timeout()
-        
+
         with mock.patch('paramiko.SSHClient', mock.MagicMock(return_value=mock_paramiko_connection(channel))), \
                 mock.patch('select.select', mock.MagicMock(return_value=([channel], [], []))):
             result = runner.invoke(rshell.cli, [LINECARD_NAME])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
**_Microsoft ADO 24703217_**
#### What I did
In this PR the following enhancements are done
- Add support for user to pass username
- Add support to login to all linecards before executing any commands 
- 
#### How I did it

#### How to verify it
UT and chassis 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

