### PR TITLE
CLI enhancements to revtrieve data from TRANSCEIVER_FIRMWARE_INFO table

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -305,7 +305,7 @@ class SFPShow(object):
         return output
 
     # Convert sfp info in DB to cli output string
-    def convert_sfp_info_to_output_string(self, sfp_info_dict):
+    def convert_sfp_info_to_output_string(self, sfp_info_dict, sfp_firmware_info_dict):
         indent = ' ' * 8
         output = ''
         is_sfp_cmis = 'cmis_rev' in sfp_info_dict
@@ -333,6 +333,8 @@ class SFPShow(object):
                         output += '{}N/A\n'.format((indent * 2))
             elif key == 'application_advertisement':
                 output += covert_application_advertisement_to_output_string(indent, sfp_info_dict)
+            elif key == 'active_firmware' or key == 'inactive_firmware':
+                output += '{}{}: {}\n'.format(indent, data_map[key], sfp_firmware_info_dict[key] if key in sfp_firmware_info_dict else 'N/A')
             else:
                 output += '{}{}: {}\n'.format(indent, data_map[key], sfp_info_dict[key])
 
@@ -441,12 +443,13 @@ class SFPShow(object):
         output = ''
 
         sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
+        sfp_firmware_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(interface_name))
         if sfp_info_dict:
             if sfp_info_dict['type'] == RJ45_PORT_TYPE:
                 output = 'SFP EEPROM is not applicable for RJ45 port\n'
             else:
                 output = 'SFP EEPROM detected\n'
-                sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict)
+                sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict, sfp_firmware_info_dict)
                 output += sfp_info_output
 
                 if dump_dom:

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -84,8 +84,6 @@ QSFP_DD_DATA_MAP = {
     'encoding': 'Encoding',
     'connector': 'Connector',
     'application_advertisement': 'Application Advertisement',
-    'active_firmware': 'Active Firmware Version',
-    'inactive_firmware': 'Inactive Firmware Version',
     'hardware_rev': 'Hardware Revision',
     'media_interface_code': 'Media Interface Code',
     'host_electrical_interface': 'Host Electrical Interface',
@@ -1314,9 +1312,12 @@ def update_firmware_info_to_state_db(port_name):
         state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
         if state_db is not None:
             state_db.connect(state_db.STATE_DB)
-            active_firmware, inactive_firmware = platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
-            state_db.set(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port_name), "active_firmware", active_firmware)
-            state_db.set(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port_name), "inactive_firmware", inactive_firmware)
+            transceiver_firmware_info_dict = platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
+            if transceiver_firmware_info_dict is not None:
+                active_firmware = transceiver_firmware_info_dict.get('active_firmware', 'N/A')
+                inactive_firmware = transceiver_firmware_info_dict.get('inactive_firmware', 'N/A')
+                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "active_firmware", active_firmware)
+                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "inactive_firmware", inactive_firmware)
 
 # 'firmware' subgroup
 @cli.group()

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1304,6 +1304,21 @@ def reset(port_name):
 
         i += 1
 
+def update_firmware_info_to_state_db(port_name):
+    physical_port = logical_port_to_physical_port_index(port_name)
+
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        if state_db is not None:
+            state_db.connect(state_db.STATE_DB)
+            transceiver_firmware_info_dict = platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
+            if transceiver_firmware_info_dict is not None:
+                active_firmware = transceiver_firmware_info_dict.get('active_firmware', 'N/A')
+                inactive_firmware = transceiver_firmware_info_dict.get('inactive_firmware', 'N/A')
+                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "active_firmware", active_firmware)
+                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "inactive_firmware", inactive_firmware)
+
 # 'firmware' subgroup
 @cli.group()
 def firmware():
@@ -1494,6 +1509,7 @@ def download_firmware(port_name, filepath):
         click.echo("Platform doesn't implement optoe write max change. Skipping value restore!")
 
     status = api.cdb_firmware_download_complete()
+    update_firmware_info_to_state_db(port_name)
     click.echo('CDB: firmware download complete')
     return status
 
@@ -1521,6 +1537,7 @@ def run(port_name, mode):
         click.echo('Failed to run firmware in mode={}! CDB status: {}'.format(mode, status))
         sys.exit(EXIT_FAIL)
 
+    update_firmware_info_to_state_db(port_name)
     click.echo("Firmware run in mode={} success".format(mode))
 
 # 'commit' subcommand
@@ -1542,6 +1559,7 @@ def commit(port_name):
         click.echo('Failed to commit firmware! CDB status: {}'.format(status))
         sys.exit(EXIT_FAIL)
 
