### PR TITLE
[pbh]: Fix show PBH counters when cache is partial

### DIFF
--- a/show/plugins/pbh.py
+++ b/show/plugins/pbh.py
@@ -395,7 +395,7 @@ def get_counter_value(pbh_counters, saved_pbh_counters, key, type):
     if not pbh_counters[key]:
         return '0'
 
-    if key in saved_pbh_counters:
+    if key in saved_pbh_counters and saved_pbh_counters[key]:
         new_value = int(pbh_counters[key][type]) - int(saved_pbh_counters[key][type])
         if new_value >= 0:
             return str(new_value)

--- a/tests/pbh_input/assert_show_output.py
+++ b/tests/pbh_input/assert_show_output.py
@@ -78,6 +78,14 @@ pbh_table2  vxlan   300                 400
 """
 
 
+show_pbh_statistics_partial = """\
+TABLE       RULE    RX PACKETS COUNT    RX BYTES COUNT
+----------  ------  ------------------  ----------------
+pbh_table1  nvgre   100                 200
+pbh_table2  vxlan   0                   0
+"""
+
+
 show_pbh_statistics_updated="""\
 TABLE       RULE    RX PACKETS COUNT    RX BYTES COUNT
 ----------  ------  ------------------  ----------------

--- a/tests/pbh_input/counters_db_partial.json
+++ b/tests/pbh_input/counters_db_partial.json
@@ -1,0 +1,11 @@
+{
+    "COUNTERS:oid:0x9000000000000": { },
+    "COUNTERS:oid:0x9000000000001": {
+        "SAI_ACL_COUNTER_ATTR_PACKETS": "300",
+        "SAI_ACL_COUNTER_ATTR_BYTES": "400"
+    },
+    "ACL_COUNTER_RULE_MAP": {
+        "pbh_table1:nvgre": "oid:0x9000000000000",
+        "pbh_table2:vxlan": "oid:0x9000000000001"
+    }
+}

--- a/tests/pbh_test.py
+++ b/tests/pbh_test.py
@@ -946,6 +946,34 @@ class TestPBH:
         assert result.exit_code == SUCCESS
         assert result.output == assert_show_output.show_pbh_statistics_zero
 
+    def test_show_pbh_statistics_after_clear_and_counters_partial(self):
+        dbconnector.dedicated_dbs['COUNTERS_DB'] = os.path.join(mock_db_path, 'counters_db_partial')
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'full_pbh_config')
+
+        self.remove_pbh_counters_file()
+
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(
+            clear.cli.commands["pbh"].
+            commands["statistics"], [], obj=db
+        )
+
+        logger.debug("\n" + result.output)
+        logger.debug(result.exit_code)
+
+        dbconnector.dedicated_dbs['COUNTERS_DB'] = os.path.join(mock_db_path, 'counters_db')
+
+        result = runner.invoke(
+            show.cli.commands["pbh"].
+            commands["statistics"], [], obj=db
+        )
+
+        logger.debug("\n" + result.output)
+        logger.debug(result.exit_code)
+        assert result.exit_code == SUCCESS
+        assert result.output == assert_show_output.show_pbh_statistics_partial
 
     def test_show_pbh_statistics_after_clear_and_counters_updated(self):
         dbconnector.dedicated_dbs['COUNTERS_DB'] = os.path.join(mock_db_path, 'counters_db')


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

During system init the initial snapshot of PBH rule counters doesn't contain all the necessary information, which makes a dump invalid. Thus, it fails CLI to do a comparison logic which prints a traceback. After some time, when counters are getting updated in the DB, the snapshot can be taken correctly and the issue is gone.

#### What I did
* Fixed PBH CLI output when counter's cache is partial

#### How I did it
* Added additional constraint

#### How to verify it
1. Reboot the switch
2. Run `sonic-clear pbh statistics`
3. Run `show pbh statistics`

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show pbh statistics
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1114, in invoke
    return Command.invoke(self, ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/show/plugins/pbh.py", line 386, in PBH_STATISTICS
    get_counter_value(pbh_counters, saved_pbh_counters, key, COUNTER_PACKETS_ATTR),
  File "/usr/local/lib/python3.9/dist-packages/show/plugins/pbh.py", line 401, in get_counter_value
    new_value = int(pbh_counters[key][type]) - int(saved_pbh_counters[key][type])
KeyError: 'SAI_ACL_COUNTER_ATTR_PACKETS'
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show pbh statistics
TABLE      RULE             RX PACKETS COUNT    RX BYTES COUNT
---------  ---------------  ------------------  ----------------
pbh_table  nvgre_ipv4_ipv4  0                   0
pbh_table  nvgre_ipv4_ipv6  0                   0
pbh_table  nvgre_ipv6_ipv4  0                   0
pbh_table  nvgre_ipv6_ipv6  0                   0
pbh_table  vxlan_ipv4_ipv4  0                   0
pbh_table  vxlan_ipv4_ipv6  0                   0
pbh_table  vxlan_ipv6_ipv4  0                   0
pbh_table  vxlan_ipv6_ipv6  0                   0
```