### PR TITLE
route_check.py should not print too many outputs to stdout

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -114,11 +114,12 @@ def set_level(lvl, log_to_syslog):
         report_level = syslog.LOG_DEBUG
 
 
-def print_message(lvl, *args):
+def print_message(lvl, *args, write_to_stdout=True):
     """
     print and log the message for given level.
     :param lvl: Log level for this message as ERR/INFO/DEBUG
     :param args: message as list of strings or convertible to string
+    :param write_to_stdout: print the message to stdout if set to true
     :return None
     """
     msg = ""
@@ -129,7 +130,8 @@ def print_message(lvl, *args):
                 break
             msg += str(arg)[0:rem_len]
 
-        print(msg)
+        if write_to_stdout:
+            print(msg)
         if write_to_syslog:
             syslog.syslog(lvl, msg)
 
@@ -575,7 +577,7 @@ def mitigate_installed_not_offloaded_frr_routes(missed_frr_rt, rt_appl):
         fvs = swsscommon.FieldValuePairs([('err_str', 'SWSS_RC_SUCCESS'), ('protocol', entry['protocol'])])
         response_producer.send('SWSS_RC_SUCCESS', entry['prefix'], fvs)
 
-        print_message(syslog.LOG_ERR, f'Mitigated route {entry["prefix"]}')
+        print_message(syslog.LOG_ERR, f'Mitigated route {entry["prefix"]}', write_to_stdout=False)
 
 
 def get_soc_ips(config_db):

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -1,4 +1,5 @@
 import copy
+from io import StringIO
 import json
 import os
 import logging
@@ -7,7 +8,7 @@ import syslog
 import time
 from sonic_py_common import device_info
 from unittest.mock import MagicMock, patch
-from tests.route_check_test_data import APPL_DB, ARGS, ASIC_DB, CONFIG_DB, DEFAULT_CONFIG_DB, DESCR, OP_DEL, OP_SET, PRE, RESULT, RET, TEST_DATA, UPD, FRR_ROUTES
+from tests.route_check_test_data import APPL_DB, ARGS, ASIC_DB, CONFIG_DB, DEFAULT_CONFIG_DB, APPL_STATE_DB, DESCR, OP_DEL, OP_SET, PRE, RESULT, RET, TEST_DATA, UPD, FRR_ROUTES
 
 import pytest
 
@@ -89,7 +90,7 @@ class Table:
         return True, ret
 
 
-db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB}
+db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB, "APPL_STATE_DB": APPL_STATE_DB }
 def conn_side_effect(arg, _):
     return db_conns[arg]
 
@@ -321,3 +322,11 @@ class TestRouteCheck(object):
         assert len(msg) == 5
         msg = route_check.print_message(syslog.LOG_ERR, "a", "b", "c", "d", "e", "f")
         assert len(msg) == 5
+
+    def test_mitigate_routes(self, mock_dbs):
+        missed_frr_rt = [ { 'prefix': '192.168.0.1', 'protocol': 'bgp' } ]
+        rt_appl = [ '192.168.0.1' ]
+        with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+           route_check.mitigate_installed_not_offloaded_frr_routes(missed_frr_rt, rt_appl)
+        # Verify that the stdout are suppressed in this function
+        assert not mock_stdout.getvalue()

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -4,6 +4,7 @@ RET = "return"
 APPL_DB = 0
 ASIC_DB = 1
 CONFIG_DB = 4
+APPL_STATE_DB = 14
 PRE = "pre-value"
 UPD = "update"
 FRR_ROUTES = "frr-routes"


### PR DESCRIPTION
Otherwise it fills up the pipe and print() will block. When this happens, `route_check.py` will timeout and eventually killed by `monit` after several minutes.

Request to cast the change to `202305` branch.

#### What I did
Add an option in `print_message()` to skip printing.

#### How I did it
Add an option `write_to_stdout=True`, in `mitigate_installed_not_offloaded_frr_routes()` call `print_message()` with `write_to_stdout=False`.

#### How to verify it
Manually run route_check.py, verify that the messages were shown in syslog but not in stdout.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

