### PR TITLE
[202205] Fix issue: out of range sflow polling interval is accepted and stored in config_db (#2847)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6308,7 +6308,7 @@ def disable(ctx):
 def polling_int(ctx, interval):
     """Set polling-interval for counter-sampling (0 to disable)"""
     if interval not in range(5, 301) and interval != 0:
-        click.echo("Polling interval must be between 5-300 (0 to disable)")
+        ctx.fail("Polling interval must be between 5-300 (0 to disable)")
 
     config_db = ctx.obj['db']
     sflow_tbl = config_db.get_table('SFLOW')

--- a/tests/sflow_test.py
+++ b/tests/sflow_test.py
@@ -182,6 +182,13 @@ class TestShowSflow(object):
         runner = CliRunner()
         obj = {'db':db.cfgdb}
 
+        # set to 500 out of range
+        result = runner.invoke(config.config.commands["sflow"].
+            commands["polling-interval"], ["500"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert "Polling interval must be between 5-300" in result.output
+
         # set to 20
         result = runner.invoke(config.config.commands["sflow"].
             commands["polling-interval"], ["20"], obj=obj)


### PR DESCRIPTION
This is to backport #2847 to 202205

Fixed issue: out of range sflow polling interval is accepted and stored in config_db.

Reproduce step:
```
1. Enable sflow feature:   config feature state sflow enabled
2. Enable sflow itself:   config sflow enable
3. Configure out of range polling interval:  config sflow polling-interval 1. Error message is shown as expected
4. Save config:    config save -y
5. Check "SFLOW" section inside config_db
```

As the interval is invalid, the expected behavior is that the interval is not saved to redis. But we see the invalid value was written to redis.

Change `click.echo` to `ctx.fail`

1. Manual test
2. Add a check in existing unit test case to cover the change

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

