### PR TITLE
[202305] Migrate AAA table in db_migrator

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -695,6 +695,39 @@ class DBMigrator():
                 flex_counter['FLEX_COUNTER_DELAY_STATUS'] = 'true'
                 self.configDB.mod_entry('FLEX_COUNTER_TABLE', obj, flex_counter)
 
+    def migrate_tacplus(self):
+        if not self.config_src_data or 'TACPLUS' not in self.config_src_data:
+            return
+
+        tacplus_new = self.config_src_data['TACPLUS']
+        log.log_notice('Migrate TACPLUS configuration')
+
+        global_old = self.configDB.get_entry('TACPLUS', 'global')
+        if not global_old:
+            global_new = tacplus_new.get("global")
+            self.configDB.set_entry("TACPLUS", "global", global_new)
+            log.log_info('Migrate TACPLUS global: {}'.format(global_new))
+
+    def migrate_aaa(self):
+        if not self.config_src_data or 'AAA' not in self.config_src_data:
+            return
+
+        aaa_new = self.config_src_data['AAA']
+        log.log_notice('Migrate AAA configuration')
+
+        authentication = self.configDB.get_entry('AAA', 'authentication')
+        if not authentication:
+            authentication_new = aaa_new.get("authentication")
+            self.configDB.set_entry("AAA", "authentication", authentication_new)
+            log.log_info('Migrate AAA authentication: {}'.format(authentication_new))
+
+        # setup per-command accounting
+        accounting = self.configDB.get_entry('AAA', 'accounting')
+        if not accounting:
+            accounting_new = aaa_new.get("accounting")
+            self.configDB.set_entry("AAA", "accounting", accounting_new)
+            log.log_info('Migrate AAA accounting: {}'.format(accounting_new))
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -1078,6 +1111,9 @@ class DBMigrator():
         self.update_edgezone_aggregator_config()
         # update FRR config mode based on minigraph parser on target image
         self.migrate_routing_config_mode()
+
+        self.migrate_tacplus()
+        self.migrate_aaa()
 
     def migrate(self):
         version = self.get_version()

