### PR TITLE
Remove SFP index usage in generating list of SFP hw error

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -917,17 +917,25 @@ def fetch_error_status_from_platform_api(port):
 
     output_list = output.split('\n')
     for output_str in output_list:
-        # The output of all SFP error status are a list consisting of element with convention of '<sfp no>:<error status>'
+        # The output of all SFP error status are a list consisting of <error status> sorted physical port indices
         # Besides, there can be some logs captured during the platform API executing
         # So, first of all, we need to skip all the logs until find the output list of SFP error status
         if output_str[0] == '[' and output_str[-1] == ']':
             output_list = ast.literal_eval(output_str)
             break
 
+    physical_port_set = set()
+    for port in logical_port_list: 
+        physical_port_set.add(logical_port_to_physical_port_index(port))
+
+    physical_port_list = list(physical_port_set)
+    # Map of <physical port# : error status> 
+    error_map = {physical_port_list[i] : output_list[i] for i in range(len(physical_port_list))}
+
     output = []
-    assert len(output_list) == len(logical_port_list)
     for i in range(len(logical_port_list)):
-        output.append([logical_port_list[i], output_list[i]])
+        physical_port = logical_port_to_physical_port_index(logical_port_list[i])
+        output.append([logical_port_list[i], error_map[physical_port]])
     return output
 
 def fetch_error_status_from_state_db(port, state_db):

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -901,9 +901,9 @@ def fetch_error_status_from_platform_api(port):
     # Code to fetch the error status
     get_error_status_code = \
         "try:\n"\
-        "    errors=['{}:{}'.format(sfp.index, sfp.get_error_description()) for sfp in sfp_list]\n" \
+        "    errors=['{}'.format(sfp.get_error_description()) for sfp in sfp_list]\n" \
         "except NotImplementedError as e:\n"\
-        "    errors=['{}:{}'.format(sfp.index, 'OK (Not implemented)') for sfp in sfp_list]\n" \
+        "    errors=['{}'.format('OK (Not implemented)') for sfp in sfp_list]\n" \
         "print(errors)\n"
 
     get_error_status_command = "docker exec pmon python3 -c \"{}{}{}\"".format(
@@ -924,21 +924,10 @@ def fetch_error_status_from_platform_api(port):
             output_list = ast.literal_eval(output_str)
             break
 
-    output_dict = {}
-    for output in output_list:
-        sfp_index, error_status = output.split(':')
-        output_dict[int(sfp_index)] = error_status
-
     output = []
-    for logical_port_name in logical_port_list:
-        physical_port_list = logical_port_name_to_physical_port_list(logical_port_name)
-        port_name = get_physical_port_name(logical_port_name, 1, False)
-
-        if is_port_type_rj45(logical_port_name):
-            output.append([port_name, "N/A"])
-        else:
-            output.append([port_name, output_dict.get(physical_port_list[0])])
-
+    assert len(output_list) == len(logical_port_list)
+    for i in range(len(logical_port_list)):
+        output.append([logical_port_list[i], output_list[i]])
     return output
 
 def fetch_error_status_from_state_db(port, state_db):

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -935,7 +935,7 @@ def fetch_error_status_from_platform_api(port):
     output = []
     for i in range(len(logical_port_list)):
         physical_port = logical_port_to_physical_port_index(logical_port_list[i])
-        output.append([logical_port_list[i], error_map[physical_port]])
+        output.append([logical_port_list[i], error_map[physical_port] if not is_port_type_rj45(logical_port_list[i]) else 'N/A'])
     return output
 
 def fetch_error_status_from_state_db(port, state_db):

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -319,14 +319,14 @@ class TestSfputil(object):
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
-    @patch('subprocess.check_output', MagicMock(return_value="['0:OK']"))
+    @patch('subprocess.check_output', MagicMock(return_value="['OK']"))
     def test_fetch_error_status_from_platform_api(self):
         output = sfputil.fetch_error_status_from_platform_api('Ethernet0')
-        assert output == [['Ethernet0', None]]
+        assert output == [['Ethernet0', 'OK']]
 
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
-    @patch('subprocess.check_output', MagicMock(return_value="['0:OK']"))
+    @patch('subprocess.check_output', MagicMock(return_value="['OK']"))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=True))
     def test_fetch_error_status_from_platform_api_RJ45(self):
         output = sfputil.fetch_error_status_from_platform_api('Ethernet0')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Removed usage of sfp_index in generating the list of sfp hw errors list. The iteration of 1:1 mapping between logical port and sfp object  works because the chassis's _sfp_list [] is sorted in increasing order of physical port indices.

#### How to verify it
Works fine on Arista, Cisco, Dell, Mellanox

````
Verified the changes with different types of vendors

1. vendorA
Automated run
Passed

Manual run
show int status
sfputil show error-status -hw
sfputil show error-status -hw -p Ethernet0
sfputil show error-status -hw -p Ethernet

root@vendorA:/home/admin# show int status
til show error-status -hw -p Ethernet0     Interface            Lanes    Speed    MTU    FEC    Alias            Vlan    Oper    Admin                                      Type    Asym PFC
--------------  ---------------  -------  -----  -----  -------  --------------  ------  -------  ----------------------------------------  ----------
     Ethernet0          0,1,2,3     100G   9100     rs     etp1          routed    down     down                           QSFP28 or later         off
     Ethernet4          4,5,6,7     100G   9100     rs     etp2           trunk      up       up                           QSFP28 or later         off
     Ethernet8        8,9,10,11     100G   9100     rs     etp3           trunk      up       up                           QSFP28 or later         off
    Ethernet12      12,13,14,15     100G   9100     rs     etp4           trunk      up       up                           QSFP28 or later         off
    Ethernet16      16,17,18,19     100G   9100     rs     etp5           trunk      up       up                           QSFP28 or later         off
    Ethernet20      20,21,22,23     100G   9100     rs     etp6           trunk      up       up                           QSFP28 or later         off
    Ethernet24      24,25,26,27     100G   9100     rs     etp7           trunk      up       up                           QSFP28 or later         off
    Ethernet28      28,29,30,31     100G   9100     rs     etp8           trunk      up       up                           QSFP28 or later         off
    Ethernet32      32,33,34,35     100G   9100     rs     etp9           trunk      up       up                           QSFP28 or later         off
    Ethernet36      36,37,38,39     100G   9100     rs    etp10           trunk      up       up                           QSFP28 or later         off
    Ethernet40      40,41,42,43     100G   9100     rs    etp11           trunk      up       up                           QSFP28 or later         off
    Ethernet44      44,45,46,47     100G   9100     rs    etp12           trunk      up       up                           QSFP28 or later         off
    Ethernet48      48,49,50,51     100G   9100     rs    etp13           trunk      up       up                           QSFP28 or later         off
    Ethernet52      52,53,54,55     100G   9100     rs    etp14           trunk      up       up                           QSFP28 or later         off
    Ethernet56      56,57,58,59     100G   9100     rs    etp15           trunk      up       up                           QSFP28 or later         off
    Ethernet60      60,61,62,63     100G   9100     rs    etp16           trunk      up       up                           QSFP28 or later         off
    Ethernet64      64,65,66,67     100G   9100     rs    etp17           trunk      up       up                           QSFP28 or later         off
    Ethernet68      68,69,70,71     100G   9100     rs    etp18           trunk      up       up                           QSFP28 or later         off
    Ethernet72      72,73,74,75     100G   9100     rs    etp19           trunk      up       up                           QSFP28 or later         off
    Ethernet76      76,77,78,79     100G   9100     rs    etp20           trunk      up       up                           QSFP28 or later         off
    Ethernet80      80,81,82,83     100G   9100     rs    etp21           trunk      up       up                           QSFP28 or later         off
    Ethernet84      84,85,86,87     100G   9100     rs    etp22           trunk      up       up                           QSFP28 or later         off
    Ethernet88      88,89,90,91     100G   9100     rs    etp23           trunk      up       up                           QSFP28 or later         off
    Ethernet92      92,93,94,95     100G   9100     rs    etp24           trunk      up       up                           QSFP28 or later         off
    Ethernet96      96,97,98,99     100G   9100     rs    etp25           trunk      up       up                           QSFP28 or later         off
   Ethernet100  100,101,102,103     100G   9100     rs    etp26          routed    down     down                           QSFP28 or later         off
   Ethernet104  104,105,106,107     100G   9100     rs    etp27          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
   Ethernet108  108,109,110,111     100G   9100     rs    etp28          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
   Ethernet112  112,113,114,115     100G   9100     rs    etp29  PortChannel101      up       up                           QSFP28 or later         off
   Ethernet116  116,117,118,119     100G   9100     rs    etp30  PortChannel102      up       up                           QSFP28 or later         off
   Ethernet120  120,121,122,123     100G   9100     rs    etp31  PortChannel103      up       up                           QSFP28 or later         off
   Ethernet124  124,125,126,127     100G   9100     rs    etp32  PortChannel104      up       up                           QSFP28 or later         off
