### PR TITLE
[Sonic-utilities] Static lag support rebase master

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2154,8 +2154,11 @@ def portchannel(db, ctx, namespace):
 @click.option('--fast-rate', default='false',
               type=click.Choice(['true', 'false'],
                                 case_sensitive=False))
+@click.option('--static', default='false',
+              type=click.Choice(['true', 'false'],
+                                case_sensitive=False))
 @click.pass_context
-def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
+def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate, static):
     """Add port channel"""
     
     fvs = {
@@ -2169,6 +2172,8 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
         fvs['min_links'] = str(min_links)
     if fallback != 'false':
         fvs['fallback'] = 'true'
+    if static != 'false':
+        fvs['static'] = 'true'
     
     db = ValidatedConfigDBConnector(ctx.obj['db'])
     if ADHOC_VALIDATION:

--- a/show/interfaces/portchannel.py
+++ b/show/interfaces/portchannel.py
@@ -107,8 +107,19 @@ class Teamshow(object):
                 self.summary[team_id]['ports'] = ''
                 continue
             state = self.teamsraw[team_id]
-            info['protocol'] = "LACP"
-            info['protocol'] += "(A)" if state['runner.active'] == "true" else '(I)'
+            if 'setup.runner_name' in state and state['setup.runner_name'] == "roundrobin":
+                runner_name = "roundrobin"
+            elif 'setup.runner_name' in state and state['setup.runner_name'] == "loadbalance":
+                runner_name = "loadbalance"
+            else:
+                runner_name = "lacp"
+
+            if runner_name == "roundrobin" or runner_name == "loadbalance":
+                info['protocol'] = "NONE"
+                info['protocol'] += "(A)"
+            else:
+                info['protocol'] = "LACP"
+                info['protocol'] += "(A)" if state['runner.active'] == "true" else '(I)'
 
             portchannel_status = self.get_portchannel_status(team)
             if portchannel_status is None:
@@ -129,7 +140,9 @@ class Teamshow(object):
                 for port in ports:
                     status = self.get_portchannel_member_status(team, port)
                     pstate = self.db.get_all(self.db.STATE_DB, PORT_CHANNEL_MEMBER_STATE_TABLE_PREFIX+team+'|'+port)
-                    selected = True if pstate['runner.aggregator.selected'] == "true" else False
+                    selected = True if pstate['link.up'] == "true" else False
+                    if runner_name == "lacp":
+                        selected = True if pstate['runner.aggregator.selected'] == "true" else False
                     if clicommon.get_interface_naming_mode() == "alias":
                         alias = clicommon.InterfaceAliasConverter().name_to_alias(port)
                         info["ports"] += alias + "("

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -129,6 +129,7 @@ Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
  0002  PortChannel0002  LACP(A)(Up)  Ethernet116(S)
  0003  PortChannel0003  LACP(A)(Up)  Ethernet120(S)
  0004  PortChannel0004  LACP(A)(Up)  N/A
+ 0100  PortChannel0100  NONE(A)(Up)  N/A
  1001  PortChannel1001  N/A
 """
 
@@ -141,6 +142,7 @@ Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
  0002  PortChannel0002  LACP(A)(Up)  etp30(S)
  0003  PortChannel0003  LACP(A)(Up)  etp31(S)
  0004  PortChannel0004  LACP(A)(Up)  N/A
+ 0100  PortChannel0100  NONE(A)(Up)  N/A
  1001  PortChannel1001  N/A
 """
 

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -183,6 +183,7 @@ PortChannel0001  routed
 PortChannel0002  routed
 PortChannel0003  routed
 PortChannel0004  routed
+PortChannel0100  routed
 PortChannel1001  trunk
 """
 
@@ -222,6 +223,7 @@ PortChannel0001  routed
 PortChannel0002  routed
 PortChannel0003  routed
 PortChannel0004  routed
+PortChannel0100  routed
 PortChannel1001  trunk               4000
 """
 

--- a/tests/ipv6_link_local_test.py
+++ b/tests/ipv6_link_local_test.py
@@ -84,6 +84,8 @@ show_ipv6_link_local_mode_output="""\
 +------------------+----------+
 | PortChannel0004  | Disabled |
 +------------------+----------+
+| PortChannel0100  | Disabled |
++------------------+----------+
 | Vlan1000         | Disabled |
 +------------------+----------+
 | Vlan2000         | Disabled |

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -282,6 +282,12 @@
         "tpid": "0x88A8",
         "oper_status": "up"
     },
+    "LAG_TABLE:PortChannel0100": {
+        "admin_status": "up",
+        "mtu": "9100",
+        "tpid": "0x88A8",
+        "oper_status": "up"
+    },
     "SWITCH_TABLE:switch": {
         "vxlan_port": "13550"
     },

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -208,6 +208,14 @@
         "setup.kernel_team_mode_name": "loadbalance",
         "runner.active": "true"
     },
+    "LAG_TABLE|PortChannel0100": {
+        "setup.runner_name": "roundrobin",
+        "team_device.ifinfo.dev_addr": "52:54:00:f2:e1:23",
+        "team_device.ifinfo.ifindex": "74",
+        "setup.pid": "56",
+        "state": "ok",
+        "setup.kernel_team_mode_name": "roundrobin"
+    },
     "FAN_INFO|fan1": {
         "drawer_name": "drawer1",
         "presence": "True",

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -192,6 +192,14 @@
         "setup.kernel_team_mode_name": "loadbalance",
         "runner.active": "true"
     },
+    "LAG_TABLE|PortChannel0100": {
+        "setup.runner_name": "roundrobin",
+        "team_device.ifinfo.dev_addr": "52:54:00:f2:e1:23",
+        "team_device.ifinfo.ifindex": "74",
+        "setup.pid": "56",
+        "state": "ok",
+        "setup.kernel_team_mode_name": "roundrobin"
+    },
     "FAN_INFO|fan1": {
         "drawer_name": "drawer1",
         "presence": "True",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -734,6 +734,13 @@
         "tpid": "0x8100",
         "mtu": "9100"
     },
+    "PORTCHANNEL|PortChannel0100": {
+        "admin_status": "up",
+        "min_links": "1",
+        "tpid": "0x8100",
+        "static": "true",
+        "mtu": "9100"
+    },
     "PORTCHANNEL_MEMBER|PortChannel1001|Ethernet32": {
         "NULL": "NULL"
     },

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1130,6 +1130,14 @@
         "setup.kernel_team_mode_name": "loadbalance",
         "runner.active": "true"
     },
+    "LAG_TABLE|PortChannel0100": {
+        "setup.runner_name": "roundrobin",
+        "team_device.ifinfo.dev_addr": "52:54:00:f2:e1:23",
+        "team_device.ifinfo.ifindex": "74",
+        "setup.pid": "56",
+        "state": "ok",
+        "setup.kernel_team_mode_name": "roundrobin"
+    },
     "FAN_INFO|fan1": {
         "drawer_name": "drawer1",
         "presence": "True",

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -127,6 +127,32 @@ class TestPortChannel(object):
         assert result.exit_code != 0
         assert 'Invalid value for "--fast-rate"'  in result.output
 
+    @pytest.mark.parametrize("static", ["False", "True", "false", "true"])
+    def test_add_portchannel_with_static_adhoc_validation(self, static):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # add a portchannel with fats rate
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChannel0101", "--static", static], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+    @pytest.mark.parametrize("static", ["Fls", "tru"])
+    def test_add_portchannel_with_invalid_static(self, static):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+
+        # add a portchannel with invalid fats rate
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChannel0101", "--static", static], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Invalid value for "--static"'  in result.output
+
     def test_add_portchannel_member_with_invalid_name(self):
         runner = CliRunner()
         db = Db()


### PR DESCRIPTION
 

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
       Why ?
        Static lag support changes in SWSS module
        sonic-net/SONiC#1039

#### How I did it

        Patch explanation
        1. static lag supported with option roundrobin.
        2. config and show command support
        3. test cases -> updated

    CLI config
    config portchannel add PortChannel04 --static true

    root@sonic:~# show inter port
    Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not
    available,
           S - selected, D - deselected, * - not synced
      No.  Team Dev       Protocol     Ports
    -----  -------------  -----------
    -----------------------------------------
       01  PortChannel01  LACP(A)(Up)  Ethernet16(S)
       02  PortChannel02  NONE(A)(Up)  Ethernet48(S) Ethernet64(S)
    Ethernet32(S)
    root@sonic:~#


#### How to verify it
        UT:-
                Test cases
        1       Create static port channel with static flag     pass    pass
        2       verify static has option flag true or false     pass    pass
        3       Add static member see the portchannel is up     pass    pass
        4       verify teamd is created with round-robin option by default
        pass    pass
        5       Remove last portchannel member check port channel down  pass
        pass
        6       Remove portchannel member check port channel still up   pass
        pass
        7       verify teamdctl config dump     pass    pass
        8       verify teamdctl state dump      pass    pass
        9       shutdown the portchannel check the kernel state pass    pass
        10      no shutdown the portchannel check the kernel state      pass
        pass
        11      "Check the show output matches the review comment
        root@sonic:~# show inter port
        Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not
        available,
               S - selected, D - deselected, * - not synced
          No.  Team Dev       Protocol     Ports
        -----  -------------  -----------
        -----------------------------------------
           01  PortChannel01  LACP(A)(Up)  Ethernet16(S)
           02  PortChannel02  NONE(A)(Up)  Ethernet48(S) Ethernet64(S)
        Ethernet32(S)
        root@sonic:~#
        12      teamnl is set to roundrobin     pass    pass
        13      save and reload and verify portchannel is up    pass    pass
        14      "docker restart teamd
        teamd stopped
        swss stopped
        syncd stopped

        swss started
        syncd started
        teamd started"  pass    pass
        syncd started
        teamd started"  pass    pass
        15      warm-reboot fails even without any port channel config  fail
        16      verify teamd settles doesnt hog cpu with 100% cpu usage pass
        17      "trying with static port channel config on non supported
        branches
        port channel will be configured as LACP."               pass

        Not Supported Options
        1. Min links and
        2. fall back are not supported


#### Previous command output (if the output of a command-line utility has changed)
    root@sonic:~# show inter port
    Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not
    available,
           S - selected, D - deselected, * - not synced
      No.  Team Dev       Protocol     Ports
    -----  -------------  -----------
    -----------------------------------------
       01  PortChannel01  LACP(A)(Up)  Ethernet16(S)

#### New command output (if the output of a command-line utility has changed)
    root@sonic:~# show inter port
    Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not
    available,
           S - selected, D - deselected, * - not synced
      No.  Team Dev       Protocol     Ports
    -----  -------------  -----------
    -----------------------------------------
       01  PortChannel01  LACP(A)(Up)  Ethernet16(S)
       02  PortChannel02  NONE(A)(Up)  Ethernet48(S) Ethernet64(S)
    Ethernet32(S)
