### PR TITLE
Add target mode to sfputil firmware

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -41,7 +41,7 @@
   * [Console clear commands](#console-clear-commands)
 * [CMIS firmware upgrade](#cmis-firmware-upgrade)
   * [CMIS firmware version show commands](#cmis-firmware-version-show-commands)
-  * [CMIS firmware upgrade commands](#cmis-firmware-upgrade-cmmands)
+  * [CMIS firmware upgrade commands](#cmis-firmware-upgrade-commands)
   * [CMIS firmware target mode commands](#cmis-firmware-target-mode-commands)
 * [DHCP Relay](#dhcp-relay)
   * [DHCP Relay show commands](#dhcp-relay-show-commands)
@@ -2814,7 +2814,7 @@ The sfputil command shows the current major and minor versions of active/inactiv
   Committed Image: A
   Active Firmware: 0.3.5
   Inactive Firmware: 0.3.5
-   ```
+  ```
 
 ### CMIS firmware upgrade commands
 
@@ -2846,7 +2846,7 @@ This command is used for downloading firmware tp upgrade the transciever module.
   Committed Image: A
   Active Firmware: 0.3.5
   Inactive Firmware: 0.3.6
-   ```
+  ```
 **sfputil firmware run**
 
 This command is used to start and run a downloaded image. This command transfers control from the currently running firmware to a new firmware. 
@@ -2870,7 +2870,7 @@ This command is used to start and run a downloaded image. This command transfers
   Committed Image: A
   Active Firmware: 0.3.6
   Inactive Firmware: 0.3.5
-   ```
+  ```
 
 **sfputil firmware commit**
 
@@ -2894,11 +2894,15 @@ This command to commit the running image so that the module will boot from it on
   Committed Image: B
   Active Firmware: 0.3.6
   Inactive Firmware: 0.3.5
-   ```
+  ```
 
 ### CMIS firmware target mode commands
 
-This command is vendor-specific and supported on the modules to set the target mode to perform remote firmware upgrades. The target modes can be set as 0 (local- E0), 1 (remote end E1), or 2 (remote end E2). Depending on the mode set, the remote or local end will respoond to CDB/I2C commands from host's E0 end. After setting the target mode, which we can use sfputil firmware upgrade commands, which will be executed on the module for whihc target mode is set.
+This command is vendor-specific and supported on the modules to set the target mode to perform remote firmware upgrades. The target modes can be set as 0 (local- E0), 1 (remote end E1), or 2 (remote end E2). Depending on the mode set, the remote or local end will respond to CDB/I2C commands from host's E0 end. After setting the target mode, we can use **sfputil** firmware upgrade commands, will be executed on the module for which target mode is set.
+
+Example of the module supporting target mode
+
+![RMT_UPGRD](https://github.com/AnoopKamath/sonic-utilities_remote_upgrade/assets/115578705/c3b0bb62-eb14-4b05-b0a8-96b8c082455a)
 
 **sfputil firmware target**
 
@@ -2918,7 +2922,7 @@ This command is vendor-specific and supported on the modules to set the target m
   ```
   admin@sonic:~$ sfputil firmware target Ethernet180 1
   Target Mode set to 1
-   ```
+  ```
 
 ## DHCP Relay
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2806,7 +2806,7 @@ The sfputil command shows the current major and minor versions of active/inactiv
 
 - Example:
   ```
-  sfputil show fwversion Ethernet180
+  admin@sonic:~$ sfputil show fwversion Ethernet180
   Image A Version: 0.3.5
   Image B Version: 0.3.5
   Factory Image Version: 0.0.0
@@ -2831,14 +2831,14 @@ This command is used for downloading firmware tp upgrade the transciever module.
 
 - Example:
   ```
-  sfputil firmware download Ethernet180 AEC_Camano_YCable__0.3.6_20230905.bin
+  admin@sonic:~$ sfputil firmware download Ethernet180 AEC_Camano_YCable__0.3.6_20230905.bin
   CDB: Starting firmware download
   Downloading ...  [####################################]  100%
   CDB: firmware download complete
   Firmware download complete success
   Total download Time: 0:01:55.731397
 
-  sfputil show fwversion Ethernet180
+  admin@sonic:~$ sfputil show fwversion Ethernet180
   Image A Version: 0.3.5
   Image B Version: 0.3.6
   Factory Image Version: 0.0.0
@@ -2858,11 +2858,11 @@ This command is used to start and run a downloaded image. This command transfers
 
 - Example:
   ```
-  sfputil firmware run Ethernet180
+  admin@sonic:~$ sfputil firmware run Ethernet180
   Running firmware: Non-hitless Reset to Inactive Image
   Firmware run in mode=0 success
 
-  sfputil show fwversion Ethernet180
+  admin@sonic:~$ sfputil show fwversion Ethernet180
   Image A Version: 0.3.5
   Image B Version: 0.3.6
   Factory Image Version: 0.0.0
@@ -2883,10 +2883,10 @@ This command to commit the running image so that the module will boot from it on
 
 - Example:
   ```
-  sfputil firmware commit Ethernet180
+  admin@sonic:~$ sfputil firmware commit Ethernet180
   Firmware commit successful
 
-  sfputil show fwversion Ethernet180
+  admin@sonic:~$ sfputil show fwversion Ethernet180
   Image A Version: 0.3.5
   Image B Version: 0.3.6
   Factory Image Version: 0.0.0
@@ -2916,7 +2916,7 @@ This command is vendor-specific and supported on the modules to set the target m
 
 - Example:
   ```
-  sfputil firmware target Ethernet180 1
+  admin@sonic:~$ sfputil firmware target Ethernet180 1
   Target Mode set to 1
    ```
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2795,7 +2795,7 @@ Go Back To [Beginning of the document](#) or [Beginning of this section](#consol
 
 ### CMIS firmware version show commands
 
-The sfputil command shows the current active/inactive firmware, running Image details. The output may vary based on the single vs dual bank supported modules.
+The sfputil command shows the current major and minor versions of active/inactive firmware, running Image details. The output may vary based on the single vs dual bank supported modules.
 
 **sfputil show fwversion**
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1529,22 +1529,17 @@ def version():
 # 'target' subcommand
 @firmware.command()
 @click.argument('port_name', required=True, default=None)
-@click.argument('target', type=click.INT, required=True, default=None)
+@click.argument('target', type=click.IntRange(0, 2), required=True, default=None)
 def target(port_name, target):
     """Select target end for firmware download 0-(local) \n
                                                1-(remote-A) \n
                                                2-(remote-B)
     """
-    if target > 2:
-        click.echo("Error: Invalid Target value")
-        click.echo("Target Mode value should be 0 (local), 1 (remote-A) or 2 (remote-B)")
-        sys.exit(EXIT_FAIL)
-
     physical_port = logical_port_to_physical_port_index(port_name)
     sfp = platform_chassis.get_sfp(physical_port)
 
     if is_port_type_rj45(port_name):
-        click.echo("This functionality is not applicable for RJ45 port {}.".format(port_name))
+        click.echo("{}: This functionality is not applicable for RJ45 port".format(port_name))
         sys.exit(EXIT_FAIL)
 
     if not is_sfp_present(port_name):
@@ -1554,13 +1549,13 @@ def target(port_name, target):
     try:
         api = sfp.get_xcvr_api()
     except NotImplementedError:
-        click.echo("This functionality is currently not implemented for this module")
+        click.echo("{}: This functionality is currently not implemented for this module".format(port_name))
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
     try:
         status = api.set_firmware_download_target_end(target)
     except AttributeError:
-        click.echo("This functionality is currently not implemented for this module")
+        click.echo("{}: This functionality is currently not implemented for this module".format(port_name))
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
     if status:

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1520,33 +1520,6 @@ def unlock(port_name, password):
     else:
         click.echo("CDB: Host password NOT accepted! status = {}".format(status))
 
-# 'target' subcommand
-@firmware.command()
-@click.argument('port_name', required=True, default=None)
-@click.argument('target', type=click.INT, required=True, default=None)
-def target(port_name, target):
-    """Select target end for firmware download 0(local), 1(remote-A), 2-(remote-B)"""
-    physical_port = logical_port_to_physical_port_index(port_name)
-    sfp = platform_chassis.get_sfp(physical_port)
-
-    if is_port_type_rj45(port_name):
-        click.echo("This functionality is not applicable for RJ45 port {}.".format(port_name))
-        sys.exit(EXIT_FAIL)
-
-    if not is_sfp_present(port_name):
-       click.echo("{}: SFP EEPROM not detected\n".format(port_name))
-       sys.exit(EXIT_FAIL)
-
-    try:
-        api = sfp.get_xcvr_api()
-    except NotImplementedError:
-        click.echo("This functionality is currently not implemented for this platform")
-        sys.exit(ERROR_NOT_IMPLEMENTED)
-
-    status = api.set_firmware_download_target_end(target)
-    click.echo("{}". format(status))
-    sys.exit(EXIT_FAIL)
-    
 # 'version' subcommand
 @cli.command()
 def version():

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1520,12 +1520,81 @@ def unlock(port_name, password):
     else:
         click.echo("CDB: Host password NOT accepted! status = {}".format(status))
 
+# 'target' subcommand
+@firmware.command()
+@click.argument('port_name', required=True, default=None)
+@click.argument('target', type=click.INT, required=True, default=None)
+def target(port_name, target):
+    """Select target end for firmware download 0(local), 1(remote-A), 2-(remote-B)"""
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    if is_port_type_rj45(port_name):
+        click.echo("This functionality is not applicable for RJ45 port {}.".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    if not is_sfp_present(port_name):
+       click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+       sys.exit(EXIT_FAIL)
+
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo("This functionality is currently not implemented for this platform")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    status = api.set_firmware_download_target_end(target)
+    click.echo("{}". format(status))
+    sys.exit(EXIT_FAIL)
+    
 # 'version' subcommand
 @cli.command()
 def version():
     """Display version info"""
     click.echo("sfputil version {0}".format(VERSION))
 
+# 'target' subcommand
+@firmware.command()
+@click.argument('port_name', required=True, default=None)
+@click.argument('target', type=click.INT, required=True, default=None)
+def target(port_name, target):
+    """Select target end for firmware download 0-(local) \n
+                                               1-(remote-A) \n
+                                               2-(remote-B)
+    """
+    if target > 2:
+        click.echo("Error: Invalid Target value")
+        click.echo("Target Mode value should be 0 (local), 1 (remote-A) or 2 (remote-B)")
+        sys.exit(EXIT_FAIL)
+
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    if is_port_type_rj45(port_name):
+        click.echo("This functionality is not applicable for RJ45 port {}.".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    if not is_sfp_present(port_name):
+       click.echo("{}: SFP EEPROM not detected\n".format(port_name))
+       sys.exit(EXIT_FAIL)
+
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo("This functionality is currently not implemented for this module")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    try:
+        status = api.set_firmware_download_target_end(target)
+    except AttributeError:
+        click.echo("This functionality is currently not implemented for this module")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    if status:
+        click.echo("Target Mode set to {}". format(target))
+    else:
+        click.echo("Target Mode set failed!")
+        sys.exit(EXIT_FAIL)
 
 if __name__ == '__main__':
     cli()

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1555,7 +1555,7 @@ def target(port_name, target):
     try:
         status = api.set_firmware_download_target_end(target)
     except AttributeError:
-        click.echo("{}: This functionality is currently not implemented for this module".format(port_name))
+        click.echo("{}: This functionality is not applicable for this module".format(port_name))
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
     if status:

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -981,4 +981,22 @@ Ethernet0  N/A
         result = runner.invoke(sfputil.cli.commands['firmware'].commands['target'], ["Ethernet0", "2"])
         assert result.output == 'Target Mode set to 2\n'
         assert result.exit_code == 0
+
+        mock_sfp.get_presence.return_value = False
+        result = runner.invoke(sfputil.cli.commands['firmware'].commands['target'], ["Ethernet0", "2"])
+        assert result.output == 'Ethernet0: SFP EEPROM not detected\n\n'
+
+        mock_sfp.get_presence.return_value = True
+        mock_sfp.get_xcvr_api = MagicMock(side_effect=NotImplementedError)
+        result = runner.invoke(sfputil.cli.commands['firmware'].commands['target'], ["Ethernet0", "2"])
+        assert result.output == 'Ethernet0: This functionality is currently not implemented for this module\n'
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_api.set_firmware_download_target_end.return_value = 0
+        result = runner.invoke(sfputil.cli.commands['firmware'].commands['target'], ["Ethernet0", "1"])
+        assert result.output == 'Target Mode set failed!\n'
+        assert result.exit_code == EXIT_FAIL
+
         

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -967,3 +967,18 @@ Ethernet0  N/A
         mock_sfp.get_transceiver_info_firmware_versions.return_value = ['a.b.c', 'd.e.f']
 
         sfputil.update_firmware_info_to_state_db("Ethernet0")
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    def test_target_firmware(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_api.set_firmware_download_target_end.return_value = 1
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['firmware'].commands['target'], ["Ethernet0", "2"])
+        assert result.output == 'Target Mode set to 2\n'
+        assert result.exit_code == 0
+        


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add 'target' option to sfputil CLI. This target mode will be set in the vendor custom registers in the module page 0h Byte 60, which will direct the right path to upgrade remote module

#### How I did it
Add target option in the sfputil file and add related vendor specific apis in the CMIS code.

#### How to verify it
Use remote upgraded module and execute the sfputil firmware command.

#### Previous command output (if the output of a command-line utility has changed)

```
root@sonic:/home/cisco# sfputil firmware ?
Usage: sfputil firmware [OPTIONS] COMMAND [ARGS]...

  Download/Upgrade firmware on the transceiver

Options:
  --help  Show this message and exit.

Commands:
  commit    Commit the running firmware
  download  Download firmware on the transceiver
  run       Run the firmware with default mode=0
  unlock    Unlock the firmware download feature via CDB host password
  upgrade   Upgrade firmware on the transceiver
```
#### New command output (if the output of a command-line utility has changed)

```
root@sonic:/home/cisco# sfputil firmware ?
Usage: sfputil firmware [OPTIONS] COMMAND [ARGS]...

  Download/Upgrade firmware on the transceiver

Options:
  --help  Show this message and exit.

Commands:
  commit    Commit the running firmware
  download  Download firmware on the transceiver
  run       Run the firmware with default mode=0
  target    Select target end for firmware download 0-(local) 1-(remote-A)...
  unlock    Unlock the firmware download feature via CDB host password
  upgrade   Upgrade firmware on the transceiver
root@sonic:/home/cisco#

root@sonic:/home/cisco# sfputil firmware target --help
Usage: sfputil firmware target [OPTIONS] PORT_NAME TARGET

  Select target end for firmware download 0-(loca)

  1-(remote-A)

  2-(remote-B)

Options:
  --help  Show this message and exit.
root@sonic:/home/cisco#

```
