### PR TITLE
Fix for GCU function modification for HEAD PR

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -108,8 +108,8 @@ class ConfigReplacer:
         self.logger.log_notice("Getting current config db.")
         old_config = self.config_wrapper.get_config_db_as_json()
 
-        old_config = switchport_mode_remove(old_config)
-        target_config = switchport_mode_remove(target_config)
+        old_config = self.switchport_mode_remove(old_config)
+        target_config = self.switchport_mode_remove(target_config)
         
         self.logger.log_notice("Generating patch between target config and current config db.")
         patch = self.patch_wrapper.generate_patch(old_config, target_config)
@@ -125,6 +125,7 @@ class ConfigReplacer:
 
         self.logger.log_notice("Config replacement completed.")
 
+    @staticmethod
     def switchport_mode_remove(config):
         if 'PORT' in config:
             for port, port_data in config['PORT'].items():

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -131,6 +131,7 @@ class ConfigReplacer:
             for port, port_data in config['PORT'].items():
                 if 'mode' in port_data:
                     del config['PORT'][port]['mode']
+        return config
 
 class FileSystemConfigRollbacker:
     def __init__(self,

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -108,6 +108,7 @@ class ConfigReplacer:
         self.logger.log_notice("Getting current config db.")
         old_config = self.config_wrapper.get_config_db_as_json()
 
+        # mode from PORT table will be remove from both old_config & target_config to resolve rollback & replace issue
         old_config = self.switchport_mode_remove(old_config)
         target_config = self.switchport_mode_remove(target_config)
         
@@ -127,10 +128,17 @@ class ConfigReplacer:
 
     @staticmethod
     def switchport_mode_remove(config):
-        if 'PORT' in config:
-            for port, port_data in config['PORT'].items():
-                if 'mode' in port_data:
-                    del config['PORT'][port]['mode']
+        """ 
+        This method will check & remove mode attribute in PORT table. 
+        It is to resolve rollback check patch where it failed 
+        due to missing "mode"  in patch applier. 
+        """
+        current_mode  = 'mode'
+        exisitng_port = 'PORT'
+        if exisitng_port in config:
+            for port, port_data in config[exisitng_port].items():
+                if current_mode in port_data:
+                    del config[exisitng_port][port][current_mode]
         return config
 
 class FileSystemConfigRollbacker:

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -108,6 +108,9 @@ class ConfigReplacer:
         self.logger.log_notice("Getting current config db.")
         old_config = self.config_wrapper.get_config_db_as_json()
 
+        old_config = switchport_mode_remove(old_config)
+        target_config = switchport_mode_remove(target_config)
+        
         self.logger.log_notice("Generating patch between target config and current config db.")
         patch = self.patch_wrapper.generate_patch(old_config, target_config)
         self.logger.log_debug(f"Generated patch: {patch}.") # debug since the patch will printed again in 'patch_applier.apply'
@@ -121,6 +124,12 @@ class ConfigReplacer:
             raise GenericConfigUpdaterError(f"After replacing config, there is still some parts not updated")
 
         self.logger.log_notice("Config replacement completed.")
+
+    def switchport_mode_remove(config):
+        if 'PORT' in config:
+            for port, port_data in config['PORT'].items():
+                if 'mode' in port_data:
+                    del config['PORT'][port]['mode']
 
 class FileSystemConfigRollbacker:
     def __init__(self,


### PR DESCRIPTION
#### What I did
This PR is created to resolve submodule HEAD PR KVM t0 Elastic failure issues. KVM Elastic test cases are failing due to missing mode attribute in configuration. When a rollback checks an exisitng patch it showns error: 
 "All keys are not parsed in PORT". 
"dict_keys(['Ethernet4'])"
"exceptionList: [" 'mode' "] 

This PR Updated GCU function  so that it can be compatible with HEAD PR and passed. This proposed change is a temporary solution to pass failing testcases and it will be reverted back once in hand issue is resolved and sub-modules are added in HEAD.



#### How I did it

Modified generic_updater.py. Added a logic in def replace function such that it will not fail in rollback. In this way it will pass KVM Elastic (GCU_Dhcp_relay.py test)