### PR TITLE
[acl-loader] Identity ICMP v4/v6 based on IP_PROTOCOL for custom ACL table types

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -598,6 +598,14 @@ class AclLoader(object):
                     is_rule_v6 = True
             except Exception as e:
                 pass
+        else:
+            # get the IP version type using IP_PROTOCOL.
+            try:
+                ip_protocol = rule.ip.config.protocol
+                if ip_protocol == "IP_ICMPV6" or int(ip_protocol) == self.ip_protocol_map["IP_ICMPV6"]:
+                    is_rule_v6 = True
+            except Exception as e:
+                pass
 
         type_key = "ICMPV6_TYPE" if is_rule_v6 else "ICMP_TYPE"
         code_key = "ICMPV6_CODE" if is_rule_v6 else "ICMP_CODE"

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -235,7 +235,7 @@
 									}
 								}
 							},
-							"2": {
+							"100": {
 								"config": {
 									"sequence-id": 100
 								},
@@ -285,6 +285,27 @@
 										}
 									}
 								}
+							},
+							"2": {
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"config": {
+									"sequence-id": 2
+								},
+								"ip": {
+									"config": {
+										"protocol": "1"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "136",
+										"code": "0"
+									}
+								}
 							}
 						}
 					},
@@ -308,6 +329,27 @@
 									"config": {
 										"protocol": "0",
 										"destination-ip-address": "fc02::/64"
+									}
+								}
+							},
+							"2": {
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"config": {
+									"sequence-id": 2
+								},
+								"ip": {
+									"config": {
+										"protocol": "58"
+									}
+								},
+								"icmp": {
+									"config": {
+										"type": "136",
+										"code": "0"
 									}
 								}
 							}

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -150,7 +150,6 @@ class TestAclLoader(object):
     def test_icmpv6_translation(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
-        print(acl_loader.rules_info)
         assert acl_loader.rules_info[("DATAACL_2", "RULE_1")] == {
             "ICMPV6_TYPE": 1,
             "ICMPV6_CODE": 0,
@@ -169,6 +168,30 @@ class TestAclLoader(object):
             "IP_TYPE": "IPV6ANY",
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9900"
+        }
+
+    def test_icmp_translation_in_custom_acl_table_type(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("BMC_ACL_NORTHBOUND", "RULE_2")]
+        assert acl_loader.rules_info[("BMC_ACL_NORTHBOUND", "RULE_2")] == {
+            "ICMP_TYPE": 136,
+            "ICMP_CODE": 0,
+            "IP_PROTOCOL": 1,
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9998"
+        }
+
+    def test_icmpv6_translation_in_custom_acl_table_type(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("BMC_ACL_NORTHBOUND_V6", "RULE_2")]
+        assert acl_loader.rules_info[("BMC_ACL_NORTHBOUND_V6", "RULE_2")] == {
+            "ICMPV6_TYPE": 136,
+            "ICMPV6_CODE": 0,
+            "IP_PROTOCOL": 58,
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9998"
         }
 
     def test_ingress_default_deny_rule(self, acl_loader):
@@ -250,7 +273,7 @@ class TestAclLoader(object):
         assert not acl_loader.rules_info.get("RULE_1")
 
 
-    def test_icmp_fields_with_non_tcp_protocol(self, acl_loader):
+    def test_tcp_fields_with_non_tcp_protocol(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/tcp_bad_protocol_number.json'))
         assert not acl_loader.rules_info.get("RULE_1")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When adding ICMPv6 ACL rules in custom ACL table type, current `acl-loader` will incorrectly treat the ACL table as IPv4. I open this PR to fix this bug and let `acl-loader` identify ICMP v4 or v6 based on IP_PROTOCOL.

_Also fixed some typo in UT of acl-loader to avoid confusion._

#### How I did it

In function `convert_icmp`, add one step to identify the rule is v4 or v6 based on IP_PROTOCOL.

#### How to verify it

Verified by UT:

```
Name                                                   Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------------------------------
acl_loader/__init__.py                                     0      0      0      0   100%
acl_loader/main.py                                       691    154    320     50    74%
...
=============================================== short test summary info ================================================
FAILED tests/disk_check_test.py::TestDiskCheck::test_readonly - assert 1 == 0
FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts - AssertionError: assert ('    IFACE    STATE   ...
FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts_with_group - AssertionError: assert ('\n'\n '   ...
FAILED tests/drops_group_test.py::TestDropCounters::test_show_counts_with_type - AssertionError: assert ('    IFACE  ...
========================== 4 failed, 2722 passed, 3 skipped, 17 warnings in 666.50s (0:11:06) ==========================
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

