### PR TITLE
[fast/warm-reboot] Put ERR message in syslog when a failure is seen

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -54,6 +54,7 @@ EXIT_TEAMD_RETRY_COUNT_FAILURE=23
 function error()
 {
     echo $@ >&2
+    logger -p user.err "Error seen during warm-reboot shutdown process: $@"
 }
 
 function debug()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

MSFT ADO: 26918588

This change is to add ERR logs generated during warm-reboot script to syslog.

Currently the ERR logs are sent in stdout and a corresponding entry is not added to syslog.

This makes it difficult to debug issues when stdout is not readily available.

#### How I did it
Modified existing error function to add the log entry to syslog.

#### How to verify it

Verified manually on physical device

W/o this fix:

Simulated a failure and confirmed that error is not captured in syslog.

```
Mar  1 23:56:22.060584 str2-7060cx-32s-29 NOTICE admin: Starting warm-reboot
Mar  1 23:56:23.756585 str2-7060cx-32s-29 NOTICE admin: Saving counters folder before warmboot...
Mar  1 23:56:26.049133 str2-7060cx-32s-29 NOTICE admin: warm-reboot failure (1) cleanup ...
Mar  1 23:56:27.076923 str2-7060cx-32s-29 NOTICE admin: Cancel warm-reboot: code (0)
```

W/ this change:

```
Mar  1 23:57:36.638452 str2-7060cx-32s-29 NOTICE admin: Starting warm-reboot
Mar  1 23:57:38.076240 str2-7060cx-32s-29 NOTICE admin: Saving counters folder before warmboot...
Mar  1 23:57:40.015017 str2-7060cx-32s-29 ERR admin: Error seen during warm-reboot shutdown process: Docker exec on radv timedout
Mar  1 23:57:40.024768 str2-7060cx-32s-29 NOTICE admin: warm-reboot failure (1) cleanup ...
Mar  1 23:57:40.916501 str2-7060cx-32s-29 NOTICE admin: Cancel warm-reboot: code (0)
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

