### PR TITLE
SONIC CLI for CLI-Sessions feature

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -7794,7 +7794,7 @@ def ssh():
 
 @ssh.command('inactivity-timeout')
 @click.argument('inactivity_timeout', metavar='<timeout>', required=True,
-                type=click.IntRange(0,35000))
+                type=click.IntRange(0, 35000))
 def inactivity_timeout_ssh(inactivity_timeout):
     """Set ssh inactivity timeout"""
 

--- a/config/main.py
+++ b/config/main.py
@@ -7760,7 +7760,7 @@ def serial_console():
 
 
 @serial_console.command('sysrq-capabilities')
-@click.argument('sysrq_capabilities', metavar='<enabled|disabled>', required=True, 
+@click.argument('sysrq_capabilities', metavar='<enabled|disabled>', required=True,
                 type=click.Choice(['enabled', 'disabled']))
 def sysrq_capabilities(sysrq_capabilities):
     """Set serial console sysrq-capabilities state"""
@@ -7772,8 +7772,8 @@ def sysrq_capabilities(sysrq_capabilities):
 
 
 @serial_console.command('inactivity-timeout')
-@click.argument('inactivity_timeout', metavar='<timeout>', required=True, 
-                type=click.IntRange(0,35000))
+@click.argument('inactivity_timeout', metavar='<timeout>', required=True,
+                type=click.IntRange(0, 35000))
 def inactivity_timeout_serial(inactivity_timeout):
     """Set serial console inactivity timeout"""
 
@@ -7791,8 +7791,9 @@ def ssh():
     """Configuring system ssh behavior"""
     pass
 
+
 @ssh.command('inactivity-timeout')
-@click.argument('inactivity_timeout', metavar='<timeout>', required=True, 
+@click.argument('inactivity_timeout', metavar='<timeout>', required=True,
                 type=click.IntRange(0,35000))
 def inactivity_timeout_ssh(inactivity_timeout):
     """Set ssh inactivity timeout"""
@@ -7802,9 +7803,10 @@ def inactivity_timeout_ssh(inactivity_timeout):
     config_db.mod_entry("SSH_SERVER", 'POLICIES',
                         {'inactivity_timeout': inactivity_timeout})
 
+
 @ssh.command('max-sessions')
-@click.argument('max-sessions', metavar='<max-sessions>', required=True, 
-                type=click.IntRange(0,100))
+@click.argument('max-sessions', metavar='<max-sessions>', required=True,
+                type=click.IntRange(0, 100))
 def max_sessions(max_sessions):
     """Set max number of concurrent logins"""
 

--- a/config/main.py
+++ b/config/main.py
@@ -7750,5 +7750,69 @@ def notice(db, category_list, max_events, namespace):
     handle_asic_sdk_health_suppress(db, 'notice', category_list, max_events, namespace)
 
 
+#
+# 'serial_console' group ('config  serial_console')
+#
+@config.group()
+def serial_console():
+    """Configuring system serial-console behavior"""
+    pass
+
+
+@serial_console.command('sysrq-capabilities')
+@click.argument('sysrq_capabilities', metavar='<enabled|disabled>', required=True, 
+                type=click.Choice(['enabled', 'disabled']))
+def sysrq_capabilities(sysrq_capabilities):
+    """Set serial console sysrq-capabilities state"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("SERIAL_CONSOLE", 'POLICIES',
+                        {'sysrq_capabilities': sysrq_capabilities})
+
+
+@serial_console.command('inactivity-timeout')
+@click.argument('inactivity_timeout', metavar='<timeout>', required=True, 
+                type=click.IntRange(0,35000))
+def inactivity_timeout_serial(inactivity_timeout):
+    """Set serial console inactivity timeout"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("SERIAL_CONSOLE", 'POLICIES',
+                        {'inactivity_timeout': inactivity_timeout})
+
+
+#
+# 'ssh' group ('config  ssh')
+#
+@config.group()
+def ssh():
+    """Configuring system ssh behavior"""
+    pass
+
+@ssh.command('inactivity-timeout')
+@click.argument('inactivity_timeout', metavar='<timeout>', required=True, 
+                type=click.IntRange(0,35000))
+def inactivity_timeout_ssh(inactivity_timeout):
+    """Set ssh inactivity timeout"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("SSH_SERVER", 'POLICIES',
+                        {'inactivity_timeout': inactivity_timeout})
+
+@ssh.command('max-sessions')
+@click.argument('max-sessions', metavar='<max-sessions>', required=True, 
+                type=click.IntRange(0,100))
+def max_sessions(max_sessions):
+    """Set max number of concurrent logins"""
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry("SSH_SERVER", 'POLICIES',
+                        {'max_sessions': max_sessions})
+
+
 if __name__ == '__main__':
     config()

--- a/config/main.py
+++ b/config/main.py
@@ -7753,7 +7753,7 @@ def notice(db, category_list, max_events, namespace):
 #
 # 'serial_console' group ('config  serial_console')
 #
-@config.group()
+@config.group(cls=clicommon.AbbreviationGroup, name='serial_console')
 def serial_console():
     """Configuring system serial-console behavior"""
     pass
@@ -7786,7 +7786,7 @@ def inactivity_timeout_serial(inactivity_timeout):
 #
 # 'ssh' group ('config  ssh')
 #
-@config.group()
+@config.group(cls=clicommon.AbbreviationGroup, name='ssh')
 def ssh():
     """Configuring system ssh behavior"""
     pass

--- a/show/main.py
+++ b/show/main.py
@@ -2254,6 +2254,45 @@ def received(db, namespace):
         ctx.fail("ASIC/SDK health event is not supported on the platform")
 
 
+#
+# 'serial_console' command group ("show serial_console ...")
+#
+@cli.group('serial_console', invoke_without_command=True)
+@clicommon.pass_db
+def serial_console(db):
+    """Show serial_console configuration"""
+
+    serial_console_table = db.cfgdb.get_entry('SERIAL_CONSOLE', 'POLICIES')
+
+    hdrs = ['inactivity-timeout', 'sysrq-capabilities']
+    data = []
+
+    data.append(serial_console_table.get('inactivity_timeout', '900 <default>'))
+    data.append(serial_console_table.get('sysrq_capabilities', 'disabled <default>'))    
+    
+    configuration = [data]
+    click.echo(tabulate(configuration, headers=hdrs, tablefmt='simple', missingval=''))
+
+#
+# 'ssh' command group ("show ssh ...")
+#
+@cli.group('ssh', invoke_without_command=True)
+@clicommon.pass_db
+def ssh(db):
+    """Show ssh configuration"""
+
+    serial_console_table = db.cfgdb.get_entry('SSH_SERVER', 'POLICIES')
+
+    hdrs = ['inactivity-timeout', 'max-sessions']
+    data = []
+
+    data.append(serial_console_table.get('inactivity_timeout', '900 <default>'))
+    data.append(serial_console_table.get('max_session', '0 <default>'))    
+    
+    configuration = [data]
+    click.echo(tabulate(configuration, headers=hdrs, tablefmt='simple', missingval=''))
+
+
 # Load plugins and register them
 helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)

--- a/show/main.py
+++ b/show/main.py
@@ -2268,10 +2268,11 @@ def serial_console(db):
     data = []
 
     data.append(serial_console_table.get('inactivity_timeout', '900 <default>'))
-    data.append(serial_console_table.get('sysrq_capabilities', 'disabled <default>'))    
-    
+    data.append(serial_console_table.get('sysrq_capabilities', 'disabled <default>'))
+
     configuration = [data]
     click.echo(tabulate(configuration, headers=hdrs, tablefmt='simple', missingval=''))
+
 
 #
 # 'ssh' command group ("show ssh ...")
@@ -2287,8 +2288,8 @@ def ssh(db):
     data = []
 
     data.append(serial_console_table.get('inactivity_timeout', '900 <default>'))
-    data.append(serial_console_table.get('max_session', '0 <default>'))    
-    
+    data.append(serial_console_table.get('max_session', '0 <default>'))
+
     configuration = [data]
     click.echo(tabulate(configuration, headers=hdrs, tablefmt='simple', missingval=''))
 

--- a/tests/cli_sessions_test.py
+++ b/tests/cli_sessions_test.py
@@ -1,0 +1,32 @@
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+
+class TestCliSessionsCommands:
+    def test_config_command(self):
+        runner = CliRunner()
+
+        db = Db()
+
+        result = runner.invoke(config.config.commands['serial_console'].commands['sysrq-capabilities'],
+                               ['enabled'], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands['serial_console'].commands['inactivity-timeout'],
+                               ['180'], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands['serial_console'], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands['ssh'].commands['inactivity-timeout'], ['190'], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands['ssh'].commands['max-sessions'], ['60'], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands['ssh'], obj=db)
+        assert result.exit_code == 0


### PR DESCRIPTION
HLD: https://github.com/sonic-net/SONiC/pull/1367

| Module name  | PR  | state | context |
| ------------- | ------------- | ----|-----|
| [sonic-buildimage](https://github.com/sonic-net/sonic-buildimage) | [Dev cli sessions](https://github.com/sonic-net/sonic-buildimage/pull/17623) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-buildimage/17623) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/sonic-net/sonic-buildimage/17623) |
| [sonic-host-services](https://github.com/sonic-net/sonic-host-services)  | [cli-sessions](https://github.com/sonic-net/sonic-host-services/pull/99) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-host-services/99) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/sonic-net/sonic-host-services/99) |
| [sonic-utilities](https://github.com/sonic-net/sonic-utilities)  | [SONIC CLI for CLI-Sessions feature #3175](https://github.com/sonic-net/sonic-utilities/pull/3175) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-utilities/3175)   | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/sonic-net/sonic-utilities/3175)  |

#### What I did

Implement next commands for CLI-sessions feature:

- config serial-console inactivity-timeout  
- config serial-console sysrq-capabilities
- show serial-console

- config ssh  max-sessions
- config ssh  inactivity-timeout 
- show ssh

#### How I did it
Write handlers in config/main.py for serial-console and ssh commands to cover configuration set;
Write handlers in show/main.py for serial-console and ssh to cover show commands.
#### How to verify it
Manual tests

#### Previous command output (if the output of a command-line utility has changed)
n/a
#### New command output (if the output of a command-line utility has changed)
n/a
