### PR TITLE
Fix multi-asic behaviour for mmuconfig

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6425,13 +6425,26 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, verbos
 @config.command()
 @click.option('-p', metavar='<profile_name>', type=str, required=True, help="Profile name")
 @click.option('-a', metavar='<alpha>', type=click.IntRange(-8,8), help="Set alpha for profile type dynamic")
-@click.option('-s', metavar='<staticth>', type=int, help="Set staticth for profile type static")
-def mmu(p, a, s):
+@click.option('-s', metavar='<staticth>', type=click.IntRange(min=0), help="Set staticth for profile type static")
+@click.option('--verbose', '-vv', is_flag=True, help="Enable verbose output")
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def mmu(p, a, s, namespace, verbose):
     """mmuconfig configuration tasks"""
     log.log_info("'mmuconfig -p {}' executing...".format(p))
     command = ['mmuconfig', '-p', str(p)]
     if a is not None: command += ['-a', str(a)]
     if s is not None: command += ['-s', str(s)]
+    if namespace is not None:
+        command += ['-n', str(namespace)]
+    if verbose:
+        command += ['-vv']
     clicommon.run_command(command)
 
 

--- a/scripts/mmuconfig
+++ b/scripts/mmuconfig
@@ -22,6 +22,8 @@ import argparse
 import tabulate
 import traceback
 import json
+from utilities_common.general import load_db_config
+from sonic_py_common import multi_asic
 
 BUFFER_POOL_TABLE_NAME = "BUFFER_POOL"
 BUFFER_PROFILE_TABLE_NAME = "BUFFER_PROFILE"
@@ -42,24 +44,29 @@ try:
         sys.path.insert(0, modules_path)
         sys.path.insert(0, tests_path)
         import mock_tables.dbconnector
-
+    if os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] == "multi_asic":
+        import mock_tables.mock_multi_asic
+        mock_tables.dbconnector.load_namespace_config()
 except KeyError:
     pass
 
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 
 class MmuConfig(object):
-    def __init__(self, verbose, config, filename):
+    def __init__(self, verbose, config, filename, namespace):
         self.verbose = verbose
         self.config = config
         self.filename = filename
+        self.namespace = namespace
+
+        self.use_unix_socket_path = self.namespace != None
 
         # Set up db connections
         if self.config:
-            self.db = ConfigDBConnector()
+            self.db = ConfigDBConnector(namespace=namespace, use_unix_socket_path=self.use_unix_socket_path)
             self.db.connect()
         else:
-            self.db = SonicV2Connector(use_unix_socket_path=False)
+            self.db = SonicV2Connector(namespace=namespace, use_unix_socket_path=self.use_unix_socket_path)
             self.db.connect(self.db.STATE_DB, False)
 
     def get_table(self, tablename):
@@ -67,13 +74,17 @@ class MmuConfig(object):
             return self.db.get_table(tablename)
 
         entries = {}
-        keys = self.db.keys(self.db.STATE_DB, tablename + '*')
+        for ns in multi_asic.get_namespace_list(self.namespace):
+            db = SonicV2Connector(namespace=ns, use_unix_socket_path=True)
+            db.connect(db.STATE_DB, False)
+            keys = db.keys(db.STATE_DB, tablename + '*')
 
-        if not keys:
+            if keys:
+                for key in keys:
+                    entries[key.split('|')[1]] = db.get_all(db.STATE_DB, key)
+
+        if not entries:
             return None
-
-        for key in keys:
-            entries[key.split('|')[1]] = self.db.get_all(self.db.STATE_DB, key)
 
         return entries
 
@@ -120,6 +131,9 @@ class MmuConfig(object):
         if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
             sys.exit("Root privileges required for this operation")
 
+        if not self.namespace and multi_asic.is_multi_asic():
+            sys.exit("Namespace must be specified for this operation")
+
         field = BUFFER_PROFILE_FIELDS[field_alias]
         buf_profs = self.db.get_table(BUFFER_PROFILE_TABLE_NAME)
         v = int(value)
@@ -164,6 +178,7 @@ def main(config):
         parser.add_argument('-l', '--list', action='store_true', help='show buffer state')
         parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
 
+    parser.add_argument('-n', '--namespace', type=str, help='Namespace name', default=None)
     parser.add_argument('-vv', '--verbose', action='store_true', help='verbose output', default=False)
     parser.add_argument('-f', '--filename', help='file used by mock tests', type=str, default=None)
 
@@ -174,7 +189,14 @@ def main(config):
     args = parser.parse_args()
 
     try:
-        mmu_cfg = MmuConfig(args.verbose, config, args.filename)
+        load_db_config()
+        namespaces = multi_asic.get_namespace_list()
+
+        if args.namespace and args.namespace not in namespaces:
+            print("Invalid namespace: Namespace must be one of", *namespaces)
+            sys.exit(1)
+
+        mmu_cfg = MmuConfig(args.verbose, config, args.filename, args.namespace)
         if args.list:
             mmu_cfg.list()
         elif config and args.profile:

--- a/scripts/mmuconfig
+++ b/scripts/mmuconfig
@@ -18,19 +18,23 @@ optional arguments:
 
 import os
 import sys
-import argparse
+import click
 import tabulate
 import traceback
 import json
 from utilities_common.general import load_db_config
 from sonic_py_common import multi_asic
