### PR TITLE
Fix the sfputil treats page number as decimal instead of hexadecimal

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -703,10 +703,12 @@ def eeprom_hexdump(port, page):
     if port:
         if page is None:
             page = 0
-        return_code, output = eeprom_hexdump_single_port(port, page)
+        return_code, output = eeprom_hexdump_single_port(port, int(str(page), base=16))
         click.echo(output)
         sys.exit(return_code)
     else:
+        if page is not None:
+            page = int(str(page), base=16)
         logical_port_list = natsorted(platform_sfputil.logical)
         lines = []
         for logical_port_name in logical_port_list:
@@ -729,7 +731,7 @@ def validate_eeprom_page(page):
         int page
     """
     try:
-        page = int(page)
+        page = int(page, base=16)
     except ValueError:
         click.echo('Please enter a numeric page number')
         sys.exit(ERROR_NOT_IMPLEMENTED)
@@ -830,7 +832,7 @@ def eeprom_hexdump_pages_general(logical_port_name, pages, target_page):
         tuple(0, dump string) if success else tuple(error_code, error_message)
     """
     if target_page is not None:
-        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page}h']
+        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page:x}h']
     else:
         lines = [f'EEPROM hexdump for port {logical_port_name}']
     physical_port = logical_port_to_physical_port_index(logical_port_name)
@@ -871,7 +873,7 @@ def eeprom_hexdump_pages_sff8472(logical_port_name, pages, target_page):
         tuple(0, dump string) if success else tuple(error_code, error_message)
     """
     if target_page is not None:
-        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page}h']
+        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page:x}h']
     else:
         lines = [f'EEPROM hexdump for port {logical_port_name}']
     physical_port = logical_port_to_physical_port_index(logical_port_name)
@@ -915,28 +917,6 @@ def eeprom_dump_general(physical_port, page, flat_offset, size, page_offset, no_
         page_offset: offset within a page, only for print purpose
         no_format: False if dump with hex format else dump with flat hex string. Default False.
 
-    Returns:
-        tuple(0, dump string) if success else tuple(error_code, error_message)
-    """
-    sfp = platform_chassis.get_sfp(physical_port)
-    page_dump = sfp.read_eeprom(flat_offset, size)
-    if page_dump is None:
-        return ERROR_NOT_IMPLEMENTED, f'Error: Failed to read EEPROM for page {page:x}h, flat_offset {flat_offset}, page_offset {page_offset}, size {size}!'
-    if not no_format:
-        return 0, hexdump(EEPROM_DUMP_INDENT, page_dump, page_offset, start_newline=False)
-    else:
-        return 0, ''.join('{:02x}'.format(x) for x in page_dump)
-
-
-
-def eeprom_dump_general(physical_port, page, flat_offset, size, page_offset, no_format=False):
-    """
-    Dump module EEPROM for given pages in hex format.
-    Args:
-        logical_port_name: logical port name
-        pages: a list of pages to be dumped. The list always include a default page list and the target_page input by
-               user
-        target_page: user input page number, optional. target_page is only for display purpose
     Returns:
         tuple(0, dump string) if success else tuple(error_code, error_message)
     """


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

https://github.com/sonic-net/sonic-utilities/pull/3009 breaks the number base rule, treats the page number CLI input as decimal rather than hex, this is used to fix it.

it also containes a redundancy function definition, so remove it.


#### How I did it

#### How to verify it

unit test and manually test

#### Previous command output (if the output of a command-line utility has changed)

