### PR TITLE
Enable Local auth only till system is ready

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -5,6 +5,9 @@ PLATFORM_UPDATE_REBOOT_CAUSE="platform_update_reboot_cause"
 REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 PLATFORM_REBOOT_PRE_CHECK="platform_reboot_pre_check"
 REBOOT_TIME=$(date)
+PAM_AUTH_CONF="/etc/pam.d/common-auth-sonic"
+PAM_AUTH_CONF_TEMPLATE="/usr/share/sonic/templates/common-auth-sonic.j2"
+TMP_AUTH_JSON="/tmp/auth.json"
 
 # Reboot immediately if we run the kdump capture kernel
 VMCORE_FILE=/proc/vmcore
@@ -96,6 +99,13 @@ function stop_services_asan()
 {
     debug "Stopping swss for ASAN"
     systemctl stop swss
+}
+
+function restore_local_auth()
+{
+    echo '{"auth":{"login":"local"}}' > ${TMP_AUTH_JSON}
+    j2 -f json ${PAM_AUTH_CONF_TEMPLATE} ${TMP_AUTH_JSON} > ${PAM_AUTH_CONF}
+    rm -rf ${TMP_AUTH_JSON}
 }
 
 function clear_warm_boot()
@@ -212,6 +222,9 @@ stop_sonic_services
 if [[ x"$ASAN" == x"yes" ]]; then
     stop_services_asan
 fi
+
+# Restore local authentication to enable login before system gets ready in the upcoming bootup
+restore_local_auth
 
 clear_warm_boot
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Restore AAA authentication during reboot so that subsequence boot up will not allow system access to  unsaved radius/tacacs config users till system gets ready
#### How I did it
Modified the common-auth-sonic fiile to have only local authentication during reboot
#### How to verify it
1) Configure valid RADIUS server
2) Configure AAA authentication login to radius alone
3) Reboot the system without saving the configuration
4) After reboot, (before system gets ready) observe that console only allows local user alone.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

