### PR TITLE
Revert "[generate_dump] call hw-management-generate-dump.sh in collec…

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1564,27 +1564,6 @@ collect_cisco_8000() {
         echo "'/usr/share/sonic/device/${platform}' does not exist" > /tmp/error
         save_file /tmp/error sai false
     fi
-
-    save_cmd "show platform versions" "platform.versions"
-
-    # run 'hw-management-generate-dump.sh' script and save the result file
-    HW_DUMP_FILE=/usr/bin/hw-management-generate-dump.sh
-    if [[ -x $HW_DUMP_FILE ]]; then
-      ${CMD_PREFIX} $HW_DUMP_FILE $ALLOW_PROCESS_STOP
-      ret=$?
-      if [[ $ret -ne 0 ]]; then
-        if [[ $ret -eq $TIMEOUT_EXIT_CODE ]]; then
-          echo "hw-management dump timedout after ${TIMEOUT_MIN} minutes."
-        else
-          echo "hw-management dump failed ..."
-        fi
-      else
-        save_file "/tmp/hw-mgmt-dump*" "hw-mgmt" false
-        rm -f /tmp/hw-mgmt-dump*
-      fi
-    else
-      echo "HW Mgmt dump script $HW_DUMP_FILE does not exist"
-    fi
 }
 
 ##############################################################################


### PR DESCRIPTION
…t_cisco_8000 (#2809)"

This reverts commit bd86d33b29e1d868c975cf5d52fe95e7cb58f364.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

