### PR TITLE
[master][chassis][show-runningconfig] Fix the show runningconfiguration all issue on the Supervisor

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1437,7 +1437,8 @@ def all(verbose):
         ns_list = multi_asic.get_namespace_list()
         for ns in ns_list:
             ns_config = get_config_json_by_namespace(ns)
-            ns_config['bgpraw'] = bgp_util.run_bgp_show_command(bgpraw_cmd, ns)
+            if bgp_util.is_bgp_feature_state_enabled(ns):
+                ns_config['bgpraw'] = bgp_util.run_bgp_show_command(bgpraw_cmd, ns)
             output[ns] = ns_config
         click.echo(json.dumps(output, indent=4))
     else:

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -38,6 +38,15 @@ def is_bgp_neigh_present(neighbor_ip, namespace=multi_asic.DEFAULT_NAMESPACE):
     return False
 
 
+def is_bgp_feature_state_enabled(namespace=multi_asic.DEFAULT_NAMESPACE):
+    config_db = multi_asic.connect_config_db_for_ns(namespace)
+    bgp= config_db.get_entry("FEATURE","bgp")
+    if "state" in bgp:
+        if bgp["state"] == "enabled":
+            return True
+    return False
+    
+
 def is_ipv4_address(ip_address):
     """
     Checks if given ip is ipv4


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
bgp is not supported on Supervisor card,  "show runningconfiguration all" fails on the Supervisor since the bgp services is disable. Add code to check if bgp state in the FEATURE table is able before it tries to get the BGP configuration to avoid the error. Fix issue https://github.com/sonic-net/sonic-buildimage/issues/18276
#### How I did it
Since BGP feature state is disabled in the FEATURE table on Supervisor card, add method is_bgp_feature_state_enabled() to the bgp_util.py check the BGP feature state.  Modify the "show runningconfiguration all" to call the is_bgp_feature_state_enabled(), then call the run_ngp_show _command to get the bgp configuration.

#### How to verify it
1) Execute the "show runningconfiguration all" command on Supervisor. The following output should be shown without any error.
```
admin@ixre-cpm-chassis15:~$ show runningconfiguration all | more
{
    "localhost": {
        "AUTO_TECHSUPPORT": {
            "GLOBAL": {
                "available_mem_threshold": "10.0",
                "max_core_limit": "5.0",
                "max_techsupport_limit": "10.0",
                "min_available_mem": "200",
                "rate_limit_interval": "180",
                "since": "2 days ago",
                "state": "enabled"
            }
        },
        "AUTO_TECHSUPPORT_FEATURE": {
            "bgp": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "database": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "dhcp_relay": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "eventd": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "gnmi": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "lldp": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
....
    },
    "asic0": {
        "AUTO_TECHSUPPORT": {
            "GLOBAL": {
                "available_mem_threshold": "10.0",
                "max_core_limit": "5.0",
                "max_techsupport_limit": "10.0",
                "min_available_mem": "200",
                "rate_limit_interval": "180",
                "since": "2 days ago",
                "state": "enabled"
            }
        },
        "AUTO_TECHSUPPORT_FEATURE": {
            "bgp": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "database": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
    "asic1": {
        "AUTO_TECHSUPPORT": {
            "GLOBAL": {
                "available_mem_threshold": "10.0",
                "max_core_limit": "5.0",
                "max_techsupport_limit": "10.0",
                "min_available_mem": "200",
                "rate_limit_interval": "180",
                "since": "2 days ago",
                "state": "enabled"
            }
        },
        "AUTO_TECHSUPPORT_FEATURE": {
            "bgp": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "database": {
                "available_mem_threshold": "10.0",
                "rate_limit_interval": "600",
                "state": "enabled"
            },
            "dhcp_relay": {
                "available_mem_threshold": "10.0",
...
...
    }
}

```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

