### PR TITLE
Update TRANSCEIVER_FIRMWARE_INFO table for all targets in sfputil

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1316,10 +1316,8 @@ def update_firmware_info_to_state_db(port_name):
             state_db.connect(state_db.STATE_DB)
             transceiver_firmware_info_dict = platform_chassis.get_sfp(physical_port).get_transceiver_info_firmware_versions()
             if transceiver_firmware_info_dict is not None:
-                active_firmware = transceiver_firmware_info_dict.get('active_firmware', 'N/A')
-                inactive_firmware = transceiver_firmware_info_dict.get('inactive_firmware', 'N/A')
-                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "active_firmware", active_firmware)
-                state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), "inactive_firmware", inactive_firmware)
+                for key, value in transceiver_firmware_info_dict.items():
+                    state_db.set(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(port_name), key, value)
 
 # 'firmware' subgroup
 @cli.group()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
For transceivers which are CMIS target FW upgrade capable, sfputil needs to update FW version for all targets as part of firmware download, run and commit.
However, the current function update_firmware_info_to_state_db updates the firmware info to redis-db only for target 0.

MSFT ADO - 27920760

#### How I did it
Updating the active, inactive firmware versions for all sides. Also, updating the server firmware version for E1 and E2.

#### How to verify it
Ran the below sequence and ensured that the firmware info is updated for all targets in redis-db.
1. sfputil firmware target PORT_NAME TARGET
2. sfputil firmware download PORT_NAME FILE_PATH
3. sfputil firmware target PORT_NAME TARGET
4. sfputil firmware run PORT_NAME
5. sfputil firmware target PORT_NAME TARGET
6. sfputil firmware commit PORT_NAME
 
Also, tested the changes on transceiver which is not target FW upgradable.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

