### PR TITLE
Validate config_db json file before config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1518,14 +1518,13 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
     #Validate config_db.json file
     if file_format == 'config_db':
         if os.path.exists(DEFAULT_CONFIG_DB_FILE):
-            command = [str(SONIC_CFGGEN_PATH), '-j', str(DEFAULT_CONFIG_DB_FILE)]
-            clicommon.run_command(command, display_cmd=True)
-        if  num_cfg_file > 1:
-            for inst in range(0, num_cfg_file-1):
-                file = "/etc/sonic/config_db{}.json".format(inst)
-                if os.path.exists(file) :
-                    command = [str(SONIC_CFGGEN_PATH), '-j', str(file)]
-                    clicommon.run_command(command, display_cmd=True)
+            command = [SONIC_CFGGEN_PATH, '-j', DEFAULT_CONFIG_DB_FILE]
+            clicommon.run_command(command)
+        for inst in range(0, num_cfg_file-1):
+            file = "/etc/sonic/config_db{}.json".format(inst)
+            if os.path.exists(file):
+                command = [SONIC_CFGGEN_PATH, '-j', file]
+                clicommon.run_command(command)
     
     #Stop services before config push
     if not no_service_restart:

--- a/config/main.py
+++ b/config/main.py
@@ -1517,8 +1517,9 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
 
     #Validate config_db.json file
     if file_format == 'config_db':
-        if os.path.exists(DEFAULT_CONFIG_DB_FILE):
-            command = [SONIC_CFGGEN_PATH, '-j', DEFAULT_CONFIG_DB_FILE]
+        file = DEFAULT_CONFIG_DB_FILE
+        if os.path.exists(file):
+            command = [SONIC_CFGGEN_PATH, '-j', file]
             clicommon.run_command(command)
         for inst in range(0, num_cfg_file-1):
             file = "/etc/sonic/config_db{}.json".format(inst)

--- a/config/main.py
+++ b/config/main.py
@@ -1515,6 +1515,18 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
+    #Validate config_db.json file
+    if file_format == 'config_db':
+        if os.path.exists(DEFAULT_CONFIG_DB_FILE):
+            command = [str(SONIC_CFGGEN_PATH), '-j', str(DEFAULT_CONFIG_DB_FILE)]
+            clicommon.run_command(command, display_cmd=True)
+        if  num_cfg_file > 1:
+            for inst in range(0, num_cfg_file-1):
+                file = "/etc/sonic/config_db{}.json".format(inst)
+                if os.path.exists(file) :
+                    command = [str(SONIC_CFGGEN_PATH), '-j', str(file)]
+                    clicommon.run_command(command, display_cmd=True)
+    
     #Stop services before config push
     if not no_service_restart:
         log.log_notice("'reload' stopping services...")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Check config_db json file before stopping the services. If there is an error, DB wont be able to connect to any services

#### How I did it
Run the SONIC_CFGGEN_PATH to all the one or more config_db.json file. If there is any error, it will come out of config reload loop before stopping all the services.

#### How to verify it
Create an error in config_db.json and we should see any error before all the services go down.

#### Previous command output (if the output of a command-line utility has changed)
Suppose there is an extra ","  issue in one of the config_db.json file and when we issue 'config reload' there is no validation for config_db.json file. Only when DB services will restart and encounter issue it will flag it but it has brought all the services down. Now none of the services will start and most of the commands wont run and system will hang when we issue config reload or reboot.

