### PR TITLE
[SPM] Add logic to disable the feature before stopping it and enabling it before starting

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -1017,8 +1017,10 @@ class PackageManager:
 
     def _stop_feature(self, package: Package):
         self._systemctl_action(package, 'stop')
+        self._systemctl_action(package, 'disable')
 
     def _start_feature(self, package: Package):
+        self._systemctl_action(package, 'enable')
         self._systemctl_action(package, 'start')
 
     def _systemctl_action(self, package: Package, action: str):

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -2,7 +2,7 @@
 
 import re
 import unittest
-from unittest.mock import Mock, call, patch, mock_open
+from unittest.mock import Mock, call, patch, call, mock_open
 import pytest
 
 import sonic_package_manager
@@ -324,7 +324,7 @@ def test_manager_installation_version_range(package_manager):
         package_manager.install(f'test-package>=1.6.0')
 
 
-def test_manager_upgrade(package_manager, sonic_fs):
+def test_manager_upgrade(package_manager, sonic_fs, mock_run_command):
     package_manager.install('test-package-6=1.5.0')
     package = package_manager.get_installed_package('test-package-6')
 
@@ -332,6 +332,15 @@ def test_manager_upgrade(package_manager, sonic_fs):
     upgraded_package = package_manager.get_installed_package('test-package-6')
     assert upgraded_package.entry.version == Version.parse('2.0.0')
     assert upgraded_package.entry.default_reference == package.entry.default_reference
+
+    mock_run_command.assert_has_calls(
+        [
+            call(['systemctl', 'stop', 'test-package-6']),
+            call(['systemctl', 'disable', 'test-package-6']),
+            call(['systemctl', 'enable', 'test-package-6']),
+            call(['systemctl', 'start', 'test-package-6']),
+        ]
+    )
 
 
 def test_manager_package_reset(package_manager, sonic_fs):
@@ -370,7 +379,7 @@ def mock_get_docker_client(dockerd_sock):
             class Image:
                 def __init__(self, image_id):
                     self.image_id = image_id
-                
+
                 def save(self, named):
                     return ["named: {}".format(named).encode()]
 

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -2,7 +2,7 @@
 
 import re
 import unittest
-from unittest.mock import Mock, call, patch, call, mock_open
+from unittest.mock import Mock, call, patch, mock_open
 import pytest
 
 import sonic_package_manager


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add logic to disable the feature before stopping and enabling it before starting in order to properly clean the `systemd` symlinks to avoid issues with `delayed` attribute explained in the `How to verify it` section.

#### How I did it
Add the `systemctl disable ...` after the `systemctl stop...` and the `systemctl enable ...` before the `systemctl start ..` for some feature.

#### How to verify it
- Add repository for some `featureX`
- `sonic-package-manager repository <featureX> <URL>`
- Install `featureX` version 1.0.0 where the `delayed` flag is equal to `false` (`delayed` flag means - the feature will be started right after the system boots or after the `PortInitDone` event)
- `sonic-package-manager install featureX==1.0.0 -y`
- Enable the feature in SONiC
- `config feature state featureX enabled`
- Install `featureX` version 1.0.1 where the `delayed` flag is equal to `true`
- `sonic-package-manager install featureX==1.0.1 -y`
- Check the `manifest` file to verify the `delayed` field value
- `sonic-package-manager show package manifest featureX`
- `config save -y`
- `reboot`
- Check that the `featureX` is delayed on the system start

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