+from utilities_common import multi_asic as multi_asic_util
 
 BUFFER_POOL_TABLE_NAME = "BUFFER_POOL"
 BUFFER_PROFILE_TABLE_NAME = "BUFFER_PROFILE"
 DEFAULT_LOSSLESS_BUFFER_PARAMETER_NAME = "DEFAULT_LOSSLESS_BUFFER_PARAMETER"
 
 DYNAMIC_THRESHOLD = "dynamic_th"
+DYNAMIC_THRESHOLD_MIN = -8
+DYNAMIC_THRESHOLD_MAX = 8
 STATIC_THRESHOLD = "static_th"
+STATIC_THRESHOLD_MIN = 0
 BUFFER_PROFILE_FIELDS = {
     "alpha": DYNAMIC_THRESHOLD,
     "staticth" : STATIC_THRESHOLD
@@ -47,6 +51,9 @@ try:
     if os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] == "multi_asic":
         import mock_tables.mock_multi_asic
         mock_tables.dbconnector.load_namespace_config()
+    else:
+        mock_tables.dbconnector.load_database_config()
+
 except KeyError:
     pass
 
@@ -58,43 +65,37 @@ class MmuConfig(object):
         self.config = config
         self.filename = filename
         self.namespace = namespace
+        self.multi_asic = multi_asic_util.MultiAsic(namespace_option=namespace)
+        self.config_db = None
+        self.db = None
 
-        self.use_unix_socket_path = self.namespace != None
-
-        # Set up db connections
-        if self.config:
-            self.db = ConfigDBConnector(namespace=namespace, use_unix_socket_path=self.use_unix_socket_path)
-            self.db.connect()
-        else:
-            self.db = SonicV2Connector(namespace=namespace, use_unix_socket_path=self.use_unix_socket_path)
-            self.db.connect(self.db.STATE_DB, False)
+        # For unit testing
+        self.updated_profile_table = {}
 
     def get_table(self, tablename):
         if self.config:
-            return self.db.get_table(tablename)
+            return self.config_db.get_table(tablename)
 
         entries = {}
-        for ns in multi_asic.get_namespace_list(self.namespace):
-            db = SonicV2Connector(namespace=ns, use_unix_socket_path=True)
-            db.connect(db.STATE_DB, False)
-            keys = db.keys(db.STATE_DB, tablename + '*')
+        keys = self.db.keys(self.db.STATE_DB, tablename + '*')
 
-            if keys:
-                for key in keys:
-                    entries[key.split('|')[1]] = db.get_all(db.STATE_DB, key)
-
-        if not entries:
+        if not keys:
             return None
+
+        for key in keys:
+            entries[key.split('|')[1]] = self.db.get_all(self.db.STATE_DB, key)
 
         return entries
 
+    @multi_asic_util.run_on_multi_asic
     def list(self):
+        namespace_str = f" for namespace {self.multi_asic.current_namespace}" if multi_asic.is_multi_asic() else ''
         lossless_traffic_pattern = self.get_table(DEFAULT_LOSSLESS_BUFFER_PARAMETER_NAME)
         if lossless_traffic_pattern:
             for _, pattern in lossless_traffic_pattern.items():
                 config = []
 
-                print("Lossless traffic pattern:")
+                print(f"Lossless traffic pattern{namespace_str}:")
                 for field, value in pattern.items():
                     config.append([field, value])
                 print(tabulate.tabulate(config) + "\n")
@@ -104,108 +105,88 @@ class MmuConfig(object):
             for pool_name, pool_data in buf_pools.items():
                 config = []
 
-                print("Pool: " + pool_name)
+                print(f"Pool{namespace_str}: " + pool_name)
                 for field, value in pool_data.items():
                     config.append([field, value])
                 print(tabulate.tabulate(config) + "\n")
             if self.verbose:
                 print("Total pools: %d\n\n" % len(buf_pools))
         else:
-            print("No buffer pool information available")
+            print(f"No buffer pool information available{namespace_str}")
 
         buf_profs = self.get_table(BUFFER_PROFILE_TABLE_NAME)
         if buf_profs:
             for prof_name, prof_data in buf_profs.items():
                 config = []
 
-                print("Profile: " + prof_name)
+                print(f"Profile{namespace_str}: " + prof_name)
                 for field, value in prof_data.items():
                     config.append([field, value])
                 print(tabulate.tabulate(config) + "\n")
             if self.verbose:
                 print("Total profiles: %d" % len(buf_profs))
         else:
-            print("No buffer profile information available")
+            print(f"No buffer profile information available{namespace_str}")
 
+    @multi_asic_util.run_on_multi_asic
     def set(self, profile, field_alias, value):
+        namespace_str = f" for namespace {self.multi_asic.current_namespace}" if multi_asic.is_multi_asic() else ''
         if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
             sys.exit("Root privileges required for this operation")
 
-        if not self.namespace and multi_asic.is_multi_asic():
-            sys.exit("Namespace must be specified for this operation")
-
         field = BUFFER_PROFILE_FIELDS[field_alias]
-        buf_profs = self.db.get_table(BUFFER_PROFILE_TABLE_NAME)
-        v = int(value)
+        buf_profs = self.config_db.get_table(BUFFER_PROFILE_TABLE_NAME)
         if field == DYNAMIC_THRESHOLD:
-            if v < -8 or v > 8:
-                sys.exit("Invalid alpha value: 2^(%s)" % (value))
-
             if profile in buf_profs and DYNAMIC_THRESHOLD not in buf_profs[profile]:
                 sys.exit("%s not using dynamic thresholding" % (profile))
         elif field == STATIC_THRESHOLD:
