### PR TITLE
[DPB]Fix return code in case of failure

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4709,7 +4709,7 @@ def breakout(ctx, interface_name, mode, verbose, force_remove_dependencies, load
     except Exception as e:
         click.secho("Failed to break out Port. Error: {}".format(str(e)), fg='magenta')
 
-        sys.exit(0)
+        sys.exit(1)
 
 def _get_all_mgmtinterface_keys():
     """Returns list of strings containing mgmt interface keys

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -350,7 +350,7 @@ class TestConfigDPB(object):
             commands["breakout"], ['{}'.format(interface), '{}'.format(newMode), '-v', '-y'], obj=obj)
 
         print(result.exit_code, result.output)
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert 'Below Config can not be verified' in result.output
         assert 'UNKNOWN_TABLE' in result.output
         assert 'Do you wish to Continue?' in result.output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix return code when DPB command fails. Return of 0 indicates success which might be a problem to detect failures using automation

#### How I did it
Updated return code to 1

#### How to verify it
Basic manual testing

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

