### PR TITLE
[202205] Allow using latest sonic-swss-common build even if tests failed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,7 @@ stages:
         artifact: sonic-swss-common.bullseye.amd64
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/$(sourceBranch)'
+        allowPartiallySucceededBuilds: true
       displayName: "Download sonic swss common deb packages"
 
     - script: |


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

The current 202205 branch build of sonic-swss-common has failing test cases. This is blocking sonic-utilities, since this is the only build available in that branch.

#### How I did it

Allow using that build even though tests are failing, to unblock PRs in this repo.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