PortChannel101              N/A     100G   9100    N/A      N/A          routed      up       up                                       N/A         N/A
PortChannel102              N/A     100G   9100    N/A      N/A          routed      up       up                                       N/A         N/A
PortChannel103              N/A     100G   9100    N/A      N/A          routed      up       up                                       N/A         N/A
PortChannel104              N/A     100G   9100    N/A      N/A          routed      up       up                                       N/A         N/A
root@vendorA:/home/admin# sfputil show error-status -hw
Port         Error Status
-----------  --------------
Ethernet0    OK
Ethernet4    OK
Ethernet8    OK
Ethernet12   OK
Ethernet16   OK
Ethernet20   OK
Ethernet24   OK
Ethernet28   OK
Ethernet32   OK
Ethernet36   OK
Ethernet40   OK
Ethernet44   OK
Ethernet48   OK
Ethernet52   OK
Ethernet56   OK
Ethernet60   OK
Ethernet64   OK
Ethernet68   OK
Ethernet72   OK
Ethernet76   OK
Ethernet80   OK
Ethernet84   OK
Ethernet88   OK
Ethernet92   OK
Ethernet96   OK
Ethernet100  OK
Ethernet104  OK
Ethernet108  OK
Ethernet112  OK
Ethernet116  OK
Ethernet120  OK
Ethernet124  OK
root@vendorA:/home/admin# sfputil show error-status -hw -p Ethernet0
Port       Error Status
---------  --------------
Ethernet0  OK
root@vendorA:/home/admin# sfputil show error-status -hw -p Ethernet124
Port         Error Status
-----------  --------------
Ethernet124  OK
root@vendorA:/home/admin# 

2. vendorB
Automated run
Passed

Manual run
root@vendorB:/home/admin# show int status
til show error-status -hw -p Ethernet0
sfputil show error-status -hw -p Ethernet
     Interface    Lanes    Speed    MTU    FEC            Alias            Vlan    Oper    Admin                                      Type    Asym PFC
--------------  -------  -------  -----  -----  ---------------  --------------  ------  -------  ----------------------------------------  ----------
     Ethernet0  101,102      40G   9100    N/A   fortyGigE1/1/1  PortChannel101      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet1  103,104      40G   9100    N/A   fortyGigE1/1/2  PortChannel101      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet2    97,98      40G   9100    N/A   fortyGigE1/1/3          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet3   99,100      40G   9100    N/A   fortyGigE1/1/4          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet4    69,70      40G   9100    N/A   fortyGigE1/1/5  PortChannel102      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet5    71,72      40G   9100    N/A   fortyGigE1/1/6  PortChannel102      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet6    65,66      40G   9100    N/A   fortyGigE1/1/7           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet7    67,68      40G   9100    N/A   fortyGigE1/1/8           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet8    53,54      40G   9100    N/A   fortyGigE1/1/9           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
     Ethernet9    55,56      40G   9100    N/A  fortyGigE1/1/10           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet10    49,50      40G   9100    N/A  fortyGigE1/1/11           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet11    51,52      40G   9100    N/A  fortyGigE1/1/12           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet12    21,22      40G   9100    N/A  fortyGigE1/1/13           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet13    23,24      40G   9100    N/A  fortyGigE1/1/14           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet14    17,18      40G   9100    N/A  fortyGigE1/1/15           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet15    19,20      40G   9100    N/A  fortyGigE1/1/16           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet16    25,26      40G   9100    N/A   fortyGigE1/2/1  PortChannel103      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet17    27,28      40G   9100    N/A   fortyGigE1/2/2  PortChannel103      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet18    29,30      40G   9100    N/A   fortyGigE1/2/3          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet19    31,32      40G   9100    N/A   fortyGigE1/2/4          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet20    57,58      40G   9100    N/A   fortyGigE1/2/5  PortChannel104      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet21    59,60      40G   9100    N/A   fortyGigE1/2/6  PortChannel104      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet22    61,62      40G   9100    N/A   fortyGigE1/2/7           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet23    63,64      40G   9100    N/A   fortyGigE1/2/8           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet24    73,74      40G   9100    N/A   fortyGigE1/2/9           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet25    75,76      40G   9100    N/A  fortyGigE1/2/10           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet26    77,78      40G   9100    N/A  fortyGigE1/2/11           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet27    79,80      40G   9100    N/A  fortyGigE1/2/12           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet28  105,106      40G   9100    N/A  fortyGigE1/2/13           trunk      up       up                           QSFP28 or later         off
    Ethernet29  107,108      40G   9100    N/A  fortyGigE1/2/14           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet30  109,110      40G   9100    N/A  fortyGigE1/2/15           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet31  111,112      40G   9100    N/A  fortyGigE1/2/16           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet32    13,14      40G   9100    N/A   fortyGigE1/3/1           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet33    15,16      40G   9100    N/A   fortyGigE1/3/2          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet34     9,10      40G   9100    N/A   fortyGigE1/3/3          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet35    11,12      40G   9100    N/A   fortyGigE1/3/4          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet36  125,126      40G   9100    N/A   fortyGigE1/3/5           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet37  127,128      40G   9100    N/A   fortyGigE1/3/6           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet38  121,122      40G   9100    N/A   fortyGigE1/3/7           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet39  123,124      40G   9100    N/A   fortyGigE1/3/8           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet40    93,94      40G   9100    N/A   fortyGigE1/3/9           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet41    95,96      40G   9100    N/A  fortyGigE1/3/10           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet42    89,90      40G   9100    N/A  fortyGigE1/3/11           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet43    91,92      40G   9100    N/A  fortyGigE1/3/12          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet44    45,46      40G   9100    N/A  fortyGigE1/3/13          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet45    47,48      40G   9100    N/A  fortyGigE1/3/14          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet46    41,42      40G   9100    N/A  fortyGigE1/3/15          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet47    43,44      40G   9100    N/A  fortyGigE1/3/16          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet48  113,114      40G   9100    N/A   fortyGigE1/4/1           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet49  115,116      40G   9100    N/A   fortyGigE1/4/2          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet50  117,118      40G   9100    N/A   fortyGigE1/4/3          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet51  119,120      40G   9100    N/A   fortyGigE1/4/4          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet52      1,2      40G   9100    N/A   fortyGigE1/4/5           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet53      3,4      40G   9100    N/A   fortyGigE1/4/6           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet54      5,6      40G   9100    N/A   fortyGigE1/4/7           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet55      7,8      40G   9100    N/A   fortyGigE1/4/8           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet56    33,34      40G   9100    N/A   fortyGigE1/4/9           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet57    35,36      40G   9100    N/A  fortyGigE1/4/10           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet58    37,38      40G   9100    N/A  fortyGigE1/4/11           trunk      up       up  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet59    39,40      40G   9100    N/A  fortyGigE1/4/12          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet60    81,82      40G   9100    N/A  fortyGigE1/4/13          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet61    83,84      40G   9100    N/A  fortyGigE1/4/14          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet62    85,86      40G   9100    N/A  fortyGigE1/4/15          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet63    87,88      40G   9100    N/A  fortyGigE1/4/16          routed    down     down  QSFP+ or later with SFF-8636 or SFF-8436         off
    Ethernet64      129      10G   9100    N/A       tenGigE1/1          routed    down     down                                       N/A         off
    Ethernet65      131      10G   9100    N/A       tenGigE1/2          routed    down     down                                       N/A         off
