### PR TITLE
lag MTU setting fix - fix for #18695

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2338,13 +2338,13 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
                 port_mtu = port_entry.get(PORT_MTU)
                 portchannel_mtu = portchannel_entry.get(PORT_MTU)
                 # If portchannel MTU is not set, set it to the first port MTU
-                if not portchannel_mtu:
+                if (str(portchannel_mtu) == 'None'):
                     portchannel_mtu = port_mtu
                     db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: port_mtu})
 
                 if (portchannel_mtu != port_mtu):  # TODO: MISSING CONSTRAINT IN YANG MODEL
-                    ctx.fail("Port MTU of {} is different than the {} MTU size "
-                             .format(port_name, portchannel_name))
+                    ctx.fail("Port MTU of {} is {} different than the {} MTU size which is {}"
+                             .format(port_name, port_mtu, portchannel_name, portchannel_mtu))
 
         # Dont allow a port to be member of port channel if its TPID is not at default 0x8100
         # If TPID is supported at LAG level, when member is added, the LAG's TPID is applied to the
@@ -2406,8 +2406,7 @@ def del_portchannel_member(ctx, portchannel_name, port_name):
     try:
         db.set_entry('PORTCHANNEL_MEMBER', portchannel_name + '|' + port_name, None)
         # If this was the last port in the portchannel, set the portchannel MTU to None
-        portchannel_list = db.get_table(CFG_PORTCHANNEL_PREFIX)
-        if (portchannel_list is None) or (portchannel_list == {}):
+        if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) == 0:
             db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: None})
 
     except JsonPatchConflict:

--- a/config/main.py
+++ b/config/main.py
@@ -2336,15 +2336,15 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
             port_entry = db.get_entry('PORT', port_name)
             if port_entry and port_entry.get(PORT_MTU) is not None:
                 port_mtu = port_entry.get(PORT_MTU)
-                portchannel_mtu = portchannel_entry.get(PORT_MTU)                
+                portchannel_mtu = portchannel_entry.get(PORT_MTU)
                 # If portchannel MTU is not set, set it to the first port MTU
                 if not portchannel_mtu:
                     portchannel_mtu = port_mtu
                     db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: port_mtu})
-                
+
                 if (portchannel_mtu != port_mtu):  # TODO: MISSING CONSTRAINT IN YANG MODEL
                     ctx.fail("Port MTU of {} is different than the {} MTU size "
-                             .format(port_name, portchannel_name))                    
+                             .format(port_name, portchannel_name))
 
         # Dont allow a port to be member of port channel if its TPID is not at default 0x8100
         # If TPID is supported at LAG level, when member is added, the LAG's TPID is applied to the

--- a/config/main.py
+++ b/config/main.py
@@ -2342,7 +2342,7 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
                     portchannel_mtu = port_mtu
                     db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: port_mtu})
                 
-                if (not isinstance(portchannel_mtu, type(port_mtu))) or (portchannel_mtu != port_mtu):  # TODO: MISSING CONSTRAINT IN YANG MODEL
+                if (portchannel_mtu != port_mtu):  # TODO: MISSING CONSTRAINT IN YANG MODEL
                     ctx.fail("Port MTU of {} is different than the {} MTU size "
                              .format(port_name, portchannel_name))                    
 

--- a/config/main.py
+++ b/config/main.py
@@ -2208,7 +2208,6 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
 
     fvs = {
         'admin_status': 'up',
-        'mtu': '9100',
         'lacp_key': 'auto',
         'fast_rate': fast_rate.lower(),
     }
@@ -2333,16 +2332,19 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
 
         # Dont allow a port to be member of port channel if its MTU does not match with portchannel
         portchannel_entry =  db.get_entry('PORTCHANNEL', portchannel_name)
-        if portchannel_entry and portchannel_entry.get(PORT_MTU) is not None :
+        if portchannel_entry:
             port_entry = db.get_entry('PORT', port_name)
-
             if port_entry and port_entry.get(PORT_MTU) is not None:
                 port_mtu = port_entry.get(PORT_MTU)
