### PR TITLE
Default value of global passkey in TACACS and RADIUS to be removed in show command output

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1874,8 +1874,7 @@ def tacacs():
     tacplus = {
         'global': {
             'auth_type': 'pap (default)',
-            'timeout': '5 (default)',
-            'passkey': '<EMPTY_STRING> (default)'
+            'timeout': '5 (default)'
         }
     }
     if 'global' in data:
@@ -1904,8 +1903,7 @@ def radius(db):
         'global': {
             'auth_type': 'pap (default)',
             'retransmit': '3 (default)',
-            'timeout': '5 (default)',
-            'passkey': '<EMPTY_STRING> (default)'
+            'timeout': '5 (default)'
         }
     }
     if 'global' in data:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Removed the displaying of default passkey in TACACS and RADIUS
#### How I did it
As there is no default value for global passkey (in TACACS and RADIUS), displaying the passkey as "EMPTY_STRING" is misleading. Hence removed them from show command output.
#### How to verify it
Execute show tacacs/show radius commands 

#### Previous command output (if the output of a command-line utility has changed)
admin@sonic:~$ show radius
```
RADIUS global auth_type pap (default)
RADIUS global retransmit 3 (default)
RADIUS global timeout 5 (default)
RADIUS global passkey <EMPTY_STRING> (default)

admin@sonic:~$ show tacacs
TACPLUS global auth_type pap (default)
TACPLUS global timeout 5 (default)
TACPLUS global passkey <EMPTY_STRING> (default)
```

#### New command output (if the output of a command-line utility has changed)
```
RADIUS global auth_type pap (default)
RADIUS global retransmit 3 (default)
RADIUS global timeout 5 (default)

admin@sonic:~$ show tacacs
TACPLUS global auth_type pap (default)
TACPLUS global timeout 5 (default)
```