### PR TITLE
Remove the CONFIG_DB_INIT flag dependency on db_migrator

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -92,7 +92,6 @@ class DBMigrator():
         if not self.asic_type:
             log.log_error("ASIC type information not obtained. DB migration will not be reliable")
 
-        # TODO: Update get_hwsku API to take in a custom configDB object
         self.hwsku = device_info.get_localhost_info('hwsku', self.configDB)
         if not self.hwsku:
             log.log_error("HWSKU information not obtained. DB migration will not be reliable")

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -91,7 +91,9 @@ class DBMigrator():
         self.asic_type = version_info.get('asic_type')
         if not self.asic_type:
             log.log_error("ASIC type information not obtained. DB migration will not be reliable")
-        self.hwsku = device_info.get_hwsku()
+
+        # TODO: Update get_hwsku API to take in a custom configDB object
+        self.hwsku = device_info.get_localhost_info('hwsku', self.configDB)
         if not self.hwsku:
             log.log_error("HWSKU information not obtained. DB migration will not be reliable")
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

db_migrator should not depend on CONFIG_DB_INITIALIZED flag. get_hwsku api call busy waits on that flag

#### How I did it

Replace get_hwsku call with get_localhost_info call which takes in a custom config_db object

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