```
root@sonic:/home/cisco# config reload -fy
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db.json  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db0.json  -n asic0  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic0
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db1.json  -n asic1  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic1
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db2.json  -n asic2  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic2
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db3.json  -n asic3  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic3
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db4.json  -n asic4  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic4
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db5.json  -n asic5  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic5
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db6.json  -n asic6  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic6
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db7.json  -n asic7  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic7
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db8.json  -n asic8  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic8
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db9.json  -n asic9  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic9
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db10.json  -n asic10  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic10
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db11.json  -n asic11  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic11
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db12.json  -n asic12  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic12
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db13.json  -n asic13  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic13
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db14.json  -n asic14  --write-to-db
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 443, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 314, in main
    _process_json(args, data)
  File "/usr/local/bin/sonic-cfggen", line 229, in _process_json
    deep_update(data, FormatConverter.to_deserialized(json.load(stream)))
  File "/usr/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 9 column 5 (char 225)

root@sonic:/etc/sonic# docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED      STATUS                        PORTS     NAMES
d41d5419dc56   af822c4583ec                         "/usr/bin/docker_ini…"   3 days ago   Exited (0) 12 minutes ago               dhcp_relay
a468c03915b7   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Exited (137) 28 seconds ago             lldp1
fda201d8c426   docker-orchagent:latest              "/usr/bin/docker-ini…"   3 days ago   Exited (0) 13 minutes ago               swss1
3010924db239   docker-syncd-cisco:latest            "/usr/local/bin/supe…"   3 days ago   Exited (0) 11 minutes ago               syncd3
57b1b2e62c3c   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Exited (137) 27 seconds ago             lldp2
67c6614c0921   docker-teamd:latest                  "/usr/local/bin/supe…"   3 days ago   Exited (0) 12 minutes ago               teamd0
aa8997f64cd2   docker-teamd:latest                  "/usr/local/bin/supe…"   3 days ago   Exited (0) 14 minutes ago               teamd3
71f44d14787b   docker-orchagent:latest              "/usr/bin/docker-ini…"   3 days ago   Exited (0) 13 minutes ago               swss3
869459e36ab4   docker-syncd-cisco:latest            "/usr/local/bin/supe…"   3 days ago   Exited (0) 12 minutes ago               syncd0
3ae9ff74396f   docker-orchagent:latest              "/usr/bin/docker-ini…"   3 days ago   Exited (0) 13 minutes ago               swss2
0b6e8d390327   docker-syncd-cisco:latest            "/usr/local/bin/supe…"   3 days ago   Exited (0) 11 minutes ago               syncd1
d89aca1e0d2a   docker-syncd-cisco:latest            "/usr/local/bin/supe…"   3 days ago   Exited (0) 11 minutes ago               syncd2
9c87c155d63a   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Exited (137) 27 seconds ago             lldp3
75a69a5fdb71   docker-teamd:latest                  "/usr/local/bin/supe…"   3 days ago   Exited (0) 14 minutes ago               teamd1
452c1e0db61d   docker-orchagent:latest              "/usr/bin/docker-ini…"   3 days ago   Exited (0) 12 minutes ago               swss0
8e18a0199bfb   docker-teamd:latest                  "/usr/local/bin/supe…"   3 days ago   Exited (0) 14 minutes ago               teamd2
eaba5e80106a   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Exited (137) 27 seconds ago             lldp0
a064de1a4783   docker-snmp:latest                   "/usr/local/bin/supe…"   3 days ago   Exited (0) 11 minutes ago               snmp
7c0e81bc88f6   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp12
0036ffede900   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp9
2b8a6cfc1ca3   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp2
c02f7d7a5f1b   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp10
7497c8ccbc7b   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 28 seconds ago             bgp1
2d25a34f6317   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp8
3e60e9c2e830   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp11
32f0d3eca2d7   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp5
e9bdea910039   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp7
da2c565a34b3   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp6
ed0edaeb2899   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp0
4f42f6184ba3   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp15
2db9e1b0882f   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp14
4a442bf9323e   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp13
e25201b2c2f2   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp4
b8411f0f5e50   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Exited (137) 27 seconds ago             bgp3
db26c690003a   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   3 days ago   Exited (0) 14 minutes ago               radv
c84cd81bc10e   docker-sonic-telemetry:latest        "/usr/local/bin/supe…"   3 days ago   Exited (0) 36 seconds ago               telemetry
7ad4b993711b   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   3 days ago   Exited (0) 36 seconds ago               mgmt-framework
1b1c0927a4ed   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Exited (137) 29 seconds ago             lldp
6c66e26dc538   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   3 days ago   Exited (0) 29 seconds ago               pmon
b2e84d1f7447   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database8
cc617c5521de   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database15
6930e15d2d0b   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database7
51d9697a84c8   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database3
fe3d0a9746c5   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database9
7bcb9bd1bbd9   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database14
e7081d7d5c07   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database11
e004c7889e6a   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database4
306db0812270   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database0
413a76a6b850   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database5
b51555321cb4   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database13
635e04c0c286   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database2
3d599b4d0892   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database12
f7c632958d87   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database1
dc4da9b9ed70   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database6
28693403fa83   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database10
b517ebdda46b   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days                               database
3089c7551d0a   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 3 days 
```
#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/cisco# config reload -fy
Delete
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db.json
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db0.json
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db1.json
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db2.json
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db3.json
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/config_db4.json
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 443, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 314, in main
    _process_json(args, data)
  File "/usr/local/bin/sonic-cfggen", line 229, in _process_json
    deep_update(data, FormatConverter.to_deserialized(json.load(stream)))
  File "/usr/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 12 column 5 (char 340)
