### PR TITLE
Add the ability to create a P2P tunnel from the CLI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [aliases]
 test=pytest
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203,E701

--- a/tests/vxlan_test.py
+++ b/tests/vxlan_test.py
@@ -15,13 +15,6 @@ from .mock_tables import dbconnector
 test_path = os.path.dirname(os.path.abspath(__file__))
 mock_db_path = os.path.join(test_path, "vnet_input")
 
-show_vxlan_interface_output="""\
-VTEP Information:
-
-	VTEP Name : vtep1, SIP  : 1.1.1.1
-	NVO Name  : nvo1,  VTEP : vtep1
-"""
-
 show_vxlan_vlanvnimap_output="""\
 +---------+-------+
 | VLAN    |   VNI |
@@ -71,6 +64,13 @@ vtep1                1.1.1.1                        map_100_Vlan100    100 -> Vl
                                                     map_102_Vlan102    102 -> Vlan102
                                                     map_200_Vlan200    200 -> Vlan200
 """
+
+show_vxlan_interface_output = """\
+VTEP Information:
+
+	VTEP Name : vtep1, SIP  : 1.1.1.1
+	NVO Name  : nvo1,  VTEP : vtep1
+"""  # noqa: E101,W191
 
 show_vxlan_remotevni_output="""\
 +---------+--------------+-------+
@@ -330,6 +330,30 @@ class TestVxlan(object):
         assert result.exit_code == 0
 
         result = runner.invoke(config.config.commands["vxlan"].commands["del"], ["vtep1"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands['vxlan'].commands['add'],
+                               ['vtep1', '1.1.1.1', '1.2.3.4.5'], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands['vxlan'].commands['add'],
+                               ['vtep1', '1.2.3.4.5', '2.2.2.2.2'], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+
+        result = runner.invoke(config.config.commands['vxlan'].commands['add'],
+                               ['vtep1', '1.1.1.1', '2.2.2.2'], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands['vxlan'].commands['del'],
+                               ['vtep1'], obj=db)
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0


### PR DESCRIPTION
#### What I did
Added the ability to create a P2P VxLAN tunnel from the CLI

#### How I did it
Extended the existing `config vxlan add ...` command with an optional dst_ip argument. The implementation logic was already existent.

#### How to verify it
```
root@sonic:~# config vxlan add vxlan0 1.1.1.1 2.2.2.2
root@sonic:~# config vlan add 100
root@sonic:~# config vxlan map add vxlan0 100 1000

root@sonic:~# ip -d link show dev vxlan0-100
53: vxlan0-100: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master Bridge state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 0c:52:4a:3a:00:00 brd ff:ff:ff:ff:ff:ff promiscuity 1 minmtu 68 maxmtu 65535 
    vxlan id 1000 remote 2.2.2.2 local 1.1.1.1 srcport 0 0 dstport 4789 nolearning ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx 
    bridge_slave state forwarding priority 32 cost 100 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.c:52:4a:3a:0:0 designated_root 8000.c:52:4a:3a:0:0 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 

root@sonic:~# jq '.VXLAN_TUNNEL' /etc/sonic/config_db.json 
{
  "vxlan0": {
    "dst_ip": "2.2.2.2",
    "src_ip": "1.1.1.1"
  }
}
```

#### Previous command output (if the output of a command-line utility has changed)
No output was modified

#### New command output (if the output of a command-line utility has changed)
Help message now shows additional optional argument:
```
root@sonic:~# config vxlan add -h
Usage: config vxlan add [OPTIONS] <vxlan_name> <src_ip> [dst_ip]

  Add VXLAN

Options:
  -h, -?, --help  Show this message and exit.
  ```

Error message for invalid `dst_ip`:
```
root@sonic:~# config vxlan add vxlan0 10.0.0.1 1.2.3.4.5
Usage: config vxlan add [OPTIONS] <vxlan_name> <src_ip> [dst_ip]
Try "config vxlan add -h" for help.

Error: 1.2.3.4.5 invalid dst ip address
```