### PR TITLE
Add full configuration validation.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1165,7 +1165,7 @@ def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_ru
     scope_for_log = scope if scope else HOST_NAMESPACE
     try:
         # Call apply_patch with the ASIC-specific changes and predefined parameters
-        GenericUpdater(scope=scope).apply_patch(jsonpatch.JsonPatch(changes),
+        GenericUpdater(namespace=scope).apply_patch(jsonpatch.JsonPatch(changes),
                                                 config_format,
                                                 verbose,
                                                 dry_run,
@@ -1201,13 +1201,14 @@ def validate_patch(patch):
 
         # Verify target config by YANG models
         target_config = all_target_config.pop(HOST_NAMESPACE) if multi_asic.is_multi_asic() else all_target_config
+        target_config.pop("bgpraw", None)
         if not SonicYangCfgDbGenerator().validate_config_db_json(target_config):
             return False
 
         if multi_asic.is_multi_asic():
             for asic in multi_asic.get_namespace_list():
                 target_config = all_target_config.pop(asic)
-
+                target_config.pop("bgpraw", None)
                 if not SonicYangCfgDbGenerator().validate_config_db_json(target_config):
                     return False
 

--- a/config/main.py
+++ b/config/main.py
@@ -1164,12 +1164,18 @@ def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_ru
     scope_for_log = scope if scope else "localhost"
     try:
         # Call apply_patch with the ASIC-specific changes and predefined parameters
-        GenericUpdater(scope==scope).apply_patch(jsonpatch.JsonPatch(changes), config_format, verbose, dry_run, ignore_non_yang_tables, ignore_path)
+        GenericUpdater(scope=scope).apply_patch(jsonpatch.JsonPatch(changes),
+                                                config_format,
+                                                verbose,
+                                                dry_run,
+                                                ignore_non_yang_tables,
+                                                ignore_path)
         results[scope_for_log] = {"success": True, "message": "Success"}
         log.log_notice(f"'apply-patch' executed successfully for {scope_for_log} by {changes}")
     except Exception as e:
         results[scope_for_log] = {"success": False, "message": str(e)}
         log.log_error(f"'apply-patch' executed failed for {scope_for_log} by {changes} due to {str(e)}")
+
 
 def validate_patch(patches):
     command = "show runningconfiguration all"
@@ -1191,7 +1197,7 @@ def validate_patch(patches):
 
         # Structure validation and simulate apply patch.
         all_target_config = patches.apply(json.loads(all_running_config))
-        
+
         # Verify target config by YANG models
         target_config = all_target_config.pop("localhost") if multi_asic.is_multi_asic() else all_target_config
         if not SonicYangCfgDbGenerator().validate_config_db_json(target_config):

--- a/config/main.py
+++ b/config/main.py
@@ -1187,15 +1187,6 @@ def validate_patch(patch):
             log.log_notice(f"Fetch all runningconfiguration failed as output:{all_running_config}")
             return False
 
-        # Duplicate check
-        resource_usage = {}
-        for operation in patch:
-            resource_path = operation['path']
-            if resource_path in resource_usage:
-                log.log_notice(f"Conflict detected: multiple patches modify {resource_path}")
-                return False
-            resource_usage[resource_path] = operation
-
         # Structure validation and simulate apply patch.
         all_target_config = patch.apply(json.loads(all_running_config))
 

--- a/config/main.py
+++ b/config/main.py
@@ -1165,7 +1165,7 @@ def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_ru
     scope_for_log = scope if scope else HOST_NAMESPACE
     try:
         # Call apply_patch with the ASIC-specific changes and predefined parameters
-        GenericUpdater(namespace=scope).apply_patch(jsonpatch.JsonPatch(changes), 
+        GenericUpdater(namespace=scope).apply_patch(jsonpatch.JsonPatch(changes),
                                                     config_format,
                                                     verbose,
                                                     dry_run,

--- a/config/main.py
+++ b/config/main.py
@@ -1165,12 +1165,12 @@ def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_ru
     scope_for_log = scope if scope else HOST_NAMESPACE
     try:
         # Call apply_patch with the ASIC-specific changes and predefined parameters
-        GenericUpdater(namespace=scope).apply_patch(jsonpatch.JsonPatch(changes),
-                                                config_format,
-                                                verbose,
-                                                dry_run,
-                                                ignore_non_yang_tables,
-                                                ignore_path)
+        GenericUpdater(namespace=scope).apply_patch(jsonpatch.JsonPatch(changes), 
+                                                    config_format,
+                                                    verbose,
+                                                    dry_run,
+                                                    ignore_non_yang_tables,
+                                                    ignore_path)
         results[scope_for_log] = {"success": True, "message": "Success"}
         log.log_notice(f"'apply-patch' executed successfully for {scope_for_log} by {changes}")
     except Exception as e:

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -84,8 +84,8 @@ class PatchApplier:
         self.config_wrapper.validate_field_operation(old_config, target_config)
 
         # Validate target config does not have empty tables since they do not show up in ConfigDb
-        self.logger.log_notice(f"{scope}: validating target config does not have empty tables, 
-                               since they do not show up in ConfigDb.")
+        self.logger.log_notice(f"""{scope}: validating target config does not have empty tables,
+                               since they do not show up in ConfigDb.""")
         empty_tables = self.config_wrapper.get_empty_tables(target_config)
         if empty_tables:  # if there are empty tables
             empty_tables_txt = ", ".join(empty_tables)

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -84,10 +84,10 @@ class PatchApplier:
         self.config_wrapper.validate_field_operation(old_config, target_config)
 
         # Validate target config does not have empty tables since they do not show up in ConfigDb
-        self.logger.log_notice(f"{scope}: validating target config does not have empty tables, " \
-                               "since they do not show up in ConfigDb.")
+        self.logger.log_notice(f"{scope}: validating target config does not have empty tables, 
+                               since they do not show up in ConfigDb.")
         empty_tables = self.config_wrapper.get_empty_tables(target_config)
-        if empty_tables: # if there are empty tables
+        if empty_tables:  # if there are empty tables
             empty_tables_txt = ", ".join(empty_tables)
             raise EmptyTableError(f"{scope}: given patch is not valid because it will result in empty tables " \
                              "which is not allowed in ConfigDb. " \

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -84,7 +84,7 @@ class PatchApplier:
         self.config_wrapper.validate_field_operation(old_config, target_config)
 
         # Validate target config does not have empty tables since they do not show up in ConfigDb
-        self.logger.log_notice(f"{scope}: alidating target config does not have empty tables, " \
+        self.logger.log_notice(f"{scope}: validating target config does not have empty tables, " \
                                "since they do not show up in ConfigDb.")
         empty_tables = self.config_wrapper.get_empty_tables(target_config)
         if empty_tables: # if there are empty tables
@@ -104,9 +104,6 @@ class PatchApplier:
         changes_len = len(changes)
         self.logger.log_notice(f"The {scope} patch was converted into {changes_len} " \
                           f"change{'s' if changes_len != 1 else ''}{':' if changes_len > 0 else '.'}")
-
-        for change in changes:
-            self.logger.log_notice(f"  * {change}")
 
         # Apply changes in order
         self.logger.log_notice(f"{scope}: applying {changes_len} change{'s' if changes_len != 1 else ''} " \

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -35,18 +35,6 @@ def extract_scope(path):
 
     return scope, remainder
 
-def get_all_running_configs(db):
-    all_running_config = {}
-    cfgdb_clients = db.cfgdb_clients
-
-    for ns, config_db in cfgdb_clients.items():
-        current_config = config_db.get_config()
-        sonic_cfggen.FormatConverter.to_serialized(current_config)
-        asic_name = HOST_NAMESPACE if ns == multi_asic.DEFAULT_NAMESPACE else ns
-        all_running_config[asic_name] = sort_dict(current_config)
-
-    return all_running_config
-
 
 class ConfigLock:
     def acquire_lock(self):

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -16,6 +16,7 @@ YANG_DIR = "/usr/local/yang-models"
 SYSLOG_IDENTIFIER = "GenericConfigUpdater"
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 GCU_FIELD_OP_CONF_FILE = f"{SCRIPT_DIR}/gcu_field_operation_validators.conf.json"
+HOST_NAMESPACE = "localhost"
 
 class GenericConfigUpdaterError(Exception):
     pass

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2718,7 +2718,7 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
                 "value": "9200"
             }
         ]
-        
+
         test_config = copy.deepcopy(config_temp)
         data = test_config.pop("scope")
         self.all_config = {}
@@ -2826,7 +2826,7 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
                     "type": "L3"
                 }
             })
-        
+
         # Mock open to simulate file reading
         with patch('builtins.open', mock_open(read_data=json.dumps(duplicate_patch)), create=True) as mocked_open:
             # Mock GenericUpdater to avoid actual patch application

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2798,7 +2798,9 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
 
                 print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
                 # Invocation of the command with the CliRunner
-                result = self.runner.invoke(config.config.commands["apply-patch"], [self.patch_file_path], catch_exceptions=True)
+                result = self.runner.invoke(config.config.commands["apply-patch"],
+                                            [self.patch_file_path],
+                                            catch_exceptions=True)
 
                 print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
                 # Assertions and verifications
@@ -2835,12 +2837,14 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
 
                 print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
                 # Invocation of the command with the CliRunner
-                result = self.runner.invoke(config.config.commands["apply-patch"], [self.patch_file_path], catch_exceptions=True)
+                result = self.runner.invoke(config.config.commands["apply-patch"],
+                                            [self.patch_file_path],
+                                            catch_exceptions=True)
 
                 print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
                 # Assertions and verifications
                 self.assertNotEqual(result.exit_code, 0, "Command should failed.")
-                self.assertIn("Failed to apply patch.", result.output)
+                self.assertIn("Failed to apply patch", result.output)
 
                 # Verify mocked_open was called as expected
                 mocked_open.assert_called_with(self.patch_file_path, 'r')

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2849,45 +2849,6 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
 
     @patch('config.main.subprocess.Popen')
     @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
-    def test_apply_patch_validate_patch_with_duplicatepath_multiasic(self, mock_subprocess_popen):
-        mock_instance = MagicMock()
-        mock_instance.communicate.return_value = (json.dumps(self.all_config), 0)
-        mock_subprocess_popen.return_value = mock_instance
-
-        duplicate_patch = copy.deepcopy(self.patch_content)
-        duplicate_patch.append({
-                "op": "replace",
-                "path": "/asic0/ACL_TABLE/NEW_ACL_TABLE",
-                "value": {
-                    "policy_desc": "New ACL Table",
-                    "ports": ["Ethernet3", "Ethernet4"],
-                    "stage": "ingress",
-                    "type": "L3"
-                }
-            })
-
-        # Mock open to simulate file reading
-        with patch('builtins.open', mock_open(read_data=json.dumps(duplicate_patch)), create=True) as mocked_open:
-            # Mock GenericUpdater to avoid actual patch application
-            with patch('config.main.GenericUpdater') as mock_generic_updater:
-                mock_generic_updater.return_value.apply_patch = MagicMock()
-
-                print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
-                # Invocation of the command with the CliRunner
-                result = self.runner.invoke(config.config.commands["apply-patch"],
-                                            [self.patch_file_path],
-                                            catch_exceptions=True)
-
-                print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
-                # Assertions and verifications
-                self.assertNotEqual(result.exit_code, 0, "Command should failed.")
-                self.assertIn("Failed to apply patch", result.output)
-
-                # Verify mocked_open was called as expected
-                mocked_open.assert_called_with(self.patch_file_path, 'r')
-
-    @patch('config.main.subprocess.Popen')
-    @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
     def test_apply_patch_validate_patch_with_wrong_fetch_config(self, mock_subprocess_popen):
         mock_instance = MagicMock()
         mock_instance.communicate.return_value = (json.dumps(self.all_config), 2)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -2812,6 +2812,43 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
 
     @patch('config.main.subprocess.Popen')
     @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
+    def test_apply_patch_validate_patch_with_badpath_multiasic(self, mock_subprocess_popen):
+        mock_instance = MagicMock()
+        mock_instance.communicate.return_value = (json.dumps(self.all_config), 0)
+        mock_subprocess_popen.return_value = mock_instance
+
+        bad_patch = copy.deepcopy(self.patch_content)
+        bad_patch.append({
+                "value": {
+                    "policy_desc": "New ACL Table",
+                    "ports": ["Ethernet3", "Ethernet4"],
+                    "stage": "ingress",
+                    "type": "L3"
+                }
+            })
+
+        # Mock open to simulate file reading
+        with patch('builtins.open', mock_open(read_data=json.dumps(bad_patch)), create=True) as mocked_open:
+            # Mock GenericUpdater to avoid actual patch application
+            with patch('config.main.GenericUpdater') as mock_generic_updater:
+                mock_generic_updater.return_value.apply_patch = MagicMock()
+
+                print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                # Invocation of the command with the CliRunner
+                result = self.runner.invoke(config.config.commands["apply-patch"],
+                                            [self.patch_file_path],
+                                            catch_exceptions=True)
+
+                print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                # Assertions and verifications
+                self.assertNotEqual(result.exit_code, 0, "Command should failed.")
+                self.assertIn("Failed to apply patch", result.output)
+
+                # Verify mocked_open was called as expected
+                mocked_open.assert_called_with(self.patch_file_path, 'r')
+
+    @patch('config.main.subprocess.Popen')
+    @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
     def test_apply_patch_validate_patch_with_duplicatepath_multiasic(self, mock_subprocess_popen):
         mock_instance = MagicMock()
         mock_instance.communicate.return_value = (json.dumps(self.all_config), 0)
@@ -2831,6 +2868,33 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
 
         # Mock open to simulate file reading
         with patch('builtins.open', mock_open(read_data=json.dumps(duplicate_patch)), create=True) as mocked_open:
+            # Mock GenericUpdater to avoid actual patch application
+            with patch('config.main.GenericUpdater') as mock_generic_updater:
+                mock_generic_updater.return_value.apply_patch = MagicMock()
+
+                print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                # Invocation of the command with the CliRunner
+                result = self.runner.invoke(config.config.commands["apply-patch"],
+                                            [self.patch_file_path],
+                                            catch_exceptions=True)
+
+                print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                # Assertions and verifications
+                self.assertNotEqual(result.exit_code, 0, "Command should failed.")
+                self.assertIn("Failed to apply patch", result.output)
+
+                # Verify mocked_open was called as expected
+                mocked_open.assert_called_with(self.patch_file_path, 'r')
+
+    @patch('config.main.subprocess.Popen')
+    @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
+    def test_apply_patch_validate_patch_with_wrong_fetch_config(self, mock_subprocess_popen):
+        mock_instance = MagicMock()
+        mock_instance.communicate.return_value = (json.dumps(self.all_config), 2)
+        mock_subprocess_popen.return_value = mock_instance
+
+        # Mock open to simulate file reading
+        with patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as mocked_open:
             # Mock GenericUpdater to avoid actual patch application
             with patch('config.main.GenericUpdater') as mock_generic_updater:
                 mock_generic_updater.return_value.apply_patch = MagicMock()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 import filecmp
 import importlib
@@ -166,6 +167,39 @@ Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
 Restarting SONiC target ...
 Reloading Monit configuration ...
 """
+
+config_temp = {
+        "scope": {
+            "ACL_TABLE": {
+                "MY_ACL_TABLE": {
+                    "policy_desc": "My ACL",
+                    "ports": ["Ethernet1", "Ethernet2"],
+                    "stage": "ingress",
+                    "type": "L3"
+                }
+            },
+            "PORT": {
+                "Ethernet1": {
+                    "alias": "fortyGigE0/0",
+                    "description": "fortyGigE0/0",
+                    "index": "0",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet2": {
+                    "alias": "fortyGigE0/100",
+                    "description": "fortyGigE0/100",
+                    "index": "25",
+                    "lanes": "125,126,127,128",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        }
+    }
 
 def mock_run_command_side_effect(*args, **kwargs):
     command = args[0]
@@ -1023,6 +1057,7 @@ class TestGenericUpdateCommands(unittest.TestCase):
         self.any_checkpoints_list = ["checkpoint1", "checkpoint2", "checkpoint3"]
         self.any_checkpoints_list_as_text = json.dumps(self.any_checkpoints_list, indent=4)
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def test_apply_patch__no_params__get_required_params_error_msg(self):
         # Arrange
         unexpected_exit_code = 0
@@ -1035,6 +1070,7 @@ class TestGenericUpdateCommands(unittest.TestCase):
         self.assertNotEqual(unexpected_exit_code, result.exit_code)
         self.assertTrue(expected_output in result.output)
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def test_apply_patch__help__gets_help_msg(self):
         # Arrange
         expected_exit_code = 0
@@ -1047,6 +1083,7 @@ class TestGenericUpdateCommands(unittest.TestCase):
         self.assertEqual(expected_exit_code, result.exit_code)
         self.assertTrue(expected_output in result.output)
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def test_apply_patch__only_required_params__default_values_used_for_optional_params(self):
         # Arrange
         expected_exit_code = 0
@@ -1065,6 +1102,7 @@ class TestGenericUpdateCommands(unittest.TestCase):
         mock_generic_updater.apply_patch.assert_called_once()
         mock_generic_updater.apply_patch.assert_has_calls([expected_call_with_default_values])
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def test_apply_patch__all_optional_params_non_default__non_default_values_used(self):
         # Arrange
         expected_exit_code = 0
@@ -1094,6 +1132,7 @@ class TestGenericUpdateCommands(unittest.TestCase):
         mock_generic_updater.apply_patch.assert_called_once()
         mock_generic_updater.apply_patch.assert_has_calls([expected_call_with_non_default_values])
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def test_apply_patch__exception_thrown__error_displayed_error_code_returned(self):
         # Arrange
         unexpected_exit_code = 0
@@ -1129,6 +1168,7 @@ class TestGenericUpdateCommands(unittest.TestCase):
             ["--ignore-path", "/ANY_TABLE"],
             mock.call(self.any_patch, ConfigFormat.CONFIGDB, False, False, False, ("/ANY_TABLE",)))
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def validate_apply_patch_optional_parameter(self, param_args, expected_call):
         # Arrange
         expected_exit_code = 0
@@ -2678,7 +2718,17 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
                 "value": "9200"
             }
         ]
+        
+        test_config = copy.deepcopy(config_temp)
+        data = test_config.pop("scope")
+        self.all_config = {}
+        self.all_config["localhost"] = data
+        self.all_config["asic0"] = data
+        self.all_config["asic0"]["bgpraw"] = ""
+        self.all_config["asic1"] = data
+        self.all_config["asic1"]["bgpraw"] = ""
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def test_apply_patch_multiasic(self):
         # Mock open to simulate file reading
         with patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as mocked_open:
@@ -2698,6 +2748,7 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
                 # Verify mocked_open was called as expected
                 mocked_open.assert_called_with(self.patch_file_path, 'r')
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
     def test_apply_patch_dryrun_multiasic(self):
         # Mock open to simulate file reading
         with patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as mocked_open:
@@ -2731,6 +2782,68 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
 
                     # Ensure ConfigDBConnector was never instantiated or called
                     mock_config_db_connector.assert_not_called()
+
+    @patch('config.main.subprocess.Popen')
+    @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
+    def test_apply_patch_validate_patch_multiasic(self, mock_subprocess_popen):
+        mock_instance = MagicMock()
+        mock_instance.communicate.return_value = (json.dumps(self.all_config), 0)
+        mock_subprocess_popen.return_value = mock_instance
+
+        # Mock open to simulate file reading
+        with patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as mocked_open:
+            # Mock GenericUpdater to avoid actual patch application
+            with patch('config.main.GenericUpdater') as mock_generic_updater:
+                mock_generic_updater.return_value.apply_patch = MagicMock()
+
+                print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                # Invocation of the command with the CliRunner
+                result = self.runner.invoke(config.config.commands["apply-patch"], [self.patch_file_path], catch_exceptions=True)
+
+                print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                # Assertions and verifications
+                self.assertEqual(result.exit_code, 0, "Command should succeed.")
+                self.assertIn("Patch applied successfully.", result.output)
+
+                # Verify mocked_open was called as expected
+                mocked_open.assert_called_with(self.patch_file_path, 'r')
+
+    @patch('config.main.subprocess.Popen')
+    @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
+    def test_apply_patch_validate_patch_with_duplicatepath_multiasic(self, mock_subprocess_popen):
+        mock_instance = MagicMock()
+        mock_instance.communicate.return_value = (json.dumps(self.all_config), 0)
+        mock_subprocess_popen.return_value = mock_instance
+
+        duplicate_patch = copy.deepcopy(self.patch_content)
+        duplicate_patch.append({
+                "op": "replace",
+                "path": "/asic0/ACL_TABLE/NEW_ACL_TABLE",
+                "value": {
+                    "policy_desc": "New ACL Table",
+                    "ports": ["Ethernet3", "Ethernet4"],
+                    "stage": "ingress",
+                    "type": "L3"
+                }
+            })
+        
+        # Mock open to simulate file reading
+        with patch('builtins.open', mock_open(read_data=json.dumps(duplicate_patch)), create=True) as mocked_open:
+            # Mock GenericUpdater to avoid actual patch application
+            with patch('config.main.GenericUpdater') as mock_generic_updater:
+                mock_generic_updater.return_value.apply_patch = MagicMock()
+
+                print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                # Invocation of the command with the CliRunner
+                result = self.runner.invoke(config.config.commands["apply-patch"], [self.patch_file_path], catch_exceptions=True)
+
+                print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                # Assertions and verifications
+                self.assertNotEqual(result.exit_code, 0, "Command should failed.")
+                self.assertIn("Failed to apply patch.", result.output)
+
+                # Verify mocked_open was called as expected
+                mocked_open.assert_called_with(self.patch_file_path, 'r')
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Before apply the json patch, we will precheck and simulate-patch the payload in entire box level.

#### How I did it

1. Add Duplication check
2. JSON patch structure validating
3. Simulating patch to full configuration
4. Verifying simulating result match YANG validation.

#### How to verify it

1. Single ASIC

```
admin@str2-msn2700-spy-2:~/gcu$ cat empty.json 
[]
admin@str2-msn2700-spy-2:~/gcu$ sudo config apply-patch empty.json 
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: []
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                               since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 0 changes.
Patch Applier: localhost: applying 0 changes in order.
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
```

2. Multi ASIC

```
stli@str2-7250-2-lc01:~/gcu$ cat empty.json 
[]
stli@str2-7250-2-lc01:~/gcu$ sudo config apply-patch empty.json 
sonic_yang(6):Note: Below table(s) have no YANG models: DHCP_SERVER, KUBERNETES_MASTER
sonic_yang(6):Note: Below table(s) have no YANG models: KUBERNETES_MASTER
sonic_yang(6):Note: Below table(s) have no YANG models: KUBERNETES_MASTER
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: []
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                               since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 0 changes.
Patch Applier: localhost: applying 0 changes in order.
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: []
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic0: validating target config does not have empty tables,
                               since they do not show up in ConfigDb.
Patch Applier: asic0: sorting patch updates.
Patch Applier: The asic0 patch was converted into 0 changes.
Patch Applier: asic0: applying 0 changes in order.
Patch Applier: asic0: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic0 patch application completed.
Patch Applier: asic1: Patch application starting.
Patch Applier: asic1: Patch: []
Patch Applier: asic1 getting current config db.
Patch Applier: asic1: simulating the target full config after applying the patch.
Patch Applier: asic1: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic1: validating target config does not have empty tables,
                               since they do not show up in ConfigDb.
Patch Applier: asic1: sorting patch updates.
Patch Applier: The asic1 patch was converted into 0 changes.
Patch Applier: asic1: applying 0 changes in order.
Patch Applier: asic1: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic1 patch application completed.
Patch applied successfully.
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

