### PR TITLE
Modify click ntp add command to include minpoll & maxpoll for a ntp server configuration

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6541,7 +6541,7 @@ def add_ntp_server(ctx, ntp_ip_address):
     """ Add NTP server IP """
     if ADHOC_VALIDATION:
         if not clicommon.is_ipaddress(ntp_ip_address): 
-            ctx.fail('Invalid IP address')
+            ctx.fail('Invalid IP address really')
     db = ValidatedConfigDBConnector(ctx.obj['db'])    
     ntp_servers = db.get_table("NTP_SERVER")
     if ntp_ip_address in ntp_servers:

--- a/config/main.py
+++ b/config/main.py
@@ -6536,28 +6536,71 @@ def ntp(ctx):
 
 @ntp.command('add')
 @click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.argument('minpoll_maxpoll', metavar='[minpoll <minpoll> maxpoll <maxpoll>]', required=False, type=click.Path())
 @click.pass_context
-def add_ntp_server(ctx, ntp_ip_address):
+def add_ntp_server(ctx, ntp_ip_address, minpoll_maxpoll):
     """ Add NTP server IP """
+    DEFAULT_MINPOLL = 6
+    DEFAULT_MAXPOLL = 10
+    MIN_POLL = 3
+    MAX_POLL = 17
+
+    new_minpoll = DEFAULT_MINPOLL
+    new_maxpoll = DEFAULT_MAXPOLL
+
     if ADHOC_VALIDATION:
-        if not clicommon.is_ipaddress(ntp_ip_address): 
-            ctx.fail('Invalid IP address really')
-    db = ValidatedConfigDBConnector(ctx.obj['db'])    
-    ntp_servers = db.get_table("NTP_SERVER")
-    if ntp_ip_address in ntp_servers:
-        click.echo("NTP server {} is already configured".format(ntp_ip_address))
-        return
-    else:
-        try:
-            db.set_entry('NTP_SERVER', ntp_ip_address, {'NULL': 'NULL'})
-        except ValueError as e:
-            ctx.fail("Invalid ConfigDB. Error: {}".format(e)) 
-        click.echo("NTP server {} added to configuration".format(ntp_ip_address))
-        try:
-            click.echo("Restarting ntp-config service...")
-            clicommon.run_command(['systemctl', 'restart', 'ntp-config'], display_cmd=False)
-        except SystemExit as e:
-            ctx.fail("Restart service ntp-config failed with error {}".format(e))
+        if not clicommon.is_ipaddress(ntp_ip_address):
+            ctx.fail('Invalid IP address')
+
+        if len(minpoll_maxpoll) != 0 and len(minpoll_maxpoll) != 4:
+            ctx.fail('Invalid input for minpoll and maxpoll')
+
+        if len(minpoll_maxpoll) != 0:
+            new_minpoll = int(minpoll_maxpoll[1])
+           new_maxpoll = int(minpoll_maxpoll[3])
+
+        if new_minpoll not in range(MIN_POLL, MAX_POLL + 1) or new_maxpoll not in range(MIN_POLL, MAX_POLL + 1):
+            ctx.fail('minpoll and maxpoll must be in the range 3-17')
+
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    ntp_server_entry = db.get_entry('NTP_SERVER', ntp_ip_address)
+
+    # init the curr_minpoll & curr_maxpoll with default values
+    curr_minpoll = DEFAULT_MINPOLL
+    curr_maxpoll = DEFAULT_MAXPOLL
+
+    if ntp_server_entry:
+        if ntp_server_entry.get('minpoll'):
+            curr_minpoll = int(ntp_server_entry.get('minpoll'))
+        if ntp_server_entry and ntp_server_entry.get('maxpoll'):
+            curr_maxpoll = int(ntp_server_entry.get('maxpoll'))
+
+        if (curr_minpoll == minpoll) and (curr_maxpoll == maxpoll):
+            click.echo("NTP server {} is already configured".format(ntp_ip_address))
+            return
+   # if create or update
+    if new_minpoll >= new_maxpoll:
+        ctx.fail("Invalid minpoll:{} and maxpoll:{}".format(curr_minpoll, curr_maxpoll))
+
+    serverInfo = {
+        "minpoll": new_minpoll,
+        "maxpoll": new_maxpoll
+    }
+    try:
+        if ntp_server_entry:
+            db.mod_entry('NTP_SERVER', ntp_ip_address, serverInfo)
+        else:
+            db.set_entry('NTP_SERVER', ntp_ip_address, serverInfo)
+
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+    click.echo("NTP server {} minpoll {} maxpoll {} added to configuration".format(ntp_ip_address, new_minpoll, new_maxpoll))
+    try:
+        click.echo("Restarting ntp-config service...")
+        clicommon.run_command(['systemctl', 'restart', 'ntp-config'], display_cmd=False)
+   except SystemExit as e:
+        ctx.fail("Restart service ntp-config failed with error {}".format(e))
+
 
 @ntp.command('del')
 @click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -7458,18 +7458,23 @@ This sub-section of commands is used to add or remove the configured NTP servers
 **config ntp add**
 
 This command is used to add a NTP server IP address to the NTP server list.  Note that more that one NTP server IP address can be added in the device.