PortChannel101      N/A      80G   9100    N/A              N/A          routed      up       up                                       N/A         N/A
PortChannel102      N/A      80G   9100    N/A              N/A          routed      up       up                                       N/A         N/A
PortChannel103      N/A      80G   9100    N/A              N/A          routed      up       up                                       N/A         N/A
PortChannel104      N/A      80G   9100    N/A              N/A          routed      up       up                                       N/A         N/A
root@vendorB:/home/admin# sfputil show error-status -hw
Port        Error Status
----------  --------------
Ethernet0   OK
Ethernet1   OK
Ethernet2   OK
Ethernet3   OK
Ethernet4   OK
Ethernet5   OK
Ethernet6   OK
Ethernet7   OK
Ethernet8   OK
Ethernet9   OK
Ethernet10  OK
Ethernet11  OK
Ethernet12  OK
Ethernet13  OK
Ethernet14  OK
Ethernet15  OK
Ethernet16  OK
Ethernet17  OK
Ethernet18  OK
Ethernet19  OK
Ethernet20  OK
Ethernet21  OK
Ethernet22  OK
Ethernet23  OK
Ethernet24  OK
Ethernet25  OK
Ethernet26  OK
Ethernet27  OK
Ethernet28  OK
Ethernet29  OK
Ethernet30  OK
Ethernet31  OK
Ethernet32  OK
Ethernet33  OK
Ethernet34  OK
Ethernet35  OK
Ethernet36  OK
Ethernet37  OK
Ethernet38  OK
Ethernet39  OK
Ethernet40  OK
Ethernet41  OK
Ethernet42  OK
Ethernet43  OK
Ethernet44  OK
Ethernet45  OK
Ethernet46  OK
Ethernet47  OK
Ethernet48  OK
Ethernet49  OK
Ethernet50  OK
Ethernet51  OK
Ethernet52  OK
Ethernet53  OK
Ethernet54  OK
Ethernet55  OK
Ethernet56  OK
Ethernet57  OK
Ethernet58  OK
Ethernet59  OK
Ethernet60  OK
Ethernet61  OK
Ethernet62  OK
Ethernet63  OK
Ethernet64  Unplugged
Ethernet65  Unplugged
root@vendorB:/home/admin# sfputil show error-status -hw -p Ethernet0
Port       Error Status
---------  --------------
Ethernet0  OK
root@vendorB:/home/admin# sfputil show error-status -hw -p Ethernet
Error: invalid port 'Ethernet'

Valid values for port: ['Ethernet3', 'Ethernet43', 'Ethernet57', 'Ethernet22', 'Ethernet26', 'Ethernet36', 'Ethernet32', 'Ethernet42', 'Ethernet0', 'Ethernet44', 'Ethernet16', 'Ethernet25', 'Ethernet28', 'Ethernet55', 'Ethernet33', 'Ethernet9', 'Ethernet10', 'Ethernet59', 'Ethernet17', 'Ethernet41', 'Ethernet40', 'Ethernet19', 'Ethernet24', 'Ethernet29', 'Ethernet46', 'Ethernet65', 'Ethernet27', 'Ethernet2', 'Ethernet21', 'Ethernet4', 'Ethernet47', 'Ethernet30', 'Ethernet64', 'Ethernet50', 'Ethernet20', 'Ethernet34', 'Ethernet62', 'Ethernet60', 'Ethernet51', 'Ethernet37', 'Ethernet11', 'Ethernet48', 'Ethernet52', 'Ethernet5', 'Ethernet35', 'Ethernet38', 'Ethernet49', 'Ethernet58', 'Ethernet14', 'Ethernet13', 'Ethernet63', 'Ethernet1', 'Ethernet56', 'Ethernet61', 'Ethernet31', 'Ethernet12', 'Ethernet23', 'Ethernet7', 'Ethernet8', 'Ethernet18', 'Ethernet6', 'Ethernet15', 'Ethernet45', 'Ethernet39', 'Ethernet53', 'Ethernet54']

root@vendorB:/home/admin# sfputil show error-status -hw -p Ethernet65
Port        Error Status
----------  --------------
Ethernet65  Unplugged
root@vendorB:/home/admin# 

3. vendorC
Automated run
Passed

