### PR TITLE
[fast/warm-reboot] Retain TRANSCEIVER_INFO tables on fast/warm-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -252,6 +252,8 @@ function backup_database()
                                           and not string.match(k, 'MIRROR_SESSION_TABLE|') \
                                           and not string.match(k, 'FG_ROUTE_TABLE|') \
                                           and not string.match(k, 'WARM_RESTART_ENABLE_TABLE|') \
+                                          and not string.match(k, 'TRANSCEIVER_INFO|') \
+                                          and not string.match(k, 'TRANSCEIVER_STATUS|') \
                                           and not string.match(k, 'VXLAN_TUNNEL_TABLE|') \
                                           and not string.match(k, 'BUFFER_MAX_PARAM_TABLE|') \
                                           and not string.match(k, 'FAST_RESTART_ENABLE_TABLE|') then

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -253,7 +253,6 @@ function backup_database()
                                           and not string.match(k, 'FG_ROUTE_TABLE|') \
                                           and not string.match(k, 'WARM_RESTART_ENABLE_TABLE|') \
                                           and not string.match(k, 'TRANSCEIVER_INFO|') \
-                                          and not string.match(k, 'TRANSCEIVER_STATUS|') \
                                           and not string.match(k, 'VXLAN_TUNNEL_TABLE|') \
                                           and not string.match(k, 'BUFFER_MAX_PARAM_TABLE|') \
                                           and not string.match(k, 'FAST_RESTART_ENABLE_TABLE|') then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Retain TRANSCEIVER_INFO tables on fast/warm reboot. The PHY isn't reset on fast/warm reboot. Knowing about plugged modules is required for orchagent to set SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE=true on start.

#### How I did it

Save TRANSCEIVER_INFO tables on warm/fast-reboot.

#### How to verify it

Run fast/warm-reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

