### PR TITLE
Tacacs password encryption

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -339,15 +339,16 @@ default.add_command(passkey)
 @click.option('-e', '--enc', help="Encrypt the provided key", is_flag=True)
 def add(address, timeout, key, enckey, auth_type, port, pri, use_mgmt_vrf, enc):
     """Specify a TACACS+ server"""
-    if not clicommon.is_ipaddress(address):
-        click.echo('Invalid IP address')
-        return
+    if ADHOC_VALIDATION:
+        if not clicommon.is_ipaddress(address):
+            click.echo('Invalid ip address') # TODO: MISSING CONSTRAINT IN YANG MODEL
+            return
 
     config_db = ConfigDBConnector()
     config_db.connect()
     old_data = config_db.get_entry('TACPLUS_SERVER', address)
     if old_data:
-        click.echo('Server %s already exists' % address)
+        click.echo('server %s already exists' % address)
     else:
         data = {
             'tcp_port': str(port),

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -344,7 +344,7 @@ def add(address, timeout, key, enckey, auth_type, port, pri, use_mgmt_vrf, enc):
             click.echo('Invalid ip address') # TODO: MISSING CONSTRAINT IN YANG MODEL
             return
 
-    config_db = ConfigDBConnector()
+    config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
     old_data = config_db.get_entry('TACPLUS_SERVER', address)
     if old_data:

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -389,9 +389,13 @@ def add(address, timeout, key, enckey, auth_type, port, pri, use_mgmt_vrf, enc):
                 click.echo('please use command "config system key" to add an encryption key')
                 click.echo('no change applied')
                 return
-        if use_mgmt_vrf:
+        if use_mgmt_vrf :
             data['vrf'] = "mgmt"
-        config_db.set_entry('TACPLUS_SERVER', address, data)
+        try:
+            config_db.set_entry('TACPLUS_SERVER', address, data)
+        except ValueError as e:
+            ctx = click.get_current_context()
+            ctx.fail("Invalid ip address. Error: {}".format(e))
 tacacs.add_command(add)
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -57,6 +57,7 @@ from .config_mgmt import ConfigMgmtDPB, ConfigMgmt
 from . import mclag
 from . import syslog
 from . import dns
+from . import system
 
 # mock masic APIs for unit test
 try:

--- a/config/main.py
+++ b/config/main.py
@@ -1203,6 +1203,9 @@ config.add_command(syslog.syslog)
 # DNS module
 config.add_command(dns.dns)
 
+# system module
+config.add_command(system.system)
+
 @config.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
                 expose_value=False, prompt='Existing files will be overwritten, continue?')