-            if v < 0:
-                sys.exit("Invalid static threshold value: (%s)" % (value))
-
             if profile in buf_profs and STATIC_THRESHOLD not in buf_profs[profile]:
                 sys.exit("%s not using static threshold" % (profile))
         else:
             sys.exit("Set field %s not supported" % (field))
 
         if self.verbose:
-            print("Setting %s %s value to %s" % (profile, field, value))
-        self.db.mod_entry(BUFFER_PROFILE_TABLE_NAME, profile, {field: value})
+            print("Setting %s %s value to %s%s" % (profile, field, value, namespace_str))
+        self.config_db.mod_entry(BUFFER_PROFILE_TABLE_NAME, profile, {field: value})
         if self.filename is not None:
-            prof_table = self.db.get_table(BUFFER_PROFILE_TABLE_NAME)
+            self.updated_profile_table[self.multi_asic.current_namespace] = self.config_db.get_table(BUFFER_PROFILE_TABLE_NAME)
             with open(self.filename, "w") as fd:
-                json.dump(prof_table, fd)
+                json.dump(self.updated_profile_table, fd)
 
-
-def main(config):
-    if config:
-        parser = argparse.ArgumentParser(description='Show and change: mmu configuration',
-                                         formatter_class=argparse.RawTextHelpFormatter)
-
-        parser.add_argument('-l', '--list', action='store_true', help='show mmu configuration')
-        parser.add_argument('-p', '--profile', type=str, help='specify buffer profile name', default=None)
-        parser.add_argument('-a', '--alpha', type=str, help='set n for dyanmic threshold alpha 2^(n)', default=None)
-        parser.add_argument('-s', '--staticth', type=str, help='set static threshold', default=None)
-        parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
-    else:
-        parser = argparse.ArgumentParser(description='Show buffer state',
-                                         formatter_class=argparse.RawTextHelpFormatter)
-
-        parser.add_argument('-l', '--list', action='store_true', help='show buffer state')
-        parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
-
-    parser.add_argument('-n', '--namespace', type=str, help='Namespace name', default=None)
-    parser.add_argument('-vv', '--verbose', action='store_true', help='verbose output', default=False)
-    parser.add_argument('-f', '--filename', help='file used by mock tests', type=str, default=None)
-
+@click.command(help='Show and change: mmu configuration')
+@click.option('-l', '--list', 'show_config', is_flag=True, help='show mmu configuration')
+@click.option('-p', '--profile', type=str, help='specify buffer profile name', default=None)
+@click.option('-a', '--alpha', type=click.IntRange(DYNAMIC_THRESHOLD_MIN, DYNAMIC_THRESHOLD_MAX), help='set n for dyanmic threshold alpha 2^(n)', default=None)
+@click.option('-s', '--staticth', type=click.IntRange(min=STATIC_THRESHOLD_MIN), help='set static threshold', default=None)
+@click.option('-n', '--namespace', type=click.Choice(multi_asic.get_namespace_list()), help='Namespace name or skip for all', default=None)
+@click.option('-vv', '--verbose', is_flag=True, help='verbose output', default=False)
+@click.version_option(version='1.0')
+def main(show_config, profile, alpha, staticth, namespace, verbose):
+    # A test file created for unit test purposes
+    filename=None
     if os.environ.get("UTILITIES_UNIT_TESTING", "0") == "2":
-        sys.argv.extend(['-f', '/tmp/mmuconfig'])
+        filename = '/tmp/mmuconfig'
 
-
-    args = parser.parse_args()
+    # Buffershow and mmuconfig cmds share this script
+    # Buffershow cmd cannot modify configs hence config is set to False
+    config = True if sys.argv[0].split('/')[-1] == "mmuconfig" else False
 
     try:
         load_db_config()
-        namespaces = multi_asic.get_namespace_list()
+        mmu_cfg = MmuConfig(verbose, config, filename, namespace)
 
-        if args.namespace and args.namespace not in namespaces:
-            print("Invalid namespace: Namespace must be one of", *namespaces)
-            sys.exit(1)
-
-        mmu_cfg = MmuConfig(args.verbose, config, args.filename, args.namespace)
-        if args.list:
+        # Both mmuconfig and buffershow have access to show_config option
+        if show_config:
             mmu_cfg.list()
-        elif config and args.profile:
-            if args.alpha:
-                mmu_cfg.set(args.profile, "alpha", args.alpha)
-            elif args.staticth:
-                mmu_cfg.set(args.profile, "staticth", args.staticth)
+        # Buffershow cannot modify profiles
+        elif config and profile:
+            if alpha:
+                mmu_cfg.set(profile, "alpha", alpha)
+            elif staticth:
+                mmu_cfg.set(profile, "staticth", staticth)
         else:
-            parser.print_help()
+            ctx = click.get_current_context()
+            click.echo(ctx.get_help())
             sys.exit(1)
 
     except Exception as e:
@@ -214,7 +195,4 @@ def main(config):
         sys.exit(1)
 
 if __name__ == "__main__":
-    if sys.argv[0].split('/')[-1] == "mmuconfig":
-        main(True)
-    else:
-        main(False)
+    main()

--- a/show/main.py
+++ b/show/main.py
@@ -291,7 +291,6 @@ def cli(ctx):
     load_db_config()
     ctx.obj = Db()
 
