### PR TITLE
[202311]Fix the sfputil treats page number as decimal instead of hexadecimal 

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -13023,7 +13023,7 @@ Usage: sfputil read-eeprom [OPTIONS]
 
 Options:
   -p, --port <logical_port_name>  Logical port name  [required]
-  -n, --page <page>               EEPROM page number  [required]
+  -n, --page <page>               EEPROM page number in hex [required]
   -o, --offset <offset>           EEPROM offset within the page  [required]
   -s, --size <size>               Size of byte to be read  [required]
   --no-format                     Display non formatted data
@@ -13055,7 +13055,7 @@ Usage: sfputil write-eeprom [OPTIONS]
 
 Options:
   -p, --port <logical_port_name>  Logical port name  [required]
-  -n, --page <page>               EEPROM page number  [required]
+  -n, --page <page>               EEPROM page number in hex [required]
   -o, --offset <offset>           EEPROM offset within the page  [required]
   -d, --data <data>               Hex string EEPROM data  [required]
   --wire-addr TEXT                Wire address of sff8472

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -697,16 +697,20 @@ def eeprom(port, dump_dom, namespace):
 # 'eeprom-hexdump' subcommand
 @show.command()
 @click.option('-p', '--port', metavar='<port_name>', help="Display SFP EEPROM hexdump for port <port_name>")
-@click.option('-n', '--page', metavar='<page_number>', type=click.IntRange(0, MAX_EEPROM_PAGE), help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
+@click.option('-n', '--page', metavar='<page_number>', help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
 def eeprom_hexdump(port, page):
     """Display EEPROM hexdump of SFP transceiver(s)"""
     if port:
         if page is None:
             page = 0
-        return_code, output = eeprom_hexdump_single_port(port, page)
+        else:
+            page = validate_eeprom_page(page)
+        return_code, output = eeprom_hexdump_single_port(port, int(str(page), base=16))
         click.echo(output)
         sys.exit(return_code)
     else:
+        if page is not None:
+            page = validate_eeprom_page(page)
         logical_port_list = natsorted(platform_sfputil.logical)
         lines = []
         for logical_port_name in logical_port_list:
@@ -718,6 +722,23 @@ def eeprom_hexdump(port, page):
             lines.append(output)
         click.echo('\n'.join(lines))
 
+def validate_eeprom_page(page):
+    """
+    Validate input page module EEPROM
+    Args:
+        page: str page input by user
+    Returns:
+        int page
+    """
+    try:
+        page = int(str(page), base=16)
+    except ValueError:
+        click.echo('Please enter a numeric page number')
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+    if page < 0 or page > MAX_EEPROM_PAGE:
+        click.echo(f'Error: Invalid page number {page}')
+        sys.exit(ERROR_INVALID_PAGE)
+    return page
 
 def eeprom_hexdump_single_port(logical_port_name, page):
     """
@@ -810,7 +831,7 @@ def eeprom_hexdump_pages_general(logical_port_name, pages, target_page):
         tuple(0, dump string) if success else tuple(error_code, error_message)
     """
     if target_page is not None:
-        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page}h']
+        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page:x}h']
     else:
         lines = [f'EEPROM hexdump for port {logical_port_name}']
     physical_port = logical_port_to_physical_port_index(logical_port_name)
@@ -851,7 +872,7 @@ def eeprom_hexdump_pages_sff8472(logical_port_name, pages, target_page):
         tuple(0, dump string) if success else tuple(error_code, error_message)
     """
     if target_page is not None:
-        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page}h']
+        lines = [f'EEPROM hexdump for port {logical_port_name} page {target_page:x}h']
     else:
         lines = [f'EEPROM hexdump for port {logical_port_name}']
     physical_port = logical_port_to_physical_port_index(logical_port_name)
@@ -1695,7 +1716,7 @@ def target(port_name, target):
 # 'read-eeprom' subcommand
 @cli.command()
 @click.option('-p', '--port', metavar='<logical_port_name>', help="Logical port name", required=True)
-@click.option('-n', '--page', metavar='<page>', type=click.IntRange(0, MAX_EEPROM_PAGE), help="EEPROM page number", required=True)
+@click.option('-n', '--page', metavar='<page>', help="EEPROM page number in hex", required=True)
 @click.option('-o', '--offset', metavar='<offset>', type=click.IntRange(0, MAX_EEPROM_OFFSET), help="EEPROM offset within the page", required=True)
 @click.option('-s', '--size', metavar='<size>', type=click.IntRange(1, MAX_EEPROM_OFFSET + 1), help="Size of byte to be read", required=True)
 @click.option('--no-format', is_flag=True, help="Display non formatted data")
@@ -1723,6 +1744,8 @@ def read_eeprom(port, page, offset, size, no_format, wire_addr):
         api = sfp.get_xcvr_api()
         if api is None:
             click.echo('Error: SFP EEPROM not detected!')
+        if page is not None:
+            page = validate_eeprom_page(page)
         if not isinstance(api, sff8472.Sff8472Api):
             overall_offset = get_overall_offset_general(api, page, offset, size)
         else:
@@ -1743,7 +1766,7 @@ def read_eeprom(port, page, offset, size, no_format, wire_addr):
 # 'write-eeprom' subcommand
 @cli.command()
 @click.option('-p', '--port', metavar='<logical_port_name>', help="Logical port name", required=True)
-@click.option('-n', '--page', metavar='<page>', type=click.IntRange(0, MAX_EEPROM_PAGE), help="EEPROM page number", required=True)
+@click.option('-n', '--page', metavar='<page>', help="EEPROM page number in hex", required=True)
 @click.option('-o', '--offset', metavar='<offset>', type=click.IntRange(0, MAX_EEPROM_OFFSET), help="EEPROM offset within the page", required=True)
 @click.option('-d', '--data', metavar='<data>', help="Hex string EEPROM data", required=True)
 @click.option('--wire-addr', help="Wire address of sff8472")
@@ -1777,7 +1800,8 @@ def write_eeprom(port, page, offset, data, wire_addr, verify):
         if api is None:
             click.echo('Error: SFP EEPROM not detected!')
             sys.exit(EXIT_FAIL)
-
+        if page is not None:
+            page = validate_eeprom_page(page)
         if not isinstance(api, sff8472.Sff8472Api):
             overall_offset = get_overall_offset_general(api, page, offset, len(bytes))
         else:
@@ -1813,11 +1837,11 @@ def get_overall_offset_general(api, page, offset, size):
     """
     if api.is_flat_memory():
         if page != 0:
-            raise ValueError(f'Invalid page number {page}, only page 0 is supported')
+            raise ValueError(f'Invalid page number {page:x}h, only page 0 is supported')
 
     if page != 0:
         if offset < MIN_OFFSET_FOR_NON_PAGE0:
-            raise ValueError(f'Invalid offset {offset} for page {page}, valid range: [128, 255]')
+            raise ValueError(f'Invalid offset {offset} for page {page:x}h, valid range: [80h, FFh]')
 
     if size + offset - 1 > MAX_EEPROM_OFFSET:
         raise ValueError(f'Invalid size {size}, valid range: [1, {255 - offset + 1}]')


### PR DESCRIPTION
Manual cherry-pick of (#3153)


Fix the sfputil treats page number as decimal instead of hexadecimal



---------

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
https://github.com/sonic-net/sonic-utilities/pull/3009 breaks the number base rule, treats the page number CLI input as decimal rather than hex, this is used to fix it.

it also containes a redundancy function definition, so remove it.
#### How I did it

#### How to verify it
unit test and manually test



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

