### PR TITLE
Update GCU rsyslog validator

### DIFF
--- a/generic_config_updater/gcu_services_validator.conf.json
+++ b/generic_config_updater/gcu_services_validator.conf.json
@@ -31,6 +31,9 @@
         "PORT": {
             "services_to_validate": [ "port_service" ]
         },
+        "SYSLOG_SERVER":{
+            "services_to_validate": [ "rsyslog" ]
+        },
         "DHCP_RELAY": {
             "services_to_validate": [ "dhcp-relay" ]
         },
@@ -56,6 +59,9 @@
         },
         "port_service": {
             "validate_commands": [ ]
+        },
+        "rsyslog": {
+            "validate_commands": [ "generic_config_updater.services_validator.rsyslog_validator" ]
         },
         "dhcp-relay": {
             "validate_commands": [ "generic_config_updater.services_validator.dhcp_validator" ]

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -48,6 +48,18 @@ def _service_restart(svc_name):
     return rc == 0
 
 
+def rsyslog_validator(old_config, upd_config, keys):
+    old_syslog = old_config.get("SYSLOG_SERVER", {})
+    upd_syslog = upd_config.get("SYSLOG_SERVER", {})
+
+    if old_syslog != upd_syslog:
+        os.system("systemctl reset-failed rsyslog-config rsyslog")
+        rc = os.system("systemctl restart rsyslog-config")
+        if rc != 0:
+            return False
+    return True
+
+
 def dhcp_validator(old_config, upd_config, keys):
     return _service_restart("dhcp_relay")
 

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -144,31 +144,67 @@ test_caclrule = [
 
 test_rsyslog_data = [
         { "old": {}, "upd": {}, "cmd": "" },
-        {
+        {# Same config but in different order
             "old": { "SYSLOG_SERVER": {
-                "2.2.2.2": {} } },
+                "10.13.14.17": {
+                    "source": "1.1.1.1",
+                    "port": "514"
+                },
+                "2001:aa:aa::aa": {
+                    "source": "1111::1111",
+                    "port": "514"
+                } } },
             "upd": { "SYSLOG_SERVER": {
-                "2.2.2.2": {} } },
+                "2001:aa:aa::aa": {
+                    "port": "514",
+                    "source": "1111::1111"
+                },
+                "10.13.14.17": {
+                    "port": "514",
+                    "source": "1.1.1.1"
+                } } },
             "cmd": ""
         },
-        {
+        {# Change port of one syslog server
             "old": { "SYSLOG_SERVER": {
-                "2.2.2.2": {} } },
+                "10.13.14.17": {
+                    "source": "1.1.1.1",
+                    "port": "514"
+                },
+                "2001:aa:aa::aa": {
+                    "source": "1111::1111",
+                    "port": "514"
+                } } },
             "upd": { "SYSLOG_SERVER": {
-                "1.1.1.1": {} } },
+                "2001:aa:aa::aa": {
+                    "port": "514",
+                    "source": "1111::1111"
+                },
+                "10.13.14.17": {
+                    "port": "513",
+                    "source": "1.1.1.1"
+                } } },
             "cmd": "systemctl reset-failed rsyslog-config rsyslog,systemctl restart rsyslog-config"
         },
-        {
+
+        {# Different syslog server
             "old": { "SYSLOG_SERVER": {
-                "2.2.2.2": {} } },
+                "10.13.14.17": {} } },
             "upd": { "SYSLOG_SERVER": {
-                "1.1.1.1": {},
-                "2.2.2.2": {} } },
+                "2001:aa:aa::aa": {} } },
             "cmd": "systemctl reset-failed rsyslog-config rsyslog,systemctl restart rsyslog-config"
         },
