### PR TITLE
Skip the validation of action in acl-loader if capability table in STATE_DB is empty

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1759,7 +1759,7 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
     update_sonic_environment()
 
     if os.path.isfile('/etc/sonic/acl.json'):
-        clicommon.run_command(['acl-loader', 'update', 'full', '/etc/sonic/acl.json'], display_cmd=True)
+        clicommon.run_command(['acl-loader', 'update', 'full', '/etc/sonic/acl.json', '--skip_action_validation'], display_cmd=True)
 
     # Load port_config.json
     try:

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -56,6 +56,35 @@ class TestAclLoader(object):
         assert acl_loader.validate_actions("DATAACL", forward_packet_action)
         assert not acl_loader.validate_actions("DATAACL", drop_packet_action)
 
+    def test_load_rules_when_capability_table_is_empty(self, acl_loader):
+        """
+        Test case to verify that acl_loader can still load dataplane acl rules when skip_action_validation
+        is true, and capability table in state_db is absent
+        """
+        # Backup and empty the capability table from state_db
+        if acl_loader.per_npu_statedb:
+            statedb = list(acl_loader.per_npu_statedb.values())[0]
+        else:
+            statedb = acl_loader.statedb
+        switchcapability = statedb.get_all("STATE_DB", "SWITCH_CAPABILITY|switch")
+        statedb.delete("STATE_DB", "SWITCH_CAPABILITY|switch")
+        try:
+            acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'), skip_action_validation=True)
+            assert acl_loader.rules_info[("DATAACL", "RULE_2")]
+            assert acl_loader.rules_info[("DATAACL", "RULE_2")] == {
+                "VLAN_ID": 369,
+                "ETHER_TYPE": "2048",
+                "IP_PROTOCOL": 6,
+                "SRC_IP": "20.0.0.2/32",
+                "DST_IP": "30.0.0.3/32",
+                "PACKET_ACTION": "FORWARD",
+                "PRIORITY": "9998"
+            }
+        finally:
+            # Restore the capability table in state_db
+            for key, value in switchcapability.items():
+                statedb.set("STATE_DB", key, value)
+
     def test_vlan_id_translation(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -62,12 +62,13 @@ class TestAclLoader(object):
         is true, and capability table in state_db is absent
         """
         # Backup and empty the capability table from state_db
+        SWITCH_CAPABILITY = "SWITCH_CAPABILITY|switch"
         if acl_loader.per_npu_statedb:
             statedb = list(acl_loader.per_npu_statedb.values())[0]
         else:
             statedb = acl_loader.statedb
-        switchcapability = statedb.get_all("STATE_DB", "SWITCH_CAPABILITY|switch")
-        statedb.delete("STATE_DB", "SWITCH_CAPABILITY|switch")
+        switchcapability = statedb.get_all("STATE_DB", SWITCH_CAPABILITY)
+        statedb.delete("STATE_DB", SWITCH_CAPABILITY)
         try:
             acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'), skip_action_validation=True)
             assert acl_loader.rules_info[("DATAACL", "RULE_2")]
@@ -83,7 +84,7 @@ class TestAclLoader(object):
         finally:
             # Restore the capability table in state_db
             for key, value in switchcapability.items():
-                statedb.set("STATE_DB", key, value)
+                statedb.set("STATE_DB", SWITCH_CAPABILITY, key, value)
 
     def test_vlan_id_translation(self, acl_loader):
         acl_loader.rules_info = {}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to fix a racing condition in system bootup path.

In the system bootup path, `config-setup` service will call `config load_minigraph` if it's the first startup, and then `/etc/sonic/acl.json` is loaded by `config load_minigraph`.

If `orchagent` hasn't written `ACL_STAGE_CAPABILITY_TABLE` or `SWITCH_CAPABILITY_TABLE` into `STATE_DB` before being terminated, then the dataplane ACL rules defined in `/etc/sonic/acl.json` is skipped.

This PR is to fix the racing condition by adding an option `skip_action_validation` to `acl-loader`.  If the option `skip_action_validation` is true, and `ACL_STAGE_CAPABILITY_TABLE` or `SWITCH_CAPABILITY_TABLE` is empty, the action validation is skipped.

#### How I did it
This PR added an option `skip_action_validation` to `acl-loader`.  If the option `skip_action_validation` is true, and `ACL_STAGE_CAPABILITY_TABLE` or `SWITCH_CAPABILITY_TABLE` is empty, the action validation is skipped.

#### How to verify it
1. Verified by UT
2. Verified by running on a physical testbed.
```
Mar  8 21:37:37.397041 str2-msn2700-spy-2 INFO config-setup[2603]: Use minigraph.xml from old system...
Mar  8 21:37:37.399330 str2-msn2700-spy-2 INFO config-setup[2603]: Reloading minigraph...
Mar  8 21:37:39.179990 str2-msn2700-spy-2 INFO config-setup[2701]: Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Mar  8 21:37:44.390483 str2-msn2700-spy-2 INFO config-setup[2701]: Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Mar  8 21:37:44.897351 str2-msn2700-spy-2 INFO config-setup[2701]: Running command: acl-loader update full /etc/sonic/acl.json --skip_action_validation
Mar  8 21:37:45.353639 str2-msn2700-spy-2 INFO config-setup[2701]: Warning: Skipped action validation as capability table is not present in STATE_DB
Mar  8 21:37:45.354330 str2-msn2700-spy-2 INFO config-setup[2701]: Running command: config qos reload --no-dynamic-buffer --no-delay
Mar  8 21:37:47.266357 str2-msn2700-spy-2 INFO config-setup[2701]: Running command: /usr/local/bin/sonic-cfggen -d --write-to-db -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers.json.j2,config-db -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml
Mar  8 21:37:47.266489 str2-msn2700-spy-2 INFO config-setup[2701]: Buffer calculation model updated, restarting swss is required to take effect
Mar  8 21:37:47.769088 str2-msn2700-spy-2 INFO config-setup[2701]: Running command: pfcwd start_default
Mar  8 21:37:48.741003 str2-msn2700-spy-2 INFO config-setup[2701]: Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
Mar  8 21:37:49.586524 str2-msn2700-spy-2 INFO config-setup[5379]: Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
Mar  8 21:37:50.738952 str2-msn2700-spy-2 INFO config-setup[5391]: True
```
The rules are loaded successfully after reloading.
```
admin@str2-msn2700-spy-2:~$ show acl rule
Table    Rule          Priority    Action    Match               Status
-------  ------------  ----------  --------  ------------------  --------
DATAACL  RULE_1        9999        DROP      DST_IP: 9.5.9.3/32  Active
                                             ETHER_TYPE: 2048
DATAACL  DEFAULT_RULE  1           DROP      ETHER_TYPE: 2048    Active
```
#### Previous command output (if the output of a command-line utility has changed)
```
admin@str2-msn2700-spy-2:~$ acl-loader update full --help
Usage: acl-loader update full [OPTIONS] FILENAME

  Full update of ACL rules configuration. If a table_name is provided, the
  operation will be restricted in the specified table.

Options:
  --table_name TEXT
  --session_name TEXT
  --mirror_stage [ingress|egress]
  --max_priority INTEGER
  --help                          Show this message and exit.
```
#### New command output (if the output of a command-line utility has changed)
The help info changed.
```
admin@str2-msn2700-spy-2:~$ acl-loader update full --help
Usage: acl-loader update full [OPTIONS] FILENAME

  Full update of ACL rules configuration. If a table_name is provided, the
  operation will be restricted in the specified table.

Options:
  --table_name TEXT
  --session_name TEXT
  --mirror_stage [ingress|egress]
  --max_priority INTEGER
  --skip_action_validation        Skip action validation
  --help                          Show this message and exit.
```