### PR TITLE
Configure Max NTP Server limit 

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6723,6 +6723,8 @@ def add_ntp_server(ctx, ntp_ip_address):
         return
     else:
         try:
+            if len(ntp_servers) >= 10:
+                ctx.fail('Max elements limit 10 reached.')
             db.set_entry('NTP_SERVER', ntp_ip_address,
                          {'resolve_as': ntp_ip_address,
                           'association_type': 'server'})

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2220,11 +2220,12 @@ class TestConfigNtp(object):
         db = Db()
         obj = {'db': db.cfgdb}
         # Assume 10 NTP Servers has been configured to verify the Maximum NTP Server Limit.
-        with mock.patch('config.main.ConfigDBConnector.get_table', mock.MagicMock(return_value=["10.10.10.1", 
-        "10.10.10.2", "10.10.10.3", "10.10.10.4", "10.10.10.5", "10.10.10.6", "10.10.10.7", "10.10.10.8", 
-        "10.10.10.9", "10.10.10.0"])):
-            with mock.patch('utilities_common.cli.run_command', mock.MagicMock(side_effect=
-            mock_run_command_side_effect)):
+        with mock.patch('config.main.ConfigDBConnector.get_table',
+        mock.MagicMock(return_value=["10.10.10.1", "10.10.10.2", "10.10.10.3", "10.10.10.4",
+                                     "10.10.10.5", "10.10.10.6", "10.10.10.7", "10.10.10.8",
+                                     "10.10.10.9", "10.10.10.0"])):
+            with mock.patch('utilities_common.cli.run_command',
+                            mock.MagicMock(side_effect=mock_run_command_side_effect)):
                 result = runner.invoke(config.config.commands["ntp"], ["add", "10.10.10.11"], obj=obj)
         print(result.exit_code)
         print(result.output)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2218,11 +2218,13 @@ class TestConfigNtp(object):
         config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'db': db.cfgdb}
         # Assume 10 NTP Servers has been configured to verify the Maximum NTP Server Limit.
-        with mock.patch('config.main.ConfigDBConnector.get_table', mock.MagicMock(return_value=["10.10.10.1","10.10.10.2",\
-        "10.10.10.3","10.10.10.4","10.10.10.5","10.10.10.6","10.10.10.7","10.10.10.8","10.10.10.9","10.10.10.0"])):
-            with mock.patch('utilities_common.cli.run_command', mock.MagicMock(side_effect=mock_run_command_side_effect)):
+        with mock.patch('config.main.ConfigDBConnector.get_table', mock.MagicMock(return_value=["10.10.10.1", 
+        "10.10.10.2", "10.10.10.3", "10.10.10.4", "10.10.10.5", "10.10.10.6", "10.10.10.7", "10.10.10.8", 
+        "10.10.10.9", "10.10.10.0"])):
+            with mock.patch('utilities_common.cli.run_command', mock.MagicMock(side_effect=
+            mock_run_command_side_effect)):
                 result = runner.invoke(config.config.commands["ntp"], ["add", "10.10.10.11"], obj=obj)
         print(result.exit_code)
         print(result.output)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2221,9 +2221,10 @@ class TestConfigNtp(object):
         obj = {'db': db.cfgdb}
         # Assume 10 NTP Servers has been configured to verify the Maximum NTP Server Limit.
         with mock.patch('config.main.ConfigDBConnector.get_table',
-        mock.MagicMock(return_value=["10.10.10.1", "10.10.10.2", "10.10.10.3", "10.10.10.4",
-                                     "10.10.10.5", "10.10.10.6", "10.10.10.7", "10.10.10.8",
-                                     "10.10.10.9", "10.10.10.0"])):
+                        mock.MagicMock(return_value=["10.10.10.1", "10.10.10.2", "10.10.10.3",
+                                                     "10.10.10.4", "10.10.10.5", "10.10.10.6",
+                                                     "10.10.10.7", "10.10.10.8", "10.10.10.9",
+                                                     "10.10.10.0"])):
             with mock.patch('utilities_common.cli.run_command',
                             mock.MagicMock(side_effect=mock_run_command_side_effect)):
                 result = runner.invoke(config.config.commands["ntp"], ["add", "10.10.10.11"], obj=obj)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2214,6 +2214,20 @@ class TestConfigNtp(object):
         print(result.output)
         assert "Invalid ConfigDB. Error" in result.output
 
+    def test_add_ntp_server_max_limit(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db':db.cfgdb}
+        # Assume 10 NTP Servers has been configured to verify the Maximum NTP Server Limit.
+        with mock.patch('config.main.ConfigDBConnector.get_table', mock.MagicMock(return_value=["10.10.10.1","10.10.10.2",\
+        "10.10.10.3","10.10.10.4","10.10.10.5","10.10.10.6","10.10.10.7","10.10.10.8","10.10.10.9","10.10.10.0"])):
+            with mock.patch('utilities_common.cli.run_command', mock.MagicMock(side_effect=mock_run_command_side_effect)):
+                result = runner.invoke(config.config.commands["ntp"], ["add", "10.10.10.11"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert "Max elements limit 10 reached." in result.output
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Maximum NTP Server limit has been added as 10 with an appropriate error message.
Ref : [NTP Scalability Requirements](https://github.com/project-arlo/SONiC/blob/ntp_doc/doc/SONiC_OC_NTP_HLD.md#116-scalability-requirements)

#### How I did it

In config/main.py, Validation code has been added to check whether the maximum NTP server limit is reached or not .
An error message has been added when it exceeds the limit.

#### How to verify it

Issue `config ntp add <ip_address>` 10 times.
After the max limit , error message `Error: Max elements limit 10 reached.` will be thrown.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