-
 # Add groups from other modules
 cli.add_command(acl.acl)
 cli.add_command(chassis_modules.chassis)
@@ -2033,9 +2032,22 @@ def boot():
 # 'mmu' command ("show mmu")
 #
 @cli.command('mmu')
-def mmu():
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+@click.option('--verbose', '-vv', is_flag=True, help="Enable verbose output")
+def mmu(namespace, verbose):
     """Show mmu configuration"""
     cmd = ['mmuconfig', '-l']
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
+    if verbose:
+        cmd += ['-vv']
     run_command(cmd)
 
 #
@@ -2049,10 +2061,25 @@ def buffer():
 #
 # 'configuration' command ("show buffer command")
 #
+
+
 @buffer.command()
-def configuration():
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+@click.option('--verbose', '-vv', is_flag=True, help="Enable verbose output")
+def configuration(namespace, verbose):
     """show buffer configuration"""
     cmd = ['mmuconfig', '-l']
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
+    if verbose:
+        cmd += ['-vv']
     run_command(cmd)
 
 #

--- a/tests/mmuconfig_input/mmuconfig_test_vectors.py
+++ b/tests/mmuconfig_input/mmuconfig_test_vectors.py
@@ -83,6 +83,36 @@ size        0
 
 """
 
+show_mmu_config_one = """\
+Pool: ingress_lossy_pool
+----  -------
+mode  dynamic
+type  ingress
+----  -------
+
+Pool: ingress_lossless_pool_hbm
+----  ---------
+mode  static
+size  139458240
+type  ingress
+----  ---------
+
+Profile: ingress_lossy_profile
+----------  ------------------
+dynamic_th  3
+pool        ingress_lossy_pool
+size        0
+----------  ------------------
+
+Profile: ingress_lossless_profile_hbm
+---------  -------------------------
+static_th  12121212
+pool       ingress_lossless_pool_hbm
+size       0
+---------  -------------------------
+
+"""
+
 testData = {
              'mmuconfig_list' : {'cmd' : ['show'],
                                     'args' : [],

--- a/tests/mmuconfig_input/mmuconfig_test_vectors.py
+++ b/tests/mmuconfig_input/mmuconfig_test_vectors.py
@@ -83,33 +83,168 @@ size        0
 
 """
 
-show_mmu_config_one = """\
-Pool: ingress_lossy_pool
+show_mmu_config_asic0 = """\
+Pool for namespace asic0: ingress_lossy_pool
 ----  -------
 mode  dynamic
 type  ingress
 ----  -------
 
-Pool: ingress_lossless_pool_hbm
+Pool for namespace asic0: ingress_lossless_pool_hbm
 ----  ---------
 mode  static
 size  139458240
 type  ingress
 ----  ---------
 
-Profile: ingress_lossy_profile
+Profile for namespace asic0: ingress_lossy_profile
 ----------  ------------------
 dynamic_th  3
 pool        ingress_lossy_pool
 size        0
 ----------  ------------------
 
-Profile: ingress_lossless_profile_hbm
+Profile for namespace asic0: ingress_lossless_profile_hbm
 ---------  -------------------------
 static_th  12121212
 pool       ingress_lossless_pool_hbm
 size       0
 ---------  -------------------------
