### PR TITLE
Remove syslog service validator in GCU

### DIFF
--- a/generic_config_updater/gcu_services_validator.conf.json
+++ b/generic_config_updater/gcu_services_validator.conf.json
@@ -31,9 +31,6 @@
         "PORT": {
             "services_to_validate": [ "port_service" ]
         },
-        "SYSLOG_SERVER":{
-            "services_to_validate": [ "rsyslog" ]
-        },
         "DHCP_RELAY": {
             "services_to_validate": [ "dhcp-relay" ]
         },
@@ -59,9 +56,6 @@
         },
         "port_service": {
             "validate_commands": [ ]
-        },
-        "rsyslog": {
-            "validate_commands": [ "generic_config_updater.services_validator.rsyslog_validator" ]
         },
         "dhcp-relay": {
             "validate_commands": [ "generic_config_updater.services_validator.dhcp_validator" ]

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -48,14 +48,6 @@ def _service_restart(svc_name):
     return rc == 0
 
 
-def rsyslog_validator(old_config, upd_config, keys):
-    rc = os.system("/usr/bin/rsyslog-config.sh")
-    if rc != 0:
-        return _service_restart("rsyslog")
-    else:
-        return True
-
-
 def dhcp_validator(old_config, upd_config, keys):
     return _service_restart("dhcp_relay")
 

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -6,7 +6,7 @@ import unittest
 from collections import defaultdict
 from unittest.mock import patch
 
-from generic_config_updater.services_validator import vlan_validator, rsyslog_validator, caclmgrd_validator, vlanintf_validator
+from generic_config_updater.services_validator import vlan_validator, caclmgrd_validator, vlanintf_validator
 import generic_config_updater.gu_common
 
 
@@ -142,16 +142,6 @@ test_caclrule = [
         },
     ]
 
-test_rsyslog_fail = [
-        # Fail the calls, to get the entire fail path calls invoked
-        #
-        { "cmd": "/usr/bin/rsyslog-config.sh", "rc": 1 },        # config update; fails
-        { "cmd": "systemctl restart rsyslog", "rc": 1 },         # rsyslog restart; fails
-        { "cmd": "systemctl reset-failed rsyslog", "rc": 1 },    # reset; failure here just logs
-        { "cmd": "systemctl restart rsyslog", "rc": 1 },         # restart again; fails
-        { "cmd": "systemctl restart rsyslog", "rc": 1 },         # restart again; fails
-    ]
-
 test_vlanintf_data = [
         { "old": {}, "upd": {}, "cmd": "" },
         {
@@ -211,12 +201,6 @@ class TestServiceValidator(unittest.TestCase):
 
         # Test failure case
         #
-        os_system_calls = test_rsyslog_fail
-        os_system_call_index = 0
-
-        rc = rsyslog_validator("", "", "")
-        assert not rc, "rsyslog_validator expected to fail"
-
         os_system_calls = []
         os_system_call_index = 0
         for entry in test_vlanintf_data:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove rsyslog related service validator in GCU because it has been supported in latest image
#### How I did it
Remove related code
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

