### PR TITLE
[config] Only register mclag, not its subcommands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1199,11 +1199,7 @@ config.add_command(muxcable.muxcable)
 config.add_command(nat.nat)
 config.add_command(vlan.vlan)
 config.add_command(vxlan.vxlan)
-
-#add mclag commands
 config.add_command(mclag.mclag)
-config.add_command(mclag.mclag_member)
-config.add_command(mclag.mclag_unique_ip)
 
 # syslog module
 config.add_command(syslog.syslog)


### PR DESCRIPTION
#### What I did
Only mclag needs to be registered with the config utility. Registering the mclag subcommands results in "config members" and "config unique-ip" becoming valid subcommands, without the added "mclag". Having them as "config mclag members" and "config members unique-ip" is sufficient.

#### How I did it
Removed the command registration for `mclag.mclag_member` and `mclag.mclag_unique_ip`

#### How to verify it
Search for `member` or `unique-ip` in `config --help` and check if they're gone.

#### Previous command output (if the output of a command-line utility has changed)
```
# config |grep -e member -e unique-ip
  member
  unique-ip                 Configure Unique IP on MCLAG Vlan interface
```
#### New command output (if the output of a command-line utility has changed)
```
# config |grep -e member -e unique-ip
#
```
