### PR TITLE
Enhance the default PFC detect/restore time calculation method

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -375,7 +375,7 @@ class PfcwdCli(object):
         port_num = len(list(self.config_db.get_table('PORT').keys()))
 
         # Paramter values positively correlate to the number of ports.
-        multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
+        multiply = max(1, port_num//DEFAULT_PORT_NUM+1)
         pfcwd_info = {
             'detection_time': DEFAULT_DETECTION_TIME * multiply,
             'restoration_time': DEFAULT_RESTORATION_TIME * multiply,


### PR DESCRIPTION
- What I did Enhance the calculation method for default PFC detect/restore time, to be better suit for some platforms whose port number 32xN.

- How I did it Use the port number divided by the DEFAULT_PORT_NUM directly

- How to verify it Check on some platform whose port nubmer is 32 x N, run pfcwd start_default, check the detect/restore time should be increased 200ms

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

