### PR TITLE
[chassis][LLDP] Fix the show lldp table issue on the supervisor

### DIFF
--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -134,11 +134,16 @@ class Lldpshow(object):
                     continue
                 remote_port = intf.find('port')
                 r_portid = remote_port.find('id').text
-                key = l_intf + "#" + r_portid
+                chassis = intf.find('chassis')
+                rmt_name = chassis.find('name')
+                if rmt_name is not None: 
+                    rmt_host_name = rmt_name.text
+                else:
+                    rmt_host_name = ""
+                key = l_intf + "#" + rmt_host_name + "#" + r_portid
                 self.lldpsum[key] = {}
                 self.lldpsum[key]['l_intf'] = l_intf
                 self.lldpsum[key]['r_portid'] = r_portid
-                chassis = intf.find('chassis')
                 capabs = chassis.findall('capability')
                 capab = self.parse_cap(capabs)
                 rmt_name = chassis.find('name')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Chassis with multiple linecards,  if the mgmt port eth0 on the supervisor is a bridge interface which are connected the linecard internal mgmt port eth0.  CLI command "show lldp table" will shows only one entry although the show lldp neighbor shows multiple entries.  
Fixes #https://github.com/sonic-net/sonic-buildimage/issues/16746

#### How I did it
The root cause is the function parse_info() in lldpshow script use a key which is not unique to parse the neighbors info on the Supervisor.  Instead of use "<localPort>#<remotePort>" as key to parse and store neighbor info, we should use "<localPort>#<remoteHostName>#<remotePort>" as key which is unique to avoid the entry info be overwrited. 


#### How to verify it
execute both CLI commands "show lldp table" and "show lldp neighbor" on supervisor on the chassis.  the output entries should be the same.
Example
```
admin@ixre-cpm-chassis7:~$ show lldp table
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice      RemotePortID       Capability    RemotePortDescr
-----------  ----------------  -----------------  ------------  -----------------
eth0         ixre-egl-board25  eth0               BR            eth0
eth0         sonic             40:7c:7d:bb:25:e5  BR            eth0
eth0         ixre-egl-board26  eth0               BR            eth0
--------------------------------------------------
Total entries displayed:  3

admin@ixre-cpm-chassis7:~$ show lldp neighbors
-------------------------------------------------------------------------------
LLDP neighbors:
-------------------------------------------------------------------------------
Interface:    eth0, via: LLDP, RID: 1, Time: 0 day, 02:34:30
  Chassis:     
    ChassisID:    mac 40:7c:7d:bb:26:13
    SysName:      ixre-egl-board25
    SysDescr:     SONiC Software Version: SONiC.HEAD.543461-msft-2205-ndk-968500c6 - HwSku: Nokia-IXR7250E-36x100G - Distribution: Debian 11.7 - Kernel: 5.10.0-18-2-amd64
    MgmtIP:       152.148.151.114
    Capability:   Bridge, on
    Capability:   Router, on
    Capability:   Wlan, off
    Capability:   Station, off
  Port:        
    PortID:       local eth0
    PortDescr:    eth0
    TTL:          120
-------------------------------------------------------------------------------
Interface:    eth0, via: LLDP, RID: 2, Time: 0 day, 02:34:21
  Chassis:     
    ChassisID:    mac 40:7c:7d:bb:25:e5
    SysName:      sonic
    SysDescr:     SONiC Software Version: SONiC.HEAD.256061-dirty-20220426.133059 - HwSku: Nokia-IXR7250E-60x100G - Distribution: Debian 11.3 - Kernel: 5.10.0-8-2-amd64
    MgmtIP:       240.127.1.1
    MgmtIP:       fd00::1
    Capability:   Bridge, on
    Capability:   Router, on
    Capability:   Wlan, off
    Capability:   Station, off
  Port:        
    PortID:       mac 40:7c:7d:bb:25:e5
    PortDescr:    eth0
    TTL:          120
-------------------------------------------------------------------------------
Interface:    eth0, via: LLDP, RID: 3, Time: 0 day, 02:34:17
  Chassis:     
    ChassisID:    mac 40:7c:7d:bb:27:6b
    SysName:      ixre-egl-board26
    SysDescr:     SONiC Software Version: SONiC.HEAD.543461-msft-2205-ndk-968500c6 - HwSku: Nokia-IXR7250E-36x100G - Distribution: Debian 11.7 - Kernel: 5.10.0-18-2-amd64
    MgmtIP:       152.148.151.116
    Capability:   Bridge, on
    Capability:   Router, on
    Capability:   Wlan, off
    Capability:   Station, off
  Port:        
    PortID:       local eth0
    PortDescr:    eth0
    TTL:          120
-------------------------------------------------------------------------------
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

