### PR TITLE
[GCU] Marking Ports index field as create-only

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -553,6 +553,7 @@ class CreateOnlyFilter:
         self.path_addressing = path_addressing
         self.patterns = [
             ["PORT", "*", "lanes"],
+            ["PORT", "*", "index"],
             ["LOOPBACK_INTERFACE", "*", "vrf_name"],
             ["BGP_NEIGHBOR", "*", "holdtime"],
             ["BGP_NEIGHBOR", "*", "keepalive"],

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1066,9 +1066,15 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
     def test_hard_coded_create_only_paths(self):
         config = {
             "PORT": {
-                "Ethernet0":{"lanes":"65"},
+                "Ethernet0":{
+                    "lanes":"65",
+                    "index": "0"
+                },
                 "Ethernet1":{},
-                "Ethernet2":{"lanes":"66,67"}
+                "Ethernet2":{
+                    "lanes":"66,67",
+                    "index": "2"
+                }
             },
             "LOOPBACK_INTERFACE": {
                 "Loopback0":{"vrf_name":"vrf0"},
@@ -1139,6 +1145,8 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
         expected = [
             "/PORT/Ethernet0/lanes",
             "/PORT/Ethernet2/lanes",
+            "/PORT/Ethernet0/index",
+            "/PORT/Ethernet2/index",
             "/LOOPBACK_INTERFACE/Loopback0/vrf_name",
             "/LOOPBACK_INTERFACE/Loopback2/vrf_name",
             "/BGP_NEIGHBOR/10.0.0.57/asn",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it
Mark the field index under PORT as create-only
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

