### PR TITLE
Update intfutil and sfpshow to support DPC role

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -29,6 +29,7 @@ from utilities_common import multi_asic as multi_asic_util
 from utilities_common.intf_filter import parse_interface_in_filter
 from utilities_common.platform_sfputil_helper import is_rj45_port, RJ45_PORT_TYPE
 from sonic_py_common.interface import get_intf_longname
+from sonic_py_common import multi_asic
 
 # ========================== Common interface-utils logic ==========================
 
@@ -53,6 +54,7 @@ PORT_INTERFACE_TYPE = 'interface_type'
 PORT_ADV_INTERFACE_TYPES = 'adv_interface_types'
 PORT_TPID = "tpid"
 OPTICS_TYPE_RJ45 = RJ45_PORT_TYPE
+TYPE_DPC = 'DPU-NPU Data Port'
 PORT_LINK_TRAINING = 'link_training'
 PORT_LINK_TRAINING_STATUS = 'link_training_status'
 
@@ -214,15 +216,17 @@ def port_oper_speed_get_raw(db, intf_name):
         speed = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_SPEED)
     return speed
 
-def port_optics_get(state_db, intf_name, type):
+def port_optics_get(db, intf_name, type):
     """
     Get optic type info for port
     """
     full_table_id = PORT_TRANSCEIVER_TABLE_PREFIX + intf_name
-    optics_type = state_db.get(state_db.STATE_DB, full_table_id, type)
+    optics_type = db.get(db.STATE_DB, full_table_id, type)
     if optics_type is None:
         if is_rj45_port(intf_name):
             return OPTICS_TYPE_RJ45
+        elif db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, multi_asic.PORT_ROLE) == multi_asic.DPU_CONNECT_PORT:
+            return TYPE_DPC
         else:
             return "N/A"
     return optics_type

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -14,7 +14,6 @@ from typing import Dict
 
 import click
 from natsort import natsorted
