### PR TITLE
reboot mechanism enhanced with reboot cause

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -34,6 +34,7 @@ PLATFORM_FWUTIL_AU_REBOOT_HANDLE="platform_fw_au_reboot_handle"
 REBOOT_SCRIPT_NAME=$(basename $0)
 REBOOT_TYPE="${REBOOT_SCRIPT_NAME}"
 TAG_LATEST=no
+REBOOT_CAUSE=null
 
 function debug()
 {
@@ -121,8 +122,8 @@ function show_help_and_exit()
     echo " "
     echo "    Available options:"
     echo "        -h, -? : getting this help"
-    echo "        -f     : execute reboot force"
-
+    echo "        -f     : execute reboot force" 
+    echo "        -r     : specify reboot cause (reason) string in quotes"
     exit 0
 }
 
@@ -172,22 +173,33 @@ function check_conflict_boot_in_fw_update()
 
 function parse_options()
 {
-    while getopts "h?vf" opt; do
+    while getopts "h?vftr:" opt; do
         case ${opt} in
             h|\? )
                 show_help_and_exit
                 ;;
+            f )
+                REBOOT_FORCE=true
+                echo "force: $REBOOT_FORCE"
+                ;;
             v )
                 VERBOSE=yes
+                echo "verbose: $VERBOSE"
                 ;;
             t )
                 TAG_LATEST=no
+                echo "tag_latest: $TAG_LATEST"
+                ;;
+            r )
+                REBOOT_CAUSE="$OPTARG"
+                # alternatives: $OPTARG or ${OPTARG} or "${OPTARG[@]}"
+                echo "reboot_cause: ${REBOOT_CAUSE}"
                 ;;
         esac
     done
 }
 
-parse_options $@
+parse_options "$@"
 
 # Exit if not superuser
 if [[ "$EUID" -ne 0 ]]; then
@@ -218,7 +230,11 @@ clear_warm_boot
 # Update the reboot cause file to reflect that user issued 'reboot' command
 # Upon next boot, the contents of this file will be used to determine the
 # cause of the previous reboot
-echo "User issued 'reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+if [[ ${REBOOT_CAUSE} != null  ]]; then
+    echo "System triggered reboot. reason: '${REBOOT_CAUSE}' [User: system, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+else
+    echo "User issued 'reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+fi
 sync
 /sbin/fstrim -av
 sleep 3
@@ -260,4 +276,18 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
 fi
 
 VERBOSE=yes debug "Issuing OS-level reboot ..." >&2