root@sonic:/home/cisco# vi /etc/sonic/config_db4.json
root@sonic:/home/cisco# config reload -fy
root@sonic:/home/cisco# docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED      STATUS          PORTS     NAMES
a468c03915b7   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Up 18 minutes             lldp1
57b1b2e62c3c   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Up 18 minutes             lldp2
9c87c155d63a   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Up 18 minutes             lldp3
eaba5e80106a   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Up 18 minutes             lldp0
7c0e81bc88f6   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp12
0036ffede900   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp9
2b8a6cfc1ca3   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp2
c02f7d7a5f1b   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp10
7497c8ccbc7b   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp1
2d25a34f6317   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp8
3e60e9c2e830   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp11
32f0d3eca2d7   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp5
e9bdea910039   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp7
da2c565a34b3   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp6
ed0edaeb2899   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp0
4f42f6184ba3   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp15
2db9e1b0882f   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp14
4a442bf9323e   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp13
e25201b2c2f2   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp4
b8411f0f5e50   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             bgp3
c84cd81bc10e   docker-sonic-telemetry:latest        "/usr/local/bin/supe…"   3 days ago   Up 18 minutes             telemetry
7ad4b993711b   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   3 days ago   Up 18 minutes             mgmt-framework
1b1c0927a4ed   docker-lldp:latest                   "/usr/bin/docker-lld…"   3 days ago   Up 19 minutes             lldp
6c66e26dc538   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   3 days ago   Up 19 minutes             pmon
b2e84d1f7447   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database8
cc617c5521de   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database15
6930e15d2d0b   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database7
51d9697a84c8   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database3
fe3d0a9746c5   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database9
7bcb9bd1bbd9   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database14
e7081d7d5c07   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database11
e004c7889e6a   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database4
306db0812270   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database0
413a76a6b850   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database5
b51555321cb4   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database13
635e04c0c286   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database2
3d599b4d0892   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database12
f7c632958d87   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database1
dc4da9b9ed70   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database6
28693403fa83   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database10
b517ebdda46b   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database
3089c7551d0a   docker-database:latest               "/usr/local/bin/dock…"   3 days ago   Up 20 minutes             database-chassis
root@sonic:/home/cisco# /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db14.json
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 443, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 314, in main
    _process_json(args, data)
  File "/usr/local/bin/sonic-cfggen", line 229, in _process_json
    deep_update(data, FormatConverter.to_deserialized(json.load(stream)))
  File "/usr/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 9 column 5 (char 225)
root@sonic:/home/cisco# vi /etc/sonic/config_db14.json
root@sonic:/home/cisco# /usr/local/bin/sonic-cfggen  -j /etc/sonic/config_db14.json
root@sonic:/home/cisco# config reload -fy
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db.json  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db0.json  -n asic0  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic0
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db1.json  -n asic1  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic1
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db2.json  -n asic2  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic2
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db3.json  -n asic3  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic3
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db4.json  -n asic4  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic4
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db5.json  -n asic5  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic5
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db6.json  -n asic6  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic6
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db7.json  -n asic7  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic7
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db8.json  -n asic8  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic8
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db9.json  -n asic9  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic9
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db10.json  -n asic10  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic10
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db11.json  -n asic11  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic11
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db12.json  -n asic12  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic12
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db13.json  -n asic13  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic13
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db14.json  -n asic14  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic14
Running command: /usr/local/bin/sonic-cfggen  -j /etc/sonic/init_cfg.json  -j /etc/sonic/config_db15.json  -n asic15  --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate -n asic15
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon

