### PR TITLE
Make PFC commands use a class

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -8,153 +8,161 @@ from natsort import natsorted
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
 
-def configPfcAsym(interface, pfc_asym):
-    """
-    PFC handler to configure asymmentric PFC.
-    """
-    configdb = ConfigDBConnector()
-    configdb.connect()
+class Pfc(object):
+    def configPfcAsym(self, interface, pfc_asym):
+        """
+        PFC handler to configure asymmentric PFC.
+        """
+        configdb = ConfigDBConnector()
+        configdb.connect()
 
-    configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
+        configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
 
 
-def showPfcAsym(interface):
-    """
-    PFC handler to display asymmetric PFC information.
-    """
-    header = ('Interface', 'Asymmetric')
+    def showPfcAsym(self, interface):
+        """
+        PFC handler to display asymmetric PFC information.
+        """
+        header = ('Interface', 'Asymmetric')
 
-    configdb = ConfigDBConnector()
-    configdb.connect()
+        configdb = ConfigDBConnector()
+        configdb.connect()
 
-    if interface:
-        db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|{0}'.format(interface))
-    else:
-        db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|*')
+        if interface:
+            db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|{0}'.format(interface))
+        else:
+            db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|*')
 
-    table = []
+        table = []
+
+        for i in db_keys or [None]:
+            key = None
+            if i:
+                key = i.split('|')[-1]
+
+            if key and key.startswith('Ethernet'):
+                entry = configdb.get_entry('PORT', key)
+                table.append([key, entry.get('pfc_asym', 'N/A')])
+
+        sorted_table = natsorted(table)
+
+        click.echo()
+        click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
+        click.echo()
+
+    def configPfcPrio(self, status, interface, priority):
+        configdb = ConfigDBConnector()
+        configdb.connect()
+
+        if interface not in configdb.get_keys('PORT_QOS_MAP'):
+            click.echo('Cannot find interface {0}'.format(interface))
+            return
+
+        """Current lossless priorities on the interface"""
+        entry = configdb.get_entry('PORT_QOS_MAP', interface)
+        enable_prio = entry.get('pfc_enable').split(',')
+
+        """Avoid '' in enable_prio"""
+        enable_prio = [x.strip() for x in enable_prio if x.strip()]
+
+        if status == 'on' and priority in enable_prio:
+            click.echo('Priority {0} has already been enabled on {1}'.format(priority, interface))
+            return
+
+        if status == 'off' and priority not in enable_prio:
+            click.echo('Priority {0} is not enabled on {1}'.format(priority, interface))
+            return
+
+        if status == 'on':
+            enable_prio.append(priority)
+
+        else:
+            enable_prio.remove(priority)
+
+        enable_prio.sort()
+        configdb.mod_entry("PORT_QOS_MAP", interface, {'pfc_enable': ','.join(enable_prio)})
+
+        """Show the latest PFC configuration"""
+        self.showPfcPrio(interface)
         
-    for i in db_keys or [None]:
-        key = None 
-        if i:
-            key = i.split('|')[-1]
+    def showPfcPrio(self, interface):
+        """
+        PFC handler to display PFC enabled priority information.
+        """
+        header = ('Interface', 'Lossless priorities')
+        table = []
 
-        if key and key.startswith('Ethernet'):
-            entry = configdb.get_entry('PORT', key)
-            table.append([key, entry.get('pfc_asym', 'N/A')])
+        configdb = ConfigDBConnector()
+        configdb.connect()
 
-    sorted_table = natsorted(table)
+        """Get all the interfaces with QoS map information"""
+        intfs = configdb.get_keys('PORT_QOS_MAP')
 
-    click.echo()
-    click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
-    click.echo()
+        """The user specifies an interface but we cannot find it"""
+        if interface and interface not in intfs:
+            click.echo('Cannot find interface {0}'.format(interface))
+            return
 
-def configPfcPrio(status, interface, priority):
-    configdb = ConfigDBConnector()
-    configdb.connect()
+        if interface:
+            intfs = [interface]
 
