### PR TITLE
Added BGP CLI commands set

### DIFF
--- a/config/bgp.py
+++ b/config/bgp.py
@@ -1,0 +1,2100 @@
+import click
+import ipaddress
+
+from sonic_py_common import multi_asic
+from sonic_py_common.interface import get_interface_table_name
+from swsscommon.swsscommon import ConfigDBConnector
+import utilities_common.cli as clicommon
+
+from .utils import log
+
+DEFAULT_NAMESPACE = ''
+
+BGP_NEIGHBOR_ALLOWAS_MIN = 1
+BGP_NEIGHBOR_ALLOWAS_MAX = 10
+BGP_ASN_MIN = 1
+BGP_ASN_MAX = 4294967295
+BGP_ASN_RANGE = click.IntRange(min=BGP_ASN_MIN, max=BGP_ASN_MAX)
+BGP_LISTEN_LIMIT_RANGE = click.IntRange(min=1, max=65535)
+BGP_GR_RESTART_TIME_RANGE = click.IntRange(min=0, max=4095)
+BGP_GR_STALEPATH_TIME_RANGE = click.IntRange(min=1, max=4095)
+BGP_NEIGHBOR_ADV_INTERVAL_RANGE = click.IntRange(min=0, max=600)
+BGP_NEIGHBOR_TIMER_RANGE = click.IntRange(min=0, max=65535)
+BGP_NEIGHBOR_MULTIHOP_RANGE = click.IntRange(min=1, max=255)
+BGP_IPV4_UNICAST_MAX_PATHS_RANGE = click.IntRange(min=1, max=256)
+BGP_IPV4_UNICAST_DISTANCE_RANGE = click.IntRange(min=1, max=255)
+
+
+
+def _is_neighbor_ipaddress(config_db, ipaddress):
+    """Returns True if a neighbor has the IP address <ipaddress>, False if not
+    """
+    entry = config_db.get_entry('BGP_NEIGHBOR', ipaddress)
+    return True if entry else False
+
+def _get_all_neighbor_ipaddresses(config_db):
+    """Returns list of strings containing IP addresses of all BGP neighbors
+    """
+    addrs = []
+    bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
+    for addr, session in bgp_sessions.items():
+        addrs.append(addr)
+    return addrs
+
+def _get_neighbor_ipaddress_list_by_hostname(config_db, hostname):
+    """Returns list of strings, each containing an IP address of neighbor with
+       hostname <hostname>. Returns empty list if <hostname> not a neighbor
+    """
+    addrs = []
+    bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
+    for addr, session in bgp_sessions.items():
+        if 'name' in session and session['name'] == hostname:
+            addrs.append(addr)
+    return addrs
+
+def _change_bgp_session_status_by_addr(config_db, ipaddress, status, verbose):
+    """Start up or shut down BGP session by IP address
+    """
+    verb = 'Starting' if status == 'up' else 'Shutting'
+    click.echo("{} {} BGP session with neighbor {}...".format(verb, status, ipaddress))
+
+    config_db.mod_entry('bgp_neighbor', ipaddress, {'admin_status': status})
+
+def _change_bgp_session_status(config_db, ipaddr_or_hostname, status, verbose):
+    """Start up or shut down BGP session by IP address or hostname
+    """
+    ip_addrs = []
+
+    # If we were passed an IP address, convert it to lowercase because IPv6 addresses were
+    # stored in ConfigDB with all lowercase alphabet characters during minigraph parsing
+    if _is_neighbor_ipaddress(config_db, ipaddr_or_hostname.lower()):
+        ip_addrs.append(ipaddr_or_hostname.lower())
+    else:
+        # If <ipaddr_or_hostname> is not the IP address of a neighbor, check to see if it's a hostname
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, ipaddr_or_hostname)
+
+    if not ip_addrs:
+        return False
+
+    for ip_addr in ip_addrs:
+        _change_bgp_session_status_by_addr(config_db, ip_addr, status, verbose)
+
+    return True
+
+def _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname):
+    """validates whether the given ip or host name is a BGP neighbor
+    """
+    ip_addrs = []
+    if _is_neighbor_ipaddress(config_db, neighbor_ip_or_hostname.lower()):
+        ip_addrs.append(neighbor_ip_or_hostname.lower())
+    else:
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, neighbor_ip_or_hostname.upper())
+
+    return ip_addrs
+
+def _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
+    """Removes BGP configuration of the given neighbor
+    """
+    ip_addrs = _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname)
+
+    if not ip_addrs:
+        return False
+
+    for ip_addr in ip_addrs:
+        config_db.mod_entry('bgp_neighbor', ip_addr, None)
+        click.echo("Removed configuration of BGP neighbor {}".format(ip_addr))
+
+    return True
+
+
+#
+# 'bgp' group ('config bgp ...')
+#
+
+@click.group(cls=clicommon.AbbreviationGroup, name='bgp')
+def bgp():
+    """BGP-related configuration tasks"""
+    pass
+
+#
+# 'shutdown' subgroup ('config bgp shutdown ...')
+#
+
+@bgp.group(cls=clicommon.AbbreviationGroup)
+def shutdown():
+    """Shut down BGP session(s)"""
+    pass
+
+# 'all' subcommand
+@shutdown.command()
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+def all(verbose):
+    """Shut down all BGP sessions
+       In the case of Multi-Asic platform, we shut only the EBGP sessions with external neighbors.
+    """
+    log.log_info("'bgp shutdown all' executing...")
+    namespaces = [DEFAULT_NAMESPACE]
+
+    if multi_asic.is_multi_asic():
+        ns_list = multi_asic.get_all_namespaces()
+        namespaces = ns_list['front_ns']
+
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db)
+        for ipaddress in bgp_neighbor_ip_list:
+            _change_bgp_session_status_by_addr(config_db, ipaddress, 'down', verbose)
+
+# 'neighbor' subcommand
+@shutdown.command()
+@click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+def neighbor(ipaddr_or_hostname, verbose):
+    """Shut down BGP session by neighbor IP address or hostname.
+       User can specify either internal or external BGP neighbor to shutdown
+    """
+    log.log_info("'bgp shutdown neighbor {}' executing...".format(ipaddr_or_hostname))
+    namespaces = [DEFAULT_NAMESPACE]
+    found_neighbor = False
+
+    if multi_asic.is_multi_asic():
+        ns_list = multi_asic.get_all_namespaces()
+        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'down', verbose):
+            found_neighbor = True
+
+    if not found_neighbor:
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+
+@bgp.group(cls=clicommon.AbbreviationGroup)
+def startup():
+    """Start up BGP session(s)"""
+    pass
+
+# 'all' subcommand
+@startup.command()
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+def all(verbose):
+    """Start up all BGP sessions
+       In the case of Multi-Asic platform, we startup only the EBGP sessions with external neighbors.
+    """
+    log.log_info("'bgp startup all' executing...")
+    namespaces = [DEFAULT_NAMESPACE]
+
+    if multi_asic.is_multi_asic():
+        ns_list = multi_asic.get_all_namespaces()
+        namespaces = ns_list['front_ns']
+
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db)
+        for ipaddress in bgp_neighbor_ip_list:
+            _change_bgp_session_status_by_addr(config_db, ipaddress, 'up', verbose)
+
+# 'neighbor' subcommand
+@startup.command()
+@click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+def neighbor(ipaddr_or_hostname, verbose):
+    log.log_info("'bgp startup neighbor {}' executing...".format(ipaddr_or_hostname))
+    """Start up BGP session by neighbor IP address or hostname.
+       User can specify either internal or external BGP neighbor to startup
+    """
+    namespaces = [DEFAULT_NAMESPACE]
+    found_neighbor = False
+
+    if multi_asic.is_multi_asic():
+        ns_list = multi_asic.get_all_namespaces()
+        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'up', verbose):
+            found_neighbor = True
+
+    if not found_neighbor:
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+
+#
+# 'remove' subgroup ('config bgp remove ...')
+#
+
+@bgp.group(cls=clicommon.AbbreviationGroup)
+def remove():
+    "Remove BGP neighbor configuration from the device"
+    pass
+
+@remove.command('neighbor')
+@click.argument('neighbor_ip_or_hostname', metavar='<neighbor_ip_or_hostname>', required=True)
+def remove_neighbor(neighbor_ip_or_hostname):
+    """Deletes BGP neighbor configuration of given hostname or ip from devices
+       User can specify either internal or external BGP neighbor to remove
+    """
+    namespaces = [DEFAULT_NAMESPACE]
+    removed_neighbor = False
+
+    if multi_asic.is_multi_asic():
+        ns_list = multi_asic.get_all_namespaces()
+        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+
+    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
+    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db.connect()
+        if _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
+            removed_neighbor = True
+
+    if not removed_neighbor:
+        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor_ip_or_hostname))
+
+
+#
+# 'bgp autonomous-system' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='autonomous-system')
+def bgp_asn():
+    """Specify autonomous system number"""
+    pass
+
+#
+# 'bgp autonomous-system add' command
+#
+@bgp_asn.command('add')
+@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@clicommon.pass_db
+def asn_add(db, as_num):
+    """Add autonomous system number"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if bgp_globals.get("local_asn"):
+        ctx.fail("AS number is already specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"local_asn": as_num})
+
+#
+# 'bgp autonomous-system del' command
+#
+@bgp_asn.command('del')
+@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@clicommon.pass_db
+def asn_del(db, as_num):
+    """Delete autonomous system number"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    local_asn = bgp_globals.get("local_asn")
+    if local_asn:
+        if local_asn != str(as_num):
+            ctx.fail("Configured AS number is {}".format(local_asn))
+    else:
+        ctx.fail("AS number is not configured")
+
+    db.cfgdb.delete_table("ROUTE_REDISTRIBUTE")
+    db.cfgdb.delete_table("BGP_NEIGHBOR_AF")
+    db.cfgdb.delete_table("BGP_NEIGHBOR")
+    db.cfgdb.delete_table("BGP_GLOBALS_AF_NETWORK")
+    db.cfgdb.delete_table("BGP_GLOBALS_AF")
+    db.cfgdb.delete_table("BGP_GLOBALS")
+
+#
+# 'bgp router-id' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='router-id')
+def bgp_router_id():
+    """Configure router identifier"""
+    pass
+
+#
+# 'bgp router-id add' command
+#
+@bgp_router_id.command('add')
+@click.argument('router_id', metavar='<router_id>', required=True)
+@clicommon.pass_db
+def router_id_add(db, router_id):
+    """Add router identifier"""
+    ctx = click.get_current_context()
+
+    try:
+        ipaddress.IPv4Address(router_id)
+    except ValueError as err:
+        ctx.fail("IP address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if bgp_globals.get("router_id"):
+        ctx.fail("Router identifier is already specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"router_id": router_id})
+
+#
+# 'bgp router-id set' command
+#
+@bgp_router_id.command('set')
+@click.argument('router_id', metavar='<router_id>', required=True)
+@clicommon.pass_db
+def router_id_set(db, router_id):
+    """Set router identifier"""
+    ctx = click.get_current_context()
+
+    try:
+        ipaddress.IPv4Address(router_id)
+    except ValueError as err:
+        ctx.fail("IP address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if not bgp_globals.get("router_id"):
+        ctx.fail("Router ID is not configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"router_id": router_id})
+
+#
+# 'bgp router-id del' command
+#
+@bgp_router_id.command('del')
+@click.argument('router_id', metavar='<router_id>', required=True)
+@clicommon.pass_db
+def router_id_del(db, router_id):
+    """Delete router identifier"""
+    ctx = click.get_current_context()
+
+    try:
+        ipaddress.IPv4Address(router_id)
+    except ValueError as err:
+        ctx.fail("IP address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    r_id = bgp_globals.get("router_id")
+    if r_id:
+        if r_id != str(router_id):
+            ctx.fail("Configured router ID is {}".format(r_id))
+    else:
+        ctx.fail("Router ID is not configured")
+
+    if bgp_globals.get("router_id"):
+        del bgp_globals["router_id"]
+        db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
+
+#
+# 'bgp cluster-id' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='cluster-id')
+def bgp_cluster_id():
+    """Configure cluster identifier"""
+    pass
+
+#
+# 'bgp cluster-id add' command
+#
+@bgp_cluster_id.command('add')
+@click.argument('cluster_id', metavar='<cluster_id>', required=True)
+@clicommon.pass_db
+def cluster_id_add(db, cluster_id):
+    """Add cluster identifier"""
+    ctx = click.get_current_context()
+
+    try:
+        ipaddress.IPv4Address(cluster_id)
+    except ValueError as err:
+        ctx.fail("IP address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if bgp_globals.get("rr_cluster_id"):
+        ctx.fail("Cluster ID is already added")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"rr_cluster_id": cluster_id})
+
+#
+# 'bgp cluster-id set' command
+#
+@bgp_cluster_id.command('set')
+@click.argument('cluster_id', metavar='<cluster_id>', required=True)
+@clicommon.pass_db
+def cluster_id_set(db, cluster_id):
+    """Set cluster identifier"""
+    ctx = click.get_current_context()
+
+    try:
+        ipaddress.IPv4Address(cluster_id)
+    except ValueError as err:
+        ctx.fail("IP address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if not bgp_globals.get("rr_cluster_id"):
+        ctx.fail("Cluster ID is not configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"rr_cluster_id": cluster_id})
+
+#
+# 'bgp cluster-id del' command
+#
+@bgp_cluster_id.command('del')
+@click.argument('cluster_id', metavar='<cluster_id>', required=True)
+@clicommon.pass_db
+def cluster_id_del(db, cluster_id):
+    """Delete cluster identifier"""
+    ctx = click.get_current_context()
+
+    try:
+        ipaddress.IPv4Address(cluster_id)
+    except ValueError as err:
+        ctx.fail("IP address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    rr_cluster_id = bgp_globals.get("rr_cluster_id")
+    if rr_cluster_id:
+        if rr_cluster_id != str(cluster_id):
+            ctx.fail("Configured cluster ID is {}".format(rr_cluster_id))
+    else:
+        ctx.fail("Cluster ID is not configured")
+
+    if bgp_globals.get("rr_cluster_id"):
+        del bgp_globals["rr_cluster_id"]
+        db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
+
+#
+# 'bgp ebgp-requires-policy' command
+#
+@bgp.command('ebgp-requires-policy')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def ebgp_requires_policy(db, mode):
+    """Require in and out policy for eBGP peers"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"ebgp_requires_policy": "true" if mode == "on" else "false"})
+
+#
+# 'bgp fast-external-failover' command
+#
+@bgp.command('fast-external-failover')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def fast_ext_failover(db, mode):
+    """Immediately reset session if a link to a directly connected external peer goes down"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"fast_external_failover": "true" if mode == "on" else "false"})
+
+#
+# 'bgp default' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='default')
+def bgp_default():
+    """Configure BGP defaults"""
+    pass
+
+#
+# 'bgp default ipv4-unicast' command
+#
+@bgp_default.command('ipv4-unicast')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def default_ipv4_unicast(db, mode):
+    """Configure ipv4-unicast for a peer by default"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"default_ipv4_unicast": "true" if mode == "on" else "false"})
+
+
+#
+# 'bgp client-to-client' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='client-to-client')
+def bgp_clnt_to_clnt():
+    """Configure client to client route reflection"""
+    pass
+
+#
+# 'bgp client-to-client reflection' command
+#
+@bgp_clnt_to_clnt.command('reflection')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def clnt_to_clnt_refl(db, mode):
+    """Configure reflection of routes"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"rr_clnt_to_clnt_reflection": "true" if mode == "on" else "false"})
+
+#
+# 'bgp bestpath' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='bestpath')
+def bgp_bestpath():
+    """Configure bestpath selection"""
+    pass
+
+#
+# 'bgp bestpath compare-routerid' command
+#
+@bgp_bestpath.command('compare-routerid')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def bestpath_cmp_router_id(db, mode):
+    """Compare router-id for identical EBGP paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"external_compare_router_id": "true" if mode == "on" else "false"})
+
+#
+# 'bgp bestpath as-path' group
+#
+@bgp_bestpath.group(cls=clicommon.AbbreviationGroup, name="as-path")
+def bgp_bestpath_as_path():
+    """Configure AS-path attribute"""
+    pass
+
+#
+# 'bgp bestpath as-path multipath-relax' command
+#
+@bgp_bestpath_as_path.command('multipath-relax')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def as_path_multipath_relax(db, mode):
+    """Allow load sharing across routes that have different AS paths (but same length)"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"load_balance_mp_relax": "true" if mode == "on" else "false"})
+
+#
+# 'bgp listen' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='listen')
+def bgp_listen():
+    """BGP Dynamic Neighbors listen configuration"""
+    pass
+
+#
+# 'bgp listen limit' group
+#
+@bgp_listen.group(cls=clicommon.AbbreviationGroup, name='limit')
+def bgp_listen_limit():
+    """Maximum number of BGP Dynamic Neighbors that can be created"""
+    pass
+
+#
+# 'bgp listen limit add' command
+#
+@bgp_listen_limit.command('add')
+@click.argument('limit', metavar='<limit>', required=True, type=BGP_LISTEN_LIMIT_RANGE)
+@clicommon.pass_db
+def listen_limit_add(db, limit):
+    """Add Dynamic Neighbors listen limit value"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if bgp_globals.get("max_dynamic_neighbors"):
+        ctx.fail("Listen limit is already specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"max_dynamic_neighbors": limit})
+
+#
+# 'bgp listen limit set' command
+#
+@bgp_listen_limit.command('set')
+@click.argument('limit', metavar='<limit>', required=True, type=BGP_LISTEN_LIMIT_RANGE)
+@clicommon.pass_db
+def listen_limit_set(db, limit):
+    """Set Dynamic Neighbors listen limit value"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if not bgp_globals.get("max_dynamic_neighbors"):
+        ctx.fail("Listen limit is not configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"max_dynamic_neighbors": limit})
+
+#
+# 'bgp listen limit del' command
+#
+@bgp_listen_limit.command('del')
+@click.argument('limit', metavar='<limit>', required=True, type=BGP_LISTEN_LIMIT_RANGE)
+@clicommon.pass_db
+def listen_limit_del(db, limit):
+    """Delete Dynamic Neighbors listen limit value"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    max_dyn_neighbors = bgp_globals.get("max_dynamic_neighbors")
+    if max_dyn_neighbors:
+        if max_dyn_neighbors != str(limit):
+            ctx.fail("Configured listen limit is {}".format(max_dyn_neighbors))
+    else:
+        ctx.fail("Listen limit is not configured")
+
+    if bgp_globals.get("max_dynamic_neighbors"):
+        del bgp_globals["max_dynamic_neighbors"]
+        db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
+
+#
+# 'bgp graceful-restart' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='graceful-restart')
+def bgp_gr_restart():
+    """Graceful restart capability parameters"""
+    pass
+
+#
+# 'bgp graceful-restart mode' command
+#
+@bgp_gr_restart.command('mode')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def gr_restart_state(db, mode):
+    """Configure graceful-restart state"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"graceful_restart_enable": "true" if mode == "on" else "false"})
+
+#
+# 'bgp graceful-restart preserve-fw-state' command
+#
+@bgp_gr_restart.command('preserve-fw-state')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def gr_restart_preserve_fw_state(db, mode):
+    """Sets F-bit indication that fib is preserved while doing Graceful Restart"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_preserve_fw_state": "true" if mode == "on" else "false"})
+
+#
+# 'bgp graceful-restart restart-time' group
+#
+@bgp_gr_restart.group(cls=clicommon.AbbreviationGroup, name='restart-time')
+def bgp_gr_restart_time():
+    """Time to wait to delete stale routes before a BGP open message is received"""
+    pass
+
+#
+# 'bgp graceful-restart restart-time add' command
+#
+@bgp_gr_restart_time.command('add')
+@click.argument('time', metavar='<time>', required=True, type=BGP_GR_RESTART_TIME_RANGE)
+@clicommon.pass_db
+def gr_restart_time_add(db, time):
+    """Add the time to wait to delete stale routes before a BGP open message is received"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if bgp_globals.get("gr_restart_time"):
+        ctx.fail("Graceful restart time is already specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_restart_time": time})
+
+#
+# 'bgp graceful-restart restart-time set' command
+#
+@bgp_gr_restart_time.command('set')
+@click.argument('time', metavar='<time>', required=True, type=BGP_GR_RESTART_TIME_RANGE)
+@clicommon.pass_db
+def gr_restart_time_set(db, time):
+    """Set the time to wait to delete stale routes before a BGP open message is received"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if not bgp_globals.get("gr_restart_time"):
+        ctx.fail("Graceful restart time is not configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_restart_time": time})
+
+#
+# 'bgp graceful-restart restart-time del' command
+#
+@bgp_gr_restart_time.command('del')
+@click.argument('time', metavar='<time>', required=True, type=BGP_GR_RESTART_TIME_RANGE)
+@clicommon.pass_db
+def gr_restart_time_del(db, time):
+    """Delete the time to wait to delete stale routes before a BGP open message is received"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    gr_restart_time = bgp_globals.get("gr_restart_time")
+    if gr_restart_time:
+        if gr_restart_time != str(time):
+            ctx.fail("Configured graceful restart time is {}".format(gr_restart_time))
+    else:
+        ctx.fail("Graceful restart time is not configured")
+
+    if bgp_globals.get("gr_restart_time"):
+        del bgp_globals["gr_restart_time"]
+        db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
+
+#
+# 'bgp graceful-restart stalepath-time' group
+#
+@bgp_gr_restart.group(cls=clicommon.AbbreviationGroup, name='stalepath-time')
+def bgp_gr_stalepath_time():
+    """Max time to hold onto restarting peer's stale paths"""
+    pass
+
+#
+# 'bgp graceful-restart stalepath-time add' command
+#
+@bgp_gr_stalepath_time.command('add')
+@click.argument('time', metavar='<time>', required=True, type=BGP_GR_STALEPATH_TIME_RANGE)
+@clicommon.pass_db
+def gr_stalepath_time_add(db, time):
+    """Add the max time to hold onto restarting peer's stale paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if bgp_globals.get("gr_stale_routes_time"):
+        ctx.fail("Graceful restart stalepath time is already specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_stale_routes_time": time})
+
+#
+# 'bgp graceful-restart stalepath-time set' command
+#
+@bgp_gr_stalepath_time.command('set')
+@click.argument('time', metavar='<time>', required=True, type=BGP_GR_STALEPATH_TIME_RANGE)
+@clicommon.pass_db
+def gr_stalepath_time_set(db, time):
+    """Set the max time to hold onto restarting peer's stale paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    if not bgp_globals.get("gr_stale_routes_time"):
+        ctx.fail("Graceful restart stalepath time is not configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_stale_routes_time": time})
+
+#
+# 'bgp graceful-restart stalepath-time del' command
+#
+@bgp_gr_stalepath_time.command('del')
+@click.argument('time', metavar='<time>', required=True, type=BGP_GR_STALEPATH_TIME_RANGE)
+@clicommon.pass_db
+def gr_stalepath_time_del(db, time):
+    """Delete the max time to hold onto restarting peer's stale paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    gr_stale_routes_time = bgp_globals.get("gr_stale_routes_time")
+    if gr_stale_routes_time:
+        if gr_stale_routes_time != str(time):
+            ctx.fail("Configured graceful restart stalepath time is {}".format(gr_stale_routes_time))
+    else:
+        ctx.fail("Graceful restart stalepath time is not configured")
+
+    if bgp_globals.get("gr_stale_routes_time"):
+        del bgp_globals["gr_stale_routes_time"]
+        db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
+
+#
+# 'bgp neighbor' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='neighbor')
+def bgp_neighbor():
+    """Configure BGP neighbors"""
+    pass
+
+#
+# 'bgp neighbor remote-as' group
+#
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='remote-as')
+def bgp_remote_as():
+    """Configure BGP neighbor remote-as"""
+    pass
+
+#
+# 'bgp neighbor remote-as add' command
+#
+@bgp_remote_as.command('add')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('remote-as', metavar='<as_num|external|internal>', required=True)
+@clicommon.pass_db
+def neighbor_remote_as_add(db, ip_intf, remote_as):
+    """Add BGP neighbor remote-as"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    if remote_as not in ["external", "internal"]:
+        try:
+            if int(remote_as) not in range(BGP_ASN_MIN, BGP_ASN_MAX):
+                raise ValueError
+        except ValueError:
+            ctx.fail("Remote AS is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if bgp_neighbor.get("asn"):
+        ctx.fail("BGP neighbor remote-as already exists")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"asn": remote_as})
+
+#
+# 'bgp neighbor remote-as set' command
+#
+@bgp_remote_as.command('set')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('remote-as', metavar='<as_num|external|internal>', required=True)
+@clicommon.pass_db
+def neighbor_remote_as_set(db, ip_intf, remote_as):
+    """Set BGP neighbor remote-as"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    if remote_as not in ["external", "internal"]:
+        try:
+            if int(remote_as) not in range(BGP_ASN_MIN, BGP_ASN_MAX):
+                raise ValueError
+        except ValueError:
+            ctx.fail("Remote AS is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("BGP neighbor remote-as is not configured")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"asn": remote_as})
+
+#
+# 'bgp neighbor remote-as del' command
+#
+@bgp_remote_as.command('del')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('remote-as', metavar='<as_num|external|internal>', required=True)
+@clicommon.pass_db
+def neighbor_remote_as_del(db, ip_intf, remote_as):
+    """Delete BGP neighbor remote-as"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    if remote_as not in ["external", "internal"]:
+        try:
+            if int(remote_as) not in range(BGP_ASN_MIN, BGP_ASN_MAX):
+                raise ValueError
+        except ValueError:
+            ctx.fail("Remote AS is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor:
+        ctx.fail("BGP neighbor does not exist")
+
+    asn = bgp_neighbor.get("asn")
+    if asn:
+        if asn != str(remote_as):
+            ctx.fail("Configured BGP neighbor remote-as is {}".format(asn))
+    else:
+        ctx.fail("BGP neighbor remote-as is not configured")
+
+    db.cfgdb.set_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), None)
+    db.cfgdb.set_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "ipv4_unicast"), None)
+    db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), None)
+
+#
+# 'bgp neighbor update-source' group
+#
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='update-source')
+def bgp_neighbor_upd_source():
+    """Configure BGP neighbor update-source"""
+    pass
+
+#
+# 'bgp neighbor update-source add' command
+#
+@bgp_neighbor_upd_source.command('add')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('upd_source', metavar='<ip_addr|interface_name>', required=True)
+@clicommon.pass_db
+def neighbor_upd_source_add(db, ip_intf, upd_source):
+    """Add BGP neighbor update-source"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    if not get_interface_table_name(upd_source):
+        try:
+            ipaddress.ip_address(upd_source)
+        except ValueError:
+            ctx.fail("Update source interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if bgp_neighbor.get("local_addr"):
+        ctx.fail("BGP neighbor update source already exists")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"local_addr": upd_source})
+
+#
+# 'bgp neighbor update-source set' command
+#
+@bgp_neighbor_upd_source.command('set')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('upd_source', metavar='<ip_addr|interface_name>', required=True)
+@clicommon.pass_db
+def neighbor_upd_source_set(db, ip_intf, upd_source):
+    """Set BGP neighbor update-source"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    if not get_interface_table_name(upd_source):
+        try:
+            ipaddress.ip_address(upd_source)
+        except ValueError:
+            ctx.fail("Update source interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if not bgp_neighbor.get("local_addr"):
+        ctx.fail("BGP neighbor update source is not configured")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"local_addr": upd_source})
+
+#
+# 'bgp neighbor update-source del' command
+#
+@bgp_neighbor_upd_source.command('del')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('upd_source', metavar='<ip_addr|interface_name>', required=True)
+@clicommon.pass_db
+def neighbor_upd_source_del(db, ip_intf, upd_source):
+    """Delete BGP neighbor update-source"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    if not get_interface_table_name(upd_source):
+        try:
+            ipaddress.ip_address(upd_source)
+        except ValueError:
+            ctx.fail("Update source interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor:
+        ctx.fail("BGP neighbor does not exist")
+
+    local_addr = bgp_neighbor.get("local_addr")
+    if local_addr:
+        if upd_source != str(local_addr):
+            ctx.fail("Configured BGP neighbor update source is {}".format(local_addr))
+    else:
+        ctx.fail("BGP neighbor update source is not configured")
+
+    del bgp_neighbor["local_addr"]
+    db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
+
+#
+# 'bgp neighbor advertisement-interval' group
+#
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='advertisement-interval')
+def bgp_neighbor_adv_interval():
+    """Minimum interval between sending BGP routing updates"""
+    pass
+
+#
+# 'bgp neighbor advertisement-interval add' command
+#
+@bgp_neighbor_adv_interval.command('add')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('interval', metavar='<interval>', required=True, type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE)
+@clicommon.pass_db
+def neighbor_adv_int_add(db, ip_intf, interval):
+    """Add minimum interval between sending BGP routing updates"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if bgp_neighbor.get("min_adv_interval"):
+        ctx.fail("BGP neighbor advertisement interval already exists")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"min_adv_interval": interval})
+
+#
+# 'bgp neighbor advertisement-interval set' command
+#
+@bgp_neighbor_adv_interval.command('set')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('interval', metavar='<interval>', required=True, type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE)
+@clicommon.pass_db
+def neighbor_adv_int_set(db, ip_intf, interval):
+    """Set minimum interval between sending BGP routing updates"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if not bgp_neighbor.get("min_adv_interval"):
+        ctx.fail("BGP neighbor advertisement interval is not configured")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"min_adv_interval": interval})
+
+#
+# 'bgp neighbor advertisement-interval del' command
+#
+@bgp_neighbor_adv_interval.command('del')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('interval', metavar='<interval>', required=True, type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE)
+@clicommon.pass_db
+def neighbor_adv_int_del(db, ip_intf, interval):
+    """Delete minimum interval between sending BGP routing updates"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor:
+        ctx.fail("BGP neighbor does not exist")
+
+    min_adv_interval = bgp_neighbor.get("min_adv_interval")
+    if min_adv_interval:
+        if min_adv_interval != str(interval):
+            ctx.fail("Configured BGP neighbor advertisement interval is {}".format(min_adv_interval))
+    else:
+        ctx.fail("BGP neighbor advertisement interval is not configured")
+
+    del bgp_neighbor["min_adv_interval"]
+    db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
+
+#
+# 'bgp neighbor timers' group
+#
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='timers')
+def bgp_neighbor_timers():
+    """Configure BGP neighbor timers"""
+    pass
+
+#
+# 'bgp neighbor timers add' command
+#
+@bgp_neighbor_timers.command('add')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('keepalive', metavar='<keepalive>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@click.argument('holdtime', metavar='<holdtime>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@clicommon.pass_db
+def neighbor_timers_add(db, ip_intf, keepalive, holdtime):
+    """Add BGP neighbor timers"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if bgp_neighbor.get("keepalive") and bgp_neighbor.get("holdtime"):
+        ctx.fail("BGP neighbor timers are already configured")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"keepalive": keepalive,
+                                                              "holdtime": holdtime})
+
+#
+# 'bgp neighbor timers set' command
+#
+@bgp_neighbor_timers.command('set')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('keepalive', metavar='<keepalive>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@click.argument('holdtime', metavar='<holdtime>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@clicommon.pass_db
+def neighbor_timers_set(db, ip_intf, keepalive, holdtime):
+    """Set BGP neighbor timers"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if not bgp_neighbor.get("keepalive") or not bgp_neighbor.get("holdtime"):
+        ctx.fail("BGP neighbor timers are not configured")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"keepalive": keepalive,
+                                                              "holdtime": holdtime})
+
+#
+# 'bgp neighbor timers del' command
+#
+@bgp_neighbor_timers.command('del')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('keepalive', metavar='<keepalive>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@click.argument('holdtime', metavar='<holdtime>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@clicommon.pass_db
+def neighbor_timers_del(db, ip_intf, keepalive, holdtime):
+    """Delete BGP neighbor timers"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor:
+        ctx.fail("BGP neighbor does not exist")
+
+    keepalive_entry = bgp_neighbor.get("keepalive")
+    holdtime_entry = bgp_neighbor.get("holdtime")
+    if keepalive_entry and holdtime_entry:
+        if keepalive_entry != str(keepalive) or holdtime_entry != str(holdtime):
+            ctx.fail("Configured BGP neighbor timers are {} {}".format(keepalive_entry, holdtime_entry))
+    else:
+        ctx.fail("BGP neighbor timers are not configured")
+
+    if bgp_neighbor.get("keepalive"):
+        del bgp_neighbor["keepalive"]
+    if bgp_neighbor.get("holdtime"):
+        del bgp_neighbor["holdtime"]
+    db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
+
+#
+# 'bgp neighbor local-as' group
+#
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='local-as')
+def bgp_neighbor_local_as():
+    """Specify a local-as number"""
+    pass
+
+#
+# 'bgp neighbor local-as add' command
+#
+@bgp_neighbor_local_as.command('add')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@click.option('--no-prepend', required=False, is_flag=True)
+@click.option('--replace-as', required=False, is_flag=True)
+@clicommon.pass_db
+def neighbor_local_as_add(db, ip_intf, as_num, no_prepend, replace_as):
+    """Add AS number used as local AS"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if bgp_neighbor.get("local_asn"):
+        ctx.fail("BGP neighbor local AS is already specified")
+
+    if str(as_num) == bgp_globals.get("local_asn"):
+        ctx.fail("Cannot have local-as same as BGP AS number")
+
+    if not no_prepend and replace_as:
+        ctx.fail("--no-prepend flag must be used with --replace-as")
+
+    bgp_neighbor["local_asn"] = as_num
+    bgp_neighbor["local_as_no_prepend"] = "true" if no_prepend else "false"
+    bgp_neighbor["local_as_replace_as"] = "true" if replace_as else "false"
+    db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
+
+#
+# 'bgp neighbor local-as set' command
+#
+@bgp_neighbor_local_as.command('set')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@click.option('--no-prepend', required=False, is_flag=True)
+@click.option('--replace-as', required=False, is_flag=True)
+@clicommon.pass_db
+def neighbor_local_as_set(db, ip_intf, as_num, no_prepend, replace_as):
+    """Set AS number used as local AS"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+    if not bgp_neighbor.get("local_asn"):
+        ctx.fail("BGP neighbor local AS is not configured")
+
+    if str(as_num) == bgp_globals.get("local_asn"):
+        ctx.fail("Cannot have local-as same as BGP AS number")
+
+    if not no_prepend and replace_as:
+        ctx.fail("--no-prepend flag must be used with --replace-as")
+
+    bgp_neighbor["local_asn"] = as_num
+    bgp_neighbor["local_as_no_prepend"] = "true" if no_prepend else "false"
+    bgp_neighbor["local_as_replace_as"] = "true" if replace_as else "false"
+    db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
+
+#
+# 'bgp neighbor local-as del' command
+#
+@bgp_neighbor_local_as.command('del')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@clicommon.pass_db
+def neighbor_local_as_del(db, ip_intf, as_num):
+    """Delete AS number used as local AS"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor:
+        ctx.fail("BGP neighbor does not exist")
+
+    local_asn = bgp_neighbor.get("local_asn")
+    if local_asn:
+        if local_asn != str(as_num):
+            ctx.fail("Configured BGP neighbor local AS is {}".format(local_asn))
+    else:
+        ctx.fail("BGP neighbor local AS is not configured")
+
+    del bgp_neighbor["local_asn"]
+    if bgp_neighbor.get("local_as_no_prepend"):
+        del bgp_neighbor["local_as_no_prepend"]
+    if bgp_neighbor.get("local_as_replace_as"):
+        del bgp_neighbor["local_as_replace_as"]
+    db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
+
+#
+# 'bgp neighbor shutdown' command
+#
+@bgp_neighbor.command('shutdown')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def neighbor_shutdown(db, ip_intf, mode):
+    """Administratively shut down BGP neighbor"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"admin_status": "false" if mode == "on" else "true"})
+
+#
+# 'bgp neighbor ebgp-multihop' command
+#
+@bgp_neighbor.command('ebgp-multihop')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@click.option('--max-hops', metavar='<max_hops>', required=False, type=BGP_NEIGHBOR_MULTIHOP_RANGE)
+@clicommon.pass_db
+def neighbor_multihop(db, ip_intf, mode, max_hops):
+    """Allow EBGP neighbors on not directly connected networks"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+
+    if bgp_neighbor.get("asn") != "internal" and bgp_neighbor.get("asn") != bgp_globals.get("local_asn"):
+        bgp_neighbor["ebgp_multihop"] = "true" if mode == "on" else "false"
+        if max_hops:
+            bgp_neighbor["ebgp_multihop_ttl"] = max_hops
+        elif bgp_neighbor.get("ebgp_multihop_ttl"):
+            del bgp_neighbor["ebgp_multihop_ttl"]
+        db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
+    else:
+        ctx.fail("Invalid command. Not an external neighbor")
+
+#
+# 'bgp address-family' group
+#
+@bgp.group(cls=clicommon.AbbreviationGroup, name='address-family')
+def bgp_addr():
+    """Address family configuration"""
+    pass
+
+#
+# 'bgp address-family ipv4' group
+#
+@bgp_addr.group(cls=clicommon.AbbreviationGroup, name='ipv4')
+def bgp_addr_ipv4():
+    """IPv4 address family configuration"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast' group
+#
+@bgp_addr_ipv4.group(cls=clicommon.AbbreviationGroup, name='unicast')
+def bgp_addr_ipv4_unicast():
+    """IPv4 unicast address family configuration"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast neighbor' group
+#
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='neighbor')
+def bgp_addr_ipv4_unicast_neighbor():
+    """IPv4 unicast neighbor address family configuration"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast neighbor activate' command
+#
+@bgp_addr_ipv4_unicast_neighbor.command('activate')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def ipv4_neighbor_activate(db, ip_intf, mode):
+    """IPv4 neighbor activate"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "ipv4_unicast"), {"admin_status": "true" if mode == "on" else "false"})
+
+#
+# 'bgp address-family ipv4 unicast network' group
+#
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='network')
+def bgp_addr_ipv4_unicast_network():
+    """IPv4 unicast network address family configuration"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast network add' command
+#
+@bgp_addr_ipv4_unicast_network.command('add')
+@click.argument('network', metavar='<network>', required=True)
+@clicommon.pass_db
+def ipv4_unicast_network_add(db, network):
+    """Add IPv4 unicast network"""
+    ctx = click.get_current_context()
+
+    try:
+        network = ipaddress.IPv4Network(network, True)
+    except ValueError as err:
+        ctx.fail("Network address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af_net = db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK").keys()
+    if ("default", "ipv4_unicast", str(network)) in bgp_globals_af_net:
+        ctx.fail("IPv4 unicast network already exists")
+
+    db.cfgdb.set_entry("BGP_GLOBALS_AF_NETWORK", ("default|ipv4_unicast", str(network)), {})
+
+#
+# 'bgp address-family ipv4 unicast network del' command
+#
+@bgp_addr_ipv4_unicast_network.command('del')
+@click.argument('network', metavar='<network>', required=True)
+@clicommon.pass_db
+def ipv4_unicast_network_del(db, network):
+    """Delete IPv4 unicast network"""
+    ctx = click.get_current_context()
+
+    try:
+        network = ipaddress.IPv4Network(network, True)
+    except ValueError as err:
+        ctx.fail("Network address is not valid: {}".format(err))
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af_net = db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK").keys()
+    if ("default", "ipv4_unicast", str(network)) not in bgp_globals_af_net:
+        ctx.fail("IPv4 unicast network does not exist")
+
+    db.cfgdb.set_entry("BGP_GLOBALS_AF_NETWORK", ("default|ipv4_unicast", str(network)), None)
+
+#
+# 'bgp address-family ipv4 unicast max-paths' group
+#
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='max-paths')
+def bgp_addr_ipv4_unicast_max_paths():
+    """IPv4 unicast max-paths address family configuration"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast max-paths add' command
+#
+@bgp_addr_ipv4_unicast_max_paths.command('add')
+@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@clicommon.pass_db
+def max_paths_add(db, paths_num):
+    """Add IPv4 unicast max-paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    if bgp_globals_af.get("max_ebgp_paths"):
+        ctx.fail("Max paths number is already specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"max_ebgp_paths": paths_num})
+
+#
+# 'bgp address-family ipv4 unicast max-paths set' command
+#
+@bgp_addr_ipv4_unicast_max_paths.command('set')
+@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@clicommon.pass_db
+def max_paths_set(db, paths_num):
+    """Set IPv4 unicast max-paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    if not bgp_globals_af.get("max_ebgp_paths"):
+        ctx.fail("Max-paths number is not configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"max_ebgp_paths": paths_num})
+
+#
+# 'bgp address-family ipv4 unicast max-paths del' command
+#
+@bgp_addr_ipv4_unicast_max_paths.command('del')
+@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@clicommon.pass_db
+def max_paths_del(db, paths_num):
+    """Delete IPv4 unicast max-paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    max_ebgp_paths = bgp_globals_af.get("max_ebgp_paths")
+    if max_ebgp_paths:
+        if max_ebgp_paths != str(paths_num):
+            ctx.fail("Configured max-paths number is {}".format(max_ebgp_paths))
+    else:
+        ctx.fail("Max-paths number is not configured")
+
+    del bgp_globals_af["max_ebgp_paths"]
+    db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
+
+
+#
+# 'bgp address-family ipv4 unicast max-paths ibgp' group
+#
+@bgp_addr_ipv4_unicast_max_paths.group(cls=clicommon.AbbreviationGroup, name='ibgp')
+def bgp_addr_ipv4_unicast_max_paths_ibgp():
+    """IPv4 unicast ibgp max-paths address family configuration"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast max-paths ibgp add' command
+#
+@bgp_addr_ipv4_unicast_max_paths_ibgp.command('add')
+@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@click.option('--equal-cluster-length', required=False, is_flag=True)
+@clicommon.pass_db
+def max_paths_ibgp_add(db, paths_num, equal_cluster_length):
+    """Add IPv4 unicast ibgp max-paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    if bgp_globals_af.get("max_ibgp_paths"):
+        ctx.fail("Max ibgp paths number is already specified")
+
+    bgp_globals_af["max_ibgp_paths"] = paths_num
+    bgp_globals_af["ibgp_equal_cluster_length"] = "true" if equal_cluster_length else "false"
+    db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
+
+#
+# 'bgp address-family ipv4 unicast max-paths ibgp set' command
+#
+@bgp_addr_ipv4_unicast_max_paths_ibgp.command('set')
+@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@click.option('--equal-cluster-length', required=False, is_flag=True)
+@clicommon.pass_db
+def max_paths_ibgp_set(db, paths_num, equal_cluster_length):
+    """Set IPv4 unicast ibgp max-paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    if not bgp_globals_af.get("max_ibgp_paths"):
+        ctx.fail("Max-paths ibgp number is not configured")
+
+    bgp_globals_af["max_ibgp_paths"] = paths_num
+    bgp_globals_af["ibgp_equal_cluster_length"] = "true" if equal_cluster_length else "false"
+    db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
+
+#
+# 'bgp address-family ipv4 unicast max-paths ibgp del' command
+#
+@bgp_addr_ipv4_unicast_max_paths_ibgp.command('del')
+@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@clicommon.pass_db
+def max_paths_ibgp_del(db, paths_num):
+    """Delete IPv4 unicast ibgp max-paths"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    max_ibgp_paths = bgp_globals_af.get("max_ibgp_paths")
+    if max_ibgp_paths:
+        if max_ibgp_paths != str(paths_num):
+            ctx.fail("Configured max-paths ibgp number is {}".format(max_ibgp_paths))
+    else:
+        ctx.fail("Max-paths ibgp number is not configured")
+
+    del bgp_globals_af["max_ibgp_paths"]
+    if bgp_globals_af.get("ibgp_equal_cluster_length"):
+        del bgp_globals_af["ibgp_equal_cluster_length"]
+    db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
+
+#
+# 'bgp address-family ipv4 unicast distance' group
+#
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='distance')
+def bgp_addr_ipv4_unicast_dist():
+    """Define an administrative distance"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast distance bgp' group
+#
+@bgp_addr_ipv4_unicast_dist.group(cls=clicommon.AbbreviationGroup, name='bgp')
+def bgp_addr_ipv4_unicast_dist_bgp():
+    """BGP distance"""
+    pass
+
+#
+# 'bgp address-family ipv4 unicast distance bgp add' command
+#
+@bgp_addr_ipv4_unicast_dist_bgp.command('add')
+@click.argument('ebgp_dist', metavar='<ebgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@click.argument('ibgp_dist', metavar='<ibgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@click.argument('local_dist', metavar='<local_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@clicommon.pass_db
+def distance_bgp_add(db, ebgp_dist, ibgp_dist, local_dist):
+    """Add BGP distance"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    if (bgp_globals_af.get("ebgp_route_distance") and
+        bgp_globals_af.get("ibgp_route_distance") and
+        bgp_globals_af.get("local_route_distance")):
+        ctx.fail("BGP distance values are already configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"ebgp_route_distance": ebgp_dist,
+                                                                  "ibgp_route_distance": ibgp_dist,
+                                                                  "local_route_distance": local_dist})
+
+#
+# 'bgp address-family ipv4 unicast distance bgp set' command
+#
+@bgp_addr_ipv4_unicast_dist_bgp.command('set')
+@click.argument('ebgp_dist', metavar='<ebgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@click.argument('ibgp_dist', metavar='<ibgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@click.argument('local_dist', metavar='<local_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@clicommon.pass_db
+def distance_bgp_set(db, ebgp_dist, ibgp_dist, local_dist):
+    """Set BGP distance"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    if (not bgp_globals_af.get("ebgp_route_distance") or
+        not bgp_globals_af.get("ibgp_route_distance") or
+        not bgp_globals_af.get("local_route_distance")):
+        ctx.fail("Distance bgp values are not configured")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"ebgp_route_distance": ebgp_dist,
+                                                                  "ibgp_route_distance": ibgp_dist,
+                                                                  "local_route_distance": local_dist})
+
+#
+# 'bgp address-family ipv4 unicast distance bgp del' command
+#
+@bgp_addr_ipv4_unicast_dist_bgp.command('del')
+@click.argument('ebgp_dist', metavar='<ebgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@click.argument('ibgp_dist', metavar='<ibgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@click.argument('local_dist', metavar='<local_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@clicommon.pass_db
+def distance_bgp_del(db, ebgp_dist, ibgp_dist, local_dist):
+    """Delete BGP distance"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
+    ebgp_rt_dist = bgp_globals_af.get("ebgp_route_distance")
+    ibgp_rt_dist = bgp_globals_af.get("ibgp_route_distance")
+    local_rt_dist = bgp_globals_af.get("local_route_distance")
+
+    if ebgp_rt_dist and ibgp_rt_dist and local_rt_dist:
+        if (ebgp_rt_dist != str(ebgp_dist) or
+            ibgp_rt_dist != str(ibgp_dist) or
+            local_rt_dist != str(local_dist)):
+            ctx.fail("Configured distance bgp values are {} {} {}".format(ebgp_rt_dist, ibgp_rt_dist, local_rt_dist))
+    else:
+        ctx.fail("Distance bgp values are not configured")
+
+    if bgp_globals_af.get("ebgp_route_distance"):
+        del bgp_globals_af["ebgp_route_distance"]
+    if bgp_globals_af.get("ibgp_route_distance"):
+        del bgp_globals_af["ibgp_route_distance"]
+    if bgp_globals_af.get("local_route_distance"):
+        del bgp_globals_af["local_route_distance"]
+    db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
+
+#
+# 'bgp address-family ipv4 redistribute' group
+#
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='redistribute')
+def bgp_addr_ipv4_unicast_redist():
+    """Redistribute information from another routing protocol"""
+    pass
+
+#
+# 'bgp address-family ipv4 redistribute connected' command
+#
+@bgp_addr_ipv4_unicast_redist.command('connected')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def redist_connected(db, mode):
+    """Connected routes (directly attached subnet or host)"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.set_entry("ROUTE_REDISTRIBUTE", "default|connected|bgp|ipv4", {} if mode == "on" else None)
+
+#
+# 'bgp address-family l2vpn' group
+#
+@bgp_addr.group(cls=clicommon.AbbreviationGroup, name='l2vpn')
+def bgp_addr_l2vpn():
+    """L2VPN address family configuration"""
+    pass
+
+#
+# 'bgp address-family l2vpn evpn' group
+#
+@bgp_addr_l2vpn.group(cls=clicommon.AbbreviationGroup, name='evpn')
+def bgp_addr_l2vpn_evpn():
+    """L2VPN EVPN address family configuration"""
+    pass
+
+#
+# 'bgp address-family l2vpn evpn advertise-all-vni' command
+#
+@bgp_addr_l2vpn_evpn.command('advertise-all-vni')
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def advertise_all_vni(db, mode):
+    """Advertise all local VNIs"""
+    ctx = click.get_current_context()
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|l2vpn_evpn", {"advertise-all-vni": "true" if mode == "on" else "false"})
+
+#
+# 'bgp address-family l2vpn evpn neighbor' group
+#
+@bgp_addr_l2vpn_evpn.group(cls=clicommon.AbbreviationGroup, name='neighbor')
+def bgp_addr_l2vpn_evpn_neighbor():
+    """L2VPN EVPN neighbor address family configuration"""
+    pass
+
+#
+# 'bgp address-family l2vpn evpn neighbor activate' command
+#
+@bgp_addr_l2vpn_evpn_neighbor.command('activate')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def evpn_neighbor_activate(db, ip_intf, mode):
+    """L2VPN EVPN neighbor activate"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), {"admin_status": "true" if mode == "on" else "false"})
+
+#
+# 'bgp address-family l2vpn evpn neighbor route-reflector-client' command
+#
+@bgp_addr_l2vpn_evpn_neighbor.command('route-reflector-client')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def evpn_neighbor_rrc(db, ip_intf, mode):
+    """L2VPN EVPN neighbor route-reflector-client"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+
+    if bgp_neighbor.get("asn") == bgp_globals.get("local_asn") or bgp_neighbor.get("asn") == "internal":
+        db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), {"rrclient": "true" if mode == "on" else "false"})
+    else:
+        ctx.fail("Invalid command. Not an internal neighbor")
+
+#
+# 'bgp address-family l2vpn evpn neighbor soft-reconf' group
+#
+@bgp_addr_l2vpn_evpn_neighbor.group(cls=clicommon.AbbreviationGroup, name='soft-reconf')
+def bgp_addr_l2vpn_evpn_neighbor_soft_reconf():
+    """L2VPN EVPN neighbor soft reconfiguration"""
+    pass
+
+#
+# 'bgp address-family l2vpn evpn neighbor soft-reconf inbound' command
+#
+@bgp_addr_l2vpn_evpn_neighbor_soft_reconf.command('inbound')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@clicommon.pass_db
+def evpn_neighbor_reconf_inbound(db, ip_intf, mode):
+    """Allow neighbor inbound soft reconfiguration"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+
+    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), {"soft_reconfiguration_in": "true" if mode == "on" else "false"})
+
+#
+# 'bgp address-family l2vpn evpn neighbor allowas-in' command
+#
+@bgp_addr_l2vpn_evpn_neighbor.command('allowas-in')
+@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@click.option('--allowas', metavar='<1-10|origin>', required=False)
+@clicommon.pass_db
+def evpn_neighbor_allowas_in(db, ip_intf, mode, allowas):
+    """Accept as-path with my AS present in it"""
+    ctx = click.get_current_context()
+
+    if not get_interface_table_name(ip_intf):
+        try:
+            ipaddress.ip_address(ip_intf)
+        except ValueError:
+            ctx.fail("Neighbor interface/IP address is not valid")
+
+    if allowas:
+        if allowas != "origin":
+            try:
+                if int(allowas) not in range(BGP_NEIGHBOR_ALLOWAS_MIN, BGP_NEIGHBOR_ALLOWAS_MAX):
+                    raise ValueError
+            except ValueError:
+                ctx.fail("'--allowas' argument is not valid")
+
+    bgp_globals = db.cfgdb.get_entry("BGP_GLOBALS", "default")
+    if not bgp_globals.get("local_asn"):
+        ctx.fail("AS number is not specified")
+
+    bgp_neighbor = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    if not bgp_neighbor.get("asn"):
+        ctx.fail("Specify BGP neighbor remote-as first")
+
+    bgp_neighbor_af = db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", ip_intf))
+    bgp_neighbor_af["allow_as_in"] = "true" if mode == "on" else "false"
+    if allowas:
+        if allowas == "origin":
+            bgp_neighbor_af["allow_as_origin"] = "true"
+        else:
+            bgp_neighbor_af["allow_as_count"] = allowas
+    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), bgp_neighbor_af)
+

--- a/config/bgp.py
+++ b/config/bgp.py
@@ -8,7 +8,7 @@ import utilities_common.cli as clicommon
 
 from .utils import log
 
-DEFAULT_NAMESPACE = ''
+DEFAULT_NAMESPACE = ""
 
 BGP_NEIGHBOR_ALLOWAS_MIN = 1
 BGP_NEIGHBOR_ALLOWAS_MAX = 10
@@ -25,44 +25,43 @@ BGP_IPV4_UNICAST_MAX_PATHS_RANGE = click.IntRange(min=1, max=256)
 BGP_IPV4_UNICAST_DISTANCE_RANGE = click.IntRange(min=1, max=255)
 
 
-
 def _is_neighbor_ipaddress(config_db, ipaddress):
-    """Returns True if a neighbor has the IP address <ipaddress>, False if not
-    """
-    entry = config_db.get_entry('BGP_NEIGHBOR', ipaddress)
+    """Returns True if a neighbor has the IP address <ipaddress>, False if not"""
+    entry = config_db.get_entry("BGP_NEIGHBOR", ipaddress)
     return True if entry else False
 
+
 def _get_all_neighbor_ipaddresses(config_db):
-    """Returns list of strings containing IP addresses of all BGP neighbors
-    """
+    """Returns list of strings containing IP addresses of all BGP neighbors"""
     addrs = []
-    bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
+    bgp_sessions = config_db.get_table("BGP_NEIGHBOR")
     for addr, session in bgp_sessions.items():
         addrs.append(addr)
     return addrs
 
+
 def _get_neighbor_ipaddress_list_by_hostname(config_db, hostname):
     """Returns list of strings, each containing an IP address of neighbor with
