### PR TITLE
[SfpUtil] sfp eeprom with option dom is not working on Xcvrs with flat memory

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -674,6 +674,20 @@ def eeprom(port, dump_dom, namespace):
 
                 if dump_dom:
                     try:
+                        api = platform_chassis.get_sfp(physical_port).get_xcvr_api()
+                    except NotImplementedError:
+                        output += "API is currently not implemented for this platform\n"
+                        click.echo(output)
+                        sys.exit(ERROR_NOT_IMPLEMENTED)
+                    if api is None:
+                        output += "API is none while getting DOM info!\n"
+                        click.echo(output)
+                        sys.exit(ERROR_NOT_IMPLEMENTED)
+                    else:
+                        if api.is_flat_memory():
+                            output += "DOM values not supported for flat memory module\n"
+                            continue
+                    try:
                         xcvr_dom_info = platform_chassis.get_sfp(physical_port).get_transceiver_bulk_status()
                     except NotImplementedError:
                         click.echo("Sfp.get_transceiver_bulk_status() is currently not implemented for this platform")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
fixes https://github.com/sonic-net/sonic-buildimage/issues/19032

`sfputil show eeprom -d -p Ethernet0` command is failing for CMIS flat memory modules with a traceback.
```
root@switch/home/admin# sfputil show eeprom -d -p Ethernet0
Traceback (most recent call last):
  File "/usr/local/bin/sfputil", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sfputil/main.py", line 677, in eeprom
    xcvr_dom_info = platform_chassis.get_sfp(physical_port).get_transceiver_bulk_status()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py", line 32, in get_transceiver_bulk_status
    return api.get_transceiver_bulk_status() if api is not None else None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sonic_xcvr/api/public/cmis.py", line 233, in get_transceiver_bulk_status
    self.vdm_dict = self.get_vdm(self.vdm.VDM_REAL_VALUE)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'VDM_REAL_VALUE'
```
MSFT ADO - 28363057

#### How I did it
After https://github.com/sonic-net/sonic-platform-common/pull/397 was merged, the below line was added
`self.vdm_dict = self.get_vdm(self.vdm.VDM_REAL_VALUE)`.
However, for certain CMIS flat memory modules, `self.vdm` could be `None` due to https://github.com/sonic-net/sonic-platform-common/blob/8e673d5cfcb9ee184950f4fb1d32f999cbb39735/sonic_platform_base/sonic_xcvr/api/public/cmis.py#L31
Hence, since such flat memory modules do not have DOM information, we need to skip displaying DOM information for such modules (similar to the fix done via https://github.com/sonic-net/sonic-platform-daemons/pull/458).

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/var/log# sfputil show eeprom -d -p Ethernet4
Ethernet4: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 64B/66B
        Extended Identifier: Power Class 1 Module (1.5W max.), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Extended Specification Compliance: 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Gigabit Ethernet Compliant Codes: Unknown
                SAS/SATA Compliance Codes: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2019-10-23   
        Vendor Name: AAAA    
        Vendor OUI: 78-a7-14
        Vendor PN: YYYY   
        Vendor Rev: P 
        Vendor SN: XXXX
        ChannelMonitorValues:
                TX1Bias: 0.0mA
                TX2Bias: 0.0mA
                TX3Bias: 0.0mA
                TX4Bias: 0.0mA
        ChannelThresholdValues:
        ModuleMonitorValues:
        ModuleThresholdValues:


root@sonic:/var/log# 
```
#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/var/log# sfputil show eeprom -d -p Ethernet4
Ethernet4: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: No separable connector
        Encoding: 64B/66B
        Extended Identifier: Power Class 1 Module (1.5W max.), No CLEI code present in Page 02h, No CDR in TX, No CDR in RX
        Extended RateSelect Compliance: Unknown
        Identifier: QSFP28 or later
        Length Cable Assembly(m): 1.0
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Extended Specification Compliance: 100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Gigabit Ethernet Compliant Codes: Unknown
                SAS/SATA Compliance Codes: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2019-10-23   
        Vendor Name: AAAA    
        Vendor OUI: 78-a7-14
        Vendor PN: YYYY   
        Vendor Rev: P 
        Vendor SN: XXXX
DOM values not supported for flat memory module

root@sonic:/var/log# 
```
