### PR TITLE
[Chassis] Add CLI "reboot" command to "config chassis module" to provide ability to reboot linecard on Supervisor

### DIFF
--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -1,9 +1,8 @@
 #!/usr/sbin/env python
 
 import click
-
 import utilities_common.cli as clicommon
-
+from sonic_py_common import device_info
 #
 # 'chassis_modules' group ('config chassis_modules ...')
 #
@@ -47,3 +46,34 @@ def startup_chassis_module(db, chassis_module_name):
     config_db = db.cfgdb
 
     config_db.set_entry('CHASSIS_MODULE', chassis_module_name, None)
+
+#
+# 'reboot' subcommand ('config chassis_modules reboot ...')
+#
+@modules.command('reboot')
+@clicommon.pass_db
+@click.argument('chassis_module_name', metavar='<module_name>', required=True)
+def reboot_chassis_module(db, chassis_module_name):
+    """Chassis-module reboot of module"""
+    ctx = click.get_current_context()
+
+    if not chassis_module_name.startswith("SUPERVISOR") and \
+       not chassis_module_name.startswith("LINE-CARD") and \
+       not chassis_module_name.startswith("FABRIC-CARD"):
+        ctx.fail("'module_name' has to begin with 'SUPERVISOR', 'LINE-CARD' or 'FABRIC-CARD'")
+
+    if not device_info.is_supervisor():
+         ctx.fail("Command is only supported on Supervisor")
+
+    import sonic_platform
+    chassis = sonic_platform.platform.Platform().get_chassis()
+    module_index = chassis.get_module_index(chassis_module_name)
+    if module_index == -1:
+        ctx.fail("Error: Invalid module name")
+    
+    module =  chassis.get_module(module_index)
+    ret = module.reboot("Default")
+    if ret is False:
+        click.echo("Error: Failed to reboot {}. Reboot may not be supported on this module ".format(chassis_module_name))
+
+    


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add new CLI command "reboot" to the "config chassis module" to provide the ability to reboot linecard from Supervisor


#### How I did it
On Chassis platform, add a new CLI command "reboot" to the existing "config chassis module".  Command imports sonic-platform module and calling the existing function reboot() in the module.py to reboot a module (incldues linecards).  Add consistencyCheck to only allow command issued on Supervisor card.   
The command syntax:
```
admin@Supervisor:~$ sudo config chassis modules reboot -h
Usage: config chassis modules reboot [OPTIONS] <module_name>
```
PR should be merged to the follow branch:
[x] 202205
[x] 202305

#### How to verify it
1) Checking the command syntax on the new image on Supervisor. "reboot"  command will be listed in help text
```
dmin@ixre-cpm-chassis14:~$ sudo config chassis modules -h
Usage: config chassis modules [OPTIONS] COMMAND [ARGS]...

  Configure chassis modules

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  reboot    Chassis-module reboot of module
  shutdown  Chassis-module shutdown of module
  startup   Chassis-module startup of module
admin@ixre-cpm-chassis14:~$ 
```
2)  Issue command "sudo config chassis module reboot LINE-CARD0" on Supervisor,  linecard in slot 1 should be restarted

#### Previous command output (if the output of a command-line utility has changed)
n/a
#### New command output (if the output of a command-line utility has changed)
n/a