-exec /sbin/reboot $@
+echo "Going to issue reboot command..."
+if [ $# -eq 0 ]; then
+    echo "no argument passed"
+    exec /sbin/reboot $@
+elif [ $# -eq 1 ] && [[ $REBOOT_FORCE == true ]]; then
+    echo "force reboot"
+    exec /sbin/reboot $@
+elif [ $# -eq 2 ] && [[ ${REBOOT_CAUSE} != null ]]; then
+    echo "reboot cause specified"
+    exec /sbin/reboot
+elif [ $# -gt 2 ] && [[ $REBOOT_FORCE == true ]] && [[ ${REBOOT_CAUSE} != null ]]; then
+    echo "both options - force reboot and reboot cause - specified"
+    exec /sbin/reboot -f
+else echo "No appropriate match found, exiting"
+fi

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -34,7 +34,7 @@ PLATFORM_FWUTIL_AU_REBOOT_HANDLE="platform_fw_au_reboot_handle"
 REBOOT_SCRIPT_NAME=$(basename $0)
 REBOOT_TYPE="${REBOOT_SCRIPT_NAME}"
 TAG_LATEST=no
-REBOOT_CAUSE=null
+REBOOT_CAUSE=""
 
 function debug()
 {
@@ -193,7 +193,7 @@ function parse_options()
             r )
                 REBOOT_CAUSE="$OPTARG"
                 # alternatives: $OPTARG or ${OPTARG} or "${OPTARG[@]}"
-                echo "reboot_cause: ${REBOOT_CAUSE}"
+                echo "reboot_cause: $REBOOT_CAUSE"
                 ;;
         esac
     done
@@ -227,10 +227,13 @@ fi
 
 clear_warm_boot
 
-# Update the reboot cause file to reflect that user issued 'reboot' command
-# Upon next boot, the contents of this file will be used to determine the
-# cause of the previous reboot
-if [[ ${REBOOT_CAUSE} != null  ]]; then
+# Update the 'reboot cause' file to reflect the right reboot reason.
+# If 'reboot cause' is specified via the -r option, then update the same to
+# this file; else update the 'reboot cause' to reflect that user issued the
+# 'reboot' command.
+# Upon next boot, the contents of this file will be used to determine
+# the cause of the previous reboot.
+if [[ -n $REBOOT_CAUSE ]]; then
     echo "System triggered reboot. reason: '${REBOOT_CAUSE}' [User: system, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
 else
     echo "User issued 'reboot' command [User: ${REBOOT_USER}, Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
@@ -276,18 +279,12 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
 fi
 
 VERBOSE=yes debug "Issuing OS-level reboot ..." >&2
-echo "Going to issue reboot command..."
-if [ $# -eq 0 ]; then
-    echo "no argument passed"
-    exec /sbin/reboot $@
-elif [ $# -eq 1 ] && [[ $REBOOT_FORCE == true ]]; then
-    echo "force reboot"
-    exec /sbin/reboot $@
-elif [ $# -eq 2 ] && [[ ${REBOOT_CAUSE} != null ]]; then
+if [ $# -eq 2 ] && [ -n "$REBOOT_CAUSE" ]; then
     echo "reboot cause specified"
     exec /sbin/reboot
-elif [ $# -gt 2 ] && [[ $REBOOT_FORCE == true ]] && [[ ${REBOOT_CAUSE} != null ]]; then
+elif [ $# -gt 2 ] && [[ $REBOOT_FORCE == true ]] && [[ -n $REBOOT_CAUSE ]]; then
     echo "both options - force reboot and reboot cause - specified"
     exec /sbin/reboot -f
-else echo "No appropriate match found, exiting"
+else
+    exec /sbin/reboot $@
 fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
- Prior to this change, reboot script is only externally trigged where reboot cause is always fixed i.e. (default's to 'user issued reboot command')
- In this PR (changeset), SONiC reboot is enhanced to accept reboot cause (reason) as an optional argument
- This enhancement enables system applications' (e.g. Fault detector/producer, Fault Manager/Handler) to pass reboot cause as an argument while initiating (system level) reboot
- This reboot cause in turn is saved to REBOOT_CAUSE_FILE for tracking and debugging purposes

#### How I did it
- Facilitated passing of a new optional argument (-r) to reboot command and handled it in reboot script
- For further details, refer to the 'Files changed' tab

#### How to verify it
Refer to UT scenarios and logs:
[UT-reboot.txt](https://github.com/sonic-net/sonic-utilities/files/14274644/UT-reboot.txt)

root@sonic:/home/cisco# reboot -h
Usage /usr/local/bin/reboot [options]
    Request rebooting the device. Invoke platform-specific tool when available.
    This script will shutdown syncd before rebooting.
 
    Available options:
        -h, -? : getting this help
        -f     : execute reboot force
        -r     : specify reboot cause (reason) string in quotes
root@sonic:/home/cisco# 

root@sonic:/home/cisco# reboot -r "rebooting due to xyz reason"
reboot_cause: rebooting due to xyz reason
requested COLD shutdown
/var/log: 0 B (0 bytes) trimmed on /dev/loop1
/host: 204.6 MiB (214548480 bytes) trimmed on /dev/sda3
Tue 06 Feb 2024 06:20:22 AM UTC Issuing OS-level reboot ...
Going to issue reboot command...
reboot cause specified
root@sonic:/home/cisco# 

root@sonic:/home/cisco# show reboot-cause history 
Name                 Cause                                                                                                                 
-------------------  --------------------------------------------------------------------------------------------------------------------  -------------------------------  ------  ---------
2024_02_06_06_23_30  System triggered reboot. reason: 'rebooting due to xyz reason' [User: system, Time: Tue 06 Feb 2024 06:20:13 AM UTC]  
2024_02_06_01_07_29  reboot                                                                                                                Tue 06 Feb 2024 01:04:43 AM UTC  



#### Previous command output (if the output of a command-line utility has changed)
root@sonic:/home/cisco# reboot 
requested COLD shutdown
/var/log: 0 B (0 bytes) trimmed on /dev/loop1
/host: 204.6 MiB (214548480 bytes) trimmed on /dev/sda3
Tue 06 Feb 2024 06:20:22 AM UTC Issuing OS-level reboot ...
root@sonic:/home/cisco# 

#### New command output (if the output of a command-line utility has changed)
**Note: Above-mentioned default 'reboot' command is kept intact.**

**Additional (optional) argument -r, if passed to the reboot, would have following outcome**:
root@sonic:/home/cisco# reboot -r "rebooting due to xyz reason"
reboot_cause: rebooting due to xyz reason
requested COLD shutdown
/var/log: 0 B (0 bytes) trimmed on /dev/loop1
/host: 204.6 MiB (214548480 bytes) trimmed on /dev/sda3
Tue 06 Feb 2024 06:20:22 AM UTC Issuing OS-level reboot ...
Going to issue reboot command...
reboot cause specified
root@sonic:/home/cisco# 

