### PR TITLE
[202305] [cherry-pick] Improve load_mingraph to wait eth0 restart before exit (#3365)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -891,9 +891,46 @@ def _reset_failed_services():
     for service in _get_sonic_services():
         clicommon.run_command(['systemctl', 'reset-failed', str(service)])
 
+
+def get_service_finish_timestamp(service):
+    out, _ = clicommon.run_command(['sudo',
+                                    'systemctl',
+                                    'show',
+                                    '--no-pager',
+                                    service,
+                                    '-p',
+                                    'ExecMainExitTimestamp',
+                                    '--value'],
+                                   return_cmd=True)
+    return out.strip(' \t\n\r')
+
+
+def wait_service_restart_finish(service, last_timestamp, timeout=30):
+    start_time = time.time()
+    elapsed_time = 0
+    while elapsed_time < timeout:
+        current_timestamp = get_service_finish_timestamp(service)
+        if current_timestamp and (current_timestamp != last_timestamp):
+            return
+
+        time.sleep(1)
+        elapsed_time = time.time() - start_time
+
+    log.log_warning("Service: {} does not restart in {} seconds, stop waiting".format(service, timeout))
+
+
 def _restart_services():
+    last_interface_config_timestamp = get_service_finish_timestamp('interfaces-config')
+    last_networking_timestamp = get_service_finish_timestamp('networking')
+
     click.echo("Restarting SONiC target ...")
     clicommon.run_command(['sudo', 'systemctl', 'restart', 'sonic.target'])
+
+    # These service will restart eth0 and cause device lost network for 10 seconds
+    # When enable TACACS, every remote user commands will authorize by TACACS service via network
+    # If load_minigraph exit before eth0 restart, commands after load_minigraph may failed
+    wait_service_restart_finish('interfaces-config', last_interface_config_timestamp)
+    wait_service_restart_finish('networking', last_networking_timestamp)
 
     try:
         subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 import filecmp
 import importlib
@@ -186,6 +187,10 @@ def mock_run_command_side_effect(*args, **kwargs):
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
             return '101', 0
+        elif command == 'sudo systemctl show --no-pager interfaces-config -p ExecMainExitTimestamp --value':
+            return f'{datetime.datetime.now()}', 0
+        elif command == 'sudo systemctl show --no-pager networking -p ExecMainExitTimestamp --value':
+            return f'{datetime.datetime.now()}', 0
         else:
             return '', 0
 
@@ -413,7 +418,7 @@ class TestLoadMinigraph(object):
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 8
+            assert mock_run_command.call_count == 12
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_path, None)))
     def test_load_minigraph_platform_plugin(self, get_cmd_module, setup_single_broadcom_asic):
@@ -428,7 +433,7 @@ class TestLoadMinigraph(object):
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_platform_plugin_command_output
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 8
+            assert mock_run_command.call_count == 12
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_false_path, None)))
     def test_load_minigraph_platform_plugin_fail(self, get_cmd_module, setup_single_broadcom_asic):


### PR DESCRIPTION
Improve load_mingraph to wait eth0 restart before exit
This is cherry-pick PR for https://github.com/sonic-net/sonic-utilities/pull/3365

#### Why I did it
    load_minigraph will restart eth0, which cause device randomly lost network for 10-20 seconds after load_minigraph
    When enable TACACS, this will cause commands randomly failed after load_minigraph

#### How I did it
    Wait interfaces-config and networking service restart after restart all sonic.target services.

##### Work item tracking
- Microsoft ADO: 28302676

#### How to verify it
    Pass all test case.
    Add new test case.
    Verified on SONiC.202305.562827-f73bc5bfb

##### Manually check on test device:
    admin@TEST_DEVICE:~$ date && sudo config load_minigraph -y && date
    Wed Jun 12 08:30:59 AM UTC 2024
    Stopping SONiC target ...
    Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
    Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
    Running command: config qos reload --no-dynamic-buffer --no-delay
    Running command: /usr/local/bin/sonic-cfggen -d --write-to-db -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers.json.j2,config-db -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml
    Buffer calculation model updated, restarting swss is required to take effect
    Running command: pfcwd start_default
    Restarting SONiC target ...
    Enabling container monitoring ...
    Reloading Monit configuration ...
    Reinitializing monit daemon
    Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
    Wed Jun 12 08:32:17 AM UTC 2024
    admin@TEST_DEVICE:~$
    
    
    In syslog, eth0 restart before load_minigraph finish:
    
    2024 Jun 12 08:31:50.743828 TEST_DEVICE INFO systemd-networkd[358]: eth0: Link DOWN
    2024 Jun 12 08:31:50.743957 TEST_DEVICE INFO systemd-networkd[358]: eth0: Lost carrier
    
    2024 Jun 12 08:31:58.182663 TEST_DEVICE INFO interfaces-config.sh[15321]: net.ipv6.conf.eth0.accept_ra_defrtr = 0
    2024 Jun 12 08:31:58.182777 TEST_DEVICE INFO interfaces-config.sh[15321]: net.ipv6.conf.eth0.accept_ra = 0
    2024 Jun 12 08:31:58.182838 TEST_DEVICE INFO interfaces-config.sh[15321]: net.ipv6.conf.eth0.ra_defrtr_metric = 1996489704
    
    2024 Jun 12 08:32:08.572423 TEST_DEVICE INFO systemd-networkd[358]: eth0: Link UP



#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202305
- [x] 202311
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

will updated with this PR image later.
- [x] SONiC.202305.562827-f73bc5bfb
- [x] SONiC.202311.562838-e1f4859bf

#### Description for the changelog
    Improve load_mingraph to wait eth0 restart before exit

#### A picture of a cute animal (not mandatory but encouraged)

