### PR TITLE
[vlan][dhcp_relay] Fix error while delete vlan

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -30,7 +30,8 @@ def set_dhcp_relay_table(table, config_db, vlan_name, value):
 
 
 def is_dhcp_relay_running():
-    out, _ = clicommon.run_command("systemctl show dhcp_relay.service --property ActiveState --value", return_cmd=True)
+    out, _ = clicommon.run_command(["systemctl", "show", "dhcp_relay.service", "--property", "ActiveState", "--value"],
+                                   return_cmd=True)
     return out.strip() == "active"
 
 def is_dhcpv6_relay_config_exist(db, vlan_name):

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -2723,5 +2723,10 @@
         "alias": "Fabric2",
         "isolateStatus": "False",
         "lanes": "2"
+    },
+    "DHCP_RELAY|Vlan1000": {
+        "dhcpv6_servers": [
+            "fc02:2000::1"
+        ]
     }
 }

--- a/utilities_common/dhcp_relay_util.py
+++ b/utilities_common/dhcp_relay_util.py
@@ -7,9 +7,9 @@ def restart_dhcp_relay_service():
     Restart dhcp_relay service
     """
     click.echo("Restarting DHCP relay service...")
-    clicommon.run_command("systemctl stop dhcp_relay", display_cmd=False)
-    clicommon.run_command("systemctl reset-failed dhcp_relay", display_cmd=False)
-    clicommon.run_command("systemctl start dhcp_relay", display_cmd=False)
+    clicommon.run_command(["systemctl", "stop", "dhcp_relay"], display_cmd=False)
+    clicommon.run_command(["systemctl", "reset-failed", "dhcp_relay"], display_cmd=False)
+    clicommon.run_command(["systemctl", "start", "dhcp_relay"], display_cmd=False)
 
 
 def handle_restart_dhcp_relay_service():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
**MSFT work item: 25218077**

#### Why I did
Use static str to run_command would encounter error because change in this PR: https://github.com/sonic-net/sonic-utilities/pull/2718.

#### How I did it
Change command from static str to list.

#### How to verify it
1. UT passed
2. Build whl and install in testbed.
3. Init vlan config:
```
admin@hostname:~$ show vlan bri
+-----------+-----------------+------------+----------------+-------------+
|   VLAN ID | IP Address      | Ports      | Port Tagging   | Proxy ARP   |
+===========+=================+============+================+=============+
|      1000 | 192.168.0.1/24  | Ethernet0  | untagged       | disabled    |
|           | fc02:1000::1/64 | Ethernet1  | untagged       |             |
|           |                 | Ethernet2  | untagged       |             |
|           |                 | Ethernet3  | untagged       |             |
|           |                 | Ethernet4  | untagged       |             |
|           |                 | Ethernet5  | untagged       |             |
|           |                 | Ethernet6  | untagged       |             |
|           |                 | Ethernet7  | untagged       |             |
|           |                 | Ethernet8  | untagged       |             |
|           |                 | Ethernet9  | untagged       |             |
|           |                 | Ethernet10 | untagged       |             |
|           |                 | Ethernet11 | untagged       |             |
|           |                 | Ethernet12 | untagged       |             |
|           |                 | Ethernet13 | untagged       |             |
|           |                 | Ethernet14 | untagged       |             |
|           |                 | Ethernet15 | untagged       |             |
|           |                 | Ethernet16 | untagged       |             |
|           |                 | Ethernet17 | untagged       |             |
|           |                 | Ethernet18 | untagged       |             |
|           |                 | Ethernet19 | untagged       |             |
|           |                 | Ethernet20 | untagged       |             |
|           |                 | Ethernet21 | untagged       |             |
|           |                 | Ethernet22 | untagged       |             |
|           |                 | Ethernet23 | untagged       |             |
|           |                 | Ethernet24 | untagged       |             |
|           |                 | Ethernet25 | untagged       |             |
|           |                 | Ethernet26 | untagged       |             |
|           |                 | Ethernet27 | untagged       |             |
|           |                 | Ethernet28 | untagged       |             |
|           |                 | Ethernet29 | untagged       |             |
|           |                 | Ethernet30 | untagged       |             |
|           |                 | Ethernet31 | untagged       |             |
|           |                 | Ethernet32 | untagged       |             |
|           |                 | Ethernet33 | untagged       |             |
|           |                 | Ethernet34 | untagged       |             |
|           |                 | Ethernet35 | untagged       |             |
|           |                 | Ethernet36 | untagged       |             |
|           |                 | Ethernet37 | untagged       |             |
|           |                 | Ethernet38 | untagged       |             |
|           |                 | Ethernet39 | untagged       |             |
|           |                 | Ethernet40 | untagged       |             |
|           |                 | Ethernet41 | untagged       |             |
|           |                 | Ethernet42 | untagged       |             |
|           |                 | Ethernet43 | untagged       |             |
|           |                 | Ethernet44 | untagged       |             |
|           |                 | Ethernet45 | untagged       |             |
+-----------+-----------------+------------+----------------+-------------+
```
4. Remove all members and interface ips of Vlan1000
5. del Vlan1000 and error no happen and dhcp_relay container restarted as expected.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

