### PR TITLE
Modify transceiver PM CLI to handle N/A value for DOM threshold

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -517,8 +517,10 @@ class SFPShow(object):
                 for suffix in ZR_PM_THRESHOLD_KEY_SUFFIXS:
                     key = self.convert_pm_prefix_to_threshold_prefix(
                         prefix) + suffix
-                    thresholds.append(
-                        float(sfp_threshold_dict[key]) if key in sfp_threshold_dict else None)
+                    if key in sfp_threshold_dict and sfp_threshold_dict[key] != 'N/A':
+                        thresholds.append(float(sfp_threshold_dict[key]))
+                    else:
+                        thresholds.append(None)
 
                 tca_high, tca_low = None, None
                 if values[2] is not None and thresholds[0] is not None:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
MSFT ADO - 26894627

#### What I did
As part of the code changes through https://github.com/sonic-net/sonic-platform-common/pull/442, for the VDM fields which are not implemented by a vendor, "N/A" will be set in redis-db for such fields.

This change is breaking the "show int transceiver pm <port_name>" CLI since it parses the TRASNCEIVER_DOM_THRESHOLD table and converts the values to float. However, the handler of the CLI needs to be modified to ensure that "N/A" value is not converted to float.

#### How I did it
The function `convert_interface_sfp_pm_to_cli_output_string` now doesn't convert `sfp_threshold_dict[key]` to float if the value is `N/A`.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
root@admin:/home/admin# show int transceiver pm -n asic0 Ethernet88
Ethernet88: 
    Parameter        Unit    Min       Avg       Max       Threshold    Threshold    Threshold     Threshold    Threshold    Threshold
                                                           High         High         Crossing      Low          Low          Crossing
                                                           Alarm        Warning      Alert-High    Alarm        Warning      Alert-Low
    ---------------  ------  --------  --------  --------  -----------  -----------  ------------  -----------  -----------  -----------
    Tx Power         dBm     -40.0     -40.0     -40.0     -5.0         -6.0         False         -16.99       -16.003      True
    Rx Total Power   dBm     0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    Rx Signal Power  dBm     0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    CD-short link    ps/nm   0.0       0.0       0.0       32767.0      32767.0      False         -32768.0     -32768.0     False
    PDL              dB      0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    OSNR             dB      0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    eSNR             dB      0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    CFO              MHz     0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    DGD              ps      0.0       0.0       0.0       655.35       655.35       False         0.0          0.0          False
    SOPMD            ps^2    0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    SOP ROC          krad/s  0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    Pre-FEC BER      N/A     1.00E+00  1.00E+00  1.00E+00  1.25E-02     1.10E-02     1.00E+00      0.0          0.0          0.0
    Post-FEC BER     N/A     0.0       0.0       0.0       1000.0       1.0          False         0.0          0.0          False
    EVM              %       0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
```

#### New command output (if the output of a command-line utility has changed)
```
root@admin:/home/admin# show int transceiver pm -n asic0 Ethernet88
Ethernet88: 
    Parameter        Unit    Min       Avg       Max       Threshold    Threshold    Threshold     Threshold    Threshold    Threshold
                                                           High         High         Crossing      Low          Low          Crossing
                                                           Alarm        Warning      Alert-High    Alarm        Warning      Alert-Low
    ---------------  ------  --------  --------  --------  -----------  -----------  ------------  -----------  -----------  -----------
    Tx Power         dBm     -40.0     -40.0     -40.0     -5.0         -6.0         False         -16.99       -16.003      True
    Rx Total Power   dBm     0.0       0.0       0.0       2.0          0.0          False         -21.0        -18.0        False
    Rx Signal Power  dBm     0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    CD-short link    ps/nm   0.0       0.0       0.0       32767.0      32767.0      False         -32768.0     -32768.0     False
    PDL              dB      0.0       0.0       0.0       99.0         99.0         False         0.0          0.0          False
    OSNR             dB      0.0       0.0       0.0       99.0         99.0         False         0.0          0.0          False
    eSNR             dB      0.0       0.0       0.0       99.0         99.0         False         0.0          0.0          False
    CFO              MHz     0.0       0.0       0.0       32767.0      32767.0      False         -32768.0     -32768.0     False
    DGD              ps      0.0       0.0       0.0       655.35       655.35       False         0.0          0.0          False
    SOPMD            ps^2    0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
    SOP ROC          krad/s  0.0       0.0       0.0       65535.0      65535.0      False         0.0          0.0          False
    Pre-FEC BER      N/A     1.00E+00  1.00E+00  1.00E+00  1.25E-02     1.10E-02     1.00E+00      0.0          0.0          0.0
    Post-FEC BER     N/A     0.0       0.0       0.0       1000.0       1.0          False         0.0          0.0          False
    EVM              %       0.0       0.0       0.0       N/A          N/A          N/A           N/A          N/A          N/A
```