### PR TITLE
[config] no op if Golden Config is invalid

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1844,8 +1844,10 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
         # Dependency check golden config json
         config_to_check = read_json_file(golden_config_path)
         if multi_asic.is_multi_asic():
-            config_to_check = config_to_check.get('localhost', {})
-        table_hard_dependency_check(config_to_check)
+            host_config = config_to_check.get('localhost', {})
+        else:
+            host_config = config_to_check
+        table_hard_dependency_check(host_config)
 
     #Stop services before config push
     if not no_service_restart:

--- a/config/main.py
+++ b/config/main.py
@@ -1841,6 +1841,12 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
                         fg='magenta')
             raise click.Abort()
 
+        # Dependency check golden config json
+        config_to_check = read_json_file(golden_config_path)
+        if multi_asic.is_multi_asic():
+            config_to_check = config_to_check.get('localhost', {})
+        table_hard_dependency_check(config_to_check)
+
     #Stop services before config push
     if not no_service_restart:
         log.log_notice("'load_minigraph' stopping services...")

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -793,6 +793,34 @@ class TestLoadMinigraph(object):
             assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
+    def test_load_minigraph_hard_dependency_check(self, get_cmd_module):
+        def is_file_side_effect(filename):
+            return True if 'golden_config' in filename else False
+
+        def read_json_file_side_effect(filename):
+            return {
+                "AAA": {
+                    "authentication": {
+                        "login": "tacacs+"
+                    }
+                },
+                "TACPLUS": {
+                    "global": {
+                        "passkey": ""
+                    }
+                }
+            }
+
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)), \
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
+                mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
+            (config, _) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "-y"])
+            assert result.exit_code != 0
+            assert "Authentication with 'tacacs+' is not allowed when passkey not exits." in result.output
+
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_traffic_shift_away(self, get_cmd_module):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
             (config, show) = get_cmd_module

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -762,8 +762,11 @@ class TestLoadMinigraph(object):
     def test_load_minigraph_with_specified_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
+        def read_json_file_side_effect(filename):
+            return {}
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
-                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
+                mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
             result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "--golden_config_path",  "golden_config.json", "-y"])
@@ -774,8 +777,11 @@ class TestLoadMinigraph(object):
     def test_load_minigraph_with_default_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
+        def read_json_file_side_effect(filename):
+            return {}
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
-                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
+                mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
             result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "-y"])
@@ -799,7 +805,10 @@ class TestLoadMinigraph(object):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
             def is_file_side_effect(filename):
                 return True if 'golden_config' in filename else False
-            with mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)):
+            def read_json_file_side_effect(filename):
+                return {}
+            with mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
+                    mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
                 (config, show) = get_cmd_module
                 db = Db()
                 golden_config = {}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -762,8 +762,10 @@ class TestLoadMinigraph(object):
     def test_load_minigraph_with_specified_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
+
         def read_json_file_side_effect(filename):
             return {}
+
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
                 mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
@@ -777,8 +779,10 @@ class TestLoadMinigraph(object):
     def test_load_minigraph_with_default_golden_config_path(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
+
         def read_json_file_side_effect(filename):
             return {}
+
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
                 mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
@@ -805,8 +809,10 @@ class TestLoadMinigraph(object):
         with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
             def is_file_side_effect(filename):
                 return True if 'golden_config' in filename else False
+
             def read_json_file_side_effect(filename):
                 return {}
+
             with mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
                     mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
                 (config, show) = get_cmd_module

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -792,7 +792,8 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
-    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
+                mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_hard_dependency_check(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 27941719
#### What I did
Improve Golden Config workflow and make sure no op if invalid config detected
#### How I did it
Add table dependency check right after Golden Config path is enabled
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