-from sonic_py_common.interface import front_panel_prefix, backplane_prefix, inband_prefix, recirc_prefix
 from sonic_py_common import multi_asic
 from utilities_common.sfp_helper import covert_application_advertisement_to_output_string
 from utilities_common.sfp_helper import (
@@ -544,6 +543,10 @@ class SFPShow(object):
             output = ZR_PM_NOT_APPLICABLE_STR + '\n'
         return output
 
+    def is_valid_physical_port(self, port_name):
+        role = self.db.get(self.db.APPL_DB, 'PORT_TABLE:{}'.format(port_name), multi_asic.PORT_ROLE)
+        return multi_asic.is_front_panel_port(port_name, role)
+
     @multi_asic_util.run_on_multi_asic
     def get_eeprom(self):
         if self.intf_name is not None:
@@ -553,7 +556,7 @@ class SFPShow(object):
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
-                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+                if interface and self.is_valid_physical_port(interface):
                     self.intf_eeprom[interface] = self.convert_interface_sfp_info_to_cli_output_string(
                         self.db, interface, self.dump_dom)
 
@@ -577,7 +580,7 @@ class SFPShow(object):
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 key = re.split(':', i, maxsplit=1)[-1].strip()
-                if key and key.startswith(front_panel_prefix()) and not key.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+                if key and self.is_valid_physical_port(key):
                     presence_string = self.convert_interface_sfp_presence_state_to_cli_output_string(self.db, key)
                     port_table.append((key, presence_string))
 
@@ -592,7 +595,7 @@ class SFPShow(object):
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
-                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+                if interface and self.is_valid_physical_port(interface):
                     self.intf_pm[interface] = self.convert_interface_sfp_pm_to_cli_output_string(
                         self.db, interface)
 
@@ -605,7 +608,7 @@ class SFPShow(object):
             port_table_keys = self.db.keys(self.db.APPL_DB, "PORT_TABLE:*")
             for i in port_table_keys:
                 interface = re.split(':', i, maxsplit=1)[-1].strip()
-                if interface and interface.startswith(front_panel_prefix()) and not interface.startswith((backplane_prefix(), inband_prefix(), recirc_prefix())):
+                if interface and self.is_valid_physical_port(interface):
                     self.intf_status[interface] = self.convert_interface_sfp_status_to_cli_output_string(
                         self.db, interface)
 

--- a/tests/intfutil_test.py
+++ b/tests/intfutil_test.py
@@ -11,23 +11,23 @@ modules_path = os.path.dirname(root_path)
 scripts_path = os.path.join(modules_path, "scripts")
 
 show_interface_status_output="""\
-      Interface            Lanes    Speed    MTU    FEC      Alias             Vlan    Oper    Admin             Type    Asym PFC
----------------  ---------------  -------  -----  -----  ---------  ---------------  ------  -------  ---------------  ----------
-      Ethernet0                0      25G   9100     rs  Ethernet0           routed    down       up  QSFP28 or later         off
-     Ethernet16               16     100M   9100    N/A       etp5            trunk      up       up             RJ45         off
-     Ethernet24               24       1G   9100    N/A       etp6            trunk      up       up  QSFP28 or later         off
-     Ethernet28               28    1000M   9100    N/A       etp8            trunk      up       up             RJ45         off
-     Ethernet32      13,14,15,16      40G   9100     rs       etp9  PortChannel1001      up       up              N/A         off
-     Ethernet36       9,10,11,12      10M   9100    N/A      etp10           routed      up       up             RJ45         off
-    Ethernet112      93,94,95,96      40G   9100     rs      etp29  PortChannel0001      up       up              N/A         off
-    Ethernet116      89,90,91,92      40G   9100     rs      etp30  PortChannel0002      up       up              N/A         off
-    Ethernet120  101,102,103,104      40G   9100     rs      etp31  PortChannel0003      up       up              N/A         off
-    Ethernet124     97,98,99,100      40G   9100   auto      etp32  PortChannel0004      up       up              N/A         off
-PortChannel0001              N/A      40G   9100    N/A        N/A           routed    down       up              N/A         N/A
-PortChannel0002              N/A      40G   9100    N/A        N/A           routed      up       up              N/A         N/A
-PortChannel0003              N/A      40G   9100    N/A        N/A           routed      up       up              N/A         N/A
-PortChannel0004              N/A      40G   9100    N/A        N/A           routed      up       up              N/A         N/A
-PortChannel1001              N/A      40G   9100    N/A        N/A            trunk     N/A      N/A              N/A         N/A
+      Interface            Lanes    Speed    MTU    FEC      Alias             Vlan    Oper    Admin               Type    Asym PFC
+---------------  ---------------  -------  -----  -----  ---------  ---------------  ------  -------  -----------------  ----------
+      Ethernet0                0      25G   9100     rs  Ethernet0           routed    down       up    QSFP28 or later         off
+     Ethernet16               16     100M   9100    N/A       etp5            trunk      up       up               RJ45         off
+     Ethernet24               24       1G   9100    N/A       etp6            trunk      up       up  DPU-NPU Data Port         off
+     Ethernet28               28    1000M   9100    N/A       etp8            trunk      up       up               RJ45         off
+     Ethernet32      13,14,15,16      40G   9100     rs       etp9  PortChannel1001      up       up                N/A         off
+     Ethernet36       9,10,11,12      10M   9100    N/A      etp10           routed      up       up               RJ45         off
+    Ethernet112      93,94,95,96      40G   9100     rs      etp29  PortChannel0001      up       up                N/A         off
+    Ethernet116      89,90,91,92      40G   9100     rs      etp30  PortChannel0002      up       up                N/A         off
+    Ethernet120  101,102,103,104      40G   9100     rs      etp31  PortChannel0003      up       up                N/A         off
+    Ethernet124     97,98,99,100      40G   9100   auto      etp32  PortChannel0004      up       up                N/A         off
+PortChannel0001              N/A      40G   9100    N/A        N/A           routed    down       up                N/A         N/A
+PortChannel0002              N/A      40G   9100    N/A        N/A           routed      up       up                N/A         N/A
+PortChannel0003              N/A      40G   9100    N/A        N/A           routed      up       up                N/A         N/A
+PortChannel0004              N/A      40G   9100    N/A        N/A           routed      up       up                N/A         N/A
+PortChannel1001              N/A      40G   9100    N/A        N/A            trunk     N/A      N/A                N/A         N/A
 """
 
 show_interface_status_Ethernet32_output="""\

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -79,7 +79,8 @@
         "pfc_asym": "off",
         "mtu": "9100",
         "tpid": "0x8100",
-        "admin_status": "up"
+        "admin_status": "up",
+        "role": "Dpc"
     },
     "PORT_TABLE:Ethernet28": {
         "index": "7",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -104,7 +104,8 @@
         "tpid": "0x8100",
         "mode": "trunk",
         "pfc_asym": "off",
-        "speed": "1000"
+        "speed": "1000",
+        "role": "Dpc"
     },
     "PORT|Ethernet28": {
         "admin_status": "up",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -173,24 +173,6 @@
         "nominal_bit_rate": "N/A",
         "application_advertisement": "N/A"
     },
-    "TRANSCEIVER_INFO|Ethernet24": {
-        "type": "QSFP28 or later",
-        "hardware_rev": "AC",
-        "serial": "MT1706FT02066",
-        "manufacturer": "Mellanox",
-        "model": "MFA1A00-C003",
-        "vendor_oui": "00-02-c9",
-        "vendor_date": "2017-01-13 ",
-        "connector": "No separable connector",
-        "encoding": "64B66B",
-        "ext_identifier": "Power Class 3(2.5W max), CDR present in Rx Tx",
-        "ext_rateselect_compliance": "QSFP+ Rate Select Version 1",
-        "cable_type": "Length Cable Assembly(m)",
-        "cable_length": "3",
-        "specification_compliance": "{'10/40G Ethernet Compliance Code': '40G Active Cable (XLPPI)'}",
-        "nominal_bit_rate": "255",
-        "application_advertisement": "N/A"
-    },
     "TRANSCEIVER_INFO|Ethernet28": {
         "type": "RJ45",
         "hardware_rev": "N/A",

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -884,6 +884,28 @@ Ethernet36  Present
         assert result.exit_code == 0
         assert result.output == expected
 
+    def test_sfp_dpc_ports(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["presence"])
+        assert result.exit_code == 0
+        assert "Ethernet24" not in result.output
+
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"])
+        assert result.exit_code == 0
+        assert "Ethernet24" not in result.output
+
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["status"])
+        assert result.exit_code == 0
+        assert "Ethernet24" not in result.output
+
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["pm"])
+        assert result.exit_code == 0
+        assert "Ethernet24" not in result.output
+
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["info"])
+        assert result.exit_code == 0
+        assert "Ethernet24" not in result.output
+
     def test_sfp_eeprom_with_dom(self):
         runner = CliRunner()
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ["Ethernet0", "-d"])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added support for new role type. New role is shown as "DPU-NPU Data Port" in the output of "show interface status"

output for sfpshow commands doesn't show an output for internal ports.

Requires: https://github.com/sonic-net/sonic-buildimage/pull/18465

#### How I did it

#### How to verify it

Output with role set

```
root@mtvr-leopard-01:/home/admin# show interfaces status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------------------------  ----------
  Ethernet0                  0,1,2,3,4,5,6,7     400G   9100    N/A     etp1  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
  Ethernet8            8,9,10,11,12,13,14,15     400G   9100    N/A     etp2  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet16          16,17,18,19,20,21,22,23     400G   9100    N/A     etp3  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet24          24,25,26,27,28,29,30,31     400G   9100    N/A     etp4  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet32          32,33,34,35,36,37,38,39     400G   9100    N/A     etp5  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet40          40,41,42,43,44,45,46,47     400G   9100    N/A     etp6  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet48          48,49,50,51,52,53,54,55     400G   9100    N/A     etp7  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet56          56,57,58,59,60,61,62,63     400G   9100    N/A     etp8  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet64          64,65,66,67,68,69,70,71     400G   9100    N/A     etp9  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
..........................
Ethernet208  208,209,210,211,212,213,214,215     400G   9100    N/A    etp27  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet216  216,217,218,219,220,221,222,223     400G   9100    N/A    etp28  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet224  224,225,226,227,228,229,230,231     400G   9100    N/A    etp29  routed     N/A       up                                DPU-NPU Data Port         N/A
Ethernet232  232,233,234,235,236,237,238,239     400G   9100    N/A    etp30  routed     N/A       up                                DPU-NPU Data Port         N/A
Ethernet240  240,241,242,243,244,245,246,247     400G   9100    N/A    etp31  routed     N/A       up                                DPU-NPU Data Port         N/A
Ethernet248  248,249,250,251,252,253,254,255     400G   9100    N/A    etp32  routed     N/A       up                                DPU-NPU Data Port         N/A
```

```
root@mtvr-leopard-01:/home/admin# sfputil show presence
Port         Presence
-----------  ----------
Ethernet0    Present
Ethernet8    Present
Ethernet16   Present
Ethernet24   Present
Ethernet32   Present
Ethernet40   Present
Ethernet48   Present
Ethernet56   Present
Ethernet64   Present
Ethernet72   Present
Ethernet80   Present
Ethernet88   Present
Ethernet96   Present
Ethernet104  Present
Ethernet112  Present
Ethernet120  Present
Ethernet128  Present
Ethernet136  Present
Ethernet144  Present
Ethernet152  Present
Ethernet160  Present
Ethernet168  Present
Ethernet176  Present
Ethernet184  Present
Ethernet192  Present
Ethernet200  Present
Ethernet208  Present
Ethernet216  Present

```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