-        {
+        {# Add syslog server
             "old": { "SYSLOG_SERVER": {
-                "2.2.2.2": {} } },
+                "10.13.14.17": {} } },
+            "upd": { "SYSLOG_SERVER": {
+                "10.13.14.17": {},
+                "2001:aa:aa::aa": {} } },
+            "cmd": "systemctl reset-failed rsyslog-config rsyslog,systemctl restart rsyslog-config"
+        },
+        {# Remove syslog server
+            "old": { "SYSLOG_SERVER": {
+                "10.13.14.17": {} } },
             "upd": {},
             "cmd": "systemctl reset-failed rsyslog-config rsyslog,systemctl restart rsyslog-config"
         }

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -6,7 +6,7 @@ import unittest
 from collections import defaultdict
 from unittest.mock import patch
 
-from generic_config_updater.services_validator import vlan_validator, caclmgrd_validator, vlanintf_validator
+from generic_config_updater.services_validator import vlan_validator, rsyslog_validator, caclmgrd_validator, vlanintf_validator
 import generic_config_updater.gu_common
 
 
@@ -142,6 +142,38 @@ test_caclrule = [
         },
     ]
 
+test_rsyslog_data = [
+        { "old": {}, "upd": {}, "cmd": "" },
+        {
+            "old": { "SYSLOG_SERVER": {
+                "2.2.2.2": {} } },
+            "upd": { "SYSLOG_SERVER": {
+                "2.2.2.2": {} } },
+            "cmd": ""
+        },
+        {
+            "old": { "SYSLOG_SERVER": {
+                "2.2.2.2": {} } },
+            "upd": { "SYSLOG_SERVER": {
+                "1.1.1.1": {} } },
+            "cmd": "systemctl reset-failed rsyslog-config rsyslog,systemctl restart rsyslog-config"
+        },
+        {
+            "old": { "SYSLOG_SERVER": {
+                "2.2.2.2": {} } },
+            "upd": { "SYSLOG_SERVER": {
+                "1.1.1.1": {},
+                "2.2.2.2": {} } },
+            "cmd": "systemctl reset-failed rsyslog-config rsyslog,systemctl restart rsyslog-config"
+        },
+        {
+            "old": { "SYSLOG_SERVER": {
+                "2.2.2.2": {} } },
+            "upd": {},
+            "cmd": "systemctl reset-failed rsyslog-config rsyslog,systemctl restart rsyslog-config"
+        }
+    ]
+
 test_vlanintf_data = [
         { "old": {}, "upd": {}, "cmd": "" },
         {
@@ -198,9 +230,17 @@ class TestServiceValidator(unittest.TestCase):
             vlan_validator(entry["old"], entry["upd"], None)
 
 
+        os_system_calls = []
+        os_system_call_index = 0
+        for entry in test_rsyslog_data:
+            if entry["cmd"]:
+                for c in entry["cmd"].split(","):
+                    os_system_calls.append({"cmd": c, "rc": 0})
+            msg = "case failed: {}".format(str(entry))
 
-        # Test failure case
-        #
+            rsyslog_validator(entry["old"], entry["upd"], None)
+
+
         os_system_calls = []
         os_system_call_index = 0
         for entry in test_vlanintf_data:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 25468726
#### What I did
In the privous PR https://github.com/sonic-net/sonic-utilities/pull/2991, we removed the rsyslog validator because the background daemon can now react(reset-failed & restart) the rsyslog service when the configuration changes. 

However, this change introduced an issue found in nightly tests. The problem is that there is a chance that the rsyslog service is not refreshed promptly after modification. 

We have two potential solutions: we can either modify the sonic-mgmt syslog test to wait more time for the completion of the rsyslog update or reintroduce the syslog validator with enhancements. As the update for rsyslog happens after the completion of the GCU apply-patch, I choose to modify in GCU to ensure that it accurately reflects the completion of the rsyslog change when the apply-patch process is finished.

Now the behavior in this pull request aligns with the SONiC CLI when updating rsyslog settings.

#### How I did it
Add back and update GCU rsyslog validator and align it with syslog CLI.
#### How to verify it
Unit test and E2E test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

