### PR TITLE
[Techsupport]Handle SAI kv pair if present in sai common profile

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1268,6 +1268,11 @@ collect_mellanox_dfw_dumps() {
     local hwsku=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_hwsku())")
     local sdk_dump_path=`cat /usr/share/sonic/device/${platform}/${hwsku}/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
 
+    if [ -z $sdk_dump_path ]; then
+        # If the SAI_DUMP_STORE_PATH is not found in device specific sai profile, check in common sai profile
+        sdk_dump_path=`docker exec -t syncd cat /etc/mlnx/sai-common.profile | grep "SAI_DUMP_STORE_PATH" |cut -d = -f2`
+    fi
+
     if [[ ! -d $sdk_dump_path ]]; then
        # This would mean the SAI_DUMP_STORE_PATH is not mounted on the host and is only accessible though the container 
        # This is a bad design and not recommended But there is nothing which restricts against it and thus the special handling

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1271,7 +1271,7 @@ collect_mellanox_dfw_dumps() {
 
     if [ -z $sdk_dump_path ]; then
         # If the SAI_DUMP_STORE_PATH is not found in device specific sai profile, check in common sai profile
-        sdk_dump_path=`docker exec -t syncd cat /etc/mlnx/sai-common.profile | grep "SAI_DUMP_STORE_PATH" |cut -d = -f2`
+        sdk_dump_path=`docker exec syncd cat /etc/mlnx/sai-common.profile | grep "SAI_DUMP_STORE_PATH" |cut -d = -f2`
         if [ -z $sdk_dump_path ]; then
             # If the above two mechanisms fail e.g. when syncd is not running , fallback to default sdk dump path
             sdk_dump_path=$def_dump_path

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1272,12 +1272,12 @@ collect_mellanox_dfw_dumps() {
     if [ -z $sdk_dump_path ]; then
         # If the SAI_DUMP_STORE_PATH is not found in device specific sai profile, check in common sai profile
         sdk_dump_path=`docker exec -t syncd cat /etc/mlnx/sai-common.profile | grep "SAI_DUMP_STORE_PATH" |cut -d = -f2`
+        if [ -z $sdk_dump_path ]; then
+            # If the above two mechanisms fail e.g. when syncd is not running , fallback to default sdk dump path
+            sdk_dump_path=$def_dump_path
+        fi
     fi
 
-    if [ -z $sdk_dump_path ]; then
-        # If the above two mechanisms fail e.g. when syncd is not running , fallback to default sdk dump path
-        sdk_dump_path=$def_dump_path
-    fi
 
     if [[ ! -d $sdk_dump_path ]]; then
        # This would mean the SAI_DUMP_STORE_PATH is not mounted on the host and is only accessible though the container 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1266,11 +1266,17 @@ collect_mellanox_dfw_dumps() {
     trap 'handle_error $? $LINENO' ERR
     local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
     local hwsku=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_hwsku())")
+    local def_dump_path="/var/log/mellanox/sdk-dumps"
     local sdk_dump_path=`cat /usr/share/sonic/device/${platform}/${hwsku}/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
 
     if [ -z $sdk_dump_path ]; then
         # If the SAI_DUMP_STORE_PATH is not found in device specific sai profile, check in common sai profile
         sdk_dump_path=`docker exec -t syncd cat /etc/mlnx/sai-common.profile | grep "SAI_DUMP_STORE_PATH" |cut -d = -f2`
+    fi
+
+    if [ -z $sdk_dump_path ]; then
+        # If the above two mechanisms fail e.g. when syncd is not running , fallback to default sdk dump path
+        sdk_dump_path=$def_dump_path
     fi
 
     if [[ ! -d $sdk_dump_path ]]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Handle the SAI key value pair if it is present in sai common profile rather than specific profile for mellanox platforms. The concept of common sai profile is introduced in https://github.com/sonic-net/sonic-buildimage/pull/18074 . After this the techsupport started to fail because of the absence of SAI_DUMP_STORE_PATH

#### How I did it
Check if the variable is not present in platform specific file and then read the common file. If the common file is not accessible due to syncd being down, fallback to default path which is hardcoded.


#### How to verify it
Running techsupport and ensuring it exits with code 0


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

