### PR TITLE
CLI to skip polling for periodic information for a port in DomInfoUpdateTask thread

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -106,6 +106,8 @@ PORT_SPEED = "speed"
 PORT_TPID = "tpid"
 DEFAULT_TPID = "0x8100"
 
+DOM_CONFIG_SUPPORTED_SUBPORTS = ['0', '1']
+
 asic_type = None
 
 DSCP_RANGE = click.IntRange(min=0, max=63)
@@ -5136,6 +5138,40 @@ def reset(ctx, interface_name):
 
     cmd = ['sudo', 'sfputil', 'reset', str(interface_name)]
     clicommon.run_command(cmd)
+
+#
+# 'dom' subcommand ('config interface transceiver dom ...')
+# This command is supported only for
+#   1. non-breakout ports (subport = 0 or subport field is absent in CONFIG_DB)
+#   2. first subport of breakout ports (subport = 1)
+
+@transceiver.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('desired_config', metavar='(enable|disable)', type=click.Choice(['enable', 'disable']))
+@click.pass_context
+def dom(ctx, interface_name, desired_config):
+    """Enable/disable DOM monitoring for SFP transceiver module"""
+    log.log_info("interface transceiver dom {} {} executing...".format(interface_name, desired_config))
+    # Get the config_db connector
+    config_db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(config_db, interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    port_table_entry = config_db.get_entry("PORT", interface_name)
+    if not port_table_entry:
+        ctx.fail("Interface {} does not exist".format(interface_name))
+
+    # Reject config if port's corresponding subport is not part of DOM_CONFIG_SUPPORTED_SUBPORTS
+    if port_table_entry.get("subport", '0') not in DOM_CONFIG_SUPPORTED_SUBPORTS:
+        ctx.fail("DOM monitoring config only supported for subports {}".format(DOM_CONFIG_SUPPORTED_SUBPORTS))
+    else:
+        config_db.mod_entry("PORT", interface_name, {"dom_status": "disabled" if desired_config == "disable" else "enabled"})
 
 #
 # 'mpls' subgroup ('config interface mpls ...')

--- a/config/main.py
+++ b/config/main.py
@@ -5207,7 +5207,7 @@ def dom(ctx, interface_name, desired_config):
     if port_table_entry.get("subport", '0') not in DOM_CONFIG_SUPPORTED_SUBPORTS:
         ctx.fail("DOM monitoring config only supported for subports {}".format(DOM_CONFIG_SUPPORTED_SUBPORTS))
     else:
-        config_db.mod_entry("PORT", interface_name, {"dom_status": "disabled" if desired_config == "disable" else "enabled"})
+        config_db.mod_entry("PORT", interface_name, {"dom_polling": "disabled" if desired_config == "disable" else "enabled"})
 
 #
 # 'mpls' subgroup ('config interface mpls ...')

--- a/config/main.py
+++ b/config/main.py
@@ -5203,7 +5203,10 @@ def dom(ctx, interface_name, desired_config):
     if not port_table_entry:
         ctx.fail("Interface {} does not exist".format(interface_name))
 
-    # Reject config if port's corresponding subport is not part of DOM_CONFIG_SUPPORTED_SUBPORTS
+    # We are handling port configuration only for the below mentioned scenarios
+    # Port is a non-breakout port (subport = 0 or subport field is absent in CONFIG_DB)
+    # Port is first subport of breakout ports (subport = 1)
+    # If the port is not in the above mentioned scenarios, then fail the command
     if port_table_entry.get("subport", '0') not in DOM_CONFIG_SUPPORTED_SUBPORTS:
         ctx.fail("DOM monitoring config only supported for subports {}".format(DOM_CONFIG_SUPPORTED_SUBPORTS))
     else:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5281,6 +5281,22 @@ This command is used to reset an SFP transceiver
   Resetting port Ethernet0...  OK
   ```
 
+**config interface transceiver dom**
+
+This command is used to configure the Digital Optical Monitoring (DOM) for an interface.
+
+- Usage:
+  ```
+  config interface transceiver dom <interface_name> (enable | disable)
+  ```
+
+- Examples:
+  ```
+  user@sonic~$ sudo config interface transceiver dom Ethernet0 enable
+
+  user@sonic~$ sudo config interface transceiver dom Ethernet0 disable
+  ```
+
 **config interface mtu <interface_name> (Versions >= 201904)**
 
 This command is used to configure the mtu for the Physical interface. Use the value 1500 for setting max transfer unit size to 1500 bytes.

--- a/tests/config_xcvr_test.py
+++ b/tests/config_xcvr_test.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock, patch
 import click
 import config.main as config
 import operator
@@ -46,6 +47,27 @@ class TestConfigXcvr(object):
         # Setting tx power on a port channel is not supported
         result = self.basic_check("tx_power", ["PortChannel0001", "11.3"], ctx, operator.ne)
         assert 'Invalid port PortChannel0001' in result.output
+
+    @patch("config.main.ConfigDBConnector.get_entry")
+    def test_dom(self, mock_get_entry, ctx):
+        interface_name = 'Ethernet0'
+        desired_config = 'enable'
+
+        config.interface_name_is_valid = MagicMock(return_value=False)
+        result = self.basic_check("dom", [interface_name, desired_config], ctx, operator.ne)
+        assert "Interface name is invalid. Please enter a valid interface name!!" in result.output
+
+        config.interface_name_is_valid = MagicMock(return_value=True)
+        mock_get_entry.return_value = None
+        result = self.basic_check("dom", [interface_name, desired_config], ctx, operator.ne)
+        assert "Interface {} does not exist".format(interface_name) in result.output
+
+        mock_get_entry.return_value = {'subport': '2'}
+        result = self.basic_check("dom", [interface_name, desired_config], ctx, operator.ne)
+        assert "DOM monitoring config only supported for subports {}".format(config.DOM_CONFIG_SUPPORTED_SUBPORTS) in result.output
+
+        mock_get_entry.return_value = {'subport': '1'}
+        result = self.basic_check("dom", [interface_name, desired_config], ctx)
 
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):
         runner = CliRunner()

--- a/tests/config_xcvr_test.py
+++ b/tests/config_xcvr_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 import click
 import config.main as config
 import operator
@@ -53,11 +53,9 @@ class TestConfigXcvr(object):
         interface_name = 'Ethernet0'
         desired_config = 'enable'
 
-        config.interface_name_is_valid = MagicMock(return_value=False)
-        result = self.basic_check("dom", [interface_name, desired_config], ctx, operator.ne)
+        result = self.basic_check("dom", ["", desired_config], ctx, operator.ne)
         assert "Interface name is invalid. Please enter a valid interface name!!" in result.output
 
-        config.interface_name_is_valid = MagicMock(return_value=True)
         mock_get_entry.return_value = None
         result = self.basic_check("dom", [interface_name, desired_config], ctx, operator.ne)
         assert "Interface {} does not exist".format(interface_name) in result.output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
MSFT ADO - 26801913

#### What I did
Created a CLI to enable/disable periodic polling through DomInfoUpdateTask thread in XCVRD.
The CLI handler related code changes in xcvrd can be found at https://github.com/sonic-net/sonic-platform-daemons/pull/443

#### Why I did this
With https://github.com/sonic-net/sonic-platform-daemons/pull/443, the DomInfoUpdateTask thread in xcvrd now polls periodically for reading CDB firmware version of transceiver to update the TRANSCEIVER_FIRMWARE_INFO table.
However, transceivers cannot handle multiple CDB commands issued from different sources at the same time.
This scenario is likely to occur during CDB firmware upgrade (triggered through `sfputil firmware download/run/commit`) and while issuing `sfputil show fwversion PORT_NAME` CLI wherein 1 or more CDB commands are issued to the transceiver. At the same time, the DomInfoUpdateTask thread can issue a CDB command to read the firmware version as part of its periodic polling.
Hence, in order to ensure that only one process accesses the CDB command feature on transceivers at a time, the `config interface transceiver dom PORT_NAME enable/disable` CLI has been created to allow user to disable background polling of DomInfoUpdateTask thread for the particular port before upgrading the CDB firmware or before issuing `sfputil show fwversion PORT_NAME` CLI.

#### How I did it
With the execution of `config interface transceiver dom PORT_NAME enable/disable` CLI, the `dom_polling` field in PORT table of CONFIG_DB will be modified with the below value
1. Upon executing `config interface transceiver dom PORT_NAME enable` CLI, the `dom_polling` field will be set to `enabled`
2. Upon executing `config interface transceiver dom PORT_NAME disable` CLI, the `dom_polling` field will be set to `disabled`

#### How to verify it
Please refer to the test details attached to https://github.com/sonic-net/sonic-platform-daemons/pull/443

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

