### PR TITLE
[DPB]Fixing return code of breakout command on failure

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -249,7 +249,7 @@ def breakout_Ports(cm, delPorts=list(), portJson=dict(), force=False, \
             click.echo("*** Printing dependencies ***")
             for dep in deps:
                 click.echo(dep)
-            sys.exit(0)
+            sys.exit(1)
         else:
             click.echo("[ERROR] Port breakout Failed!!! Opting Out")
             raise click.Abort()

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -396,7 +396,7 @@ class TestConfigDPB(object):
             commands["breakout"], ['{}'.format(interface), '{}'.format(newMode), '-v', '-y'], obj=obj)
 
         print(result.exit_code, result.output)
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert 'Dependencies Exist.' in result.output
 
         # verbose must be set while creating instance of ConfigMgmt class
@@ -538,7 +538,7 @@ class TestConfigDPB(object):
                 commands["breakout"], ['{}'.format(interface), '{}'.format(newMode), '-v','-y'], obj=obj)
 
             print(result.exit_code, result.output)
-            assert result.exit_code == 0
+            assert result.exit_code == 1
             assert 'Dependencies Exist.' in result.output
             assert 'Printing dependencies' in result.output
             assert 'NO-NSW-PACL-V4' in result.output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Changing the return code of DPB command to 1 on failure when dependencies exit.


#### How I did it
Updating the exit code


#### How to verify it
Modified UT to verify


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

