### PR TITLE
Update port2alias to work for multi-asic systems.

### DIFF
--- a/scripts/port2alias
+++ b/scripts/port2alias
@@ -7,6 +7,7 @@ from io import StringIO
 from portconfig import get_port_config
 from sonic_py_common import device_info
 from sonic_py_common import multi_asic
+from utilities_common.general import load_db_config
 
 # mock the redis for unit test purposes #
 try:
@@ -50,6 +51,7 @@ def translate_line(line, ports):
 def main():
     (platform, hwsku) = device_info.get_platform_and_hwsku()
     ports = {}
+    load_db_config()
     for ns in multi_asic.get_namespace_list():
         (ports_ns, _, _) = get_port_config(hwsku=hwsku, platform=platform, asic_name=ns)
         ports.update(ports_ns)


### PR DESCRIPTION
What I did

Basically `port2alias` Cli became broken on multi-asic platforms after introduction of https://github.com/sonic-net/sonic-buildimage/pull/10960 which removed the initialization of global DB config from portconfig.py (library side) and expects application to do it, but here application side (`port2alias`) was not updated accordingly.

How I did it
Add load_db_config call to `port2alias` for initialization

How to verify it:

Before fix
```
admin@svcstr2-xxxx-lc3-1:/usr/local/bin$ show interface status | port2alias
Traceback (most recent call last):
  File "/usr/local/bin/port2alias", line 60, in <module>
    main()
  File "/usr/local/bin/port2alias", line 54, in main
    (ports_ns, _, _) = get_port_config(hwsku=hwsku, platform=platform, asic_name=ns)
  File "/usr/local/lib/python3.9/dist-packages/portconfig.py", line 172, in get_port_config
    config_db = db_connect_configdb(asic_name)
  File "/usr/local/lib/python3.9/dist-packages/portconfig.py", line 75, in db_connect_configdb
    config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2337, in __init__
    super(ConfigDBConnector, self).__init__(use_unix_socket_path = use_unix_socket_path, namespace = namespace)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1966, in __init__
    for db_name in self.get_db_list():
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1902, in get_db_list
    return _swsscommon.SonicV2Connector_Native_get_db_list(self)
RuntimeError: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig

```

After fix:

```
admin@svcstr2-xxxx-lc3-1:/usr/local/bin$ show interface status | port2alias
      Interface                  Lanes    Speed    MTU    FEC        Alias             Vlan    Oper    Admin             Type    Asym PFC
---------------  ---------------------  -------  -----  -----  -----------  ---------------  ------  -------  ---------------  ----------
      Eth0/2/0/0    1288,1289,1290,1291     100G   9100     rs   Eth0/2/0/0  PortChannel1049      up       up  QSFP28 or later         off
      Eth0/2/0/1    1280,1281,1282,1283     100G   9100     rs   Eth0/2/0/1  PortChannel1049      up       up  QSFP28 or later         off
     Eth0/2/0/2    1032,1033,1034,1035     100G   9100     rs   Eth0/2/0/2  PortChannel1050      up       up  QSFP28 or later         off
     Eth0/2/0/3    1024,1025,1026,1027     100G   9100     rs   Eth0/2/0/3  PortChannel1050      up       up  QSFP28 or later         off
     Eth0/2/0/4        776,777,778,779     100G   9100     rs   Eth0/2/0/4  PortChannel1051      up       up  QSFP28 or later         off
     Eth0/2/0/5        768,769,770,771     100G   9100     rs   Eth0/2/0/5  PortChannel1051      up       up  QSFP28 or later         off
     Eth0/2/0/6        520,521,522,523     100G   9100     rs   Eth0/2/0/6  PortChannel1052      up       up  QSFP28 or later         off
```