### PR TITLE
[show] Update show run all to cover all asic config in multiasic

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -142,6 +142,24 @@ def get_cmd_output(cmd):
     proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
     return proc.communicate()[0], proc.returncode
 
+def get_config_json_by_namespace(namespace):
+    cmd = ['sonic-cfggen', '-d', '--print-data']
+    if namespace is not None and namespace != multi_asic.DEFAULT_NAMESPACE:
+        cmd += ['-n', namespace]
+
+    stdout, rc = get_cmd_output(cmd)
+    if rc:
+        click.echo("Failed to get cmd output '{}':rc {}".format(cmd, rc))
+        raise click.Abort()
+
+    try:
+        config_json = json.loads(stdout)
+    except JSONDecodeError as e:
+        click.echo("Failed to load output '{}':{}".format(cmd, e))
+        raise click.Abort()
+
+    return config_json
+
 # Lazy global class instance for SONiC interface name to alias conversion
 iface_alias_converter = lazy_object_proxy.Proxy(lambda: clicommon.InterfaceAliasConverter())
 
@@ -1407,24 +1425,24 @@ def runningconfiguration():
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def all(verbose):
     """Show full running configuration"""
-    cmd = ['sonic-cfggen', '-d', '--print-data']
-    stdout, rc = get_cmd_output(cmd)
-    if rc:
-        click.echo("Failed to get cmd output '{}':rc {}".format(cmd, rc))
-        raise click.Abort()
 
-    try:
-        output = json.loads(stdout)
-    except JSONDecodeError as e:
-        click.echo("Failed to load output '{}':{}".format(cmd, e))
-        raise click.Abort()
+    if multi_asic.is_multi_asic():
+        output = {}
+        # In multiaisc, the namespace is changed to localhost by design
+        output['localhost'] = get_config_json_by_namespace(multi_asic.DEFAULT_NAMESPACE)
 
-    if not multi_asic.is_multi_asic():
+        ns_list = multi_asic.get_namespace_list()
+        for ns in ns_list:
+            output[ns] = get_config_json_by_namespace(ns)
+    else:
+        output = get_config_json_by_namespace(None)
+
         bgpraw_cmd = [constants.RVTYSH_COMMAND, '-c', 'show running-config']
         bgpraw, rc = get_cmd_output(bgpraw_cmd)
         if rc:
             bgpraw = ""
         output['bgpraw'] = bgpraw
+
     click.echo(json.dumps(output, indent=4))
 
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 26574293
#### What I did
Update `show runningconfiguration all` to cover asics config
#### How I did it
Loop host and each asic to get config, then combine into one.
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)
```
admin@str3-7800-lc3-1:~$ show runningconfiguration all
{
    "ACL_TABLE": {
        ...
    },
    ...
}
```
#### New command output (if the output of a command-line utility has changed)
```
admin@str3-7800-lc3-1:~$ show runningconfiguration all
{
    "localhost": {
        "ACL_TABLE": {
             ...
        },
        ...
    },
    "asic0": {
        "ACL_TABLE": {
            ...
        },
        ...
    },
    ...
}
```