Manual run
root@vendorC:/home/admin# show int status
til show error-status -hw -p Ethernet0
     Interface            Lanes    Speed    MTU    FEC         Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  ------------  --------------  ------  -------  ---------------  ----------
     Ethernet0            77,78      50G   9100    N/A   Ethernet1/1           trunk      up       up  QSFP28 or later         off
     Ethernet2            79,80      50G   9100    N/A   Ethernet1/3           trunk      up       up  QSFP28 or later         off
     Ethernet4            65,66      50G   9100    N/A   Ethernet2/1           trunk      up       up  QSFP28 or later         off
     Ethernet6            67,68      50G   9100    N/A   Ethernet2/3           trunk      up       up  QSFP28 or later         off
     Ethernet8            85,86      50G   9100    N/A   Ethernet3/1           trunk      up       up  QSFP28 or later         off
    Ethernet10            87,88      50G   9100    N/A   Ethernet3/3           trunk      up       up  QSFP28 or later         off
    Ethernet12            89,90      50G   9100    N/A   Ethernet4/1           trunk      up       up  QSFP28 or later         off
    Ethernet14            91,92      50G   9100    N/A   Ethernet4/3           trunk      up       up  QSFP28 or later         off
    Ethernet16          109,110      50G   9100    N/A   Ethernet5/1           trunk      up       up  QSFP28 or later         off
    Ethernet18          111,112      50G   9100    N/A   Ethernet5/3           trunk      up       up  QSFP28 or later         off
    Ethernet20            97,98      50G   9100    N/A   Ethernet6/1           trunk      up       up  QSFP28 or later         off
    Ethernet22           99,100      50G   9100    N/A   Ethernet6/3           trunk      up       up  QSFP28 or later         off
    Ethernet24              5,6      50G   9100    N/A   Ethernet7/1           trunk      up       up  QSFP28 or later         off
    Ethernet26              7,8      50G   9100    N/A   Ethernet7/3           trunk      up       up  QSFP28 or later         off
    Ethernet28            13,14      50G   9100    N/A   Ethernet8/1           trunk      up       up  QSFP28 or later         off
    Ethernet30            15,16      50G   9100    N/A   Ethernet8/3           trunk      up       up  QSFP28 or later         off
    Ethernet32            25,26      50G   9100    N/A   Ethernet9/1           trunk      up       up  QSFP28 or later         off
    Ethernet34            27,28      50G   9100    N/A   Ethernet9/3           trunk      up       up  QSFP28 or later         off
    Ethernet36            21,22      50G   9100    N/A  Ethernet10/1           trunk      up       up  QSFP28 or later         off
    Ethernet38            23,24      50G   9100    N/A  Ethernet10/3           trunk      up       up  QSFP28 or later         off
    Ethernet40            37,38      50G   9100    N/A  Ethernet11/1           trunk      up       up  QSFP28 or later         off
    Ethernet42            39,40      50G   9100    N/A  Ethernet11/3           trunk      up       up  QSFP28 or later         off
    Ethernet44            45,46      50G   9100    N/A  Ethernet12/1           trunk      up       up  QSFP28 or later         off
    Ethernet46            47,48      50G   9100    N/A  Ethernet12/3           trunk      up       up  QSFP28 or later         off
    Ethernet48      57,58,59,60     100G   9100     rs  Ethernet13/1  PortChannel101      up       up  QSFP28 or later         off
    Ethernet52      53,54,55,56     100G   9100     rs  Ethernet14/1  PortChannel101      up       up  QSFP28 or later         off
    Ethernet56  117,118,119,120     100G   9100     rs  Ethernet15/1  PortChannel102      up       up  QSFP28 or later         off
    Ethernet60  121,122,123,124     100G   9100     rs  Ethernet16/1  PortChannel102      up       up  QSFP28 or later         off
    Ethernet64  141,142,143,144     100G   9100     rs  Ethernet17/1  PortChannel103      up       up  QSFP28 or later         off
    Ethernet68  133,134,135,136     100G   9100     rs  Ethernet18/1  PortChannel103      up       up  QSFP28 or later         off
    Ethernet72  197,198,199,200     100G   9100     rs  Ethernet19/1  PortChannel104      up       up  QSFP28 or later         off
    Ethernet76  205,206,207,208     100G   9100     rs  Ethernet20/1  PortChannel104      up       up  QSFP28 or later         off
    Ethernet80          217,218      50G   9100    N/A  Ethernet21/1           trunk      up       up  QSFP28 or later         off
    Ethernet82          219,220      50G   9100    N/A  Ethernet21/3           trunk      up       up  QSFP28 or later         off
    Ethernet84          213,214      50G   9100    N/A  Ethernet22/1           trunk      up       up  QSFP28 or later         off
    Ethernet86          215,216      50G   9100    N/A  Ethernet22/3           trunk      up       up  QSFP28 or later         off
    Ethernet88          229,230      50G   9100    N/A  Ethernet23/1           trunk      up       up  QSFP28 or later         off
    Ethernet90          231,232      50G   9100    N/A  Ethernet23/3           trunk      up       up  QSFP28 or later         off
    Ethernet92          237,238      50G   9100    N/A  Ethernet24/1           trunk      up       up  QSFP28 or later         off
    Ethernet94          239,240      50G   9100    N/A  Ethernet24/3           trunk      up       up  QSFP28 or later         off
    Ethernet96          249,250      50G   9100    N/A  Ethernet25/1           trunk      up       up  QSFP28 or later         off
    Ethernet98          251,252      50G   9100    N/A  Ethernet25/3           trunk      up       up  QSFP28 or later         off
   Ethernet100          245,246      50G   9100    N/A  Ethernet26/1           trunk      up       up  QSFP28 or later         off
   Ethernet102          247,248      50G   9100    N/A  Ethernet26/3           trunk      up       up  QSFP28 or later         off
   Ethernet104          149,150      50G   9100    N/A  Ethernet27/1           trunk      up       up  QSFP28 or later         off
   Ethernet106          151,152      50G   9100    N/A  Ethernet27/3           trunk      up       up  QSFP28 or later         off
   Ethernet108          153,154      50G   9100    N/A  Ethernet28/1           trunk      up       up  QSFP28 or later         off
   Ethernet110          155,156      50G   9100    N/A  Ethernet28/3           trunk      up       up  QSFP28 or later         off
   Ethernet112          173,174      50G   9100    N/A  Ethernet29/1           trunk      up       up  QSFP28 or later         off
   Ethernet114          175,176      50G   9100    N/A  Ethernet29/3           trunk      up       up  QSFP28 or later         off
   Ethernet116          161,162      50G   9100    N/A  Ethernet30/1           trunk      up       up  QSFP28 or later         off
   Ethernet118          163,164      50G   9100    N/A  Ethernet30/3           trunk      up       up  QSFP28 or later         off
   Ethernet120          181,182      50G   9100    N/A  Ethernet31/1           trunk      up       up  QSFP28 or later         off
   Ethernet122          183,184      50G   9100    N/A  Ethernet31/3           trunk      up       up  QSFP28 or later         off
   Ethernet124          185,186      50G   9100    N/A  Ethernet32/1           trunk      up       up  QSFP28 or later         off
   Ethernet126          187,188      50G   9100    N/A  Ethernet32/3           trunk      up       up  QSFP28 or later         off
   Ethernet128            69,70      50G   9100    N/A  Ethernet33/1           trunk      up       up  QSFP28 or later         off
   Ethernet130            71,72      50G   9100    N/A  Ethernet33/3           trunk      up       up  QSFP28 or later         off
   Ethernet132            73,74      50G   9100    N/A  Ethernet34/1           trunk      up       up  QSFP28 or later         off
   Ethernet134            75,76      50G   9100    N/A  Ethernet34/3           trunk      up       up  QSFP28 or later         off
   Ethernet136            93,94      50G   9100    N/A  Ethernet35/1           trunk      up       up  QSFP28 or later         off
   Ethernet138            95,96      50G   9100    N/A  Ethernet35/3           trunk      up       up  QSFP28 or later         off
   Ethernet140            81,82      50G   9100    N/A  Ethernet36/1           trunk      up       up  QSFP28 or later         off
   Ethernet142            83,84      50G   9100    N/A  Ethernet36/3           trunk      up       up  QSFP28 or later         off
   Ethernet144          101,102      50G   9100    N/A  Ethernet37/1           trunk      up       up  QSFP28 or later         off
   Ethernet146          103,104      50G   9100    N/A  Ethernet37/3           trunk      up       up  QSFP28 or later         off
   Ethernet148          105,106      50G   9100    N/A  Ethernet38/1           trunk      up       up  QSFP28 or later         off
   Ethernet150          107,108      50G   9100    N/A  Ethernet38/3           trunk      up       up  QSFP28 or later         off
   Ethernet152             9,10      50G   9100    N/A  Ethernet39/1           trunk      up       up  QSFP28 or later         off
   Ethernet154            11,12      50G   9100    N/A  Ethernet39/3           trunk      up       up  QSFP28 or later         off
   Ethernet156              1,2      50G   9100    N/A  Ethernet40/1           trunk      up       up  QSFP28 or later         off
   Ethernet158              3,4      50G   9100    N/A  Ethernet40/3           trunk      up       up  QSFP28 or later         off
   Ethernet160            17,18      50G   9100    N/A  Ethernet41/1           trunk      up       up  QSFP28 or later         off
   Ethernet162            19,20      50G   9100    N/A  Ethernet41/3           trunk      up       up  QSFP28 or later         off
   Ethernet164            29,30      50G   9100    N/A  Ethernet42/1           trunk      up       up  QSFP28 or later         off
   Ethernet166            31,32      50G   9100    N/A  Ethernet42/3           trunk      up       up  QSFP28 or later         off
   Ethernet168            41,42      50G   9100    N/A  Ethernet43/1           trunk      up       up  QSFP28 or later         off
   Ethernet170            43,44      50G   9100    N/A  Ethernet43/3           trunk      up       up  QSFP28 or later         off
   Ethernet172            33,34      50G   9100    N/A  Ethernet44/1           trunk      up       up  QSFP28 or later         off
   Ethernet174            35,36      50G   9100    N/A  Ethernet44/3           trunk      up       up  QSFP28 or later         off
   Ethernet176            49,50      50G   9100    N/A  Ethernet45/1           trunk      up       up  QSFP28 or later         off
   Ethernet178            51,52      50G   9100    N/A  Ethernet45/3           trunk      up       up  QSFP28 or later         off
   Ethernet180            61,62      50G   9100    N/A  Ethernet46/1           trunk      up       up  QSFP28 or later         off
   Ethernet182            63,64      50G   9100    N/A  Ethernet46/3           trunk      up       up  QSFP28 or later         off
   Ethernet184          125,126      50G   9100    N/A  Ethernet47/1           trunk      up       up  QSFP28 or later         off
   Ethernet186          127,128      50G   9100    N/A  Ethernet47/3           trunk      up       up  QSFP28 or later         off
   Ethernet188          113,114      50G   9100    N/A  Ethernet48/1           trunk      up       up  QSFP28 or later         off
   Ethernet190          115,116      50G   9100    N/A  Ethernet48/3           trunk      up       up  QSFP28 or later         off
   Ethernet192          129,130      50G   9100    N/A  Ethernet49/1           trunk      up       up  QSFP28 or later         off
   Ethernet194          131,132      50G   9100    N/A  Ethernet49/3           trunk      up       up  QSFP28 or later         off
   Ethernet196          137,138      50G   9100    N/A  Ethernet50/1           trunk      up       up  QSFP28 or later         off
   Ethernet198          139,140      50G   9100    N/A  Ethernet50/3           trunk      up       up  QSFP28 or later         off
   Ethernet200          201,202      50G   9100    N/A  Ethernet51/1           trunk      up       up  QSFP28 or later         off
   Ethernet202          203,204      50G   9100    N/A  Ethernet51/3           trunk      up       up  QSFP28 or later         off
   Ethernet204          193,194      50G   9100    N/A  Ethernet52/1           trunk      up       up  QSFP28 or later         off
   Ethernet206          195,196      50G   9100    N/A  Ethernet52/3           trunk      up       up  QSFP28 or later         off
   Ethernet208          209,210      50G   9100    N/A  Ethernet53/1           trunk      up       up  QSFP28 or later         off
   Ethernet210          211,212      50G   9100    N/A  Ethernet53/3           trunk      up       up  QSFP28 or later         off
   Ethernet212          221,222      50G   9100    N/A  Ethernet54/1           trunk      up       up  QSFP28 or later         off
   Ethernet214          223,224      50G   9100    N/A  Ethernet54/3           trunk      up       up  QSFP28 or later         off
   Ethernet216          233,234      50G   9100    N/A  Ethernet55/1           trunk      up       up  QSFP28 or later         off
   Ethernet218          235,236      50G   9100    N/A  Ethernet55/3           trunk      up       up  QSFP28 or later         off
   Ethernet220          225,226      50G   9100    N/A  Ethernet56/1           trunk      up       up  QSFP28 or later         off
   Ethernet222          227,228      50G   9100    N/A  Ethernet56/3           trunk      up       up  QSFP28 or later         off
   Ethernet224          241,242      50G   9100    N/A  Ethernet57/1           trunk      up       up  QSFP28 or later         off
   Ethernet226          243,244      50G   9100    N/A  Ethernet57/3           trunk      up       up  QSFP28 or later         off
   Ethernet228          253,254      50G   9100    N/A  Ethernet58/1           trunk      up       up  QSFP28 or later         off
   Ethernet230          255,256      50G   9100    N/A  Ethernet58/3           trunk      up       up  QSFP28 or later         off
   Ethernet232          157,158      50G   9100    N/A  Ethernet59/1           trunk      up       up  QSFP28 or later         off
   Ethernet234          159,160      50G   9100    N/A  Ethernet59/3           trunk      up       up  QSFP28 or later         off
   Ethernet236          145,146      50G   9100    N/A  Ethernet60/1           trunk      up       up  QSFP28 or later         off
   Ethernet238          147,148      50G   9100    N/A  Ethernet60/3           trunk      up       up  QSFP28 or later         off
   Ethernet240          165,166      50G   9100    N/A  Ethernet61/1           trunk      up       up  QSFP28 or later         off
   Ethernet242          167,168      50G   9100    N/A  Ethernet61/3           trunk      up       up  QSFP28 or later         off
   Ethernet244          169,170      50G   9100    N/A  Ethernet62/1           trunk      up       up  QSFP28 or later         off
   Ethernet246          171,172      50G   9100    N/A  Ethernet62/3           trunk      up       up  QSFP28 or later         off
   Ethernet248          189,190      50G   9100    N/A  Ethernet63/1           trunk      up       up  QSFP28 or later         off
   Ethernet250          191,192      50G   9100    N/A  Ethernet63/3           trunk      up       up  QSFP28 or later         off
   Ethernet252          177,178      50G   9100    N/A  Ethernet64/1           trunk      up       up  QSFP28 or later         off
   Ethernet254          179,180      50G   9100    N/A  Ethernet64/3           trunk      up       up  QSFP28 or later         off
   Ethernet256              257      10G   9100    N/A    Ethernet65          routed    down     down              N/A         off
   Ethernet260              259      10G   9100    N/A    Ethernet66          routed    down     down              N/A         off
