### PR TITLE
[cherry-pick][202311] Show running config when bgp is down

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1437,11 +1437,11 @@ def all(verbose):
         ns_list = multi_asic.get_namespace_list()
         for ns in ns_list:
             ns_config = get_config_json_by_namespace(ns)
-            ns_config['bgpraw'] = bgp_util.run_bgp_show_command(bgpraw_cmd, ns)
+            ns_config['bgpraw'] = bgp_util.run_bgp_show_command(bgpraw_cmd, ns, exit_on_fail=False)
             output[ns] = ns_config
         click.echo(json.dumps(output, indent=4))
     else:
-        host_config['bgpraw'] = bgp_util.run_bgp_show_command(bgpraw_cmd)
+        host_config['bgpraw'] = bgp_util.run_bgp_show_command(bgpraw_cmd, exit_on_fail=False)
         click.echo(json.dumps(output['localhost'], indent=4))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,7 +310,7 @@ def setup_multi_asic_bgp_instance(request):
         else:
             return ""
 
-    def mock_run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND):
+    def mock_run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.RVTYSH_COMMAND, exit_on_fail=True):
         if m_asic_json_file.startswith('bgp_v4_network') or \
             m_asic_json_file.startswith('bgp_v6_network'):
             return mock_show_bgp_network_multi_asic(m_asic_json_file)
@@ -328,7 +328,8 @@ def setup_multi_asic_bgp_instance(request):
         else:
             return ""
 
-    def mock_run_show_sum_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.VTYSH_COMMAND):
+    def mock_run_show_sum_bgp_command(
+            vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.VTYSH_COMMAND, exit_on_fail=True):
         if vtysh_cmd == "show ip bgp summary json":
             m_asic_json_file = 'no_bgp_neigh.json'
         else:
@@ -343,7 +344,8 @@ def setup_multi_asic_bgp_instance(request):
         else:
             return ""
 
-    def mock_run_show_summ_bgp_command_no_ext_neigh_on_all_asic(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.VTYSH_COMMAND):
+    def mock_run_show_summ_bgp_command_no_ext_neigh_on_all_asic(
+            vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.VTYSH_COMMAND, exit_on_fail=True):
         if vtysh_cmd == "show ip bgp summary json":
             m_asic_json_file = 'no_ext_bgp_neigh.json'
         else:
@@ -358,7 +360,8 @@ def setup_multi_asic_bgp_instance(request):
         else:
             return ""
 
-    def mock_run_show_summ_bgp_command_no_ext_neigh_on_asic1(vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.VTYSH_COMMAND):
+    def mock_run_show_summ_bgp_command_no_ext_neigh_on_asic1(
+            vtysh_cmd, bgp_namespace, vtysh_shell_cmd=constants.VTYSH_COMMAND, exit_on_fail=True):
         if vtysh_cmd == "show ip bgp summary json":
             if bgp_namespace == "asic1":
                 m_asic_json_file = 'no_ext_bgp_neigh.json'

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -188,7 +188,7 @@ def get_neighbor_dict_from_table(db, table_name):
         return neighbor_dict
 
 
-def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, vtysh_shell_cmd=constants.VTYSH_COMMAND):
+def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, vtysh_shell_cmd=constants.VTYSH_COMMAND, exit_on_fail=True):
     bgp_instance_id = []
     output = None
     if bgp_namespace is not multi_asic.DEFAULT_NAMESPACE:
@@ -199,16 +199,18 @@ def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, vtysh
         output, ret = clicommon.run_command(cmd, return_cmd=True)
         if ret != 0:
             click.echo(output.rstrip('\n'))
-            sys.exit(ret)
+            if exit_on_fail:
+                sys.exit(ret)
     except Exception:
         ctx = click.get_current_context()
-        ctx.fail("Unable to get summary from bgp {}".format(bgp_instance_id))
+        if exit_on_fail:
+            ctx.fail("Unable to get summary from bgp {}".format(bgp_instance_id))
 
     return output
 
 
-def run_bgp_show_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE):
-    output = run_bgp_command(vtysh_cmd, bgp_namespace, constants.RVTYSH_COMMAND)
+def run_bgp_show_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, exit_on_fail=True):
+    output = run_bgp_command(vtysh_cmd, bgp_namespace, constants.RVTYSH_COMMAND, exit_on_fail)
     # handle the the alias mode in the following code
     if output is not None:
         if clicommon.get_interface_naming_mode() == "alias" and re.search("show ip|ipv6 route", vtysh_cmd):

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -188,7 +188,8 @@ def get_neighbor_dict_from_table(db, table_name):
         return neighbor_dict
 
 
-def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, vtysh_shell_cmd=constants.VTYSH_COMMAND, exit_on_fail=True):
+def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE,
+                    vtysh_shell_cmd=constants.VTYSH_COMMAND, exit_on_fail=True):
     bgp_instance_id = []
     output = None
     if bgp_namespace is not multi_asic.DEFAULT_NAMESPACE:
@@ -199,12 +200,10 @@ def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, vtysh
         output, ret = clicommon.run_command(cmd, return_cmd=True)
         if ret != 0:
             click.echo(output.rstrip('\n'))
-            if exit_on_fail:
-                sys.exit(ret)
+            output = "" if not exit_on_fail else sys.exit(ret)
     except Exception:
         ctx = click.get_current_context()
-        if exit_on_fail:
-            ctx.fail("Unable to get summary from bgp {}".format(bgp_instance_id))
+        ctx.fail("Unable to get summary from bgp {}".format(bgp_instance_id)) if exit_on_fail else None
 
     return output
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
cherry pick conflict for https://github.com/sonic-net/sonic-utilities/pull/3313
#### What I did

#### How I did it

#### How to verify it

- output of `show run all` before fix:

```
admin@bjw-can-7260-8:~$ show ver

SONiC Software Version: SONiC.20231110.10
...
admin@bjw-can-7260-8:~$ docker kill bgp
bgp
admin@bjw-can-7260-8:~$ show run all
Error response from daemon: Container 94f750dbed0fdd990bb34c302c52f0fe16ec34d2092d3ff754500fcc647744bf is not running

admin@bjw-can-7260-8:~$ 
```

- output of `show run all` after fix:

```
admin@bjw-can-7260-8:~$ docker kill bgp
bgp
admin@bjw-can-7260-8:~$ show run all | more
Error response from daemon: Container 94f750dbed0fdd990bb34c302c52f0fe16ec34d2092d3ff754500fcc647744bf is not running

{
    "ACL_TABLE": {
        "DATAACL": {
            "policy_desc": "DATAACL",
            "ports": [
                "PortChannel101",
                "PortChannel102",
                "PortChannel103",
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