+    update_firmware_info_to_state_db(port_name)
     click.echo("Firmware commit successful")
 
 # 'upgrade' subcommand

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -29,8 +29,6 @@
         "media_interface_technology" : "1550 nm DFB",
         "vendor_rev" : "XX",
         "cmis_rev" : "4.1",
-        "active_firmware" : "X.X",
-        "inactive_firmware" : "X.X",
         "supported_max_tx_power" : "4.0",
         "supported_min_tx_power" : "-22.9",
         "supported_max_laser_freq" : "196100",
@@ -69,6 +67,10 @@
         "vcchighwarning": "3.4650",
         "vcclowalarm": "2.9700",
         "vcclowwarning": "3.1349"
+    },
+    "TRANSCEIVER_FIRMWARE_INFO|Ethernet64": {
+        "active_firmware": "X.X",
+        "inactive_firmware": "X.X"
     },
     "CHASSIS_INFO|chassis 1": {
         "psu_num": "2"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -684,16 +684,17 @@
         "media_interface_technology" : "1550 nm DFB",
         "vendor_rev" : "XX",
         "cmis_rev" : "4.1",
-        "active_firmware" : "X.X",
-        "inactive_firmware" : "X.X",
         "supported_max_tx_power" : "4.0",
         "supported_min_tx_power" : "-22.9",
         "supported_max_laser_freq" : "196100",
         "supported_min_laser_freq" : "191300"
     },
+    "TRANSCEIVER_FIRMWARE_INFO|Ethernet64": {
+        "active_firmware": "X.X",
+        "inactive_firmware": "X.X"
+    },
     "TRANSCEIVER_INFO|Ethernet72": {
         "active_apsel_hostlane4": "N/A",
-        "active_firmware": "0.0",
         "is_replaceable": "True",
         "application_advertisement": "{1: {'host_electrical_interface_id': 'IB NDR', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}, 2: {'host_electrical_interface_id': 'IB SDR (Arch.Spec.Vol.2)', 'module_media_interface_id': 'Copper cable', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 17}}",
         "host_electrical_interface": "N/A",
@@ -710,7 +711,6 @@
         "supported_min_laser_freq": "N/A",
         "serial": "serial1   ",
         "active_apsel_hostlane7": "N/A",
-        "inactive_firmware": "N/A",
         "active_apsel_hostlane1": "N/A",
         "type": "OSFP 8X Pluggable Transceiver",
         "cable_length": "1.0",
@@ -795,6 +795,10 @@
         "txbiashighwarning": "N/A",
         "txbiaslowalarm": "N/A",
         "txbiaslowwarning": "N/A"
+    },
+    "TRANSCEIVER_FIRMWARE_INFO|Ethernet72": {
+        "active_firmware": "0.0",
+        "inactive_firmware": "N/A"
     },
     "TRANSCEIVER_STATUS|Ethernet0": {
         "status": "67",

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -151,8 +151,6 @@ class TestSfputil(object):
                 'specification_compliance': "sm_media_interface",
                 'dom_capability': "{'Tx_power_support': 'no', 'Rx_power_support': 'no', 'Voltage_support': 'no', 'Temp_support': 'no'}",
                 'nominal_bit_rate': '0',
-                'active_firmware': '0.1',
-                'inactive_firmware': '0.0',
                 'hardware_rev': '0.0',
                 'media_interface_code': '400ZR, DWDM, amplified',
                 'host_electrical_interface': '400GAUI-8 C2M (Annex 120E)',
@@ -184,7 +182,6 @@ class TestSfputil(object):
             "        Active App Selection Host Lane 6: 1\n"
             "        Active App Selection Host Lane 7: 1\n"
             "        Active App Selection Host Lane 8: 1\n"
-            "        Active Firmware Version: 0.1\n"
             "        Application Advertisement: 400G CR8 - Host Assign (0x1) - Copper cable - Media Assign (0x2)\n"
             "                                   200GBASE-CR4 (Clause 136) - Host Assign (Unknown) - Unknown - Media Assign (Unknown)\n"
             "        CMIS Revision: 5.0\n"
@@ -197,7 +194,6 @@ class TestSfputil(object):
             "        Host Lane Assignment Options: 1\n"
             "        Host Lane Count: 8\n"
             "        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver\n"
-            "        Inactive Firmware Version: 0.0\n"
             "        Length Cable Assembly(m): 0\n"
             "        Media Interface Code: 400ZR, DWDM, amplified\n"
             "        Media Interface Technology: C-band tunable laser\n"
@@ -1113,7 +1109,7 @@ EEPROM hexdump for port Ethernet4
     def test_update_firmware_info_to_state_db(self, mock_chassis):
         mock_sfp = MagicMock()
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
-        mock_sfp.get_transceiver_info_firmware_versions.return_value = ['a.b.c', 'd.e.f']
+        mock_sfp.get_transceiver_info_firmware_versions.return_value = {'active_firmware' : 'a.b.c', 'inactive_firmware' : 'd.e.f'}
 
         sfputil.update_firmware_info_to_state_db("Ethernet0")
 

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -970,6 +970,7 @@ EEPROM hexdump for port Ethernet4
     @patch('builtins.open')
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.update_firmware_info_to_state_db', MagicMock())
     def test_download_firmware(self, mock_chassis, mock_file):
         mock_file.return_value.tell.return_value = 0
         mock_sfp = MagicMock()
@@ -1086,6 +1087,7 @@ EEPROM hexdump for port Ethernet4
     @patch('sfputil.main.is_sfp_present', MagicMock(return_value=True))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
     @patch('sfputil.main.run_firmware', MagicMock(return_value=1))
+    @patch('sfputil.main.update_firmware_info_to_state_db', MagicMock())
     def test_firmware_run_cli(self):
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['firmware'].commands['run'], ["Ethernet0"])
@@ -1094,10 +1096,22 @@ EEPROM hexdump for port Ethernet4
     @patch('sfputil.main.is_sfp_present', MagicMock(return_value=True))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
     @patch('sfputil.main.commit_firmware', MagicMock(return_value=1))
