### PR TITLE
sonic-utilities: Add CLI commands to set sflow drop-monitor-limit

### DIFF
--- a/show/sflow.py
+++ b/show/sflow.py
@@ -86,6 +86,12 @@ def show_sflow_global(config_db):
     else:
         click.echo("default")
 
+    click.echo("  sFlow Drop Rate Limit:".ljust(30), nl=False)
+    if (sflow_info and 'drop_monitor_limit' in sflow_info['global']):
+        click.echo("{}".format(sflow_info['global']['drop_monitor_limit']))
+    else:
+        click.echo("0")
+
     sflow_info = config_db.get_table('SFLOW_COLLECTOR')
     click.echo("\n  {} Collectors configured:".format(len(sflow_info)))
     for collector_name in sorted(list(sflow_info.keys())):


### PR DESCRIPTION
* added CLI: config sflow drop-monitor-limit 1-999 (0 to disable)
* added line to show sflow output to indicate current setting
* added test to ensure that out-of-range value is denied

The effect is to add the redis field drop_monitor_limit to the sflow configuration table in redis, as described in pull-request [PR#1484](https://github.com/sonic-net/SONiC/pull/1484) on the sonic-net/SONiC repo.


Note: hsflowd version 2.0.52 will apply this setting. Older versions will ignore it.

### Example:

% sudo config sflow drop-monitor-limit 50
% show sflow

sFlow Global Information:
  sFlow Admin State:            up
  sFlow Sample Direction:   rx
  sFlow Polling Interval:       default
  sFlow AgentID:                  default
 **sFlow Drop Rate Limit:      50**

Signed-off-by: Neil McKee  neil.mckee@inmon.com
