### PR TITLE
Support to clear ACL counters cache to avoid inconsistency when table is re-created with same name

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5849,6 +5849,12 @@ def table(table_name):
     """
     Remove ACL table
     """
+    log.log_info("'config acl remove table {}' executing...".format(table_name))
+    command = "acl-loader delete {}".format(table_name)
+    clicommon.run_command(command)
+    command = "aclshow -cc -t {}".format(table_name)
+    clicommon.run_command(command)
+
     config_db = ConfigDBConnector()
     config_db.connect()
     config_db.set_entry("ACL_TABLE", table_name, None)

--- a/scripts/aclshow
+++ b/scripts/aclshow
@@ -15,6 +15,8 @@ optional arguments:
   -a,  --all                  show all ACL counters
   -r RULES,  --rules RULES    action by specific rules list: Rule_1,Rule_2
   -t TABLES, --tables TABLES  action by specific tables list: Table_1,Table_2
+  -cc, --clearcache           clears ACL counters cache for given rule or rule,table.
+                              Always use with -t or -r
 """
 
 import argparse
@@ -211,11 +213,54 @@ class AclStat(object):
         with open(COUNTERS_CACHE, 'w') as fp:
             json.dump(remap_keys(self.acl_counters), fp)
 
+    def clear_cache_counters(self, table, rule):
+        """
+        clear counters cache -- remove saved counters matching to given table or rule in counter cache file
+        on removing a rule or a table. This command will be invoked from config/main.py on removing
+        a rule or a table. If this is not called during deletion then if a new table is created
+        with same name then the old values in the file will create inconsistency in the output.
+        """
+        def remap_keys_load(list):
+            res = {}
+            for e in list:
+                res[e['key'][0], e['key'][1]] = e['value']
+            return res
+
+        def remap_keys_dump(dict):
+            return [{'key': k, 'value': v} for k, v in dict.items()]
+
+        if os.path.isfile(COUNTERS_CACHE):
+            try:
+                counters_dump = {}
+                new_counters_dump = {}
+                with open(COUNTERS_CACHE) as fp:
+                    counters_dump = remap_keys_load(json.load(fp))
+
+                if rule is not None:
+                    del counters_dump[table,rule]
+                    with open(COUNTERS_CACHE, 'w') as fp:
+                        json.dump(remap_keys_dump(counters_dump), fp)
+
+                else :
+                    new_counters_dump = {k:v for k,v in counters_dump.items() if k[0] != table}
+                    with open(COUNTERS_CACHE, 'w') as fp:
+                        json.dump(remap_keys_dump(new_counters_dump), fp)
+
+            except:
+                pass
+
+    def validate_params(self, table, rule):
+        if table is None:
+            print("Error: Table cannot be NULL")
+            return False
+        return True
+
 def main():
     parser = argparse.ArgumentParser(description='Display SONiC switch Acl Rules and Counters',
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-a', '--all', action='store_true', help='Show all ACL counters')
     parser.add_argument('-c', '--clear', action='store_true', help='Clear ACL counters statistics')
+    parser.add_argument('-cc', '--clearcache', action='store_true', help='Clear ACL counters from cache eg: aclshow -cc -r RULE -t TABLE, aclshow -cc -t TABLE')
     parser.add_argument('-r', '--rules', type=str, help='action by specific rules list: Rule1_Name,Rule2_Name', default=None)
     parser.add_argument('-t', '--tables', type=str, help='action by specific tables list: Table1_Name,Table2_Name', default=None)
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
@@ -225,6 +270,11 @@ def main():
     try:
         acls = AclStat(args.rules, args.tables)
         acls.redis_acl_read(args.verbose)
+        if args.clearcache:
+            if not acls.validate_params(args.tables, args.rules):
+                sys.exit(1)
+            acls.clear_cache_counters(args.tables, args.rules)
+            return
         if args.clear:
             acls.clear_counters()
             return


### PR DESCRIPTION
When clearing ACL counters, the counters are stored in tmp file and the entry in this file is not removed. So if new table, is created with same name then the values stored in this file creates inconsistency.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Acl counters are cleared using the command aclshow -c.

This stores the current counters in file /tmp/cache/aclshow/0/aclstat. When the table is removed or the rule is removed, the entry in this file remains in tact. 

So if user creates new table with the same name and sends traffic, the value from this file is considered as previous counters and the aclshow -a output keeps returning the diff of the current counters and the value stored for the old ACL table with the same name.
Added support to remove file created by aclshow -c once the table is deleted.

#### How I did it
RCA: On executing "aclshow -c", the ACL counters are stored in /tmp folder. This is notcleared on removing the table. So if new ACL table is created with same name, then it creates inconsistency when displaying counter stats using aclshow -a
Fix: When removing ACL table or removing ACL rule, the counters in /tmp file should also be cleared. For this new option "aclshow -cc" or "aclshow --clearcache" is introduced. This command is called internally when deleting a rule or a table. This ensures that the entry in /tmp file corresponding to the entry deleted gets cleared.
Usage:
aclshow -cc -t TABLENAME -r RULENAME
#### How to verify it
config acl add table -s ingress -p Ethernet1 DATAACL L3 => Create ACL table
Counters when 20000 packets sent for RULE_1:
```
root@sonic:~# aclshow -a
RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
------------  ------------  ------  ---------------  -------------
RULE_1        DATAACL         9999            20000        2000000
```
Now delete ACL table and then send 30000 packets.
```
root@sonic:~# aclshow -a
RULE NAME     TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT
------------  ------------  ------  ---------------  -------------
RULE_1        DATAACL         9999            10000        1000000 ==> shows 10000 instead of 30000
```
Verified that this issue is fixed and proper counters are displayed when ACL table is deleted and re-created.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