-    if interface not in configdb.get_keys('PORT_QOS_MAP'):
-        click.echo('Cannot find interface {0}'.format(interface))
-        return 
+        for intf in intfs:
+            entry = configdb.get_entry('PORT_QOS_MAP', intf)
+            table.append([intf, entry.get('pfc_enable', 'N/A')])
 
-    """Current lossless priorities on the interface""" 
-    entry = configdb.get_entry('PORT_QOS_MAP', interface)
-    enable_prio = entry.get('pfc_enable').split(',')
-    
-    """Avoid '' in enable_prio"""
-    enable_prio = [x.strip() for x in enable_prio if x.strip()]
-    
-    if status == 'on' and priority in enable_prio:
-        click.echo('Priority {0} has already been enabled on {1}'.format(priority, interface))
-        return
-    
-    if status == 'off' and priority not in enable_prio:
-        click.echo('Priority {0} is not enabled on {1}'.format(priority, interface))
-        return
-    
-    if status == 'on':
-        enable_prio.append(priority)
-    
-    else:
-        enable_prio.remove(priority)
-     
-    enable_prio.sort()    
-    configdb.mod_entry("PORT_QOS_MAP", interface, {'pfc_enable': ','.join(enable_prio)})
-    
-    """Show the latest PFC configuration"""
-    showPfcPrio(interface)
-     
-def showPfcPrio(interface):
-    """
-    PFC handler to display PFC enabled priority information.
-    """
-    header = ('Interface', 'Lossless priorities')
-    table = []
-        
-    configdb = ConfigDBConnector()
-    configdb.connect()
-    
-    """Get all the interfaces with QoS map information"""
-    intfs = configdb.get_keys('PORT_QOS_MAP')
-    
-    """The user specifies an interface but we cannot find it"""    
-    if interface and interface not in intfs:
-        click.echo('Cannot find interface {0}'.format(interface))
-        return 
-    
-    if interface:
-        intfs = [interface]
-    
-    for intf in intfs: 
-        entry = configdb.get_entry('PORT_QOS_MAP', intf)
-        table.append([intf, entry.get('pfc_enable', 'N/A')])
-    
-    sorted_table = natsorted(table)
-    click.echo()
-    click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
-    click.echo()
+        sorted_table = natsorted(table)
+        click.echo()
+        click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
+        click.echo()
     
 @click.group()
-def cli():
+@click.pass_context
+def cli(ctx):
     """PFC Command Line"""
-    pass
+    ctx.obj = { 'pfc': Pfc() }
 
 @cli.group()
-def config():
+@click.pass_context
+def config(ctx):
     """Config PFC"""
     pass
 
 @cli.group()
-def show():
+@click.pass_context
+def show(ctx):
     """Show PFC information"""
     pass
 
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
-def configAsym(status, interface):
+@click.pass_context
+def configAsym(ctx, status, interface):
     """Configure asymmetric PFC on a given port."""
-    configPfcAsym(interface, status)
+    ctx.obj['pfc'].configPfcAsym(interface, status)
 
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
 @click.argument('priority', type=click.Choice(ALL_PRIORITIES))
-def configPrio(status, interface, priority):
+@click.pass_context
+def configPrio(ctx, status, interface, priority):
     """Configure PFC on a given priority."""
-    configPfcPrio(status, interface, priority)
-    
-@click.command()
-@click.argument('interface', type=click.STRING, required=False)
-def showAsym(interface):
-    """Show asymmetric PFC information"""
-    showPfcAsym(interface)
+    ctx.obj['pfc'].configPfcPrio(status, interface, priority)
 
 @click.command()
 @click.argument('interface', type=click.STRING, required=False)
-def showPrio(interface):
+@click.pass_context
+def showAsym(ctx, interface):
+    """Show asymmetric PFC information"""
+    ctx.obj['pfc'].showPfcAsym(interface)
+
+@click.command()
+@click.argument('interface', type=click.STRING, required=False)
+@click.pass_context
+def showPrio(ctx, interface):
     """Show PFC priority information"""
-    showPfcPrio(interface)
+    ctx.obj['pfc'].showPfcPrio(interface)
 
 config.add_command(configAsym, "asymmetric")
 config.add_command(configPrio, "priority")

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -5,8 +5,6 @@ import click
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted
-from importlib import reload
-from utilities_common import multi_asic as multi_asic_util
 
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
@@ -22,10 +20,10 @@ except KeyError:
     pass
 
 class Pfc(object):
