### PR TITLE
[cherry-pick][202205][build] Fix base OS compilation issue caused by incompatibility between urllib3 and requests packages (#3328)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,13 @@ stages:
 
     steps:
     - script: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y python3-pip
+        sudo pip3 install requests==2.31.0
+      displayName: "Install dependencies"
+
+    - script: |
         sourceBranch=$(Build.SourceBranchName)
         if [[ "$(Build.Reason)" == "PullRequest" ]];then
           sourceBranch=$(System.PullRequest.TargetBranch)

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ setup(
         'semantic-version>=2.8.5',
         'prettyprinter>=0.18.0',
         'pyroute2>=0.5.14, <0.6.1',
-        'requests>=2.25.0',
+        'requests>=2.25.0, <=2.31.0',
         'sonic-config-engine',
         'sonic-platform-common',
         'sonic-py-common',


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Cherry-pick PR https://github.com/sonic-net/sonic-utilities/pull/3328 [build] Fix base OS compilation issue caused by incompatibility between urllib3 and requests packages

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