+    @patch('sfputil.main.update_firmware_info_to_state_db', MagicMock())
     def test_firmware_commit_cli(self):
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['firmware'].commands['commit'], ["Ethernet0"])
         assert result.exit_code == 0
+
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sonic_py_common.multi_asic.get_front_end_namespaces', MagicMock(return_value=['']))
+    @patch('sfputil.main.SonicV2Connector', MagicMock())
+    @patch('sfputil.main.platform_chassis')
+    def test_update_firmware_info_to_state_db(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_sfp.get_transceiver_info_firmware_versions.return_value = {'active_firmware' : 'a.b.c', 'inactive_firmware' : 'd.e.f'}
+
+        sfputil.update_firmware_info_to_state_db("Ethernet0")
 
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -970,7 +970,6 @@ EEPROM hexdump for port Ethernet4
     @patch('builtins.open')
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
-    @patch('sfputil.main.update_firmware_info_to_state_db', MagicMock())
     def test_download_firmware(self, mock_chassis, mock_file):
         mock_file.return_value.tell.return_value = 0
         mock_sfp = MagicMock()
@@ -1087,7 +1086,6 @@ EEPROM hexdump for port Ethernet4
     @patch('sfputil.main.is_sfp_present', MagicMock(return_value=True))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
     @patch('sfputil.main.run_firmware', MagicMock(return_value=1))
-    @patch('sfputil.main.update_firmware_info_to_state_db', MagicMock())
     def test_firmware_run_cli(self):
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['firmware'].commands['run'], ["Ethernet0"])
@@ -1096,22 +1094,10 @@ EEPROM hexdump for port Ethernet4
     @patch('sfputil.main.is_sfp_present', MagicMock(return_value=True))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
     @patch('sfputil.main.commit_firmware', MagicMock(return_value=1))
-    @patch('sfputil.main.update_firmware_info_to_state_db', MagicMock())
     def test_firmware_commit_cli(self):
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['firmware'].commands['commit'], ["Ethernet0"])
         assert result.exit_code == 0
