### PR TITLE
kdump load fail

### DIFF
--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -391,6 +391,7 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file)
         if crash_kernel_mem == memory:
             if crash_kernel_mem == crash_kernel_in_cmdline:
                 print("kdump is already enabled")
+                return changed
             else:
                 changed = True
         else:
@@ -401,6 +402,11 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file)
 
     if changed:
         rewrite_cfg(lines, cmdline_file)
+
+    # if kdump is enabled but cfg is changed, unload kdump before re-writng kdump memory
+    if get_kdump_oper_mode(get_kdump_administrative_mode()) == 'Ready' and changed:
+        print("unload kdump before re-writng kdump memory")
+        write_use_kdump(0)
 
     write_use_kdump(1)
     if crash_kernel_in_cmdline is not None:


### PR DESCRIPTION
    Root Cause:
        1. Cannot change symbolic links when kdump is loaded

    Solution:
        1.if kdump is already enabled and crash_kernel_mem is configurated, kdump should not be reload again before unload

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

