### PR TITLE
Run yang validation in unit test

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -1139,6 +1139,11 @@ class DBMigrator():
                         new_table[table_key] = table_val
                 if hit:
                     config[table_name] = new_table
+            # Run yang validation
+            yang_parser = sonic_yang.SonicYang(YANG_MODELS_DIR)
+            yang_parser.loadYangModel()
+            yang_parser.loadData(configdbJson=config)
+            yang_parser.validate_data_tree()
 
 
 def main():

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_expected.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_expected.json
@@ -3,17 +3,17 @@
         "VERSION": "version_4_0_3"
     },
     "FLEX_COUNTER_TABLE|ACL": {
-        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_STATUS": "enable",
         "FLEX_COUNTER_DELAY_STATUS": "true",
         "POLL_INTERVAL": "10000"
     },
     "FLEX_COUNTER_TABLE|QUEUE": {
-        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_STATUS": "enable",
         "FLEX_COUNTER_DELAY_STATUS": "true",
         "POLL_INTERVAL": "10000"
     },
     "FLEX_COUNTER_TABLE|PG_WATERMARK": {
-        "FLEX_COUNTER_STATUS": "false",
+        "FLEX_COUNTER_STATUS": "disable",
         "FLEX_COUNTER_DELAY_STATUS": "true"
     }
 }

--- a/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_input.json
+++ b/tests/db_migrator_input/config_db/cross_branch_upgrade_to_4_0_3_input.json
@@ -3,16 +3,16 @@
         "VERSION": "version_1_0_1"
     },
     "FLEX_COUNTER_TABLE|ACL": {
-        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_STATUS": "enable",
         "FLEX_COUNTER_DELAY_STATUS": "true",
         "POLL_INTERVAL": "10000"
     },
     "FLEX_COUNTER_TABLE|QUEUE": {
-        "FLEX_COUNTER_STATUS": "true",
+        "FLEX_COUNTER_STATUS": "enable",
         "FLEX_COUNTER_DELAY_STATUS": "false",
         "POLL_INTERVAL": "10000"
     },
     "FLEX_COUNTER_TABLE|PG_WATERMARK": {
-        "FLEX_COUNTER_STATUS": "false"
+        "FLEX_COUNTER_STATUS": "disable"
     }
 }

--- a/tests/db_migrator_input/config_db/portchannel-expected.json
+++ b/tests/db_migrator_input/config_db/portchannel-expected.json
@@ -1,28 +1,24 @@
 {
     "PORTCHANNEL|PortChannel0": {
         "admin_status": "up",
-        "members@": "Ethernet0,Ethernet4",
         "min_links": "2",
         "mtu": "9100",
         "lacp_key": "auto"
     },
     "PORTCHANNEL|PortChannel1": {
         "admin_status": "up",
-        "members@": "Ethernet8,Ethernet12",
         "min_links": "2",
         "mtu": "9100",
         "lacp_key": "auto"
     },
     "PORTCHANNEL|PortChannel0123": {
         "admin_status": "up",
-        "members@": "Ethernet16",
         "min_links": "1",
         "mtu": "9100",
         "lacp_key": "auto"
     },
     "PORTCHANNEL|PortChannel0011": {
         "admin_status": "up",
-        "members@": "Ethernet20,Ethernet24",
         "min_links": "2",
         "mtu": "9100",
         "lacp_key": "auto"

--- a/tests/db_migrator_input/config_db/portchannel-input.json
+++ b/tests/db_migrator_input/config_db/portchannel-input.json
@@ -1,25 +1,21 @@
 {
     "PORTCHANNEL|PortChannel0": {
         "admin_status": "up",
-        "members@": "Ethernet0,Ethernet4",
         "min_links": "2",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel1": {
         "admin_status": "up",
-        "members@": "Ethernet8,Ethernet12",
         "min_links": "2",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0123": {
         "admin_status": "up",
-        "members@": "Ethernet16",
         "min_links": "1",
         "mtu": "9100"
     },
     "PORTCHANNEL|PortChannel0011": {
         "admin_status": "up",
-        "members@": "Ethernet20,Ethernet24",
         "min_links": "2",
         "mtu": "9100"
     },

--- a/tests/db_migrator_input/config_db/qos_map_table_expected.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_expected.json
@@ -29,6 +29,14 @@
         "pfc_to_queue_map": "AZURE",
         "tc_to_pg_map": "AZURE",
         "tc_to_queue_map": "AZURE"
-    }
+    },
+    "TC_TO_QUEUE_MAP|AZURE": {"0": "0"},
+    "TC_TO_PRIORITY_GROUP_MAP|AZURE": {"0": "0"},
+    "MAP_PFC_PRIORITY_TO_QUEUE|AZURE": {"0": "0"},
+    "DSCP_TO_TC_MAP|AZURE": {"0": "0"},
+    "PORT|Ethernet0": {"lanes": "0", "speed": "1000"},
+    "PORT|Ethernet92": {"lanes": "92", "speed": "1000"},
+    "PORT|Ethernet96": {"lanes": "96", "speed": "1000"},
+    "PORT|Ethernet100": {"lanes": "100", "speed": "1000"}
 }
 

