### PR TITLE
Fix database initialization for db_migrator

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -1242,9 +1242,11 @@ def main():
         namespace = args.namespace
 
         if args.namespace is not None:
-            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
+            if not SonicDBConfig.isGlobalInit():
+                SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
         else:
-            SonicDBConfig.initialize()
+            if not SonicDBConfig.isInit():
+                SonicDBConfig.initialize()
 
         if socket_path:
             dbmgtr = DBMigrator(namespace, socket=socket_path)

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -11,6 +11,7 @@ from sonic_py_common import device_info, logger
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
 from minigraph import parse_xml
 from utilities_common.helper import update_config
+from utilities_common.general import load_db_config
 
 INIT_CFG_FILE = '/etc/sonic/init_cfg.json'
 MINIGRAPH_FILE = '/etc/sonic/minigraph.xml'
@@ -1241,12 +1242,7 @@ def main():
         socket_path = args.socket
         namespace = args.namespace
 
-        if args.namespace is not None:
-            if not SonicDBConfig.isGlobalInit():
-                SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
-        else:
-            if not SonicDBConfig.isInit():
-                SonicDBConfig.initialize()
+        load_db_config()
 
         if socket_path:
             dbmgtr = DBMigrator(namespace, socket=socket_path)

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -8,7 +8,7 @@ import traceback
 import re
 
 from sonic_py_common import device_info, logger
-from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig
+from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from minigraph import parse_xml
 from utilities_common.helper import update_config
 from utilities_common.general import load_db_config

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -883,13 +883,5 @@ class TestMain(object):
     @mock.patch('argparse.ArgumentParser.parse_args')
     def test_init(self, mock_args):
         mock_args.return_value=argparse.Namespace(namespace=None, operation='get_version', socket=None)
-        SonicDBConfig.reset()
-        import db_migrator
-        db_migrator.main()
-
-    @mock.patch('argparse.ArgumentParser.parse_args')
-    def test_global_init(self, mock_args):
-        mock_args.return_value=argparse.Namespace(namespace='', operation='get_version', socket=None)
-        SonicDBConfig.reset()
         import db_migrator
         db_migrator.main()

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1,7 +1,8 @@
 import os
 import pytest
 import sys
-
+import argparse
+from unittest import mock
 from deepdiff import DeepDiff
 
 from swsscommon.swsscommon import SonicV2Connector
@@ -869,3 +870,26 @@ class TestGoldenConfigInvalid(object):
         hostname = host.get('hostname', '')
         # hostname is from minigraph.xml
         assert hostname == 'SONiC-Dummy'
+
+class TestMain(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+    @mock.patch('argparse.ArgumentParser.parse_args')
+    @mock.patch('db_migrator.SonicDBConfig.load_sonic_global_db_config')
+    def test_init(self, mock_init, mock_args):
+        mock_args.return_value=argparse.Namespace(namespace=None, operation='get_version', socket=None)
+        import db_migrator
+        db_migrator.main()
+
+    @mock.patch('argparse.ArgumentParser.parse_args')
+    @mock.patch('db_migrator.SonicDBConfig.initialize')
+    def test_global_init(self, mock_init, mock_args):
+        mock_args.return_value=argparse.Namespace(namespace='', operation='get_version', socket=None)
+        import db_migrator
+        db_migrator.main()

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -881,15 +881,13 @@ class TestMain(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
 
     @mock.patch('argparse.ArgumentParser.parse_args')
-    @mock.patch('db_migrator.SonicDBConfig.load_sonic_global_db_config')
-    def test_init(self, mock_init, mock_args):
+    def test_init(self, mock_args):
         mock_args.return_value=argparse.Namespace(namespace=None, operation='get_version', socket=None)
         import db_migrator
         db_migrator.main()
 
     @mock.patch('argparse.ArgumentParser.parse_args')
-    @mock.patch('db_migrator.SonicDBConfig.initialize')
-    def test_global_init(self, mock_init, mock_args):
+    def test_global_init(self, mock_args):
         mock_args.return_value=argparse.Namespace(namespace='', operation='get_version', socket=None)
         import db_migrator
         db_migrator.main()

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -881,17 +881,15 @@ class TestMain(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
 
     @mock.patch('argparse.ArgumentParser.parse_args')
-    @mock.patch('db_migrator.SonicDBConfig.isGlobalInit')
-    def test_init(self, mock_init, mock_args):
+    def test_init(self, mock_args):
         mock_args.return_value=argparse.Namespace(namespace=None, operation='get_version', socket=None)
-        mock_init.return_value=False
+        SonicDBConfig.reset()
         import db_migrator
         db_migrator.main()
 
     @mock.patch('argparse.ArgumentParser.parse_args')
-    @mock.patch('db_migrator.SonicDBConfig.isInit')
-    def test_global_init(self, mock_init, mock_args):
+    def test_global_init(self, mock_args):
         mock_args.return_value=argparse.Namespace(namespace='', operation='get_version', socket=None)
-        mock_init.return_value=False
+        SonicDBConfig.reset()
         import db_migrator
         db_migrator.main()

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -881,13 +881,17 @@ class TestMain(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
 
     @mock.patch('argparse.ArgumentParser.parse_args')
-    def test_init(self, mock_args):
+    @mock.patch('db_migrator.SonicDBConfig.isGlobalInit')
+    def test_init(self, mock_init, mock_args):
         mock_args.return_value=argparse.Namespace(namespace=None, operation='get_version', socket=None)
+        mock_init.return_value=False
         import db_migrator
         db_migrator.main()
 
     @mock.patch('argparse.ArgumentParser.parse_args')
-    def test_global_init(self, mock_args):
+    @mock.patch('db_migrator.SonicDBConfig.isInit')
+    def test_global_init(self, mock_init, mock_args):
         mock_args.return_value=argparse.Namespace(namespace='', operation='get_version', socket=None)
+        mock_init.return_value=False
         import db_migrator
         db_migrator.main()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
db_migrator failed to initialize SonicDBConfig, and I fix this issue.

#### How I did it
If SonicDBConfig is already initialized, do not invoke initialize() again.

#### How to verify it
Run unit test, and verified on DUT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

