### PR TITLE
Add sonic-clear logging command

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import click
+import glob
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 from sonic_py_common.general import getstatusoutput_noshell_pipe
@@ -545,6 +546,32 @@ def route(prefix, vrf, namespace):
         command += ['-n', str(namespace)]
     clicommon.run_command(command)
 
+@click.option('--all', '-a', is_flag=True, help='Delete also compressed logs')
+@cli.command()
+def logging(all):
+    """Clear logging files"""
+    if os.path.exists("/var/log.tmpfs"):
+        log_path = "/var/log.tmpfs"
+    else:
+        log_path = "/var/log"
+    
+    if all:
+        files_to_delete = glob.glob(f"{log_path}/syslog*")
+    else:
+        files_to_delete = [f"{log_path}/syslog"]
+        
+    if os.path.isfile(f"{log_path}/syslog.1"):
+        files_to_delete += [f"{log_path}/syslog.1"]
+
+    for f in files_to_delete:
+        cmd = ['sudo', 'rm','-f',f]
+        run_command(cmd)
+
+@click.command()
+@def nothing():
+    """ do nothing """
+    cmd = ['echo', 'doing' , 'nothing']
+    run_command(cmd)
 
 # Load plugins and register them
 helper = util_base.UtilHelper()

--- a/clear/main.py
+++ b/clear/main.py
@@ -567,11 +567,6 @@ def logging(all):
         cmd = ['sudo', 'rm','-f',f]
         run_command(cmd)
 
-@click.command()
-@def nothing():
-    """ do nothing """
-    cmd = ['echo', 'doing' , 'nothing']
-    run_command(cmd)
 
 # Load plugins and register them
 helper = util_base.UtilHelper()

--- a/clear/main.py
+++ b/clear/main.py
@@ -550,7 +550,9 @@ def route(prefix, vrf, namespace):
 @cli.command()
 def logging(all):
     """Clear logging files"""
-    log_path_arr = ["/var/log"]
+    log_path_arr = []
+    if os.path.exists("/var/log"):
+        log_path_arr += ["/var/log"]
     if os.path.exists("/var/log.tmpfs"):
         log_path_arr += ["/var/log.tmpfs"]
     

--- a/clear/main.py
+++ b/clear/main.py
@@ -550,18 +550,19 @@ def route(prefix, vrf, namespace):
 @cli.command()
 def logging(all):
     """Clear logging files"""
+    log_path_arr = ["/var/log"]
     if os.path.exists("/var/log.tmpfs"):
-        log_path = "/var/log.tmpfs"
-    else:
-        log_path = "/var/log"
+        log_path_arr += ["/var/log.tmpfs"]
     
-    if all:
-        files_to_delete = glob.glob(f"{log_path}/syslog*")
-    else:
-        files_to_delete = [f"{log_path}/syslog"]
-        
-    if os.path.isfile(f"{log_path}/syslog.1"):
-        files_to_delete += [f"{log_path}/syslog.1"]
+    files_to_delete=[]
+    for log_path in log_path_arr:
+        if all:
+            files_to_delete += glob.glob(f"{log_path}/syslog*")
+        else:
+            if os.path.isfile(f"{log_path}/syslog"):
+                files_to_delete += [f"{log_path}/syslog"]            
+            if os.path.isfile(f"{log_path}/syslog.1"):
+                files_to_delete += [f"{log_path}/syslog.1"]
 
     for f in files_to_delete:
         cmd = ['sudo', 'rm','-f',f]

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -1,6 +1,5 @@
 import click
 import pytest
-import sys
 import glob
 import clear.main as clear
 from click.testing import CliRunner
@@ -324,14 +323,7 @@ class TestClearFlowcnt(object):
 class TestClearLogging(object):
     def setup(self):
         print('SETUP')
