### PR TITLE
[sfputil] Add loopback sub-command for debugging and module diagnosti…

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -47,6 +47,8 @@
   * [CMIS firmware version show commands](#cmis-firmware-version-show-commands)
   * [CMIS firmware upgrade commands](#cmis-firmware-upgrade-commands)
   * [CMIS firmware target mode commands](#cmis-firmware-target-mode-commands)
+* [CMIS debug](#cmis-debug)
+* [CMIS debug loopback](#cmis-debug-loopback)
 * [DHCP Relay](#dhcp-relay)
   * [DHCP Relay show commands](#dhcp-relay-show-commands)
   * [DHCP Relay clear commands](#dhcp-relay-clear-commands)
@@ -3130,6 +3132,31 @@ Example of the module supporting target mode
   ```
   admin@sonic:~$ sfputil firmware target Ethernet180 1
   Target Mode set to 1
+  ```
+
+## CMIS debug
+
+### CMIS debug loopback
+
+This command is the standard CMIS diagnostic control used for troubleshooting link and performance issues between the host switch and transceiver module.
+
+**sfputil debug loopback**
+
+- Usage:
+  ```
+  sfputil debug loopback [OPTIONS] PORT_NAME LOOPBACK_MODE
+
+  Set the loopback mode
+  host-side-input: host side input loopback mode
+  host-side-output: host side output loopback mode
+  media-side-input: media side input loopback mode
+  media-side-output: media side output loopback mode
+  none: disable loopback mode
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sfputil firmware target Ethernet88 host-side-input
   ```
 
 ## DHCP Relay

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3144,7 +3144,7 @@ This command is the standard CMIS diagnostic control used for troubleshooting li
 
 - Usage:
   ```
-  sfputil debug loopback [OPTIONS] PORT_NAME LOOPBACK_MODE
+  sfputil debug loopback PORT_NAME LOOPBACK_MODE
 
   Set the loopback mode
   host-side-input: host side input loopback mode
@@ -3156,7 +3156,7 @@ This command is the standard CMIS diagnostic control used for troubleshooting li
 
 - Example:
   ```
-  admin@sonic:~$ sfputil firmware target Ethernet88 host-side-input
+  admin@sonic:~$ sfputil debug loopback Ethernet88 host-side-input
   ```
 
 ## DHCP Relay

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1890,5 +1890,50 @@ def get_overall_offset_sff8472(api, page, offset, size, wire_addr):
         return page * PAGE_SIZE + offset + PAGE_SIZE_FOR_A0H
 
 
+# 'debug' subgroup
+@cli.group()
+def debug():
+    """Module debug and diagnostic control"""
+    pass
+
+
+# 'loopback' subcommand
+@debug.command()
+@click.argument('port_name', required=True, default=None)
+@click.argument('loopback_mode', required=True, default="none",
+                type=click.Choice(["none", "host-side-input", "host-side-output",
+                                   "media-side-input", "media-side-output"]))
+def loopback(port_name, loopback_mode):
+    """Set module diagnostic loopback mode
+    """
+    physical_port = logical_port_to_physical_port_index(port_name)
+    sfp = platform_chassis.get_sfp(physical_port)
+
+    if is_port_type_rj45(port_name):
+        click.echo("{}: This functionality is not applicable for RJ45 port".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    if not is_sfp_present(port_name):
+        click.echo("{}: SFP EEPROM not detected".format(port_name))
+        sys.exit(EXIT_FAIL)
+
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo("{}: This functionality is not implemented".format(port_name))
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    try:
+        status = api.set_loopback_mode(loopback_mode)
+    except AttributeError:
+        click.echo("{}: Set loopback mode is not applicable for this module".format(port_name))
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    if status:
+        click.echo("{}: Set {} loopback".format(port_name, loopback_mode))
+    else:
+        click.echo("{}: Set {} loopback failed".format(port_name, loopback_mode))
+        sys.exit(EXIT_FAIL)
+
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
#### What I did
Add a **debug** group and a sub-command **loopback** under the sfputil command for debugging and module diagnostic purposes.

#### How I did it
Implement the loopback command by directly calling the **set_loopback_mode**() API.

#### How to verify it
Tested under Cisco8111 with Credo C1 cable.

- Turn off loopback mode
`sfputil debug loopback Ethernet88 none`
- Turn on host input loopback
`sfputil debug loopback Ethernet88 host-side-input`

#### Previous command output (if the output of a command-line utility has changed)
The loopback command is not supported in previous version.

#### New command output (if the output of a command-line utility has changed)
![image](https://github.com/sonic-net/sonic-utilities/assets/11884092/e6b43395-7b37-4e27-9995-d1c548997059)

#### Test logs
- local end (E0) with toggling **host side input** loopback mode
  page 0x00, byte 0x40 = 0  // target mode register set to E0
  page 0x13, byte 0xB7 = 0xFF  // turn on host side input loopback on lane 1 ~ 8
![image](https://github.com/sonic-net/sonic-utilities/assets/11884092/5ae35a2e-e80f-4961-aaf4-896045a1b839)

- remote end1 (E1) with toggling **media side input** loopback mode
page 0x00, byte 0x40 = 1 // target mode register set to E1
page 0x13, byte 0xB5 = 0x0F // turn on media side input loopback on lane 1 ~ 4
![image](https://github.com/sonic-net/sonic-utilities/assets/11884092/fe9fd451-1da0-4f92-8c9b-2a5f4ad987f9)

