### PR TITLE
Fix PINS link in ToC of Command Reference

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -136,7 +136,7 @@
 * [Platform Specific Commands](#platform-specific-commands)
   * [Mellanox Platform Specific Commands](#mellanox-platform-specific-commands)
   * [Barefoot Platform Specific Commands](#barefoot-platform-specific-commands)
-* [PINS](#pins-show commands)
+* [PINS](#pins-show-commands)
 * [PortChannels](#portchannels)
   * [PortChannel Show commands](#portchannel-show-commands)
   * [PortChannel Config commands](#portchannel-config-commands)
@@ -8788,7 +8788,7 @@ communicate with the P4RT application.
   }
   ```
 
-Go Back To [Beginning of the document](#) or [Beginning of this section](#pbh)
+Go Back To [Beginning of the document](#) or [Beginning of this section](#pins)
 
 ## QoS
 


### PR DESCRIPTION

#### What I did

- Added a - to `doc/Command-Reference.md` to fix the Table of Contents
- Also corrected the link for `Beginning of this section`

#### How I did it
Using the Github Editor
#### How to verify it
N/A
#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A

