### PR TITLE
Add the definition of `log` in script `decode-syseeprom`

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -17,13 +17,15 @@ import sys
 
 import sonic_platform
 from sonic_platform_base.sonic_eeprom.eeprom_tlvinfo import TlvInfoDecoder
-from sonic_py_common import device_info
+from sonic_py_common import device_info, logger
 from swsscommon.swsscommon import SonicV2Connector
 from tabulate import tabulate
 
 
 EEPROM_INFO_TABLE = 'EEPROM_INFO'
+SYSLOG_IDENTIFIER = 'decode-syseeprom'
 
+log = logger.Logger(SYSLOG_IDENTIFIER)
 
 def instantiate_eeprom_object():
     eeprom = None


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
If there is something wrong getting eeprom while exectuing script `decode-syseeprom`, it will raise an exception and log the error. There was no definition of `log` in script `decode-syseeprom`, which will raise such error 
```
Traceback (most recent call last):
  File "/usr/local/bin/decode-syseeprom", line 264, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/bin/decode-syseeprom", line 246, in main
    print_serial(use_db)
  File "/usr/local/bin/decode-syseeprom", line 171, in print_serial
    eeprom = instantiate_eeprom_object()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/decode-syseeprom", line 36, in instantiate_eeprom_object
    log.log_error('Failed to obtain EEPROM object due to {}'.format(repr(e)))
    ^^^
NameError: name 'log' is not defined
```
In this PR, I add the definition of log to avoid such error. 

#### How I did it
Add the definition of log. 

#### How to verify it
```
admin@vlab-01:~$ sudo decode-syseeprom -s                
Failed to read system EEPROM info
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