+
     def __init__(self, db=None):
         self.db = None
         self.cfgdb = db
-        self.multi_asic = multi_asic_util.MultiAsic()
 
     def configPfcAsym(self, interface, pfc_asym):
         """
@@ -34,10 +32,7 @@ class Pfc(object):
 
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
@@ -53,10 +48,7 @@ class Pfc(object):
 
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         if interface:
@@ -84,10 +76,7 @@ class Pfc(object):
     def configPfcPrio(self, status, interface, priority):
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         if interface not in configdb.get_keys('PORT_QOS_MAP'):
@@ -130,10 +119,7 @@ class Pfc(object):
 
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         """Get all the interfaces with QoS map information"""
@@ -162,7 +148,7 @@ def cli(ctx):
     # Use the db object if given as input.
     db = None if ctx.obj is None else ctx.obj.cfgdb
     """PFC Command Line"""
-    ctx.obj = { 'pfc': Pfc(db) }
+    ctx.obj = {'pfc': Pfc(db)}
 
 @cli.group()
 @click.pass_context

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,23 +1,11 @@
 #!/usr/bin/env python3
 import click
-import os
-import sys
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted
 
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
-
-# mock the redis for unit test purposes #
-try:
-    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
-        modules_path = os.path.join(os.path.dirname(__file__), "..")
-        tests_path = os.path.join(modules_path, "tests")
-        sys.path.insert(0, modules_path)
-        sys.path.insert(0, tests_path)
-except KeyError:
-    pass
 
 
 class Pfc(object):
@@ -32,9 +20,6 @@ class Pfc(object):
         configdb.connect()
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
-
-        if "UTILITIES_UNIT_TESTING" in os.environ and os.environ["UTILITIES_UNIT_TESTING"] == "2":
-            self.showPfcAsym(interface)
 
     def showPfcAsym(self, interface):
         """

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -21,6 +21,7 @@ except KeyError:
 
 class Pfc(object):
 
+
     def __init__(self, db=None):
         self.db = None
         self.cfgdb = db

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -21,20 +21,15 @@ except KeyError:
 
 
 class Pfc(object):
-
-    def __init__(self, db=None):
-        self.db = None
-        self.cfgdb = db
+    def __init__(self, cfgdb=None):
+        self.cfgdb = cfgdb
 
     def configPfcAsym(self, interface, pfc_asym):
         """
         PFC handler to configure asymmetric PFC.
         """
-
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
 
@@ -47,10 +42,8 @@ class Pfc(object):
         """
         header = ('Interface', 'Asymmetric')
 
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         if interface:
             db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|{0}'.format(interface))
@@ -75,10 +68,8 @@ class Pfc(object):
         click.echo()
 
     def configPfcPrio(self, status, interface, priority):
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         if interface not in configdb.get_keys('PORT_QOS_MAP'):
             click.echo('Cannot find interface {0}'.format(interface))
@@ -118,10 +109,8 @@ class Pfc(object):
         header = ('Interface', 'Lossless priorities')
         table = []
 
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         """Get all the interfaces with QoS map information"""
         intfs = configdb.get_keys('PORT_QOS_MAP')
@@ -146,10 +135,11 @@ class Pfc(object):
 @click.group()
 @click.pass_context
 def cli(ctx):
-    # Use the db object if given as input.
-    db = None if ctx.obj is None else ctx.obj.cfgdb
     """PFC Command Line"""
-    ctx.obj = {'pfc': Pfc(db)}
+    # Use the cfgdb object if given as input.
+    cfgdb = None if ctx.obj is None else ctx.obj.cfgdb
+
+    ctx.obj = {'pfc': Pfc(cfgdb)}
 
 @cli.group()
 @click.pass_context

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -19,8 +19,8 @@ try:
 except KeyError:
     pass
 
-class Pfc(object):
 
+class Pfc(object):
 
     def __init__(self, db=None):
         self.db = None

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,12 +1,24 @@
 #!/usr/bin/env python3
-
+import os
+import sys
 import click
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted
+from importlib import reload
 
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
+
+# mock the redis for unit test purposes #
+try:
+    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
+        modules_path = os.path.join(os.path.dirname(__file__), "..")
+        tests_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, tests_path)
+except KeyError:
+    pass
 
 class Pfc(object):
     def configPfcAsym(self, interface, pfc_asym):
@@ -18,6 +30,8 @@ class Pfc(object):
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
 
+        if "UTILITIES_UNIT_TESTING" in os.environ and os.environ["UTILITIES_UNIT_TESTING"] == "2":
+            self.showPfcAsym(interface)
 
     def showPfcAsym(self, interface):
         """

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import click
 import os
 import sys
