### PR TITLE
[chassis][midplane] Add notification to Supervisor when LC is graceful reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -198,6 +198,21 @@ function parse_options()
     done
 }
 
+function linecard_reboot_notify_supervisor()
+{
+    is_linecard=$(python3 -c 'from sonic_py_common import device_info; print("True") if device_info.is_chassis() == True and device_info.is_supervisor() == False else print("False")')
+    if [ $is_linecard == "True" ]; then
+        key=$(sonic-db-cli STATE_DB keys "CHASSIS_MODULE_TABLE|LINE-CARD*")
+        status=$?
+        if [ $status -eq 0 ]; then
+            module="${key#CHASSIS_MODULE_TABLE}"
+            if [ ! -z module ]; then
+                sonic-db-cli CHASSIS_STATE_DB hset "CHASSIS_MODULE_REBOOT_INFO_TABLE${module}" "reboot" "expected"
+            fi
+        fi
+    fi
+}
+
 parse_options $@
 
 # Exit if not superuser
@@ -215,6 +230,9 @@ reboot_pre_check
 
 # Tag remotely deployed images as local
 tag_images
+
+# Linecard reboot notify supervisor
+linecard_reboot_notify_supervisor
 
 # Stop SONiC services gracefully.
 stop_sonic_services

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -208,6 +208,10 @@ function linecard_reboot_notify_supervisor()
             module="${key#CHASSIS_MODULE_TABLE}"
             if [ ! -z module ]; then
                 sonic-db-cli CHASSIS_STATE_DB hset "CHASSIS_MODULE_REBOOT_INFO_TABLE${module}" "reboot" "expected"
+                status=$?
+                if [ $status -ne 0 ]; then
+                    debug "Failed to notify Supervisor: Linecard reboot is expected"
+                fi
             fi
         fi
     fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modify the "sudo reboot" script to notify the Supervisor card by creating/inserting CHASSIS_MODULE_REBOOT_INFO_TABLE|LINE-CARD#" entry to CHASSIS_STATE_DB when reboot command is issued on the Linecard. This provides the sufficient information to allow Supervisor to log a proper message to address issue https://github.com/sonic-net/sonic-buildimage/issues/18540
#### How I did it
Add a new function linecard_reboot_notity_supervisor() to the reboot script.  If this platform is a linecard in a chassis, call sonic-db-cli to add a "CHASSIS_MODULE_REBOOT_INFO_TABLE|LINE-CARD#" to the CHASSIS_STATE_DB.  This provides the information to chassisd on Supervisor card to log a proper message.
This PRs requires the following 2 PRs to address issue https://github.com/sonic-net/sonic-buildimage/issues/18540 : 
https://github.com/sonic-net/sonic-buildimage/pull/18805
https://github.com/sonic-net/sonic-platform-daemons/pull/480
https://github.com/sonic-net/sonic-buildimage/pull/18862

This PR is needed by branch 202205

#### How to verify it
1) Test expected log. Use the CLI command "sudo reboot" to reboot  a linecard, then check the syslog on Supervisor.  The below message is logged
```
Apr 25 19:44:40.818378 ixre-cpm-chassis7 WARNING pmon#chassisd: Expected: Module LINE-CARD0 lost midplane connectivity
``` 
2. Test unepxpected log.  Using "sudo /sbin/reboot" or reboot a linecard with any crash method, then ccheck the syslog on Supervusor. The below message is logged.
```
Apr 25 19:50:22.549416 ixre-cpm-chassis7 WARNING pmon#chassisd: Unexpected: Module LINE-CARD0 lost midplane connectivity
``` 
3. Test the expexcted reboot with timeout case.  Use the CLI command "sudo reboot" on linecard. and keep it down for more than 4 minutes. The below messages are logged. 
```
Apr 25 01:25:53.877143 ixre-cpm-chassis7 WARNING sr_device_mgr: Unable to reach slot 1 (Linecard) via Midplane
Apr 25 01:25:58.402511 ixre-cpm-chassis7 WARNING pmon#chassisd: Module LINE-CARD0 went off-line!
Apr 25 01:26:01.658959 ixre-cpm-chassis7 WARNING pmon#chassisd: Expected: Module LINE-CARD0 lost midplane connectivity.
( 3 minutes after the first log)
Apr 25 01:29:10.259527 ixre-cpm-chassis7 WARNING pmon#chassisd: Unexpected: Module LINE-CARD0 midplane connectivity is not restored in 180 seconds
```
#### Previous command output (if the output of a command-line utility has changed)
NA
#### New command output (if the output of a command-line utility has changed)

NA