-
-                portchannel_mtu = portchannel_entry.get(PORT_MTU) # TODO: MISSING CONSTRAINT IN YANG MODEL
-                if portchannel_mtu != port_mtu:
-                    ctx.fail("Port MTU of {} is different than the {} MTU size"
-                             .format(port_name, portchannel_name))
+                portchannel_mtu = portchannel_entry.get(PORT_MTU)                
+                # If portchannel MTU is not set, set it to the first port MTU
+                if not portchannel_mtu:
+                    portchannel_mtu = port_mtu
+                    db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: port_mtu})
+                
+                if (not isinstance(portchannel_mtu, type(port_mtu))) or (portchannel_mtu != port_mtu):  # TODO: MISSING CONSTRAINT IN YANG MODEL
+                    ctx.fail("Port MTU of {} is different than the {} MTU size "
+                             .format(port_name, portchannel_name))                    
 
         # Dont allow a port to be member of port channel if its TPID is not at default 0x8100
         # If TPID is supported at LAG level, when member is added, the LAG's TPID is applied to the
@@ -2403,6 +2405,11 @@ def del_portchannel_member(ctx, portchannel_name, port_name):
 
     try:
         db.set_entry('PORTCHANNEL_MEMBER', portchannel_name + '|' + port_name, None)
+        # If this was the last port in the portchannel, set the portchannel MTU to None
+        portchannel_list = db.get_table(CFG_PORTCHANNEL_PREFIX)
+        if (portchannel_list is None) or (portchannel_list == {}):
+            db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: None})
+            
     except JsonPatchConflict:
         ctx.fail("Invalid or nonexistent portchannel or interface. Please ensure existence of portchannel member.")
 

--- a/config/main.py
+++ b/config/main.py
@@ -2409,7 +2409,7 @@ def del_portchannel_member(ctx, portchannel_name, port_name):
         portchannel_list = db.get_table(CFG_PORTCHANNEL_PREFIX)
         if (portchannel_list is None) or (portchannel_list == {}):
             db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: None})
-            
+
     except JsonPatchConflict:
         ctx.fail("Invalid or nonexistent portchannel or interface. Please ensure existence of portchannel member.")
 

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -30,18 +30,21 @@ class TestConfigInterfaceMtu(object):
         db = Db()
         obj = {'db': db.cfgdb, 'db_wrap': db, 'namespace': ''}
         # Ethernet32 is already member of PortChannel1001, try (fail) to change mtu
-        result = runner.invoke(config.config.commands["interface"].commands["mtu"],
-                               ["Ethernet32", "1000"], obj=obj)
+        result = runner.invoke(
+                            config.config.commands["interface"].commands["mtu"],
+                            ["Ethernet32", "1000"], obj=obj)
         assert result.exit_code != 0
         # remove port from portchannel
-        result1 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["del"],
-                               ["PortChannel1001", "Ethernet32"], obj=obj)
+        result1 = runner.invoke(
+                            config.config.commands["portchannel"].commands["member"].commands["del"],
+                            ["PortChannel1001", "Ethernet32"], obj=obj)
         assert result1.exit_code == 0
         # Set mtu for port interface
         result2 = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)
         assert result2.exit_code != 0
         # Add port back to portchannel
-        result3 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"],
-                               ["PortChannel1001", "Ethernet32"], obj=obj)
+        result3 = runner.invoke(
+                            config.config.commands["portchannel"].commands["member"].commands["add"],
+                            ["PortChannel1001", "Ethernet32"], obj=obj)
         print(result3.output)
         assert result3.exit_code == 0

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -2,7 +2,6 @@ import pytest
 import config.main as config
 from click.testing import CliRunner
 from utilities_common.db import Db
-import time
 
 class TestConfigInterfaceMtu(object):
     def test_interface_mtu_check(self):
@@ -43,4 +42,5 @@ class TestConfigInterfaceMtu(object):
         # Add port back to portchannel
         result3 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], 
                                ["PortChannel1001", "Ethernet32"], obj=obj)
+        print(result3.output)
         assert result3.exit_code==0

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -35,16 +35,16 @@ class TestConfigInterfaceMtu(object):
                             ["Ethernet32", "1000"], obj=obj)
         assert result.exit_code != 0
         # remove port from portchannel
-        result1 = runner.invoke(
+        result = runner.invoke(
                             config.config.commands["portchannel"].commands["member"].commands["del"],
                             ["PortChannel1001", "Ethernet32"], obj=obj)
-        assert result1.exit_code == 0
+        assert result.exit_code == 0
         # Set mtu for port interface
-        result2 = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)
-        assert result2.exit_code != 0
+        result = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)
+        assert result.exit_code != 0
         # Add port back to portchannel
