### PR TITLE
Fix in config override when all asic namespaces not present in golden_config_db

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1907,8 +1907,8 @@ def override_config_table(db, input_config_db, dry_run):
                 if ns in config_input.keys():
                     ns_config_input = config_input[ns]
                 else:
-                    click.secho("Wrong config format! {} not found in asic config! cannot override.. abort".format(ns))
-                    sys.exit(1)
+                    click.echo("Override config not present for {}".format(ns))
+                    continue
         if not ns_config_input:
             # if ns_config_input is not defined, define it
             # it could be single-asic dut, or config_input is empty

--- a/tests/config_override_input/multi_asic_missing_asic.json
+++ b/tests/config_override_input/multi_asic_missing_asic.json
@@ -1,5 +1,8 @@
 {
     "localhost": {
         "DEVICE_METADATA": {}
+    },
+    "asic0": {
+        "DEVICE_METADATA": {}
     }
 }

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -413,7 +413,7 @@ class TestConfigOverrideMultiasic(object):
             runner = CliRunner()
             result = runner.invoke(config.config.commands["override-config-table"],
                                    ['golden_config_db.json'], obj=db)
-            assert "not found in asic config" in result.output
+            assert "Override config not present for asic1" in result.output
             # make sure program aborted with return code 1
             assert result.exit_code == 1
 

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -414,8 +414,8 @@ class TestConfigOverrideMultiasic(object):
             result = runner.invoke(config.config.commands["override-config-table"],
                                    ['golden_config_db.json'], obj=db)
             assert "Override config not present for asic1" in result.output
-            # make sure program aborted with return code 1
-            assert result.exit_code == 1
+            # make sure program did not abort
+            assert result.exit_code == 0
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
#### What I did
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16164

#### How I did it
In the multi-asic devices for eg: supervisor card of a chassis, the asics are not of its own -- it is the asic present in the fabric cards in the chassis. On then -- all the fabric cards need not be present in the chassis everytime.

In that case golden_config_db.json file generated by NDM ( based on the Subdevices in the minigraph ) will not have all ASICs -- it will be for the fabric cards present in the chassis  

With the current logic, if there is an asic namespace missing -- config load_minigraph will exit with error as in the Issue #https://github.com/sonic-net/sonic-buildimage/issues/16164 and not restart dockers.

Add logic to check and continue if the "asic" namespace is not present in the golden_config_db.json for multi-asic platforms.

#### How to verify it
Verified on a SUP

```
admin@str2-xxxx-sup-1:~$ sudo config load_minigraph -y --override_config 
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json   --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic0 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic1 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic2 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic3 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic4 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic5 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic6 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic7 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic8 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic9 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic10 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic11 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic12 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic13 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic14 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json  -n asic15 --write-to-db
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer --no-delay
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/0/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/1/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/2/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/3/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/4/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/5/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/6/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/7/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/8/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/9/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/10/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/11/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/12/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/13/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/14/buffers.json.j2
Buffer definition template not found at /usr/share/sonic/device/x86_64-nokia_ixrxxxxe_sup-r0/Nokia-IXRxxxxE-SUP-10/15/buffers.json.j2
Running command: pfcwd start_default
Running command: config override-config-table /etc/sonic/golden_config_db.json
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Override config not present for asic1                                   <<<<<<<<<<<<<<<<<<<<<
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Removing configDB overriden table first ...
Overriding input config to configDB ...
Overriding completed. No service is restarted.
Override config not present for asic14                          <<<<<<<<<<<<<<<<<<<<<
Override config not present for asic15                          <<<<<<<<<<<<<<<<<<<<<
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon

```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

