### PR TITLE
Fix to use IPv6 linklocal address as snmp agent address

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3250,7 +3250,13 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
         ipaddresses = netifaces.ifaddresses(intf)
         if ip_family[ip.version] in ipaddresses:
             for ipaddr in ipaddresses[ip_family[ip.version]]:
-                if agentip.lower() == ipaddr['addr'].lower():
+                # link local address will have scope along with ip address
+                # for ex fe80::1%eth0
+                if agentip.lower() == ipaddr['addr'].lower().split('%')[0]:
+                    agent_address = ipaddress.ip_address(agentip)
+                    if agent_address.version == 6 and agent_address.is_link_local:
+                        # add scope id for link local ip address
+                        agentip = agentip + '%' + intf
                     found = 1
                     break
         if found == 1:

--- a/config/main.py
+++ b/config/main.py
@@ -3253,7 +3253,7 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
         ipaddresses = netifaces.ifaddresses(intf)
         if ip_family[ip.version] in ipaddresses:
             for ipaddr in ipaddresses[ip_family[ip.version]]:
-                if agent_ip_addr.lower() == ipaddr['addr'].lower():
+                if agentip.lower() == ipaddr['addr'].lower():
                     found = 1
                     break
         if found == 1:

--- a/config/main.py
+++ b/config/main.py
@@ -3237,7 +3237,8 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
     #Construct SNMP_AGENT_ADDRESS_CONFIG table key in the format ip|<port>|<vrf>
     # Link local IP address should be provided along with zone id
     # <link_local_ip>%<zone_id> for ex fe80::1%eth0
-    if not clicommon.is_ipaddress(agentip.split('%')[0]):
+    ip_addr = agentip.split('%')[0]
+    if not clicommon.is_ipaddress(ip_addr):
         click.echo("Invalid IP address")
         return False
     config_db = ctx.obj['db']
@@ -3247,7 +3248,7 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
             click.echo("ManagementVRF is Enabled. Provide vrf.")
             return False
     found = 0
-    ip = ipaddress.ip_address(agentip.split('%')[0])
+    ip = ipaddress.ip_address(ip_addr)
     for intf in netifaces.interfaces():
         ipaddresses = netifaces.ifaddresses(intf)
         if ip_family[ip.version] in ipaddresses:

--- a/config/main.py
+++ b/config/main.py
@@ -3237,8 +3237,8 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
     #Construct SNMP_AGENT_ADDRESS_CONFIG table key in the format ip|<port>|<vrf>
     # Link local IP address should be provided along with zone id
     # <link_local_ip>%<zone_id> for ex fe80::1%eth0
-    ip_addr = agentip.split('%')[0]
-    if not clicommon.is_ipaddress(ip_addr):
+    agent_ip_addr = agentip.split('%')[0]
+    if not clicommon.is_ipaddress(agent_ip_addr):
         click.echo("Invalid IP address")
         return False
     config_db = ctx.obj['db']
@@ -3248,12 +3248,12 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
             click.echo("ManagementVRF is Enabled. Provide vrf.")
             return False
     found = 0
-    ip = ipaddress.ip_address(ip_addr)
+    ip = ipaddress.ip_address(agent_ip_addr)
     for intf in netifaces.interfaces():
         ipaddresses = netifaces.ifaddresses(intf)
         if ip_family[ip.version] in ipaddresses:
             for ipaddr in ipaddresses[ip_family[ip.version]]:
-                if agentip.lower() == ipaddr['addr'].lower():
+                if agent_ip_addr.lower() == ipaddr['addr'].lower():
                     found = 1
                     break
         if found == 1:

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -903,7 +903,7 @@ class TestSNMPConfigCommands(object):
         runner = CliRunner()
         runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["10.1.0.32"], obj=obj)
         assert ('10.1.0.32', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
-        assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "i10.1.0.32||") == {}
+        assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "10.1.0.32||") == {}
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -881,7 +881,7 @@ class TestSNMPConfigCommands(object):
     @patch('netifaces.ifaddresses', mock.Mock(return_value={2:
                                               [{'addr': '10.1.0.32', 'netmask': '255.255.255.0',
                                                 'broadcast': '10.1.0.255'}],
-                                                10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
+                                                10: [{'addr': 'fe80::1%eth0', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
     @patch('os.system', mock.Mock(return_value=0))
     def test_config_snmpagentaddress_add_linklocal(self):
         db = Db()

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -878,9 +878,10 @@ class TestSNMPConfigCommands(object):
         assert 'SNMP community configuration failed' in result.output
 
     @patch('netifaces.interfaces', mock.Mock(return_value=['eth0']))
-    @patch('netifaces.ifaddresses', mock.Mock(return_value={2:\
-            [{'addr': '10.1.0.32', 'netmask': '255.255.255.0', 'broadcast': '10.1.0.255'}], \
-            10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
+    @patch('netifaces.ifaddresses', mock.Mock(return_value={2:
+                                              [{'addr': '10.1.0.32', 'netmask': '255.255.255.0',
+                                                'broadcast': '10.1.0.255'}],
+                                                10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
     @patch('os.system', mock.Mock(return_value=0))
     def test_config_snmpagentaddress_add_linklocal(self):
         db = Db()

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -891,6 +891,20 @@ class TestSNMPConfigCommands(object):
         assert ('fe80::1%eth0', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
         assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "fe80::1%eth0||") == {}
 
+    @patch('netifaces.interfaces', mock.Mock(return_value=['eth0']))
+    @patch('netifaces.ifaddresses', mock.Mock(return_value={2:
+                                              [{'addr': '10.1.0.32', 'netmask': '255.255.255.0',
+                                                'broadcast': '10.1.0.255'}],
+                                                10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
+    @patch('os.system', mock.Mock(return_value=0))
+    def test_config_snmpagentaddress_add_ipv4(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["10.1.0.32"], obj=obj)
+        assert ('10.1.0.32', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
+        assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "i10.1.0.32||") == {}
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -877,6 +877,19 @@ class TestSNMPConfigCommands(object):
         assert result.exit_code != 0
         assert 'SNMP community configuration failed' in result.output
 
+    @patch('netifaces.interfaces', mock.Mock(return_value=['eth0']))
+    @patch('netifaces.ifaddresses', mock.Mock(return_value={2: [{'addr': '10.1.0.32', 'netmask': '255.255.255.0', 'broadcast': '10.1.0.255'}], 10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
+    @patch('os.system', mock.Mock(return_value=0))
+    def test_config_snmpagentaddress_add_linklocal(self):
+        db = Db()
+        obj = {'db':db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1"], obj=obj)
+        print(result.exit_code)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "fe80::1%eth0|161|") == {}
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -884,11 +884,9 @@ class TestSNMPConfigCommands(object):
         db = Db()
         obj = {'db':db.cfgdb}
         runner = CliRunner()
-        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
-            result = runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1"], obj=obj)
-        print(result.exit_code)
-        assert result.exit_code == 0
-        assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "fe80::1%eth0|161|") == {}
+        runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1"], obj=obj)
+        assert ('fe80::1%eth0', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
+        assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "fe80::1%eth0||") == {}
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -887,7 +887,7 @@ class TestSNMPConfigCommands(object):
         db = Db()
         obj = {'db': db.cfgdb}
         runner = CliRunner()
-        runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1"], obj=obj)
+        runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1%eth0"], obj=obj)
         assert ('fe80::1%eth0', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
         assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "fe80::1%eth0||") == {}
 

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -878,11 +878,13 @@ class TestSNMPConfigCommands(object):
         assert 'SNMP community configuration failed' in result.output
 
     @patch('netifaces.interfaces', mock.Mock(return_value=['eth0']))
-    @patch('netifaces.ifaddresses', mock.Mock(return_value={2: [{'addr': '10.1.0.32', 'netmask': '255.255.255.0', 'broadcast': '10.1.0.255'}], 10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
+    @patch('netifaces.ifaddresses', mock.Mock(return_value={2:\
+            [{'addr': '10.1.0.32', 'netmask': '255.255.255.0', 'broadcast': '10.1.0.255'}], \
+            10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
     @patch('os.system', mock.Mock(return_value=0))
     def test_config_snmpagentaddress_add_linklocal(self):
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'db': db.cfgdb}
         runner = CliRunner()
         runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1"], obj=obj)
         assert ('fe80::1%eth0', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
If link local IPv6 address is added as SNMP agent address, it will fail.
This PR requires changes in snmpd.conf.j2 template here https://github.com/sonic-net/sonic-buildimage/pull/18350/
#### How I did it
Append scope id to ipv6 link local IP address.
#### How to verify it
Able to configure link local ipv6 address as snmp agent address
```
sudo config snmpagentaddress add fe80::2a99:3aff:fe17:1c08%eth0


 sonic-db-cli CONFIG_DB keys "*SNMP*AGENT*"
SNMP_AGENT_ADDRESS_CONFIG|FC00:1::32|161|
SNMP_AGENT_ADDRESS_CONFIG|2a01::ae|161|
SNMP_AGENT_ADDRESS_CONFIG|10.1.0.32|161|
SNMP_AGENT_ADDRESS_CONFIG|10..0.13|161|
SNMP_AGENT_ADDRESS_CONFIG|fe80::2a99:3aff:fe17:1c08%eth0||
..
SNMP_AGENT_ADDRESS_CONFIG|fe80::3a38:a6ff:fe98:e960%eth0||  ---- Newly added agent IP along with zone id
SNMP_AGENT_ADDRESS_CONFIG|FC00:1::32|161|
SNMP_COMMUNITY|<>
...

docker exec -it snmp cat /etc/snmp/snmpd.conf | grep agentAddress
agentAddress udp:[10.1.0.32]:161
agentAddress udp:[10.0.0.13]:161
agentAddress udp6:[2a01::a]:161
agentAddress udp6:[FC00:1::32]:161
agentAddress udp6:[fe80::2a99:3aff:fe17:1c08%eth0]

docker exec -it snmp snmpwalk -v2c -c <comm> fe80::2a99:3aff:fe17:1c08%eth0 1.3.6.1.2.1.1.1.0
iso.3.6.1.2.1.1.1.0 = STRING: "SONiC Software Version: SONiC.<> - HwSku: Arista-<> - Distribution: Debian 11.10 - Kernel: 5.10.0-23-2-amd64"
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

