### PR TITLE
[sonic-package-manager] insert newline in /etc/sonic/generated_services.conf

### DIFF
--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -352,6 +352,7 @@ class ServiceCreator:
         # Write to tmp file and replace the original file with it
         with tempfile.NamedTemporaryFile('w', delete=False) as tmp:
             tmp.write('\n'.join(list_of_services))
+            tmp.write('\n')
             tmp.flush()
 
             shutil.move(tmp.name, GENERATED_SERVICES_CONF_FILE)

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -113,7 +113,10 @@ def test_service_creator(sonic_fs, manifest, service_creator, package_manager):
     assert read_file('warm-reboot_order') == 'swss teamd test syncd'
     assert read_file('fast-reboot_order') == 'teamd test swss syncd'
     assert read_file('test_reconcile') == 'test-process test-process-3'
-    assert set(read_file('generated_services.conf').split()) == set(['test.service', 'test@.service'])
+
+    generated_services_conf_content = read_file('generated_services.conf')
+    assert generated_services_conf_content.endswith('\n')
+    assert set(generated_services_conf_content.split()) == set(['test.service', 'test@.service'])
 
 
 def test_service_creator_with_timer_unit(sonic_fs, manifest, service_creator):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This issue is seen during upgrade from older branches to 202305 with PR https://github.com/sonic-net/sonic-utilities/pull/3037.

When sonic-package-manager installs an extension it re-generates /etc/sonic/generated_services.conf. The file does not contain newline at the end.

If packages are installed at runtime everything is ok, but when they are installed at build time, /etc/sonic/generated_services.conf gets later appended with new services:

```
echo "{{service}}" | sudo tee -a $GENERATED_SERVICE_FILE
```

It results in having this line in /etc/sonic/generated_services.conf:

```
interfaces-config.servicedatabase.service
```

This pattern is used multiple times in sonic_debian_extension.j2 script, thus fixing it in sonic-utilities.

#### How I did it

Added \n at the end of generated_services.conf

#### How to verify it

Build with app.ext integrated, make sure /etc/sonic/generated_services.conf is correct.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

