### PR TITLE
[202012][Techsupport] Techsupport tmpfs logging

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -981,8 +981,26 @@ save_log_files() {
     trap enable_logrotate HUP INT QUIT TERM KILL ABRT ALRM
 
     start_t=$(date +%s%3N)
+    log_dir_1="/var/log/"
+    log_dir_2="/var/log.tmpfs/"
+    file_list=""
+
+    if [ -d "$log_dir_1" ]; then
+        file_list_1=$(find_files ${log_dir_1})
+        file_list="${file_list} ${file_list_1}"
+    fi
+
+    if [ -d "$log_dir_2" ]; then
+        file_list_2=$(find_files ${log_dir_2})
+        file_list="${file_list} ${file_list_2}"
+    fi
+
     # gzip up all log files individually before placing them in the incremental tarball
-    for file in $(find_files "/var/log/"); do
+    for file in $file_list; do
+        dest_dir="log"
+        if [[ $file == *"tmpfs"* ]]; then
+            dest_dir="log.tmpfs"
+        fi
         # ignore the sparse file lastlog
         if [ "$file" = "/var/log/lastlog" ]; then
             continue
@@ -990,9 +1008,9 @@ save_log_files() {
         # don't gzip already-gzipped log files :)
         # do not append the individual files to the main tarball
         if [ -z "${file##*.gz}" ]; then
-            save_file $file log false false
+            save_file $file $dest_dir false false
         else
-            save_file $file log true false
+            save_file $file $dest_dir true false
         fi
     done
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1015,11 +1015,19 @@ save_log_files() {
     done
 
     # Append the log folder to the main tarball
-    ($TAR $V -rhf $TARFILE -C $DUMPDIR ${BASE}/log \
-        || abort "${ERROR_TAR_FAILED}" "tar append operation failed. Aborting for safety") \
-        && $RM $V -rf $TARDIR/log
+    if [ -d "$log_dir_1" ]; then
+        ($TAR $V -rhf $TARFILE -C $DUMPDIR ${BASE}/log \
+            || abort "${ERROR_TAR_FAILED}" "tar append operation failed. Aborting for safety") \
+            && $RM $V -rf $TARDIR/log
+    fi
+    if [ -d "$log_dir_2" ]; then
+        # Append the log.tmpfs folder to the main tarball
+        ($TAR $V -rhf $TARFILE -C $DUMPDIR ${BASE}/log.tmpfs \
+            || abort "${ERROR_TAR_FAILED}" "tar append operation failed. Aborting for safety") \
+            && $RM $V -rf $TARDIR/log.tmpfs
+    fi
     end_t=$(date +%s%3N)
-    echo "[ TAR /var/log Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
+    echo "[ TAR /var/log and /var/log.tmpfs Files ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
 
     enable_logrotate
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Cherry pick #2979 
ADO - 25129114

202012 specific change
- Added support to include "log.tmpfs" in the final tar file. On other branches, save_to_tar function addresses this.

#### What I did
It seems that "show techsupport" currently doesn't archive the log files under "/var/log.tmpfs" directory. Hence, this PR addresses this issue.


#### How I did it
We are now checking if "/var/log.tmpfs" directory exists and include the corresponding log files.

#### How to verify it
1. "show techsupport" on a system with logging to "/var/log/"
2. "show techsupport" on a system with logging to "/var/log.tmpfs/"

```
**************************************************************
1. "show techsupport" on a system with logging to "/var/log/"
**************************************************************
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_184002/log# path="/var/log/"
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_184002/log# df -Th
Filesystem     Type      Size  Used Avail Use% Mounted on
udev           devtmpfs  3.9G     0  3.9G   0% /dev
tmpfs          tmpfs     797M  9.0M  788M   2% /run
root-overlay   overlay   7.1G  5.9G  1.3G  83% /
/dev/mmcblk0p1 ext4      7.1G  5.9G  1.3G  83% /host
tmpfs          tmpfs     400M   12M  389M   3% /var/log
tmpfs          tmpfs     3.9G     0  3.9G   0% /dev/shm
tmpfs          tmpfs     5.0M     0  5.0M   0% /run/lock
tmpfs          tmpfs     4.0M     0  4.0M   0% /sys/fs/cgroup
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/d7760142c9cc902813809a89d3acad242d6021f4b1cbc209b0b3a5e00ebd4e6b/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/c3cbe013940e342b645c166a8cf010634d450f23686622740fd6d0715d4e6345/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/d9462c01ae0b84d945cd7722a3c8c3d95bf3ee3eaa6783d42aa3bcc31ca07143/merged
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/68140c8d1383fa5724b021c2525c167677a726d702b38878de8dda7f13b38313/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/8bcf08339e2cf7055d2acdeb4a8fca6dcc9572062efcf709a590163a98c744b5/mounts/shm
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/6a9d18ef87b65399fd5aa40e82e03676dacbaaa8599a73551fb33b482e196c92/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/30eed42ce617fce8f785141c7bf860b34b25dd7475ac38ba6c8459d1e8152485/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/6ff786747f80697427b6893e4ead5eb3605ae92886e6c404318929f96ad2d79c/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/a9125dc25b0521d495b36b693cc75e1389ed7bd6a9e7622b39f013c3b193c93a/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/8eb9e716b82951593c31f0649686c152415e164f3944e8b8f0ecbfcf2e117dc2/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/017d2caa80d15ed5c86a692dc871dbc8152c962ab58d429981a09efac0de871e/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/7fe46d2e2c3c441da19e3f0d22f23421c144f91a0be5cb7067b4d490f992e1f2/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/2e795d776ca00f03fea4345158aa12e92672c1936ddf78b594672b73fadfd5ae/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/9da07cac33edf9617bf9ad7e739478fddc99dbe56206b75aeb1cdb72a95f1d08/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/f38b24f0af7a59400b66731a4f01d513d4242c5dc1527e5b7ac578a4f758035d/merged
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/8fd8f52c9ba6d2a79340db023d9d11a058de886497944327158da30351d52a69/merged
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/961ab45478a14cee429109f6c7f81767b2b95a0b1524f7260a75b71ef80c5087/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/2df11b27e46cc2148dc289fba35c7a169440f108decc5a75843d6be605f96a86/mounts/shm
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/b2eb517afd1eeaa164a5659c9ce9d882c77f9a28e5bab0ebf901a0d084517b94/mounts/shm
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/62f431fe0f819edac4cafa672b8a90d716000362c2b68cee17d98478678c7fa7/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/0cf822aa4087ad41df45e67463e489762563954940a4e9bd0f510c657312cf97/merged
shm            tmpfs      64M   60K   64M   1% /var/lib/docker/containers/a18a9553813c8ec6ced766be1c06c4f3b3e9781ffc068e2682b99faa2e503f77/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/9db3b5d0ae93a19751dfb8f3b5c1f2d1b59b4fcce3bf68868efee4d79ffc93fa/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/c72cabd7623c0f573e287c13885819d265a10c52bec3ca14079759f36a591527/mounts/shm
overlay        overlay   7.1G  5.9G  1.3G  83% /var/lib/docker/overlay2/fc96adbc74ace47c8e98e96ecadc58d013908d463f5a5d3604f3f7cb9aac19e8/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/f69ad7eaf70982e27e6ab924c029b716f3de08720b5be907222570d40774cf8d/mounts/shm
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_184002/log# 

Time taken to generate the "log" and "log.tmpfs" folder in archive
[ TAR /var/log and /var/log.tmpfs Files ] : 480 msec

File count at original log file location
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_184002/log# find $path -type f | wc -l
20

File count at extracted tar file location
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_184002/log# find . -type f | wc -l
20

**************************************************************
2. "show techsupport" on a system with logging to "/var/log.tmpfs/"
**************************************************************
path="/var/log.tmpfs/"
df -Th
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_182328/log.tmpfs# path="/var/log.tmpfs/"
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_182328/log.tmpfs# df -Th
Filesystem     Type      Size  Used Avail Use% Mounted on
udev           devtmpfs  3.9G     0  3.9G   0% /dev
tmpfs          tmpfs     797M   16M  781M   2% /run
root-overlay   overlay   7.1G  5.8G  1.3G  82% /
/dev/mmcblk0p1 ext4      7.1G  5.8G  1.3G  82% /host
tmpfs          tmpfs     400M  4.2M  396M   2% /var/log
tmpfs          tmpfs     3.9G     0  3.9G   0% /dev/shm
tmpfs          tmpfs     5.0M     0  5.0M   0% /run/lock
tmpfs          tmpfs     4.0M     0  4.0M   0% /sys/fs/cgroup
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/9dea9147c82a42bd106c5420b2344ab4beb013a4057f82a69937bf90bf15494e/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/8989f3edd9f8ae480c72fbc1679a20f4d7a975bf3a019210fc27e7335dd3ef8d/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/b1c971d0d17c0a3e292af2b2e3094329e8ba14d295a97fd10f7d0961445cdb47/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/831217d766cf724d733bc53c5b8b30c323b85d640a980cd986ed08b915e971b2/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/e044734dde4ee733d4b73f007a8e74baae6c641e98c974dd3211bb25344c7f07/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/8a657f7cae61b36e07e1da792c9b47a5077c4f035a17685497627b4333d1b4e0/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/f2d851f1c23a2ab6615b8a2afcc0c00c2f9109013085a475979ad4dfa46e5c7a/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/430a43216bd0303dbf130ed3de24e95c8704dcf9df3c4b0361b06c55eca8a15b/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/d2123bc6cdcb676667c74c4266742f6906b09766b99fc10dbb08cd205a42b527/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/aeb136da7562037cfa83d62903b845f71f26a33faf5f1de316ce82efadd0b4bf/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/ed4dab39ee878aa8aba814955acb40330d1b1441389a6e8a8d88b848296cb9c5/merged
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/71078ee10e4134de74c20c4b693afbf3715d2fffd497a44c6836965e72784583/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/990147b69eecdb7599403252fc02a21348a5331066f3e4221f0723a0dda11105/mounts/shm
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/1ffa4ba408454e916f28a10ba2235b5ee077e87e6a369f4983d47fdbc40414a7/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/648c059a12da27dfe53b45ca0583f20d3604a5de3aa0861cb0551e98b65889da/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/af15de285989af8e35d30580664ec283a7adcb4b6bbc61d5f2336e8517d9c367/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/7edde99f86900b5fe0703553fd9213ef66faa4f1bc1ea4d0524faaaa9ae36974/merged
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/d441443de467232b6abb29052de0274d577dd02cc4bbb5d328b118d226fabf92/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/8098818bf790ad93fabd408f5838f2701e71a017774820d8d6c08f0e208af152/mounts/shm
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/2f7ad5316861d6646cb8cd5ce5a771443f83f5e5ac0441b469f31ff78bf2fb24/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/345ae39a83279d427f769cccc5dbe4de8b162ce69c571df7a09ff6c3c68846c4/merged
shm            tmpfs      64M   60K   64M   1% /var/lib/docker/containers/a612124a0759faf5c37abfd5665e13309264cef61cd9b63eca27da798aa160ec/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/128cdce3c6165dd82044a3abb02ac3ff1b5ba7af66f21a1112a957da6d50fdde/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/3955762b4368a1596fe943b185d2967a70f17f003311948763fe5b03ad6fd380/mounts/shm
overlay        overlay   7.1G  5.8G  1.3G  82% /var/lib/docker/overlay2/4acfcf4e7b50eb086a658f5729bf54148a5f3419def9b96e6d1291db72a17d4a/merged
shm            tmpfs      64M     0   64M   0% /var/lib/docker/containers/741f4cc6c24e2ecd99dd89838eef65acc9457709b737cea95bfa3bd3df2a4ee9/mounts/shm
tmpfs          tmpfs     512M  9.4M  503M   2% /var/log.tmpfs
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_182328/log.tmpfs#

Time taken to generate the "log" and "log.tmpfs" folder in archive
[ TAR /var/log and /var/log.tmpfs Files ] : 721 msec

File count at original log file location
find $path -type f | wc -l
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_182328/log.tmpfs# find $path -type f | wc -l
14

File count at extracted tar file location
find . -type f | wc -l
root@sonic:/tmp/temp/sonic_dump_sonic_20230921_182328/log.tmpfs# find . -type f | wc -l
14

```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
