### PR TITLE
[Reboot] remove exec from the platform_reboot call when executing reboot in kdump kernel

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -20,7 +20,7 @@ if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
         sync
         PLATFORM=$(grep -oP 'sonic_platform=\K\S+' /proc/cmdline)
         if [ ! -z "${PLATFORM}" -a -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
-            exec ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
+            ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT}
         fi
         # If no platform-specific reboot tool, just run /sbin/reboot
         /sbin/reboot


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove exec from the platform_reboot call to handle any hang issue during reboot in kdump kernel

#### How I did it

#### How to verify it
Trigger kernel panic after uninstalling the platform driver and check if the device can reboot without hang.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