--- a/tests/db_migrator_input/config_db/qos_map_table_input.json
+++ b/tests/db_migrator_input/config_db/qos_map_table_input.json
@@ -27,5 +27,13 @@
         "pfc_to_queue_map": "AZURE",
         "tc_to_pg_map": "AZURE",
         "tc_to_queue_map": "AZURE"
-    }
+    },
+    "TC_TO_QUEUE_MAP|AZURE": {"0": "0"},
+    "TC_TO_PRIORITY_GROUP_MAP|AZURE": {"0": "0"},
+    "MAP_PFC_PRIORITY_TO_QUEUE|AZURE": {"0": "0"},
+    "DSCP_TO_TC_MAP|AZURE": {"0": "0"},
+    "PORT|Ethernet0": {"lanes": "0", "speed": "1000"},
+    "PORT|Ethernet92": {"lanes": "92", "speed": "1000"},
+    "PORT|Ethernet96": {"lanes": "96", "speed": "1000"},
+    "PORT|Ethernet100": {"lanes": "100", "speed": "1000"}
 }

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-expected.json
@@ -12,7 +12,7 @@
         "profile": "NULL"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "customized_lossless_profile"
+        "profile": "customized_ingress_lossless_profile"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "ingress_lossy_profile"
@@ -103,6 +103,11 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
         "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
     },
+    "BUFFER_PROFILE|customized_egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
         "pool": "egress_lossless_pool",
@@ -112,6 +117,11 @@
         "dynamic_th": "7",
         "pool": "egress_lossy_pool",
         "size": "9216"
+    },
+    "BUFFER_PROFILE|customized_ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
         "dynamic_th": "7",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-input.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-double-pools-input.json
@@ -3,7 +3,7 @@
         "profile": "NULL"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "customized_lossless_profile"
+        "profile": "customized_ingress_lossless_profile"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "ingress_lossy_profile"
@@ -55,6 +55,11 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
         "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
     },
+    "BUFFER_PROFILE|customized_egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
         "pool": "egress_lossless_pool",
@@ -64,6 +69,11 @@
         "dynamic_th": "7",
         "pool": "egress_lossy_pool",
         "size": "9216"
+    },
+    "BUFFER_PROFILE|customized_ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
         "dynamic_th": "7",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-expected.json
@@ -12,7 +12,7 @@
         "profile": "NULL"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "customized_lossless_profile"
+        "profile": "customized_ingress_lossless_profile"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "ingress_lossy_profile"
@@ -99,6 +99,11 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
         "profile_list": "ingress_lossless_profile"
     },
+    "BUFFER_PROFILE|customized_egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
         "pool": "egress_lossless_pool",
@@ -108,6 +113,11 @@
         "dynamic_th": "7",
         "pool": "egress_lossy_pool",
         "size": "9216"
+    },
+    "BUFFER_PROFILE|customized_ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
         "dynamic_th": "7",

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-input.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-dynamic-single-pool-input.json
@@ -3,7 +3,7 @@
         "profile": "NULL"
     },
     "BUFFER_PG|Ethernet8|3-4": {
-        "profile": "customized_lossless_profile"
+        "profile": "customized_ingress_lossless_profile"
     },
     "BUFFER_PG|Ethernet12|0": {
         "profile": "ingress_lossy_profile"
@@ -51,6 +51,11 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
         "profile_list": "ingress_lossless_profile"
     },
+    "BUFFER_PROFILE|customized_egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
     "BUFFER_PROFILE|egress_lossless_profile": {
         "dynamic_th": "7",
         "pool": "egress_lossless_pool",
@@ -60,6 +65,11 @@
         "dynamic_th": "7",
         "pool": "egress_lossy_pool",
         "size": "9216"
+    },
+    "BUFFER_PROFILE|customized_ingress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
     },
     "BUFFER_PROFILE|ingress_lossless_profile": {
         "dynamic_th": "7",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add unit test for db_migrator.py: ConfigDB passing yang validation.
Microsoft ADO: 24657445
Pending on https://github.com/sonic-net/sonic-buildimage/pull/16974

#### How I did it
Add yang validation for unit test, and fix test data to pass yang validation.

#### How to verify it
Run sonic-utilities end to end test.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