-
-    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
-    @patch('sonic_py_common.multi_asic.get_front_end_namespaces', MagicMock(return_value=['']))
-    @patch('sfputil.main.SonicV2Connector', MagicMock())
-    @patch('sfputil.main.platform_chassis')
-    def test_update_firmware_info_to_state_db(self, mock_chassis):
-        mock_sfp = MagicMock()
-        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
-        mock_sfp.get_transceiver_info_firmware_versions.return_value = {'active_firmware' : 'a.b.c', 'inactive_firmware' : 'd.e.f'}
-
-        sfputil.update_firmware_info_to_state_db("Ethernet0")
 
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Since we are moving active_firmware and inactive_firmware fields from TRANSCEIVER_INFO to TRANSCEIVER_FIRMWARE_INFO table (https://github.com/sonic-net/sonic-platform-daemons/pull/435 and https://github.com/sonic-net/sonic-platform-common/pull/440), following changes are needed to support existing CLIs

1. Modify "show int transceiver eeprom" o/p to include firmware information from TRANSCEIVER_FIRMWARE_INFO table
2. Modify "sfputil show eeprom" o/p to remove `active_firmware` and `inactive_firmware` fields from the output.
Reasoning for removing the fields
For transceivers supporting firmware version read through CDB command, a CDB command will be sent to the module. Parallelly, the DomInfoUpdateTask thread from xcvrd performs periodic firmware version reads. Hence, this could cause contention between sfputil and DomInfoUpdateTask thread. Hence, we have decided to remote the firmware version fields from this CLI.
Alternatively, firmware version can be read via
    - For transceivers supporting CDB functionality, `sfputil show fwversion PORT_NAME` CLI can be used. The DomInfoUpdateTask thread needs to be disabled before using this CLI so that sfputil and DomInfoUpdateTask thread do not simultaneously use CDB command for the same port. A config CLI is currently being created to disable the DomInfoUpdateTask thread polling for a specific port.
    - For transceivers not supporting CDB functionality, `sfputil show eeprom-hexdump -p PORT_NAME -n PAGE_NUM` CLI can be used to dump the firmware version from the EEPROM
3. Modify calls to `update_firmware_info_to_state_db` function to update information in the TRANSCEIVER_FIRMWARE_INFO table instead of TRANSCEIVER_INFO table

fixes https://github.com/sonic-net/sonic-platform-daemons/issues/439

MSFT ADO - 26788517

#### How I did it

#### How to verify it
Verified the following
1. `show int transceiver info` and `show int transceiver eeprom` CLIs display the active and inactive firmware version of a transceiver
3. `sfputil show eeprom -p PORT_NAME` CLI does not display active_firmware and inactive_firmware
4. Ensured that TRANSCEIVER_FIRMWARE_INFO table is updated after firmware download, run and commit operation.

#### Previous command output (if the output of a command-line utility has changed)
```
root@admin:/home/admin# sfputil show eeprom -p Ethernet8
Ethernet8: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 1
        Active App Selection Host Lane 6: 1
        Active App Selection Host Lane 7: 1
        Active App Selection Host Lane 8: 1
		Active Firmware Version: 1.1.1
        Application Advertisement: 400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - Active Cable assembly with BER < 10^-6 - Media Assign (0x11)
                                   400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - Active Cable assembly with BER < 10^-6 - Media Assign (0x11)
        CMIS Revision: 5.0
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 6 (12.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 10.0
        Host Electrical Interface: 400GAUI-4-S C2M (Annex 120G)
        Host Lane Assignment Options: 17
        Host Lane Count: 4
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
		Inactive Firmware Version: 0.1.0
        Length Cable Assembly(m): 1.0
        Media Interface Code: Active Cable assembly with BER < 10^-6
        Media Interface Technology: Copper cable, near and far end limiting active equalizers
        Media Lane Assignment Options: 17
        Media Lane Count: 4
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: active_cable_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): YYYY-MM-DD 
        Vendor Name: VENDOR         
        Vendor OUI: AA-BB-CC-DD
        Vendor PN: ABCD
        Vendor Rev:   
        Vendor SN: XYZ1234
```
#### New command output (if the output of a command-line utility has changed)
```
root@admin:/home/admin# sfputil show eeprom -p Ethernet8
Ethernet8: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 1
        Active App Selection Host Lane 6: 1
        Active App Selection Host Lane 7: 1
        Active App Selection Host Lane 8: 1
        Application Advertisement: 400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - Active Cable assembly with BER < 10^-6 - Media Assign (0x11)
                                   400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - Active Cable assembly with BER < 10^-6 - Media Assign (0x11)
        CMIS Revision: 5.0
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 6 (12.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 10.0
        Host Electrical Interface: 400GAUI-4-S C2M (Annex 120G)
        Host Lane Assignment Options: 17
        Host Lane Count: 4
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Length Cable Assembly(m): 1.0
        Media Interface Code: Active Cable assembly with BER < 10^-6
        Media Interface Technology: Copper cable, near and far end limiting active equalizers
        Media Lane Assignment Options: 17
        Media Lane Count: 4
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: active_cable_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): YYYY-MM-DD 
        Vendor Name: VENDOR         
        Vendor OUI: AA-BB-CC-DD
        Vendor PN: ABCD
        Vendor Rev:   
        Vendor SN: XYZ1234
```
