### PR TITLE
[Mellanox] added component versions to techsupport

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1251,6 +1251,7 @@ collect_mellanox() {
       echo "HW Mgmt dump script $HW_DUMP_FILE does not exist"
     fi
 
+    save_cmd "get_component_versions.py" "component_versions"
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added get component versions to techsupport

get_component_versions.py is a script that output a table that gathers the versions of all the Nvidia-related components in SONiC.

This PR depends on https://github.com/sonic-net/sonic-buildimage/pull/18591 and should be merged second.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

