### PR TITLE
route_check - get ROUTE_TABLE content fail - patch

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -356,6 +356,12 @@ def filter_out_local_interfaces(keys):
     tbl = swsscommon.Table(db, 'ROUTE_TABLE')
 
     for k in keys:
+        if tbl.get(k)[0] == False:
+            # ISU2023101259067, if kernel route prefix is xxxx::yy/128, fpmsyncd will write ROUTE_TABLE:xxxx::yy without /128 to apll db
+            # then, tbl.get(k) will get content fail because of missing key
+            if "/128" in k:
+                k = k.split("/")[0]
+
         e = dict(tbl.get(k)[1])
 
         ifname = e.get('ifname', '')


### PR DESCRIPTION
    Root Cause:
        1. Not all /128 routes can be removed and should be treated as special

    Solution:
        1. only remove /128 when tbl.get(k)[0] == False

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

