### PR TITLE
add click cmd for minpoll/maxpoll configuration on a ntp server

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -7411,19 +7411,25 @@ This sub-section of commands is used to add or remove the configured NTP servers
 **config ntp add**
 
 This command is used to add a NTP server IP address to the NTP server list.  Note that more that one NTP server IP address can be added in the device.
-
+User may optionally configure minpoll and maxpoll for each NTP server. Minpoll and maxpoll is in the range from 3-17. When not configured, minpoll has default value "6" and maxpoll has default value "10"
 - Usage:
   ```
-  config ntp add <ip_address>
+  config ntp add <ip_address> [minpoll] [maxpoll]
   ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config ntp add 9.9.9.9
-  NTP server 9.9.9.9 added to configuration
+  NTP server 9.9.9.9 {'minpoll': 6, 'maxpoll': 10} added to configuration
   Restarting ntp-config service...
   ```
 
+  ```
+  admin@sonic:~# config ntp add 8.8.8.8 12 16
+  NTP server 8.8.8.8 {'minpoll': 12, 'maxpoll': 16} added to configuration
+  Restarting ntp-config service...
+  ```
+    
 **config ntp delete**
 
 This command is used to delete a configured NTP server IP address.
@@ -9553,11 +9559,10 @@ This command displays the running configuration of the ntp module.
 
 - Example:
   ```
-  admin@sonic:~$ show runningconfiguration ntp
   NTP Servers
-  -------------
-  1.1.1.1
-  2.2.2.2
+  -----------------------------
+  8.8.8.8 minpoll 12 maxpoll 16
+  9.9.9.9 minpoll 6 maxpoll 10
   ```
 
 **show runningconfiguration syslog**

--- a/show/main.py
+++ b/show/main.py
@@ -1511,8 +1511,13 @@ def ntp(verbose):
         data = ntp_file.readlines()
     for line in data:
         if line.startswith("server "):
-            ntp_server = line.split(" ")[1]
-            ntp_servers.append(ntp_server)
+            info = line.split(" ")
+            click.echo("ntp server: {} minpoll {} maxpoll {}".format(info[1], info[4], info[6]))
+            #ntp_server = line.split(" ")[1]
+            ntp_server = info[1]
+            minpoll = info[4]
+            maxpoll = info[6]
+            ntp_servers.append(ntp_server + " minpoll " + minpoll + " maxpoll " + maxpoll)
     ntp_dict['NTP Servers'] = ntp_servers
     print(tabulate(ntp_dict, headers=list(ntp_dict.keys()), tablefmt="simple", stralign='left', missingval=""))
 


### PR DESCRIPTION
#### What I did
Modify click ntp add command to include minpoll & maxpoll for NTP server configuration.

#### How I did it
In configi/main.py ntp add command, add the optional "minpoll <minpoll> maxpoll <maxpoll>" arguments. When not provided, the default values for minpoll(6) and maxpoll(10) will be used.
In show/main.py "show runningconfig ntp" output, add the "minpoll" and "maxpoll" info.

#### How to verify it
Issue "config ntp add" command with and without the optional minpoll&maxpoll arguments.
Issue "show runningconfig ntp" command.

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/usr/local/lib/python3.9/dist-packages/show# config ntp add 10.10.10.10
NTP server 10.10.10.10 added to configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/show#
root@sonic:/usr/local/lib/python3.9/dist-packages/show#
root@sonic:/usr/local/lib/python3.9/dist-packages/show# show runningconfiguration ntp
NTP Servers
-------------
10.10.10.10

```

#### New command output (if the output of a command-line utility has changed)
- configure ntp server without optional minpoll/maxpoll params
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 10.10.10.10
NTP server 10.10.10.10 minpoll 6 maxpoll 10 added to configuration
Restarting ntp-config service...

root@sonic:/usr/local/lib/python3.9/dist-packages/show# show runningconfiguration ntp
NTP Servers
--------------------------------
10.10.10.10 minpoll 6 maxpoll 10

```
- configure ntp server with minpoll and maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 11.11.11.11 minpoll 4 maxpoll 5
NTP server 11.11.11.11 minpoll 4 maxpoll 5 added to configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
--------------------------------
10.10.10.10 minpoll 6 maxpoll 10
11.11.11.11 minpoll 4 maxpoll 5
```

-modify ntp server with valid minpoll and maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 11.11.11.11 minpoll 10 maxpoll 12
NTP server 11.11.11.11 minpoll 10 maxpoll 12 added to configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
---------------------------------
10.10.10.10 minpoll 6 maxpoll 10
11.11.11.11 minpoll 10 maxpoll 12
```

- add ntp server with invalid minpoll / maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 2 maxpoll 12
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: minpoll and maxpoll must be in the range 3-17
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 3 maxpoll 18
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: minpoll and maxpoll must be in the range 3-17
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 6 maxpoll 6
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid minpoll:6 and maxpoll:10
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minpoll 6
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid input for minpoll and maxpoll
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 maxpoll 14
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid input for minpoll and maxpoll
root@sonic:/usr/local/lib/python3.9/dist-packages/config#

root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 maxpoll 5 minpoll 23
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid parameters
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 12.12.12.12 minmin 12 max 15
Usage: config ntp add [OPTIONS] <ntp_ip_address> [minpoll <minpoll> maxpoll
                      <maxpoll>]
Try "config ntp add -h" for help.

Error: Invalid parameters
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
```

- configure ntp server with same ip, minpoll&maxpoll
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp add 10.10.10.10 minpoll 6 maxpoll 10
NTP server 10.10.10.10 is already configured
```

- delete ntp servers
```
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
---------------------------------
10.10.10.10 minpoll 6 maxpoll 10
11.11.11.11 minpoll 10 maxpoll 12
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp del 10.10.10.10
NTP server 10.10.10.10 removed from configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# config ntp del 11.11.11.11
NTP server 11.11.11.11 removed from configuration
Restarting ntp-config service...
root@sonic:/usr/local/lib/python3.9/dist-packages/config# show runningconfiguration ntp
NTP Servers
-------------
root@sonic:/usr/local/lib/python3.9/dist-packages/config#
```