### PR TITLE
[sonic-package-manager] Increate timeout for sonic-package-manager migrate

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -660,6 +660,10 @@ class PackageManager:
                                  skip_host_plugins=skip_host_plugins)
 
     @under_lock
+    def get_docker_client(self, dockerd_sock:str):
+        return docker.DockerClient(base_url=f'unix://{dockerd_sock}', timeout=120)
+
+    @under_lock
     def migrate_packages(self,
                          old_package_database: PackageDatabase,
                          dockerd_sock: Optional[str] = None):
@@ -701,7 +705,8 @@ class PackageManager:
                 # dockerd_sock is defined, so use docked_sock to connect to
                 # dockerd and fetch package image from it.
                 log.info(f'installing {name} from old docker library')
-                docker_api = DockerApi(docker.DockerClient(base_url=f'unix://{dockerd_sock}', timeout=120))
+                docker_client = self.get_docker_client(dockerd_sock)
+                docker_api = DockerApi(docker_client)
 
                 image = docker_api.get_image(old_package_entry.image_id)
 

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -701,7 +701,7 @@ class PackageManager:
                 # dockerd_sock is defined, so use docked_sock to connect to
                 # dockerd and fetch package image from it.
                 log.info(f'installing {name} from old docker library')
-                docker_api = DockerApi(docker.DockerClient(base_url=f'unix://{dockerd_sock}'))
+                docker_api = DockerApi(docker.DockerClient(base_url=f'unix://{dockerd_sock}', timeout=120))
 
                 image = docker_api.get_image(old_package_entry.image_id)
 

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -356,3 +356,31 @@ def test_manager_migration(package_manager, fake_db_for_migration):
         call('test-package-6=2.0.0')],
         any_order=True
     )
+
+
+def mock_get_docker_client(dockerd_sock):
+    class DockerClient:
+        def __init__(self, dockerd_sock):
+            class Image:
+                def __init__(self, image_id):
+                    self.image_id = image_id
+                
+                def save(self, named):
+                    return ["named: {}".format(named).encode()]
+
+            image = Image("dummy_id")
+            self.images = {
+                "Azure/docker-test-3:1.6.0": image,
+                "Azure/docker-test-6:2.0.0": image
+            }
+            self.dockerd_sock = dockerd_sock
+
+    return DockerClient(dockerd_sock)
+
+
+def test_manager_migration_dockerd(package_manager, fake_db_for_migration, mock_docker_api):
+    package_manager.install = Mock()
+    package_manager.get_docker_client = Mock(side_effect=mock_get_docker_client)
+    package_manager.migrate_packages(fake_db_for_migration, '/var/run/docker.sock')
+    package_manager.get_docker_client.assert_has_calls([
+        call('/var/run/docker.sock')], any_order=True)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When we migrate package via sonic-package-manager in some low-performance device, getting docker image from old image via docker socket may timeout by default timeout setting (60s) [client.py](https://github.com/docker/docker-py/blob/main/docker/api/client.py#L106). This PR is to increase timeout to 120s.

#### How I did it
Increase docker client timeout from 60s to 120s.

#### How to verify it
1. ut passed.
2. Build image with INCLUDE_MACSEC, and install it, macsec image was not include. And the build image with this PR, install it. Migrate package successfully.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

