### PR TITLE
[sfputil] Retrieve error-status for transceiver using sfp API

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -889,15 +889,15 @@ def fetch_error_status_from_platform_api(port):
     for logical_port_name in logical_port_list:
         physical_port = logical_port_to_physical_port_index(logical_port_name)
 
-        try:
-            error_description = platform_chassis.get_sfp(physical_port).get_error_description()
-            if is_port_type_rj45(logical_port_name):
-                output.append([logical_port_name, "N/A"])
-            else:
+        if is_port_type_rj45(logical_port_name):
+            output.append([logical_port_name, "N/A"])
+        else:
+            try:
+                error_description = platform_chassis.get_sfp(physical_port).get_error_description()
                 output.append([logical_port_name, error_description])
-        except NotImplementedError:
-            click.echo("get_error_description NOT implemented for port {}".format(logical_port_name))
-            sys.exit(ERROR_NOT_IMPLEMENTED)
+            except NotImplementedError:
+                click.echo("get_error_description NOT implemented for port {}".format(logical_port_name))
+                sys.exit(ERROR_NOT_IMPLEMENTED)
 
     return output
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -882,62 +882,22 @@ def fetch_error_status_from_platform_api(port):
     """
     if port is None:
         logical_port_list = natsort.natsorted(platform_sfputil.logical)
-        # Create a list containing the logical port names of all ports we're interested in
-        generate_sfp_list_code = \
-            "sfp_list = chassis.get_all_sfps()\n"
     else:
-        physical_port_list = logical_port_name_to_physical_port_list(port)
         logical_port_list = [port]
-        # Create a list containing the logical port names of all ports we're interested in
-        generate_sfp_list_code = \
-            "sfp_list = [chassis.get_sfp(x) for x in {}]\n".format(physical_port_list)
-
-    # Code to initialize chassis object
-    init_chassis_code = \
-        "import sonic_platform.platform\n" \
-        "platform = sonic_platform.platform.Platform()\n" \
-        "chassis = platform.get_chassis()\n"
-
-    # Code to fetch the error status
-    get_error_status_code = \
-        "try:\n"\
-        "    errors=['{}:{}'.format(sfp.index, sfp.get_error_description()) for sfp in sfp_list]\n" \
-        "except NotImplementedError as e:\n"\
-        "    errors=['{}:{}'.format(sfp.index, 'OK (Not implemented)') for sfp in sfp_list]\n" \
-        "print(errors)\n"
-
-    get_error_status_command = ["docker", "exec", "pmon", "python3", "-c", "{}{}{}".format(
-        init_chassis_code, generate_sfp_list_code, get_error_status_code)]
-    # Fetch error status from pmon docker
-    try:
-        output = subprocess.check_output(get_error_status_command, universal_newlines=True)
-    except subprocess.CalledProcessError as e:
-        click.Abort("Error! Unable to fetch error status for SPF modules. Error code = {}, error messages: {}".format(e.returncode, e.output))
-        return None
-
-    output_list = output.split('\n')
-    for output_str in output_list:
-        # The output of all SFP error status are a list consisting of element with convention of '<sfp no>:<error status>'
-        # Besides, there can be some logs captured during the platform API executing
-        # So, first of all, we need to skip all the logs until find the output list of SFP error status
-        if output_str[0] == '[' and output_str[-1] == ']':
-            output_list = ast.literal_eval(output_str)
-            break
-
-    output_dict = {}
-    for output in output_list:
-        sfp_index, error_status = output.split(':')
-        output_dict[int(sfp_index)] = error_status
 
     output = []
     for logical_port_name in logical_port_list:
-        physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
-        port_name = get_physical_port_name(logical_port_name, 1, False)
+        physical_port = logical_port_to_physical_port_index(logical_port_name)
 
-        if is_port_type_rj45(logical_port_name):
-            output.append([port_name, "N/A"])
-        else:
-            output.append([port_name, output_dict.get(physical_port_list[0])])
+        try:
+            error_description = platform_chassis.get_sfp(physical_port).get_error_description()
+            if is_port_type_rj45(logical_port_name):
+                output.append([logical_port_name, "N/A"])
+            else:
+                output.append([logical_port_name, error_description])
+        except NotImplementedError:
+            click.echo("get_error_description NOT implemented for port {}".format(logical_port_name))
+            sys.exit(ERROR_NOT_IMPLEMENTED)
 
     return output
 

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -445,6 +445,22 @@ class TestSfputil(object):
         assert output == [['Ethernet0', 'N/A']]
 
     @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
+    def test_fetch_error_status_from_platform_api_exception(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_error_description = MagicMock(side_effect=NotImplementedError)
+
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['show'].commands['error-status'], ["-hw", "-p", "Ethernet0"])
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        expected_output = "get_error_description NOT implemented for port Ethernet0\n"
+        assert result.output == expected_output
+
+    @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
     def test_show_firmware_version(self, mock_chassis):
         mock_sfp = MagicMock()

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -424,13 +424,17 @@ class TestSfputil(object):
         output = sfputil.fetch_error_status_from_state_db('Ethernet0', db.db)
         assert output == expected_output_ethernet0
 
+    @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
-    @patch('subprocess.check_output', MagicMock(return_value="['0:OK']"))
-    def test_fetch_error_status_from_platform_api(self):
+    def test_fetch_error_status_from_platform_api(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_error_description = MagicMock(return_value='OK')
+
         output = sfputil.fetch_error_status_from_platform_api('Ethernet0')
-        assert output == [['Ethernet0', None]]
+        assert output == [['Ethernet0', 'OK']]
 
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The mismatch in 0 based or 1 based port numbering between sfp.index and physical_port number is causing the below issues while executing the "sfputil show error-status -hw" command

1.	“sfputil show error-status -hw” command doesn’t show error-status for Ethernet0 or the last port for some platforms and the remaining ports show error-status of the next or previous port
2.	“sfputil show error-status -hw -p <port>” doesn’t display error-status
3. platform_tests/sfp/test_sfputil.py::test_check_sfputil_error_status sonic-mgmt testcase fails for some platforms

Issue details with an example of sfp.index being 1 based while physical_port being 0 based:
The sfp.index https://github.com/sonic-net/sonic-utilities/blob/7435b1ca539382e644f29d424c551f6258fd2920/sfputil/main.py#L904 is 1 based whereas the physical port numbering is 0 based (retried from port_config.ini file).
Hence, for Ethernet0 (sfp.index = 1), there is no key-value defined in output_dict (dictionary of <sfp.index>:<error_status>) for physical_port = 0.
https://github.com/sonic-net/sonic-utilities/blob/7435b1ca539382e644f29d424c551f6258fd2920/sfputil/main.py#L940

#### How I did it
I am now directly calling get_error_description using sfp object to retrieve the error description. This removes the dependency with sfp.index to retrieve error description for a port.

#### How to verify it
Ran platform_tests/sfp/test_sfputil.py::test_check_sfputil_error_status sonic-mgmt testcase and ensured it passes successfully.

#### Previous command output (if the output of a command-line utility has changed)
No change in CLI o/p. Also, platforms which didn't work with this CLI earlier, will now show a valid CLI output.

#### New command output (if the output of a command-line utility has changed)