-import click
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted

--- a/tests/pfc_input/assert_show_output.py
+++ b/tests/pfc_input/assert_show_output.py
@@ -1,3 +1,10 @@
+pfc_asym_cannot_find_intf = """\
+
+Interface    Asymmetric
+-----------  ------------
+
+"""
+
 pfc_cannot_find_intf = """\
 Cannot find interface Ethernet1234
 """

--- a/tests/pfc_input/assert_show_output.py
+++ b/tests/pfc_input/assert_show_output.py
@@ -73,14 +73,6 @@ Ethernet0    3,4
 
 """
 
-pfc_config_asymmetric = """\
-
-Interface    Asymmetric
------------  ------------
-Ethernet0    on
-
-"""
-
 pfc_config_priority_on = """\
 
 Interface    Lossless priorities

--- a/tests/pfc_input/assert_show_output.py
+++ b/tests/pfc_input/assert_show_output.py
@@ -1,0 +1,83 @@
+pfc_cannot_find_intf = """\
+Cannot find interface Ethernet1234
+"""
+
+pfc_show_asymmetric_all = """\
+
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    off
+Ethernet4    off
+Ethernet8    off
+Ethernet12   off
+Ethernet16   off
+Ethernet20   off
+Ethernet24   off
+Ethernet28   off
+Ethernet32   off
+Ethernet36   off
+Ethernet40   off
+Ethernet44   off
+Ethernet48   off
+Ethernet52   off
+Ethernet56   off
+Ethernet60   off
+Ethernet64   off
+Ethernet68   off
+Ethernet72   off
+Ethernet76   off
+Ethernet80   off
+Ethernet84   off
+Ethernet88   off
+Ethernet92   off
+Ethernet96   off
+Ethernet100  off
+Ethernet104  off
+Ethernet108  off
+Ethernet112  off
+Ethernet116  off
+Ethernet120  off
+Ethernet124  off
+
+"""
+
+pfc_show_asymmetric_intf = """\
+
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    off
+
+"""
+
+pfc_show_priority_all = """\
+
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4
+Ethernet4    3,4
+
+"""
+
+pfc_show_priority_intf = """\
+
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4
+
+"""
+
+pfc_config_asymmetric = """\
+
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    on
+
+"""
+
+pfc_config_priority_on = """\
+
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4,5
+
+"""

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import pfc.main as pfc
+from pfc_input.assert_show_output import *
+
+from click.testing import CliRunner
+from importlib import reload
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "pfc")
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+class TestPfcBase(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
+        result = runner.invoke(command, args)
+        print(result.exit_code)
+        print(result.output)
+
+        if result.exit_code != expected_rc:
+            print(result.exception)
+
+        assert result.exit_code == expected_rc
+        if expected_output:
+            assert result.output == expected_output
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        print("TEARDOWN")
+
+class TestPfc(TestPfcBase):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        from mock_tables import dbconnector
+        from mock_tables import mock_single_asic
+        reload(mock_single_asic)
+        dbconnector.load_namespace_config()
+
+    def test_pfc_show_asymmetric_all(self):
+        self.executor(pfc.cli, ['show', 'asymmetric'],
+                      expected_output=pfc_show_asymmetric_all)
+
+    def test_pfc_show_asymmetric_intf(self):
+        self.executor(pfc.cli, ['show', 'asymmetric', 'Ethernet0'],
+                      expected_output=pfc_show_asymmetric_intf)
+
+    def test_pfc_show_asymmetric_intf_fake(self):
+        self.executor(pfc.cli, ['show', 'asymmetric', 'Ethernet1234'],
+                      expected_output=pfc_cannot_find_intf)
+
+    def test_pfc_show_priority_all(self):
+        self.executor(pfc.cli, ['show', 'priority'],
+                      expected_output=pfc_show_priority_all)
+
+    def test_pfc_show_priority_intf(self):
+        self.executor(pfc.cli, ['show', 'priority', 'Ethernet0'],
+                      expected_output=pfc_show_priority_intf)
+
+    def test_pfc_show_asymmetric_intf_fake(self):
+        self.executor(pfc.cli, ['show', 'priority', 'Ethernet1234'],
+                      expected_output=pfc_cannot_find_intf)
+
+    def test_pfc_config_asymmetric(self):
+        self.executor(pfc.cli, ['config', 'asymmetric', 'on', 'Ethernet0'],
+                      expected_output=pfc_config_asymmetric)
+
+    def test_pfc_config_priority(self):
+        self.executor(pfc.cli, ['config', 'priority', 'on', 'Ethernet0', '5'],
+                      expected_output=pfc_config_priority_on)

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -2,6 +2,7 @@ import os
 import sys
 import pfc.main as pfc
 from pfc_input.assert_show_output import *
+from utilities_common.db import Db
 
 from click.testing import CliRunner
 from importlib import reload
@@ -20,7 +21,9 @@ class TestPfcBase(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
 
     def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
-        result = runner.invoke(command, args)
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        result = runner.invoke(command, args, obj=db)
         print(result.exit_code)
         print(result.output)
 

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,7 +1,9 @@
 import os
 import sys
 import pfc.main as pfc
-from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, pfc_config_asymmetric, pfc_config_priority_on
+from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
+   pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, \
+   pfc_config_asymmetric, pfc_config_priority_on
 from utilities_common.db import Db
 
 from click.testing import CliRunner
@@ -14,6 +16,7 @@ sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
 class TestPfcBase(object):
+
 
     @classmethod
     def setup_class(cls):
@@ -41,6 +44,7 @@ class TestPfcBase(object):
         print("TEARDOWN")
 
 class TestPfc(TestPfcBase):
+
 
     @classmethod
     def setup_class(cls):

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pfc.main as pfc
-from pfc_input.assert_show_output import *
+from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, pfc_config_asymmetric, pfc_config_priority_on
 from utilities_common.db import Db
 
 from click.testing import CliRunner
@@ -14,6 +14,7 @@ sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
 class TestPfcBase(object):
+
     @classmethod
     def setup_class(cls):
         print("SETUP")
@@ -22,7 +23,6 @@ class TestPfcBase(object):
 
     def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
         db = Db()
-        obj = {'config_db':db.cfgdb}
         result = runner.invoke(command, args, obj=db)
         print(result.exit_code)
         print(result.output)
@@ -41,6 +41,7 @@ class TestPfcBase(object):
         print("TEARDOWN")
 
 class TestPfc(TestPfcBase):
+
     @classmethod
     def setup_class(cls):
         super().setup_class()
@@ -69,7 +70,7 @@ class TestPfc(TestPfcBase):
         self.executor(pfc.cli, ['show', 'priority', 'Ethernet0'],
                       expected_output=pfc_show_priority_intf)
 
-    def test_pfc_show_asymmetric_intf_fake(self):
+    def test_pfc_show_priority_intf_fake(self):
         self.executor(pfc.cli, ['show', 'priority', 'Ethernet1234'],
                       expected_output=pfc_cannot_find_intf)
 

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -15,8 +15,8 @@ scripts_path = os.path.join(modules_path, "pfc")
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
-class TestPfcBase(object):
 
+class TestPfcBase(object):
 
     @classmethod
     def setup_class(cls):
@@ -43,8 +43,8 @@ class TestPfcBase(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
         print("TEARDOWN")
 
-class TestPfc(TestPfcBase):
 
+class TestPfc(TestPfcBase):
 
     @classmethod
     def setup_class(cls):

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -3,7 +3,7 @@ import sys
 import pfc.main as pfc
 from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
    pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, \
-   pfc_config_asymmetric, pfc_config_priority_on
+   pfc_config_asymmetric, pfc_config_priority_on, pfc_asym_cannot_find_intf
 from utilities_common.db import Db
 
 from click.testing import CliRunner

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -24,9 +24,9 @@ class TestPfcBase(object):
         os.environ["PATH"] += os.pathsep + scripts_path
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
 
-    def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
+    def executor(self, cliobj, command, expected_rc=0, expected_output=None, runner=CliRunner()):
         db = Db()
-        result = runner.invoke(command, args, obj=db)
+        result = runner.invoke(cliobj, command, obj=db)
         print(result.exit_code)
         print(result.output)
 

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import pfc.main as pfc
-from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
+from .pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
    pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, \
-   pfc_config_asymmetric, pfc_config_priority_on, pfc_asym_cannot_find_intf
+   pfc_config_priority_on, pfc_asym_cannot_find_intf
 from utilities_common.db import Db
 
 from click.testing import CliRunner
@@ -18,13 +18,8 @@ sys.path.insert(0, modules_path)
 
 class TestPfcBase(object):
 
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
-        os.environ["PATH"] += os.pathsep + scripts_path
-        os.environ['UTILITIES_UNIT_TESTING'] = "2"
-
-    def executor(self, cliobj, command, expected_rc=0, expected_output=None, runner=CliRunner()):
+    def executor(self, cliobj, command, expected_rc=0, expected_output=None, expected_cfgdb_entry=None,
+                 runner=CliRunner()):
         db = Db()
         result = runner.invoke(cliobj, command, obj=db)
         print(result.exit_code)
@@ -32,23 +27,22 @@ class TestPfcBase(object):
 
         if result.exit_code != expected_rc:
             print(result.exception)
-
         assert result.exit_code == expected_rc
+
         if expected_output:
             assert result.output == expected_output
 
-    @classmethod
-    def teardown_class(cls):
-        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
-        os.environ["UTILITIES_UNIT_TESTING"] = "0"
-        print("TEARDOWN")
+        if expected_cfgdb_entry:
+            (table, key, field, expected_val) = expected_cfgdb_entry
+            configdb = db.cfgdb
+            entry = configdb.get_entry(table, key)
+            assert entry.get(field) == expected_val
 
 
 class TestPfc(TestPfcBase):
 
     @classmethod
     def setup_class(cls):
-        super().setup_class()
         from mock_tables import dbconnector
         from mock_tables import mock_single_asic
         reload(mock_single_asic)
@@ -80,7 +74,7 @@ class TestPfc(TestPfcBase):
 
     def test_pfc_config_asymmetric(self):
         self.executor(pfc.cli, ['config', 'asymmetric', 'on', 'Ethernet0'],
-                      expected_output=pfc_config_asymmetric)
+                      expected_cfgdb_entry=('PORT', 'Ethernet0', 'pfc_asym', 'on'))
 
     def test_pfc_config_priority(self):
         self.executor(pfc.cli, ['config', 'priority', 'on', 'Ethernet0', '5'],

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -64,7 +64,7 @@ class TestPfc(TestPfcBase):
 
     def test_pfc_show_asymmetric_intf_fake(self):
         self.executor(pfc.cli, ['show', 'asymmetric', 'Ethernet1234'],
-                      expected_output=pfc_cannot_find_intf)
+                      expected_output=pfc_asym_cannot_find_intf)
 
     def test_pfc_show_priority_all(self):
         self.executor(pfc.cli, ['show', 'priority'],


### PR DESCRIPTION
#### What I did
This change puts contents originally in pfc/main.py into a class, to support the usage of the multi-asic helper in a future change. This change is required, as multi-asic helper being used expects members `self.config_db` and `self.db` to exist when a function with the decorator `run_on_multi_asic` is called. The multi-asic class helper will be used to add multi-asic support to pfc commands in a following pull request.

This is a part of the set of changes being pushed for https://github.com/sonic-net/sonic-buildimage/issues/15148

#### How I did it
Moved contents of PFC commands into a class. There are no functional changes.