PortChannel101              N/A     200G   9100    N/A           N/A          routed      up       up              N/A         N/A
PortChannel102              N/A     200G   9100    N/A           N/A          routed      up       up              N/A         N/A
PortChannel103              N/A     200G   9100    N/A           N/A          routed      up       up              N/A         N/A
PortChannel104              N/A     200G   9100    N/A           N/A          routed      up       up              N/A         N/A
root@vendorC:/home/admin# sfputil show error-status -hw
Port         Error Status
-----------  --------------
Ethernet0    OK
Ethernet2    OK
Ethernet4    OK
Ethernet6    OK
Ethernet8    OK
Ethernet10   OK
Ethernet12   OK
Ethernet14   OK
Ethernet16   OK
Ethernet18   OK
Ethernet20   OK
Ethernet22   OK
Ethernet24   OK
Ethernet26   OK
Ethernet28   OK
Ethernet30   OK
Ethernet32   OK
Ethernet34   OK
Ethernet36   OK
Ethernet38   OK
Ethernet40   OK
Ethernet42   OK
Ethernet44   OK
Ethernet46   OK
Ethernet48   OK
Ethernet52   OK
Ethernet56   OK
Ethernet60   OK
Ethernet64   OK
Ethernet68   OK
Ethernet72   OK
Ethernet76   OK
Ethernet80   OK
Ethernet82   OK
Ethernet84   OK
Ethernet86   OK
Ethernet88   OK
Ethernet90   OK
Ethernet92   OK
Ethernet94   OK
Ethernet96   OK
Ethernet98   OK
Ethernet100  OK
Ethernet102  OK
Ethernet104  OK
Ethernet106  OK
Ethernet108  OK
Ethernet110  OK
Ethernet112  OK
Ethernet114  OK
Ethernet116  OK
Ethernet118  OK
Ethernet120  OK
Ethernet122  OK
Ethernet124  OK
Ethernet126  OK
Ethernet128  OK
Ethernet130  OK
Ethernet132  OK
Ethernet134  OK
Ethernet136  OK
Ethernet138  OK
Ethernet140  OK
Ethernet142  OK
Ethernet144  OK
Ethernet146  OK
Ethernet148  OK
Ethernet150  OK
Ethernet152  OK
Ethernet154  OK
Ethernet156  OK
Ethernet158  OK
Ethernet160  OK
Ethernet162  OK
Ethernet164  OK
Ethernet166  OK
Ethernet168  OK
Ethernet170  OK
Ethernet172  OK
Ethernet174  OK
Ethernet176  OK
Ethernet178  OK
Ethernet180  OK
Ethernet182  OK
Ethernet184  OK
Ethernet186  OK
Ethernet188  OK
Ethernet190  OK
Ethernet192  OK
Ethernet194  OK
Ethernet196  OK
Ethernet198  OK
Ethernet200  OK
Ethernet202  OK
Ethernet204  OK
Ethernet206  OK
Ethernet208  OK
Ethernet210  OK
Ethernet212  OK
Ethernet214  OK
Ethernet216  OK
Ethernet218  OK
Ethernet220  OK
Ethernet222  OK
Ethernet224  OK
Ethernet226  OK
Ethernet228  OK
Ethernet230  OK
Ethernet232  OK
Ethernet234  OK
Ethernet236  OK
Ethernet238  OK
Ethernet240  OK
Ethernet242  OK
Ethernet244  OK
Ethernet246  OK
Ethernet248  OK
Ethernet250  OK
Ethernet252  OK
Ethernet254  OK
Ethernet256  Unplugged
Ethernet260  Unplugged
root@vendorC:/home/admin# sfputil show error-status -hw -p Ethernet0
Port       Error Status
---------  --------------
Ethernet0  OK
root@vendorC:/home/admin# sfputil show error-status -hw -p Ethernet260
Port         Error Status
-----------  --------------
Ethernet260  Unplugged
root@vendorC:/home/admin#