-
+User may optionally configure minpoll and maxpoll for each NTP server. Minpoll and maxpoll is in the range from 3-17. When not configured, minpoll has default value "6" and maxpoll has default value "10"
 - Usage:
   ```
-  config ntp add <ip_address>
+  config ntp add <ip_address> [minpoll] [maxpoll]
   ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config ntp add 9.9.9.9
-  NTP server 9.9.9.9 added to configuration
+  NTP server 9.9.9.9 {'minpoll': 6, 'maxpoll': 10} added to configuration
   Restarting ntp-config service...
   ```
+
+  ```
+  admin@sonic:~# config ntp add 8.8.8.8 12 16
+  NTP server 8.8.8.8 {'minpoll': 12, 'maxpoll': 16} added to configuration
+  Restarting ntp-config service...
 
 **config ntp delete**
 
@@ -9600,11 +9605,10 @@ This command displays the running configuration of the ntp module.
 
 - Example:
   ```
-  admin@sonic:~$ show runningconfiguration ntp
   NTP Servers
-  -------------
-  1.1.1.1
-  2.2.2.2
+  -----------------------------
+  8.8.8.8 minpoll 12 maxpoll 16
+  9.9.9.9 minpoll 6 maxpoll 10
   ```
 
 **show runningconfiguration syslog**

--- a/show/main.py
+++ b/show/main.py
@@ -1511,8 +1511,13 @@ def ntp(verbose):
         data = ntp_file.readlines()
     for line in data:
         if line.startswith("server "):
-            ntp_server = line.split(" ")[1]
-            ntp_servers.append(ntp_server)
+            info = line.split(" ")
+            click.echo("ntp server: {} minpoll {} maxpoll {}".format(info[1], info[4], info[6]))
+            #ntp_server = line.split(" ")[1]
+            ntp_server = info[1]
+            minpoll = info[4]
+            maxpoll = info[6]
+            ntp_servers.append(ntp_server + " minpoll " + minpoll + " maxpoll " + maxpoll)
     ntp_dict['NTP Servers'] = ntp_servers
     print(tabulate(ntp_dict, headers=list(ntp_dict.keys()), tablefmt="simple", stralign='left', missingval=""))
 


### PR DESCRIPTION
#### What I did
Modify click ntp add command to include minpoll & maxpoll for NTP server configuration.

#### How I did it
In configi/main.py ntp add command, add the optional "minpoll <minpoll> maxpoll <maxpoll>" arguments. When not provided, the default values for minpoll(6) and maxpoll(10) will be used.
In show/main.py "show runningconfig ntp" output, add the "minpoll" and "maxpoll" info.

#### How to verify it
Issue "config ntp add" command with and without the optional minpoll&maxpoll arguments.
Issue "show runningconfig ntp" command.

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/usr/local/lib/python3.9/dist-packages/show# config ntp add 10.10.10.10
NTP server 10.10.10.10 added to configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/show#
root@sonic:/usr/local/lib/python3.9/dist-packages/show#
root@sonic:/usr/local/lib/python3.9/dist-packages/show# show runningconfiguration ntp
NTP Servers
-------------
10.10.10.10

```

#### New command output (if the output of a command-line utility has changed)
- configure ntp server without optional minpoll/maxpoll params
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 10.10.10.10
NTP server 10.10.10.10 minpoll 6 maxpoll 10 added to configuration
Restarting ntp-config service...

root@sonic:/usr/local/lib/python3.9/dist-packages/show# show runningconfiguration ntp
NTP Servers
--------------------------------
10.10.10.10 minpoll 6 maxpoll 10

```
- configure ntp server with minpoll and maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 11.11.11.11 minpoll 4 maxpoll 5
NTP server 11.11.11.11 minpoll 4 maxpoll 5 added to configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
--------------------------------
10.10.10.10 minpoll 6 maxpoll 10
11.11.11.11 minpoll 4 maxpoll 5
```

-modify ntp server with valid minpoll and maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 11.11.11.11 minpoll 10 maxpoll 12
NTP server 11.11.11.11 minpoll 10 maxpoll 12 added to configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
---------------------------------
10.10.10.10 minpoll 6 maxpoll 10
11.11.11.11 minpoll 10 maxpoll 12
```

- add ntp server with invalid minpoll / maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 2 maxpoll 12
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: minpoll and maxpoll must be in the range 3-17
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 3 maxpoll 18
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: minpoll and maxpoll must be in the range 3-17
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 6 maxpoll 6
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid minpoll:6 and maxpoll:10
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 6
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid input for minpoll and maxpoll
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 maxpoll 14
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid input for minpoll and maxpoll
root@sonic:/usr/local/lib/python3.9/dist-packages/config#

root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 maxpoll 5 minpoll 23
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid parameters
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minmin 12 max 15
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid parameters
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
```

- configure ntp server with same ip, minpoll&maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 10.10.10.10 minpoll 6 maxpoll 10
NTP server 10.10.10.10 is already configured
```

- delete ntp servers
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
---------------------------------
10.10.10.10 minpoll 6 maxpoll 10
11.11.11.11 minpoll 10 maxpoll 12
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp del 10.10.10.10
NTP server 10.10.10.10 removed from configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp del 11.11.11.11
NTP server 11.11.11.11 removed from configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
-------------
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
```



