### PR TITLE
[chassis][multi-asic]Fix show acl table for masic

### DIFF
--- a/tests/mock_tables/asic2/config_db.json
+++ b/tests/mock_tables/asic2/config_db.json
@@ -132,7 +132,7 @@
     },
     "ACL_TABLE|DATAACL_5": {
         "policy_desc": "DATAACL_5",
-        "ports@": "Ethernet124",
+        "ports@": "Ethernet20",
         "type": "L3",
         "stage": "ingress"
     }

--- a/tests/show_acl_test.py
+++ b/tests/show_acl_test.py
@@ -11,6 +11,11 @@ root_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(root_path)
 scripts_path = os.path.join(modules_path, "scripts")
 
+MASIC_SHOW_ACL_OUTPUT = """Name       Type    Binding      Description    Stage    Status
+---------  ------  -----------  -------------  -------  --------------------------------------
+DATAACL_5  L3      Ethernet20   DATAACL_5      ingress  {'asic0': 'Active', 'asic2': 'Active'}
+                   Ethernet124
+"""
 
 @pytest.fixture()
 def setup_teardown_single_asic():
@@ -74,10 +79,7 @@ class TestShowACLMultiASIC(object):
         }
         result = runner.invoke(acl_loader_show.cli.commands['show'].commands['table'], ['DATAACL_5'], obj=context)
         assert result.exit_code == 0
-        # We only care about the third line, which contains the 'Active'
-        result_top = result.output.split('\n')[2]
-        expected_output = "DATAACL_5  L3      Ethernet124  DATAACL_5      ingress  {'asic0': 'Active', 'asic2': 'Active'}"
-        assert result_top == expected_output
+        assert result.output == MASIC_SHOW_ACL_OUTPUT
 
     def test_show_acl_rule(self, setup_teardown_multi_asic):
         runner = CliRunner()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16012
The `show acl table` command currently get the ports from host config_db on multi asic platforms.
This  host config_db will not the phyiscal ports in the binding ports because the host doesnt have any front panel ports on the host.  This causes the `show acl table`  not to display the phyiscal ports in the output on multi asic devices/linecards.

The test `iface_namingmode/test_iface_namingmode.py::test_show_acl_table` fails because of this issue.

Details from the test failure
```
iface_namingmode/test_iface_namingmode.py::test_show_acl_table[alias-sonic-lc1-1] 
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /var/src/sonic-mgmt-int/tests/iface_namingmode/test_iface_namingmode.py(818)test_show_acl_table()
-> for item in minigraph_acls['DataAcl']:
(Pdb) list 
813  
814         acl_table = dutHostGuest.shell('SONIC_CLI_IFACE_MODE={} show acl table DATAACL'.format(ifmode))['stdout']
815         logger.info('acl_table:\n{}'.format(acl_table))
816  
817         import pdb;pdb.set_trace()
818  ->     for item in minigraph_acls['DataAcl']:
819             if item in setup['physical_interfaces']:
820                 if mode == 'alias':
821                     assert setup['port_name_map'][item] in acl_table
822                 elif mode == 'default':
823                     assert item in acl_table
(Pdb) minigraph_acls['DataAcl']
[u'Ethernet32', u'Ethernet40', u'Ethernet208', u'Ethernet216', u'Ethernet128', u'Ethernet184']
(Pdb) setup['port_name_map']
{u'Ethernet8': 'TestAlias0', u'Ethernet184': 'TestAlias1', u'Ethernet280': 'TestAlias2', u'Ethernet248': 'TestAlias3', u'Ethernet104': 'TestAlias4', u'Ethernet240': 'TestAlias5', u'Ethernet264': 'TestAlias6', u'Ethernet96': 'TestAlias7', u'Ethernet168': 'TestAlias8', u'Ethernet120': 'TestAlias9', u'Ethernet144': 'TestAlias10', u'Ethernet208': 'TestAlias11', u'Ethernet160': 'TestAlias12', u'Ethernet224': 'TestAlias13', u'Ethernet56': 'TestAlias14', u'Ethernet128': 'TestAlias15', u'Ethernet72': 'TestAlias16', u'Ethernet32': 'TestAlias17', u'Ethernet16': 'TestAlias18', u'Ethernet0': 'TestAlias19', u'Ethernet192': 'TestAlias20', u'Ethernet200': 'TestAlias21', u'Ethernet88': 'TestAlias22', u'Ethernet80': 'TestAlias23', u'Ethernet112': 'TestAlias24', u'Ethernet256': 'TestAlias25', u'Ethernet152': 'TestAlias26', u'Ethernet136': 'TestAlias27', u'Ethernet272': 'TestAlias28', u'Ethernet48': 'TestAlias29', u'Ethernet232': 'TestAlias30', u'Ethernet216': 'TestAlias31', u'Ethernet176': 'TestAlias32', u'Ethernet40': 'TestAlias33', u'Ethernet64': 'TestAlias34', u'Ethernet24': 'TestAlias35'}
(Pdb) acl_table
u"Name     Type    Binding         Description    Stage    Status\n-------  ------  --------------  -------------  -------  --------------------------------------\nDATAACL  L3      PortChannel102  DATAACL        ingress  {'asic0': 'Active', 'asic1': 'Active'}\n                 PortChannel106"
(Pdb) mode
'alias'
```
#### How I did it
For the `show acl table` command the following approach is followed
- for single asic, get the all the acl_tables from config_db on the host **_(No change)_**
-  for multi asic:
    - get the control_plane acl info from host.
    - get the dataplane and everflow acl table from each namespace and append the ports. 


#### How to verify it
- Verify with updated UT
- test on chassis multi asic linecard

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