-        result3 = runner.invoke(
+        result = runner.invoke(
                             config.config.commands["portchannel"].commands["member"].commands["add"],
                             ["PortChannel1001", "Ethernet32"], obj=obj)
-        print(result3.output)
-        assert result3.exit_code == 0
+        print(result.output)
+        assert result.exit_code == 0

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -24,3 +24,21 @@ class TestConfigInterfaceMtu(object):
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9217"], obj=db)
         assert "Error: Invalid value" in result1.output
+
+    def test_portchannel_mtu_check(self):
+        config.ADHOC_VALIDATION = False
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+        # Ethernet32 is already member of PortChannel1001, try (fail) to change mtu
+        result = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)        
+        assert result.exit_code!=0
+        # remove port from portchannel
+        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["del"], ["PortChannel1001", "Ethernet32"], obj=obj)
+        assert result.exit_code==0
+        # Set mtu for port interface
+        result = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)
+        assert result.exit_code!=0
+        # Add port back to portchannel
+        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], ["PortChannel1001", "Ethernet32"], obj=obj)
+        assert result.exit_code==0

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -2,6 +2,7 @@ import pytest
 import config.main as config
 from click.testing import CliRunner
 from utilities_common.db import Db
+import time
 
 class TestConfigInterfaceMtu(object):
     def test_interface_mtu_check(self):
@@ -24,21 +25,22 @@ class TestConfigInterfaceMtu(object):
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9217"], obj=db)
         assert "Error: Invalid value" in result1.output
-
     def test_portchannel_mtu_check(self):
-        config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'db':db.cfgdb, 'db_wrap':db, 'namespace':''}
         # Ethernet32 is already member of PortChannel1001, try (fail) to change mtu
-        result = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)        
+        result = runner.invoke(config.config.commands["interface"].commands["mtu"], 
+                               ["Ethernet32", "1000"], obj=obj)        
         assert result.exit_code!=0
         # remove port from portchannel
-        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["del"], ["PortChannel1001", "Ethernet32"], obj=obj)
-        assert result.exit_code==0
+        result1 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["del"], 
+                               ["PortChannel1001", "Ethernet32"], obj=obj)
+        assert result1.exit_code==0
         # Set mtu for port interface
-        result = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)
-        assert result.exit_code!=0
+        result2 = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)
+        assert result2.exit_code!=0
         # Add port back to portchannel
-        result = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], ["PortChannel1001", "Ethernet32"], obj=obj)
-        assert result.exit_code==0
+        result3 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], 
+                               ["PortChannel1001", "Ethernet32"], obj=obj)
+        assert result3.exit_code==0

--- a/tests/config_int_mtu_test.py
+++ b/tests/config_int_mtu_test.py
@@ -24,23 +24,24 @@ class TestConfigInterfaceMtu(object):
         result1 = runner.invoke(config.config.commands["interface"].commands["mtu"],
             ["Ethernet0", "9217"], obj=db)
         assert "Error: Invalid value" in result1.output
+
     def test_portchannel_mtu_check(self):
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb, 'db_wrap':db, 'namespace':''}
+        obj = {'db': db.cfgdb, 'db_wrap': db, 'namespace': ''}
         # Ethernet32 is already member of PortChannel1001, try (fail) to change mtu
-        result = runner.invoke(config.config.commands["interface"].commands["mtu"], 
-                               ["Ethernet32", "1000"], obj=obj)        
-        assert result.exit_code!=0
+        result = runner.invoke(config.config.commands["interface"].commands["mtu"],
+                               ["Ethernet32", "1000"], obj=obj)
+        assert result.exit_code != 0
         # remove port from portchannel
-        result1 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["del"], 
+        result1 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["del"],
                                ["PortChannel1001", "Ethernet32"], obj=obj)
-        assert result1.exit_code==0
+        assert result1.exit_code == 0
         # Set mtu for port interface
         result2 = runner.invoke(config.config.commands["interface"].commands["mtu"], ["Ethernet32", "1000"], obj=obj)
-        assert result2.exit_code!=0
+        assert result2.exit_code != 0
         # Add port back to portchannel
-        result3 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"], 
+        result3 = runner.invoke(config.config.commands["portchannel"].commands["member"].commands["add"],
                                ["PortChannel1001", "Ethernet32"], obj=obj)
         print(result3.output)
