### PR TITLE
Fix sfputil CLI failure for multi-asic platforms

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -24,6 +24,7 @@ from sonic_py_common import device_info, logger, multi_asic
 from utilities_common.sfp_helper import covert_application_advertisement_to_output_string
 from utilities_common.sfp_helper import QSFP_DATA_MAP
 from tabulate import tabulate
+from utilities_common.general import load_db_config
 
 VERSION = '3.0'
 
@@ -563,6 +564,7 @@ def load_sfputilhelper():
 
 
 def load_port_config():
+    load_db_config()
     try:
         if multi_asic.is_multi_asic():
             # For multi ASIC platforms we pass DIR of port_config_file_path and the number of asics

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1412,3 +1412,11 @@ EEPROM hexdump for port Ethernet4
         result = runner.invoke(sfputil.cli.commands['firmware'].commands['target'], ["Ethernet0", "1"])
         assert result.output == 'Target Mode set failed!\n'
         assert result.exit_code == EXIT_FAIL
+
+    @patch('sfputil.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    @patch('sfputil.main.platform_sfputil', MagicMock())
+    @patch('sfputil.main.device_info.get_paths_to_platform_and_hwsku_dirs',
+        MagicMock(return_value=(None, None)))
+    @patch('sfputil.main.device_info.get_path_to_port_config_file', MagicMock(return_value=('')))
+    def test_load_port_config(self):
+        assert sfputil.load_port_config() == True

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1413,10 +1413,14 @@ EEPROM hexdump for port Ethernet4
         assert result.output == 'Target Mode set failed!\n'
         assert result.exit_code == EXIT_FAIL
 
-    @patch('sfputil.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    @patch('sfputil.main.multi_asic.is_multi_asic')
     @patch('sfputil.main.platform_sfputil', MagicMock())
     @patch('sfputil.main.device_info.get_paths_to_platform_and_hwsku_dirs',
         MagicMock(return_value=(None, None)))
     @patch('sfputil.main.device_info.get_path_to_port_config_file', MagicMock(return_value=('')))
-    def test_load_port_config(self):
+    def test_load_port_config(self, mock_is_multi_asic):
+        mock_is_multi_asic.return_value = True
+        assert sfputil.load_port_config() == True
+
+        mock_is_multi_asic.return_value = False
         assert sfputil.load_port_config() == True


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to fix issue https://github.com/sonic-net/sonic-utilities/issues/3167

Basically sfputil Cli became broken on multi-asic platforms after introduction of https://github.com/sonic-net/sonic-buildimage/pull/10960 which removed the initialization of global DB config from portconfig.py (library side) and expects application to do it, but here application side (sfputil) was not updated accordingly. 


#### How I did it
Add load_db_config call to sfputil for initialization

#### How to verify it
Before fix:
```
root@sonic:/home# sfputil show presence                                                                                                                                                                                     
Error reading port info (:- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig)                                                                                                       
```

After fix:
```
root@sonic:/home# sfputil show presence
Port         Presence                                   
-----------  -----------                                
Ethernet0    Present                                    
Ethernet4    Not present                                
Ethernet8    Present                                    
Ethernet12   Present                                    
Ethernet16   Not present       
...
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