-       hostname <hostname>. Returns empty list if <hostname> not a neighbor
+    hostname <hostname>. Returns empty list if <hostname> not a neighbor
     """
     addrs = []
-    bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
+    bgp_sessions = config_db.get_table("BGP_NEIGHBOR")
     for addr, session in bgp_sessions.items():
-        if 'name' in session and session['name'] == hostname:
+        if "name" in session and session["name"] == hostname:
             addrs.append(addr)
     return addrs
 
+
 def _change_bgp_session_status_by_addr(config_db, ipaddress, status, verbose):
-    """Start up or shut down BGP session by IP address
-    """
-    verb = 'Starting' if status == 'up' else 'Shutting'
+    """Start up or shut down BGP session by IP address"""
+    verb = "Starting" if status == "up" else "Shutting"
     click.echo("{} {} BGP session with neighbor {}...".format(verb, status, ipaddress))
 
-    config_db.mod_entry('bgp_neighbor', ipaddress, {'admin_status': status})
+    config_db.mod_entry("bgp_neighbor", ipaddress, {"admin_status": status})
+
 
 def _change_bgp_session_status(config_db, ipaddr_or_hostname, status, verbose):
-    """Start up or shut down BGP session by IP address or hostname
-    """
+    """Start up or shut down BGP session by IP address or hostname"""
     ip_addrs = []
 
     # If we were passed an IP address, convert it to lowercase because IPv6 addresses were
@@ -71,7 +70,9 @@ def _change_bgp_session_status(config_db, ipaddr_or_hostname, status, verbose):
         ip_addrs.append(ipaddr_or_hostname.lower())
     else:
         # If <ipaddr_or_hostname> is not the IP address of a neighbor, check to see if it's a hostname
-        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, ipaddr_or_hostname)
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(
+            config_db, ipaddr_or_hostname
+        )
 
     if not ip_addrs:
         return False
@@ -81,27 +82,29 @@ def _change_bgp_session_status(config_db, ipaddr_or_hostname, status, verbose):
 
     return True
 
+
 def _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname):
-    """validates whether the given ip or host name is a BGP neighbor
-    """
+    """validates whether the given ip or host name is a BGP neighbor"""
     ip_addrs = []
     if _is_neighbor_ipaddress(config_db, neighbor_ip_or_hostname.lower()):
         ip_addrs.append(neighbor_ip_or_hostname.lower())
     else:
-        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, neighbor_ip_or_hostname.upper())
+        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(
+            config_db, neighbor_ip_or_hostname.upper()
+        )
 
     return ip_addrs
 
+
 def _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
-    """Removes BGP configuration of the given neighbor
-    """
+    """Removes BGP configuration of the given neighbor"""
     ip_addrs = _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname)
 
     if not ip_addrs:
         return False
 
     for ip_addr in ip_addrs:
-        config_db.mod_entry('bgp_neighbor', ip_addr, None)
+        config_db.mod_entry("bgp_neighbor", ip_addr, None)
         click.echo("Removed configuration of BGP neighbor {}".format(ip_addr))
 
     return True
@@ -111,33 +114,37 @@ def _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
 # 'bgp' group ('config bgp ...')
 #
 
-@click.group(cls=clicommon.AbbreviationGroup, name='bgp')
+
+@click.group(cls=clicommon.AbbreviationGroup, name="bgp")
 def bgp():
     """BGP-related configuration tasks"""
     pass
 
+
 #
 # 'shutdown' subgroup ('config bgp shutdown ...')
 #
+
 
 @bgp.group(cls=clicommon.AbbreviationGroup)
 def shutdown():
     """Shut down BGP session(s)"""
     pass
 
+
 # 'all' subcommand
 @shutdown.command()
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output")
 def all(verbose):
     """Shut down all BGP sessions
-       In the case of Multi-Asic platform, we shut only the EBGP sessions with external neighbors.
+    In the case of Multi-Asic platform, we shut only the EBGP sessions with external neighbors.
     """
     log.log_info("'bgp shutdown all' executing...")
     namespaces = [DEFAULT_NAMESPACE]
 
     if multi_asic.is_multi_asic():
         ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns']
+        namespaces = ns_list["front_ns"]
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
     # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
@@ -145,16 +152,17 @@ def all(verbose):
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
         bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db)
-        for ipaddress in bgp_neighbor_ip_list:
-            _change_bgp_session_status_by_addr(config_db, ipaddress, 'down', verbose)
+        for ipaddr in bgp_neighbor_ip_list:
+            _change_bgp_session_status_by_addr(config_db, ipaddr, "down", verbose)
+
 
 # 'neighbor' subcommand
 @shutdown.command()
-@click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+@click.argument("ipaddr_or_hostname", metavar="<ipaddr_or_hostname>", required=True)
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output")
 def neighbor(ipaddr_or_hostname, verbose):
     """Shut down BGP session by neighbor IP address or hostname.
-       User can specify either internal or external BGP neighbor to shutdown
+    User can specify either internal or external BGP neighbor to shutdown
     """
     log.log_info("'bgp shutdown neighbor {}' executing...".format(ipaddr_or_hostname))
     namespaces = [DEFAULT_NAMESPACE]
@@ -162,37 +170,41 @@ def neighbor(ipaddr_or_hostname, verbose):
 
     if multi_asic.is_multi_asic():
         ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+        namespaces = ns_list["front_ns"] + ns_list["back_ns"]
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
     # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
-        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'down', verbose):
+        if _change_bgp_session_status(config_db, ipaddr_or_hostname, "down", verbose):
             found_neighbor = True
 
     if not found_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+        click.get_current_context().fail(
+            "Could not locate neighbor '{}'".format(ipaddr_or_hostname)
+        )
+
 
 @bgp.group(cls=clicommon.AbbreviationGroup)
 def startup():
     """Start up BGP session(s)"""
     pass
 
+
 # 'all' subcommand
 @startup.command()
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def all(verbose):
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output")
+def all(verbose):  # noqa: F811
     """Start up all BGP sessions