```
sudo sfputil show eeprom-hexdump -n 10 -p Ethernet32
EEPROM hexdump for port Ethernet32 page 10h
        Lower page 0h
        00000000 0d 06 06 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000010 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000020 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000030 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000040 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000050 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000060 00 00 00 00 00 00 00 00  00 00 00 00 00 01 08 00 |................|
        00000070 00 10 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|

        Upper page 0h
        00000080 0d 00 23 88 00 00 00 00  00 00 00 00 ff 00 00 00 |..#.............|
        00000090 00 00 01 a0 4d 65 6c 6c  61 6e 6f 78 20 20 20 20 |....Mellanox    |
        000000a0 20 20 20 20 1f 00 02 c9  4d 43 50 31 36 30 30 2d |    ....MCP1600-|
        000000b0 45 30 30 41 20 20 20 20  41 33 02 03 04 06 46 85 |E00A    A3....F.|
        000000c0 0b 00 00 00 4d 54 31 37  30 38 56 53 30 36 35 36 |....MT1708VS0656|
        000000d0 36 20 20 20 31 36 31 31  31 35 20 20 00 00 67 62 |6   161115  ..gb|
        000000e0 31 39 32 32 36 32 36 41  5a 34 30 50 00 00 00 00 |1922626AZ40P....|
        000000f0 00 00 00 00 00 00 00 00  00 00 00 00 00 30 00 00 |.............0..|

        Upper page ah
        00000080 0d 00 23 88 00 00 00 00  00 00 00 00 ff 00 00 00 |..#.............|
        00000090 00 00 01 a0 4d 65 6c 6c  61 6e 6f 78 20 20 20 20 |....Mellanox    |
        000000a0 20 20 20 20 1f 00 02 c9  4d 43 50 31 36 30 30 2d |    ....MCP1600-|
        000000b0 45 30 30 41 20 20 20 20  41 33 02 03 04 06 46 85 |E00A    A3....F.|
        000000c0 0b 00 00 00 4d 54 31 37  30 38 56 53 30 36 35 36 |....MT1708VS0656|
        000000d0 36 20 20 20 31 36 31 31  31 35 20 20 00 00 67 62 |6   161115  ..gb|
        000000e0 31 39 32 32 36 32 36 41  5a 34 30 50 00 00 00 00 |1922626AZ40P....|
        000000f0 00 00 00 00 00 00 00 00  00 00 00 00 00 30 00 00 |.............0..|

```
#### New command output (if the output of a command-line utility has changed)
```
sudo sfputil show eeprom-hexdump -n 10 -p Ethernet32
EEPROM hexdump for port Ethernet32 page 10h
        Lower page 0h
        00000000 11 06 06 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000010 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000020 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000030 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000040 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000050 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
        00000060 00 00 00 00 00 00 00 00  00 00 00 00 00 01 08 00 |................|
        00000070 00 10 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|

        Upper page 0h
        00000080 11 00 23 88 00 00 00 00  00 00 00 05 ff 00 00 00 |..#.............|
        00000090 00 00 01 a0 4d 65 6c 6c  61 6e 6f 78 20 20 20 20 |....Mellanox    |
        000000a0 20 20 20 20 00 00 02 c9  4d 43 50 31 36 30 30 2d |    ....MCP1600-|
        000000b0 43 30 30 41 45 33 30 4e  41 34 02 03 04 06 46 e4 |C00AE30NA4....F.|
        000000c0 0d 00 00 00 4d 54 31 39  35 32 56 42 30 33 38 38 |....MT1952VB0388|
        000000d0 30 20 20 20 31 39 31 32  32 38 20 20 00 00 67 58 |0   191228  ..gX|
        000000e0 32 34 30 32 39 34 35 43  39 31 4c 30 00 1e 00 00 |2402945C91L0....|
        000000f0 00 00 00 00 00 00 00 00  00 00 00 00 00 30 00 00 |.............0..|

        Upper page 10h
        00000080 11 00 23 88 00 00 00 00  00 00 00 05 ff 00 00 00 |..#.............|
        00000090 00 00 01 a0 4d 65 6c 6c  61 6e 6f 78 20 20 20 20 |....Mellanox    |
        000000a0 20 20 20 20 00 00 02 c9  4d 43 50 31 36 30 30 2d |    ....MCP1600-|
        000000b0 43 30 30 41 45 33 30 4e  41 34 02 03 04 06 46 e4 |C00AE30NA4....F.|
        000000c0 0d 00 00 00 4d 54 31 39  35 32 56 42 30 33 38 38 |....MT1952VB0388|
        000000d0 30 20 20 20 31 39 31 32  32 38 20 20 00 00 67 58 |0   191228  ..gX|
        000000e0 32 34 30 32 39 34 35 43  39 31 4c 30 00 1e 00 00 |2402945C91L0....|
        000000f0 00 00 00 00 00 00 00 00  00 00 00 00 00 30 00 00 |.............0..|
```