--- a/tests/db_migrator_input/config_db/per_command_aaa_disable.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_disable.json
@@ -1,0 +1,6 @@
+{
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_disable_expected.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_disable_expected.json
@@ -1,0 +1,6 @@
+{
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_disable_golden.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_disable_golden.json
@@ -1,0 +1,8 @@
+{
+    "TACPLUS": {
+        "global": {
+            "auth_type": "login",
+            "passkey": "testpasskey"
+        }
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_enable.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_enable.json
@@ -1,0 +1,9 @@
+{
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_enable_expected.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_enable_expected.json
@@ -1,0 +1,12 @@
+{
+    "AAA|accounting": {
+        "login": "tacacs+,local"
+    },
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_enable_golden.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_enable_golden.json
@@ -1,0 +1,19 @@
+{
+    "AAA": {
+        "accounting": {
+            "login": "tacacs+,local"
+        },
+        "authentication": {
+            "login": "tacacs+"
+        },
+        "authorization": {
+            "login": "tacacs+"
+        }
+    },
+    "TACPLUS": {
+        "global": {
+            "auth_type": "login",
+            "passkey": "testpasskey"
+        }
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_authentication.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_authentication.json
@@ -1,0 +1,9 @@
+{
+    "AAA|accounting": {
+        "login": "tacacs+,local"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_authentication_expected.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_authentication_expected.json
@@ -1,0 +1,12 @@
+{
+    "AAA|accounting": {
+        "login": "tacacs+,local"
+    },
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_authentication_golden.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_authentication_golden.json
@@ -1,0 +1,19 @@
+{
+    "AAA": {
+        "accounting": {
+            "login": "tacacs+,local"
+        },
+        "authentication": {
+            "login": "tacacs+"
+        },
+        "authorization": {
+            "login": "tacacs+"
+        }
+    },
+    "TACPLUS": {
+        "global": {
+            "auth_type": "login",
+            "passkey": "testpasskey"
+        }
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_change.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_change.json
@@ -1,0 +1,15 @@
+{
+    "AAA|accounting": {
+        "login": "local"
+    },
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "AAA|authorization": {
+        "login": "local"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_change_expected.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_change_expected.json
@@ -1,0 +1,15 @@
+{
+    "AAA|accounting": {
+        "login": "local"
+    },
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "AAA|authorization": {
+        "login": "local"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_change_golden.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_change_golden.json
@@ -1,0 +1,19 @@
+{
+    "AAA": {
+        "accounting": {
+            "login": "tacacs+,local"
+        },
+        "authentication": {
+            "login": "tacacs+"
+        },
+        "authorization": {
+            "login": "tacacs+"
+        }
+    },
+    "TACPLUS": {
+        "global": {
+            "auth_type": "login",
+            "passkey": "testpasskey"
+        }
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_passkey.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_passkey.json
@@ -1,0 +1,8 @@
+{
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_passkey_expected.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_passkey_expected.json
@@ -1,0 +1,11 @@
+{
+    "AAA|accounting": {
+        "login": "tacacs+,local"
+    },
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_passkey_golden.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_passkey_golden.json
@@ -1,0 +1,15 @@
+{
+    "AAA": {
+        "accounting": {
+            "login": "tacacs+,local"
+        },
+        "authentication": {
+            "login": "tacacs+"
+        }
+    },
+    "TACPLUS": {
+        "global": {
+            "auth_type": "login"
+        }
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_tacplus.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_tacplus.json
@@ -1,0 +1,5 @@
+{
+    "AAA|authentication": {
+        "login": "tacacs+"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_tacplus_expected.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_tacplus_expected.json
@@ -1,0 +1,12 @@
+{
+    "AAA|accounting": {
+        "login": "tacacs+,local"
+    },
+    "AAA|authentication": {
+        "login": "tacacs+"
+    },
+    "TACPLUS|global": {
+        "auth_type": "login",
+        "passkey": "testpasskey"
+    }
+}

--- a/tests/db_migrator_input/config_db/per_command_aaa_no_tacplus_golden.json
+++ b/tests/db_migrator_input/config_db/per_command_aaa_no_tacplus_golden.json
@@ -1,0 +1,19 @@
+{
+    "AAA": {
+        "accounting": {
+            "login": "tacacs+,local"
+        },
+        "authentication": {
+            "login": "tacacs+"
+        },
+        "authorization": {
+            "login": "tacacs+"
+        }
+    },
+    "TACPLUS": {
+        "global": {
+            "auth_type": "login",
+            "passkey": "testpasskey"
+        }
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -3,6 +3,7 @@ import pytest
 import sys
 
 from deepdiff import DeepDiff
+import json
 
 from swsscommon.swsscommon import SonicV2Connector
 from sonic_py_common import device_info
@@ -734,3 +735,52 @@ class TestFastUpgrade_to_4_0_3(object):
         advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_4_0_3')
         assert not self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)
         assert dbmgtr.CURRENT_VERSION == expected_db.cfgdb.get_entry('VERSIONS', 'DATABASE')['VERSION'], '{} {}'.format(dbmgtr.CURRENT_VERSION, dbmgtr.get_version())
+
+
+class TestAAAMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+
+    def load_golden_config(self, dbmgtr, test_json):
+        dbmgtr.config_src_data = {}
+
+        json_path = os.path.join(mock_db_path, 'config_db', test_json + ".json")
+        if os.path.exists(json_path):
+            with open(json_path) as f:
+                dbmgtr.config_src_data = json.load(f)
+                print("test_per_command_aaa load golden config success, config_src_data: {}".format(dbmgtr.config_src_data))
+        else:
+            print("test_per_command_aaa load golden config failed, file {} does not exist.".format(test_json))
+
+
+    @pytest.mark.parametrize('test_json', ['per_command_aaa_enable',
+                                           'per_command_aaa_no_passkey',
+                                           'per_command_aaa_disable',
+                                           'per_command_aaa_no_change',
+                                           'per_command_aaa_no_tacplus',
+                                           'per_command_aaa_no_authentication'])
+    def test_per_command_aaa(self, test_json):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', test_json)
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        self.load_golden_config(dbmgtr, test_json + '_golden')
+        dbmgtr.migrate_tacplus()
+        dbmgtr.migrate_aaa()
+        resulting_table = dbmgtr.configDB.get_table("AAA")
+
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', test_json + '_expected')
+        expected_db = Db()
+        expected_table = expected_db.cfgdb.get_table("AAA")
+
+        print("test_per_command_aaa: {}".format(test_json))
+        print("test_per_command_aaa, resulting_table: {}".format(resulting_table))
+        print("test_per_command_aaa, expected_table: {}".format(expected_table))
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff


### PR DESCRIPTION
Migrate AAA table in db_migrator
This is a cherry-pick PR for https://github.com/sonic-net/sonic-utilities/pull/3284

#### Why I did it
    per-command AAA need enable in warm-upgrade case

#### How I did it
    Add db_migrator code to migrate AAA table

#### How to verify it
    Pass all test case.
    Add new test case.

#### Which release branch to backport (provide reason below if selected)
    N/A

#### Description for the changelog
    Migrate AAA table in db_migrator

#### A picture of a cute animal (not mandatory but encouraged)