-       In the case of Multi-Asic platform, we startup only the EBGP sessions with external neighbors.
+    In the case of Multi-Asic platform, we startup only the EBGP sessions with external neighbors.
     """
     log.log_info("'bgp startup all' executing...")
     namespaces = [DEFAULT_NAMESPACE]
 
     if multi_asic.is_multi_asic():
         ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns']
+        namespaces = ns_list["front_ns"]
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
     # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
@@ -200,14 +212,15 @@ def all(verbose):
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
         bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db)
-        for ipaddress in bgp_neighbor_ip_list:
-            _change_bgp_session_status_by_addr(config_db, ipaddress, 'up', verbose)
+        for ipaddr in bgp_neighbor_ip_list:
+            _change_bgp_session_status_by_addr(config_db, ipaddr, "up", verbose)
+
 
 # 'neighbor' subcommand
 @startup.command()
-@click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def neighbor(ipaddr_or_hostname, verbose):
+@click.argument("ipaddr_or_hostname", metavar="<ipaddr_or_hostname>", required=True)
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output")
+def neighbor(ipaddr_or_hostname, verbose):  # noqa: F811
     log.log_info("'bgp startup neighbor {}' executing...".format(ipaddr_or_hostname))
     """Start up BGP session by neighbor IP address or hostname.
        User can specify either internal or external BGP neighbor to startup
@@ -217,40 +230,47 @@ def neighbor(ipaddr_or_hostname, verbose):
 
     if multi_asic.is_multi_asic():
         ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+        namespaces = ns_list["front_ns"] + ns_list["back_ns"]
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
     # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
-        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'up', verbose):
+        if _change_bgp_session_status(config_db, ipaddr_or_hostname, "up", verbose):
             found_neighbor = True
 
     if not found_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+        click.get_current_context().fail(
+            "Could not locate neighbor '{}'".format(ipaddr_or_hostname)
+        )
+
 
 #
 # 'remove' subgroup ('config bgp remove ...')
 #
+
 
 @bgp.group(cls=clicommon.AbbreviationGroup)
 def remove():
     "Remove BGP neighbor configuration from the device"
     pass
 
-@remove.command('neighbor')
-@click.argument('neighbor_ip_or_hostname', metavar='<neighbor_ip_or_hostname>', required=True)
+
+@remove.command("neighbor")
+@click.argument(
+    "neighbor_ip_or_hostname", metavar="<neighbor_ip_or_hostname>", required=True
+)
 def remove_neighbor(neighbor_ip_or_hostname):
     """Deletes BGP neighbor configuration of given hostname or ip from devices
-       User can specify either internal or external BGP neighbor to remove
+    User can specify either internal or external BGP neighbor to remove
     """
     namespaces = [DEFAULT_NAMESPACE]
     removed_neighbor = False
 
     if multi_asic.is_multi_asic():
         ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns'] + ns_list['back_ns']
+        namespaces = ns_list["front_ns"] + ns_list["back_ns"]
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
     # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
@@ -261,22 +281,25 @@ def remove_neighbor(neighbor_ip_or_hostname):
             removed_neighbor = True
 
     if not removed_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor_ip_or_hostname))
+        click.get_current_context().fail(
+            "Could not locate neighbor '{}'".format(neighbor_ip_or_hostname)
+        )
 
 
 #
 # 'bgp autonomous-system' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='autonomous-system')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="autonomous-system")
 def bgp_asn():
     """Specify autonomous system number"""
     pass
 
+
 #
 # 'bgp autonomous-system add' command
 #
-@bgp_asn.command('add')
-@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@bgp_asn.command("add")
+@click.argument("as_num", metavar="<as_num>", required=True, type=BGP_ASN_RANGE)
 @clicommon.pass_db
 def asn_add(db, as_num):
     """Add autonomous system number"""
@@ -288,11 +311,12 @@ def asn_add(db, as_num):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"local_asn": as_num})
 
+
 #
 # 'bgp autonomous-system del' command
 #
-@bgp_asn.command('del')
-@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@bgp_asn.command("del")
+@click.argument("as_num", metavar="<as_num>", required=True, type=BGP_ASN_RANGE)
 @clicommon.pass_db
 def asn_del(db, as_num):
     """Delete autonomous system number"""
@@ -313,19 +337,21 @@ def asn_del(db, as_num):
     db.cfgdb.delete_table("BGP_GLOBALS_AF")
     db.cfgdb.delete_table("BGP_GLOBALS")
 
+
 #
 # 'bgp router-id' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='router-id')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="router-id")
 def bgp_router_id():
     """Configure router identifier"""
     pass
 
+
 #
 # 'bgp router-id add' command
 #
-@bgp_router_id.command('add')
-@click.argument('router_id', metavar='<router_id>', required=True)
+@bgp_router_id.command("add")
+@click.argument("router_id", metavar="<router_id>", required=True)
 @clicommon.pass_db
 def router_id_add(db, router_id):
     """Add router identifier"""
@@ -345,11 +371,12 @@ def router_id_add(db, router_id):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"router_id": router_id})
 
+
 #
 # 'bgp router-id set' command
 #
-@bgp_router_id.command('set')
-@click.argument('router_id', metavar='<router_id>', required=True)
+@bgp_router_id.command("set")
+@click.argument("router_id", metavar="<router_id>", required=True)
 @clicommon.pass_db
 def router_id_set(db, router_id):
     """Set router identifier"""
@@ -369,11 +396,12 @@ def router_id_set(db, router_id):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"router_id": router_id})
 
+
 #
 # 'bgp router-id del' command
 #
-@bgp_router_id.command('del')
-@click.argument('router_id', metavar='<router_id>', required=True)
+@bgp_router_id.command("del")
+@click.argument("router_id", metavar="<router_id>", required=True)
 @clicommon.pass_db
 def router_id_del(db, router_id):
     """Delete router identifier"""
@@ -399,19 +427,21 @@ def router_id_del(db, router_id):
         del bgp_globals["router_id"]
         db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
 
+
 #
 # 'bgp cluster-id' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='cluster-id')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="cluster-id")
 def bgp_cluster_id():
     """Configure cluster identifier"""
     pass
 
+
 #
 # 'bgp cluster-id add' command
 #
-@bgp_cluster_id.command('add')
-@click.argument('cluster_id', metavar='<cluster_id>', required=True)
+@bgp_cluster_id.command("add")
+@click.argument("cluster_id", metavar="<cluster_id>", required=True)
 @clicommon.pass_db
 def cluster_id_add(db, cluster_id):
     """Add cluster identifier"""
@@ -431,11 +461,12 @@ def cluster_id_add(db, cluster_id):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"rr_cluster_id": cluster_id})
 
+
 #
 # 'bgp cluster-id set' command
 #
-@bgp_cluster_id.command('set')
-@click.argument('cluster_id', metavar='<cluster_id>', required=True)
+@bgp_cluster_id.command("set")
+@click.argument("cluster_id", metavar="<cluster_id>", required=True)
 @clicommon.pass_db
 def cluster_id_set(db, cluster_id):
     """Set cluster identifier"""
@@ -455,11 +486,12 @@ def cluster_id_set(db, cluster_id):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"rr_cluster_id": cluster_id})
 
+
 #
 # 'bgp cluster-id del' command
 #
-@bgp_cluster_id.command('del')
-@click.argument('cluster_id', metavar='<cluster_id>', required=True)
+@bgp_cluster_id.command("del")
+@click.argument("cluster_id", metavar="<cluster_id>", required=True)
 @clicommon.pass_db
 def cluster_id_del(db, cluster_id):
     """Delete cluster identifier"""
@@ -485,11 +517,14 @@ def cluster_id_del(db, cluster_id):
         del bgp_globals["rr_cluster_id"]
         db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
 
+
 #
 # 'bgp ebgp-requires-policy' command
 #
-@bgp.command('ebgp-requires-policy')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp.command("ebgp-requires-policy")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def ebgp_requires_policy(db, mode):
     """Require in and out policy for eBGP peers"""
@@ -499,13 +534,20 @@ def ebgp_requires_policy(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"ebgp_requires_policy": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"ebgp_requires_policy": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp fast-external-failover' command
 #
-@bgp.command('fast-external-failover')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp.command("fast-external-failover")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def fast_ext_failover(db, mode):
     """Immediately reset session if a link to a directly connected external peer goes down"""
@@ -515,21 +557,29 @@ def fast_ext_failover(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"fast_external_failover": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"fast_external_failover": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp default' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='default')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="default")
 def bgp_default():
     """Configure BGP defaults"""
     pass
 
+
 #
 # 'bgp default ipv4-unicast' command
 #
-@bgp_default.command('ipv4-unicast')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_default.command("ipv4-unicast")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def default_ipv4_unicast(db, mode):
     """Configure ipv4-unicast for a peer by default"""
@@ -539,22 +589,29 @@ def default_ipv4_unicast(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"default_ipv4_unicast": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"default_ipv4_unicast": "true" if mode == "on" else "false"},
+    )
 
 
 #
 # 'bgp client-to-client' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='client-to-client')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="client-to-client")
 def bgp_clnt_to_clnt():
     """Configure client to client route reflection"""
     pass
 
+
 #
 # 'bgp client-to-client reflection' command
 #
-@bgp_clnt_to_clnt.command('reflection')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_clnt_to_clnt.command("reflection")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def clnt_to_clnt_refl(db, mode):
     """Configure reflection of routes"""
@@ -564,21 +621,29 @@ def clnt_to_clnt_refl(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"rr_clnt_to_clnt_reflection": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"rr_clnt_to_clnt_reflection": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp bestpath' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='bestpath')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="bestpath")
 def bgp_bestpath():
     """Configure bestpath selection"""
     pass
 
+
 #
 # 'bgp bestpath compare-routerid' command
 #
-@bgp_bestpath.command('compare-routerid')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_bestpath.command("compare-routerid")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def bestpath_cmp_router_id(db, mode):
     """Compare router-id for identical EBGP paths"""
@@ -588,7 +653,12 @@ def bestpath_cmp_router_id(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"external_compare_router_id": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"external_compare_router_id": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp bestpath as-path' group
@@ -598,11 +668,14 @@ def bgp_bestpath_as_path():
     """Configure AS-path attribute"""
     pass
 
+
 #
 # 'bgp bestpath as-path multipath-relax' command
 #
-@bgp_bestpath_as_path.command('multipath-relax')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_bestpath_as_path.command("multipath-relax")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def as_path_multipath_relax(db, mode):
     """Allow load sharing across routes that have different AS paths (but same length)"""
@@ -612,29 +685,36 @@ def as_path_multipath_relax(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"load_balance_mp_relax": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"load_balance_mp_relax": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp listen' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='listen')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="listen")
 def bgp_listen():
     """BGP Dynamic Neighbors listen configuration"""
     pass
 
+
 #
 # 'bgp listen limit' group
 #
-@bgp_listen.group(cls=clicommon.AbbreviationGroup, name='limit')
+@bgp_listen.group(cls=clicommon.AbbreviationGroup, name="limit")
 def bgp_listen_limit():
     """Maximum number of BGP Dynamic Neighbors that can be created"""
     pass
 
+
 #
 # 'bgp listen limit add' command
 #
-@bgp_listen_limit.command('add')
-@click.argument('limit', metavar='<limit>', required=True, type=BGP_LISTEN_LIMIT_RANGE)
+@bgp_listen_limit.command("add")
+@click.argument("limit", metavar="<limit>", required=True, type=BGP_LISTEN_LIMIT_RANGE)
 @clicommon.pass_db
 def listen_limit_add(db, limit):
     """Add Dynamic Neighbors listen limit value"""
@@ -649,11 +729,12 @@ def listen_limit_add(db, limit):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"max_dynamic_neighbors": limit})
 
+
 #
 # 'bgp listen limit set' command
 #
-@bgp_listen_limit.command('set')
-@click.argument('limit', metavar='<limit>', required=True, type=BGP_LISTEN_LIMIT_RANGE)
+@bgp_listen_limit.command("set")
+@click.argument("limit", metavar="<limit>", required=True, type=BGP_LISTEN_LIMIT_RANGE)
 @clicommon.pass_db
 def listen_limit_set(db, limit):
     """Set Dynamic Neighbors listen limit value"""
@@ -668,11 +749,12 @@ def listen_limit_set(db, limit):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"max_dynamic_neighbors": limit})
 
+
 #
 # 'bgp listen limit del' command
 #
-@bgp_listen_limit.command('del')
-@click.argument('limit', metavar='<limit>', required=True, type=BGP_LISTEN_LIMIT_RANGE)
+@bgp_listen_limit.command("del")
+@click.argument("limit", metavar="<limit>", required=True, type=BGP_LISTEN_LIMIT_RANGE)
 @clicommon.pass_db
 def listen_limit_del(db, limit):
     """Delete Dynamic Neighbors listen limit value"""
@@ -693,19 +775,23 @@ def listen_limit_del(db, limit):
         del bgp_globals["max_dynamic_neighbors"]
         db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
 
+
 #
 # 'bgp graceful-restart' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='graceful-restart')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="graceful-restart")
 def bgp_gr_restart():
     """Graceful restart capability parameters"""
     pass
 
+
 #
 # 'bgp graceful-restart mode' command
 #
-@bgp_gr_restart.command('mode')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_gr_restart.command("mode")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def gr_restart_state(db, mode):
     """Configure graceful-restart state"""
@@ -715,13 +801,20 @@ def gr_restart_state(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"graceful_restart_enable": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"graceful_restart_enable": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp graceful-restart preserve-fw-state' command
 #
-@bgp_gr_restart.command('preserve-fw-state')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_gr_restart.command("preserve-fw-state")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def gr_restart_preserve_fw_state(db, mode):
     """Sets F-bit indication that fib is preserved while doing Graceful Restart"""
@@ -731,21 +824,27 @@ def gr_restart_preserve_fw_state(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_preserve_fw_state": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS",
+        "default",
+        {"gr_preserve_fw_state": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp graceful-restart restart-time' group
 #
-@bgp_gr_restart.group(cls=clicommon.AbbreviationGroup, name='restart-time')
+@bgp_gr_restart.group(cls=clicommon.AbbreviationGroup, name="restart-time")
 def bgp_gr_restart_time():
     """Time to wait to delete stale routes before a BGP open message is received"""
     pass
 
+
 #
 # 'bgp graceful-restart restart-time add' command
 #
-@bgp_gr_restart_time.command('add')
-@click.argument('time', metavar='<time>', required=True, type=BGP_GR_RESTART_TIME_RANGE)
+@bgp_gr_restart_time.command("add")
+@click.argument("time", metavar="<time>", required=True, type=BGP_GR_RESTART_TIME_RANGE)
 @clicommon.pass_db
 def gr_restart_time_add(db, time):
     """Add the time to wait to delete stale routes before a BGP open message is received"""
@@ -760,11 +859,12 @@ def gr_restart_time_add(db, time):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_restart_time": time})
 
+
 #
 # 'bgp graceful-restart restart-time set' command
 #
-@bgp_gr_restart_time.command('set')
-@click.argument('time', metavar='<time>', required=True, type=BGP_GR_RESTART_TIME_RANGE)
+@bgp_gr_restart_time.command("set")
+@click.argument("time", metavar="<time>", required=True, type=BGP_GR_RESTART_TIME_RANGE)
 @clicommon.pass_db
 def gr_restart_time_set(db, time):
     """Set the time to wait to delete stale routes before a BGP open message is received"""
@@ -779,11 +879,12 @@ def gr_restart_time_set(db, time):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_restart_time": time})
 
+
 #
 # 'bgp graceful-restart restart-time del' command
 #
-@bgp_gr_restart_time.command('del')
-@click.argument('time', metavar='<time>', required=True, type=BGP_GR_RESTART_TIME_RANGE)
+@bgp_gr_restart_time.command("del")
+@click.argument("time", metavar="<time>", required=True, type=BGP_GR_RESTART_TIME_RANGE)
 @clicommon.pass_db
 def gr_restart_time_del(db, time):
     """Delete the time to wait to delete stale routes before a BGP open message is received"""
@@ -804,19 +905,23 @@ def gr_restart_time_del(db, time):
         del bgp_globals["gr_restart_time"]
         db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
 
+
 #
 # 'bgp graceful-restart stalepath-time' group
 #
-@bgp_gr_restart.group(cls=clicommon.AbbreviationGroup, name='stalepath-time')
+@bgp_gr_restart.group(cls=clicommon.AbbreviationGroup, name="stalepath-time")
 def bgp_gr_stalepath_time():
     """Max time to hold onto restarting peer's stale paths"""
     pass
 
+
 #
 # 'bgp graceful-restart stalepath-time add' command
 #
-@bgp_gr_stalepath_time.command('add')
-@click.argument('time', metavar='<time>', required=True, type=BGP_GR_STALEPATH_TIME_RANGE)
+@bgp_gr_stalepath_time.command("add")
+@click.argument(
+    "time", metavar="<time>", required=True, type=BGP_GR_STALEPATH_TIME_RANGE
+)
 @clicommon.pass_db
 def gr_stalepath_time_add(db, time):
     """Add the max time to hold onto restarting peer's stale paths"""
@@ -831,11 +936,14 @@ def gr_stalepath_time_add(db, time):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_stale_routes_time": time})
 
+
 #
 # 'bgp graceful-restart stalepath-time set' command
 #
-@bgp_gr_stalepath_time.command('set')
-@click.argument('time', metavar='<time>', required=True, type=BGP_GR_STALEPATH_TIME_RANGE)
+@bgp_gr_stalepath_time.command("set")
+@click.argument(
+    "time", metavar="<time>", required=True, type=BGP_GR_STALEPATH_TIME_RANGE
+)
 @clicommon.pass_db
 def gr_stalepath_time_set(db, time):
     """Set the max time to hold onto restarting peer's stale paths"""
@@ -850,11 +958,14 @@ def gr_stalepath_time_set(db, time):
 
     db.cfgdb.mod_entry("BGP_GLOBALS", "default", {"gr_stale_routes_time": time})
 
+
 #
 # 'bgp graceful-restart stalepath-time del' command
 #
-@bgp_gr_stalepath_time.command('del')
-@click.argument('time', metavar='<time>', required=True, type=BGP_GR_STALEPATH_TIME_RANGE)
+@bgp_gr_stalepath_time.command("del")
+@click.argument(
+    "time", metavar="<time>", required=True, type=BGP_GR_STALEPATH_TIME_RANGE
+)
 @clicommon.pass_db
 def gr_stalepath_time_del(db, time):
     """Delete the max time to hold onto restarting peer's stale paths"""
@@ -867,7 +978,11 @@ def gr_stalepath_time_del(db, time):
     gr_stale_routes_time = bgp_globals.get("gr_stale_routes_time")
     if gr_stale_routes_time:
         if gr_stale_routes_time != str(time):
-            ctx.fail("Configured graceful restart stalepath time is {}".format(gr_stale_routes_time))
+            ctx.fail(
+                "Configured graceful restart stalepath time is {}".format(
+                    gr_stale_routes_time
+                )
+            )
     else:
         ctx.fail("Graceful restart stalepath time is not configured")
 
@@ -875,28 +990,31 @@ def gr_stalepath_time_del(db, time):
         del bgp_globals["gr_stale_routes_time"]
         db.cfgdb.set_entry("BGP_GLOBALS", "default", bgp_globals)
 
+
 #
 # 'bgp neighbor' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='neighbor')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="neighbor")
 def bgp_neighbor():
     """Configure BGP neighbors"""
     pass
 
+
 #
 # 'bgp neighbor remote-as' group
 #
-@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='remote-as')
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name="remote-as")
 def bgp_remote_as():
     """Configure BGP neighbor remote-as"""
     pass
 
+
 #
 # 'bgp neighbor remote-as add' command
 #
-@bgp_remote_as.command('add')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('remote-as', metavar='<as_num|external|internal>', required=True)
+@bgp_remote_as.command("add")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("remote-as", metavar="<as_num|external|internal>", required=True)
 @clicommon.pass_db
 def neighbor_remote_as_add(db, ip_intf, remote_as):
     """Add BGP neighbor remote-as"""
@@ -925,12 +1043,13 @@ def neighbor_remote_as_add(db, ip_intf, remote_as):
 
     db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"asn": remote_as})
 
+
 #
 # 'bgp neighbor remote-as set' command
 #
-@bgp_remote_as.command('set')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('remote-as', metavar='<as_num|external|internal>', required=True)
+@bgp_remote_as.command("set")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("remote-as", metavar="<as_num|external|internal>", required=True)
 @clicommon.pass_db
 def neighbor_remote_as_set(db, ip_intf, remote_as):
     """Set BGP neighbor remote-as"""
@@ -959,12 +1078,13 @@ def neighbor_remote_as_set(db, ip_intf, remote_as):
 
     db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"asn": remote_as})
 
+
 #
 # 'bgp neighbor remote-as del' command
 #
-@bgp_remote_as.command('del')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('remote-as', metavar='<as_num|external|internal>', required=True)
+@bgp_remote_as.command("del")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("remote-as", metavar="<as_num|external|internal>", required=True)
 @clicommon.pass_db
 def neighbor_remote_as_del(db, ip_intf, remote_as):
     """Delete BGP neighbor remote-as"""
@@ -1002,20 +1122,22 @@ def neighbor_remote_as_del(db, ip_intf, remote_as):
     db.cfgdb.set_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "ipv4_unicast"), None)
     db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), None)
 
+
 #
 # 'bgp neighbor update-source' group
 #
-@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='update-source')
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name="update-source")
 def bgp_neighbor_upd_source():
     """Configure BGP neighbor update-source"""
     pass
 
+
 #
 # 'bgp neighbor update-source add' command
 #
-@bgp_neighbor_upd_source.command('add')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('upd_source', metavar='<ip_addr|interface_name>', required=True)
+@bgp_neighbor_upd_source.command("add")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("upd_source", metavar="<ip_addr|interface_name>", required=True)
 @clicommon.pass_db
 def neighbor_upd_source_add(db, ip_intf, upd_source):
     """Add BGP neighbor update-source"""
@@ -1045,12 +1167,13 @@ def neighbor_upd_source_add(db, ip_intf, upd_source):
 
     db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"local_addr": upd_source})
 
+
 #
 # 'bgp neighbor update-source set' command
 #
-@bgp_neighbor_upd_source.command('set')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('upd_source', metavar='<ip_addr|interface_name>', required=True)
+@bgp_neighbor_upd_source.command("set")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("upd_source", metavar="<ip_addr|interface_name>", required=True)
 @clicommon.pass_db
 def neighbor_upd_source_set(db, ip_intf, upd_source):
     """Set BGP neighbor update-source"""
@@ -1080,12 +1203,13 @@ def neighbor_upd_source_set(db, ip_intf, upd_source):
 
     db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"local_addr": upd_source})
 
+
 #
 # 'bgp neighbor update-source del' command
 #
-@bgp_neighbor_upd_source.command('del')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('upd_source', metavar='<ip_addr|interface_name>', required=True)
+@bgp_neighbor_upd_source.command("del")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("upd_source", metavar="<ip_addr|interface_name>", required=True)
 @clicommon.pass_db
 def neighbor_upd_source_del(db, ip_intf, upd_source):
     """Delete BGP neighbor update-source"""
@@ -1121,20 +1245,27 @@ def neighbor_upd_source_del(db, ip_intf, upd_source):
     del bgp_neighbor["local_addr"]
     db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
 
+
 #
 # 'bgp neighbor advertisement-interval' group
 #
-@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='advertisement-interval')
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name="advertisement-interval")
 def bgp_neighbor_adv_interval():
     """Minimum interval between sending BGP routing updates"""
     pass
 
+
 #
 # 'bgp neighbor advertisement-interval add' command
 #
-@bgp_neighbor_adv_interval.command('add')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('interval', metavar='<interval>', required=True, type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE)
+@bgp_neighbor_adv_interval.command("add")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "interval",
+    metavar="<interval>",
+    required=True,
+    type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE,
+)
 @clicommon.pass_db
 def neighbor_adv_int_add(db, ip_intf, interval):
     """Add minimum interval between sending BGP routing updates"""
@@ -1156,14 +1287,22 @@ def neighbor_adv_int_add(db, ip_intf, interval):
     if bgp_neighbor.get("min_adv_interval"):
         ctx.fail("BGP neighbor advertisement interval already exists")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"min_adv_interval": interval})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR", ("default", ip_intf), {"min_adv_interval": interval}
+    )
+
 
 #
 # 'bgp neighbor advertisement-interval set' command
 #
-@bgp_neighbor_adv_interval.command('set')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('interval', metavar='<interval>', required=True, type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE)
+@bgp_neighbor_adv_interval.command("set")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "interval",
+    metavar="<interval>",
+    required=True,
+    type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE,
+)
 @clicommon.pass_db
 def neighbor_adv_int_set(db, ip_intf, interval):
     """Set minimum interval between sending BGP routing updates"""
@@ -1185,14 +1324,22 @@ def neighbor_adv_int_set(db, ip_intf, interval):
     if not bgp_neighbor.get("min_adv_interval"):
         ctx.fail("BGP neighbor advertisement interval is not configured")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"min_adv_interval": interval})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR", ("default", ip_intf), {"min_adv_interval": interval}
+    )
+
 
 #
 # 'bgp neighbor advertisement-interval del' command
 #
-@bgp_neighbor_adv_interval.command('del')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('interval', metavar='<interval>', required=True, type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE)
+@bgp_neighbor_adv_interval.command("del")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "interval",
+    metavar="<interval>",
+    required=True,
+    type=BGP_NEIGHBOR_ADV_INTERVAL_RANGE,
+)
 @clicommon.pass_db
 def neighbor_adv_int_del(db, ip_intf, interval):
     """Delete minimum interval between sending BGP routing updates"""
@@ -1215,28 +1362,38 @@ def neighbor_adv_int_del(db, ip_intf, interval):
     min_adv_interval = bgp_neighbor.get("min_adv_interval")
     if min_adv_interval:
         if min_adv_interval != str(interval):
-            ctx.fail("Configured BGP neighbor advertisement interval is {}".format(min_adv_interval))
+            ctx.fail(
+                "Configured BGP neighbor advertisement interval is {}".format(
+                    min_adv_interval
+                )
+            )
     else:
         ctx.fail("BGP neighbor advertisement interval is not configured")
 
     del bgp_neighbor["min_adv_interval"]
     db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
 
+
 #
 # 'bgp neighbor timers' group
 #
-@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='timers')
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name="timers")
 def bgp_neighbor_timers():
     """Configure BGP neighbor timers"""
     pass
 
+
 #
 # 'bgp neighbor timers add' command
 #
-@bgp_neighbor_timers.command('add')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('keepalive', metavar='<keepalive>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
-@click.argument('holdtime', metavar='<holdtime>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@bgp_neighbor_timers.command("add")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "keepalive", metavar="<keepalive>", required=True, type=BGP_NEIGHBOR_TIMER_RANGE
+)
+@click.argument(
+    "holdtime", metavar="<holdtime>", required=True, type=BGP_NEIGHBOR_TIMER_RANGE
+)
 @clicommon.pass_db
 def neighbor_timers_add(db, ip_intf, keepalive, holdtime):
     """Add BGP neighbor timers"""
@@ -1258,16 +1415,24 @@ def neighbor_timers_add(db, ip_intf, keepalive, holdtime):
     if bgp_neighbor.get("keepalive") and bgp_neighbor.get("holdtime"):
         ctx.fail("BGP neighbor timers are already configured")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"keepalive": keepalive,
-                                                              "holdtime": holdtime})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR",
+        ("default", ip_intf),
+        {"keepalive": keepalive, "holdtime": holdtime},
+    )
+
 
 #
 # 'bgp neighbor timers set' command
 #
-@bgp_neighbor_timers.command('set')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('keepalive', metavar='<keepalive>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
-@click.argument('holdtime', metavar='<holdtime>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@bgp_neighbor_timers.command("set")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "keepalive", metavar="<keepalive>", required=True, type=BGP_NEIGHBOR_TIMER_RANGE
+)
+@click.argument(
+    "holdtime", metavar="<holdtime>", required=True, type=BGP_NEIGHBOR_TIMER_RANGE
+)
 @clicommon.pass_db
 def neighbor_timers_set(db, ip_intf, keepalive, holdtime):
     """Set BGP neighbor timers"""
@@ -1289,16 +1454,24 @@ def neighbor_timers_set(db, ip_intf, keepalive, holdtime):
     if not bgp_neighbor.get("keepalive") or not bgp_neighbor.get("holdtime"):
         ctx.fail("BGP neighbor timers are not configured")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"keepalive": keepalive,
-                                                              "holdtime": holdtime})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR",
+        ("default", ip_intf),
+        {"keepalive": keepalive, "holdtime": holdtime},
+    )
+
 
 #
 # 'bgp neighbor timers del' command
 #
-@bgp_neighbor_timers.command('del')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('keepalive', metavar='<keepalive>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
-@click.argument('holdtime', metavar='<holdtime>', required=True, type=BGP_NEIGHBOR_TIMER_RANGE)
+@bgp_neighbor_timers.command("del")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "keepalive", metavar="<keepalive>", required=True, type=BGP_NEIGHBOR_TIMER_RANGE
+)
+@click.argument(
+    "holdtime", metavar="<holdtime>", required=True, type=BGP_NEIGHBOR_TIMER_RANGE
+)
 @clicommon.pass_db
 def neighbor_timers_del(db, ip_intf, keepalive, holdtime):
     """Delete BGP neighbor timers"""
@@ -1322,7 +1495,11 @@ def neighbor_timers_del(db, ip_intf, keepalive, holdtime):
     holdtime_entry = bgp_neighbor.get("holdtime")
     if keepalive_entry and holdtime_entry:
         if keepalive_entry != str(keepalive) or holdtime_entry != str(holdtime):
-            ctx.fail("Configured BGP neighbor timers are {} {}".format(keepalive_entry, holdtime_entry))
+            ctx.fail(
+                "Configured BGP neighbor timers are {} {}".format(
+                    keepalive_entry, holdtime_entry
+                )
+            )
     else:
         ctx.fail("BGP neighbor timers are not configured")
 
@@ -1332,22 +1509,24 @@ def neighbor_timers_del(db, ip_intf, keepalive, holdtime):
         del bgp_neighbor["holdtime"]
     db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
 
+
 #
 # 'bgp neighbor local-as' group
 #
-@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name='local-as')
+@bgp_neighbor.group(cls=clicommon.AbbreviationGroup, name="local-as")
 def bgp_neighbor_local_as():
     """Specify a local-as number"""
     pass
 
+
 #
 # 'bgp neighbor local-as add' command
 #
-@bgp_neighbor_local_as.command('add')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
-@click.option('--no-prepend', required=False, is_flag=True)
-@click.option('--replace-as', required=False, is_flag=True)
+@bgp_neighbor_local_as.command("add")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("as_num", metavar="<as_num>", required=True, type=BGP_ASN_RANGE)
+@click.option("--no-prepend", required=False, is_flag=True)
+@click.option("--replace-as", required=False, is_flag=True)
 @clicommon.pass_db
 def neighbor_local_as_add(db, ip_intf, as_num, no_prepend, replace_as):
     """Add AS number used as local AS"""
