### PR TITLE
[config] Check golden config exist early if flag is set

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1709,6 +1709,15 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
     argv_str = ' '.join(['config', *sys.argv[1:]])
     log.log_notice(f"'load_minigraph' executing with command: {argv_str}")
 
+    # check if golden_config exists if override flag is set
+    if override_config:
+        if golden_config_path is None:
+            golden_config_path = DEFAULT_GOLDEN_CONFIG_DB_FILE
+        if not os.path.isfile(golden_config_path):
+            click.secho("Cannot find '{}'!".format(golden_config_path),
+                        fg='magenta')
+            raise click.Abort()
+
     #Stop services before config push
     if not no_service_restart:
         log.log_notice("'load_minigraph' stopping services...")
@@ -1780,12 +1789,6 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
 
     # Load golden_config_db.json
     if override_config:
-        if golden_config_path is None:
-            golden_config_path = DEFAULT_GOLDEN_CONFIG_DB_FILE
-        if not os.path.isfile(golden_config_path):
-            click.secho("Cannot find '{}'!".format(golden_config_path),
-                        fg='magenta')
-            raise click.Abort()
         override_config_by(golden_config_path)
 
     # Invoke platform script if available before starting the services


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix  https://github.com/sonic-net/sonic-utilities/issues/3164
Check Golden Config earlier before service is down.
#### How I did it
Move the check at the begining
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

