### PR TITLE
[build] Fix base OS compilation issue caused by incompatibility between urllib3 and requests packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,13 @@ stages:
 
     steps:
     - script: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y python3-pip
+        sudo pip3 install requests==2.31.0
+      displayName: "Install dependencies"
+
+    - script: |
         sourceBranch=$(Build.SourceBranchName)
         if [[ "$(Build.Reason)" == "PullRequest" ]];then
           sourceBranch=$(System.PullRequest.TargetBranch)

--- a/setup.py
+++ b/setup.py
@@ -250,7 +250,7 @@ setup(
         'semantic-version>=2.8.5',
         'prettyprinter>=0.18.0',
         'pyroute2>=0.5.14, <0.6.1',
-        'requests>=2.25.0',
+        'requests>=2.25.0, <=2.31.0',
         'tabulate==0.9.0',
         'toposort==1.6',
         'www-authenticate==0.9.2',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix SONiC image compilation issue:
```
+ sudo LANG=C DOCKER_HOST= chroot ./fsroot-mellanox /usr/local/bin/generate_shutdown_order.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/requests/adapters.py", line 532, in send
    conn = self._get_connection(request, verify, proxies=proxies, cert=cert)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/requests/adapters.py", line 400, in _get_connection
    conn = self.poolmanager.connection_from_host(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/urllib3/poolmanager.py", line 304, in connection_from_host
    return self.connection_from_context(request_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/urllib3/poolmanager.py", line 326, in connection_from_context
    raise URLSchemeUnknown(scheme)
urllib3.exceptions.URLSchemeUnknown: Not supported URL scheme http+docker
```

#### How I did it
Pin request version <= `<=2.31.0`.

#### How to verify it
Run SONiC image compilation.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

