### PR TITLE
Display target firmware version through CLI

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -335,6 +335,9 @@ class SFPShow(object):
                 output += covert_application_advertisement_to_output_string(indent, sfp_info_dict)
             elif key == 'active_firmware' or key == 'inactive_firmware':
                 output += '{}{}: {}\n'.format(indent, data_map[key], sfp_firmware_info_dict[key] if key in sfp_firmware_info_dict else 'N/A')
+            elif key.startswith(('e1_', 'e2_')):
+                if key in sfp_firmware_info_dict:
+                    output += '{}{}: {}\n'.format(indent, data_map[key], sfp_firmware_info_dict[key])
             else:
                 output += '{}{}: {}\n'.format(indent, data_map[key], sfp_info_dict[key])
 

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -70,7 +70,13 @@
     },
     "TRANSCEIVER_FIRMWARE_INFO|Ethernet64": {
         "active_firmware": "X.X",
-        "inactive_firmware": "X.X"
+        "inactive_firmware": "X.X",
+        "e1_active_firmware" : "X.X",
+        "e1_inactive_firmware" : "Y.Y",
+        "e1_server_firmware" : "A.B.C.D",
+        "e2_active_firmware" : "X.X",
+        "e2_inactive_firmware" : "Y.Y",
+        "e2_server_firmware" : "A.B.C.D"
     },
     "CHASSIS_INFO|chassis 1": {
         "psu_num": "2"

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -691,7 +691,13 @@
     },
     "TRANSCEIVER_FIRMWARE_INFO|Ethernet64": {
         "active_firmware": "X.X",
-        "inactive_firmware": "X.X"
+        "inactive_firmware": "X.X",
+        "e1_active_firmware" : "X.X",
+        "e1_inactive_firmware" : "Y.Y",
+        "e1_server_firmware" : "A.B.C.D",
+        "e2_active_firmware" : "X.X",
+        "e2_inactive_firmware" : "Y.Y",
+        "e2_server_firmware" : "A.B.C.D"
     },
     "TRANSCEIVER_INFO|Ethernet72": {
         "active_apsel_hostlane4": "N/A",

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -599,6 +599,12 @@ Ethernet64: SFP EEPROM detected
                                    100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
         CMIS Rev: 4.1
         Connector: LC
+        E1 Active Firmware: X.X
+        E1 Inactive Firmware: Y.Y
+        E1 Server Firmware: A.B.C.D
+        E2 Active Firmware: X.X
+        E2 Inactive Firmware: Y.Y
+        E2 Server Firmware: A.B.C.D
         Encoding: N/A
         Extended Identifier: Power Class 8 (20.0W Max)
         Extended RateSelect Compliance: N/A
@@ -689,6 +695,12 @@ Ethernet64: SFP EEPROM detected
                                    100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
         CMIS Rev: 4.1
         Connector: LC
+        E1 Active Firmware: X.X
+        E1 Inactive Firmware: Y.Y
+        E1 Server Firmware: A.B.C.D
+        E2 Active Firmware: X.X
+        E2 Inactive Firmware: Y.Y
+        E2 Server Firmware: A.B.C.D
         Encoding: N/A
         Extended Identifier: Power Class 8 (20.0W Max)
         Extended RateSelect Compliance: N/A
@@ -779,6 +791,12 @@ Ethernet64: SFP EEPROM detected
                                    100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
         CMIS Rev: 4.1
         Connector: LC
+        E1 Active Firmware: X.X
+        E1 Inactive Firmware: Y.Y
+        E1 Server Firmware: A.B.C.D
+        E2 Active Firmware: X.X
+        E2 Inactive Firmware: Y.Y
+        E2 Server Firmware: A.B.C.D
         Encoding: N/A
         Extended Identifier: Power Class 8 (20.0W Max)
         Extended RateSelect Compliance: N/A

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -38,7 +38,13 @@ QSFP_CMIS_DELTA_DATA_MAP = {
     'supported_max_tx_power': 'Supported Max TX Power',
     'supported_min_tx_power': 'Supported Min TX Power',
     'supported_max_laser_freq': 'Supported Max Laser Frequency',
-    'supported_min_laser_freq': 'Supported Min Laser Frequency'
+    'supported_min_laser_freq': 'Supported Min Laser Frequency',
+    'e1_active_firmware': 'E1 Active Firmware',
+    'e1_inactive_firmware': 'E1 Inactive Firmware',
+    'e1_server_firmware': 'E1 Server Firmware',
+    'e2_active_firmware': 'E2 Active Firmware',
+    'e2_inactive_firmware': 'E2 Inactive Firmware',
+    'e2_server_firmware': 'E2 Server Firmware'
 }
 
 CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
XCVRD is now periodically storing target firmware versions in TRANSCEIVR_FIRMWARE_INFO table of STATE_DB (https://github.com/sonic-net/sonic-platform-common/pull/455).
This change is to display the target firmware versions using `show interfaces transceiver eeprom EthernetXX` and `show interfaces transceiver info EthernetXX` CLI.

MSFT ADO - 27706023

#### How I did it
The transceiver EEPROM/INFO dump CLI now reads target firmware information from the TRANSCEIVR_FIRMWARE_INFO table of STATE_DB. This is done only for the transceivers which have their target firmware version information populated in the TRANSCEIVR_FIRMWARE_INFO table.

#### How to verify it
Please refer to the testcases described in https://github.com/sonic-net/sonic-platform-common/pull/455 for further details.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
snippet of `show interfaces transceiver info EthernetXX` CLI

Snippet of CLI o/p for transceiver supporting remote target (Other fields have been trimmed)
```
        Connector: No separable connector
        E1 Active Firmware: 4.1.2
        E1 Inactive Firmware: 2.5.0
        E1 Server Firmware: 1.3.0.3
        E2 Active Firmware: 4.1.2
        E2 Inactive Firmware: 2.5.0
        E2 Server Firmware: 1.3.0.3
        Encoding: N/A
```

CLI o/p for transceiver not supporting remote target
```
root@sonic:/home/admin# show interface transceiver info $lport
Ethernet128: SFP EEPROM detected
        Active Firmware: 5.4.0
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
                                   100GAUI-1-S C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
        CMIS Rev: 5.0
        Connector: MPO 1x16
        Encoding: N/A
        Extended Identifier: Power Class 8 (17.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 4
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: 5.3.0
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm EML
        Media Lane Count: 4
        Module Hardware Rev: 1.0
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: N/A
        Supported Max TX Power: N/A
        Supported Min Laser Frequency: N/A
        Supported Min TX Power: N/A
        Vendor Date Code(YYYY-MM-DD Lot): 2000-11-11 00
        Vendor Name: ABC
        Vendor OUI: 11-22-33
        Vendor PN: ABCDEFG
        Vendor Rev: A0
        Vendor SN: A11111         
root@sonic:/home/admin#
```
