### PR TITLE
[Mellanox buffer migrator] Do not touch the buffer model on generic SKUs if the buffer configuration is empty

### DIFF
--- a/tests/db_migrator_input/config_db/empty-config-with-device-info-generic-expected.json
+++ b/tests/db_migrator_input/config_db/empty-config-with-device-info-generic-expected.json
@@ -1,0 +1,11 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_3"
+    },
+    "DEVICE_METADATA|localhost": {
+        "synchronous_mode": "enable",
+        "docker_routing_config_mode": "separated",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "hwsku": "ACS-MSN2700"
+    }
+}

--- a/tests/db_migrator_input/config_db/empty-config-with-device-info-generic-input.json
+++ b/tests/db_migrator_input/config_db/empty-config-with-device-info-generic-input.json
@@ -1,0 +1,6 @@
+{
+    "DEVICE_METADATA|localhost": {
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "hwsku": "ACS-MSN2700"
+    }
+}

--- a/tests/db_migrator_input/config_db/empty-config-with-device-info-traditional-expected.json
+++ b/tests/db_migrator_input/config_db/empty-config-with-device-info-traditional-expected.json
@@ -1,0 +1,12 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_3"
+    },
+    "DEVICE_METADATA|localhost": {
+        "buffer_model": "traditional",
+        "synchronous_mode": "enable",
+        "docker_routing_config_mode": "separated",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "hwsku": "Mellanox-SN2700"
+    }
+}

--- a/tests/db_migrator_input/config_db/empty-config-with-device-info-traditional-input.json
+++ b/tests/db_migrator_input/config_db/empty-config-with-device-info-traditional-input.json
@@ -1,0 +1,6 @@
+{
+    "DEVICE_METADATA|localhost": {
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "hwsku": "Mellanox-SN2700"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -154,6 +154,8 @@ class TestMellanoxBufferMigrator(object):
 
     @pytest.mark.parametrize('scenario',
                              ['empty-config',
+                              'empty-config-with-device-info-generic',
+                              'empty-config-with-device-info-traditional',
                               'non-default-config',
                               'non-default-xoff',
                               'non-default-lossless-profile-in-pg',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Do not touch the buffer model on generic SKUs if the buffer configuration is empty.

#### How I did it

Set the buffer model to traditional on generic SKUs in Mellanox db migrator only if the buffer configuration is not default and not empty.

#### How to verify it

Manually and mock test.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

#### Details ####
Buffer configuration contains two parts:
1. the buffer model in `DEVICE_METADATA|localhost` which is from `init_cfg.json` and can be updated by Mellanox buffer migrator
2. the buffer pools, profiles, PGs, and queues which are renderred from the buffer templates in `config qos reload`

There was a logic to update the buffer model in Mellanox buffer migrator: if the buffer configuration is not default, the buffer model is set to traditional. However, if a device is installed from ONIE, the buffer configuration is also empty. As a result, the traditional buffer manager starts after the device is installed from ONIE, and it requires to restart the buffer manager to switch to the dynamic model. This can be done only by `config reload`.
It didn't matter since it was required to execute `config qos reload` to complete buffer configuration which required `config save` and `config reload` in any case due to issue https://github.com/sonic-net/sonic-buildimage/issues/9088.
Now that the issue has been fixed and `config reload` isn't required anymore to complete `config qos reload`, we should avoid setting the buffer model to traditional in such case, otherwise `config reload` is still required to switch the buffer model.

Verified the following scenarios:
1. non-default configuration generic SKU upgrade from 202305: warm/cold boot: expected: traditional model
2. default configuration generic SKU upgrade from 201911/202305: warm/cold boot: expected: dynamic model
3. install from ONIE: expected: dynamic model
4. MSFT SKU upgrade from 201911 by cold boot/ from 202012 by warm boot: expected: traditional model