+
+"""
+
+show_mmu_config_asic1_verbose = """\
+Pool for namespace asic1: ingress_lossless_pool
+----  -------
+mode  dynamic
+type  ingress
+----  -------
+
+Pool for namespace asic1: egress_lossless_pool
+----  --------
+mode  dynamic
+size  13945824
+type  egress
+----  --------
+
+Pool for namespace asic1: egress_lossy_pool
+----  -------
+mode  dynamic
+type  egress
+----  -------
+
+Total pools: 3
+
+
+Profile for namespace asic1: alpha_profile
+-------------  ---------------------
+dynamic_th     0
+pool           ingress_lossless_pool
+headroom_type  dynamic
+-------------  ---------------------
+
+Profile for namespace asic1: headroom_profile
+----------  ---------------------
+dynamic_th  0
+pool        ingress_lossless_pool
+xon         18432
+xoff        32768
+size        51200
+----------  ---------------------
+
+Profile for namespace asic1: egress_lossless_profile
+----------  --------------------
+dynamic_th  0
+pool        egress_lossless_pool
+size        0
+----------  --------------------
+
+Profile for namespace asic1: egress_lossy_profile
+----------  -----------------
+dynamic_th  0
+pool        egress_lossy_pool
+size        0
+----------  -----------------
+
+Total profiles: 4
+"""
+
+show_mmu_config_all_masic = """\
+Pool for namespace asic0: ingress_lossy_pool
+----  -------
+mode  dynamic
+type  ingress
+----  -------
+
+Pool for namespace asic0: ingress_lossless_pool_hbm
+----  ---------
+mode  static
+size  139458240
+type  ingress
+----  ---------
+
+Profile for namespace asic0: ingress_lossy_profile
+----------  ------------------
+dynamic_th  3
+pool        ingress_lossy_pool
+size        0
+----------  ------------------
+
+Profile for namespace asic0: ingress_lossless_profile_hbm
+---------  -------------------------
+static_th  12121212
+pool       ingress_lossless_pool_hbm
+size       0
+---------  -------------------------
+
+Pool for namespace asic1: ingress_lossless_pool
+----  -------
+mode  dynamic
+type  ingress
+----  -------
+
+Pool for namespace asic1: egress_lossless_pool
+----  --------
+mode  dynamic
+size  13945824
+type  egress
+----  --------
+
+Pool for namespace asic1: egress_lossy_pool
+----  -------
+mode  dynamic
+type  egress
+----  -------
+
+Profile for namespace asic1: alpha_profile
+-------------  ---------------------
+dynamic_th     0
+pool           ingress_lossless_pool
+headroom_type  dynamic
+-------------  ---------------------
+
+Profile for namespace asic1: headroom_profile
+----------  ---------------------
+dynamic_th  0
+pool        ingress_lossless_pool
+xon         18432
+xoff        32768
+size        51200
+----------  ---------------------
+
+Profile for namespace asic1: egress_lossless_profile
+----------  --------------------
+dynamic_th  0
+pool        egress_lossless_pool
+size        0
+----------  --------------------
+
+Profile for namespace asic1: egress_lossy_profile
+----------  -----------------
+dynamic_th  0
+pool        egress_lossy_pool
+size        0
+----------  -----------------
 
 """
 
@@ -119,24 +254,96 @@ testData = {
                                     'rc' : 0,
                                     'rc_output': show_mmu_config
                                 },
-             'mmu_cfg_static_th' : {'cmd' : ['config'],
-                                   'args' : ['-p', 'ingress_lossless_profile_hbm', '-s', '12121213'],
-                                   'rc' : 0,
-                                   'db_table' : 'BUFFER_PROFILE',
-                                   'cmp_args' : ['ingress_lossless_profile_hbm,static_th,12121213'],
-                                   'rc_msg' : ''
-                                  },
+             'mmu_cfg_static_th': {'cmd': ['config'],
+                                   'args': ['-p', 'ingress_lossless_profile_hbm', '-s', '12121213'],
+                                   'rc': 0,
+                                   'db_table': 'BUFFER_PROFILE',
+                                   'cmp_args': [',ingress_lossless_profile_hbm,static_th,12121213'],
+                                   'rc_msg': ''
+                                   },
              'mmu_cfg_alpha' :    {'cmd' : ['config'],
                                    'args' : ['-p', 'alpha_profile', '-a', '2'],
                                    'rc' : 0,
                                    'db_table' : 'BUFFER_PROFILE',
-                                   'cmp_args' : ['alpha_profile,dynamic_th,2'],
+                                   'cmp_args': [',alpha_profile,dynamic_th,2'],
                                    'rc_msg' : ''
                                   },
-             'mmu_cfg_alpha_invalid' :    {'cmd' : ['config'],
-                                   'args' : ['-p', 'alpha_profile', '-a', '12'],
-                                   'rc' : 2,
-                                   'rc_msg' : 'Usage: mmu [OPTIONS]\nTry "mmu --help" for help.\n\nError: Invalid value for "-a": 12 is not in the valid range of -8 to 8.\n'
-                                  }
-
+             'mmu_cfg_alpha_invalid': {'cmd': ['config'],
+                                       'args': ['-p', 'alpha_profile', '-a', '12'],
+                                       'rc': 2,
+                                       'rc_msg': ('Usage: mmu [OPTIONS]\nTry "mmu --help" for help.\n'
+                                                  '\nError: Invalid value for "-a": 12 is not in the '
+                                                  'valid range of -8 to 8.\n')
+                                       },
+             'mmu_cfg_list_one_masic': {'cmd': ['show'],
+                                        'args': ['-n', 'asic0'],
+                                        'rc': 0,
+                                        'rc_output': show_mmu_config_asic0
+                                        },
+             'mmu_cfg_list_one_verbose_masic': {'cmd': ['show'],
+                                                'args': ['-n', 'asic1', '-vv'],
+                                                'rc': 0,
+                                                'rc_output': show_mmu_config_asic1_verbose
+                                                },
+             'mmu_cfg_list_all_masic': {'cmd': ['show'],
+                                        'args': [],
+                                        'rc': 0,
+                                        'rc_output': show_mmu_config_all_masic
+                                        },
+             'mmu_cfg_alpha_one_masic': {'cmd': ['config'],
+                                         'args': ['-p', 'alpha_profile', '-a', '2', '-n', 'asic0'],
+                                         'rc': 0,
+                                         'db_table': 'BUFFER_PROFILE',
+                                         'cmp_args': ['asic0,alpha_profile,dynamic_th,2'],
+                                         'rc_msg': ''
+                                         },
+             'mmu_cfg_alpha_all_verbose_masic': {'cmd': ['config'],
+                                                 'args': ['-p', 'alpha_profile', '-a', '2', '-vv'],
+                                                 'rc': 0,
+                                                 'db_table': 'BUFFER_PROFILE',
+                                                 'cmp_args': ['asic0,alpha_profile,dynamic_th,2',
+                                                              'asic1,alpha_profile,dynamic_th,2'],
+                                                 'rc_msg': ('Setting alpha_profile dynamic_th value '
+                                                            'to 2 for namespace asic0\n'
+                                                            'Setting alpha_profile dynamic_th value '
+                                                            'to 2 for namespace asic1\n')
+                                                 },
+             'mmu_cfg_static_th_one_masic': {'cmd': ['config'],
+                                             'args': ['-p', 'ingress_lossless_profile_hbm',
+                                                      '-s', '12121215', '-n', 'asic0'],
+                                             'rc': 0,
+                                             'db_table': 'BUFFER_PROFILE',
+                                             'cmp_args': ['asic0,ingress_lossless_profile_hbm,static_th,12121215'],
+                                             'rc_msg': ''
+                                             },
+             'mmu_cfg_static_th_all_verbose_masic': {'cmd': ['config'],
+                                                     'args': ['-p', 'ingress_lossless_profile_hbm',
+                                                              '-s', '12121214', '-vv'],
+                                                     'rc': 0,
+                                                     'db_table': 'BUFFER_PROFILE',
+                                                     'cmp_args': [('asic0,ingress_lossless_profile_hbm,'
+                                                                   'static_th,12121214'),
+                                                                  ('asic1,ingress_lossless_profile_hbm,'
+                                                                   'static_th,12121214')],
+                                                     'rc_msg': ('Setting ingress_lossless_profile_hbm static_th '
+                                                                'value to 12121214 for namespace asic0\n'
+                                                                'Setting ingress_lossless_profile_hbm static_th '
+                                                                'value to 12121214 for namespace asic1\n')
+                                                     },
+             'mmu_cfg_alpha_invalid_masic': {'cmd': ['config'],
+                                             'args': ['-p', 'alpha_profile', '-a', '12'],
+                                             'rc': 2,
+                                             'rc_msg': ('Usage: mmu [OPTIONS]\n'
+                                                        'Try "mmu --help" for help.\n\n'
+                                                        'Error: Invalid value for "-a": 12 '
+                                                        'is not in the valid range of -8 to 8.\n')
+                                             },
+             'mmu_cfg_static_th_invalid_masic': {'cmd': ['config'],
+                                                 'args': ['-p', 'ingress_lossless_profile_hbm', '-s', '-1'],
+                                                 'rc': 2,
+                                                 'rc_msg': ('Usage: mmu [OPTIONS]\n'
+                                                            'Try "mmu --help" for help.\n\n'
+                                                            'Error: Invalid value for "-s": '
+                                                            '-1 is smaller than the minimum valid value 0.\n')
+                                                 }
            }

--- a/tests/mmuconfig_test.py
+++ b/tests/mmuconfig_test.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 import config.main as config
 import show.main as show
 from utilities_common.db import Db
-from .mmuconfig_input.mmuconfig_test_vectors import *
+from .mmuconfig_input.mmuconfig_test_vectors import testData
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -16,24 +16,12 @@ sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
 
-class Testmmuconfig(object):
+class TestMmuConfigBase(object):
     @classmethod
     def setup_class(cls):
+        print('SETUP')
         os.environ["PATH"] += os.pathsep + scripts_path
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
-        print("SETUP")
-
-    def test_mmu_show_config(self):
-        self.executor(testData['mmuconfig_list'])
-
-    def test_mmu_alpha_config(self):
-        self.executor(testData['mmu_cfg_alpha'])
-
-    def test_mmu_alpha_invalid_config(self):
-        self.executor(testData['mmu_cfg_alpha_invalid'])
-
-    def test_mmu_staticth_config(self):
-        self.executor(testData['mmu_cfg_static_th'])
 
     def executor(self, input):
         runner = CliRunner()
@@ -48,6 +36,7 @@ class Testmmuconfig(object):
             result = runner.invoke(exec_cmd, input['args'])
             exit_code = result.exit_code
             output = result.output
+
         elif 'config' in input['cmd']:
             exec_cmd = config.config.commands["mmu"]
             result = runner.invoke(exec_cmd, input['args'], catch_exceptions=False)
@@ -66,8 +55,8 @@ class Testmmuconfig(object):
             fd = open('/tmp/mmuconfig', 'r')
             cmp_data = json.load(fd)
             for args in input['cmp_args']:
-                profile, name, value = args.split(',')
-                assert(cmp_data[profile][name] == value)
+                namespace, profile, name, value = args.split(',')
+                assert(cmp_data[namespace][profile][name] == value)
             fd.close()
 
         if 'rc_msg' in input:
@@ -76,7 +65,6 @@ class Testmmuconfig(object):
         if 'rc_output' in input:
             assert output == input['rc_output']
 
-
     @classmethod
     def teardown_class(cls):
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
@@ -84,3 +72,17 @@ class Testmmuconfig(object):
         if os.path.isfile('/tmp/mmuconfig'):
             os.remove('/tmp/mmuconfig')
         print("TEARDOWN")
+
+
+class TestMmuConfig(TestMmuConfigBase):
+    def test_mmu_show_config(self):
+        self.executor(testData['mmuconfig_list'])
+
+    def test_mmu_alpha_config(self):
+        self.executor(testData['mmu_cfg_alpha'])
+
+    def test_mmu_alpha_invalid_config(self):
+        self.executor(testData['mmu_cfg_alpha_invalid'])
+
+    def test_mmu_staticth_config(self):
+        self.executor(testData['mmu_cfg_static_th'])

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -326,5 +326,24 @@
     "QUEUE|Ethernet4|1": {
         "scheduler": "[SCHEDULAR|scheduler.0]",
         "wred_profile": "AZURE_LOSSLESS"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "mode": "dynamic",
+        "type": "ingress"
+    },
+    "BUFFER_POOL|ingress_lossless_pool_hbm": {
+        "mode": "static",
+        "size": "139458240",
+         "type": "ingress"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "ingress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile_hbm": {
+        "static_th": "12121212",
+        "pool": "ingress_lossless_pool_hbm",
+        "size": "0"
     }
 }

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -262,5 +262,40 @@
     },
     "QUEUE|Ethernet0|1": {
         "scheduler": "[SCHEDULAR|scheduler.0]"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "mode": "dynamic",
+        "type": "ingress"
+    },
+    "BUFFER_PROFILE|alpha_profile": {
+        "dynamic_th": "0",
+        "pool": "ingress_lossless_pool",
+        "headroom_type": "dynamic"
+    },
+    "BUFFER_PROFILE|headroom_profile": {
+        "dynamic_th": "0",
+        "pool": "ingress_lossless_pool",
+        "xon": "18432",
+        "xoff": "32768",
+        "size": "51200"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "mode": "dynamic",
+        "size": "13945824",
+        "type": "egress"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "mode": "dynamic",
+        "type": "egress"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "0",
+        "pool": "egress_lossy_pool",
+        "size": "0"
     }
 }

--- a/tests/multi_asic_mmuconfig_test.py
+++ b/tests/multi_asic_mmuconfig_test.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from utils import get_result_and_return_code
-from mmuconfig_input.mmuconfig_test_vectors import *
+from mmuconfig_input.mmuconfig_test_vectors import show_mmu_config, show_mmu_config_one, test_data 
 from json import load
 
 root_path = os.path.dirname(os.path.abspath(__file__))
@@ -11,39 +11,40 @@ scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, root_path)
 sys.path.insert(0, modules_path)
 
+
 class TestMmuconfigMultiAsic(object):
-   @classmethod
-   def setup_class(cls):
-      os.environ["PATH"] += os.pathsep + scripts_path
-      os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
-      os.environ['UTILITIES_UNIT_TESTING'] = "2"
-      print("SETUP")
+    @classmethod
+    def setup_class(cls):
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+        print("SETUP")
 
-   def executor(self, command, expected_result=None):
-      return_code, result = get_result_and_return_code(command)
-      print("return_code: {}".format(return_code))
-      print("result = {}".format(result))
-      assert return_code == 0
-      if expected_result:
-         assert result == expected_result
+    def executor(self, command, expected_result=None):
+        return_code, result = get_result_and_return_code(command)
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        if expected_result:
+            assert result == expected_result
 
-   def test_mmu_show_config_one_masic(self):
-      self.executor(['mmuconfig', '-l', '-n', 'asic0'], show_mmu_config_one)
+    def test_mmu_show_config_one_masic(self):
+        self.executor(['mmuconfig', '-l', '-n', 'asic0'], show_mmu_config_one)
 
-   def test_mmu_show_config_all_masic(self):
-      self.executor(['mmuconfig', '-l'], show_mmu_config)
+    def test_mmu_show_config_all_masic(self):
+        self.executor(['mmuconfig', '-l'], show_mmu_config)
 
-   def test_mmu_alpha_config_masic(self):
-      self.executor(['mmuconfig', '-p', 'alpha_profile', '-a', '2', '-n', 'asic0'])
-      fd = open('/tmp/mmuconfig', 'r')
-      cmp_data = load(fd)
-      assert cmp_data['alpha_profile']['dynamic_th'] == '2'
+    def test_mmu_alpha_config_masic(self):
+        self.executor(['mmuconfig', '-p', 'alpha_profile', '-a', '2', '-n', 'asic0'])
+        fd = open('/tmp/mmuconfig', 'r')
+        cmp_data = load(fd)
+        assert cmp_data['alpha_profile']['dynamic_th'] == '2'
 
-   @classmethod
-   def teardown_class(cls):
-      os.environ['PATH'] = os.pathsep.join(os.environ['PATH'].split(os.pathsep)[:-1])
-      os.environ['UTILITIES_UNIT_TESTING'] = "0"
-      os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
-      if os.path.isfile('/tmp/mmuconfig'):
-         os.remove('/tmp/mmuconfig')
-      print("TEARDOWN")
+    @classmethod
+    def teardown_class(cls):
+        os.environ['PATH'] = os.pathsep.join(os.environ['PATH'].split(os.pathsep)[:-1])
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+        if os.path.isfile('/tmp/mmuconfig'):
+            os.remove('/tmp/mmuconfig')
+        print("TEARDOWN")

--- a/tests/multi_asic_mmuconfig_test.py
+++ b/tests/multi_asic_mmuconfig_test.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from utils import get_result_and_return_code
-from mmuconfig_input.mmuconfig_test_vectors import show_mmu_config, show_mmu_config_one, test_data 
+from mmuconfig_input.mmuconfig_test_vectors import show_mmu_config, show_mmu_config_one
 from json import load
 
 root_path = os.path.dirname(os.path.abspath(__file__))

--- a/tests/multi_asic_mmuconfig_test.py
+++ b/tests/multi_asic_mmuconfig_test.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+from utils import get_result_and_return_code
+from mmuconfig_input.mmuconfig_test_vectors import *
+from json import load
+
+root_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(root_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, root_path)
+sys.path.insert(0, modules_path)
+
+class TestMmuconfigMultiAsic(object):
+   @classmethod
+   def setup_class(cls):
+      os.environ["PATH"] += os.pathsep + scripts_path
+      os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+      os.environ['UTILITIES_UNIT_TESTING'] = "2"
+      print("SETUP")
+
+   def executor(self, command, expected_result=None):
+      return_code, result = get_result_and_return_code(command)
+      print("return_code: {}".format(return_code))
+      print("result = {}".format(result))
+      assert return_code == 0
+      if expected_result:
+         assert result == expected_result
+
+   def test_mmu_show_config_one_masic(self):
+      self.executor(['mmuconfig', '-l', '-n', 'asic0'], show_mmu_config_one)
+
+   def test_mmu_show_config_all_masic(self):
+      self.executor(['mmuconfig', '-l'], show_mmu_config)
+
+   def test_mmu_alpha_config_masic(self):
+      self.executor(['mmuconfig', '-p', 'alpha_profile', '-a', '2', '-n', 'asic0'])
+      fd = open('/tmp/mmuconfig', 'r')
+      cmp_data = load(fd)
+      assert cmp_data['alpha_profile']['dynamic_th'] == '2'
+
+   @classmethod
+   def teardown_class(cls):
+      os.environ['PATH'] = os.pathsep.join(os.environ['PATH'].split(os.pathsep)[:-1])
+      os.environ['UTILITIES_UNIT_TESTING'] = "0"
+      os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+      if os.path.isfile('/tmp/mmuconfig'):
+         os.remove('/tmp/mmuconfig')
+      print("TEARDOWN")

--- a/tests/multi_asic_mmuconfig_test.py
+++ b/tests/multi_asic_mmuconfig_test.py
@@ -1,9 +1,7 @@
 import os
 import sys
-
-from utils import get_result_and_return_code
-from mmuconfig_input.mmuconfig_test_vectors import show_mmu_config, show_mmu_config_one
-from json import load
+from .mmuconfig_test import TestMmuConfigBase
+from .mmuconfig_input.mmuconfig_test_vectors import testData
 
 root_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(root_path)
@@ -12,39 +10,40 @@ sys.path.insert(0, root_path)
 sys.path.insert(0, modules_path)
 
 
-class TestMmuconfigMultiAsic(object):
+class TestMmuConfigMultiAsic(TestMmuConfigBase):
     @classmethod
     def setup_class(cls):
-        os.environ["PATH"] += os.pathsep + scripts_path
+        super().setup_class()
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
-        os.environ['UTILITIES_UNIT_TESTING'] = "2"
-        print("SETUP")
-
-    def executor(self, command, expected_result=None):
-        return_code, result = get_result_and_return_code(command)
-        print("return_code: {}".format(return_code))
-        print("result = {}".format(result))
-        assert return_code == 0
-        if expected_result:
-            assert result == expected_result
 
     def test_mmu_show_config_one_masic(self):
-        self.executor(['mmuconfig', '-l', '-n', 'asic0'], show_mmu_config_one)
+        self.executor(testData['mmu_cfg_list_one_masic'])
+
+    def test_mmu_show_config_one_verbose_masic(self):
+        self.executor(testData['mmu_cfg_list_one_verbose_masic'])
 
     def test_mmu_show_config_all_masic(self):
-        self.executor(['mmuconfig', '-l'], show_mmu_config)
+        self.executor(testData['mmu_cfg_list_all_masic'])
 
-    def test_mmu_alpha_config_masic(self):
-        self.executor(['mmuconfig', '-p', 'alpha_profile', '-a', '2', '-n', 'asic0'])
-        fd = open('/tmp/mmuconfig', 'r')
-        cmp_data = load(fd)
-        assert cmp_data['alpha_profile']['dynamic_th'] == '2'
+    def test_mmu_alpha_config_one_masic(self):
+        self.executor(testData['mmu_cfg_alpha_one_masic'])
+
+    def test_mmu_alpha_config_all_verbose_masic(self):
+        self.executor(testData['mmu_cfg_alpha_all_verbose_masic'])
+
+    def test_mmu_staticth_config_one_masic(self):
+        self.executor(testData['mmu_cfg_static_th_one_masic'])
+
+    def test_mmu_staticth_config_all_verbose_masic(self):
+        self.executor(testData['mmu_cfg_static_th_all_verbose_masic'])
+
+    def test_mmu_alpha_config_invalid_masic(self):
+        self.executor(testData['mmu_cfg_alpha_invalid_masic'])
+
+    def test_mmu_staticth_config_invalid_masic(self):
+        self.executor(testData['mmu_cfg_static_th_invalid_masic'])
 
     @classmethod
     def teardown_class(cls):
-        os.environ['PATH'] = os.pathsep.join(os.environ['PATH'].split(os.pathsep)[:-1])
-        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        super().teardown_class()
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
-        if os.path.isfile('/tmp/mmuconfig'):
-            os.remove('/tmp/mmuconfig')
-        print("TEARDOWN")


### PR DESCRIPTION
#### What I did
Previously, mmuconfig did not function correctly on multi-asic devices as it did not traverse through the correct namespaces, as required for multi-asic devices. This change adds multi-asic support to mmuconfig with the use of multi-asic helper libraries, ensuring that mmuconfig searches throuugh the correct namespaces when used on multi-asic devices, and adds the '-n' optional argument for users to specify namespaces on multi-asic devices.

This is a part of the set of changes being pushed for https://github.com/sonic-net/sonic-buildimage/issues/15148

#### How I did it
Added namespace option -n and used multi_asic library to implement multi_asic behaviour. Added relevant unit tests to ensure functionality.

#### How to verify it
Run unit tests, or mmuconfig with `-n` option.