@@ -1380,14 +1559,15 @@ def neighbor_local_as_add(db, ip_intf, as_num, no_prepend, replace_as):
     bgp_neighbor["local_as_replace_as"] = "true" if replace_as else "false"
     db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
 
+
 #
 # 'bgp neighbor local-as set' command
 #
-@bgp_neighbor_local_as.command('set')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
-@click.option('--no-prepend', required=False, is_flag=True)
-@click.option('--replace-as', required=False, is_flag=True)
+@bgp_neighbor_local_as.command("set")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("as_num", metavar="<as_num>", required=True, type=BGP_ASN_RANGE)
+@click.option("--no-prepend", required=False, is_flag=True)
+@click.option("--replace-as", required=False, is_flag=True)
 @clicommon.pass_db
 def neighbor_local_as_set(db, ip_intf, as_num, no_prepend, replace_as):
     """Set AS number used as local AS"""
@@ -1420,12 +1600,13 @@ def neighbor_local_as_set(db, ip_intf, as_num, no_prepend, replace_as):
     bgp_neighbor["local_as_replace_as"] = "true" if replace_as else "false"
     db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
 
+
 #
 # 'bgp neighbor local-as del' command
 #
-@bgp_neighbor_local_as.command('del')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('as_num', metavar='<as_num>', required=True, type=BGP_ASN_RANGE)
+@bgp_neighbor_local_as.command("del")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument("as_num", metavar="<as_num>", required=True, type=BGP_ASN_RANGE)
 @clicommon.pass_db
 def neighbor_local_as_del(db, ip_intf, as_num):
     """Delete AS number used as local AS"""
@@ -1459,12 +1640,15 @@ def neighbor_local_as_del(db, ip_intf, as_num):
         del bgp_neighbor["local_as_replace_as"]
     db.cfgdb.set_entry("BGP_NEIGHBOR", ("default", ip_intf), bgp_neighbor)
 
+
 #
 # 'bgp neighbor shutdown' command
 #
-@bgp_neighbor.command('shutdown')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_neighbor.command("shutdown")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def neighbor_shutdown(db, ip_intf, mode):
     """Administratively shut down BGP neighbor"""
@@ -1484,15 +1668,24 @@ def neighbor_shutdown(db, ip_intf, mode):
     if not bgp_neighbor.get("asn"):
         ctx.fail("Specify BGP neighbor remote-as first")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR", ("default", ip_intf), {"admin_status": "false" if mode == "on" else "true"})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR",
+        ("default", ip_intf),
+        {"admin_status": "false" if mode == "on" else "true"},
+    )
+
 
 #
 # 'bgp neighbor ebgp-multihop' command
 #
-@bgp_neighbor.command('ebgp-multihop')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
-@click.option('--max-hops', metavar='<max_hops>', required=False, type=BGP_NEIGHBOR_MULTIHOP_RANGE)
+@bgp_neighbor.command("ebgp-multihop")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
+@click.option(
+    "--max-hops", metavar="<max_hops>", required=False, type=BGP_NEIGHBOR_MULTIHOP_RANGE
+)
 @clicommon.pass_db
 def neighbor_multihop(db, ip_intf, mode, max_hops):
     """Allow EBGP neighbors on not directly connected networks"""
@@ -1512,7 +1705,9 @@ def neighbor_multihop(db, ip_intf, mode, max_hops):
     if not bgp_neighbor.get("asn"):
         ctx.fail("Specify BGP neighbor remote-as first")
 
-    if bgp_neighbor.get("asn") != "internal" and bgp_neighbor.get("asn") != bgp_globals.get("local_asn"):
+    if bgp_neighbor.get("asn") != "internal" and bgp_neighbor.get(
+        "asn"
+    ) != bgp_globals.get("local_asn"):
         bgp_neighbor["ebgp_multihop"] = "true" if mode == "on" else "false"
         if max_hops:
             bgp_neighbor["ebgp_multihop_ttl"] = max_hops
@@ -1522,44 +1717,51 @@ def neighbor_multihop(db, ip_intf, mode, max_hops):
     else:
         ctx.fail("Invalid command. Not an external neighbor")
 
+
 #
 # 'bgp address-family' group
 #
-@bgp.group(cls=clicommon.AbbreviationGroup, name='address-family')
+@bgp.group(cls=clicommon.AbbreviationGroup, name="address-family")
 def bgp_addr():
     """Address family configuration"""
     pass
 
+
 #
 # 'bgp address-family ipv4' group
 #
-@bgp_addr.group(cls=clicommon.AbbreviationGroup, name='ipv4')
+@bgp_addr.group(cls=clicommon.AbbreviationGroup, name="ipv4")
 def bgp_addr_ipv4():
     """IPv4 address family configuration"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast' group
 #
-@bgp_addr_ipv4.group(cls=clicommon.AbbreviationGroup, name='unicast')
+@bgp_addr_ipv4.group(cls=clicommon.AbbreviationGroup, name="unicast")
 def bgp_addr_ipv4_unicast():
     """IPv4 unicast address family configuration"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast neighbor' group
 #
-@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='neighbor')
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name="neighbor")
 def bgp_addr_ipv4_unicast_neighbor():
     """IPv4 unicast neighbor address family configuration"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast neighbor activate' command
 #
-@bgp_addr_ipv4_unicast_neighbor.command('activate')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_addr_ipv4_unicast_neighbor.command("activate")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def ipv4_neighbor_activate(db, ip_intf, mode):
     """IPv4 neighbor activate"""
@@ -1579,21 +1781,27 @@ def ipv4_neighbor_activate(db, ip_intf, mode):
     if not bgp_neighbor.get("asn"):
         ctx.fail("Specify BGP neighbor remote-as first")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "ipv4_unicast"), {"admin_status": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR_AF",
+        ("default", ip_intf, "ipv4_unicast"),
+        {"admin_status": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp address-family ipv4 unicast network' group
 #
-@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='network')
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name="network")
 def bgp_addr_ipv4_unicast_network():
     """IPv4 unicast network address family configuration"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast network add' command
 #
-@bgp_addr_ipv4_unicast_network.command('add')
-@click.argument('network', metavar='<network>', required=True)
+@bgp_addr_ipv4_unicast_network.command("add")
+@click.argument("network", metavar="<network>", required=True)
 @clicommon.pass_db
 def ipv4_unicast_network_add(db, network):
     """Add IPv4 unicast network"""
@@ -1612,13 +1820,16 @@ def ipv4_unicast_network_add(db, network):
     if ("default", "ipv4_unicast", str(network)) in bgp_globals_af_net:
         ctx.fail("IPv4 unicast network already exists")
 
-    db.cfgdb.set_entry("BGP_GLOBALS_AF_NETWORK", ("default|ipv4_unicast", str(network)), {})
+    db.cfgdb.set_entry(
+        "BGP_GLOBALS_AF_NETWORK", ("default|ipv4_unicast", str(network)), {}
+    )
+
 
 #
 # 'bgp address-family ipv4 unicast network del' command
 #
-@bgp_addr_ipv4_unicast_network.command('del')
-@click.argument('network', metavar='<network>', required=True)
+@bgp_addr_ipv4_unicast_network.command("del")
+@click.argument("network", metavar="<network>", required=True)
 @clicommon.pass_db
 def ipv4_unicast_network_del(db, network):
     """Delete IPv4 unicast network"""
@@ -1637,21 +1848,30 @@ def ipv4_unicast_network_del(db, network):
     if ("default", "ipv4_unicast", str(network)) not in bgp_globals_af_net:
         ctx.fail("IPv4 unicast network does not exist")
 
-    db.cfgdb.set_entry("BGP_GLOBALS_AF_NETWORK", ("default|ipv4_unicast", str(network)), None)
+    db.cfgdb.set_entry(
+        "BGP_GLOBALS_AF_NETWORK", ("default|ipv4_unicast", str(network)), None
+    )
+
 
 #
 # 'bgp address-family ipv4 unicast max-paths' group
 #
-@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='max-paths')
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name="max-paths")
 def bgp_addr_ipv4_unicast_max_paths():
     """IPv4 unicast max-paths address family configuration"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast max-paths add' command
 #
-@bgp_addr_ipv4_unicast_max_paths.command('add')
-@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@bgp_addr_ipv4_unicast_max_paths.command("add")
+@click.argument(
+    "paths_num",
+    metavar="<paths_num>",
+    required=True,
+    type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE,
+)
 @clicommon.pass_db
 def max_paths_add(db, paths_num):
     """Add IPv4 unicast max-paths"""
@@ -1665,13 +1885,21 @@ def max_paths_add(db, paths_num):
     if bgp_globals_af.get("max_ebgp_paths"):
         ctx.fail("Max paths number is already specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"max_ebgp_paths": paths_num})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS_AF", "default|ipv4_unicast", {"max_ebgp_paths": paths_num}
+    )
+
 
 #
 # 'bgp address-family ipv4 unicast max-paths set' command
 #
-@bgp_addr_ipv4_unicast_max_paths.command('set')
-@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@bgp_addr_ipv4_unicast_max_paths.command("set")
+@click.argument(
+    "paths_num",
+    metavar="<paths_num>",
+    required=True,
+    type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE,
+)
 @clicommon.pass_db
 def max_paths_set(db, paths_num):
     """Set IPv4 unicast max-paths"""
@@ -1685,13 +1913,21 @@ def max_paths_set(db, paths_num):
     if not bgp_globals_af.get("max_ebgp_paths"):
         ctx.fail("Max-paths number is not configured")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"max_ebgp_paths": paths_num})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS_AF", "default|ipv4_unicast", {"max_ebgp_paths": paths_num}
+    )
+
 
 #
 # 'bgp address-family ipv4 unicast max-paths del' command
 #
-@bgp_addr_ipv4_unicast_max_paths.command('del')
-@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@bgp_addr_ipv4_unicast_max_paths.command("del")
+@click.argument(
+    "paths_num",
+    metavar="<paths_num>",
+    required=True,
+    type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE,
+)
 @clicommon.pass_db
 def max_paths_del(db, paths_num):
     """Delete IPv4 unicast max-paths"""
@@ -1716,17 +1952,23 @@ def max_paths_del(db, paths_num):
 #
 # 'bgp address-family ipv4 unicast max-paths ibgp' group
 #
-@bgp_addr_ipv4_unicast_max_paths.group(cls=clicommon.AbbreviationGroup, name='ibgp')
+@bgp_addr_ipv4_unicast_max_paths.group(cls=clicommon.AbbreviationGroup, name="ibgp")
 def bgp_addr_ipv4_unicast_max_paths_ibgp():
     """IPv4 unicast ibgp max-paths address family configuration"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast max-paths ibgp add' command
 #
-@bgp_addr_ipv4_unicast_max_paths_ibgp.command('add')
-@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
-@click.option('--equal-cluster-length', required=False, is_flag=True)
+@bgp_addr_ipv4_unicast_max_paths_ibgp.command("add")
+@click.argument(
+    "paths_num",
+    metavar="<paths_num>",
+    required=True,
+    type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE,
+)
+@click.option("--equal-cluster-length", required=False, is_flag=True)
 @clicommon.pass_db
 def max_paths_ibgp_add(db, paths_num, equal_cluster_length):
     """Add IPv4 unicast ibgp max-paths"""
@@ -1741,15 +1983,23 @@ def max_paths_ibgp_add(db, paths_num, equal_cluster_length):
         ctx.fail("Max ibgp paths number is already specified")
 
     bgp_globals_af["max_ibgp_paths"] = paths_num
-    bgp_globals_af["ibgp_equal_cluster_length"] = "true" if equal_cluster_length else "false"
+    bgp_globals_af["ibgp_equal_cluster_length"] = (
+        "true" if equal_cluster_length else "false"
+    )
     db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
+
 
 #
 # 'bgp address-family ipv4 unicast max-paths ibgp set' command
 #
-@bgp_addr_ipv4_unicast_max_paths_ibgp.command('set')
-@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
-@click.option('--equal-cluster-length', required=False, is_flag=True)
+@bgp_addr_ipv4_unicast_max_paths_ibgp.command("set")
+@click.argument(
+    "paths_num",
+    metavar="<paths_num>",
+    required=True,
+    type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE,
+)
+@click.option("--equal-cluster-length", required=False, is_flag=True)
 @clicommon.pass_db
 def max_paths_ibgp_set(db, paths_num, equal_cluster_length):
     """Set IPv4 unicast ibgp max-paths"""
@@ -1764,14 +2014,22 @@ def max_paths_ibgp_set(db, paths_num, equal_cluster_length):
         ctx.fail("Max-paths ibgp number is not configured")
 
     bgp_globals_af["max_ibgp_paths"] = paths_num
-    bgp_globals_af["ibgp_equal_cluster_length"] = "true" if equal_cluster_length else "false"
+    bgp_globals_af["ibgp_equal_cluster_length"] = (
+        "true" if equal_cluster_length else "false"
+    )
     db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
+
 
 #
 # 'bgp address-family ipv4 unicast max-paths ibgp del' command
 #
-@bgp_addr_ipv4_unicast_max_paths_ibgp.command('del')
-@click.argument('paths_num', metavar='<paths_num>', required=True, type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE)
+@bgp_addr_ipv4_unicast_max_paths_ibgp.command("del")
+@click.argument(
+    "paths_num",
+    metavar="<paths_num>",
+    required=True,
+    type=BGP_IPV4_UNICAST_MAX_PATHS_RANGE,
+)
 @clicommon.pass_db
 def max_paths_ibgp_del(db, paths_num):
     """Delete IPv4 unicast ibgp max-paths"""
@@ -1794,29 +2052,47 @@ def max_paths_ibgp_del(db, paths_num):
         del bgp_globals_af["ibgp_equal_cluster_length"]
     db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
 
+
 #
 # 'bgp address-family ipv4 unicast distance' group
 #