4. vendorD

Manual run
root@vendorD:/home/admin# show int status
til show error-status -hw -p Ethernet0
      Interface                                    Lanes    Speed    MTU    FEC    Alias             Vlan    Oper    Admin                                             Type    Asym PFC
---------------  ---------------------------------------  -------  -----  -----  -------  ---------------  ------  -------  -----------------------------------------------  ----------
      Ethernet0                      2304,2305,2306,2307     100G   9100     rs     etp0   PortChannel101    down       up                                              N/A         off
      Ethernet4                      2308,2309,2310,2311     100G   9100     rs     etp1   PortChannel103    down       up                                              N/A         off
      Ethernet8                      2320,2321,2322,2323     100G   9100     rs     etp2           routed    down     down                                              N/A         off
     Ethernet12                      2324,2325,2326,2327     100G   9100     rs     etp3           routed    down     down                                              N/A         off
     Ethernet16                      2312,2313,2314,2315     100G   9100     rs     etp4   PortChannel104    down       up                                              N/A         off
     Ethernet20                      2316,2317,2318,2319     100G   9100     rs     etp5   PortChannel106    down       up                                              N/A         off
     Ethernet24                      2056,2057,2058,2059     100G   9100     rs     etp6           routed    down     down                                              N/A         off
     Ethernet28                      2060,2061,2062,2063     100G   9100     rs     etp7           routed    down     down                                              N/A         off
     Ethernet32                      1792,1793,1794,1795     100G   9100     rs     etp8           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet36                      1796,1797,1798,1799     100G   9100     rs     etp9           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
     Ethernet40                      2048,2049,2050,2051     100G   9100     rs    etp10           routed    down       up                                              N/A         off
     Ethernet44                      2052,2053,2054,2055     100G   9100     rs    etp11           routed    down       up                                              N/A         off
     Ethernet48                      2560,2561,2562,2563     100G   9100     rs    etp12           routed    down     down                                              N/A         off
     Ethernet52                      2564,2565,2566,2567     100G   9100     rs    etp13           routed    down     down                                              N/A         off
     Ethernet56                      2824,2825,2826,2827     100G   9100     rs    etp14           routed    down       up                                              N/A         off
     Ethernet60                      2828,2829,2830,2831     100G   9100     rs    etp15           routed    down       up                                              N/A         off
     Ethernet64                      2832,2833,2834,2835     100G   9100     rs    etp16   PortChannel107    down       up                                              N/A         off
     Ethernet68                      2836,2837,2838,2839     100G   9100     rs    etp17   PortChannel109    down       up                                              N/A         off
     Ethernet72                      2816,2817,2818,2819     100G   9100     rs    etp18           routed    down     down                                              N/A         off
     Ethernet76                      2820,2821,2822,2823     100G   9100     rs    etp19           routed    down     down                                              N/A         off
     Ethernet80                      2568,2569,2570,2571     100G   9100     rs    etp20  PortChannel1010    down       up                                              N/A         off
     Ethernet84                      2572,2573,2574,2575     100G   9100     rs    etp21  PortChannel1012    down       up                                              N/A         off
     Ethernet88                      2576,2577,2578,2579     100G   9100     rs    etp22           routed    down     down                                              N/A         off
     Ethernet92                      2580,2581,2582,2583     100G   9100     rs    etp23           routed    down     down                                              N/A         off
     Ethernet96  1536,1537,1538,1539,1540,1541,1542,1543     400G   9100    N/A    etp24   PortChannel102    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet104  1800,1801,1802,1803,1804,1805,1806,1807     400G   9100    N/A    etp25   PortChannel102    down       up                                              N/A         off
    Ethernet112  1552,1553,1554,1555,1556,1557,1558,1559     400G   9100    N/A    etp26   PortChannel105    down     down  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet120  1544,1545,1546,1547,1548,1549,1550,1551     400G   9100    N/A    etp27   PortChannel105    down       up                                              N/A         off
    Ethernet128  1296,1297,1298,1299,1300,1301,1302,1303     400G   9100    N/A    etp28   PortChannel108    down       up                                              N/A         off
    Ethernet136  1288,1289,1290,1291,1292,1293,1294,1295     400G   9100    N/A    etp29   PortChannel108    down       up                                              N/A         off
    Ethernet144  1280,1281,1282,1283,1284,1285,1286,1287     400G   9100    N/A    etp30  PortChannel1011    down       up                                              N/A         off
    Ethernet152  1032,1033,1034,1035,1036,1037,1038,1039     400G   9100    N/A    etp31  PortChannel1011    down       up                                              N/A         off
    Ethernet160                          264,265,266,267     100G   9100     rs    etp32           routed    down     down                                              N/A         off
    Ethernet164                          268,269,270,271     100G   9100     rs    etp33           routed    down     down                                              N/A         off
    Ethernet168                          272,273,274,275     100G   9100     rs    etp34  PortChannel1013    down       up                                              N/A         off
    Ethernet172                          276,277,278,279     100G   9100     rs    etp35           routed    down     down                                              N/A         off
    Ethernet176                              16,17,18,19     100G   9100     rs    etp36           routed    down     down                                              N/A         off
    Ethernet180                              20,21,22,23     100G   9100     rs    etp37  PortChannel1014    down       up                                              N/A         off
    Ethernet184                                  0,1,2,3     100G   9100     rs    etp38           routed    down     down                                              N/A         off
    Ethernet188                                  4,5,6,7     100G   9100     rs    etp39           routed    down     down                                              N/A         off
    Ethernet192                          256,257,258,259     100G   9100     rs    etp40           routed    down     down                                  QSFP28 or later         off
    Ethernet196                          260,261,262,263     100G   9100     rs    etp41           routed    down     down                                  QSFP28 or later         off
    Ethernet200                                8,9,10,11     100G   9100     rs    etp42  PortChannel1015    down       up                                              N/A         off
    Ethernet204                              12,13,14,15     100G   9100     rs    etp43  PortChannel1016    down       up                                              N/A         off
    Ethernet208                      1024,1025,1026,1027     100G   9100     rs    etp44           routed    down     down                                  QSFP28 or later         off
    Ethernet212                      1028,1029,1030,1031     100G   9100     rs    etp45  PortChannel1017    down       up                                  QSFP28 or later         off
    Ethernet216                          768,769,770,771     100G   9100     rs    etp46  PortChannel1018    down       up                                              N/A         off
    Ethernet220                          772,773,774,775     100G   9100     rs    etp47  PortChannel1019    down       up                                              N/A         off
    Ethernet224                          524,525,526,527     100G   9100     rs    etp48           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet228                          520,521,522,523     100G   9100     rs    etp49           routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         off
    Ethernet232                          776,777,778,779     100G   9100     rs    etp50  PortChannel1020      up       up                         QSFP+ or later with CMIS         off
    Ethernet236                          780,781,782,783     100G   9100     rs    etp51           routed    down     down                         QSFP+ or later with CMIS         off
    Ethernet240                          516,517,518,519     100G   9100     rs    etp52  PortChannel1021      up       up                         QSFP+ or later with CMIS         off
    Ethernet244                          512,513,514,515     100G   9100     rs    etp53  PortChannel1022    down     down                         QSFP+ or later with CMIS         off
    Ethernet248                          528,529,530,531     100G   9100     rs    etp54  PortChannel1023    down       up                                              N/A         off
    Ethernet252                          532,533,534,535     100G   9100     rs    etp55  PortChannel1024    down       up                                              N/A         off
 PortChannel101                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel102                                      N/A     800G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel103                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel104                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel105                                      N/A     800G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel106                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel107                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel108                                      N/A     800G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
 PortChannel109                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1010                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1011                                      N/A     800G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1012                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1013                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1014                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1015                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1016                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1017                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1018                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1019                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1020                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1021                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1022                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1023                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
