### PR TITLE
[Bug] Fix fw_setenv illegel character issue

### DIFF
--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -89,7 +89,7 @@ class UbootBootloader(OnieInstallerBootloader):
         cmdline = out.strip()
         cmdline = re.sub('^linuxargs=', '', cmdline)
         cmdline = re.sub(r' sonic_fips=[^\s]', '', cmdline) + " sonic_fips=" + fips
-        run_command(['/usr/bin/fw_setenv', 'linuxargs',  cmdline])
+        run_command(['/usr/bin/fw_setenv', 'linuxargs', cmdline])
         click.echo('Done')
 
     def get_fips(self, image):

--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -89,7 +89,7 @@ class UbootBootloader(OnieInstallerBootloader):
         cmdline = out.strip()
         cmdline = re.sub('^linuxargs=', '', cmdline)
         cmdline = re.sub(r' sonic_fips=[^\s]', '', cmdline) + " sonic_fips=" + fips
-        run_command(['/usr/bin/fw_setenv', 'linuxargs'] + split(cmdline))
+        run_command(['/usr/bin/fw_setenv', 'linuxargs',  cmdline])
         click.echo('Done')
 
     def get_fips(self, image):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

The bug can be reproduced by the following command:
```
root@bjw-can-7215-6:/home/admin# sonic-installer set-fips
Command: /usr/bin/fw_setenv linuxargs net.ifnames=0 loopfstype=squashfs loop=image-fips-armhf-202305.88981472-dde4d1d844/fs.squashfs systemd.unified_cgroup_hierarchy=0 varlog_size=4096 loglevel=4 logs_inram=on sonic_fips=1
Error: illegal character '=' in variable name "loopfstype=squashfs"

```

#### How I did it
It is to set the variable linuxargs to the the environment value cmdline, as the part of the Linux Kernel Cmdline. The environment variable cannot be split.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

