### PR TITLE
[fwutil] Fix python SyntaxWarning for 'is' with literals

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -899,7 +899,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
             if status_file is not None:
                 data = self.read_au_status_file_if_exists(FW_AU_STATUS_FILE_PATH)
                 if data is not None:
-                    if boot is "none" or boot in data:
+                    if boot == "none" or boot in data:
                         click.echo("Allow firmware auto-update with boot_type {} again".format(boot))
                         return True
 

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -76,3 +76,21 @@ class TestSquashFs(object):
 
     def teardown(self):
         print('TEARDOWN')
+
+
+class TestComponentUpdateProvider(object):
+    def setup(self):
+        print('SETUP')
+
+    @patch("glob.glob", MagicMock(side_effect=[[], ['abc'], [], ['abc']]))
+    @patch("fwutil.lib.ComponentUpdateProvider.read_au_status_file_if_exists", MagicMock(return_value=['def']))
+    @patch("fwutil.lib.ComponentUpdateProvider._ComponentUpdateProvider__validate_platform_schema", MagicMock())
+    @patch("fwutil.lib.PlatformComponentsParser.parse_platform_components", MagicMock())
+    @patch("os.mkdir", MagicMock())
+    def test_is_capable_auto_update(self):
+        CUProvider = fwutil_lib.ComponentUpdateProvider()
+        assert CUProvider.is_capable_auto_update('none') == True
+        assert CUProvider.is_capable_auto_update('def') == True
+
+    def teardown(self):
+        print('TEARDOWN')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix a Python syntax warning in the fwuti command output:

**/usr/local/lib/python3.9/dist-packages/fwutil/lib.py:902: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if boot is "none" or boot in data:**

```
admin@sonic:/home/admin# sudo fwutil show status
/usr/local/lib/python3.9/dist-packages/fwutil/lib.py:902: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if boot is "none" or boot in data:
Chassis    Module    Component    Version                          Description
---------  --------  -----------  -------------------------------  ----------------------------------------
SN5600     N/A       ONIE         2022.08-5.3.0010-dev-115200-dev  ONIE - Open Network Install Environment
                     SSD          0913-000                         SSD - Solid-State Drive
                     BIOS         0ACQF_06.01.003                  BIOS - Basic Input/Output System
                     CPLD1        CPLD000232_REV0800               CPLD - Complex Programmable Logic Device
                     CPLD2        CPLD000330_REV0600               CPLD - Complex Programmable Logic Device
                     CPLD3        CPLD000331_REV0400               CPLD - Complex Programmable Logic Device
                     CPLD4        CPLD000332_REV0300               CPLD - Complex Programmable Logic Device

```

#### How I did it

Use '==' instead of 'is'  for string identity check according to python 3.8 release notes:

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers).
> 
> These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead.

#### How to verify it

run fwutil make sure no syntax warning anymore and function still work.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

