### PR TITLE
[sonic_installer]: Improve exception handling: introduce notes.

### DIFF
--- a/sonic_installer/common.py
+++ b/sonic_installer/common.py
@@ -46,10 +46,15 @@ def run_command_or_raise(argv, raise_exception=True, capture=True):
 
     stdout = subprocess.PIPE if capture else None
     proc = subprocess.Popen(argv, text=True, stdout=stdout)
-    out, _ = proc.communicate()
+    out, err = proc.communicate()
 
     if proc.returncode != 0 and raise_exception:
-        raise SonicRuntimeException("Failed to run command '{0}'".format(argv))
+        sre = SonicRuntimeException("Failed to run command '{0}'".format(argv))
+        if out:
+            sre.add_note("\nSTDOUT:\n{}".format(out.rstrip("\n")))
+        if err:
+            sre.add_note("\nSTDERR:\n{}".format(err.rstrip("\n")))
+        raise sre
 
     if out is not None:
         out = out.rstrip("\n")

--- a/sonic_installer/exception.py
+++ b/sonic_installer/exception.py
@@ -5,4 +5,15 @@ Module sonic-installer exceptions
 class SonicRuntimeException(Exception):
     """SONiC Runtime Excpetion class used to report SONiC related errors
     """
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.notes = []
+
+    def __str__(self):
+        msg = super().__str__()
+        if self.notes:
+            msg += "\n" + "\n".join(self.notes)
+        return msg
+
+    def add_note(self, note):
+        self.notes.append(note)


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
* Extended exception class with user notes

#### How I did it
* Implemented new API

#### How to verify it
* Run UTs

#### Tested branch (Please provide the tested image version)
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->

#### Previous command output (if the output of a command-line utility has changed)
```
Traceback (most recent call last):
  File "/usr/local/bin/sonic_installer", line 8, in <module>
    sys.exit(sonic_installer())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/sonic_installer/main.py", line 604, in install
    migrate_sonic_packages(bootloader, binary_image_version)
  File "/usr/local/lib/python3.9/dist-packages/sonic_installer/main.py", line 384, in migrate_sonic_packages
    run_command_or_raise(["chroot", new_image_mount, SONIC_PACKAGE_MANAGER, "migrate",
  File "/usr/local/lib/python3.9/dist-packages/sonic_installer/common.py", line 56, in run_command_or_raise
    raise sre
sonic_installer.exception.SonicRuntimeException: Failed to run command '['chroot', '/tmp/image-202305_RC.6-8c7a14378_Internal-fs', 'sonic-package-manager', 'migrate', '/tmp/packages.json', '--dockerd-socket', '/tmp/docker.sock', '-y']'
```

#### New command output (if the output of a command-line utility has changed)
```
Traceback (most recent call last):
  File "/usr/local/bin/sonic_installer", line 8, in <module>
    sys.exit(sonic_installer())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/sonic_installer/main.py", line 604, in install
    migrate_sonic_packages(bootloader, binary_image_version)
  File "/usr/local/lib/python3.9/dist-packages/sonic_installer/main.py", line 384, in migrate_sonic_packages
    run_command_or_raise(["chroot", new_image_mount, SONIC_PACKAGE_MANAGER, "migrate",
  File "/usr/local/lib/python3.9/dist-packages/sonic_installer/common.py", line 56, in run_command_or_raise
    raise sre
sonic_installer.exception.SonicRuntimeException: Failed to run command '['chroot', '/tmp/image-202305_RC.6-8c7a14378_Internal-fs', 'sonic-package-manager', 'migrate', '/tmp/packages.json', '--dockerd-socket', '/tmp/docker.sock', '-y']'

STDOUT:
Failed to migrate packages 500 Server Error for http+docker://localhost/v1.41/images/urm.nvidia.com/sw-nbu-sws-sonic-docker/doai:1.1.0-202305-6/get: Internal Server Error ("open /var/lib/docker/overlay2/abaca4cf4dead46a809f8a10d8488099cb6df653617b0017fc5913228d077436/merged/usr/lib/python3/dist-packages/_distutils_hack/__pycache__/__init__.cpython-39.pyc: no such file or directory")
```