### PR TITLE
[dualtor_neighbor_check] Adjust zero-mac check condition

### DIFF
--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -402,7 +402,10 @@ def check_neighbor_consistency(neighbors, mux_states, hw_mux_states, mac_to_port
         check_result["NEIGHBOR_IN_ASIC"] = neighbor_ip in asic_neighs
         check_result["TUNNERL_IN_ASIC"] = neighbor_ip in asic_route_destinations
         if is_zero_mac:
-            check_result["HWSTATUS"] = ((not check_result["NEIGHBOR_IN_ASIC"]) and check_result["TUNNERL_IN_ASIC"])
+            # NOTE: for zero-mac neighbors, two situations:
+            # 1. new neighbor just learnt, no neighbor entry in ASIC, tunnel route present in ASIC.
+            # 2. neighbor expired, neighbor entry still present in ASIC, no tunnel route in ASIC.
+            check_result["HWSTATUS"] = check_result["NEIGHBOR_IN_ASIC"] or check_result["TUNNERL_IN_ASIC"]
         else:
             port_name = mac_to_port_name_map[mac]
             # NOTE: mux server ips are always fixed to the mux port

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -155,7 +155,7 @@ return redis.status_reply(cjson.encode(result))
 
 DB_READ_SCRIPT_CONFIG_DB_KEY = "_DUALTOR_NEIGHBOR_CHECK_SCRIPT_SHA1"
 ZERO_MAC = "00:00:00:00:00:00"
-NEIGHBOR_ATTRIBUTES = ["NEIGHBOR", "MAC", "PORT", "MUX_STATE", "IN_MUX_TOGGLE", "NEIGHBOR_IN_ASIC", "TUNNERL_IN_ASIC", "HWSTATUS"]
+NEIGHBOR_ATTRIBUTES = ["NEIGHBOR", "MAC", "PORT", "MUX_STATE", "IN_MUX_TOGGLE", "NEIGHBOR_IN_ASIC", "TUNNEL_IN_ASIC", "HWSTATUS"]
 NOT_AVAILABLE = "N/A"
 
 
@@ -400,12 +400,12 @@ def check_neighbor_consistency(neighbors, mux_states, hw_mux_states, mac_to_port
             continue
 
         check_result["NEIGHBOR_IN_ASIC"] = neighbor_ip in asic_neighs
-        check_result["TUNNERL_IN_ASIC"] = neighbor_ip in asic_route_destinations
+        check_result["TUNNEL_IN_ASIC"] = neighbor_ip in asic_route_destinations
         if is_zero_mac:
             # NOTE: for zero-mac neighbors, two situations:
             # 1. new neighbor just learnt, no neighbor entry in ASIC, tunnel route present in ASIC.
             # 2. neighbor expired, neighbor entry still present in ASIC, no tunnel route in ASIC.
-            check_result["HWSTATUS"] = check_result["NEIGHBOR_IN_ASIC"] or check_result["TUNNERL_IN_ASIC"]
+            check_result["HWSTATUS"] = check_result["NEIGHBOR_IN_ASIC"] or check_result["TUNNEL_IN_ASIC"]
         else:
             port_name = mac_to_port_name_map[mac]
             # NOTE: mux server ips are always fixed to the mux port
@@ -418,9 +418,9 @@ def check_neighbor_consistency(neighbors, mux_states, hw_mux_states, mac_to_port
             check_result["IN_MUX_TOGGLE"] = mux_state != hw_mux_state
 
             if mux_state == "active":
-                check_result["HWSTATUS"] = (check_result["NEIGHBOR_IN_ASIC"] and (not check_result["TUNNERL_IN_ASIC"]))
+                check_result["HWSTATUS"] = (check_result["NEIGHBOR_IN_ASIC"] and (not check_result["TUNNEL_IN_ASIC"]))
             elif mux_state == "standby":
-                check_result["HWSTATUS"] = ((not check_result["NEIGHBOR_IN_ASIC"]) and check_result["TUNNERL_IN_ASIC"])
+                check_result["HWSTATUS"] = ((not check_result["NEIGHBOR_IN_ASIC"]) and check_result["TUNNEL_IN_ASIC"])
             else:
                 # skip as unknown mux state
                 continue
@@ -445,7 +445,7 @@ def parse_check_results(check_results):
         if not is_zero_mac:
             check_result["IN_MUX_TOGGLE"] = bool_to_yes_no[in_toggle]
         check_result["NEIGHBOR_IN_ASIC"] = bool_to_yes_no[check_result["NEIGHBOR_IN_ASIC"]]
-        check_result["TUNNERL_IN_ASIC"] = bool_to_yes_no[check_result["TUNNERL_IN_ASIC"]]
+        check_result["TUNNEL_IN_ASIC"] = bool_to_yes_no[check_result["TUNNEL_IN_ASIC"]]
         check_result["HWSTATUS"] = bool_to_consistency[hwstatus]
         if (not hwstatus):
             if is_zero_mac:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Work item tracking
* Microsoft ADO (number only): 25667174

Fix the `dualtor_neighbor_check` error log complaining about the zero-mac neighbor inconsistency due to no tunnel route present in the ASIC.
This is because, for zero-mac neighbors, two situations:
1. new neighbor just learnt, no neighbor entry in ASIC, tunnel route present in ASIC.
2. neighbor expired, neighbor entry still present in ASIC, no tunnel route in ASIC.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How I did it
Adjust the check condition.

#### How to verify it
UT and verify on testbed with expired neighbors.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

