### PR TITLE
[sonic-package-manager] do not modify config_db.json

### DIFF
--- a/sonic_package_manager/service_creator/sonic_db.py
+++ b/sonic_package_manager/service_creator/sonic_db.py
@@ -12,7 +12,6 @@ from sonic_package_manager.service_creator import ETC_SONIC_PATH
 from sonic_package_manager.service_creator.utils import in_chroot
 
 CONFIG_DB = 'CONFIG_DB'
-CONFIG_DB_JSON = os.path.join(ETC_SONIC_PATH, 'config_db.json')
 INIT_CFG_JSON = os.path.join(ETC_SONIC_PATH, 'init_cfg.json')
 
 
@@ -99,12 +98,9 @@ class SonicDB:
         """ Yields available DBs connectors. """
 
         initial_db_conn = cls.get_initial_db_connector()
-        persistent_db_conn = cls.get_persistent_db_connector()
         running_db_conn = cls.get_running_db_connector()
 
         yield initial_db_conn
-        if persistent_db_conn is not None:
-            yield persistent_db_conn
         if running_db_conn is not None:
             yield running_db_conn
 
@@ -126,15 +122,6 @@ class SonicDB:
                 cls._running_db_conn = None
 
         return cls._running_db_conn
-
-    @classmethod
-    def get_persistent_db_connector(cls):
-        """ Returns persistent DB connector. """
-
-        if not os.path.exists(CONFIG_DB_JSON):
-            return None
-
-        return PersistentConfigDbConnector(CONFIG_DB_JSON)
 
     @classmethod
     def get_initial_db_connector(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Installing an app.ext currently inserts app.ext specific init config into redis CONFIG_DB, /etc/sonic/config_db.json and /etc/sonic/init_cfg.json.

Since on configuration reload and boot the configuration file is merged with /etc/sonic/init_cfg.json there is no point in modifying config_db.json.

This can cause issues when config_db.json is not up-to-date. This is not a problem to configuration reload due to config migration, but it is not a valid JSON according to YANG model which does not validate old schema.

#### How I did it

Removed the relevant part of the code.

#### How to verify it

Verified by ONIE installing SONiC and installing an extension. Previosuly it failed and complaining about config_db.json not being valid:

```
Leafref "../../LOOPBACK_INTERFACE_LIST/name" of value "Loopback0" points to a non-existing leaf.
```

This is due to missing ```"Loopback0": {}``` in the ```LOOPBACK_INTERFACE``` table. This is not a problem since db_migrator can deal with it.

With this change, this is fixed - config_db.json is not modified, however app.ext initial configuration is inserted into redis CONFIG_DB after configuration reload or reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

