### PR TITLE
Change db_migrator major version on master branch from version 4 to 6

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -47,7 +47,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_4_0_4'
+        self.CURRENT_VERSION = 'version_6_0_2'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -1028,26 +1028,35 @@ class DBMigrator():
         if self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system"):
             self.migrate_config_db_flex_counter_delay_status()
 
-        self.set_version('version_4_0_3')
-        return 'version_4_0_3'
+        self.set_version('version_5_0_1')
+        return 'version_5_0_1'
 
-    def version_4_0_3(self):
+    def version_5_0_1(self):
         """
-        Version 4_0_3.
+        Version 5_0_1.
+        This is the latest version for 202305 branch
         """
-        log.log_info('Handling version_4_0_3')
+        log.log_info('Handling version_5_0_1')
+        self.set_version('version_6_0_1')
+        return 'version_6_0_1'
+
+    def version_6_0_1(self):
+        """
+        Version 6_0_1.
+        """
+        log.log_info('Handling version_6_0_1')
 
         # Updating DNS nameserver
         self.migrate_dns_nameserver()
-        self.set_version('version_4_0_4')
-        return 'version_4_0_4'
+        self.set_version('version_6_0_2')
+        return 'version_6_0_2'
 
-    def version_4_0_4(self):
+    def version_6_0_2(self):
         """
-        Version 4_0_4.
+        Version 6_0_2.
         This is the latest version for master branch
         """
-        log.log_info('Handling version_4_0_4')
+        log.log_info('Handling version_6_0_2')
         return None
 
     def get_version(self):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

DB versions before this change, and the issue of duplicated versions:
```
201811	version_1_0_1
201911	version_1_0_6
202012	version_2_0_2
202205	version_3_0_7
202211	version_4_0_2
202305	version_4_0_2	<-----	unexpected as major version is reused/duplicated
master	version_4_0_4	<-----	unexpected as major version is reused
```

New DB versions after making jumps on 202305 and master:
```
201811	version_1_0_1
201911	version_1_0_6
202012	version_2_0_2
202205	version_3_0_7
202211	version_4_0_2
202305	version_5_0_1	<---- 202305 jumped one version as part of https://github.com/sonic-net/sonic-utilities/pull/2943
master	version_6_0_1	<---- master branch jumps two versions as part of this PR.
```

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