PortChannel1024                                      N/A     100G   9100    N/A      N/A           routed    down       up                                              N/A         N/A
root@vendorD:/home/admin# sfputil show error-status -hw
Port         Error Status
-----------  --------------
Ethernet0    Unplugged
Ethernet4    Unplugged
Ethernet8    Unplugged
Ethernet12   Unplugged
Ethernet16   Unplugged
Ethernet20   Unplugged
Ethernet24   Unplugged
Ethernet28   Unplugged
Ethernet32   OK
Ethernet36   OK
Ethernet40   Unplugged
Ethernet44   Unplugged
Ethernet48   Unplugged
Ethernet52   Unplugged
Ethernet56   Unplugged
Ethernet60   Unplugged
Ethernet64   Unplugged
Ethernet68   Unplugged
Ethernet72   Unplugged
Ethernet76   Unplugged
Ethernet80   Unplugged
Ethernet84   Unplugged
Ethernet88   Unplugged
Ethernet92   Unplugged
Ethernet96   OK
Ethernet104  Unplugged
Ethernet112  OK
Ethernet120  Unplugged
Ethernet128  Unplugged
Ethernet136  Unplugged
Ethernet144  Unplugged
Ethernet152  Unplugged
Ethernet160  Unplugged
Ethernet164  Unplugged
Ethernet168  Unplugged
Ethernet172  Unplugged
Ethernet176  Unplugged
Ethernet180  Unplugged
Ethernet184  Unplugged
Ethernet188  Unplugged
Ethernet192  OK
Ethernet196  OK
Ethernet200  Unplugged
Ethernet204  Unplugged
Ethernet208  OK
Ethernet212  OK
Ethernet216  Unplugged
Ethernet220  Unplugged
Ethernet224  OK
Ethernet228  OK
Ethernet232  OK
Ethernet236  OK
Ethernet240  OK
Ethernet244  OK
Ethernet248  Unplugged
Ethernet252  Unplugged
root@vendorD:/home/admin# sfputil show error-status -hw -p Ethernet0
Port       Error Status
---------  --------------
Ethernet0  Unplugged
root@vendorD:/home/admin# sfputil show error-status -hw -p Ethernet252
Port         Error Status
-----------  --------------
Ethernet252  Unplugged
root@vendorD:/home/admin# 

