### PR TITLE
[202311] Migrate GNMI table

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -59,7 +59,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_202311_02'
+        self.CURRENT_VERSION = 'version_202311_03'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -618,6 +618,30 @@ class DBMigrator():
         if not certs:
             self.configDB.set_entry("TELEMETRY", "certs", telemetry_data.get("certs"))
 
+    def migrate_gnmi(self):
+        # If there's GNMI table in CONFIG_DB, no need to migrate
+        gnmi = self.configDB.get_entry('GNMI', 'gnmi')
+        certs = self.configDB.get_entry('GNMI', 'certs')
+        if gnmi and certs:
+            return
+        if self.config_src_data:
+            if 'GNMI' in self.config_src_data:
+                # If there's GNMI in minigraph or golden config, copy configuration from config_src_data
+                gnmi_data = self.config_src_data['GNMI']
+                log.log_notice('Migrate GNMI configuration')
+                if 'gnmi' in gnmi_data:
+                    self.configDB.set_entry("GNMI", "gnmi", gnmi_data.get('gnmi'))
+                if 'certs' in gnmi_data:
+                    self.configDB.set_entry("GNMI", "certs", gnmi_data.get('certs'))
+        else:
+            # If there's no minigraph or golden config, copy configuration from CONFIG_DB TELEMETRY table
+            gnmi = self.configDB.get_entry('TELEMETRY', 'gnmi')
+            if gnmi:
+                self.configDB.set_entry("GNMI", "gnmi", gnmi)
+            certs = self.configDB.get_entry('TELEMETRY', 'certs')
+            if certs:
+                self.configDB.set_entry("GNMI", "certs", certs)
+
     def migrate_console_switch(self):
         # CONSOLE_SWITCH - add missing key
         if not self.config_src_data or 'CONSOLE_SWITCH' not in self.config_src_data:
@@ -1159,9 +1183,20 @@ class DBMigrator():
     def version_202311_02(self):
         """
         Version 202311_02.
-        This is current last erversion for 202311 branch
         """
         log.log_info('Handling version_202311_02')
+        # Update GNMI table
+        self.migrate_gnmi()
+
+        self.set_version('version_202311_03')
+        return 'version_202311_03'
+
+    def version_202311_03(self):
+        """
+        Version 202311_03.
+        This is current last erversion for 202311 branch
+        """
+        log.log_info('Handling version_202311_03')
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/gnmi-configdb-expected.json
+++ b/tests/db_migrator_input/config_db/gnmi-configdb-expected.json
@@ -1,0 +1,15 @@
+{
+    "GNMI|gnmi": {
+        "client_auth": "true", 
+        "log_level": "2", 
+        "port": "50051"
+    }, 
+    "GNMI|certs": {
+        "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key", 
+        "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer", 
+        "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_202311_03"
+    }
+}

--- a/tests/db_migrator_input/config_db/gnmi-input.json
+++ b/tests/db_migrator_input/config_db/gnmi-input.json
@@ -1,0 +1,15 @@
+{
+    "TELEMETRY|gnmi": {
+        "client_auth": "true", 
+        "log_level": "2", 
+        "port": "50051"
+    }, 
+    "TELEMETRY|certs": {
+        "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key", 
+        "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer", 
+        "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_202311_01"
+    }
+}

--- a/tests/db_migrator_input/config_db/gnmi-minigraph-expected.json
+++ b/tests/db_migrator_input/config_db/gnmi-minigraph-expected.json
@@ -1,0 +1,15 @@
+{
+    "GNMI|gnmi": {
+        "client_auth": "true", 
+        "log_level": "2", 
+        "port": "50052"
+    }, 
+    "GNMI|certs": {
+        "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key", 
+        "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer", 
+        "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_202311_03"
+    }
+}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
We will use GNMI container to replace TELEMETRY container in public repo.
GNMI is using GNMI table for configuration, so we need to migrate configuration in CONFIG_DB.
For L2 mode, there's no GNMI configuration in minigraph, and there's no TELEMETRY table in CONFIG_DB, so we will not generate GNMI table.

Backport https://github.com/sonic-net/sonic-utilities/pull/3053

#### How I did it
If there's no minigraph and golden config, copy GNMI configuration from TELEMETRY table.
If there're minigraph and golden config, copy GNMI configuration from minigraph or golden config.

#### How to verify it
Run db migrator unit test, test with minigraph and test without minigraph.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