-@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='distance')
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name="distance")
 def bgp_addr_ipv4_unicast_dist():
     """Define an administrative distance"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast distance bgp' group
 #
-@bgp_addr_ipv4_unicast_dist.group(cls=clicommon.AbbreviationGroup, name='bgp')
+@bgp_addr_ipv4_unicast_dist.group(cls=clicommon.AbbreviationGroup, name="bgp")
 def bgp_addr_ipv4_unicast_dist_bgp():
     """BGP distance"""
     pass
 
+
 #
 # 'bgp address-family ipv4 unicast distance bgp add' command
 #
-@bgp_addr_ipv4_unicast_dist_bgp.command('add')
-@click.argument('ebgp_dist', metavar='<ebgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
-@click.argument('ibgp_dist', metavar='<ibgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
-@click.argument('local_dist', metavar='<local_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@bgp_addr_ipv4_unicast_dist_bgp.command("add")
+@click.argument(
+    "ebgp_dist",
+    metavar="<ebgp_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
+@click.argument(
+    "ibgp_dist",
+    metavar="<ibgp_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
+@click.argument(
+    "local_dist",
+    metavar="<local_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
 @clicommon.pass_db
 def distance_bgp_add(db, ebgp_dist, ibgp_dist, local_dist):
     """Add BGP distance"""
@@ -1827,22 +2103,46 @@ def distance_bgp_add(db, ebgp_dist, ibgp_dist, local_dist):
         ctx.fail("AS number is not specified")
 
     bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
-    if (bgp_globals_af.get("ebgp_route_distance") and
-        bgp_globals_af.get("ibgp_route_distance") and
-        bgp_globals_af.get("local_route_distance")):
+    if (
+        bgp_globals_af.get("ebgp_route_distance")
+        and bgp_globals_af.get("ibgp_route_distance")
+        and bgp_globals_af.get("local_route_distance")
+    ):
         ctx.fail("BGP distance values are already configured")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"ebgp_route_distance": ebgp_dist,
-                                                                  "ibgp_route_distance": ibgp_dist,
-                                                                  "local_route_distance": local_dist})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS_AF",
+        "default|ipv4_unicast",
+        {
+            "ebgp_route_distance": ebgp_dist,
+            "ibgp_route_distance": ibgp_dist,
+            "local_route_distance": local_dist,
+        },
+    )
+
 
 #
 # 'bgp address-family ipv4 unicast distance bgp set' command
 #
-@bgp_addr_ipv4_unicast_dist_bgp.command('set')
-@click.argument('ebgp_dist', metavar='<ebgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
-@click.argument('ibgp_dist', metavar='<ibgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
-@click.argument('local_dist', metavar='<local_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@bgp_addr_ipv4_unicast_dist_bgp.command("set")
+@click.argument(
+    "ebgp_dist",
+    metavar="<ebgp_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
+@click.argument(
+    "ibgp_dist",
+    metavar="<ibgp_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
+@click.argument(
+    "local_dist",
+    metavar="<local_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
 @clicommon.pass_db
 def distance_bgp_set(db, ebgp_dist, ibgp_dist, local_dist):
     """Set BGP distance"""
@@ -1853,22 +2153,46 @@ def distance_bgp_set(db, ebgp_dist, ibgp_dist, local_dist):
         ctx.fail("AS number is not specified")
 
     bgp_globals_af = db.cfgdb.get_entry("BGP_GLOBALS_AF", "default|ipv4_unicast")
-    if (not bgp_globals_af.get("ebgp_route_distance") or
-        not bgp_globals_af.get("ibgp_route_distance") or
-        not bgp_globals_af.get("local_route_distance")):
+    if (
+        not bgp_globals_af.get("ebgp_route_distance")
+        or not bgp_globals_af.get("ibgp_route_distance")
+        or not bgp_globals_af.get("local_route_distance")
+    ):
         ctx.fail("Distance bgp values are not configured")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", {"ebgp_route_distance": ebgp_dist,
-                                                                  "ibgp_route_distance": ibgp_dist,
-                                                                  "local_route_distance": local_dist})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS_AF",
+        "default|ipv4_unicast",
+        {
+            "ebgp_route_distance": ebgp_dist,
+            "ibgp_route_distance": ibgp_dist,
+            "local_route_distance": local_dist,
+        },
+    )
+
 
 #
 # 'bgp address-family ipv4 unicast distance bgp del' command
 #
-@bgp_addr_ipv4_unicast_dist_bgp.command('del')
-@click.argument('ebgp_dist', metavar='<ebgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
-@click.argument('ibgp_dist', metavar='<ibgp_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
-@click.argument('local_dist', metavar='<local_dist>', required=True, type=BGP_IPV4_UNICAST_DISTANCE_RANGE)
+@bgp_addr_ipv4_unicast_dist_bgp.command("del")
+@click.argument(
+    "ebgp_dist",
+    metavar="<ebgp_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
+@click.argument(
+    "ibgp_dist",
+    metavar="<ibgp_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
+@click.argument(
+    "local_dist",
+    metavar="<local_dist>",
+    required=True,
+    type=BGP_IPV4_UNICAST_DISTANCE_RANGE,
+)
 @clicommon.pass_db
 def distance_bgp_del(db, ebgp_dist, ibgp_dist, local_dist):
     """Delete BGP distance"""
@@ -1884,10 +2208,16 @@ def distance_bgp_del(db, ebgp_dist, ibgp_dist, local_dist):
     local_rt_dist = bgp_globals_af.get("local_route_distance")
 
     if ebgp_rt_dist and ibgp_rt_dist and local_rt_dist:
-        if (ebgp_rt_dist != str(ebgp_dist) or
-            ibgp_rt_dist != str(ibgp_dist) or
-            local_rt_dist != str(local_dist)):
-            ctx.fail("Configured distance bgp values are {} {} {}".format(ebgp_rt_dist, ibgp_rt_dist, local_rt_dist))
+        if (
+            ebgp_rt_dist != str(ebgp_dist)
+            or ibgp_rt_dist != str(ibgp_dist)
+            or local_rt_dist != str(local_dist)
+        ):
+            ctx.fail(
+                "Configured distance bgp values are {} {} {}".format(
+                    ebgp_rt_dist, ibgp_rt_dist, local_rt_dist
+                )
+            )
     else:
         ctx.fail("Distance bgp values are not configured")
 
@@ -1899,19 +2229,23 @@ def distance_bgp_del(db, ebgp_dist, ibgp_dist, local_dist):
         del bgp_globals_af["local_route_distance"]
     db.cfgdb.set_entry("BGP_GLOBALS_AF", "default|ipv4_unicast", bgp_globals_af)
 
+
 #
 # 'bgp address-family ipv4 redistribute' group
 #
-@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name='redistribute')
+@bgp_addr_ipv4_unicast.group(cls=clicommon.AbbreviationGroup, name="redistribute")
 def bgp_addr_ipv4_unicast_redist():
     """Redistribute information from another routing protocol"""
     pass
 
+
 #
 # 'bgp address-family ipv4 redistribute connected' command
 #
-@bgp_addr_ipv4_unicast_redist.command('connected')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_addr_ipv4_unicast_redist.command("connected")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def redist_connected(db, mode):
     """Connected routes (directly attached subnet or host)"""
@@ -1921,29 +2255,36 @@ def redist_connected(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.set_entry("ROUTE_REDISTRIBUTE", "default|connected|bgp|ipv4", {} if mode == "on" else None)
+    db.cfgdb.set_entry(
+        "ROUTE_REDISTRIBUTE", "default|connected|bgp|ipv4", {} if mode == "on" else None
+    )
+
 
 #
 # 'bgp address-family l2vpn' group
 #
-@bgp_addr.group(cls=clicommon.AbbreviationGroup, name='l2vpn')
+@bgp_addr.group(cls=clicommon.AbbreviationGroup, name="l2vpn")
 def bgp_addr_l2vpn():
     """L2VPN address family configuration"""
     pass
 
+
 #
 # 'bgp address-family l2vpn evpn' group
 #
-@bgp_addr_l2vpn.group(cls=clicommon.AbbreviationGroup, name='evpn')
+@bgp_addr_l2vpn.group(cls=clicommon.AbbreviationGroup, name="evpn")
 def bgp_addr_l2vpn_evpn():
     """L2VPN EVPN address family configuration"""
     pass
 
+
 #
 # 'bgp address-family l2vpn evpn advertise-all-vni' command
 #
-@bgp_addr_l2vpn_evpn.command('advertise-all-vni')
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_addr_l2vpn_evpn.command("advertise-all-vni")
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def advertise_all_vni(db, mode):
     """Advertise all local VNIs"""
@@ -1953,22 +2294,30 @@ def advertise_all_vni(db, mode):
     if not bgp_globals.get("local_asn"):
         ctx.fail("AS number is not specified")
 
-    db.cfgdb.mod_entry("BGP_GLOBALS_AF", "default|l2vpn_evpn", {"advertise-all-vni": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_GLOBALS_AF",
+        "default|l2vpn_evpn",
+        {"advertise-all-vni": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp address-family l2vpn evpn neighbor' group
 #
-@bgp_addr_l2vpn_evpn.group(cls=clicommon.AbbreviationGroup, name='neighbor')
+@bgp_addr_l2vpn_evpn.group(cls=clicommon.AbbreviationGroup, name="neighbor")
 def bgp_addr_l2vpn_evpn_neighbor():
     """L2VPN EVPN neighbor address family configuration"""
     pass
 
+
 #
 # 'bgp address-family l2vpn evpn neighbor activate' command
 #
-@bgp_addr_l2vpn_evpn_neighbor.command('activate')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_addr_l2vpn_evpn_neighbor.command("activate")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def evpn_neighbor_activate(db, ip_intf, mode):
     """L2VPN EVPN neighbor activate"""
@@ -1988,14 +2337,21 @@ def evpn_neighbor_activate(db, ip_intf, mode):
     if not bgp_neighbor.get("asn"):
         ctx.fail("Specify BGP neighbor remote-as first")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), {"admin_status": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR_AF",
+        ("default", ip_intf, "l2vpn_evpn"),
+        {"admin_status": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp address-family l2vpn evpn neighbor route-reflector-client' command
 #
-@bgp_addr_l2vpn_evpn_neighbor.command('route-reflector-client')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_addr_l2vpn_evpn_neighbor.command("route-reflector-client")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def evpn_neighbor_rrc(db, ip_intf, mode):
     """L2VPN EVPN neighbor route-reflector-client"""
@@ -2015,25 +2371,36 @@ def evpn_neighbor_rrc(db, ip_intf, mode):
     if not bgp_neighbor.get("asn"):
         ctx.fail("Specify BGP neighbor remote-as first")
 
-    if bgp_neighbor.get("asn") == bgp_globals.get("local_asn") or bgp_neighbor.get("asn") == "internal":
-        db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), {"rrclient": "true" if mode == "on" else "false"})
+    if (
+        bgp_neighbor.get("asn") == bgp_globals.get("local_asn")
+        or bgp_neighbor.get("asn") == "internal"
+    ):
+        db.cfgdb.mod_entry(
+            "BGP_NEIGHBOR_AF",
+            ("default", ip_intf, "l2vpn_evpn"),
+            {"rrclient": "true" if mode == "on" else "false"},
+        )
     else:
         ctx.fail("Invalid command. Not an internal neighbor")
+
 
 #
 # 'bgp address-family l2vpn evpn neighbor soft-reconf' group
 #
-@bgp_addr_l2vpn_evpn_neighbor.group(cls=clicommon.AbbreviationGroup, name='soft-reconf')
+@bgp_addr_l2vpn_evpn_neighbor.group(cls=clicommon.AbbreviationGroup, name="soft-reconf")
 def bgp_addr_l2vpn_evpn_neighbor_soft_reconf():
     """L2VPN EVPN neighbor soft reconfiguration"""
     pass
 
+
 #
 # 'bgp address-family l2vpn evpn neighbor soft-reconf inbound' command
 #
-@bgp_addr_l2vpn_evpn_neighbor_soft_reconf.command('inbound')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
+@bgp_addr_l2vpn_evpn_neighbor_soft_reconf.command("inbound")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
 @clicommon.pass_db
 def evpn_neighbor_reconf_inbound(db, ip_intf, mode):
     """Allow neighbor inbound soft reconfiguration"""
@@ -2053,15 +2420,22 @@ def evpn_neighbor_reconf_inbound(db, ip_intf, mode):
     if not bgp_neighbor.get("asn"):
         ctx.fail("Specify BGP neighbor remote-as first")
 
-    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), {"soft_reconfiguration_in": "true" if mode == "on" else "false"})
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR_AF",
+        ("default", ip_intf, "l2vpn_evpn"),
+        {"soft_reconfiguration_in": "true" if mode == "on" else "false"},
+    )
+
 
 #
 # 'bgp address-family l2vpn evpn neighbor allowas-in' command
 #
-@bgp_addr_l2vpn_evpn_neighbor.command('allowas-in')
-@click.argument('ip_intf', metavar='<ip_addr|interface_name>', required=True)
-@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(["on", "off"]))
-@click.option('--allowas', metavar='<1-10|origin>', required=False)
+@bgp_addr_l2vpn_evpn_neighbor.command("allowas-in")
+@click.argument("ip_intf", metavar="<ip_addr|interface_name>", required=True)
+@click.argument(
+    "mode", metavar="<mode>", required=True, type=click.Choice(["on", "off"])
+)
+@click.option("--allowas", metavar="<1-10|origin>", required=False)
 @clicommon.pass_db
 def evpn_neighbor_allowas_in(db, ip_intf, mode, allowas):
     """Accept as-path with my AS present in it"""
@@ -2076,7 +2450,9 @@ def evpn_neighbor_allowas_in(db, ip_intf, mode, allowas):
     if allowas:
         if allowas != "origin":
             try:
-                if int(allowas) not in range(BGP_NEIGHBOR_ALLOWAS_MIN, BGP_NEIGHBOR_ALLOWAS_MAX):
+                if int(allowas) not in range(
+                    BGP_NEIGHBOR_ALLOWAS_MIN, BGP_NEIGHBOR_ALLOWAS_MAX
+                ):
                     raise ValueError
             except ValueError:
                 ctx.fail("'--allowas' argument is not valid")
@@ -2096,5 +2472,6 @@ def evpn_neighbor_allowas_in(db, ip_intf, mode, allowas):
             bgp_neighbor_af["allow_as_origin"] = "true"
         else:
             bgp_neighbor_af["allow_as_count"] = allowas
-    db.cfgdb.mod_entry("BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), bgp_neighbor_af)
-
+    db.cfgdb.mod_entry(
+        "BGP_NEIGHBOR_AF", ("default", ip_intf, "l2vpn_evpn"), bgp_neighbor_af
+    )

--- a/config/main.py
+++ b/config/main.py
@@ -44,6 +44,7 @@ import utilities_common.multi_asic as multi_asic_util
 from .utils import log
 
 from . import aaa
+from . import bgp
 from . import chassis_modules
 from . import console
 from . import feature
@@ -571,86 +572,6 @@ def get_intf_ipv6_link_local_mode(ctx, interface_name, table_name):
             return "disable"
     else:
         return ""
-
-def _is_neighbor_ipaddress(config_db, ipaddress):
-    """Returns True if a neighbor has the IP address <ipaddress>, False if not
-    """
-    entry = config_db.get_entry('BGP_NEIGHBOR', ipaddress)
-    return True if entry else False
-
-def _get_all_neighbor_ipaddresses(config_db):
-    """Returns list of strings containing IP addresses of all BGP neighbors
-    """
-    addrs = []
-    bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
-    for addr, session in bgp_sessions.items():
-        addrs.append(addr)
-    return addrs
-
-def _get_neighbor_ipaddress_list_by_hostname(config_db, hostname):
-    """Returns list of strings, each containing an IP address of neighbor with
-       hostname <hostname>. Returns empty list if <hostname> not a neighbor
-    """
-    addrs = []
-    bgp_sessions = config_db.get_table('BGP_NEIGHBOR')
-    for addr, session in bgp_sessions.items():
-        if 'name' in session and session['name'] == hostname:
-            addrs.append(addr)
-    return addrs
-
-def _change_bgp_session_status_by_addr(config_db, ipaddress, status, verbose):
-    """Start up or shut down BGP session by IP address
-    """
-    verb = 'Starting' if status == 'up' else 'Shutting'
-    click.echo("{} {} BGP session with neighbor {}...".format(verb, status, ipaddress))
-
-    config_db.mod_entry('bgp_neighbor', ipaddress, {'admin_status': status})
-
-def _change_bgp_session_status(config_db, ipaddr_or_hostname, status, verbose):
-    """Start up or shut down BGP session by IP address or hostname
-    """
-    ip_addrs = []
-
-    # If we were passed an IP address, convert it to lowercase because IPv6 addresses were
-    # stored in ConfigDB with all lowercase alphabet characters during minigraph parsing
-    if _is_neighbor_ipaddress(config_db, ipaddr_or_hostname.lower()):
-        ip_addrs.append(ipaddr_or_hostname.lower())
-    else:
-        # If <ipaddr_or_hostname> is not the IP address of a neighbor, check to see if it's a hostname
-        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, ipaddr_or_hostname)
-
-    if not ip_addrs:
-        return False
-
-    for ip_addr in ip_addrs:
-        _change_bgp_session_status_by_addr(config_db, ip_addr, status, verbose)
-
-    return True
-
-def _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname):
-    """validates whether the given ip or host name is a BGP neighbor
-    """
-    ip_addrs = []
-    if _is_neighbor_ipaddress(config_db, neighbor_ip_or_hostname.lower()):
-        ip_addrs.append(neighbor_ip_or_hostname.lower())
-    else:
-        ip_addrs = _get_neighbor_ipaddress_list_by_hostname(config_db, neighbor_ip_or_hostname.upper())
-
-    return ip_addrs
-
-def _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
-    """Removes BGP configuration of the given neighbor
-    """
-    ip_addrs = _validate_bgp_neighbor(config_db, neighbor_ip_or_hostname)
-
-    if not ip_addrs:
-        return False
-
-    for ip_addr in ip_addrs:
-        config_db.mod_entry('bgp_neighbor', ip_addr, None)
-        click.echo("Removed configuration of BGP neighbor {}".format(ip_addr))
-
-    return True
 
 def _change_hostname(hostname):
     current_hostname = os.uname()[1]
@@ -1391,6 +1312,7 @@ def config(ctx):
 config.add_command(aaa.aaa)
 config.add_command(aaa.tacacs)
 config.add_command(aaa.radius)
+config.add_command(bgp.bgp)
 config.add_command(chassis_modules.chassis)
 config.add_command(console.console)
 config.add_command(fabric.fabric)
@@ -1402,6 +1324,9 @@ config.add_command(muxcable.muxcable)
 config.add_command(nat.nat)
 config.add_command(vlan.vlan)
 config.add_command(vxlan.vxlan)
+
+# BGP module extensions
+config.commands['bgp'].add_command(bgp_cli.DEVICE_GLOBAL)
 
 #add mclag commands
 config.add_command(mclag.mclag)
@@ -4147,167 +4072,6 @@ def del_user(db, user):
         except SystemExit as e:
             click.echo("Restart service snmp failed with error {}".format(e))
             raise click.Abort()
-
-#
-# 'bgp' group ('config bgp ...')
-#
-
-@config.group(cls=clicommon.AbbreviationGroup)
-def bgp():
-    """BGP-related configuration tasks"""
-    pass
-
-
-
-# BGP module extensions
-config.commands['bgp'].add_command(bgp_cli.DEVICE_GLOBAL)
-
-#
-# 'shutdown' subgroup ('config bgp shutdown ...')
-#
-
-@bgp.group(cls=clicommon.AbbreviationGroup)
-def shutdown():
-    """Shut down BGP session(s)"""
-    pass
-
-# 'all' subcommand
-@shutdown.command()
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def all(verbose):
-    """Shut down all BGP sessions
-       In the case of Multi-Asic platform, we shut only the EBGP sessions with external neighbors.
-    """
-    log.log_info("'bgp shutdown all' executing...")
-    namespaces = [DEFAULT_NAMESPACE]
-
-    if multi_asic.is_multi_asic():
-        ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns']
-
-    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    for namespace in namespaces:
-        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        config_db.connect()
-        bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db)
-        for ipaddress in bgp_neighbor_ip_list:
-            _change_bgp_session_status_by_addr(config_db, ipaddress, 'down', verbose)
-
-# 'neighbor' subcommand
-@shutdown.command()
-@click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def neighbor(ipaddr_or_hostname, verbose):
-    """Shut down BGP session by neighbor IP address or hostname.
-       User can specify either internal or external BGP neighbor to shutdown
-    """
-    log.log_info("'bgp shutdown neighbor {}' executing...".format(ipaddr_or_hostname))
-    namespaces = [DEFAULT_NAMESPACE]
-    found_neighbor = False
-
-    if multi_asic.is_multi_asic():
-        ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns'] + ns_list['back_ns']
-
-    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    for namespace in namespaces:
-        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        config_db.connect()
-        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'down', verbose):
-            found_neighbor = True
-
-    if not found_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
-
-@bgp.group(cls=clicommon.AbbreviationGroup)
-def startup():
-    """Start up BGP session(s)"""
-    pass
-
-# 'all' subcommand
-@startup.command()
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def all(verbose):
-    """Start up all BGP sessions
-       In the case of Multi-Asic platform, we startup only the EBGP sessions with external neighbors.
-    """
-    log.log_info("'bgp startup all' executing...")
-    namespaces = [DEFAULT_NAMESPACE]
-
-    if multi_asic.is_multi_asic():
-        ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns']
-
-    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    for namespace in namespaces:
-        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        config_db.connect()
-        bgp_neighbor_ip_list = _get_all_neighbor_ipaddresses(config_db)
-        for ipaddress in bgp_neighbor_ip_list:
-            _change_bgp_session_status_by_addr(config_db, ipaddress, 'up', verbose)
-
-# 'neighbor' subcommand
-@startup.command()
-@click.argument('ipaddr_or_hostname', metavar='<ipaddr_or_hostname>', required=True)
-@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
-def neighbor(ipaddr_or_hostname, verbose):
-    log.log_info("'bgp startup neighbor {}' executing...".format(ipaddr_or_hostname))
-    """Start up BGP session by neighbor IP address or hostname.
-       User can specify either internal or external BGP neighbor to startup
-    """
-    namespaces = [DEFAULT_NAMESPACE]
-    found_neighbor = False
-
-    if multi_asic.is_multi_asic():
-        ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns'] + ns_list['back_ns']
-
-    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    for namespace in namespaces:
-        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        config_db.connect()
-        if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'up', verbose):
-            found_neighbor = True
-
-    if not found_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
-
-#
-# 'remove' subgroup ('config bgp remove ...')
-#
-
-@bgp.group(cls=clicommon.AbbreviationGroup)
-def remove():
-    "Remove BGP neighbor configuration from the device"
-    pass
-
-@remove.command('neighbor')
-@click.argument('neighbor_ip_or_hostname', metavar='<neighbor_ip_or_hostname>', required=True)
-def remove_neighbor(neighbor_ip_or_hostname):
-    """Deletes BGP neighbor configuration of given hostname or ip from devices
-       User can specify either internal or external BGP neighbor to remove
-    """
-    namespaces = [DEFAULT_NAMESPACE]
-    removed_neighbor = False
-
-    if multi_asic.is_multi_asic():
-        ns_list = multi_asic.get_all_namespaces()
-        namespaces = ns_list['front_ns'] + ns_list['back_ns']
-
-    # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
-    for namespace in namespaces:
-        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        config_db.connect()
-        if _remove_bgp_neighbor_config(config_db, neighbor_ip_or_hostname):
-            removed_neighbor = True
-
-    if not removed_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(neighbor_ip_or_hostname))
 
 #
 # 'interface' group ('config interface ...')

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2722,6 +2722,514 @@ This command is used to remove particular IPv4 or IPv6 BGP neighbor configuratio
   admin@sonic:~$ sudo config bgp remove neighbor SONIC02SPINE
   ```
 
+**config bgp autonomous-system add**
+
+This command is used to enable a BGP protocol process with the specified ASN.
+
+- Usage:
+  ```
+  config bgp autonomous-system add <asn>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp autonomous-system add 100
+  ```
+
+**config bgp router-id add**
+
+This command is used to specify the router-ID. By default router ID value is selected as the largest IP Address of the interfaces.
+Loopback interface ip address is preferable option for router-ID.
+
+- Usage:
+  ```
+  config bgp router-id add <interface-ip>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp router-id add  10.10.10.10
+  ```
+
+**config bgp neighbor remote-as add**
+
+This command is used to add the BGP neighbor with specified remote AS number.
+
+- Usage:
+  ```
+  config bgp neighbor remote-as <neighbor-ip> <remote-asn>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp neighbor remote-as add 10.0.0.61 64015
+  ```
+
+**config bgp neighbor update-source add**
+
+This command is used to specify the local IP source address to use for the BGP session to this neighbour.
+
+- Usage:
+  ```
+  config bgp neighbor update-source add <neighbor-ip> <local-ip-source>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp neighbor update-source add 10.0.0.61 10.0.0.60
+  ```
+
+**config bgp bestpath as-path multipath-relax on**
+
+This command is used to specifiy that BGP decision process should consider paths of equal AS_PATH length candidates for multipath computation
+Without the knob, the entire AS_PATH must match for multipath computation.
+
+- Usage:
+  ```
+  config bgp bestpath as-path multipath-relax <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp bestpath as-path multipath-relax on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp bestpath as-path multipath-relax off
+  ```
+
+**config bgp address-family ipv4 unicast max-paths add**
+
+This command is used to set the maximum-paths value used for ecmp calculations for this address family.
+
+- Usage:
+  ```
+  config bgp address-family ipv4 unicast max-paths add <maximum-paths>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast max-paths add 64
+  ```
+
+**config bgp address-family ipv4 unicast network add**
+
+This command is used to add the announcement network. This network will be announced to all neighbors.
+
+- Usage:
+  ```
+  config bgp address-family ipv4 unicast network add <network>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast network add 10.127.127.1/32
+  ```
+
+**config bgp address-family ipv4 unicast neighbor activate**
+
+This command is used to modify whether to enable an address family for a specific neighbor.
+By default only the IPv4 unicast address family is enabled.
+
+- Usage:
+  ```
+  config bgp address-family ipv4 unicast neighbor activate <neighbor-ip> <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast neighbor activate 10.0.0.2 on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast neighbor activate 10.0.0.2 off
+  ```
+
+**config bgp graceful-restart state**
+
+This command is used to enable BGP graceful restart functionality at the global level.
+
+- Usage:
+  ```
+  config bgp graceful-restart state <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp graceful-restart state on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp graceful-restart state off
+  ```
+
+**config bgp graceful-restart restart-time add**
+
+This command is used to set the time to wait to delete stale routes before a BGP open message is received.
+
+- Usage:
+  ```
+  config bgp graceful-restart restart-time add <time>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp graceful-restart restart-time add 5
+  ```
+
+**config bgp graceful-restart stalepath-time add**
+
+This command is used to set the max time (in seconds) to hold onto restarting peer’s stale paths.
+It also controls Enhanced Route-Refresh timer.
+If this command is configured and the router does not receive a Route-Refresh EoRR message, the router removes the stale routes from the BGP table after the timer expires. The stale path timer is started when the router receives a Route-Refresh BoRR message.
+
+- Usage:
+  ```
+  config bgp graceful-restart stalepath-time add <time>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp graceful-restart stalepath-time add 6
+  ```
+
+**config bgp graceful-restart preserve-fw-state**
+
+This command is used to set Forwarding State (F) bit in “Flags for Address Family” for given AFI and SAFI.
+When set, the bit indicates that the forwarding state has been preserved. 
+
+- Usage:
+  ```
+  config bgp graceful-restart preserve-fw-state <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp graceful-restart preserve-fw-state on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp graceful-restart preserve-fw-state off
+  ```
+
+**config bgp listen limit add**
+
+This command is used to define the maximum number of peers accepted for one BGP instance. This limit is set to 100 by default.
+
+- Usage:
+  ```
+  config bgp listen limit add <max_dynamic_neighbors>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp listen limit add 10
+  ```
+
+**config bgp default ipv4-unicast**
+
+This command is used to allow the user to specify that the IPv4 Unicast address family is turned on by default or not.
+This command defaults to on.
+
+- Usage:
+  ```
+  config bgp default ipv4-unicast <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp default ipv4-unicast on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp default ipv4-unicast off
+  ```
+
+**config bgp fast-external-failover**
+
+This command is used to cause bgp to take down ebgp peers immediately when a link flaps.
+
+- Usage:
+  ```
+  config bgp fast-external-failover <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp fast-external-failover on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp fast-external-failover off
+  ```
+
+**config bgp bestpath compare-routerid**
+
+This command is used to ensure that when comparing routes where both are equal on most metrics,
+including local-pref, AS_PATH length, IGP cost, MED, that the tie is broken based on router-ID.
+
+- Usage:
+  ```
+  config bgp bestpath compare-routerid <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp bestpath compare-routerid on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp bestpath compare-routerid off
+  ```
+
+**config bgp client-to-client reflection**
+
+This command is used to enable route reflector automatically reflects routes from one BGP client to another.
+By default reflection is enabled. Off argument disables route reflection.
+
+- Usage:
+  ```
+  config bgp client-to-client reflection <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp client-to-client reflection on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp client-to-client reflection off
+  ```
+
+**config bgp cluster-id add**
+
+This command is used to add cluster. Cluster is a collection of route reflectors and their clients, and is used by route reflectors to avoid looping.
+
+- Usage:
+  ```
+  config bgp cluster-id add <cluster-ip>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp cluster-id add 10.20.30.40
+  ```
+
+**config bgp address-family ipv4 unicast distance bgp add**
+
+This command is used to change distance value of BGP. The arguments are the distance values for external routes, internal routes and local routes respectively.
+
+- Usage:
+  ```
+  config bgp address-family ipv4 unicast distance bgp add <ext_r_dist> <int_r_dist> <local_r_dist>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast distance bgp add 64 65 66
+  ```
+
+**config bgp address-family ipv4 unicast redistribute connected**
+
+This command is used to redistribute all the connected routes from other protocols into BGP.
+
+- Usage:
+  ```
+  config bgp address-family ipv4 unicast redistribute connected <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast redistribute connected on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast redistribute connected off
+  ```
+
+**config bgp neighbor local-as add**
+
+This command is used to specify an alternate AS for this BGP process when interacting with the specified peer. With no modifiers, the specified local-as is prepended to the received AS_PATH when receiving routing updates from the peer, and prepended to the outgoing AS_PATH (after the process local AS) when transmitting local routes to the peer.
+If the no-prepend attribute is specified, then the supplied local-as is not prepended to the received AS_PATH.
+If the replace-as attribute is specified, then only the supplied local-as is prepended to the AS_PATH when transmitting local-route updates to this peer.
+Note that replace-as can only be specified if no-prepend is.
+This command is only allowed for eBGP peers.
+
+- Usage:
+  ```
+  config bgp neighbor local-as add <neighbor-ip> <local-asn> [--no-prepend|--replace-as]
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp neighbor local-as add 10.0.0.61 64016 --no-prepend --replace-as
+  ```
+
+**config bgp neighbor ebgp-multihop**
+
+This command is used to allow sessions with eBGP neighbors to establish when they are multiple hops (--max-hops) away.
+When the neighbor is not directly connected and this knob is not enabled, the session will not establish.
+
+- Usage:
+  ```
+  config bgp neighbor ebgp-multihop <neighbor-ip> <on/off> [--max-hops <hops>]
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp neighbor ebgp-multihop 10.0.0.61 on --max-hops 64
+  ```
+
+**config bgp neighbor advertisement-interval add**
+
+This command is used to setup the minimum route advertisement interval(mrai) for the peer in question.
+This number is between 0 and 600 seconds, with the default advertisement interval being 0.
+
+- Usage:
+  ```
+  config bgp neighbor advertisement-interval add <neighbor-ip> <interval>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp neighbor advertisement-interval add 10.0.0.61 9
+  ```
+
+**config bgp neighbor timers add**
+
+This command is used to set keepalive and hold timers for a neighbor. 
+
+- Usage:
+  ```
+  config bgp neighbor timers add <neighbor-ip> <keepalive> <holdtime>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp neighbor advertisement-interval add 10.0.0.61 9 10
+  ```
+
+**config bgp neighbor shutdown**
+
+This command is used to shutdown the peer. 
+When you want to preserve the configuration, but want to drop the BGP peer, use this syntax.
+
+- Usage:
+  ```
+  config bgp neighbor shutdown <neighbor-ip> <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ config bgp neighbor shutdown 10.0.0.61 on
+  ```
+
+**config bgp address-family ipv4 unicast max-paths ibgp add**
+
+This command is used to sets the maximum-paths value used for ecmp calculations for this bgp instance in IBGP.
+
+- Usage:
+  ```
+  config bgp address-family ipv4 unicast max-paths ibgp add <max_ibgp_paths> [--equal-cluster-length]
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family ipv4 unicast max-paths ibgp add 8 --equal-cluster-length
+  ```
+
+**config bgp ebgp-requires-policy**
+
+This command is used to require incoming and outgoing filters to be applied for eBGP sessions as part of RFC-8212 compliance.
+Without the incoming filter, no routes will be accepted. Without the outgoing filter, no routes will be announced.
+Enabled by default.
+
+- Usage:
+  ```
+  config bgp ebgp-requires-policy <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp ebgp-requires-policy on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp ebgp-requires-policy off
+  ```
+
+**config bgp address-family l2vpn evpn neighbor activate**
+
+This command is used to activate the l2vpn evpn address-family for this peer in order to allow EVPN NLRI to be advertised and received.
+
+- Usage:
+  ```
+  config bgp address-family l2vpn evpn neighbor activate <neighbor-ip> <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn neighbor activate 10.0.0.2 on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn neighbor activate 10.0.0.2 off
+  ```
+
+**config bgp address-family l2vpn evpn advertise-all-vni**
+
+This command is used to enable EVPN for a BGP instance.
+
+- Usage:
+  ```
+  config bgp address-family l2vpn evpn advertise-all-vni <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn advertise-all-vni on
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn advertise-all-vni off
+  ```
+
+**config bgp address-family l2vpn evpn neighbor allowas-in**
+
+This command is used to accept incoming routes with AS path containing AS number with the same value as the current system AS.
+This is used when you want to use the same AS number in your sites, but you can’t connect them directly.
+This is an alternative to neighbor WORD as-override.
+The parameter (1-10) configures the amount of accepted occurrences of the system AS number in AS path.
+
+- Usage:
+  ```
+  config bgp address-family l2vpn evpn neighbor allowas-in <nighbor-ip> <on/off> [--allowas <1-10|origin>]
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn neighbor allowas-in 10.0.0.61 on --allowas origin
+  ```
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn neighbor allowas-in 10.0.0.61 on --allowas 2
+  ```
+
+**config bgp address-family l2vpn evpn neighbor route-reflector-client**
+
+This command is used to configure multiple reflector. This helps to avoid single point of failure.
+
+- Usage:
+  ```
+  config bgp address-family l2vpn evpn neighbor route-reflector-client <neighbor-ip> <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn neighbor route-reflector-client 10.0.0.61 on
+  ```
+
+**config bgp address-family l2vpn evpn neighbor soft-reconf inbound**
+
+This command is used to save the routing information from neighbor unmodified in the adj-RIB-in table. The inbound BGP policy will be applied and routing information will be stored in the BGP table.
+
+- Usage:
+  ```
+  config bgp address-family l2vpn evpn neighbor soft-reconf inbound <neighbor-ip> <on/off>
+  ```
+
+- Examples:
+  ```
+  admin@sonic:~$ sudo config bgp address-family l2vpn evpn neighbor soft-reconf inbound 10.0.0.61 on
+  ```
+
 **config bgp device-global tsa/w-ecmp**
 
 This command is used to manage BGP device global configuration.

--- a/tests/bgp_commands_extended_test.py
+++ b/tests/bgp_commands_extended_test.py
@@ -1,0 +1,1781 @@
+import os
+import pytest
+
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+
+class TestBgpExtendedCommandsAs(object):
+    @classmethod
+    def setup_class(cls):
+        #print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        #print("TEARDOWN")
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp autonomous-system add <as_num>
+    # config bgp autonomous-system del <as_num>
+
+    @pytest.mark.parametrize("asn", [
+        "1",
+        "65100",
+        "1231231231",
+        "4294967295",
+    ])
+    def test_bgp_config_as_add_del_asn_valid(self, asn):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp autonomous-system add <asn>
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [asn], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["local_asn"] == asn
+
+        # config bgp autonomous-system del <asn>
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["del"], [asn], obj=db)
+        assert result.exit_code == 0
+        assert "default" not in db.cfgdb.get_table("BGP_GLOBALS")
+
+    @pytest.mark.parametrize("asn", [
+        "0",
+        "4294967296",
+        "string",
+        "32313553434394192138954869547869324129301"
+    ])
+    def test_bgp_config_as_add_del_asn_invalid(self, asn):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp autonomous-system add <asn>
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [asn], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<as_num>\"" in result.output
+
+        # config bgp autonomous-system del <asn>
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["del"], [asn], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<as_num>\"" in result.output
+
+    def test_bgp_config_as_del_asn_nonexistent(self):
+        db = Db()
+        runner = CliRunner()
+
+        asn = "100"
+        # config bgp autonomous-system del <asn>
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["del"], [asn], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not configured" in result.output
+
+class TestBgpExtentedCommands(object):
+    @classmethod
+    def setup_class(cls):
+        #print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        #print("TEARDOWN")
+
+    default_asn = "65100"
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp fast-external-failover <on|off>
+    # config bgp default ipv4-unicast <on|off>
+    # config bgp client-to-client reflection <on|off>
+    # config bgp bestpath compare-routerid <on|off>
+    # config bgp bestpath as-path multipath-relax <on|off>
+    # config bgp graceful-restart mode <on|off>
+    # config bgp graceful-restart preserve-fw-state <on|off>
+    # config bgp address-family ipv4 unicast redistribute connected <on|off>
+    # config bgp address-family l2vpn evpn advertise-all-vni <on|off>
+
+    def test_bgp_config_fast_external_failover(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["fast-external-failover"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp fast-external-failover on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp fast-external-failover off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp fast-external-failover on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["fast_external_failover"] == "true"
+
+        # config bgp fast-external-failover off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["fast_external_failover"] == "false"
+
+
+    def test_bgp_config_default_ipv4_unicast(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["default"].commands["ipv4-unicast"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp default ipv4-unicast on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp default ipv4-unicast off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp default ipv4-unicast on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["default_ipv4_unicast"] == "true"
+
+        # config bgp default ipv4-unicast off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["default_ipv4_unicast"] == "false"
+
+    def test_bgp_config_client_to_client_reflection(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["client-to-client"].commands["reflection"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp client-to-client reflection on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp client-to-client reflection off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp client-to-client reflection on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_clnt_to_clnt_reflection"] == "true"
+
+        # config bgp client-to-client reflection off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_clnt_to_clnt_reflection"] == "false"
+
+    def test_bgp_config_bestpath_compare_routerid(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["bestpath"].commands["compare-routerid"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp bestpath compare-routerid on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp bestpath compare-routerid off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp bestpath compare-routerid on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["external_compare_router_id"] == "true"
+
+        # config bgp bestpath compare-routerid off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["external_compare_router_id"] == "false"
+
+    def test_bgp_config_bestpath_as_path_multipath_relax(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["bestpath"].commands["as-path"].commands["multipath-relax"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp bestpath as-path multipath-relax on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp bestpath as-path multipath-relax off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp bestpath as-path multipath-relax on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["load_balance_mp_relax"] == "true"
+
+        # config bgp bestpath as-path multipath-relax off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["load_balance_mp_relax"] == "false"
+
+
+    def test_bgp_config_graceful_restart(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["graceful-restart"].commands["mode"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp graceful-restart mode on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp graceful-restart mode off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart mode on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["graceful_restart_enable"] == "true"
+
+        # config bgp graceful-restart mode off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["graceful_restart_enable"] == "false"
+
+
+    def test_bgp_config_graceful_restart_preserve_fw_state(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["graceful-restart"].commands["preserve-fw-state"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp graceful-restart preserve-fw-state on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp graceful-restart preserve-fw-state off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart preserve-fw-state on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_preserve_fw_state"] == "true"
+
+        # config bgp graceful-restart preserve-fw-state off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_preserve_fw_state"] == "false"
+
+
+    def test_bgp_config_address_family_ipv4_unicast_redistribute_connected(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["redistribute"].commands["connected"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp address-family ipv4 unicast redistribute connected on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast redistribute connected off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast redistribute connected on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert ("default", "connected", "bgp", "ipv4") in db.cfgdb.get_table("ROUTE_REDISTRIBUTE")
+
+        # config bgp address-family ipv4 unicast redistribute connected off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert ("default", "connected", "bgp", "ipv4") not in db.cfgdb.get_table("ROUTE_REDISTRIBUTE")
+
+
+    def test_bgp_config_address_family_l2vpn_evpn_advertise_all_vni(self):
+        db = Db()
+        runner = CliRunner()
+        cmd = config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].commands["evpn"].commands["advertise-all-vni"]
+
+        # Invalid input
+        result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<mode>\"" in result.output
+
+        # Without configured AS
+
+        # config bgp address-family l2vpn evpn advertise-all-vni on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family l2vpn evpn advertise-all-vni off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+
+        # With configured AS
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family l2vpn evpn advertise-all-vni on
+        result = runner.invoke(cmd, ["on"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "l2vpn_evpn")]["advertise-all-vni"] == "true"
+
+        # config bgp address-family l2vpn evpn advertise-all-vni off
+        result = runner.invoke(cmd, ["off"], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "l2vpn_evpn")]["advertise-all-vni"] == "false"
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp router-id add <router_id>
+    # config bgp router-id set <router_id>
+    # config bgp router-id del <router_id>
+
+    default_router_id = "10.0.0.1"
+    router_ids_valid = [
+        "127.0.0.1",
+        "0.0.0.0",
+        "255.255.255.255",
+        "192.168.1.1",
+        "10.10.0.1",
+        "8.8.8.8"
+    ]
+
+    @pytest.mark.parametrize("router_id", router_ids_valid)
+    def test_bgp_config_router_id_add_del_valid(self, router_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp router-id add <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["router_id"] == router_id
+
+        # config bgp router-id del <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        assert result.exit_code == 0
+        assert "router_id" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+
+    @pytest.mark.parametrize("router_ids", [
+        ("192.168.1.1",),
+        ("192.168.1.1", "192.168.1.2",),
+        ("192.168.1.1", "192.168.1.2", "192.168.1.3",),
+    ])
+    def test_bgp_config_router_id_set_valid(self, router_ids):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        assert result.exit_code == 0
+
+        for router_id in router_ids:
+            # config bgp router-id set <router_id>
+            result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["router_id"] == router_id
+
+    @pytest.mark.parametrize("router_id", [
+        "192.168.1.1/32",
+        "255.255.255.256",
+        "255.255.255.2567"
+        "0.0.0",
+        "abc"
+    ])
+    def test_bgp_config_router_id_add_del_set_invalid(self, router_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp router-id add <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "IP address is not valid" in result.output
+
+        # config bgp router-id del <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "IP address is not valid" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp router-id set <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "IP address is not valid" in result.output
+
+    @pytest.mark.parametrize("router_id", router_ids_valid)
+    def test_bgp_config_router_id_set_del_nonexistent(self, router_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp router-id set <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "Router ID is not configured" in result.output
+
+        # config bgp router-id del <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "Router ID is not configured" in result.output
+
+    @pytest.mark.parametrize("router_id", router_ids_valid)
+    def test_bgp_config_router_id_add_with_existent(self, router_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp router-id add <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "Router identifier is already specified" in result.output
+
+    @pytest.mark.parametrize("router_id", router_ids_valid)
+    def test_bgp_config_router_id_del_wrong(self, router_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp router-id del <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert f"Configured router ID is {self.default_router_id}" in result.output
+
+    @pytest.mark.parametrize("router_id", router_ids_valid)
+    def test_bgp_config_router_id_add_set_del_no_as(self, router_id):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp router-id add <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp router-id set <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp router-id del <router_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp cluster-id add <cluster_id>
+    # config bgp cluster-id set <cluster_id>
+    # config bgp cluster-id del <cluster_id>
+
+    default_cluster_id = "10.0.0.1"
+    cluster_ids_valid = [
+        "127.0.0.1",
+        "0.0.0.0",
+        "255.255.255.255",
+        "192.168.1.1",
+        "10.10.0.1",
+        "8.8.8.8"
+    ]
+
+    @pytest.mark.parametrize("cluster_id", cluster_ids_valid)
+    def test_bgp_config_cluster_id_add_del_valid(self, cluster_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp cluster-id add <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_cluster_id"] == cluster_id
+
+        # config bgp cluster-id del <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        assert result.exit_code == 0
+        assert "rr_cluster_id" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+
+    @pytest.mark.parametrize("cluster_ids", [
+        ("192.168.1.1",),
+        ("192.168.1.1", "192.168.1.2",),
+        ("192.168.1.1", "192.168.1.2", "192.168.1.3",),
+    ])
+    def test_bgp_config_cluster_id_set_valid(self, cluster_ids):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        assert result.exit_code == 0
+
+        for cluster_id in cluster_ids:
+            # config bgp cluster-id set <cluster_id>
+            result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_cluster_id"] == cluster_id
+
+    @pytest.mark.parametrize("cluster_id", [
+        "192.168.1.1/32",
+        "255.255.255.256",
+        "255.255.255.2567"
+        "0.0.0",
+        "abc"
+    ])
+    def test_bgp_config_cluster_id_add_del_set_invalid(self, cluster_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp cluster-id add <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "IP address is not valid" in result.output
+
+        # config bgp cluster-id del <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "IP address is not valid" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp cluster-id set <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "IP address is not valid" in result.output
+
+    @pytest.mark.parametrize("cluster_id", cluster_ids_valid)
+    def test_bgp_config_cluster_id_set_del_nonexistent(self, cluster_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp cluster-id set <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "Cluster ID is not configured" in result.output
+
+        # config bgp cluster-id del <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "Cluster ID is not configured" in result.output
+
+    @pytest.mark.parametrize("cluster_id", cluster_ids_valid)
+    def test_bgp_config_cluster_id_add_with_existent(self, cluster_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp cluster-id add <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "Cluster ID is already added" in result.output
+
+    @pytest.mark.parametrize("cluster_id", cluster_ids_valid)
+    def test_bgp_config_cluster_id_del_wrong(self, cluster_id):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp cluster-id del <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert f"Configured cluster ID is {self.default_cluster_id}" in result.output
+
+    @pytest.mark.parametrize("cluster_id", cluster_ids_valid)
+    def test_bgp_config_cluster_id_add_set_del_no_as(self, cluster_id):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp cluster-id add <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp cluster-id set <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp cluster-id del <cluster_id>
+        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp listen limit add <limit>
+    # config bgp listen limit set <limit>
+    # config bgp listen limit del <limit>
+
+    default_listen_limit = "5"
+    listen_limits_valid = [
+        "1",
+        "100",
+        "65535"
+    ]
+
+    @pytest.mark.parametrize("listen_limit", listen_limits_valid)
+    def test_bgp_config_listen_limit_add_del_valid(self, listen_limit):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp listen limit add <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["max_dynamic_neighbors"] == listen_limit
+
+        # config bgp listen limit del <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        assert result.exit_code == 0
+        assert "max_dynamic_neighbors" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+
+    @pytest.mark.parametrize("listen_limits", [
+        ("1",),
+        ("1", "65535",),
+        ("1", "100", "65535",),
+    ])
+    def test_bgp_config_listen_limit_set_valid(self, listen_limits):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        assert result.exit_code == 0
+
+        for listen_limit in listen_limits:
+            # config bgp listen limit set <listen_limit>
+            result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["max_dynamic_neighbors"] == listen_limit
+
+    @pytest.mark.parametrize("listen_limit", [
+        "0",
+        "65536",
+        "4444444444444444",
+        "abc"
+    ])
+    def test_bgp_config_listen_limit_add_del_set_invalid(self, listen_limit):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp listen limit add <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<limit>\"" in result.output
+
+        # config bgp listen limit del <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<limit>\"" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp listen limit set <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<limit>\"" in result.output
+
+    @pytest.mark.parametrize("listen_limit", listen_limits_valid)
+    def test_bgp_config_listen_limit_set_del_nonexistent(self, listen_limit):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp listen limit set <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "Listen limit is not configured" in result.output
+
+        # config bgp listen limit del <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "Listen limit is not configured" in result.output
+
+    @pytest.mark.parametrize("listen_limit", listen_limits_valid)
+    def test_bgp_config_listen_limit_add_with_existent(self, listen_limit):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp listen limit add <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "Listen limit is already specified" in result.output
+
+    @pytest.mark.parametrize("listen_limit", listen_limits_valid)
+    def test_bgp_config_listen_limit_del_wrong(self, listen_limit):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp listen limit del <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert f"Configured listen limit is {self.default_listen_limit}" in result.output
+
+    @pytest.mark.parametrize("listen_limit", listen_limits_valid)
+    def test_bgp_config_listen_limit_add_set_del_no_as(self, listen_limit):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp listen limit add <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp listen limit set <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp listen limit del <listen_limit>
+        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp graceful-restart restart-time add <time>
+    # config bgp graceful-restart restart-time set <time>
+    # config bgp graceful-restart restart-time del <time>
+
+    default_restart_time = "1"
+    restart_times_valid = [
+        "0",
+        "100",
+        "4095"
+    ]
+
+    @pytest.mark.parametrize("restart_time", restart_times_valid)
+    def test_bgp_config_graceful_restart_restart_time_add_del_valid(self, restart_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart restart-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_restart_time"] == restart_time
+
+        # config bgp graceful-restart restart-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        assert result.exit_code == 0
+        assert "gr_restart_time" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+
+    @pytest.mark.parametrize("restart_times", [
+        ("0",),
+        ("0", "4095",),
+        ("0", "100", "4095",),
+    ])
+    def test_bgp_config_graceful_restart_restart_time_set_valid(self, restart_times):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        assert result.exit_code == 0
+
+        for restart_time in restart_times:
+            # config bgp graceful-restart restart-time set <time>
+            result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_restart_time"] == restart_time
+
+    @pytest.mark.parametrize("restart_time", [
+        "4096",
+        "4444444444444444",
+        "abc"
+    ])
+    def test_bgp_config_graceful_restart_restart_time_add_del_set_invalid(self, restart_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart restart-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<time>\"" in result.output
+
+        # config bgp graceful-restart restart-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<time>\"" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart restart-time set <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<time>\"" in result.output
+
+    @pytest.mark.parametrize("restart_time", restart_times_valid)
+    def test_bgp_config_graceful_restart_restart_time_set_del_nonexistent(self, restart_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart restart-time set <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "Graceful restart time is not configured" in result.output
+
+        # config bgp graceful-restart restart-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "Graceful restart time is not configured" in result.output
+
+    @pytest.mark.parametrize("restart_time", restart_times_valid)
+    def test_bgp_config_graceful_restart_restart_time_add_with_existent(self, restart_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart restart-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "Graceful restart time is already specified" in result.output
+
+    @pytest.mark.parametrize("restart_time", restart_times_valid)
+    def test_bgp_config_graceful_restart_restart_time_del_wrong(self, restart_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart restart-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert f"Configured graceful restart time is {self.default_restart_time}" in result.output
+
+    @pytest.mark.parametrize("restart_time", restart_times_valid)
+    def test_bgp_config_graceful_restart_restart_time_add_set_del_no_as(self, restart_time):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp graceful-restart restart-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp graceful-restart restart-time set <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp graceful-restart restart-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp graceful-restart stalepath-time add <time>
+    # config bgp graceful-restart stalepath-time set <time>
+    # config bgp graceful-restart stalepath-time del <time>
+
+    default_stalepath_time = "5"
+    stalepath_times_valid = [
+        "1",
+        "100",
+        "4095"
+    ]
+
+    @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
+    def test_bgp_config_graceful_restart_stalepath_time_add_del_valid(self, stalepath_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart stalepath-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_stale_routes_time"] == stalepath_time
+
+        # config bgp graceful-restart stalepath-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        assert result.exit_code == 0
+        assert "gr_stale_routes_time" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+
+    @pytest.mark.parametrize("stalepath_times", [
+        ("1",),
+        ("1", "4095",),
+        ("1", "100", "4095",),
+    ])
+    def test_bgp_config_graceful_restart_stalepath_time_set_valid(self, stalepath_times):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        assert result.exit_code == 0
+
+        for stalepath_time in stalepath_times:
+            # config bgp graceful-restart stalepath-time set <time>
+            result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_stale_routes_time"] == stalepath_time
+
+    @pytest.mark.parametrize("stalepath_time", [
+        "4096",
+        "4444444444444444",
+        "abc"
+    ])
+    def test_bgp_config_graceful_restart_stalepath_time_add_del_set_invalid(self, stalepath_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart stalepath-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<time>\"" in result.output
+
+        # config bgp graceful-restart stalepath-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<time>\"" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart stalepath-time set <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<time>\"" in result.output
+
+    @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
+    def test_bgp_config_graceful_restart_stalepath_time_set_del_nonexistent(self, stalepath_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart stalepath-time set <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "Graceful restart stalepath time is not configured" in result.output
+
+        # config bgp graceful-restart stalepath-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "Graceful restart stalepath time is not configured" in result.output
+
+    @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
+    def test_bgp_config_graceful_restart_stalepath_time_add_with_existent(self, stalepath_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart stalepath-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "Graceful restart stalepath time is already specified" in result.output
+
+    @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
+    def test_bgp_config_graceful_restart_stalepath_time_del_wrong(self, stalepath_time):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp graceful-restart stalepath-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert f"Configured graceful restart stalepath time is {self.default_stalepath_time}" in result.output
+
+    @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
+    def test_bgp_config_graceful_restart_stalepath_time_add_set_del_no_as(self, stalepath_time):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp graceful-restart stalepath-time add <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp graceful-restart stalepath-time set <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp graceful-restart stalepath-time del <time>
+        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp address-family ipv4 unicast max-paths add <paths_num>
+    # config bgp address-family ipv4 unicast max-paths set <paths_num>
+    # config bgp address-family ipv4 unicast max-paths del <paths_num>
+
+    default_paths_num = "5"
+    paths_nums_valid = [
+        "1",
+        "100",
+        "256"
+    ]
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_del_valid(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ebgp_paths"] == paths_num
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code == 0
+        assert "max_ebgp_paths" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+
+    @pytest.mark.parametrize("paths_nums", [
+        ("1",),
+        ("1", "256",),
+        ("1", "100", "256",),
+    ])
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_set_valid(self, paths_nums):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        for paths_num in paths_nums:
+            # config bgp address-family ipv4 unicast max-paths set <paths_num>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ebgp_paths"] == paths_num
+
+    @pytest.mark.parametrize("paths_num", [
+        "0",
+        "257",
+        "4444444444444444",
+        "abc"
+    ])
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_del_set_invalid(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<paths_num>\"" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<paths_num>\"" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths set <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<paths_num>\"" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_set_del_nonexistent(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths set <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Max-paths number is not configured" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Max-paths number is not configured" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_with_existent(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Max paths number is already specified" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_del_wrong(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert f"Configured max-paths number is {self.default_paths_num}" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_set_del_no_as(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths set <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp address-family ipv4 unicast max-paths ibgp add <paths_num> [--equal-cluster-length]
+    # config bgp address-family ipv4 unicast max-paths ibgp set <paths_num> [--equal-cluster-length]
+    # config bgp address-family ipv4 unicast max-paths ibgp del <paths_num>
+
+    default_paths_num = "5"
+    paths_nums_valid = [
+        "1",
+        "100",
+        "256"
+    ]
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_del_valid(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ibgp_paths"] == paths_num
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code == 0
+        assert "max_ibgp_paths" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+
+    @pytest.mark.parametrize("paths_nums", [
+        ("1",),
+        ("1", "256",),
+        ("1", "100", "256",),
+    ])
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_set_valid(self, paths_nums):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        for paths_num in paths_nums:
+            # config bgp address-family ipv4 unicast max-paths set <paths_num>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ibgp_paths"] == paths_num
+
+    @pytest.mark.parametrize("paths_num", [
+        "0",
+        "257",
+        "4444444444444444",
+        "abc"
+    ])
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_del_set_invalid(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<paths_num>\"" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<paths_num>\"" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths set <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<paths_num>\"" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_set_del_nonexistent(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths set <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Max-paths ibgp number is not configured" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Max-paths ibgp number is not configured" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_with_existent(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "Max ibgp paths number is already specified" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_del_wrong(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert f"Configured max-paths ibgp number is {self.default_paths_num}" in result.output
+
+    @pytest.mark.parametrize("paths_num", paths_nums_valid)
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_set_del_no_as(self, paths_num):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp address-family ipv4 unicast max-paths add <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths set <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast max-paths del <paths_num>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
+    # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
+    # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
+
+    default_distances = ["5", "5", "5"]
+    distances_valid = [
+        ["1", "1", "1"],
+        ["100", "100", "100"],
+        ["255", "255", "255"]
+    ]
+
+    @pytest.mark.parametrize("distances", distances_valid)
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_del_valid(self, distances):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ebgp_route_distance"] == distances[0] and \
+               db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ibgp_route_distance"] == distances[1] and \
+               db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["local_route_distance"] == distances[2]
+
+        # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        assert result.exit_code == 0
+        assert "ebgp_route_distance" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")] and \
+               "ibgp_route_distance" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")] and \
+               "local_route_distance" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+
+
+    @pytest.mark.parametrize("distances_sets", [
+        (["1", "1", "1"],),
+        (["1", "1", "1"], ["255", "255", "255"],),
+        (["1", "1", "1"], ["100", "100", "100"], ["255", "255", "255"],),
+    ])
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_set_valid(self, distances_sets):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        assert result.exit_code == 0
+
+        for distances in distances_sets:
+            # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ebgp_route_distance"] == distances[0] and \
+                   db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ibgp_route_distance"] == distances[1]  and \
+                   db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["local_route_distance"] == distances[2]
+
+
+    @pytest.mark.parametrize("distances", [
+        ["0", "0", "0"],
+        ["256", "256", "256"],
+        ["4444444444444444", "4444444444444444", "4444444444444444"],
+        ["abc", "abc", "abc"]
+    ])
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_del_set_invalid(self, distances):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<ebgp_dist>\"" in result.output or \
+               "Invalid value for \"<ibgp_dist>\"" in result.output or \
+               "Invalid value for \"<local_dist>\"" in result.output
+
+        # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<ebgp_dist>\"" in result.output or \
+               "Invalid value for \"<ibgp_dist>\"" in result.output or \
+               "Invalid value for \"<local_dist>\"" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "Invalid value for \"<ebgp_dist>\"" in result.output or \
+               "Invalid value for \"<ibgp_dist>\"" in result.output or \
+               "Invalid value for \"<local_dist>\"" in result.output
+
+    @pytest.mark.parametrize("distances", distances_valid)
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_set_del_nonexistent(self, distances):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "Distance bgp values are not configured" in result.output
+
+        # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "Distance bgp values are not configured" in result.output
+
+    @pytest.mark.parametrize("distances", distances_valid)
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_with_existent(self, distances):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "BGP distance values are already configured" in result.output
+
+    @pytest.mark.parametrize("distances", distances_valid)
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_del_wrong(self, distances):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        assert result.exit_code == 0
+
+        # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "Configured distance bgp values are " + " ".join(self.default_distances) in result.output
+
+    @pytest.mark.parametrize("distances", distances_valid)
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_set_del_no_as(self, distances):
+        db = Db()
+        runner = CliRunner()
+
+        # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    # -----------------------------------------------------------------------------------------------------------------------------------
+    # config bgp address-family ipv4 unicast network add <network>
+    # config bgp address-family ipv4 unicast network del <network>
+
+    networks_valid = [
+        ("127.0.0.1",),
+        ("10.0.0.1", "10.0.0.2/32", "10.10.10.0/24",),
+        ("0.0.0.0", "255.255.255.255"),
+        ("8.8.8.8", "8.8.4.4/32", "1.1.1.1",)
+    ]
+
+    @pytest.mark.parametrize("networks", networks_valid)
+    def test_bgp_config_address_family_ipv4_unicast_network_add_del_valid(self, networks):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        for network in networks:
+            # config bgp address-family ipv4 unicast network add <network>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            assert result.exit_code == 0
+
+            if "/" not in network:
+                network = network + "/32"
+
+            assert ("default", "ipv4_unicast", network) in db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK")
+
+        for network in networks:
+            # config bgp address-family ipv4 unicast network del <network>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+            assert result.exit_code == 0
+
+            if "/" not in network:
+                network = network + "/32"
+
+            assert ("default", "ipv4_unicast", network) not in db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK")
+
+    @pytest.mark.parametrize("networks", [
+        ("256.0.0.0",),
+        ("10.0.0.1/24", "10.0.0.2/0", "10.10.10.0/33",),
+        ("0.0.0.0.0", "0x0a0000a0"),
+        ("8.8.8", "qweqweqwe", "0.0.0.0\\16",)
+    ])
+    def test_bgp_config_address_family_ipv4_unicast_network_add_del_invalid(self, networks):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        for network in networks:
+            # config bgp address-family ipv4 unicast network add <network>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            assert result.exit_code != 0
+            assert "Network address is not valid" in result.output
+
+        for network in networks:
+            # config bgp address-family ipv4 unicast network del <network>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+            assert result.exit_code != 0
+            assert "Network address is not valid" in result.output
+
+    @pytest.mark.parametrize("networks", networks_valid)
+    def test_bgp_config_address_family_ipv4_unicast_network_del_nonexistent(self, networks):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        for network in networks:
+            # config bgp address-family ipv4 unicast network del <network>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+            assert result.exit_code != 0
+            assert "IPv4 unicast network does not exist" in result.output
+
+    @pytest.mark.parametrize("networks", networks_valid)
+    def test_bgp_config_address_family_ipv4_unicast_network_add_existent(self, networks):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        assert result.exit_code == 0
+
+        for network in networks:
+            # config bgp address-family ipv4 unicast network add <network>
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            assert result.exit_code == 0
+
+            if "/" not in network:
+                network = network + "/32"
+
+            assert ("default", "ipv4_unicast", network) in db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK")
+
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            assert result.exit_code != 0
+            assert "IPv4 unicast network already exists" in result.output
+
+    def test_bgp_config_address_family_ipv4_unicast_network_add_del_no_as(self):
+        db = Db()
+        runner = CliRunner()
+
+        network = "1.2.3.4"
+
+        # config bgp address-family ipv4 unicast network add <network>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        # config bgp address-family ipv4 unicast network del <network>
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output

--- a/tests/bgp_commands_extended_test.py
+++ b/tests/bgp_commands_extended_test.py
@@ -4,65 +4,82 @@ import pytest
 from click.testing import CliRunner
 
 import config.main as config
-import show.main as show
 from utilities_common.db import Db
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 
+
 class TestBgpExtendedCommandsAs(object):
     @classmethod
     def setup_class(cls):
-        #print("SETUP")
+        # print("SETUP")
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 
     @classmethod
     def teardown_class(cls):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
-        #print("TEARDOWN")
+        # print("TEARDOWN")
 
     # -----------------------------------------------------------------------------------------------------------------------------------
     # config bgp autonomous-system add <as_num>
     # config bgp autonomous-system del <as_num>
 
-    @pytest.mark.parametrize("asn", [
-        "1",
-        "65100",
-        "1231231231",
-        "4294967295",
-    ])
+    @pytest.mark.parametrize(
+        "asn",
+        [
+            "1",
+            "65100",
+            "1231231231",
+            "4294967295",
+        ],
+    )
     def test_bgp_config_as_add_del_asn_valid(self, asn):
         db = Db()
         runner = CliRunner()
 
         # config bgp autonomous-system add <asn>
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [asn],
+            obj=db,
+        )
         assert result.exit_code == 0
         assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["local_asn"] == asn
 
         # config bgp autonomous-system del <asn>
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["del"], [asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["del"],
+            [asn],
+            obj=db,
+        )
         assert result.exit_code == 0
         assert "default" not in db.cfgdb.get_table("BGP_GLOBALS")
 
-    @pytest.mark.parametrize("asn", [
-        "0",
-        "4294967296",
-        "string",
-        "32313553434394192138954869547869324129301"
-    ])
+    @pytest.mark.parametrize(
+        "asn",
+        ["0", "4294967296", "string", "32313553434394192138954869547869324129301"],
+    )
     def test_bgp_config_as_add_del_asn_invalid(self, asn):
         db = Db()
         runner = CliRunner()
 
         # config bgp autonomous-system add <asn>
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [asn],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<as_num>\"" in result.output
+        assert 'Invalid value for "<as_num>"' in result.output
 
         # config bgp autonomous-system del <asn>
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["del"], [asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["del"],
+            [asn],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<as_num>\"" in result.output
+        assert 'Invalid value for "<as_num>"' in result.output
 
     def test_bgp_config_as_del_asn_nonexistent(self):
         db = Db()
@@ -70,20 +87,25 @@ class TestBgpExtendedCommandsAs(object):
 
         asn = "100"
         # config bgp autonomous-system del <asn>
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["del"], [asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["del"],
+            [asn],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not configured" in result.output
+
 
 class TestBgpExtentedCommands(object):
     @classmethod
     def setup_class(cls):
-        #print("SETUP")
+        # print("SETUP")
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 
     @classmethod
     def teardown_class(cls):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
-        #print("TEARDOWN")
+        # print("TEARDOWN")
 
     default_asn = "65100"
 
@@ -106,7 +128,7 @@ class TestBgpExtentedCommands(object):
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -120,21 +142,29 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp fast-external-failover on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["fast_external_failover"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["fast_external_failover"]
+            == "true"
+        )
 
         # config bgp fast-external-failover off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["fast_external_failover"] == "false"
-
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["fast_external_failover"]
+            == "false"
+        )
 
     def test_bgp_config_default_ipv4_unicast(self):
         db = Db()
@@ -144,7 +174,7 @@ class TestBgpExtentedCommands(object):
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -158,30 +188,43 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp default ipv4-unicast on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["default_ipv4_unicast"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["default_ipv4_unicast"]
+            == "true"
+        )
 
         # config bgp default ipv4-unicast off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["default_ipv4_unicast"] == "false"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["default_ipv4_unicast"]
+            == "false"
+        )
 
     def test_bgp_config_client_to_client_reflection(self):
         db = Db()
         runner = CliRunner()
-        cmd = config.config.commands["bgp"].commands["client-to-client"].commands["reflection"]
+        cmd = (
+            config.config.commands["bgp"]
+            .commands["client-to-client"]
+            .commands["reflection"]
+        )
 
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -195,30 +238,43 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp client-to-client reflection on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_clnt_to_clnt_reflection"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_clnt_to_clnt_reflection"]
+            == "true"
+        )
 
         # config bgp client-to-client reflection off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_clnt_to_clnt_reflection"] == "false"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_clnt_to_clnt_reflection"]
+            == "false"
+        )
 
     def test_bgp_config_bestpath_compare_routerid(self):
         db = Db()
         runner = CliRunner()
-        cmd = config.config.commands["bgp"].commands["bestpath"].commands["compare-routerid"]
+        cmd = (
+            config.config.commands["bgp"]
+            .commands["bestpath"]
+            .commands["compare-routerid"]
+        )
 
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -232,30 +288,44 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp bestpath compare-routerid on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["external_compare_router_id"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["external_compare_router_id"]
+            == "true"
+        )
 
         # config bgp bestpath compare-routerid off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["external_compare_router_id"] == "false"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["external_compare_router_id"]
+            == "false"
+        )
 
     def test_bgp_config_bestpath_as_path_multipath_relax(self):
         db = Db()
         runner = CliRunner()
-        cmd = config.config.commands["bgp"].commands["bestpath"].commands["as-path"].commands["multipath-relax"]
+        cmd = (
+            config.config.commands["bgp"]
+            .commands["bestpath"]
+            .commands["as-path"]
+            .commands["multipath-relax"]
+        )
 
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -269,31 +339,41 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp bestpath as-path multipath-relax on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["load_balance_mp_relax"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["load_balance_mp_relax"]
+            == "true"
+        )
 
         # config bgp bestpath as-path multipath-relax off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["load_balance_mp_relax"] == "false"
-
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["load_balance_mp_relax"]
+            == "false"
+        )
 
     def test_bgp_config_graceful_restart(self):
         db = Db()
         runner = CliRunner()
-        cmd = config.config.commands["bgp"].commands["graceful-restart"].commands["mode"]
+        cmd = (
+            config.config.commands["bgp"].commands["graceful-restart"].commands["mode"]
+        )
 
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -307,31 +387,43 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart mode on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["graceful_restart_enable"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["graceful_restart_enable"]
+            == "true"
+        )
 
         # config bgp graceful-restart mode off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["graceful_restart_enable"] == "false"
-
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["graceful_restart_enable"]
+            == "false"
+        )
 
     def test_bgp_config_graceful_restart_preserve_fw_state(self):
         db = Db()
         runner = CliRunner()
-        cmd = config.config.commands["bgp"].commands["graceful-restart"].commands["preserve-fw-state"]
+        cmd = (
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["preserve-fw-state"]
+        )
 
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -345,31 +437,46 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart preserve-fw-state on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_preserve_fw_state"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_preserve_fw_state"]
+            == "true"
+        )
 
         # config bgp graceful-restart preserve-fw-state off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_preserve_fw_state"] == "false"
-
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_preserve_fw_state"]
+            == "false"
+        )
 
     def test_bgp_config_address_family_ipv4_unicast_redistribute_connected(self):
         db = Db()
         runner = CliRunner()
-        cmd = config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["redistribute"].commands["connected"]
+        cmd = (
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["redistribute"]
+            .commands["connected"]
+        )
 
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -383,31 +490,43 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast redistribute connected on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert ("default", "connected", "bgp", "ipv4") in db.cfgdb.get_table("ROUTE_REDISTRIBUTE")
+        assert ("default", "connected", "bgp", "ipv4") in db.cfgdb.get_table(
+            "ROUTE_REDISTRIBUTE"
+        )
 
         # config bgp address-family ipv4 unicast redistribute connected off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert ("default", "connected", "bgp", "ipv4") not in db.cfgdb.get_table("ROUTE_REDISTRIBUTE")
-
+        assert ("default", "connected", "bgp", "ipv4") not in db.cfgdb.get_table(
+            "ROUTE_REDISTRIBUTE"
+        )
 
     def test_bgp_config_address_family_l2vpn_evpn_advertise_all_vni(self):
         db = Db()
         runner = CliRunner()
-        cmd = config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].commands["evpn"].commands["advertise-all-vni"]
+        cmd = (
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["advertise-all-vni"]
+        )
 
         # Invalid input
         result = runner.invoke(cmd, ["qwe123qwe"], obj=db)
         assert result.exit_code != 0
-        assert "Invalid value for \"<mode>\"" in result.output
+        assert 'Invalid value for "<mode>"' in result.output
 
         # Without configured AS
 
@@ -421,20 +540,33 @@ class TestBgpExtentedCommands(object):
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-
         # With configured AS
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family l2vpn evpn advertise-all-vni on
         result = runner.invoke(cmd, ["on"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "l2vpn_evpn")]["advertise-all-vni"] == "true"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "l2vpn_evpn")][
+                "advertise-all-vni"
+            ]
+            == "true"
+        )
 
         # config bgp address-family l2vpn evpn advertise-all-vni off
         result = runner.invoke(cmd, ["off"], obj=db)
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "l2vpn_evpn")]["advertise-all-vni"] == "false"
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "l2vpn_evpn")][
+                "advertise-all-vni"
+            ]
+            == "false"
+        )
 
     # -----------------------------------------------------------------------------------------------------------------------------------
     # config bgp router-id add <router_id>
@@ -448,7 +580,7 @@ class TestBgpExtentedCommands(object):
         "255.255.255.255",
         "192.168.1.1",
         "10.10.0.1",
-        "8.8.8.8"
+        "8.8.8.8",
     ]
 
     @pytest.mark.parametrize("router_id", router_ids_valid)
@@ -456,68 +588,121 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp router-id add <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code == 0
         assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["router_id"] == router_id
 
         # config bgp router-id del <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["del"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code == 0
         assert "router_id" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
 
-    @pytest.mark.parametrize("router_ids", [
-        ("192.168.1.1",),
-        ("192.168.1.1", "192.168.1.2",),
-        ("192.168.1.1", "192.168.1.2", "192.168.1.3",),
-    ])
+    @pytest.mark.parametrize(
+        "router_ids",
+        [
+            ("192.168.1.1",),
+            (
+                "192.168.1.1",
+                "192.168.1.2",
+            ),
+            (
+                "192.168.1.1",
+                "192.168.1.2",
+                "192.168.1.3",
+            ),
+        ],
+    )
     def test_bgp_config_router_id_set_valid(self, router_ids):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [self.default_router_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for router_id in router_ids:
             # config bgp router-id set <router_id>
-            result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"].commands["router-id"].commands["set"],
+                [router_id],
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["router_id"] == router_id
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS")["default"]["router_id"] == router_id
+            )
 
-    @pytest.mark.parametrize("router_id", [
-        "192.168.1.1/32",
-        "255.255.255.256",
-        "255.255.255.2567"
-        "0.0.0",
-        "abc"
-    ])
+    @pytest.mark.parametrize(
+        "router_id",
+        ["192.168.1.1/32", "255.255.255.256", "255.255.255.2567" "0.0.0", "abc"],
+    )
     def test_bgp_config_router_id_add_del_set_invalid(self, router_id):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp router-id add <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "IP address is not valid" in result.output
 
         # config bgp router-id del <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["del"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "IP address is not valid" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [self.default_router_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp router-id set <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["set"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "IP address is not valid" in result.output
 
@@ -526,16 +711,28 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp router-id set <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["set"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Router ID is not configured" in result.output
 
         # config bgp router-id del <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["del"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Router ID is not configured" in result.output
 
@@ -544,14 +741,26 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [self.default_router_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp router-id add <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Router identifier is already specified" in result.output
 
@@ -560,14 +769,26 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [self.default_router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [self.default_router_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp router-id del <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["del"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert f"Configured router ID is {self.default_router_id}" in result.output
 
@@ -577,17 +798,29 @@ class TestBgpExtentedCommands(object):
         runner = CliRunner()
 
         # config bgp router-id add <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["add"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["add"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp router-id set <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["set"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["set"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp router-id del <router_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["router-id"].commands["del"], [router_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["router-id"].commands["del"],
+            [router_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -603,7 +836,7 @@ class TestBgpExtentedCommands(object):
         "255.255.255.255",
         "192.168.1.1",
         "10.10.0.1",
-        "8.8.8.8"
+        "8.8.8.8",
     ]
 
     @pytest.mark.parametrize("cluster_id", cluster_ids_valid)
@@ -611,68 +844,124 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp cluster-id add <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_cluster_id"] == cluster_id
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_cluster_id"] == cluster_id
+        )
 
         # config bgp cluster-id del <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["del"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code == 0
         assert "rr_cluster_id" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
 
-    @pytest.mark.parametrize("cluster_ids", [
-        ("192.168.1.1",),
-        ("192.168.1.1", "192.168.1.2",),
-        ("192.168.1.1", "192.168.1.2", "192.168.1.3",),
-    ])
+    @pytest.mark.parametrize(
+        "cluster_ids",
+        [
+            ("192.168.1.1",),
+            (
+                "192.168.1.1",
+                "192.168.1.2",
+            ),
+            (
+                "192.168.1.1",
+                "192.168.1.2",
+                "192.168.1.3",
+            ),
+        ],
+    )
     def test_bgp_config_cluster_id_set_valid(self, cluster_ids):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [self.default_cluster_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for cluster_id in cluster_ids:
             # config bgp cluster-id set <cluster_id>
-            result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"].commands["cluster-id"].commands["set"],
+                [cluster_id],
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_cluster_id"] == cluster_id
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS")["default"]["rr_cluster_id"]
+                == cluster_id
+            )
 
-    @pytest.mark.parametrize("cluster_id", [
-        "192.168.1.1/32",
-        "255.255.255.256",
-        "255.255.255.2567"
-        "0.0.0",
-        "abc"
-    ])
+    @pytest.mark.parametrize(
+        "cluster_id",
+        ["192.168.1.1/32", "255.255.255.256", "255.255.255.2567" "0.0.0", "abc"],
+    )
     def test_bgp_config_cluster_id_add_del_set_invalid(self, cluster_id):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp cluster-id add <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "IP address is not valid" in result.output
 
         # config bgp cluster-id del <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["del"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "IP address is not valid" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [self.default_cluster_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp cluster-id set <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["set"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "IP address is not valid" in result.output
 
@@ -681,16 +970,28 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp cluster-id set <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["set"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Cluster ID is not configured" in result.output
 
         # config bgp cluster-id del <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["del"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Cluster ID is not configured" in result.output
 
@@ -699,14 +1000,26 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [self.default_cluster_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp cluster-id add <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Cluster ID is already added" in result.output
 
@@ -715,14 +1028,26 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [self.default_cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [self.default_cluster_id],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp cluster-id del <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["del"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert f"Configured cluster ID is {self.default_cluster_id}" in result.output
 
@@ -732,17 +1057,29 @@ class TestBgpExtentedCommands(object):
         runner = CliRunner()
 
         # config bgp cluster-id add <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["add"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["add"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp cluster-id set <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["set"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["set"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp cluster-id del <cluster_id>
-        result = runner.invoke(config.config.commands["bgp"].commands["cluster-id"].commands["del"], [cluster_id], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["cluster-id"].commands["del"],
+            [cluster_id],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -752,96 +1089,191 @@ class TestBgpExtentedCommands(object):
     # config bgp listen limit del <limit>
 
     default_listen_limit = "5"
-    listen_limits_valid = [
-        "1",
-        "100",
-        "65535"
-    ]
+    listen_limits_valid = ["1", "100", "65535"]
 
     @pytest.mark.parametrize("listen_limit", listen_limits_valid)
     def test_bgp_config_listen_limit_add_del_valid(self, listen_limit):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp listen limit add <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["max_dynamic_neighbors"] == listen_limit
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["max_dynamic_neighbors"]
+            == listen_limit
+        )
 
         # config bgp listen limit del <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["del"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert "max_dynamic_neighbors" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+        assert (
+            "max_dynamic_neighbors" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+        )
 
-    @pytest.mark.parametrize("listen_limits", [
-        ("1",),
-        ("1", "65535",),
-        ("1", "100", "65535",),
-    ])
+    @pytest.mark.parametrize(
+        "listen_limits",
+        [
+            ("1",),
+            (
+                "1",
+                "65535",
+            ),
+            (
+                "1",
+                "100",
+                "65535",
+            ),
+        ],
+    )
     def test_bgp_config_listen_limit_set_valid(self, listen_limits):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [self.default_listen_limit],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for listen_limit in listen_limits:
             # config bgp listen limit set <listen_limit>
-            result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["listen"]
+                .commands["limit"]
+                .commands["set"],
+                [listen_limit],
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["max_dynamic_neighbors"] == listen_limit
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS")["default"]["max_dynamic_neighbors"]
+                == listen_limit
+            )
 
-    @pytest.mark.parametrize("listen_limit", [
-        "0",
-        "65536",
-        "4444444444444444",
-        "abc"
-    ])
+    @pytest.mark.parametrize("listen_limit", ["0", "65536", "4444444444444444", "abc"])
     def test_bgp_config_listen_limit_add_del_set_invalid(self, listen_limit):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp listen limit add <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<limit>\"" in result.output
+        assert 'Invalid value for "<limit>"' in result.output
 
         # config bgp listen limit del <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["del"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<limit>\"" in result.output
+        assert 'Invalid value for "<limit>"' in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [self.default_listen_limit],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp listen limit set <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["set"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<limit>\"" in result.output
+        assert 'Invalid value for "<limit>"' in result.output
 
     @pytest.mark.parametrize("listen_limit", listen_limits_valid)
     def test_bgp_config_listen_limit_set_del_nonexistent(self, listen_limit):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp listen limit set <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["set"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Listen limit is not configured" in result.output
 
         # config bgp listen limit del <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["del"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Listen limit is not configured" in result.output
 
@@ -850,14 +1282,32 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [self.default_listen_limit],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp listen limit add <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Listen limit is already specified" in result.output
 
@@ -866,16 +1316,36 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [self.default_listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [self.default_listen_limit],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp listen limit del <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["del"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert f"Configured listen limit is {self.default_listen_limit}" in result.output
+        assert (
+            f"Configured listen limit is {self.default_listen_limit}" in result.output
+        )
 
     @pytest.mark.parametrize("listen_limit", listen_limits_valid)
     def test_bgp_config_listen_limit_add_set_del_no_as(self, listen_limit):
@@ -883,17 +1353,38 @@ class TestBgpExtentedCommands(object):
         runner = CliRunner()
 
         # config bgp listen limit add <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["add"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["add"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp listen limit set <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["set"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["set"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp listen limit del <listen_limit>
-        result = runner.invoke(config.config.commands["bgp"].commands["listen"].commands["limit"].commands["del"], [listen_limit], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["listen"]
+            .commands["limit"]
+            .commands["del"],
+            [listen_limit],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -903,111 +1394,229 @@ class TestBgpExtentedCommands(object):
     # config bgp graceful-restart restart-time del <time>
 
     default_restart_time = "1"
-    restart_times_valid = [
-        "0",
-        "100",
-        "4095"
-    ]
+    restart_times_valid = ["0", "100", "4095"]
 
     @pytest.mark.parametrize("restart_time", restart_times_valid)
     def test_bgp_config_graceful_restart_restart_time_add_del_valid(self, restart_time):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart restart-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_restart_time"] == restart_time
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_restart_time"]
+            == restart_time
+        )
 
         # config bgp graceful-restart restart-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["del"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code == 0
         assert "gr_restart_time" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
 
-    @pytest.mark.parametrize("restart_times", [
-        ("0",),
-        ("0", "4095",),
-        ("0", "100", "4095",),
-    ])
+    @pytest.mark.parametrize(
+        "restart_times",
+        [
+            ("0",),
+            (
+                "0",
+                "4095",
+            ),
+            (
+                "0",
+                "100",
+                "4095",
+            ),
+        ],
+    )
     def test_bgp_config_graceful_restart_restart_time_set_valid(self, restart_times):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [self.default_restart_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for restart_time in restart_times:
             # config bgp graceful-restart restart-time set <time>
-            result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["graceful-restart"]
+                .commands["restart-time"]
+                .commands["set"],
+                [restart_time],
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_restart_time"] == restart_time
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_restart_time"]
+                == restart_time
+            )
 
-    @pytest.mark.parametrize("restart_time", [
-        "4096",
-        "4444444444444444",
-        "abc"
-    ])
-    def test_bgp_config_graceful_restart_restart_time_add_del_set_invalid(self, restart_time):
+    @pytest.mark.parametrize("restart_time", ["4096", "4444444444444444", "abc"])
+    def test_bgp_config_graceful_restart_restart_time_add_del_set_invalid(
+        self, restart_time
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart restart-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<time>\"" in result.output
+        assert 'Invalid value for "<time>"' in result.output
 
         # config bgp graceful-restart restart-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["del"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<time>\"" in result.output
+        assert 'Invalid value for "<time>"' in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [self.default_restart_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart restart-time set <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["set"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<time>\"" in result.output
+        assert 'Invalid value for "<time>"' in result.output
 
     @pytest.mark.parametrize("restart_time", restart_times_valid)
-    def test_bgp_config_graceful_restart_restart_time_set_del_nonexistent(self, restart_time):
+    def test_bgp_config_graceful_restart_restart_time_set_del_nonexistent(
+        self, restart_time
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart restart-time set <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["set"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Graceful restart time is not configured" in result.output
 
         # config bgp graceful-restart restart-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["del"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Graceful restart time is not configured" in result.output
 
     @pytest.mark.parametrize("restart_time", restart_times_valid)
-    def test_bgp_config_graceful_restart_restart_time_add_with_existent(self, restart_time):
+    def test_bgp_config_graceful_restart_restart_time_add_with_existent(
+        self, restart_time
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [self.default_restart_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart restart-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Graceful restart time is already specified" in result.output
 
@@ -1016,34 +1625,78 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [self.default_restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [self.default_restart_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart restart-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["del"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert f"Configured graceful restart time is {self.default_restart_time}" in result.output
+        assert (
+            f"Configured graceful restart time is {self.default_restart_time}"
+            in result.output
+        )
 
     @pytest.mark.parametrize("restart_time", restart_times_valid)
-    def test_bgp_config_graceful_restart_restart_time_add_set_del_no_as(self, restart_time):
+    def test_bgp_config_graceful_restart_restart_time_add_set_del_no_as(
+        self, restart_time
+    ):
         db = Db()
         runner = CliRunner()
 
         # config bgp graceful-restart restart-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["add"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["add"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp graceful-restart restart-time set <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["set"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["set"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp graceful-restart restart-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["restart-time"].commands["del"], [restart_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["restart-time"]
+            .commands["del"],
+            [restart_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -1053,111 +1706,235 @@ class TestBgpExtentedCommands(object):
     # config bgp graceful-restart stalepath-time del <time>
 
     default_stalepath_time = "5"
-    stalepath_times_valid = [
-        "1",
-        "100",
-        "4095"
-    ]
+    stalepath_times_valid = ["1", "100", "4095"]
 
     @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
-    def test_bgp_config_graceful_restart_stalepath_time_add_del_valid(self, stalepath_time):
+    def test_bgp_config_graceful_restart_stalepath_time_add_del_valid(
+        self, stalepath_time
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart stalepath-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_stale_routes_time"] == stalepath_time
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_stale_routes_time"]
+            == stalepath_time
+        )
 
         # config bgp graceful-restart stalepath-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["del"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert "gr_stale_routes_time" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+        assert (
+            "gr_stale_routes_time" not in db.cfgdb.get_table("BGP_GLOBALS")["default"]
+        )
 
-    @pytest.mark.parametrize("stalepath_times", [
-        ("1",),
-        ("1", "4095",),
-        ("1", "100", "4095",),
-    ])
-    def test_bgp_config_graceful_restart_stalepath_time_set_valid(self, stalepath_times):
+    @pytest.mark.parametrize(
+        "stalepath_times",
+        [
+            ("1",),
+            (
+                "1",
+                "4095",
+            ),
+            (
+                "1",
+                "100",
+                "4095",
+            ),
+        ],
+    )
+    def test_bgp_config_graceful_restart_stalepath_time_set_valid(
+        self, stalepath_times
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [self.default_stalepath_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for stalepath_time in stalepath_times:
             # config bgp graceful-restart stalepath-time set <time>
-            result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["graceful-restart"]
+                .commands["stalepath-time"]
+                .commands["set"],
+                [stalepath_time],
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_stale_routes_time"] == stalepath_time
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS")["default"]["gr_stale_routes_time"]
+                == stalepath_time
+            )
 
-    @pytest.mark.parametrize("stalepath_time", [
-        "4096",
-        "4444444444444444",
-        "abc"
-    ])
-    def test_bgp_config_graceful_restart_stalepath_time_add_del_set_invalid(self, stalepath_time):
+    @pytest.mark.parametrize("stalepath_time", ["4096", "4444444444444444", "abc"])
+    def test_bgp_config_graceful_restart_stalepath_time_add_del_set_invalid(
+        self, stalepath_time
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart stalepath-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<time>\"" in result.output
+        assert 'Invalid value for "<time>"' in result.output
 
         # config bgp graceful-restart stalepath-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["del"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<time>\"" in result.output
+        assert 'Invalid value for "<time>"' in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [self.default_stalepath_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart stalepath-time set <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["set"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<time>\"" in result.output
+        assert 'Invalid value for "<time>"' in result.output
 
     @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
-    def test_bgp_config_graceful_restart_stalepath_time_set_del_nonexistent(self, stalepath_time):
+    def test_bgp_config_graceful_restart_stalepath_time_set_del_nonexistent(
+        self, stalepath_time
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart stalepath-time set <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["set"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Graceful restart stalepath time is not configured" in result.output
 
         # config bgp graceful-restart stalepath-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["del"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Graceful restart stalepath time is not configured" in result.output
 
     @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
-    def test_bgp_config_graceful_restart_stalepath_time_add_with_existent(self, stalepath_time):
+    def test_bgp_config_graceful_restart_stalepath_time_add_with_existent(
+        self, stalepath_time
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [self.default_stalepath_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart stalepath-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Graceful restart stalepath time is already specified" in result.output
 
@@ -1166,34 +1943,78 @@ class TestBgpExtentedCommands(object):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [self.default_stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [self.default_stalepath_time],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp graceful-restart stalepath-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["del"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert f"Configured graceful restart stalepath time is {self.default_stalepath_time}" in result.output
+        assert (
+            f"Configured graceful restart stalepath time is {self.default_stalepath_time}"
+            in result.output
+        )
 
     @pytest.mark.parametrize("stalepath_time", stalepath_times_valid)
-    def test_bgp_config_graceful_restart_stalepath_time_add_set_del_no_as(self, stalepath_time):
+    def test_bgp_config_graceful_restart_stalepath_time_add_set_del_no_as(
+        self, stalepath_time
+    ):
         db = Db()
         runner = CliRunner()
 
         # config bgp graceful-restart stalepath-time add <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["add"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["add"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp graceful-restart stalepath-time set <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["set"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["set"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp graceful-restart stalepath-time del <time>
-        result = runner.invoke(config.config.commands["bgp"].commands["graceful-restart"].commands["stalepath-time"].commands["del"], [stalepath_time], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["graceful-restart"]
+            .commands["stalepath-time"]
+            .commands["del"],
+            [stalepath_time],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -1203,148 +2024,355 @@ class TestBgpExtentedCommands(object):
     # config bgp address-family ipv4 unicast max-paths del <paths_num>
 
     default_paths_num = "5"
-    paths_nums_valid = [
-        "1",
-        "100",
-        "256"
-    ]
+    paths_nums_valid = ["1", "100", "256"]
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_del_valid(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_del_valid(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ebgp_paths"] == paths_num
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                "max_ebgp_paths"
+            ]
+            == paths_num
+        )
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert "max_ebgp_paths" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+        assert (
+            "max_ebgp_paths"
+            not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+        )
 
-    @pytest.mark.parametrize("paths_nums", [
-        ("1",),
-        ("1", "256",),
-        ("1", "100", "256",),
-    ])
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_set_valid(self, paths_nums):
+    @pytest.mark.parametrize(
+        "paths_nums",
+        [
+            ("1",),
+            (
+                "1",
+                "256",
+            ),
+            (
+                "1",
+                "100",
+                "256",
+            ),
+        ],
+    )
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_set_valid(
+        self, paths_nums
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for paths_num in paths_nums:
             # config bgp address-family ipv4 unicast max-paths set <paths_num>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["max-paths"]
+                .commands["set"],
+                [paths_num],
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ebgp_paths"] == paths_num
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                    "max_ebgp_paths"
+                ]
+                == paths_num
+            )
 
-    @pytest.mark.parametrize("paths_num", [
-        "0",
-        "257",
-        "4444444444444444",
-        "abc"
-    ])
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_del_set_invalid(self, paths_num):
+    @pytest.mark.parametrize("paths_num", ["0", "257", "4444444444444444", "abc"])
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_del_set_invalid(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<paths_num>\"" in result.output
+        assert 'Invalid value for "<paths_num>"' in result.output
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<paths_num>\"" in result.output
+        assert 'Invalid value for "<paths_num>"' in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths set <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["set"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<paths_num>\"" in result.output
+        assert 'Invalid value for "<paths_num>"' in result.output
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_set_del_nonexistent(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_set_del_nonexistent(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths set <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["set"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Max-paths number is not configured" in result.output
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Max-paths number is not configured" in result.output
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_with_existent(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_with_existent(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Max paths number is already specified" in result.output
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_del_wrong(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_del_wrong(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert f"Configured max-paths number is {self.default_paths_num}" in result.output
+        assert (
+            f"Configured max-paths number is {self.default_paths_num}" in result.output
+        )
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_set_del_no_as(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_add_set_del_no_as(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp address-family ipv4 unicast max-paths set <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["set"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["set"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -1354,148 +2382,373 @@ class TestBgpExtentedCommands(object):
     # config bgp address-family ipv4 unicast max-paths ibgp del <paths_num>
 
     default_paths_num = "5"
-    paths_nums_valid = [
-        "1",
-        "100",
-        "256"
-    ]
+    paths_nums_valid = ["1", "100", "256"]
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_del_valid(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_del_valid(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ibgp_paths"] == paths_num
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                "max_ibgp_paths"
+            ]
+            == paths_num
+        )
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert "max_ibgp_paths" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+        assert (
+            "max_ibgp_paths"
+            not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+        )
 
-    @pytest.mark.parametrize("paths_nums", [
-        ("1",),
-        ("1", "256",),
-        ("1", "100", "256",),
-    ])
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_set_valid(self, paths_nums):
+    @pytest.mark.parametrize(
+        "paths_nums",
+        [
+            ("1",),
+            (
+                "1",
+                "256",
+            ),
+            (
+                "1",
+                "100",
+                "256",
+            ),
+        ],
+    )
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_set_valid(
+        self, paths_nums
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for paths_num in paths_nums:
             # config bgp address-family ipv4 unicast max-paths set <paths_num>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["max-paths"]
+                .commands["ibgp"]
+                .commands["set"],
+                [paths_num],
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["max_ibgp_paths"] == paths_num
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                    "max_ibgp_paths"
+                ]
+                == paths_num
+            )
 
-    @pytest.mark.parametrize("paths_num", [
-        "0",
-        "257",
-        "4444444444444444",
-        "abc"
-    ])
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_del_set_invalid(self, paths_num):
+    @pytest.mark.parametrize("paths_num", ["0", "257", "4444444444444444", "abc"])
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_del_set_invalid(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<paths_num>\"" in result.output
+        assert 'Invalid value for "<paths_num>"' in result.output
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<paths_num>\"" in result.output
+        assert 'Invalid value for "<paths_num>"' in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths set <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["set"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<paths_num>\"" in result.output
+        assert 'Invalid value for "<paths_num>"' in result.output
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_set_del_nonexistent(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_set_del_nonexistent(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths set <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["set"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Max-paths ibgp number is not configured" in result.output
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Max-paths ibgp number is not configured" in result.output
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_with_existent(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_with_existent(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Max ibgp paths number is already specified" in result.output
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_del_wrong(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_del_wrong(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [self.default_paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [self.default_paths_num],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert f"Configured max-paths ibgp number is {self.default_paths_num}" in result.output
+        assert (
+            f"Configured max-paths ibgp number is {self.default_paths_num}"
+            in result.output
+        )
 
     @pytest.mark.parametrize("paths_num", paths_nums_valid)
-    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_set_del_no_as(self, paths_num):
+    def test_bgp_config_address_family_ipv4_unicast_max_paths_ibgp_add_set_del_no_as(
+        self, paths_num
+    ):
         db = Db()
         runner = CliRunner()
 
         # config bgp address-family ipv4 unicast max-paths add <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["add"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["add"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp address-family ipv4 unicast max-paths set <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["set"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["set"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp address-family ipv4 unicast max-paths del <paths_num>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["max-paths"].commands["ibgp"].commands["del"], [paths_num], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["max-paths"]
+            .commands["ibgp"]
+            .commands["del"],
+            [paths_num],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -1505,162 +2758,413 @@ class TestBgpExtentedCommands(object):
     # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
 
     default_distances = ["5", "5", "5"]
-    distances_valid = [
-        ["1", "1", "1"],
-        ["100", "100", "100"],
-        ["255", "255", "255"]
-    ]
+    distances_valid = [["1", "1", "1"], ["100", "100", "100"], ["255", "255", "255"]]
 
     @pytest.mark.parametrize("distances", distances_valid)
-    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_del_valid(self, distances):
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_del_valid(
+        self, distances
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ebgp_route_distance"] == distances[0] and \
-               db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ibgp_route_distance"] == distances[1] and \
-               db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["local_route_distance"] == distances[2]
+        assert (
+            db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                "ebgp_route_distance"
+            ]
+            == distances[0]
+            and db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                "ibgp_route_distance"
+            ]
+            == distances[1]
+            and db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                "local_route_distance"
+            ]
+            == distances[2]
+        )
 
         # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["del"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code == 0
-        assert "ebgp_route_distance" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")] and \
-               "ibgp_route_distance" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")] and \
-               "local_route_distance" not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+        assert (
+            "ebgp_route_distance"
+            not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+            and "ibgp_route_distance"
+            not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+            and "local_route_distance"
+            not in db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]
+        )
 
-
-    @pytest.mark.parametrize("distances_sets", [
-        (["1", "1", "1"],),
-        (["1", "1", "1"], ["255", "255", "255"],),
-        (["1", "1", "1"], ["100", "100", "100"], ["255", "255", "255"],),
-    ])
-    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_set_valid(self, distances_sets):
+    @pytest.mark.parametrize(
+        "distances_sets",
+        [
+            (["1", "1", "1"],),
+            (
+                ["1", "1", "1"],
+                ["255", "255", "255"],
+            ),
+            (
+                ["1", "1", "1"],
+                ["100", "100", "100"],
+                ["255", "255", "255"],
+            ),
+        ],
+    )
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_set_valid(
+        self, distances_sets
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            self.default_distances,
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for distances in distances_sets:
             # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["distance"]
+                .commands["bgp"]
+                .commands["set"],
+                distances,
+                obj=db,
+            )
             assert result.exit_code == 0
-            assert db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ebgp_route_distance"] == distances[0] and \
-                   db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["ibgp_route_distance"] == distances[1]  and \
-                   db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")]["local_route_distance"] == distances[2]
+            assert (
+                db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                    "ebgp_route_distance"
+                ]
+                == distances[0]
+                and db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                    "ibgp_route_distance"
+                ]
+                == distances[1]
+                and db.cfgdb.get_table("BGP_GLOBALS_AF")[("default", "ipv4_unicast")][
+                    "local_route_distance"
+                ]
+                == distances[2]
+            )
 
-
-    @pytest.mark.parametrize("distances", [
-        ["0", "0", "0"],
-        ["256", "256", "256"],
-        ["4444444444444444", "4444444444444444", "4444444444444444"],
-        ["abc", "abc", "abc"]
-    ])
-    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_del_set_invalid(self, distances):
+    @pytest.mark.parametrize(
+        "distances",
+        [
+            ["0", "0", "0"],
+            ["256", "256", "256"],
+            ["4444444444444444", "4444444444444444", "4444444444444444"],
+            ["abc", "abc", "abc"],
+        ],
+    )
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_del_set_invalid(
+        self, distances
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<ebgp_dist>\"" in result.output or \
-               "Invalid value for \"<ibgp_dist>\"" in result.output or \
-               "Invalid value for \"<local_dist>\"" in result.output
+        assert (
+            'Invalid value for "<ebgp_dist>"' in result.output
+            or 'Invalid value for "<ibgp_dist>"' in result.output
+            or 'Invalid value for "<local_dist>"' in result.output
+        )
 
         # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["del"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<ebgp_dist>\"" in result.output or \
-               "Invalid value for \"<ibgp_dist>\"" in result.output or \
-               "Invalid value for \"<local_dist>\"" in result.output
+        assert (
+            'Invalid value for "<ebgp_dist>"' in result.output
+            or 'Invalid value for "<ibgp_dist>"' in result.output
+            or 'Invalid value for "<local_dist>"' in result.output
+        )
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            self.default_distances,
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["set"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Invalid value for \"<ebgp_dist>\"" in result.output or \
-               "Invalid value for \"<ibgp_dist>\"" in result.output or \
-               "Invalid value for \"<local_dist>\"" in result.output
+        assert (
+            'Invalid value for "<ebgp_dist>"' in result.output
+            or 'Invalid value for "<ibgp_dist>"' in result.output
+            or 'Invalid value for "<local_dist>"' in result.output
+        )
 
     @pytest.mark.parametrize("distances", distances_valid)
-    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_set_del_nonexistent(self, distances):
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_set_del_nonexistent(
+        self, distances
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["set"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Distance bgp values are not configured" in result.output
 
         # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["del"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "Distance bgp values are not configured" in result.output
 
     @pytest.mark.parametrize("distances", distances_valid)
-    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_with_existent(self, distances):
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_with_existent(
+        self, distances
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            self.default_distances,
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "BGP distance values are already configured" in result.output
 
     @pytest.mark.parametrize("distances", distances_valid)
-    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_del_wrong(self, distances):
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_del_wrong(
+        self, distances
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], self.default_distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            self.default_distances,
+            obj=db,
+        )
         assert result.exit_code == 0
 
         # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["del"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
-        assert "Configured distance bgp values are " + " ".join(self.default_distances) in result.output
+        assert (
+            "Configured distance bgp values are " + " ".join(self.default_distances)
+            in result.output
+        )
 
     @pytest.mark.parametrize("distances", distances_valid)
-    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_set_del_no_as(self, distances):
+    def test_bgp_config_address_family_ipv4_unicast_distance_bgp_add_set_del_no_as(
+        self, distances
+    ):
         db = Db()
         runner = CliRunner()
 
         # config bgp address-family ipv4 unicast distance bgp add <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["add"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["add"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp address-family ipv4 unicast distance bgp set <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["set"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["set"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp address-family ipv4 unicast distance bgp del <ebgp_dist> <ibgp_dist> <local_dist>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["distance"].commands["bgp"].commands["del"], distances, obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["distance"]
+            .commands["bgp"]
+            .commands["del"],
+            distances,
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
@@ -1670,97 +3174,209 @@ class TestBgpExtentedCommands(object):
 
     networks_valid = [
         ("127.0.0.1",),
-        ("10.0.0.1", "10.0.0.2/32", "10.10.10.0/24",),
+        (
+            "10.0.0.1",
+            "10.0.0.2/32",
+            "10.10.10.0/24",
+        ),
         ("0.0.0.0", "255.255.255.255"),
-        ("8.8.8.8", "8.8.4.4/32", "1.1.1.1",)
+        (
+            "8.8.8.8",
+            "8.8.4.4/32",
+            "1.1.1.1",
+        ),
     ]
 
     @pytest.mark.parametrize("networks", networks_valid)
-    def test_bgp_config_address_family_ipv4_unicast_network_add_del_valid(self, networks):
+    def test_bgp_config_address_family_ipv4_unicast_network_add_del_valid(
+        self, networks
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for network in networks:
             # config bgp address-family ipv4 unicast network add <network>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["network"]
+                .commands["add"],
+                [network],
+                obj=db,
+            )
             assert result.exit_code == 0
 
             if "/" not in network:
                 network = network + "/32"
 
-            assert ("default", "ipv4_unicast", network) in db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK")
+            assert ("default", "ipv4_unicast", network) in db.cfgdb.get_table(
+                "BGP_GLOBALS_AF_NETWORK"
+            )
 
         for network in networks:
             # config bgp address-family ipv4 unicast network del <network>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["network"]
+                .commands["del"],
+                [network],
+                obj=db,
+            )
             assert result.exit_code == 0
 
             if "/" not in network:
                 network = network + "/32"
 
-            assert ("default", "ipv4_unicast", network) not in db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK")
+            assert ("default", "ipv4_unicast", network) not in db.cfgdb.get_table(
+                "BGP_GLOBALS_AF_NETWORK"
+            )
 
-    @pytest.mark.parametrize("networks", [
-        ("256.0.0.0",),
-        ("10.0.0.1/24", "10.0.0.2/0", "10.10.10.0/33",),
-        ("0.0.0.0.0", "0x0a0000a0"),
-        ("8.8.8", "qweqweqwe", "0.0.0.0\\16",)
-    ])
-    def test_bgp_config_address_family_ipv4_unicast_network_add_del_invalid(self, networks):
+    @pytest.mark.parametrize(
+        "networks",
+        [
+            ("256.0.0.0",),
+            (
+                "10.0.0.1/24",
+                "10.0.0.2/0",
+                "10.10.10.0/33",
+            ),
+            ("0.0.0.0.0", "0x0a0000a0"),
+            (
+                "8.8.8",
+                "qweqweqwe",
+                "0.0.0.0\\16",
+            ),
+        ],
+    )
+    def test_bgp_config_address_family_ipv4_unicast_network_add_del_invalid(
+        self, networks
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for network in networks:
             # config bgp address-family ipv4 unicast network add <network>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["network"]
+                .commands["add"],
+                [network],
+                obj=db,
+            )
             assert result.exit_code != 0
             assert "Network address is not valid" in result.output
 
         for network in networks:
             # config bgp address-family ipv4 unicast network del <network>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["network"]
+                .commands["del"],
+                [network],
+                obj=db,
+            )
             assert result.exit_code != 0
             assert "Network address is not valid" in result.output
 
     @pytest.mark.parametrize("networks", networks_valid)
-    def test_bgp_config_address_family_ipv4_unicast_network_del_nonexistent(self, networks):
+    def test_bgp_config_address_family_ipv4_unicast_network_del_nonexistent(
+        self, networks
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for network in networks:
             # config bgp address-family ipv4 unicast network del <network>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["network"]
+                .commands["del"],
+                [network],
+                obj=db,
+            )
             assert result.exit_code != 0
             assert "IPv4 unicast network does not exist" in result.output
 
     @pytest.mark.parametrize("networks", networks_valid)
-    def test_bgp_config_address_family_ipv4_unicast_network_add_existent(self, networks):
+    def test_bgp_config_address_family_ipv4_unicast_network_add_existent(
+        self, networks
+    ):
         db = Db()
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], [self.default_asn], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            [self.default_asn],
+            obj=db,
+        )
         assert result.exit_code == 0
 
         for network in networks:
             # config bgp address-family ipv4 unicast network add <network>
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["network"]
+                .commands["add"],
+                [network],
+                obj=db,
+            )
             assert result.exit_code == 0
 
             if "/" not in network:
                 network = network + "/32"
 
-            assert ("default", "ipv4_unicast", network) in db.cfgdb.get_table("BGP_GLOBALS_AF_NETWORK")
+            assert ("default", "ipv4_unicast", network) in db.cfgdb.get_table(
+                "BGP_GLOBALS_AF_NETWORK"
+            )
 
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["network"]
+                .commands["add"],
+                [network],
+                obj=db,
+            )
             assert result.exit_code != 0
             assert "IPv4 unicast network already exists" in result.output
 
@@ -1771,11 +3387,29 @@ class TestBgpExtentedCommands(object):
         network = "1.2.3.4"
 
         # config bgp address-family ipv4 unicast network add <network>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["add"], [network], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["network"]
+            .commands["add"],
+            [network],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
         # config bgp address-family ipv4 unicast network del <network>
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].commands["unicast"].commands["network"].commands["del"], [network], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["network"]
+            .commands["del"],
+            [network],
+            obj=db,
+        )
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output

--- a/tests/bgp_neighbor_extended_commands_test.py
+++ b/tests/bgp_neighbor_extended_commands_test.py
@@ -1,0 +1,1178 @@
+import os
+import pytest
+
+from click.testing import CliRunner
+
+import config.main as config
+from utilities_common.db import Db
+
+class TestBgpNeighborExtendedCommands(object):
+
+    valid_neighbors = (
+        ("10.10.10.10",),
+        ("0bd3:8339:7d3b:d3bb:dd39:c1c0:6e23:f517",),
+        ("Ethernet4",)
+    )
+
+    invalid_neighbors = (
+        ("10.10.10.358",),
+        ("5efc:2mf5:6f16:acdn:e9c4:5747:fg6b:275d",),
+        ("Ether_net4",)
+    )
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        print("TEARDOWN")
+
+
+    def test_config_bgp_add_neighbor_remote_as_without_asn(self):
+        runner = CliRunner()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["10.10.10.10", "65535"])
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_add_set_del_valid_neighbor_remote_as(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "65535"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn") == "65535"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
+                    [neighbor, "62000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn") == "62000"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
+                    [neighbor, "62000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn") == None
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_add_set_del_invalid_neighbor_remote_as(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "65535"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
+                    [neighbor, "34000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
+                    [neighbor, "60000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "0"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
+                ["192.168.0.100", "1a"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
+                ["192.168.0.100", "4294967296"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+
+    def test_config_bgp_add_existing_neighbor_remote_as(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["10.10.10.10", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["10.10.10.10", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor remote-as already exists" in result.output
+
+    def test_config_bgp_set_unexisting_neighbor_remote_as(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
+                ["10.10.10.10", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor remote-as is not configured" in result.output
+
+    def test_config_bgp_del_unexisting_neighbor_remote_as(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
+                ["10.10.10.10", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor does not exist" in result.output
+
+
+    def test_config_bgp_add_neighbor_upd_src_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
+                ["10.10.10.10", "20.20.20.20"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
+                ["10.10.10.10", "20.20.20.20"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_add_set_del_valid_neighbor_upd_src(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
+                    [neighbor, "178.50.20.10"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_addr") == "178.50.20.10"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"],
+                    [neighbor, "180.122.55.50"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_addr") == "180.122.55.50"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
+                    [neighbor, "180.122.55.50"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_addr") == None
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_add_set_del_invalid_neighbor_upd_src(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
+                    [neighbor, "178.50.20.10"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"], \
+                    [neighbor, "180.122.55.50"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
+                    [neighbor, "180.122.55.50"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
+                ["192.168.0.100", "0.1a.50.20"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"], \
+                ["192.168.0.100", "4294967296"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
+                ["192.168.0.100", "500.20.50.11"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+    def test_config_bgp_add_existing_neighbor_upd_src(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
+                ["192.168.0.100", "20.20.20.20"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
+                ["192.168.0.100", "20.20.20.20"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor update source already exists" in result.output
+
+    def test_config_bgp_set_unexisting_neighbor_upd_src(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"], \
+                ["192.168.0.100", "20.20.20.20"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor update source is not configured" in result.output
+
+    def test_config_bgp_del_unexisting_neighbor_upd_src(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
+                ["192.168.0.100", "20.20.20.20"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor update source is not configured" in result.output
+
+
+    def test_config_bgp_add_neighbor_adv_interval_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
+                ["10.10.10.10", "33"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
+                ["10.10.10.10", "33"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_add_set_del_valid_neighbor_adv_interval(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
+                    [neighbor, "123"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("min_adv_interval") == "123"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
+                    [neighbor, "234"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("min_adv_interval") == "234"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
+                    [neighbor, "234"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("min_adv_interval") == None
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_add_set_del_invalid_neighbor_adv_interval(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
+                    [neighbor, "123"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
+                    [neighbor, "234"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
+                    [neighbor, "234"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
+                ["192.168.0.100", "0"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
+                ["192.168.0.100", "800"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
+                ["192.168.0.100", "-5"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+    def test_config_bgp_add_existing_neighbor_adv_interval(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor advertisement interval already exists" in result.output
+
+    def test_config_bgp_set_unexisting_neighbor_adv_interval(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
+                ["192.168.0.100", "500"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor advertisement interval is not configured" in result.output
+
+    def test_config_bgp_del_unexisting_neighbor_upd_src(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
+                ["192.168.0.100", "500"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor advertisement interval is not configured" in result.output
+
+
+    def test_config_bgp_add_neighbor_timers_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
+                ["10.10.10.10", "2", "6"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
+                ["10.10.10.10", "2", "6"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_add_set_del_neighbor_valid_timers(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
+                    [neighbor, "2", "6"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("keepalive") == "2"
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("holdtime") == "6"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
+                    [neighbor, "20", "60"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("keepalive") == "20"
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("holdtime") == "60"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
+                    [neighbor, "20", "60"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("keepalive") == None
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("holdtime") == None
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_add_set_del_neighbor_invalid_timers(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
+                    [neighbor, "2", "6"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
+                    [neighbor, "2", "6"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
+                    [neighbor, "2", "6"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
+                ["192.168.0.100", "-5"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
+                ["192.168.0.100", "70000"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
+                ["192.168.0.100", "99999"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+    def test_config_bgp_add_existing_neighbor_timers(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
+                ["192.168.0.100", "2", "6"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
+                ["192.168.0.100", "2", "6"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor timers are already configured" in result.output
+
+    def test_config_bgp_set_unexisting_neighbor_timers(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
+                ["192.168.0.100", "2", "6"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor timers are not configured" in result.output
+
+    def test_config_bgp_del_unexisting_neighbor_timers(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
+                ["192.168.0.100", "2", "6"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor timers are not configured" in result.output
+
+
+    def test_config_bgp_add_neighbor_local_as_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
+                ["10.10.10.10", "65000"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
+                ["10.10.10.10", "65000"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_add_set_del_neighbor_valid_local_as(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
+                    [neighbor, "65535"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_asn") == "65535"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
+                    [neighbor, "62000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_asn") == "62000"
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
+                    [neighbor, "62000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_asn") == None
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_add_set_del_neighbor_invalid_local_as(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
+                    [neighbor, "65535"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
+                    [neighbor, "34000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
+                    [neighbor, "60000"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+            assert "Neighbor interface/IP address is not valid" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
+                ["192.168.0.100", "0"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
+                ["192.168.0.100", "1a"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
+                ["192.168.0.100", "4294967296"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+
+    def test_config_bgp_add_existing_neighbor_local_as(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
+                ["192.168.0.100", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
+                ["192.168.0.100", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor local AS is already specified" in result.output
+
+    def test_config_bgp_set_unexisting_neighbor_local_as(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
+                ["192.168.0.100", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor local AS is not configured" in result.output
+
+    def test_config_bgp_del_unexisting_neighbor_local_as(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                ["192.168.0.100", "200"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
+                ["192.168.0.100", "65535"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "BGP neighbor local AS is not configured" in result.output
+
+
+    def test_config_bgp_neighbor_shutdown_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_valid_neighbor_shutdown(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("admin_status") == "false"
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_invalid_neighbor_shutdown(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+
+
+    def test_config_bgp_neighbor_ebgp_multihop_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
+                ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
+                ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_valid_neighbor_ebgp_multihop(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
+                        [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("ebgp_multihop") == "true"
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_invalid_neighbor_ebgp_multihop(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
+                    [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+
+
+    def test_config_bgp_addr_family_ipv4_unicast_neighbor_activate_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
+                commands["unicast"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], \
+                ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
+                commands["unicast"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_addr_family_ipv4_unicast_valid_neighbor_activate(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
+                    commands["unicast"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "ipv4_unicast")).get("admin_status") == "true"
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_addr_family_ipv4_unicast_invalid_neighbor_activate(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
+                    commands["unicast"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+
+
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_activate_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_activate(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("admin_status") == "true"
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_activate(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+
+
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["route-reflector-client"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["route-reflector-client"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["route-reflector-client"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("rrclient") == "true"
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["route-reflector-client"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+
+
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("soft_reconfiguration_in") == "true"
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0
+
+
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_allowas_without_asn(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["allowas-in"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "AS number is not specified" in result.output
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                commands["evpn"].commands["neighbor"].commands["allowas-in"], ["10.10.10.10", "on"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code != 0
+        assert "Specify BGP neighbor remote-as first" in result.output
+
+    @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_allowas(self, valid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        print(result.exit_code)
+        assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
+                    [neighbor, "200"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+
+        for neighbor in valid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["allowas-in"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code == 0
+            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("allow_as_in") == "true"
+
+    @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_allowas(self, invalid_neighbors):
+        runner = CliRunner()
+        db = Db()
+
+        for neighbor in invalid_neighbors:
+            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
+                    commands["evpn"].commands["neighbor"].commands["allowas-in"], [neighbor, "on"], obj=db)
+            print(result.exit_code)
+            assert result.exit_code != 0

--- a/tests/bgp_neighbor_extended_commands_test.py
+++ b/tests/bgp_neighbor_extended_commands_test.py
@@ -6,18 +6,19 @@ from click.testing import CliRunner
 import config.main as config
 from utilities_common.db import Db
 
+
 class TestBgpNeighborExtendedCommands(object):
 
     valid_neighbors = (
         ("10.10.10.10",),
         ("0bd3:8339:7d3b:d3bb:dd39:c1c0:6e23:f517",),
-        ("Ethernet4",)
+        ("Ethernet4",),
     )
 
     invalid_neighbors = (
         ("10.10.10.358",),
         ("5efc:2mf5:6f16:acdn:e9c4:5747:fg6b:275d",),
-        ("Ether_net4",)
+        ("Ether_net4",),
     )
 
     @classmethod
@@ -30,12 +31,16 @@ class TestBgpNeighborExtendedCommands(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
         print("TEARDOWN")
 
-
     def test_config_bgp_add_neighbor_remote_as_without_asn(self):
         runner = CliRunner()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["10.10.10.10", "65535"])
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["10.10.10.10", "65535"],
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
@@ -45,30 +50,61 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "65535"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "65535"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn") == "65535"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn")
+                == "65535"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
-                    [neighbor, "62000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["set"],
+                [neighbor, "62000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn") == "62000"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn")
+                == "62000"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
-                    [neighbor, "62000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["del"],
+                [neighbor, "62000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn") == None
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("asn")
+                is None
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
     def test_config_bgp_add_set_del_invalid_neighbor_remote_as(self, invalid_neighbors):
@@ -76,57 +112,108 @@ class TestBgpNeighborExtendedCommands(object):
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "65535"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "65535"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
-                    [neighbor, "34000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["set"],
+                [neighbor, "34000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
-                    [neighbor, "60000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["del"],
+                [neighbor, "60000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "0"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "0"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
-                ["192.168.0.100", "1a"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["set"],
+            ["192.168.0.100", "1a"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
-                ["192.168.0.100", "4294967296"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["del"],
+            ["192.168.0.100", "4294967296"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
-
 
     def test_config_bgp_add_existing_neighbor_remote_as(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["10.10.10.10", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["10.10.10.10", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["10.10.10.10", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["10.10.10.10", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor remote-as already exists" in result.output
@@ -135,12 +222,22 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["set"], \
-                ["10.10.10.10", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["set"],
+            ["10.10.10.10", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor remote-as is not configured" in result.output
@@ -149,33 +246,58 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["del"], \
-                ["10.10.10.10", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["del"],
+            ["10.10.10.10", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor does not exist" in result.output
-
 
     def test_config_bgp_add_neighbor_upd_src_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
-                ["10.10.10.10", "20.20.20.20"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["add"],
+            ["10.10.10.10", "20.20.20.20"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
-                ["10.10.10.10", "20.20.20.20"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["add"],
+            ["10.10.10.10", "20.20.20.20"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -185,36 +307,79 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
-                    [neighbor, "178.50.20.10"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["update-source"]
+                .commands["add"],
+                [neighbor, "178.50.20.10"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_addr") == "178.50.20.10"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "local_addr"
+                )
+                == "178.50.20.10"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"],
-                    [neighbor, "180.122.55.50"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["update-source"]
+                .commands["set"],
+                [neighbor, "180.122.55.50"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_addr") == "180.122.55.50"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "local_addr"
+                )
+                == "180.122.55.50"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
-                    [neighbor, "180.122.55.50"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["update-source"]
+                .commands["del"],
+                [neighbor, "180.122.55.50"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_addr") == None
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "local_addr"
+                )
+                is None
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
     def test_config_bgp_add_set_del_invalid_neighbor_upd_src(self, invalid_neighbors):
@@ -222,38 +387,74 @@ class TestBgpNeighborExtendedCommands(object):
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
-                    [neighbor, "178.50.20.10"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["update-source"]
+                .commands["add"],
+                [neighbor, "178.50.20.10"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"], \
-                    [neighbor, "180.122.55.50"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["update-source"]
+                .commands["set"],
+                [neighbor, "180.122.55.50"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
-                    [neighbor, "180.122.55.50"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["update-source"]
+                .commands["del"],
+                [neighbor, "180.122.55.50"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
-                ["192.168.0.100", "0.1a.50.20"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["add"],
+            ["192.168.0.100", "0.1a.50.20"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"], \
-                ["192.168.0.100", "4294967296"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["set"],
+            ["192.168.0.100", "4294967296"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
-                ["192.168.0.100", "500.20.50.11"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["del"],
+            ["192.168.0.100", "500.20.50.11"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
@@ -261,22 +462,44 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
-                ["192.168.0.100", "20.20.20.20"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["add"],
+            ["192.168.0.100", "20.20.20.20"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["add"], \
-                ["192.168.0.100", "20.20.20.20"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["add"],
+            ["192.168.0.100", "20.20.20.20"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor update source already exists" in result.output
@@ -285,17 +508,33 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["set"], \
-                ["192.168.0.100", "20.20.20.20"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["set"],
+            ["192.168.0.100", "20.20.20.20"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor update source is not configured" in result.output
@@ -304,38 +543,69 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["update-source"].commands["del"], \
-                ["192.168.0.100", "20.20.20.20"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["update-source"]
+            .commands["del"],
+            ["192.168.0.100", "20.20.20.20"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor update source is not configured" in result.output
-
 
     def test_config_bgp_add_neighbor_adv_interval_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
-                ["10.10.10.10", "33"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["add"],
+            ["10.10.10.10", "33"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
-                ["10.10.10.10", "33"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["add"],
+            ["10.10.10.10", "33"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -345,75 +615,156 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
-                    [neighbor, "123"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["advertisement-interval"]
+                .commands["add"],
+                [neighbor, "123"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("min_adv_interval") == "123"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "min_adv_interval"
+                )
+                == "123"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
-                    [neighbor, "234"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["advertisement-interval"]
+                .commands["set"],
+                [neighbor, "234"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("min_adv_interval") == "234"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "min_adv_interval"
+                )
+                == "234"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
-                    [neighbor, "234"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["advertisement-interval"]
+                .commands["del"],
+                [neighbor, "234"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("min_adv_interval") == None
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "min_adv_interval"
+                )
+                is None
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
-    def test_config_bgp_add_set_del_invalid_neighbor_adv_interval(self, invalid_neighbors):
+    def test_config_bgp_add_set_del_invalid_neighbor_adv_interval(
+        self, invalid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
-                    [neighbor, "123"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["advertisement-interval"]
+                .commands["add"],
+                [neighbor, "123"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
-                    [neighbor, "234"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["advertisement-interval"]
+                .commands["set"],
+                [neighbor, "234"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
-                    [neighbor, "234"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["advertisement-interval"]
+                .commands["del"],
+                [neighbor, "234"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
-                ["192.168.0.100", "0"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["add"],
+            ["192.168.0.100", "0"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
-                ["192.168.0.100", "800"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["set"],
+            ["192.168.0.100", "800"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
-                ["192.168.0.100", "-5"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["del"],
+            ["192.168.0.100", "-5"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
@@ -421,22 +772,44 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor advertisement interval already exists" in result.output
@@ -445,57 +818,104 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["set"], \
-                ["192.168.0.100", "500"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["set"],
+            ["192.168.0.100", "500"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor advertisement interval is not configured" in result.output
 
-    def test_config_bgp_del_unexisting_neighbor_upd_src(self):
+    def test_config_bgp_del_unexisting_neighbor_adv_interval(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["advertisement-interval"].commands["del"], \
-                ["192.168.0.100", "500"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["advertisement-interval"]
+            .commands["del"],
+            ["192.168.0.100", "500"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor advertisement interval is not configured" in result.output
-
 
     def test_config_bgp_add_neighbor_timers_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
-                ["10.10.10.10", "2", "6"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["add"],
+            ["10.10.10.10", "2", "6"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
-                ["10.10.10.10", "2", "6"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["add"],
+            ["10.10.10.10", "2", "6"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -505,39 +925,97 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
-                    [neighbor, "2", "6"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["timers"]
+                .commands["add"],
+                [neighbor, "2", "6"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("keepalive") == "2"
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("holdtime") == "6"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "keepalive"
+                )
+                == "2"
+            )
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "holdtime"
+                )
+                == "6"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
-                    [neighbor, "20", "60"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["timers"]
+                .commands["set"],
+                [neighbor, "20", "60"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("keepalive") == "20"
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("holdtime") == "60"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "keepalive"
+                )
+                == "20"
+            )
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "holdtime"
+                )
+                == "60"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
-                    [neighbor, "20", "60"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["timers"]
+                .commands["del"],
+                [neighbor, "20", "60"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("keepalive") == None
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("holdtime") == None
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "keepalive"
+                )
+                is None
+            )
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "holdtime"
+                )
+                is None
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
     def test_config_bgp_add_set_del_neighbor_invalid_timers(self, invalid_neighbors):
@@ -545,38 +1023,74 @@ class TestBgpNeighborExtendedCommands(object):
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
-                    [neighbor, "2", "6"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["timers"]
+                .commands["add"],
+                [neighbor, "2", "6"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
-                    [neighbor, "2", "6"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["timers"]
+                .commands["set"],
+                [neighbor, "2", "6"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
-                    [neighbor, "2", "6"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["timers"]
+                .commands["del"],
+                [neighbor, "2", "6"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
-                ["192.168.0.100", "-5"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["add"],
+            ["192.168.0.100", "-5"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
-                ["192.168.0.100", "70000"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["set"],
+            ["192.168.0.100", "70000"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
-                ["192.168.0.100", "99999"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["del"],
+            ["192.168.0.100", "99999"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
@@ -584,22 +1098,44 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
-                ["192.168.0.100", "2", "6"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["add"],
+            ["192.168.0.100", "2", "6"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["add"], \
-                ["192.168.0.100", "2", "6"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["add"],
+            ["192.168.0.100", "2", "6"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor timers are already configured" in result.output
@@ -608,17 +1144,33 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["set"], \
-                ["192.168.0.100", "2", "6"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["set"],
+            ["192.168.0.100", "2", "6"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor timers are not configured" in result.output
@@ -627,38 +1179,69 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["timers"].commands["del"], \
-                ["192.168.0.100", "2", "6"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["timers"]
+            .commands["del"],
+            ["192.168.0.100", "2", "6"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor timers are not configured" in result.output
-
 
     def test_config_bgp_add_neighbor_local_as_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
-                ["10.10.10.10", "65000"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["add"],
+            ["10.10.10.10", "65000"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
-                ["10.10.10.10", "65000"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["add"],
+            ["10.10.10.10", "65000"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -668,36 +1251,79 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
-                    [neighbor, "65535"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["local-as"]
+                .commands["add"],
+                [neighbor, "65535"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_asn") == "65535"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "local_asn"
+                )
+                == "65535"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
-                    [neighbor, "62000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["local-as"]
+                .commands["set"],
+                [neighbor, "62000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_asn") == "62000"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "local_asn"
+                )
+                == "62000"
+            )
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
-                    [neighbor, "62000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["local-as"]
+                .commands["del"],
+                [neighbor, "62000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("local_asn") == None
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "local_asn"
+                )
+                is None
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
     def test_config_bgp_add_set_del_neighbor_invalid_local_as(self, invalid_neighbors):
@@ -705,38 +1331,74 @@ class TestBgpNeighborExtendedCommands(object):
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
-                    [neighbor, "65535"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["local-as"]
+                .commands["add"],
+                [neighbor, "65535"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
-                    [neighbor, "34000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["local-as"]
+                .commands["set"],
+                [neighbor, "34000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
-                    [neighbor, "60000"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["local-as"]
+                .commands["del"],
+                [neighbor, "60000"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
             assert "Neighbor interface/IP address is not valid" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
-                ["192.168.0.100", "0"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["add"],
+            ["192.168.0.100", "0"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
-                ["192.168.0.100", "1a"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["set"],
+            ["192.168.0.100", "1a"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
-                ["192.168.0.100", "4294967296"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["del"],
+            ["192.168.0.100", "4294967296"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
 
@@ -744,22 +1406,44 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
-                ["192.168.0.100", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["add"],
+            ["192.168.0.100", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["add"], \
-                ["192.168.0.100", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["add"],
+            ["192.168.0.100", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor local AS is already specified" in result.output
@@ -768,17 +1452,33 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["set"], \
-                ["192.168.0.100", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["set"],
+            ["192.168.0.100", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor local AS is not configured" in result.output
@@ -787,36 +1487,63 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                ["192.168.0.100", "200"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["remote-as"]
+            .commands["add"],
+            ["192.168.0.100", "200"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["local-as"].commands["del"], \
-                ["192.168.0.100", "65535"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["local-as"]
+            .commands["del"],
+            ["192.168.0.100", "65535"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "BGP neighbor local AS is not configured" in result.output
-
 
     def test_config_bgp_neighbor_shutdown_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["neighbor"].commands["shutdown"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["neighbor"].commands["shutdown"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -826,21 +1553,40 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"].commands["neighbor"].commands["shutdown"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("admin_status") == "false"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "admin_status"
+                )
+                == "false"
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
     def test_config_bgp_invalid_neighbor_shutdown(self, invalid_neighbors):
@@ -848,27 +1594,44 @@ class TestBgpNeighborExtendedCommands(object):
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["shutdown"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"].commands["neighbor"].commands["shutdown"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
-
 
     def test_config_bgp_neighbor_ebgp_multihop_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
-                ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["ebgp-multihop"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
-                ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["neighbor"]
+            .commands["ebgp-multihop"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -878,22 +1641,42 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
-                        [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["ebgp-multihop"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get("ebgp_multihop") == "true"
+            assert (
+                db.cfgdb.get_entry("BGP_NEIGHBOR", ("default", neighbor)).get(
+                    "ebgp_multihop"
+                )
+                == "true"
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
     def test_config_bgp_invalid_neighbor_ebgp_multihop(self, invalid_neighbors):
@@ -901,83 +1684,160 @@ class TestBgpNeighborExtendedCommands(object):
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["ebgp-multihop"], \
-                    [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["ebgp-multihop"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
-
 
     def test_config_bgp_addr_family_ipv4_unicast_neighbor_activate_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
-                commands["unicast"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["neighbor"]
+            .commands["activate"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], \
-                ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
-                commands["unicast"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["ipv4"]
+            .commands["unicast"]
+            .commands["neighbor"]
+            .commands["activate"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
 
     @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
-    def test_config_bgp_addr_family_ipv4_unicast_valid_neighbor_activate(self, valid_neighbors):
+    def test_config_bgp_addr_family_ipv4_unicast_valid_neighbor_activate(
+        self, valid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
-                    commands["unicast"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["neighbor"]
+                .commands["activate"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "ipv4_unicast")).get("admin_status") == "true"
+            assert (
+                db.cfgdb.get_entry(
+                    "BGP_NEIGHBOR_AF", ("default", neighbor, "ipv4_unicast")
+                ).get("admin_status")
+                == "true"
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
-    def test_config_bgp_addr_family_ipv4_unicast_invalid_neighbor_activate(self, invalid_neighbors):
+    def test_config_bgp_addr_family_ipv4_unicast_invalid_neighbor_activate(
+        self, invalid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["ipv4"].\
-                    commands["unicast"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["ipv4"]
+                .commands["unicast"]
+                .commands["neighbor"]
+                .commands["activate"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
-
 
     def test_config_bgp_addr_family_l2vpn_evpn_neighbor_activate_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["activate"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["activate"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["activate"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -987,159 +1847,325 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["activate"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("admin_status") == "true"
+            assert (
+                db.cfgdb.get_entry(
+                    "BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")
+                ).get("admin_status")
+                == "true"
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
-    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_activate(self, invalid_neighbors):
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_activate_neg(
+        self, invalid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["activate"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["activate"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
-
 
     def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["route-reflector-client"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["route-reflector-client"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["route-reflector-client"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["route-reflector-client"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
 
     @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
-    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client(self, valid_neighbors):
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client(
+        self, valid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "100"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["route-reflector-client"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["route-reflector-client"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("rrclient") == "true"
+            assert (
+                db.cfgdb.get_entry(
+                    "BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")
+                ).get("rrclient")
+                == "true"
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
-    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client(self, invalid_neighbors):
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_rr_client_neg(
+        self, invalid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["route-reflector-client"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["route-reflector-client"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
 
-
-    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound_without_asn(self):
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound_without_asn(
+        self,
+    ):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["soft-reconf"]
+            .commands["inbound"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["soft-reconf"]
+            .commands["inbound"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
 
     @pytest.mark.parametrize("valid_neighbors", valid_neighbors)
-    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound(self, valid_neighbors):
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound(
+        self, valid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["soft-reconf"]
+                .commands["inbound"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("soft_reconfiguration_in") == "true"
+            assert (
+                db.cfgdb.get_entry(
+                    "BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")
+                ).get("soft_reconfiguration_in")
+                == "true"
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
-    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound(self, invalid_neighbors):
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_soft_reconf_inbound_neg(
+        self, invalid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["soft-reconf"].commands["inbound"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["soft-reconf"]
+                .commands["inbound"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0
-
 
     def test_config_bgp_addr_family_l2vpn_evpn_neighbor_allowas_without_asn(self):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["allowas-in"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["allowas-in"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "AS number is not specified" in result.output
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
-        result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                commands["evpn"].commands["neighbor"].commands["allowas-in"], ["10.10.10.10", "on"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"]
+            .commands["address-family"]
+            .commands["l2vpn"]
+            .commands["evpn"]
+            .commands["neighbor"]
+            .commands["allowas-in"],
+            ["10.10.10.10", "on"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code != 0
         assert "Specify BGP neighbor remote-as first" in result.output
@@ -1149,30 +2175,63 @@ class TestBgpNeighborExtendedCommands(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(config.config.commands["bgp"].commands["autonomous-system"].commands["add"], ["100"], obj=db)
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["autonomous-system"].commands["add"],
+            ["100"],
+            obj=db,
+        )
         print(result.exit_code)
         assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["neighbor"].commands["remote-as"].commands["add"], \
-                    [neighbor, "200"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["neighbor"]
+                .commands["remote-as"]
+                .commands["add"],
+                [neighbor, "200"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
 
         for neighbor in valid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["allowas-in"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["allowas-in"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code == 0
-            assert db.cfgdb.get_entry("BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")).get("allow_as_in") == "true"
+            assert (
+                db.cfgdb.get_entry(
+                    "BGP_NEIGHBOR_AF", ("default", neighbor, "l2vpn_evpn")
+                ).get("allow_as_in")
+                == "true"
+            )
 
     @pytest.mark.parametrize("invalid_neighbors", invalid_neighbors)
-    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_allowas(self, invalid_neighbors):
+    def test_config_bgp_addr_family_l2vpn_evpn_neighbor_allowas_neg(
+        self, invalid_neighbors
+    ):
         runner = CliRunner()
         db = Db()
 
         for neighbor in invalid_neighbors:
-            result = runner.invoke(config.config.commands["bgp"].commands["address-family"].commands["l2vpn"].\
-                    commands["evpn"].commands["neighbor"].commands["allowas-in"], [neighbor, "on"], obj=db)
+            result = runner.invoke(
+                config.config.commands["bgp"]
+                .commands["address-family"]
+                .commands["l2vpn"]
+                .commands["evpn"]
+                .commands["neighbor"]
+                .commands["allowas-in"],
+                [neighbor, "on"],
+                obj=db,
+            )
             print(result.exit_code)
             assert result.exit_code != 0


### PR DESCRIPTION
#### What I did
Added new BGP commands:

> config bgp autonomous-system add <as-num>
> config bgp neighbor remote-as add <neighbor-ip> <as-num>
> config bgp neighbor update-source add <neighbor-ip> <local-addr-ip>
> config bgp bestpath as-path multipath-relax on
> config bgp router-id add <ip>
> config bgp address-family ipv4 unicast max-paths add 64
> config bgp address-family ipv4 unicast network add <ip/mask>
> config bgp address-family l2vpn evpn neighbor activate <ip> on
> config bgp address-family ipv4 unicast neighbor activate <ip> on
> config bgp address-family l2vpn evpn advertise-all-vni on
> config bgp graceful-restart state on
> config bgp graceful-restart restart-time add <time>
> config bgp graceful-restart stalepath-time add <time>
> config bgp graceful-restart preserve-fw-state on
> config bgp listen limit add <max-dynamic-neighbors>
> config bgp default ipv4-unicast on
> config bgp fast-external-failover off
> config bgp bestpath compare-routerid on
> config bgp client-to-client reflection off
> config bgp cluster-id add <ip>
> config bgp address-family ipv4 unicast distance bgp add 64 65 66
> config bgp address-family ipv4 unicast redistribute connected on
> config bgp neighbor local-as add <ip> <as-num> --no-prepend --replace-as
> config bgp neighbor ebgp-multihop <ip> on --max-hops 64
> config bgp neighbor advertisement-interval add <ip> 9
> config bgp neighbor timers add <ip> 9 10
> config bgp neighbor shutdown <ip> on
> config bgp address-family l2vpn evpn neighbor allowas-in <ip> on --allowas <1-10|origin>
> config bgp address-family l2vpn evpn neighbor route-reflector-client <ip> on
> config bgp address-family l2vpn evpn neighbor soft-reconf inbound <ip> on
> config bgp address-family ipv4 unicast max-paths ibgp add 8 --equal-cluster-length
> config bgp ebgp-requires-policy off

and 325 UT for that commands

#### How I did it
Expanded 'config bgp' command with the new sub-commands covering the most needs of system administrator.

#### How to verify it
Two verification vectors were executed: 

1. 325 UT were prepared to verify the functionality
2. Next topology was built:
![Test network topology](https://github.com/sonic-net/sonic-utilities/assets/131658641/1ce61401-49e7-4b86-a835-5898e9e5620c)
and verified that VXLAN EVPN works over this eBGP network.

#### Previous command output (if the output of a command-line utility has changed)
No output was modified

#### New command output (if the output of a command-line utility has changed)
All added commands are set/delete commands, so no new output was added