-
-#    @patch('clear.main.run_command')
-#    def test_logging(self, mock_run_command):
-#        runner = CliRunner()
-#        result = runner.invoke(clear.cli.commands['logging'])
-#        assert result.exit_code == 0
-#        mock_run_command.assert_called_with(['sudo', 'rm' ,'-f', '/var/log/syslog']);
-        
+      
     @patch('clear.main.run_command')
     @patch("glob.glob", MagicMock(return_value=['abc']))
     def test_logging_all(self, mock_run_command):

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -1,5 +1,7 @@
 import click
 import pytest
+import sys
+import glob
 import clear.main as clear
 from click.testing import CliRunner
 from unittest.mock import patch, MagicMock
@@ -319,3 +321,31 @@ class TestClearFlowcnt(object):
     def teardown(self):
         print('TEAR DOWN')
 
+class TestClearLogging(object):
+    def setup(self):
+        print('SETUP')
+
+#    @patch('clear.main.run_command')
+#    def test_logging(self, mock_run_command):
+#        runner = CliRunner()
+#        result = runner.invoke(clear.cli.commands['logging'])
+#        assert result.exit_code == 0
+#        mock_run_command.assert_called_with(['sudo', 'rm' ,'-f', '/var/log/syslog']);
+        
+    @patch('clear.main.run_command')
+    @patch("glob.glob", MagicMock(return_value=['abc']))
+    def test_logging_all(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['logging'], ['--all'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'rm' ,'-f', 'abc'])
+    
+    @patch('clear.main.run_command')
+    def test_logging(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['logging'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'rm' ,'-f', '/var/log/syslog'])
+            
+    def teardown(self):
+        print('TEAR DOWN')

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -4,6 +4,7 @@ import glob
 import clear.main as clear
 from click.testing import CliRunner
 from unittest.mock import patch, MagicMock
+from unittest import mock
 
 class TestClear(object):
     def setup(self):
@@ -333,11 +334,14 @@ class TestClearLogging(object):
         mock_run_command.assert_called_with(['sudo', 'rm' ,'-f', 'abc'])
     
     @patch('clear.main.run_command')
+    @patch("os.path.isfile",MagicMock(return_value=True))
     def test_logging(self, mock_run_command):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands['logging'])
         assert result.exit_code == 0
-        mock_run_command.assert_called_with(['sudo', 'rm' ,'-f', '/var/log/syslog'])
+        mock_run_command.assert_has_calls([mock.call(['sudo', 'rm' ,'-f', '/var/log/syslog']),
+                                          mock.call(['sudo', 'rm' ,'-f', '/var/log/syslog.1'])],
+        any_order=True)
             
     def teardown(self):
         print('TEAR DOWN')

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -335,12 +335,15 @@ class TestClearLogging(object):
     
     @patch('clear.main.run_command')
     @patch("os.path.isfile",MagicMock(return_value=True))
+    @patch("os.path.exists",MagicMock(return_value=True))
     def test_logging(self, mock_run_command):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands['logging'])
         assert result.exit_code == 0
         mock_run_command.assert_has_calls([mock.call(['sudo', 'rm' ,'-f', '/var/log/syslog']),
-                                          mock.call(['sudo', 'rm' ,'-f', '/var/log/syslog.1'])],
+                                          mock.call(['sudo', 'rm' ,'-f', '/var/log/syslog.1']),
+                                          mock.call(['sudo', 'rm' ,'-f', '/var/log.tmpfs/syslog']),
+                                          mock.call(['sudo', 'rm' ,'-f', '/var/log.tmpfs/syslog.1'])],
         any_order=True)
             
     def teardown(self):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

###What I did
Added command
sonic-clear logging - delete syslog & syslog.1
sonic-clear logging -a/--all - delete syslog* files

###How I did it
Equivalent to "show logging" command, working on files at /var/log or at /var/log.tmpfs
delete relevant syslog* files

###How to verify it
clear logging when no syslog files exist
clear logging when only syslog file exist
clear logging when syslog & syslog.1 files exits
clear logging when syslog, syslog.1 and syslog2.gz files exits
Repeat 1-4 with
Clear logging --all

verify also that show logging behave correctly after clear

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

