### PR TITLE
Fix show fabric monitor capacity command when the feature is disabled.

### DIFF
--- a/scripts/fabricstat
+++ b/scripts/fabricstat
@@ -540,7 +540,10 @@ Examples:
             stat = FabricCapacity(namespace, table_cnt, threshold)
             stat.capacity_print()
 
-        click.echo("Monitored fabric capacity threshold: {}".format(threshold[0]))
+        print_th = ""
+        if threshold:
+            print_th = threshold[0]
+        click.echo("Monitored fabric capacity threshold: {}".format(print_th))
         click.echo()
         click.echo(tabulate(table_cnt, capacity_header, tablefmt='simple', stralign='right'))
     else:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

"show fabric monitor capacity" command has a index error if the feature is disabled. With this change, the command can still display information without errors. 

the issue is tracking at https://github.com/sonic-net/sonic-utilities/issues/3350


#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

