### PR TITLE
Improve Semgrep CI

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: semgrep ci
         env:
-           SEMGREP_RULES: p/default
+           SEMGREP_RULES: r/all

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: semgrep ci
         env:
-           SEMGREP_RULES: r/all
+           SEMGREP_RULES: "p/default r/python.lang.security.audit.dangerous-system-call-audit.dangerous-system-call-audit"

--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -169,6 +169,7 @@ class ChangeApplier:
     def _get_running_config(self):
         (_, fname) = tempfile.mkstemp(suffix="_changeApplier")
         os.system("sonic-cfggen -d --print-data > {}".format(fname))
+        os.system("sonic-cfggen -d --print-data > {}".format(fname))
         run_data = {}
         with open(fname, "r") as s:
             run_data = json.load(s)

--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -169,7 +169,6 @@ class ChangeApplier:
     def _get_running_config(self):
         (_, fname) = tempfile.mkstemp(suffix="_changeApplier")
         os.system("sonic-cfggen -d --print-data > {}".format(fname))
-        os.system("sonic-cfggen -d --print-data > {}".format(fname))
         run_data = {}
         with open(fname, "r") as s:
             run_data = json.load(s)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Semgrep's default ruleset (p/default) somehow lost some important rules
#### How I did it
Keep use p/default and add another rule
#### How to verify it
Added test code to this PR and Semgrep CI failed
```
diff --git a/generic_config_updater/change_applier.py b/generic_config_updater/change_applier.py
index d0818172..6e1473a4 100644
--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -169,6 +169,7 @@ class ChangeApplier:
     def _get_running_config(self):
         (_, fname) = tempfile.mkstemp(suffix="_changeApplier")
         os.system("sonic-cfggen -d --print-data > {}".format(fname))
+        os.system("sonic-cfggen -d --print-data > {}".format(fname))
         run_data = {}
         with open(fname, "r") as s:
             run_data = json.load(s)
```
Failed result: https://github.com/sonic-net/sonic-utilities/actions/runs/8559846841/job/23457508614?pr=3259
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

