### PR TITLE
[202311][db_migrator] add db migrator version space for 202311 branch

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -37,7 +37,14 @@ log = logger.Logger(SYSLOG_IDENTIFIER)
 class DBMigrator():
     def __init__(self, namespace, socket=None):
         """
-        Version string format:
+        Version string format (202305 and above):
+            version_<branch>_<build>
+              branch: master, 202311, 202305, etc.
+              build:  sequentially increase with leading 0 to make it 2 digits.
+                      because the minor number has been removed to make it different
+                      from the old format, adding a leading 0 to make sure that we
+                      have double digit version number spaces.
+        Version string format (before 202305):
            version_<major>_<minor>_<build>
               major: starting from 1, sequentially incrementing in master
                      branch.
@@ -47,7 +54,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_4_0_5'
+        self.CURRENT_VERSION = 'version_202311_02'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -1077,27 +1084,37 @@ class DBMigrator():
         """
         log.log_info('Handling version_4_0_3')
 
+        self.set_version('version_202305_01')
+        return 'version_202305_01'
+
+    def version_202305_01(self):
+        """
+        Version 202305_01.
+        This is current last erversion for 202305 branch
+        """
+        log.log_info('Handling version_202305_01')
+        self.set_version('version_202311_01')
+        return 'version_202311_01'
+
+    def version_202311_01(self):
+        """
+        Version 202311_01.
+        """
+        log.log_info('Handling version_202311_01')
+
         # Updating DNS nameserver
         self.migrate_dns_nameserver()
-        self.set_version('version_4_0_4')
-        return 'version_4_0_4'
-
-    def version_4_0_4(self):
-        """
-        Version 4_0_4.
-        """
-        log.log_info('Handling version_4_0_4')
 
         self.migrate_sflow_table()
-        self.set_version('version_4_0_5')
-        return 'version_4_0_5'
+        self.set_version('version_202311_02')
+        return 'version_202311_02'
 
-    def version_4_0_5(self):
+    def version_202311_02(self):
         """
-        Version 4_0_5.
-        This is the latest version for master branch
+        Version 202311_02.
+        This is current last erversion for 202311 branch
         """
-        log.log_info('Handling version_4_0_5')
+        log.log_info('Handling version_202311_02')
         return None
 
     def get_version(self):

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -25,6 +25,36 @@ os.environ["PATH"] += os.pathsep + scripts_path
 def get_sonic_version_info_mlnx():
     return {'asic_type': 'mellanox'}
 
+def version_greater_than(v1, v2):
+    # Return True when v1 is later than v2. Otherwise return False.
+    if 'master' in v1:
+        if 'master' in v2:
+            # both are master versions, directly compare.
+            return v1 > v2
+
+        # v1 is master verson and v2 is not, v1 is higher
+        return True
+
+    if 'master' in v2:
+        # v2 is master version and v1 is not.
+        return False
+
+    s1 = v1.split('_')
+    s2 = v2.split('_')
+    if len(s1) == 3:
+        # new format version_<barnch>_<ver>
+        if len(s2) == 3:
+            # Both are new format version string
+            return v1 > v2
+        return True
+
+    if len(s2) == 3:
+        # v2 is new format and v1 is old format.
+        return False
+
+    # Both are old format version_a_b_c
+    return v1 > v2
+
 
 def advance_version_for_expected_database(migrated_db, expected_db, last_interested_version):
     # In case there are new db versions greater than the latest one that mellanox buffer migrator is interested,
@@ -32,9 +62,39 @@ def advance_version_for_expected_database(migrated_db, expected_db, last_interes
     expected_dbversion = expected_db.get_entry('VERSIONS', 'DATABASE')
     dbmgtr_dbversion = migrated_db.get_entry('VERSIONS', 'DATABASE')
     if expected_dbversion and dbmgtr_dbversion:
-        if expected_dbversion['VERSION'] == last_interested_version and dbmgtr_dbversion['VERSION'] > expected_dbversion['VERSION']:
+        if expected_dbversion['VERSION'] == last_interested_version and version_greater_than(dbmgtr_dbversion['VERSION'], expected_dbversion['VERSION']):
             expected_dbversion['VERSION'] = dbmgtr_dbversion['VERSION']
             expected_db.set_entry('VERSIONS', 'DATABASE', expected_dbversion)
+
+
+class TestVersionComparison(object):
+    @classmethod
+    def setup_class(cls):
+        cls.version_comp_list = [
+                                  # Old format v.s old format
+                                  { 'v1' : 'version_1_0_1', 'v2' : 'version_1_0_2', 'result' : False },
+                                  { 'v1' : 'version_1_0_2', 'v2' : 'version_1_0_1', 'result' : True  },
+                                  { 'v1' : 'version_1_0_1', 'v2' : 'version_2_0_1', 'result' : False },
+                                  { 'v1' : 'version_2_0_1', 'v2' : 'version_1_0_1', 'result' : True  },
+                                  # New format v.s old format
+                                  { 'v1' : 'version_1_0_1', 'v2' : 'version_202311_01', 'result' : False },
+                                  { 'v1' : 'version_202311_01', 'v2' : 'version_1_0_1', 'result' : True  },
+                                  { 'v1' : 'version_1_0_1', 'v2' : 'version_master_01', 'result' : False },
+                                  { 'v1' : 'version_master_01', 'v2' : 'version_1_0_1', 'result' : True  },
+                                  # New format v.s new format
+                                  { 'v1' : 'version_202311_01', 'v2' : 'version_202311_02', 'result' : False },
+                                  { 'v1' : 'version_202311_02', 'v2' : 'version_202311_01', 'result' : True  },
+                                  { 'v1' : 'version_202305_01', 'v2' : 'version_202311_01', 'result' : False },
+                                  { 'v1' : 'version_202311_01', 'v2' : 'version_202305_01', 'result' : True  },
+                                  { 'v1' : 'version_202311_01', 'v2' : 'version_master_01', 'result' : False },
+                                  { 'v1' : 'version_master_01', 'v2' : 'version_202311_01', 'result' : True  },
+                                  { 'v1' : 'version_master_01', 'v2' : 'version_master_02', 'result' : False },
+                                  { 'v1' : 'version_master_02', 'v2' : 'version_master_01', 'result' : True  },
+                                ]
+
+    def test_version_comparison(self):
+        for rec in self.version_comp_list:
+            assert version_greater_than(rec['v1'], rec['v2']) == rec['result'], 'test failed: {}'.format(rec)
 
 
 class TestMellanoxBufferMigrator(object):
@@ -739,7 +799,7 @@ class TestFastUpgrade_to_4_0_3(object):
         expected_db = self.mock_dedicated_config_db(db_after_migrate)
         advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_4_0_3')
         assert not self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)
-        assert dbmgtr.CURRENT_VERSION == expected_db.cfgdb.get_entry('VERSIONS', 'DATABASE')['VERSION']
+        assert dbmgtr.CURRENT_VERSION == expected_db.cfgdb.get_entry('VERSIONS', 'DATABASE')['VERSION'], '{} {}'.format(dbmgtr.CURRENT_VERSION, dbmgtr.get_version())
 
 class TestSflowSampleDirectionMigrator(object):
     @classmethod


### PR DESCRIPTION
#### What I did
Create version name space for 202311/202305 branch.
Add unit test for version compare function.

#### How I did it

#### How to verify it
This is a non-functional change. this PR test is sufficient.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

