### PR TITLE
Modify teamd retry count script to base BGP status on default BGP status

### DIFF
--- a/scripts/teamd_increase_retry_count.py
+++ b/scripts/teamd_increase_retry_count.py
@@ -130,6 +130,14 @@ def getPortChannels():
                 "adminUp": False
                 }
 
+    deviceMetadataTable = Table(configDb, "DEVICE_METADATA")
+    metadata = deviceMetadataTable.get("localhost")
+    defaultBgpStatus = True
+    for key, value in metadata[1]:
+        if key == "default_bgp_status":
+            defaultBgpStatus = value == "up"
+            break
+
     bgpTable = Table(configDb, "BGP_NEIGHBOR")
     bgpNeighbors = bgpTable.getKeys()
     for bgpNeighbor in bgpNeighbors:
@@ -137,7 +145,7 @@ def getPortChannels():
         if not neighborData[0]:
             continue
         localAddr = None
-        isAdminUp = False
+        isAdminUp = defaultBgpStatus
         for key, value in neighborData[1]:
             if key == "local_addr":
                 if value not in portChannelData:


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

For each BGP status, if the `admin_status` field is not present, then whether the BGP session is admin up or admin down depends on the default BGP status (in the `default_bgp_status` field coming from `init_cfg.json`), which is specified during image build. If the default BGP status is up, then `admin_status` will be created only when the BGP session is brought down; similarly, if the default BGP status is down, then `admin_status` will be created when the BGP session is brought up.

#### How I did it

Because of that, modify the script to use the default BGP status as the initial value.

#### How to verify it

Tested on KVM and verified that the list of port channels seen were correct in the following cases:

* `default_bgp_status: down`, `config load_minigraph`
* `default_bgp_status: down`, `config load_minigraph`, `config bgp startup all`
* `default_bgp_status: up`, `config load_minigraph`
* `default_bgp_status: up`, `config load_minigraph`, `config bgp shutdown all`

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

