### PR TITLE
Modify "show interface transceiver status" CLI to show SW cmis state

### DIFF
--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -374,6 +374,7 @@
         "rx_sig_power_max": "40"
     },
     "TRANSCEIVER_STATUS|Ethernet44":{
+        "cmis_state": "READY",
         "DP1State": "DataPathActivated",
         "DP2State": "DataPathActivated",
         "DP3State": "DataPathActivated",

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -304,6 +304,7 @@ Ethernet4:
 
 test_qsfp_dd_status_output = """\
 Ethernet44:
+        CMIS State (SW): READY
         Tx fault flag on media lane 1: False
         Tx fault flag on media lane 2: False
         Tx fault flag on media lane 3: False

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -47,6 +47,7 @@ CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP}
 # For non-CMIS, only first 1 or 4 lanes are applicable.
 # For CMIS, all 8 lanes are applicable.
 QSFP_STATUS_MAP = {
+    'cmis_state': 'CMIS State (SW)',
     'txfault1': 'Tx fault flag on media lane 1',
     'txfault2': 'Tx fault flag on media lane 2',
     'txfault3': 'Tx fault flag on media lane 3',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
With the below PR, we are now storing `cmis_state` in `TRANSCEIVER_STATUS` table of `STATE_DB`. Hence, we need to modify the `show interface transceiver status` CLI to show the software `cmis_state` of a port

https://github.com/sonic-net/sonic-platform-daemons/pull/449

MSFT ADO - 27254777

#### How I did it
Added `cmis_state` in `QSFP_STATUS_MAP` to display it for all types of transceivers which have this field populated.

#### How to verify it
1. Dumped o/p of `show int transceiver status` with the `cmis_state` field present in TRANSCEIVER_STATUS table
2. Dumped o/p of `show int transceiver status` with the `cmis_state` field absent in TRANSCEIVER_STATUS table

```
root@sonic:/home/admin# show int transceiver status Ethernet256
Ethernet256: 
        CMIS State (SW): READY
        Tx fault flag on media lane 1: False
        Rx loss of signal flag on media lane 1: False
        TX disable status on lane 1: False
        Disabled TX channels: 0
root@sonic:/home/admin# redis-cli -n 6 hgetall "TRANSCEIVER_STATUS|Ethernet256"
 1) "cmis_state"
 2) "READY"
 3) "status"
 4) "1"
 5) "error"
 6) "N/A"
 7) "rxlos1"
 8) "False"
 9) "txfault1"
10) "False"
11) "tx1disable"
12) "False"
13) "tx_disabled_channel"
14) "0"
root@sonic:/home/admin# redis-cli -n 6 HDEL "TRANSCEIVER_STATUS|Ethernet256" "cmis_state"
(integer) 1
root@sonic:/home/admin# show int transceiver status Ethernet256
Ethernet256: 
        Tx fault flag on media lane 1: False
        Rx loss of signal flag on media lane 1: False
        TX disable status on lane 1: False
        Disabled TX channels: 0
root@sonic:/home/admin# 
```

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show int transceiver status Ethernet256
Ethernet256: 
        Tx fault flag on media lane 1: False
        Rx loss of signal flag on media lane 1: False
        TX disable status on lane 1: False
        Disabled TX channels: 0
root@sonic:/home/admin# 
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show int transceiver status Ethernet256
Ethernet256: 
        CMIS State (SW): READY
        Tx fault flag on media lane 1: False
        Rx loss of signal flag on media lane 1: False
        TX disable status on lane 1: False
        Disabled TX channels: 0
```
