### PR TITLE
Fix load_mgmt_config not exit when dhclient.eth0.pid not exists

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1683,17 +1683,15 @@ def load_mgmt_config(filename):
         clicommon.run_command(command, display_cmd=True, ignore_error=True)
     if len(config_data['MGMT_INTERFACE'].keys()) > 0:
         filepath = '/var/run/dhclient.eth0.pid'
-        if not os.path.isfile(filepath):
-            sys.exit('File {} does not exist'.format(filepath))
+        if os.path.isfile(filepath):
+            out0, rc0 = clicommon.run_command(['cat', filepath], display_cmd=True, return_cmd=True)
+            if rc0 != 0:
+                sys.exit('Exit: {}. Command: cat {} failed.'.format(rc0, filepath))
 
-        out0, rc0 = clicommon.run_command(['cat', filepath], display_cmd=True, return_cmd=True)
-        if rc0 != 0:
-            sys.exit('Exit: {}. Command: cat {} failed.'.format(rc0, filepath))
-
-        out1, rc1 = clicommon.run_command(['kill', str(out0).strip('\n')], return_cmd=True)
-        if rc1 != 0:
-            sys.exit('Exit: {}. Command: kill {} failed.'.format(rc1, out0))
-        clicommon.run_command(['rm', '-f', filepath], display_cmd=True, return_cmd=True)
+            out1, rc1 = clicommon.run_command(['kill', str(out0).strip('\n')], return_cmd=True)
+            if rc1 != 0:
+                sys.exit('Exit: {}. Command: kill {} failed.'.format(rc1, out0))
+            clicommon.run_command(['rm', '-f', filepath], display_cmd=True, return_cmd=True)
     click.echo("Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.")
 
 @config.command("load_minigraph")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