--- a/config/system.py
+++ b/config/system.py
@@ -1,0 +1,45 @@
+import click
+import utilities_common.cli as clicommon
+import os
+from swsscommon.swsscommon import  ConfigDBConnector
+import subprocess
+
+#
+# 'system' group ("config system ...")
+#
+
+@click.group(cls=clicommon.AliasedGroup)
+def system():
+    """configure system custom parameters"""
+    pass
+
+
+
+@system.command()
+@click.pass_context
+def key(ctx):
+    """ command to add encryption master key"""
+    current_key = subprocess.call('sudo cat /etc/sonic/enc_master_key > /dev/null 2>&1', shell=True)
+    if current_key == 0:
+        click.echo("ERROR: There is already an encryption key configured.",err=True)
+        return
+    click.echo("Enter the new encryption master key:")
+    new_key = click.prompt("",prompt_suffix="")
+    if not is_valid_key(new_key):
+            ctx.fail("ERROR: The key contains unsupported characters. Remove spaces, #, and , from the key.")
+
+    subprocess.call('echo "{}" | sudo tee /etc/sonic/enc_master_key > /dev/null'.format(new_key), shell=True)
+    subprocess.call('sudo chmod 644 /etc/sonic/enc_master_key', shell=True)
+    click.echo("New encryption key stored.")
+
+
+
+def is_valid_key(key):
+    # Define a list of unsupported characters
+    unsupported_characters = [' ', '#', ',']
+    
+    # Check if the key contains any unsupported characters
+    for char in unsupported_characters:
+        if char in key:
+            return False
+    return True

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -165,6 +165,8 @@
 * [Syslog](#syslog)
   * [Syslog show commands](#syslog-show-commands)
   * [Syslog config commands](#syslog-config-commands)
+* [system](#System)
+  * [key](#key-config-Commands)
 * [System State](#system-state)
   * [Processes](#processes)
   * [Services & Memory](#services--memory)
@@ -1571,7 +1573,7 @@ When this command is executed, the configured tacacs+ server addresses are updat
 
 - Usage:
   ```
-  config tacacs add <ip_address> [-t|--timeout <seconds>] [-k|--key <secret>] [-a|--type <type>] [-o|--port <port>] [-p|--pri <priority>] [-m|--use-mgmt-vrf]
+  config tacacs add <ip_address> [-t|--timeout <seconds>] [-k|--key <secret>] [-a|--type <type>] [-o|--port <port>] [-p|--pri <priority>] [-m|--use-mgmt-vrf] [-e|--enc] [-x|--enckey]
   ```
 
   - Parameters:
@@ -1582,11 +1584,15 @@ When this command is executed, the configured tacacs+ server addresses are updat
     - port: TCP port range is 1 to 65535, default 49
     - pri: Priority, priority range 1 to 64, default 1.
     - use-mgmt-vrf: This means that the server is part of Management vrf, default is "no vrf"
+    - enc: Encrypt TACACS key in db and configuration files[nss, PAM]
+    - enckey: used if the admin have an encrypted key and add it as it is "in case of configuration backup restore", but the same master key should be used
 
 
 - Example:
   ```
   admin@sonic:~$ sudo config tacacs add 10.11.12.13 -t 10 -k testing789 -a mschap -o 50 -p 9
+
+  admin@sonic:~$ sudo config tacacs add 10.11.12.13 -t 10 -k testing789 -a mschap -o 50 -p 9 -e
   ```
 
   - Example Server Configuration in /etc/pam.d/common-auth-sonic configuration file:
@@ -1598,9 +1604,12 @@ When this command is executed, the configured tacacs+ server addresses are updat
     auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.0.0.8:49 secret= login=mschap timeout=5  try_first_pass
     auth    [success=done new_authtok_reqd=done default=ignore]     pam_tacplus.so server=10.11.12.13:50 secret=testing789 login=mschap timeout=10  try_first_pass
     auth    [success=1 default=ignore]      pam_unix.so nullok try_first_pass
+    
+    auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=10.11.12.13:49 enc_secret=U2FsdGVkX1+WN1bG7+CYdRv3/BtNyLI9pjj94S5IpLyDBUMjOwV6eKuc94HqTdJUhgMdUvUvDsCU4om1Uvcn63IBh5kpg1OzSe619204CTPQn0EU5fVLFrMYjq87De8g login=pap timeout=5   try_first_pass
     ```
 
     *NOTE: In the above example, the servers are stored (sorted) based on the priority value configured for the server.*
+    *NOTE: In the above last example, when using passkey encryption feature.*
 
 **config tacacs delete**
 
@@ -1653,8 +1662,11 @@ When user has not configured server specific passkey, this global value shall be
 
 - Usage:
   ```
-  config tacacs passkey <pass_key>
+  config tacacs passkey <pass_key> [-e|--enc] [-x|--enckey]
   ```
+  - Parameters:
+    - enc: Encrypt TACACS key in db and configuration files[nss, PAM]
+    - enckey: used if the admin have an encrypted key and add it as it is "in case of configuration backup restore", but the same master key should be used
 
 - Example:
   ```
@@ -10107,6 +10119,14 @@ This command is used to configure syslog rate limit for containers.
 
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#syslog)
+
+## System
+
+### key config Commands
+
+This command is used to configure system encryption key used with TACACS+ server passkey encryption in DB and configration files [nss, pam]
+
+this command generate a file in [/etc/sonic/enc_master_key] to be used as Passphrase source when encrypting TACACS passkey
 
 ## System State
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **


    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add encryption feature used with TACACS+ server passkey configuration

##### another PRs will be submitted to [[sonic-host-services](https://github.com/sonic-net/sonic-host-services)] and [[sonic-buildimage](https://github.com/sonic-net/sonic-buildimage)] to complete the feature 

#### How I did it
By adding optional backward-compatible passkey encryption configuration commands flags
[-e|--enc] [-x|--enckey] 

#### How to verify it
All the following output after the modification is done, also if using clear text passkey the files will have its normal configuration "secret" tag not "enc_secret" as showing here

##### show tacacs
```
TACPLUS_SERVER address 1.1.1.1
               is_key_encrypted True
               passkey U2FsdGVkX1+WN1bG7+CYdRv3/BtNyLI9pjj94S5IpLyDBUMjOwV6eKuc94HqTdJUhgMdUvUvDsCU4om1Uvcn63IBh5kpg1OzSe619204CTPQn0EU5fVLFrMYjq87De8g
               priority 1
               tcp_port 49
               Status UP

```
##### cat /etc/pam.d/common-auth-sonic
```
auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=1.1.1.1:49 enc_secret=U2FsdGVkX1+WN1bG7+CYdRv3/BtNyLI9pjj94S5IpLyDBUMjOwV6eKuc94HqTdJUhgMdUvUvDsCU4om1Uvcn63IBh5kpg1OzSe619204CTPQn0EU5fVLFrMYjq87De8g login=pap timeout=5   try_first_pass
auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass
```
#####  cat /etc/tacplus_nss.conf
```
server=10.1.1.59:49,enc_secret=U2FsdGVkX1+WN1bG7+CYdRv3/BtNyLI9pjj94S5IpLyDBUMjOwV6eKuc94HqTdJUhgMdUvUvDsCU4om1Uvcn63IBh5kpg1OzSe619204CTPQn0EU5fVLFrMYjq87De8g,timeout=5
```


#### Previous command output (if the output of a command-line utility has changed)
##### show tacacs
```
TACPLUS global auth_type pap (default)
TACPLUS global timeout 5 (default)
TACPLUS global passkey sonic

TACPLUS_SERVER address 1.1.1.1
               passkey sonic
               priority 1
               tcp_port 49
               Status UP

```

#### New command output (if the output of a command-line utility has changed)
##### show tacacs
```
TACPLUS global auth_type pap (default)
TACPLUS global timeout 5 (default)
TACPLUS global passkey U2FsdGVkX1/cBBcVuwwJk1TUYPZcUomFNKEfpSJStLg=
TACPLUS global is_key_encrypted True

TACPLUS_SERVER address 1.1.1.1
               is_key_encrypted True
               passkey U2FsdGVkX1+WN1bG7+CYdRv3/BtNyLI9pjj94S5IpLyDBUMjOwV6eKuc94HqTdJUhgMdUvUvDsCU4om1Uvcn63IBh5kpg1OzSe619204CTPQn0EU5fVLFrMYjq87De8g
               priority 1
               tcp_port 49
               Status UP

```
