### PR TITLE
[Master]: Additional check to skip FRR-Offloaded check if the bgp route-src was not selected as best

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -542,7 +542,7 @@ def check_frr_pending_routes():
             for entry in entries:
                 if entry['protocol'] != 'bgp':
                     continue
-				
+
                 # TODO: Also handle VRF routes. Currently this script does not check for VRF routes so it would be incorrect for us
                 # to assume they are installed in ASIC_DB, so we don't handle them.
                 if entry['vrfName'] != 'default':

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -543,6 +543,10 @@ def check_frr_pending_routes():
                 if entry['protocol'] != 'bgp':
                     continue
 
+                # skip if this bgp source prefix is not selected as best
+                if 'selected' not in entry or entry['selected'] != True:
+                    continue
+
                 # TODO: Also handle VRF routes. Currently this script does not check for VRF routes so it would be incorrect for us
                 # to assume they are installed in ASIC_DB, so we don't handle them.
                 if entry['vrfName'] != 'default':

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -542,14 +542,14 @@ def check_frr_pending_routes():
             for entry in entries:
                 if entry['protocol'] != 'bgp':
                     continue
-
-                # skip if this bgp source prefix is not selected as best
-                if 'selected' not in entry or entry['selected'] != True:
-                    continue
-
+				
                 # TODO: Also handle VRF routes. Currently this script does not check for VRF routes so it would be incorrect for us
                 # to assume they are installed in ASIC_DB, so we don't handle them.
                 if entry['vrfName'] != 'default':
+                    continue
+
+		# skip if this bgp source prefix is not selected as best
+                if not entry.get('selected', False):
                     continue
 
                 if not entry.get('offloaded', False):

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -548,7 +548,7 @@ def check_frr_pending_routes():
                 if entry['vrfName'] != 'default':
                     continue
 
-		# skip if this bgp source prefix is not selected as best
+                # skip if this bgp source prefix is not selected as best
                 if not entry.get('selected', False):
                     continue
 

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -394,7 +394,8 @@ TEST_DATA = {
                     "prefix": "0.0.0.0/0",
                     "vrfName": "default",
                     "protocol": "bgp",
-                    "offloaded": "true",
+                    "selected": True,
+                    "offloaded": True,
                 },
             ],
             "10.10.196.12/31": [
@@ -402,12 +403,14 @@ TEST_DATA = {
                     "prefix": "10.10.196.12/31",
                     "vrfName": "default",
                     "protocol": "bgp",
-                    "offloaded": "true",
+                    "selected": True,
+                    "offloaded": True,
                 },
             ],
             "10.10.196.24/31": [
                 {
                     "protocol": "connected",
+                    "selected": True,
                 },
             ],
         },
@@ -442,7 +445,64 @@ TEST_DATA = {
                     "prefix": "0.0.0.0/0",
                     "vrfName": "default",
                     "protocol": "bgp",
-                    "offloaded": "true",
+                    "selected": True,
+                    "offloaded": True,
+                },
+            ],
+            "10.10.196.12/31": [
+                {
+                    "prefix": "10.10.196.12/31",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "selected": True,
+                },
+            ],
+            "10.10.196.24/31": [
+                {
+                    "protocol": "connected",
+                    "selected": True,
+                },
+            ],
+        },
+        RESULT: {
+            "missed_FRR_routes": [
+                {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp", "selected": True}
+            ],
+        },
+        RET: -1,
+    },
+    "12": {
+        DESCR: "skip bgp routes offloaded check, if not selected as best",
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            APPL_DB: {
+                ROUTE_TABLE: {
+                    "0.0.0.0/0" : { "ifname": "portchannel0" },
+                    "10.10.196.12/31" : { "ifname": "portchannel0" },
+                },
+                INTF_TABLE: {
+                    "PortChannel1013:10.10.196.24/31": {},
+                    "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                    "PortChannel1024": {}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                }
+            },
+        },
+        FRR_ROUTES: {
+            "0.0.0.0/0": [
+                {
+                    "prefix": "0.0.0.0/0",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "selected": True,
+                    "offloaded": True,
                 },
             ],
             "10.10.196.12/31": [
@@ -455,17 +515,12 @@ TEST_DATA = {
             "10.10.196.24/31": [
                 {
                     "protocol": "connected",
+                    "selected": True,
                 },
             ],
         },
-        RESULT: {
-            "missed_FRR_routes": [
-                {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp"}
-            ],
-        },
-        RET: -1,
     },
-    "10": {
+    "13": {
         DESCR: "basic good one with IPv6 address",
         ARGS: "route_check -m INFO -i 1000",
         PRE: {
@@ -483,7 +538,7 @@ TEST_DATA = {
             }
         }
     },
-    "11": {
+    "14": {
         DESCR: "dualtor ignore vlan neighbor route miss case",
         ARGS: "route_check -i 15",
         RET: -1,


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixes https://github.com/sonic-net/sonic-buildimage/issues/17877
#### How I did it
Added additional check to skip FRR-Offloaded check if the routeSrc BGP was not selected as best.
#### How to verify it
Ran the script on multi-asic KVM device, and could confirm the route_check is passing.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

