### PR TITLE
[sonic-package-manager] add generated service to /etc/sonic/generated_services.conf

### DIFF
--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -408,6 +408,7 @@ def sonic_fs(fs):
     fs.create_dir(SYSTEMD_LOCATION)
     fs.create_dir(DOCKER_CTL_SCRIPT_LOCATION)
     fs.create_dir(SERVICE_MGMT_SCRIPT_LOCATION)
+    fs.create_file(GENERATED_SERVICES_CONF_FILE)
     fs.create_file(os.path.join(TEMPLATES_PATH, SERVICE_FILE_TEMPLATE))
     fs.create_file(os.path.join(TEMPLATES_PATH, TIMER_UNIT_TEMPLATE))
     fs.create_file(os.path.join(TEMPLATES_PATH, SERVICE_MGMT_SCRIPT_TEMPLATE))

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -95,6 +95,7 @@ def service_creator(mock_feature_registry,
 
 def test_service_creator(sonic_fs, manifest, service_creator, package_manager):
     entry = PackageEntry('test', 'azure/sonic-test')
+    manifest['service']['asic-service'] = True
     package = Package(entry, Metadata(manifest))
     installed_packages = package_manager._get_installed_packages_and(package)
     service_creator.create(package)
@@ -112,6 +113,7 @@ def test_service_creator(sonic_fs, manifest, service_creator, package_manager):
     assert read_file('warm-reboot_order') == 'swss teamd test syncd'
     assert read_file('fast-reboot_order') == 'teamd test swss syncd'
     assert read_file('test_reconcile') == 'test-process test-process-3'
+    assert set(read_file('generated_services.conf').split()) == set(['test.service', 'test@.service'])
 
 
 def test_service_creator_with_timer_unit(sonic_fs, manifest, service_creator):


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed an issue that after install new image the extension service isn't started immidetally at boot but when hostcfgd starts it.

#### How I did it

There is systemd-sonic-generator that enables services listed in /etc/sonic/generated_services.conf. Add extension service to the list as well.

#### How to verify it

Build image and run, verify extension starts at boot and not by hostcfgd.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

