### PR TITLE
Revert "route_check: Skip route checks if bgp feature is not enabled"

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -533,18 +533,6 @@ def filter_out_standalone_tunnel_routes(namespace, routes):
 
     return updated_routes
 
-def is_feature_bgp_enabled(namespace):
-    """
-    Check if bgp feature is enabled or disabled.
-    Return True if enabled else False.
-    """
-    cfg_db = multi_asic.connect_config_db_for_ns(namespace)
-    feature_table = cfg_db.get_table("FEATURE")
-    bgp_enabled = False
-    if 'bgp' in feature_table:
-        if feature_table['bgp']["state"] == "enabled":
-            bgp_enabled = True
-    return bgp_enabled
 
 def check_frr_pending_routes(namespace):
     """
@@ -838,10 +826,6 @@ def main():
 
     signal.signal(signal.SIGALRM, handler)
     load_db_config()
-
-    if not is_feature_bgp_enabled(namespace):
-        print_message(syslog.LOG_INFO, "BGP feature is disabled, exiting without checking routes!!")
-        return 0, None
 
     while True:
         signal.alarm(TIMEOUT_SECONDS)

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -271,14 +271,11 @@ class TestRouteCheck(object):
         # Test timeout
         ex_raised = False
         # Use an expected failing test case to trigger the select
-        ct_data = TEST_DATA['2']
-        set_test_case_data(ct_data)
+        set_test_case_data(TEST_DATA['2'])
+
         try:
-            with patch('sys.argv', [route_check.__file__.split('/')[-1]]), \
-                patch('route_check.load_db_config', side_effect=lambda: init_db_conns(ct_data[NAMESPACE])):
-
+            with patch('sys.argv', [route_check.__file__.split('/')[-1]]):
                 ret, res = route_check.main()
-
         except Exception as err:
             ex_raised = True
             expect = "timeout occurred"

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -23,7 +23,6 @@ ROUTE_TABLE = 'ROUTE_TABLE'
 VNET_ROUTE_TABLE = 'VNET_ROUTE_TABLE'
 INTF_TABLE = 'INTF_TABLE'
 RT_ENTRY_TABLE = 'ASIC_STATE'
-FEATURE_TABLE = 'FEATURE'
 SEPARATOR = ":"
 DEVICE_METADATA = "DEVICE_METADATA"
 MUX_CABLE = "MUX_CABLE"
@@ -33,17 +32,7 @@ LOCALHOST = "localhost"
 RT_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest":\"'
 RT_ENTRY_KEY_SUFFIX = '\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000023\"}'
 
-DEFAULT_CONFIG_DB = {
-    DEVICE_METADATA: {
-        LOCALHOST: {
-            }
-        },
-    FEATURE_TABLE: {
-        "bgp": {
-            "state": "enabled"
-            }
-        }
-    }
+DEFAULT_CONFIG_DB = {DEVICE_METADATA: {LOCALHOST: {}}}
 
 TEST_DATA = {
     "0": {
@@ -341,11 +330,6 @@ TEST_DATA = {
                 CONFIG_DB: {
                     DEVICE_METADATA: {
                         LOCALHOST: {"subtype": "DualToR"}
-                    },
-                    FEATURE_TABLE: {
-                        "bgp": {
-                            "state": "enabled"
-                        }
                     }
                 },
                 APPL_DB: {
@@ -412,11 +396,6 @@ TEST_DATA = {
                             "soc_ipv6": "fc02:1000::3/128",
                             "state": "auto"
                         },
-                    },
-                    FEATURE_TABLE: {
-                        "bgp": {
-                            "state": "enabled"
-                        }
                     }
                 },
                 APPL_DB: {
@@ -584,11 +563,6 @@ TEST_DATA = {
                 CONFIG_DB: {
                     DEVICE_METADATA: {
                         LOCALHOST: {"subtype": "DualToR"}
-                    },
-                    FEATURE_TABLE: {
-                        "bgp": {
-                            "state": "enabled"
-                        }
                     }
                 },
                 APPL_DB: {
@@ -907,132 +881,5 @@ TEST_DATA = {
         },
         RET: -1,
     },
-    "21": {
-        DESCR: "basic good one on single asic, bgp disabled",
-        MULTI_ASIC: False,
-        NAMESPACE: [''],
-        ARGS: "route_check -m INFO -i 1000",
-        PRE: {
-            DEFAULTNS: {
-                CONFIG_DB: {
-                    DEVICE_METADATA: {
-                        LOCALHOST: {
-                        }
-                    },
-                    FEATURE_TABLE: {
-                        "bgp": {
-                            "state": "disabled"
-                        }
-                    }
-                },
-                APPL_DB: {
-                    ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                    },
-                    INTF_TABLE: {
-                        "PortChannel1013:10.10.196.24/31": {},
-                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
-                        "PortChannel1024": {}
-                    }
-                },
-                ASIC_DB: {
-                    RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
-                    }
-                },
-            },
-        },
-        FRR_ROUTES: {
-            DEFAULTNS: {
-                "0.0.0.0/0": [
-                    {
-                        "prefix": "0.0.0.0/0",
-                        "vrfName": "default",
-                        "protocol": "bgp",
-                        "offloaded": "true",
-                    },
-                ],
-                "10.10.196.12/31": [
-                    {
-                        "prefix": "10.10.196.12/31",
-                        "vrfName": "default",
-                        "protocol": "bgp",
-                    },
-                ],
-                "10.10.196.24/31": [
-                    {
-                        "protocol": "connected",
-                    },
-                ],
-            },
-        },
-    },
-    "22": {
-        DESCR: "basic good one on multi-asic, bgp disabled",
-        MULTI_ASIC: True,
-        NAMESPACE: ['asic0'],
-        ARGS: "route_check -m INFO -i 1000",
-        PRE: {
-            ASIC0: {
-                CONFIG_DB: {
-                    DEVICE_METADATA: {
-                        LOCALHOST: {
-                        }
-                    },
-                    FEATURE_TABLE: {
-                        "bgp": {
-                            "state": "disabled"
-                        }
-                    }
-                },
-                APPL_DB: {
-                    ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                    },
-                    INTF_TABLE: {
-                        "PortChannel1013:10.10.196.24/31": {},
-                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
-                        "PortChannel1024": {}
-                    }
-                },
-                ASIC_DB: {
-                    RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
-                    }
-                },
-            },
-        },
-        FRR_ROUTES: {
-            ASIC0: {
-                "0.0.0.0/0": [
-                    {
-                        "prefix": "0.0.0.0/0",
-                        "vrfName": "default",
-                        "protocol": "bgp",
-                        "offloaded": "true",
-                    },
-                ],
-                "10.10.196.12/31": [
-                    {
-                        "prefix": "10.10.196.12/31",
-                        "vrfName": "default",
-                        "protocol": "bgp",
-                    },
-                ],
-                "10.10.196.24/31": [
-                    {
-                        "protocol": "connected",
-                    },
-                ],
-            },
-        },
-    },
+
 }


### PR DESCRIPTION
Reverts sonic-net/sonic-utilities#3075

This change and #3077 has prevented sonic-utilities repo submodule head moving for a month.