### PR TITLE
Skip check_frr_pending_routes in Supervisor card in chassis

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -50,6 +50,7 @@ import subprocess
 from ipaddress import ip_network
 from swsscommon import swsscommon
 from utilities_common import chassis
+from sonic_py_common import device_info
 
 APPL_DB_NAME = 'APPL_DB'
 ASIC_DB_NAME = 'ASIC_DB'
@@ -748,10 +749,12 @@ def check_routes():
     if rt_asic_miss:
         results["Unaccounted_ROUTE_ENTRY_TABLE_entries"] = rt_asic_miss
 
-    rt_frr_miss = check_frr_pending_routes()
-
-    if rt_frr_miss:
-        results["missed_FRR_routes"] = rt_frr_miss
+    #Don't check the FRR pending route check in Supervisor to prevent get_frr_routes
+    #throwing backtrace in json.loads since there is no route in SUP
+    if not device_info.is_supervisor():
+        rt_frr_miss = check_frr_pending_routes()
+        if rt_frr_miss:
+            results["missed_FRR_routes"] = rt_frr_miss
 
     if results:
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
 Skip the frr_pending_routes check in Supervisor to avoid the python back trace since there is no ip or ipv6 route and json.loads fails 
#### How I did it
Added a check not to call frr_pending_routes 
#### How to verify it
Verified the route check and "sudo monit status" in SUP and LC  
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

