### PR TITLE
Don't exit immediately if running a command under alias mode

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -731,8 +731,7 @@ def run_command(command, display_cmd=False, ignore_error=False, return_cmd=False
     # with a list for next hops
     if (get_interface_naming_mode() == "alias" and not command_str.startswith("intfutil") and not re.search(
             "show ip|ipv6 route", command_str)):
-        run_command_in_alias_mode(command, shell=shell)
-        sys.exit(0)
+        return run_command_in_alias_mode(command, shell=shell)
 
     proc = subprocess.Popen(command, shell=shell, text=True, stdout=subprocess.PIPE)
 


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

There's a difference in behavior when an external command is run under the default mode vs when it is run under the alias mode. In the default mode, execution control returns to the caller unless the command had a non-zero exit code. In the alias mode, regardless of exit code, the Python script exits. This may result in some tasks not completing.

#### How I did it

Fix this by not unconditionally exiting if running a command in the alias mode. Note that there are other differences still present, but this fixes at least this one.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

