### PR TITLE
[sonic-package-manager] remove leftovers from featured on uninstall

### DIFF
--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import os
+import glob
 import sys
 import shutil
 import stat
@@ -33,6 +34,7 @@ SERVICE_FILE_TEMPLATE = 'sonic.service.j2'
 TIMER_UNIT_TEMPLATE = 'timer.unit.j2'
 
 SYSTEMD_LOCATION = '/usr/lib/systemd/system'
+ETC_SYSTEMD_LOCATION = '/etc/systemd/system'
 
 GENERATED_SERVICES_CONF_FILE = '/etc/sonic/generated_services.conf'
 
@@ -92,17 +94,29 @@ def set_executable_bit(filepath):
     os.chmod(filepath, st.st_mode | stat.S_IEXEC)
 
 
-def remove_if_exists(path):
+def remove_file(path):
     """ Remove filepath if it exists """
 
-    if not os.path.exists(path):
-        return
+    try:
+        os.remove(path)
+        log.info(f'removed {path}')
+    except FileNotFoundError:
+        pass
 
-    os.remove(path)
-    log.info(f'removed {path}')
+
+def remove_dir(path):
+    """ Remove filepath if it exists """
+
+    try:
+        shutil.rmtree(path)
+        log.info(f'removed {path}')
+    except FileNotFoundError:
+        pass
+
 
 def is_list_of_strings(command):
     return isinstance(command, list) and all(isinstance(item, str) for item in command)
+
 
 def run_command(command: List[str]):
     """ Run arbitrary bash command.
@@ -197,12 +211,22 @@ class ServiceCreator:
         """
 
         name = package.manifest['service']['name']
-        remove_if_exists(os.path.join(SYSTEMD_LOCATION, f'{name}.service'))
-        remove_if_exists(os.path.join(SYSTEMD_LOCATION, f'{name}@.service'))
-        remove_if_exists(os.path.join(SERVICE_MGMT_SCRIPT_LOCATION, f'{name}.sh'))
-        remove_if_exists(os.path.join(DOCKER_CTL_SCRIPT_LOCATION, f'{name}.sh'))
-        remove_if_exists(os.path.join(DEBUG_DUMP_SCRIPT_LOCATION, f'{name}'))
-        remove_if_exists(os.path.join(ETC_SONIC_PATH, f'{name}_reconcile'))
+        remove_file(os.path.join(SYSTEMD_LOCATION, f'{name}.service'))
+        remove_file(os.path.join(SYSTEMD_LOCATION, f'{name}@.service'))
+        remove_file(os.path.join(SERVICE_MGMT_SCRIPT_LOCATION, f'{name}.sh'))
+        remove_file(os.path.join(DOCKER_CTL_SCRIPT_LOCATION, f'{name}.sh'))
+        remove_file(os.path.join(DEBUG_DUMP_SCRIPT_LOCATION, f'{name}'))
+        remove_file(os.path.join(ETC_SONIC_PATH, f'{name}_reconcile'))
+
+        # remove symlinks and configuration directories created by featured
+        remove_file(os.path.join(ETC_SYSTEMD_LOCATION, f'{name}.service'))
+        for unit_file in glob.glob(os.path.join(ETC_SYSTEMD_LOCATION, f'{name}@*.service')):
+            remove_file(unit_file)
+
+        remove_dir(os.path.join(ETC_SYSTEMD_LOCATION, f'{name}.service.d'))
+        for unit_dir in glob.glob(os.path.join(ETC_SYSTEMD_LOCATION, f'{name}@*.service.d')):
+            remove_dir(unit_dir)
+
         self.update_dependent_list_file(package, remove=True)
         self.update_generated_services_conf_file(package, remove=True)
 

--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -16,6 +16,7 @@ from sonic_package_manager.metadata import Metadata, MetadataResolver
 from sonic_package_manager.registry import RegistryResolver
 from sonic_package_manager.version import Version
 from sonic_package_manager.service_creator.creator import *
+from sonic_package_manager.service_creator.creator import ETC_SYSTEMD_LOCATION
 
 
 @pytest.fixture

--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -405,6 +405,7 @@ def fake_db_for_migration(fake_metadata_resolver):
 def sonic_fs(fs):
     fs.create_file('/proc/1/root')
     fs.create_dir(ETC_SONIC_PATH)
+    fs.create_dir(ETC_SYSTEMD_LOCATION)
     fs.create_dir(SYSTEMD_LOCATION)
     fs.create_dir(DOCKER_CTL_SCRIPT_LOCATION)
     fs.create_dir(SERVICE_MGMT_SCRIPT_LOCATION)

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -106,6 +106,14 @@ def test_service_creator(sonic_fs, manifest, service_creator, package_manager):
     assert sonic_fs.exists(os.path.join(SERVICE_MGMT_SCRIPT_LOCATION, 'test.sh'))
     assert sonic_fs.exists(os.path.join(SYSTEMD_LOCATION, 'test.service'))
 
+    # Create symlinks and directory featured creates
+    os.symlink('/dev/null', os.path.join(ETC_SYSTEMD_LOCATION, 'test.service'))
+    os.symlink('/dev/null', os.path.join(ETC_SYSTEMD_LOCATION, 'test@1.service'))
+    os.symlink('/dev/null', os.path.join(ETC_SYSTEMD_LOCATION, 'test@2.service'))
+    os.mkdir(os.path.join(ETC_SYSTEMD_LOCATION, 'test.service.d'))
+    os.mkdir(os.path.join(ETC_SYSTEMD_LOCATION, 'test@1.service.d'))
+    os.mkdir(os.path.join(ETC_SYSTEMD_LOCATION, 'test@2.service.d'))
+
     def read_file(name):
         with open(os.path.join(ETC_SONIC_PATH, name)) as file:
             return file.read()
@@ -117,6 +125,15 @@ def test_service_creator(sonic_fs, manifest, service_creator, package_manager):
     generated_services_conf_content = read_file('generated_services.conf')
     assert generated_services_conf_content.endswith('\n')
     assert set(generated_services_conf_content.split()) == set(['test.service', 'test@.service'])
+
+    service_creator.remove(package)
+
+    assert not sonic_fs.exists(os.path.join(ETC_SYSTEMD_LOCATION, 'test.service'))
+    assert not sonic_fs.exists(os.path.join(ETC_SYSTEMD_LOCATION, 'test@1.service'))
+    assert not sonic_fs.exists(os.path.join(ETC_SYSTEMD_LOCATION, 'test@2.service'))
+    assert not sonic_fs.exists(os.path.join(ETC_SYSTEMD_LOCATION, 'test.service.d'))
+    assert not sonic_fs.exists(os.path.join(ETC_SYSTEMD_LOCATION, 'test@1.service.d'))
+    assert not sonic_fs.exists(os.path.join(ETC_SYSTEMD_LOCATION, 'test@2.service.d'))
 
 
 def test_service_creator_with_timer_unit(sonic_fs, manifest, service_creator):

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -12,6 +12,7 @@ from sonic_package_manager.manifest import Manifest
 from sonic_package_manager.metadata import Metadata
 from sonic_package_manager.package import Package
 from sonic_package_manager.service_creator.creator import *
+from sonic_package_manager.service_creator.creator import ETC_SYSTEMD_LOCATION
 from sonic_package_manager.service_creator.feature import FeatureRegistry
 
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added code to remove leftover symlinks and directories created by featured. Featured creates a symlink to /dev/null when unit is masked and an auto restart configuration is left under corresponding ```service.d/``` directory.

#### How I did it

Added necessary changes  and UT to cover it.

#### How to verify it

Uninstall an extension and verify no leftovers from featured.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