-        assert result3.exit_code==0
+        assert result3.exit_code == 0

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -516,13 +516,13 @@
     },
     "ACL_TABLE|BMC_ACL_NORTHBOUND": {
         "policy_desc": "BMC_ACL_NORTHBOUND",
-        "ports@": "Ethernet8,Ethernet0,Ethernet17,Ethernet16,Ethernet37,Ethernet4,Ethernet13,Ethernet45,Ethernet19,Ethernet24,Ethernet31,Ethernet30,Ethernet39,Ethernet40,Ethernet27,Ethernet43,Ethernet7,Ethernet3,Ethernet20,Ethernet6,Ethernet12,Ethernet34,Ethernet26,Ethernet11,Ethernet42,Ethernet5,Ethernet32,Ethernet36,Ethernet15,Ethernet33,Ethernet35,Ethernet9,Ethernet29,Ethernet21,Ethernet18,Ethernet38,Ethernet23,Ethernet41,Ethernet14,Ethernet2,Ethernet28,Ethernet22,Ethernet10,Ethernet25,Ethernet44,Ethernet1",
+        "ports@": "Ethernet8,Ethernet0,Ethernet17,Ethernet16,Ethernet37,Ethernet4,Ethernet13,Ethernet45,Ethernet19,Ethernet24,Ethernet31,Ethernet30,Ethernet39,Ethernet40,Ethernet27,Ethernet43,Ethernet7,Ethernet3,Ethernet20,Ethernet6,Ethernet12,Ethernet34,Ethernet26,Ethernet11,Ethernet42,Ethernet5,Ethernet36,Ethernet15,Ethernet33,Ethernet35,Ethernet9,Ethernet29,Ethernet21,Ethernet18,Ethernet38,Ethernet23,Ethernet41,Ethernet14,Ethernet2,Ethernet28,Ethernet22,Ethernet10,Ethernet25,Ethernet44,Ethernet1",
         "stage": "ingress",
         "type": "BMCDATA"
     },
     "ACL_TABLE|BMC_ACL_NORTHBOUND_V6": {
         "policy_desc": "BMC_ACL_NORTHBOUND_V6",
-        "ports@": "Ethernet13,Ethernet3,Ethernet32,Ethernet33,Ethernet34,Ethernet8,Ethernet6,Ethernet44,Ethernet39,Ethernet18,Ethernet15,Ethernet1,Ethernet19,Ethernet7,Ethernet14,Ethernet43,Ethernet40,Ethernet27,Ethernet4,Ethernet36,Ethernet41,Ethernet10,Ethernet31,Ethernet5,Ethernet9,Ethernet12,Ethernet16,Ethernet25,Ethernet24,Ethernet17,Ethernet35,Ethernet11,Ethernet38,Ethernet42,Ethernet29,Ethernet20,Ethernet45,Ethernet26,Ethernet21,Ethernet37,Ethernet0,Ethernet28,Ethernet23,Ethernet22,Ethernet2,Ethernet30",
+        "ports@": "Ethernet13,Ethernet3,Ethernet33,Ethernet34,Ethernet8,Ethernet6,Ethernet44,Ethernet39,Ethernet18,Ethernet15,Ethernet1,Ethernet19,Ethernet7,Ethernet14,Ethernet43,Ethernet40,Ethernet27,Ethernet4,Ethernet36,Ethernet41,Ethernet10,Ethernet31,Ethernet5,Ethernet9,Ethernet12,Ethernet16,Ethernet25,Ethernet24,Ethernet17,Ethernet35,Ethernet11,Ethernet38,Ethernet42,Ethernet29,Ethernet20,Ethernet45,Ethernet26,Ethernet21,Ethernet37,Ethernet0,Ethernet28,Ethernet23,Ethernet22,Ethernet2,Ethernet30",
         "stage": "ingress",
         "type": "BMCDATAV6"
     },
@@ -577,7 +577,7 @@
     },
     "ACL_TABLE|EVERFLOWV6": {
         "policy_desc": "EVERFLOWV6",
-        "ports@": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47",
+        "ports@": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47",
         "type": "MIRRORV6",
         "stage": "ingress"
     },


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix for [#18695](https://github.com/sonic-net/sonic-buildimage/issues/18695)
#### How I did it
When creating PortChannel, don't set MTU
MTU is set according to first port inserted to PortChannel.
When last port is removed, set PortChannel MTU back to None
#### How to verify it
Tested with new test added to UT

#### Previous command output (if the output of a command-line utility has changed)
Before this fix, you were not able to add to PortChannel a port with MTU !- 9100 (hard coded)

#### New command output (if the output of a command-line utility has changed)
PortChannel MTU will be determined according to first port inserted into PortChannel