5. vendorE
Automated run
Passed

Manual run
root@vendorE:/home/admin# show int status
til show error-status -hw -p Ethernet0
     Interface            Lanes    Speed    MTU    FEC    Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  -------  --------------  ------  -------  ---------------  ----------
     Ethernet0      65,66,67,68     100G   9100     rs     etp1          routed    down     down  QSFP28 or later         off
     Ethernet4      69,70,71,72     100G   9100     rs     etp2           trunk      up       up  QSFP28 or later         off
     Ethernet8      73,74,75,76     100G   9100     rs     etp3           trunk      up       up  QSFP28 or later         off
    Ethernet12      77,78,79,80     100G   9100     rs     etp4           trunk      up       up  QSFP28 or later         off
    Ethernet16      33,34,35,36     100G   9100     rs     etp5           trunk      up       up  QSFP28 or later         off
    Ethernet20      37,38,39,40     100G   9100     rs     etp6           trunk      up       up  QSFP28 or later         off
    Ethernet24      41,42,43,44     100G   9100     rs     etp7           trunk      up       up  QSFP28 or later         off
    Ethernet28      45,46,47,48     100G   9100     rs     etp8           trunk      up       up  QSFP28 or later         off
    Ethernet32      49,50,51,52     100G   9100     rs     etp9           trunk      up       up  QSFP28 or later         off
    Ethernet36      53,54,55,56     100G   9100     rs    etp10           trunk      up       up  QSFP28 or later         off
    Ethernet40      57,58,59,60     100G   9100     rs    etp11           trunk      up       up  QSFP28 or later         off
    Ethernet44      61,62,63,64     100G   9100     rs    etp12           trunk      up       up  QSFP28 or later         off
    Ethernet48      81,82,83,84     100G   9100     rs    etp13           trunk      up       up  QSFP28 or later         off
    Ethernet52      85,86,87,88     100G   9100     rs    etp14           trunk      up       up  QSFP28 or later         off
    Ethernet56      89,90,91,92     100G   9100     rs    etp15           trunk      up       up  QSFP28 or later         off
    Ethernet60      93,94,95,96     100G   9100     rs    etp16           trunk      up       up  QSFP28 or later         off
    Ethernet64     97,98,99,100     100G   9100     rs    etp17           trunk      up       up  QSFP28 or later         off
    Ethernet68  101,102,103,104     100G   9100     rs    etp18           trunk      up       up  QSFP28 or later         off
    Ethernet72  105,106,107,108     100G   9100     rs    etp19           trunk      up       up  QSFP28 or later         off
    Ethernet76  109,110,111,112     100G   9100     rs    etp20           trunk      up       up  QSFP28 or later         off
    Ethernet80          1,2,3,4     100G   9100     rs    etp21           trunk      up       up  QSFP28 or later         off
    Ethernet84          5,6,7,8     100G   9100     rs    etp22           trunk      up       up  QSFP28 or later         off
    Ethernet88       9,10,11,12     100G   9100     rs    etp23           trunk      up       up  QSFP28 or later         off
    Ethernet92      13,14,15,16     100G   9100     rs    etp24           trunk      up       up  QSFP28 or later         off
    Ethernet96      17,18,19,20     100G   9100     rs    etp25           trunk      up       up  QSFP28 or later         off
   Ethernet100      21,22,23,24     100G   9100     rs    etp26          routed    down     down  QSFP28 or later         off
   Ethernet104      25,26,27,28     100G   9100     rs    etp27          routed    down     down  QSFP28 or later         off
   Ethernet108      29,30,31,32     100G   9100     rs    etp28          routed    down     down  QSFP28 or later         off
   Ethernet112  113,114,115,116     100G   9100     rs    etp29  PortChannel101      up       up  QSFP28 or later         off
   Ethernet116  117,118,119,120     100G   9100     rs    etp30  PortChannel102      up       up  QSFP28 or later         off
   Ethernet120  121,122,123,124     100G   9100     rs    etp31  PortChannel103      up       up  QSFP28 or later         off
   Ethernet124  125,126,127,128     100G   9100     rs    etp32  PortChannel104      up       up  QSFP28 or later         off
PortChannel101              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel102              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel103              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
PortChannel104              N/A     100G   9100    N/A      N/A          routed      up       up              N/A         N/A
root@vendorE:/home/admin# sfputil show error-status -hw
Port         Error Status
-----------  --------------
Ethernet0    OK
Ethernet4    OK
Ethernet8    OK
Ethernet12   OK
Ethernet16   OK
Ethernet20   OK
Ethernet24   OK
Ethernet28   OK
Ethernet32   OK
Ethernet36   OK
Ethernet40   OK
Ethernet44   OK
Ethernet48   OK
Ethernet52   OK
Ethernet56   OK
Ethernet60   OK
Ethernet64   OK
Ethernet68   OK
Ethernet72   OK
Ethernet76   OK
Ethernet80   OK
Ethernet84   OK
Ethernet88   OK
Ethernet92   OK
Ethernet96   OK
Ethernet100  OK
Ethernet104  OK
Ethernet108  OK
Ethernet112  OK
Ethernet116  OK
Ethernet120  OK
Ethernet124  OK
root@vendorE:/home/admin# sfputil show error-status -hw -p Ethernet0
Port       Error Status
---------  --------------
Ethernet0  OK
root@vendorE:/home/admin# sfputil show error-status -hw -p Ethernet124
Port         Error Status
-----------  --------------
Ethernet124  OK
root@vendorE:/home/admin# 

```


