### PR TITLE
kdump-Remote-SSH-Configurations

### DIFF
--- a/config/kdump.py
+++ b/config/kdump.py
@@ -145,12 +145,14 @@ def is_remote_enabled(db):
 @pass_db
 def add_ssh_key(db, ssh_string):
     """Add an SSH string to KDUMP configuration"""
-    if not is_remote_enabled(db):
-        click.echo("Remote feature is not enabled. Please enable the remote feature first.")
-        return
 
     kdump_table = db.cfgdb.get_table("KDUMP")
     check_kdump_table_existence(kdump_table)
+    current_status = kdump_table["config"].get("remote", "false").lower()
+
+    if current_status == 'false':
+        click.echo("Remote feature is not enabled. Please enable the remote feature first.")
+        return
 
     # Add or update the 'ssh_key' entry in the KDUMP table
     db.cfgdb.mod_entry("KDUMP", "config", {"ssh_string": ssh_string})
@@ -162,12 +164,13 @@ def add_ssh_key(db, ssh_string):
 @pass_db
 def add_ssh_path(db, ssh_path):
     """Add an SSH path to KDUMP configuration"""
-    if not is_remote_enabled(db):
-        click.echo("Remote feature is not enabled. Please enable the remote feature first.")
-        return
-
+    
     kdump_table = db.cfgdb.get_table("KDUMP")
     check_kdump_table_existence(kdump_table)
+    current_status = kdump_table["config"].get("remote", "false").lower()
+    if current_status == 'false':
+        click.echo("Remote feature is not enabled. Please enable the remote feature first.")
+        return
 
     # Add or update the 'ssh_key' entry in the KDUMP table
     db.cfgdb.mod_entry("KDUMP", "config", {"ssh_path": ssh_path})

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -164,7 +164,7 @@ def add_ssh_key(db, ssh_string):
 @pass_db
 def add_ssh_path(db, ssh_path):
     """Add an SSH path to KDUMP configuration"""
-    
+
     kdump_table = db.cfgdb.get_table("KDUMP")
     check_kdump_table_existence(kdump_table)
     current_status = kdump_table["config"].get("remote", "false").lower()

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -3,6 +3,7 @@ import click
 import os
 from utilities_common.cli import AbbreviationGroup, pass_db
 from ipaddress import ip_address, AddressValueError
+import re
 #
 # 'kdump' group ('sudo config kdump ...')
 #
@@ -144,7 +145,7 @@ def add_ssh_key(db, ssh_string):
         # Check if it contains username and hostname/IP (format: username@host)
         if "@" not in ssh_string:
             return "Invalid format. SSH key must be in 'username@host' format."
-        
+
         username, host = ssh_string.split("@", 1)
 
         # Validate username
@@ -182,7 +183,6 @@ def add_ssh_key(db, ssh_string):
     click.echo(f"SSH string added to KDUMP configuration: {ssh_string}")
 
 
-
 @add.command(name="ssh_path", help="Add an SSH path to the KDUMP configuration")
 @click.argument('ssh_path', metavar='<ssh_path>', required=True)
 @pass_db
@@ -217,7 +217,6 @@ def add_ssh_path(db, ssh_path):
     # Add or update the 'ssh_path' entry in the KDUMP table
     db.cfgdb.mod_entry("KDUMP", "config", {"ssh_path": ssh_path})
     click.echo(f"SSH path added to KDUMP configuration: {ssh_path}")
-
 
 
 @kdump.group(name="remove", help="remove configuration items to KDUMP")

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -131,11 +131,24 @@ def add():
     pass
 
 
+def is_remote_enabled(db):
+    """Check if the remote feature is enabled in the KDUMP configuration."""
+    kdump_table = db.cfgdb.get_table("KDUMP")
+    check_kdump_table_existence(kdump_table)
+
+    # Assuming there is a field 'remote' that indicates if the remote feature is enabled
+    return kdump_table.get("config", {}).get("remote", False)
+
+
 @add.command(name="ssh_string", help="Add an SSH string to the KDUMP configuration")
 @click.argument('ssh_string', metavar='<ssh_key>', required=True)
 @pass_db
 def add_ssh_key(db, ssh_string):
     """Add an SSH string to KDUMP configuration"""
+    if not is_remote_enabled(db):
+        click.echo("Remote feature is not enabled. Please enable the remote feature first.")
+        return
+
     kdump_table = db.cfgdb.get_table("KDUMP")
     check_kdump_table_existence(kdump_table)
 
@@ -148,7 +161,11 @@ def add_ssh_key(db, ssh_string):
 @click.argument('ssh_path', metavar='<ssh_key>', required=True)
 @pass_db
 def add_ssh_path(db, ssh_path):
-    """Add an SSH key to KDUMP configuration"""
+    """Add an SSH path to KDUMP configuration"""
+    if not is_remote_enabled(db):
+        click.echo("Remote feature is not enabled. Please enable the remote feature first.")
+        return
+
     kdump_table = db.cfgdb.get_table("KDUMP")
     check_kdump_table_existence(kdump_table)
 

--- a/config/kdump.py
+++ b/config/kdump.py
@@ -131,15 +131,6 @@ def add():
     pass
 
 
-def is_remote_enabled(db):
-    """Check if the remote feature is enabled in the KDUMP configuration."""
-    kdump_table = db.cfgdb.get_table("KDUMP")
-    check_kdump_table_existence(kdump_table)
-
-    # Assuming there is a field 'remote' that indicates if the remote feature is enabled
-    return kdump_table.get("config", {}).get("remote", False)
-
-
 @add.command(name="ssh_string", help="Add an SSH string to the KDUMP configuration")
 @click.argument('ssh_string', metavar='<ssh_key>', required=True)
 @pass_db

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -461,8 +461,13 @@ def read_ssh_string():
 
 def write_ssh_string(ssh_string):
     ssh_string = ssh_string.replace('/', '\/')  # Escape any slashes in the SSH string
-    cmd = "/bin/sed -i -e 's/#*SSH=.*/SSH=\"%s\"/' %s" % (ssh_string, kdump_cfg)
-
+    cmd = [
+        "/bin/sed",
+        "-i",
+        "-e",
+        f"s/#*SSH=.*/SSH=\"{ssh_string}\"/",
+        kdump_cfg
+    ]
     (rc, lines, err_str) = run_command(cmd, use_shell=False)
     if rc == 0 and type(lines) == list and len(lines) == 0:
         ssh_string_in_cfg = read_ssh_string()

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -371,7 +371,7 @@ def get_kdump_ssh_path():
 #
 #  @return The integer value X from USE_KDUMP=X in /etc/default/kdump-tools
 def read_use_kdump():
-    (rc, lines, err_str) = run_command("grep 'USE_KDUMP=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=True);
+    (rc, lines, err_str) = run_command("grep 'USE_KDUMP=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=False);
     if rc == 0 and type(lines) == list and len(lines) >= 1:
         try:
             return int(lines[0])
@@ -405,7 +405,7 @@ def write_use_kdump(use_kdump):
 #
 #  @return The integer value X from KDUMP_NUM_DUMPS=X in /etc/default/kdump-tools
 def read_num_dumps():
-    (rc, lines, err_str) = run_command("grep '#*KDUMP_NUM_DUMPS=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=True);
+    (rc, lines, err_str) = run_command("grep '#*KDUMP_NUM_DUMPS=.*' %s | cut -d = -f 2" % kdump_cfg, use_shell=False);
     if rc == 0 and type(lines) == list and len(lines) >= 1:
         try:
             return int(lines[0])
@@ -438,17 +438,17 @@ def write_kdump_remote():
 
     if remote:
         # Uncomment SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/#SSH/SSH/' %s" % kdump_cfg, use_shell=True)
-        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' %s" % kdump_cfg, use_shell=True)
+        run_command("/bin/sed -i 's/#SSH/SSH/' %s" % kdump_cfg, use_shell=False)
+        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' %s" % kdump_cfg, use_shell=False)
         print("SSH and SSH_KEY uncommented for remote configuration.")
     else:
         # Comment out SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/SSH/#SSH/' %s" % kdump_cfg, use_shell=True)
-        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' %s" % kdump_cfg, use_shell=True)
+        run_command("/bin/sed -i 's/SSH/#SSH/' %s" % kdump_cfg, use_shell=False)
+        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' %s" % kdump_cfg, use_shell=False)
         print("SSH and SSH_KEY commented out for local configuration.")
 
 def read_ssh_string():
-    (rc, lines, err_str) = run_command("grep '#*SSH=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
+    (rc, lines, err_str) = run_command("grep '#*SSH=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=False)
     if rc == 0 and type(lines) == list and len(lines) >= 1:
         try:
             return lines[0].strip()  # Return the SSH string (e.g., user@ip_address)
@@ -474,7 +474,7 @@ def write_ssh_string(ssh_string):
         sys.exit(1)
 
 def read_ssh_path():
-    (rc, lines, err_str) = run_command("grep '#*SSH_KEY=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
+    (rc, lines, err_str) = run_command("grep '#*SSH_KEY=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=False)
     if rc == 0 and type(lines) == list and len(lines) >= 1:
         try:
             ssh_path = lines[0].strip()
@@ -491,7 +491,7 @@ def read_ssh_path():
 def write_ssh_path(ssh_path):
     cmd = "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"%s\"/' %s" % (ssh_path, kdump_cfg)
 
-    (rc, lines, err_str) = run_command(cmd, use_shell=True)  # Make sure to set use_shell=True
+    (rc, lines, err_str) = run_command(cmd, use_shell=False)  # Make sure to set use_shell=True
     if rc == 0 and type(lines) == list and len(lines) == 0:
         ssh_path_in_cfg = read_ssh_path()
         if ssh_path_in_cfg != ssh_path:
@@ -748,14 +748,14 @@ def cmd_kdump_remote(verbose):
 
     if remote:
         # Uncomment SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=True)
-        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        run_command("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=False)
+        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
         if verbose:
             print("SSH and SSH_KEY uncommented for remote configuration.")
     else:
         # Comment out SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=True)
-        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        run_command("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=False)
+        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
         if verbose:
             print("SSH and SSH_KEY commented out for local configuration.")
 

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -461,7 +461,7 @@ def read_ssh_string():
 
 def write_ssh_string(ssh_string):
     ssh_string = ssh_string.replace('/', '\/')  # Escape any slashes in the SSH string
-    cmd = ["/bin/sed", "-i", "-e", f"s/#*SSH=.*/SSH=\"{ssh_string}\"/", kdump_cfg]
+    cmd = "/bin/sed -i -e 's/#*SSH=.*/SSH=\"%s\"/' %s" % (ssh_string, kdump_cfg)
 
     (rc, lines, err_str) = run_command(cmd, use_shell=True)
     if rc == 0 and type(lines) == list and len(lines) == 0:

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -463,15 +463,12 @@ def write_ssh_string(ssh_string):
     ssh_string = ssh_string.replace('/', '\/')  # Escape any slashes in the SSH string
     cmd = ["/bin/sed", "-i", "-e", f"s/#*SSH=.*/SSH=\"{ssh_string}\"/", kdump_cfg]
 
-    (rc, lines, err_str) = run_command(cmd, use_shell=False)  # Make sure to set use_shell=False
+    (rc, lines, err_str) = run_command(cmd, use_shell=True)
     if rc == 0 and type(lines) == list and len(lines) == 0:
         ssh_string_in_cfg = read_ssh_string()
         if ssh_string_in_cfg != ssh_string:
-            print_err(f"Unable to write SSH_STRING into {kdump_cfg}")
+            print_err("Unable to write SSH_STRING into %s" % kdump_cfg)
             sys.exit(1)
-    else:
-        print_err(f"Error while writing SSH_STRING into {kdump_cfg}")
-        sys.exit(1)
     else:
         print_err("Error while writing SSH_STRING into %s" % kdump_cfg)
         sys.exit(1)

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -461,14 +461,17 @@ def read_ssh_string():
 
 def write_ssh_string(ssh_string):
     ssh_string = ssh_string.replace('/', '\/')  # Escape any slashes in the SSH string
-    cmd = "/bin/sed -i -e 's/#*SSH=.*/SSH=\"%s\"/' %s" % (ssh_string, kdump_cfg)
+    cmd = ["/bin/sed", "-i", "-e", f"s/#*SSH=.*/SSH=\"{ssh_string}\"/", kdump_cfg]
 
-    (rc, lines, err_str) = run_command(cmd, use_shell=True)  # Make sure to set use_shell=True
+    (rc, lines, err_str) = run_command(cmd, use_shell=False)  # Make sure to set use_shell=False
     if rc == 0 and type(lines) == list and len(lines) == 0:
         ssh_string_in_cfg = read_ssh_string()
         if ssh_string_in_cfg != ssh_string:
-            print_err("Unable to write SSH_STRING into %s" % kdump_cfg)
+            print_err(f"Unable to write SSH_STRING into {kdump_cfg}")
             sys.exit(1)
+    else:
+        print_err(f"Error while writing SSH_STRING into {kdump_cfg}")
+        sys.exit(1)
     else:
         print_err("Error while writing SSH_STRING into %s" % kdump_cfg)
         sys.exit(1)

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -463,7 +463,7 @@ def write_ssh_string(ssh_string):
     ssh_string = ssh_string.replace('/', '\/')  # Escape any slashes in the SSH string
     cmd = "/bin/sed -i -e 's/#*SSH=.*/SSH=\"%s\"/' %s" % (ssh_string, kdump_cfg)
 
-    (rc, lines, err_str) = run_command(cmd, use_shell=True)
+    (rc, lines, err_str) = run_command(cmd, use_shell=False)
     if rc == 0 and type(lines) == list and len(lines) == 0:
         ssh_string_in_cfg = read_ssh_string()
         if ssh_string_in_cfg != ssh_string:

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -460,7 +460,10 @@ def read_ssh_path():
     (rc, lines, err_str) = run_command("grep '#*SSH_KEY=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
     if rc == 0 and type(lines) == list and len(lines) >= 1:
         try:
-            return lines[0].strip()  # Return the SSH_PATH (e.g., /path/to/keys)
+            ssh_path = lines[0].strip()
+            if not ssh_path.startswith('/'):  # Validate that the path starts with a slash
+                raise ValueError("Invalid SSH path format.")
+            return ssh_path
         except Exception as e:
             print_err('Error! Exception[%s] occurred while reading SSH_PATH from %s' % (str(e), kdump_cfg))
             sys.exit(1)

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -472,7 +472,6 @@ def read_ssh_path():
         sys.exit(1)
 
 def write_ssh_path(ssh_path):
-    ssh_path = ssh_path.replace('/', '\/')  # Escape slashes in the SSH_PATH
     cmd = "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"%s\"/' %s" % (ssh_path, kdump_cfg)
 
     (rc, lines, err_str) = run_command(cmd, use_shell=True)  # Make sure to set use_shell=True

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -457,7 +457,7 @@ def write_ssh_string(ssh_string):
         sys.exit(1)
 
 def read_ssh_path():
-    (rc, lines, err_str) = run_command("grep '#*SSH_PATH=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
+    (rc, lines, err_str) = run_command("grep '#*SSH_KEY=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
     if rc == 0 and type(lines) == list and len(lines) >= 1:
         try:
             return lines[0].strip()  # Return the SSH_PATH (e.g., /path/to/keys)
@@ -470,7 +470,7 @@ def read_ssh_path():
 
 def write_ssh_path(ssh_path):
     ssh_path = ssh_path.replace('/', '\/')  # Escape slashes in the SSH_PATH
-    cmd = "/bin/sed -i -e 's/#*SSH_PATH=.*/SSH_PATH=\"%s\"/' %s" % (ssh_path, kdump_cfg)
+    cmd = "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"%s\"/' %s" % (ssh_path, kdump_cfg)
 
     (rc, lines, err_str) = run_command(cmd, use_shell=True)  # Make sure to set use_shell=True
     if rc == 0 and type(lines) == list and len(lines) == 0:

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -678,7 +678,7 @@ def cmd_kdump_disable(verbose):
     ssh_path = get_kdump_ssh_path()
 
     if verbose:
-        print("configDB: kdump_enabled=%d kdump_remote=%s memory=[%s] ssh_string=[%s] num_nums=%d ssh_path=[%ss]" % (kdump_enabled, kdump_remote, memory, ssh_string, num_dumps, ssh_path))
+        print("configDB: kdump_enabled=%d kdump_remote=%s memory=[%s] ssh_string=[%s] num_nums=%d ssh_path=[%ss]" % (kdump_enabled, remote, memory, ssh_string, num_dumps, ssh_path))
     if os.path.exists(grub_cfg):
         return kdump_disable(verbose, image, grub_cfg)
     elif open(machine_cfg, 'r').read().find('aboot_platform') >= 0:

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -430,6 +430,23 @@ def write_num_dumps(num_dumps):
         print_err("Error while writing KDUMP_NUM_DUMPS into %s" % kdump_cfg)
         sys.exit(1)
 
+def write_kdump_remote():
+    # Assuming there's a function that retrieves the remote value from the config database
+    remote = get_kdump_remote()  # This function needs to be implemented
+    
+    kdump_cfg = '/etc/default/kdump-tools'
+
+    if remote:
+        # Uncomment SSH and SSH_KEY in the /etc/default/kdump-tools file
+        run_command("/bin/sed -i 's/#SSH/SSH/' %s" % kdump_cfg, use_shell=True)
+        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' %s" % kdump_cfg, use_shell=True)
+        print("SSH and SSH_KEY uncommented for remote configuration.")
+    else:
+        # Comment out SSH and SSH_KEY in the /etc/default/kdump-tools file
+        run_command("/bin/sed -i 's/SSH/#SSH/' %s" % kdump_cfg, use_shell=True)
+        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' %s" % kdump_cfg, use_shell=True)
+        print("SSH and SSH_KEY commented out for local configuration.")
+
 def read_ssh_string():
     (rc, lines, err_str) = run_command("grep '#*SSH=.*' %s | cut -d '=' -f 2 | tr -d '\"'" % kdump_cfg, use_shell=True)
     if rc == 0 and type(lines) == list and len(lines) >= 1:
@@ -726,6 +743,22 @@ def cmd_kdump_num_dumps(verbose, num_dumps):
         kdump_enabled = get_kdump_administrative_mode()
         kdump_memory = get_kdump_memory()
 
+def cmd_kdump_remote(verbose):
+    remote = get_kdump_remote()  # Retrieve the remote value from the config database
+
+    if remote:
+        # Uncomment SSH and SSH_KEY in the /etc/default/kdump-tools file
+        run_command("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=True)
+        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        if verbose:
+            print("SSH and SSH_KEY uncommented for remote configuration.")
+    else:
+        # Comment out SSH and SSH_KEY in the /etc/default/kdump-tools file
+        run_command("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=True)
+        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        if verbose:
+            print("SSH and SSH_KEY commented out for local configuration.")
+
 def cmd_kdump_ssh_string(verbose, ssh_string):
     if ssh_string is None:
         (rc, lines, err_str) = run_command("show kdump ssh_string", use_shell=False)
@@ -826,6 +859,8 @@ def main():
             changed = cmd_kdump_disable(options.verbose)
         elif options.memory != False:
             cmd_kdump_memory(options.verbose, options.memory)
+        elif options.remote:
+            cmd_kdump_remote(options.verbose)
         elif options.ssh_string:
             cmd_kdump_ssh_string(options.verbose, options.ssh_string)
         elif options.ssh_path:

--- a/show/kdump.py
+++ b/show/kdump.py
@@ -91,7 +91,7 @@ def config():
         ssh_prv_key = get_kdump_config("ssh_path")
         click.echo("Kdump private key path: {}".format(ssh_prv_key))
 
-    if get_kdump_config("remote") == "false":
+    else:
         click.echo("Kdump ssh connection string and ssh_path not found")
 
 

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -2,6 +2,7 @@ from click.testing import CliRunner
 from utilities_common.db import Db
 import tempfile
 
+
 class TestKdump:
 
     @classmethod

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -155,9 +155,6 @@ class TestKdump:
     def test_config_kdump_add_ssh_path(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
-        runner = CliRunner()def test_config_kdump_add_ssh_path(self, get_cmd_module):
-        (config, show) = get_cmd_module
-        db = Db()
         runner = CliRunner()
 
         assert f"SSH path added to KDUMP configuration: {ssh_path_valid}" in result.output
@@ -178,7 +175,7 @@ class TestKdump:
             obj=db
         )
         assert result.exit_code == 1
-        assert "Unable to retrieve 'KDUMP' table from Config DB." in result.output
+        assert "Unable to retrieveget_cmd_module 'KDUMP' table from Config DB." in result.output
 
         # Test case when remoteis:pr is:open  feature is not enabled
         db.cfgdb.mod_entry("KDUMP", "config", {"remote": "false"})

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -152,7 +152,6 @@ class TestKdump:
         assert result.exit_code == 0
         assert "Error: Invalid format. SSH key must be in 'username@host' format." in result.output
 
-
     def test_config_kdump_add_ssh_path(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
@@ -161,10 +160,9 @@ class TestKdump:
         db = Db()
         runner = CliRunner()
 
-…        assert f"SSH path added to KDUMP configuration: {ssh_path_valid}" in result.output
-
+        assert f"SSH path added to KDUMP configuration: {ssh_path_valid}" in result.output
         # Verify that the SSH path is updated in the KDUMP table
-        kdump_table = db.cfgdb.get_table("KDUMP")
+        kdump_table = db.cfgdb.get_table("KDUMP")is:pr is:open 
         assert kdump_table["config"]["ssh_path"] == ssh_path_valid
 
 
@@ -182,7 +180,7 @@ class TestKdump:
         assert result.exit_code == 1
         assert "Unable to retrieve 'KDUMP' table from Config DB." in result.output
 
-        # Test case when remote feature is not enabled
+        # Test case when remoteis:pr is:open  feature is not enabled
         db.cfgdb.mod_entry("KDUMP", "config", {"remote": "false"})
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_path"],

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -133,8 +133,8 @@ class TestKdump:
         db.cfgdb.mod_entry("KDUMP", "config", {"remote": "true"})
 
         def mock_check_kdump_table_existence(kdump_table):
-        if not kdump_table:
-            raise Exception("Unable to retrieve 'KDUMP' table from Config DB.")
+            if not kdump_table:
+                raise Exception("Unable to retrieve 'KDUMP' table from Config DB.")
         monkeypatch.setattr('config.kdump.check_kdump_table_existence', mock_check_kdump_table_existence)
         
         valid_ssh_string = "user@hostname"

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -159,7 +159,7 @@ class TestKdump:
 
         assert f"SSH path added to KDUMP configuration: {ssh_path_valid}" in result.output
         # Verify that the SSH path is updated in the KDUMP table
-        kdump_table = db.cfgdb.get_table("KDUMP")is:pr is:open 
+        kdump_table = db.cfgdb.get_table("KDUMP") 
         assert kdump_table["config"]["ssh_path"] == ssh_path_valid
 
 

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -107,7 +107,7 @@ class TestKdump:
         runner = CliRunner()
 
         # Valid SSH string
-        valid_ssh_string = "user@hostname"
+        valid_ssh_string = "user@192.168.10.10"
 
         # Test case where KDUMP table does not exist
         db.cfgdb.delete_table("KDUMP")
@@ -136,8 +136,6 @@ class TestKdump:
             if not kdump_table:
                 raise Exception("Unable to retrieve 'KDUMP' table from Config DB.")
         monkeypatch.setattr('config.kdump.check_kdump_table_existence', mock_check_kdump_table_existence)
-
-        valid_ssh_string = "user@192.168.10.10"
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],
             [valid_ssh_string],

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -1,6 +1,6 @@
 from click.testing import CliRunner
 from utilities_common.db import Db
-
+import tempfile
 
 class TestKdump:
 

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -148,9 +148,9 @@ class TestKdump:
         assert kdump_table["config"]["ssh_string"] == ssh_string
 
         def test_config_kdump_add_ssh_path(self, get_cmd_module):
-        (config, show) = get_cmd_module
-        db = Db()
-        runner = CliRunner()
+            (config, show) = get_cmd_module
+            db = Db()
+            runner = CliRunner()
 
         ssh_path_valid = "/root/.ssh/id_rsa"
         ssh_path_invalid_relative = "root/.ssh/id_rsa"

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -101,7 +101,7 @@ class TestKdump:
         assert result.exit_code == 0
         assert db.cfgdb.get_table("KDUMP")["config"]["remote"] == "false"
 
-    def test_config_kdump_add_ssh_string(self, get_cmd_module):
+    def test_config_kdump_add_ssh_string(self, get_cmd_module, monkeypatch):
         (config, show) = get_cmd_module
         db = Db()
         runner = CliRunner()
@@ -136,7 +136,7 @@ class TestKdump:
             if not kdump_table:
                 raise Exception("Unable to retrieve 'KDUMP' table from Config DB.")
         monkeypatch.setattr('config.kdump.check_kdump_table_existence', mock_check_kdump_table_existence)
-        
+
         valid_ssh_string = "user@hostname"
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -128,7 +128,7 @@ class TestKdump:
         )
 
         # Assert that the command fails because the remote feature is disabled
-        assert result.exit_code == 1
+        assert result.exit_code == 0
         assert "Remote feature is not enabled. Please enable the remote feature first." in result.output
 
         # Test case where remote feature is enabled
@@ -175,7 +175,7 @@ class TestKdump:
         )
 
         # Assert that the command fails because the remote feature is disabled
-        assert result.exit_code == 1
+        assert result.exit_code == 0
         assert "Remote feature is not enabled. Please enable the remote feature first." in result.output
 
         # Test case where remote feature is enabled

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -105,17 +105,16 @@ class TestKdump:
         db = Db()
         runner = CliRunner()
 
-        # Test case where KDUMP table does not exist
-        ssh_string = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEArV1..."
-        db.cfgdb.delete_table("KDUMP")
+        # Valid SSH string
+        valid_ssh_string = "user@hostname"
 
+        # Test case where KDUMP table does not exist
+        db.cfgdb.delete_table("KDUMP")
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],
-            [ssh_string],
+            [valid_ssh_string],
             obj=db
         )
-
-        # Assert that the command fails when the table is missing
         assert result.exit_code == 1
         assert "Unable to retrieve 'KDUMP' table from Config DB." in result.output
 
@@ -123,34 +122,51 @@ class TestKdump:
         db.cfgdb.mod_entry("KDUMP", "config", {"remote": "false"})
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],
-            [ssh_string],
+            [valid_ssh_string],
             obj=db
         )
-
-        # Assert that the command fails because the remote feature is disabled
         assert result.exit_code == 0
         assert "Remote feature is not enabled. Please enable the remote feature first." in result.output
 
-        # Test case where remote feature is enabled
+        # Test case where remote feature is enabled with a valid SSH string
         db.cfgdb.mod_entry("KDUMP", "config", {"remote": "true"})
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],
-            [ssh_string],
+            [valid_ssh_string],
             obj=db
         )
-
-        # Assert that the command executes successfully
         assert result.exit_code == 0
-        assert f"SSH string added to KDUMP configuration: {ssh_string}" in result.output
+        assert f"SSH string added to KDUMP configuration: {valid_ssh_string}" in result.output
 
         # Retrieve the updated table to ensure the SSH string was added
         kdump_table = db.cfgdb.get_table("KDUMP")
-        assert kdump_table["config"]["ssh_string"] == ssh_string
+        assert kdump_table["config"]["ssh_string"] == valid_ssh_string
 
-        def test_config_kdump_add_ssh_path(self, get_cmd_module):
-            (config, show) = get_cmd_module
-            db = Db()
-            runner = CliRunner()
+        # Test case with an invalid SSH string (missing @)
+        invalid_ssh_string = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEArV1..."
+        result = runner.invoke(
+            config.config.commands["kdump"].commands["add"].commands["ssh_string"],
+            [invalid_ssh_string],
+            obj=db
+        )
+        assert result.exit_code == 0
+        assert "Error: Invalid format. SSH key must be in 'username@host' format." in result.output
+
+
+    def test_config_kdump_add_ssh_path(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()def test_config_kdump_add_ssh_path(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+…        assert f"SSH path added to KDUMP configuration: {ssh_path_valid}" in result.output
+
+        # Verify that the SSH path is updated in the KDUMP table
+        kdump_table = db.cfgdb.get_table("KDUMP")
+        assert kdump_table["config"]["ssh_path"] == ssh_path_valid
+
 
         ssh_path_valid = "/root/.ssh/id_rsa"
         ssh_path_invalid_relative = "root/.ssh/id_rsa"

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -137,7 +137,7 @@ class TestKdump:
                 raise Exception("Unable to retrieve 'KDUMP' table from Config DB.")
         monkeypatch.setattr('config.kdump.check_kdump_table_existence', mock_check_kdump_table_existence)
 
-        valid_ssh_string = "user@hostname"
+        valid_ssh_string = "user@192.168.10.10"
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],
             [valid_ssh_string],

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -108,7 +108,7 @@ class TestKdump:
         # Test case where KDUMP table does not exist
         ssh_string = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEArV1..."
         db.cfgdb.delete_table("KDUMP")
-        
+
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],
             [ssh_string],
@@ -155,7 +155,7 @@ class TestKdump:
         # Test case where KDUMP table does not exist
         ssh_path = "/root/.ssh/id_rsa"
         db.cfgdb.delete_table("KDUMP")
-        
+
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_path"],
             [ssh_path],

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -105,6 +105,9 @@ class TestKdump:
         db = Db()
         runner = CliRunner()
 
+        # Simulate enabling the remote feature
+        db.cfgdb.mod_entry("KDUMP", "config", {"remote": True})
+        
         # Simulate command execution for 'add ssh_string'
         ssh_string = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEArV1..."
 
@@ -134,14 +137,34 @@ class TestKdump:
         assert result.exit_code == 1
         assert "Unable to retrieve 'KDUMP' table from Config DB." in result.output
 
+        # Test case when remote feature is not enabled
+        db.cfgdb.mod_entry("KDUMP", "config", {"remote": False})
+        result = runner.invoke(
+            config.config.commands["kdump"].commands["add"].commands["ssh_string"],
+            [ssh_string],
+            obj=db
+        )
+
+        # Assert that the command fails because remote feature is disabled
+        assert result.exit_code == 1
+        assert "Remote feature is not enabled. Please enable the remote feature first." in result.output
+
+
     def test_config_kdump_add_ssh_path(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
         runner = CliRunner()
 
+        # Simulate enabling the remote feature
+        db.cfgdb.mod_entry("KDUMP", "config", {"remote": True})
+
         # Simulate command execution for 'add ssh_path'
         ssh_path = "/root/.ssh/id_rsa"
-        result = runner.invoke(config.config.commands["kdump"].commands["add"].commands["ssh_path"], [ssh_path], obj=db)
+        result = runner.invoke(
+            config.config.commands["kdump"].commands["add"].commands["ssh_path"],
+            [ssh_path],
+            obj=db
+        )
 
         # Assert that the command executed successfully
         assert result.exit_code == 0
@@ -153,9 +176,26 @@ class TestKdump:
 
         # Test case where KDUMP table is missing
         db.cfgdb.delete_table("KDUMP")
-        result = runner.invoke(config.config.commands["kdump"].commands["add"].commands["ssh_path"], [ssh_path], obj=db)
+        result = runner.invoke(
+            config.config.commands["kdump"].commands["add"].commands["ssh_path"],
+            [ssh_path],
+            obj=db
+        )
         assert result.exit_code == 1
         assert "Unable to retrieve 'KDUMP' table from Config DB." in result.output
+
+        # Test case when remote feature is not enabled
+        db.cfgdb.mod_entry("KDUMP", "config", {"remote": False})
+        result = runner.invoke(
+            config.config.commands["kdump"].commands["add"].commands["ssh_path"],
+            [ssh_path],
+            obj=db
+        )
+
+        # Assert that the command fails because remote feature is disabled
+        assert result.exit_code == 1
+        assert "Remote feature is not enabled. Please enable the remote feature first." in result.output
+
 
     def test_config_kdump_remove_ssh_string(self, get_cmd_module):
         (config, show) = get_cmd_module

--- a/tests/kdump_test.py
+++ b/tests/kdump_test.py
@@ -131,11 +131,20 @@ class TestKdump:
 
         # Test case where remote feature is enabled with a valid SSH string
         db.cfgdb.mod_entry("KDUMP", "config", {"remote": "true"})
+
+        def mock_check_kdump_table_existence(kdump_table):
+        if not kdump_table:
+            raise Exception("Unable to retrieve 'KDUMP' table from Config DB.")
+        monkeypatch.setattr('config.kdump.check_kdump_table_existence', mock_check_kdump_table_existence)
+        
+        valid_ssh_string = "user@hostname"
         result = runner.invoke(
             config.config.commands["kdump"].commands["add"].commands["ssh_string"],
             [valid_ssh_string],
             obj=db
         )
+
+        print(result.output)  # Debugging output
         assert result.exit_code == 0
         assert f"SSH string added to KDUMP configuration: {valid_ssh_string}" in result.output
 
@@ -153,7 +162,7 @@ class TestKdump:
         assert result.exit_code == 0
         assert "Error: Invalid format. SSH key must be in 'username@host' format." in result.output
 
-    def test_config_kdump_add_ssh_path(get_cmd_module):
+    def test_config_kdump_add_ssh_path(self, get_cmd_module):
         (config, show) = get_cmd_module
         db = Db()
         runner = CliRunner()

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -337,8 +337,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.write_kdump_remote()  # Call the function
 
         # Ensure the correct commands were run to uncomment SSH and SSH_KEY
-        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=True)
-        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=False)
+        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
         self.assertEqual(mock_run_command.call_count, 2)  # Ensure both commands were called
 
     @patch("sonic_kdump_config.run_command")
@@ -350,8 +350,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.write_kdump_remote()  # Call the function
 
         # Ensure the correct commands were run to comment SSH and SSH_KEY
-        mock_run_command.assert_any_call("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=True)
-        mock_run_command.assert_any_call("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        mock_run_command.assert_any_call("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=False)
+        mock_run_command.assert_any_call("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
         self.assertEqual(mock_run_command.call_count, 2)
 
     @patch("sonic_kdump_config.get_kdump_remote")
@@ -364,16 +364,16 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.cmd_kdump_remote(verbose=True)
 
         # Ensure the correct commands are being run
-        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=True)
-        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=False)
+        mock_run_command.assert_any_call("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
 
         # Test case: Remote is False
         mock_read_remote.return_value = False
         sonic_kdump_config.cmd_kdump_remote(verbose=True)
 
         # Ensure the correct commands are being run
-        mock_run_command.assert_any_call("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=True)
-        mock_run_command.assert_any_call("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
+        mock_run_command.assert_any_call("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=False)
+        mock_run_command.assert_any_call("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
 
         # Test case: Checking output messages
         with patch("builtins.print") as mock_print:
@@ -424,7 +424,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
 
         # Verify that run_command was called with the correct command
         expected_cmd = '/bin/sed -i -e \'s/#*SSH=.*/SSH="user@ip_address"/\' %s' % sonic_kdump_config.kdump_cfg
-        mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
+        mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=False)
 
         # Test case where write fails
         mock_run_cmd.return_value = (1, [], None)  # Simulate command failure
@@ -475,7 +475,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
             "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s"
             % sonic_kdump_config.kdump_cfg
         )
-        mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
+        mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=False)
 
         # Test case: SSH path in config doesn't match the provided one
         mock_read_ssh_path.return_value = '/wrong/path'

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -422,17 +422,25 @@ class TestSonicKdumpConfig(unittest.TestCase):
         # Call the function to test
         sonic_kdump_config.write_ssh_string('user@ip_address')
 
-        # Verify that run_command was called with the correct command
-        expected_cmd = '/bin/sed -i -e \'s/#*SSH=.*/SSH="user@ip_address"/\' %s' % sonic_kdump_config.kdump_cfg
+        # Verify that run_command was called with the correct command list
+        expected_cmd = [
+            "/bin/sed",
+            "-i",
+            "-e",
+            's/#*SSH=.*/SSH="user@ip_address"/',
+            sonic_kdump_config.kdump_cfg
+        ]
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=False)
 
         # Test case where write fails
+        mock_run_cmd.reset_mock()  # Reset the mock for new test
         mock_run_cmd.return_value = (1, [], None)  # Simulate command failure
         with self.assertRaises(SystemExit) as sys_exit:
             sonic_kdump_config.write_ssh_string('user@ip_address')
         self.assertEqual(sys_exit.exception.code, 1)
 
         # Test case where the written SSH string doesn't match the expected value
+        mock_run_cmd.reset_mock()  # Reset the mock for new test
         mock_run_cmd.return_value = (0, [], None)
         mock_read_ssh_string.return_value = 'different_user@ip_address'  # Simulate reading a different SSH string
         with self.assertRaises(SystemExit) as sys_exit:

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -3,7 +3,6 @@ import os
 import sys
 import unittest
 from unittest.mock import patch, mock_open, Mock
-from sonic_kdump_config import read_ssh_string, write_ssh_path, kdump_cfg, read_ssh_path, write_ssh_string
 from utilities_common.general import load_module_from_source
 from sonic_installer.common import IMAGE_PREFIX
 
@@ -291,17 +290,20 @@ class TestSonicKdumpConfig(unittest.TestCase):
         self.assertEqual(ssh_string, 'user@ip_address')
 
     @patch('sonic_kdump_config.run_command')
-    def test_write_ssh_string(self, mock_run_command):
+    @patch('sonic_kdump_config.write_ssh_string')
+    def test_write_ssh_string(self, mock_run_command, write_ssh_string):
         mock_run_command.return_value = (0, [], '')  # Mocking a successful command execution
 
         write_ssh_string('user@ip_address')  # Call the function to test
+        kdump_cfg = '/etc/default/kdump-tools'
 
         # Verify that run_command was called with the correct command
         expected_cmd = '/bin/sed -i -e \'s/#*SSH=.*/SSH="user@ip_address"\' %s' % kdump_cfg
         mock_run_command.assert_called_once_with(expected_cmd, use_shell=True)
 
     @patch('sonic_kdump_config.run_command')
-    def test_read_ssh_path(self, mock_run_command):
+    @patch('sonic_kdump_cfg.read_ssh_path')
+    def test_read_ssh_path(self, mock_run_command, read_ssh_path):
         # Mocking the output of the run_command function
         mock_run_command.return_value = (0, ['/path/to/keys'], '')
 
@@ -310,10 +312,10 @@ class TestSonicKdumpConfig(unittest.TestCase):
 
     @patch('sonic_kdump_config.run_command')
     @patch("os.path.exists")
-    def test_write_ssh_path(self, mock_path_exist, mock_run_command):
+    def test_write_ssh_path(self, mock_path_exist, mock_run_command, write_ssh_path):
         mock_path_exist.return_value = True
         mock_run_command.return_value = (0, [], '')  # Mocking a successful command execution
-
+        kdump_cfg = '/etc/default/kdump-tools'
         write_ssh_path('/path/to/keys')  # Call the function to test
         # Verify that run_command was called with the correct command
         expected_cmd = '/bin/sed -i -e \'s/#*SSH_PATH=.*/SSH_PATH="/path/to/keys"/\' %s' % kdump_cfg

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -329,7 +329,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         self.assertEqual(sys_exit.exception.code, 1)
 
     @patch("sonic_kdump_config.run_command")
-    @patch("sonic_kdump_config.read_remote_value_from_config_db")
+    @patch("sonic_kdump_config.get_kdump_remote")
     def test_write_kdump_remote_true(self, mock_read_remote, mock_run_command):
         """Test when remote is true, SSH and SSH_KEY should be uncommented."""
         mock_read_remote.return_value = True  # Simulate that remote is true
@@ -342,7 +342,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         self.assertEqual(mock_run_command.call_count, 2)  # Ensure both commands were called
 
     @patch("sonic_kdump_config.run_command")
-    @patch("sonic_kdump_config.read_remote_value_from_config_db")
+    @patch("sonic_kdump_config.get_kdump_remote")
     def test_write_kdump_remote_false(self, mock_read_remote, mock_run_command):
         """Test when remote is false, SSH and SSH_KEY should be commented."""
         mock_read_remote.return_value = False  # Simulate that remote is false
@@ -354,7 +354,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         mock_run_command.assert_any_call("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
         self.assertEqual(mock_run_command.call_count, 2)
 
-    @patch("sonic_kdump_config.read_remote_value_from_config_db")
+    @patch("sonic_kdump_config.get_kdump_remote")
     @patch("sonic_kdump_config.run_command")
     def test_cmd_kdump_remote(self, mock_run_command, mock_read_remote):
         """Tests the function `cmd_kdump_remote(...)` in script `sonic-kdump-config`."""

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -333,9 +333,9 @@ class TestSonicKdumpConfig(unittest.TestCase):
     def test_write_kdump_remote_true(self, mock_read_remote, mock_run_command):
         """Test when remote is true, SSH and SSH_KEY should be uncommented."""
         mock_read_remote.return_value = True  # Simulate that remote is true
-        
+
         sonic_kdump_config.write_kdump_remote()  # Call the function
-        
+
         # Ensure the correct commands were run to uncomment SSH and SSH_KEY
         mock_run_command.assert_any_call("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=True)
         mock_run_command.assert_any_call("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
@@ -346,14 +346,14 @@ class TestSonicKdumpConfig(unittest.TestCase):
     def test_write_kdump_remote_false(self, mock_read_remote, mock_run_command):
         """Test when remote is false, SSH and SSH_KEY should be commented."""
         mock_read_remote.return_value = False  # Simulate that remote is false
-        
+
         sonic_kdump_config.write_kdump_remote()  # Call the function
-        
+
         # Ensure the correct commands were run to comment SSH and SSH_KEY
         mock_run_command.assert_any_call("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=True)
         mock_run_command.assert_any_call("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=True)
         self.assertEqual(mock_run_command.call_count, 2)
-    
+
     @patch("sonic_kdump_config.read_remote_value_from_config_db")
     @patch("sonic_kdump_config.run_command")
     def test_cmd_kdump_remote(self, mock_run_command, mock_read_remote):

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -454,9 +454,10 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel_in_cmdline')
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
-    def test_kdump_enable_remote(self, mock_locate, mock_search_kernel, mock_search_cmdline,
-            mock_rewrite, mock_write_kdump, mock_run, mock_open
-            ):
+    def test_kdump_enable_remote(
+        self, mock_locate, mock_search_kernel, mock_search_cmdline,
+        mock_rewrite, mock_write_kdump, mock_run, mock_open
+        ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline
@@ -482,8 +483,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_remote_error(
-            self, mock_locate, mock_search_kernel, mock_search_cmdline,
-            mock_rewrite, mock_write_kdump, mock_run, mock_open
+        self, mock_locate, mock_search_kernel, mock_search_cmdline,
+        mock_rewrite, mock_write_kdump, mock_run, mock_open
         ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 from unittest.mock import patch, mock_open, Mock
-
+from sonic_kdump_config import read_ssh_string, write_ssh_path, kdump_cfg, read_ssh_path, write_ssh_string
 from utilities_common.general import load_module_from_source
 from sonic_installer.common import IMAGE_PREFIX
 
@@ -282,8 +282,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
             return_result = sonic_kdump_config.get_next_image()
         self.assertEqual(sys_exit.exception.code, 1)
 
-    @patch('sonic_kdump_config.read_ssh_string')
-    @patch("os.path.exists")
+    @patch('sonic_kdump_config.run_command')
     def test_read_ssh_string(self, mock_run_command, read_ssh_string):
         # Mocking the output of the run_command function
         mock_run_command.return_value = (0, ['user@ip_address'], '')
@@ -291,29 +290,34 @@ class TestSonicKdumpConfig(unittest.TestCase):
         ssh_string = read_ssh_string()  # Call the function to test
         self.assertEqual(ssh_string, 'user@ip_address')
 
-    @patch('sonic_kdump_config.write_ssh_string')
-    def test_write_ssh_string(self, mock_run_command, write_ssh_string):
+    @patch('sonic_kdump_config.run_command')
+    def test_write_ssh_string(self, mock_run_command):
         mock_run_command.return_value = (0, [], '')  # Mocking a successful command execution
 
         write_ssh_string('user@ip_address')  # Call the function to test
-        mock_run_command.assert_called_once()
 
-    @patch('sonic_kdump_config.read_ssh_path')
-    @patch("os.path.exists")
-    def test_read_ssh_path(self, mock_run_command, read_ssh_path):
+        # Verify that run_command was called with the correct command
+        expected_cmd = '/bin/sed -i -e \'s/#*SSH=.*/SSH="user@ip_address"\' %s' % kdump_cfg
+        mock_run_command.assert_called_once_with(expected_cmd, use_shell=True)
+
+    @patch('sonic_kdump_config.run_command')
+    def test_read_ssh_path(self, mock_run_command):
         # Mocking the output of the run_command function
         mock_run_command.return_value = (0, ['/path/to/keys'], '')
 
         ssh_path = read_ssh_path()  # Call the function to test
         self.assertEqual(ssh_path, '/path/to/keys')
 
-    @patch('sonic_kdump_config.write_ssh_path')
-    def test_write_ssh_path(self, mock_run_command, write_ssh_path):
-        # Mocking a successful command execution
-        mock_run_command.return_value = (0, [], '')
+    @patch('sonic_kdump_config.run_command')
+    @patch("os.path.exists")
+    def test_write_ssh_path(self, mock_path_exist, mock_run_command):
+        mock_path_exist.return_value = True
+        mock_run_command.return_value = (0, [], '')  # Mocking a successful command execution
 
         write_ssh_path('/path/to/keys')  # Call the function to test
-        mock_run_command.assert_called_once()
+        # Verify that run_command was called with the correct command
+        expected_cmd = '/bin/sed -i -e \'s/#*SSH_PATH=.*/SSH_PATH="/path/to/keys"/\' %s' % kdump_cfg
+        mock_run_command.assert_called_once_with(expected_cmd, use_shell=True)
 
     @patch("sonic_kdump_config.write_use_kdump")
     @patch("os.path.exists")

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -454,7 +454,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
     def test_cmd_kdump_ssh_path_update(self, mock_print, mock_write, mock_read, mock_run):
         # Mock read_ssh_path to return the current SSH path
         mock_read.return_value = '/old/path/to/keys'
-        
+
         # Call the function with a new SSH path
         sonic_kdump_config.cmd_kdump_ssh_path(verbose=True, ssh_path='/new/path/to/keys')
 

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -282,6 +282,39 @@ class TestSonicKdumpConfig(unittest.TestCase):
             return_result = sonic_kdump_config.get_next_image()
         self.assertEqual(sys_exit.exception.code, 1)
 
+    @patch('sonic_kdump_config.read_ssh_string')
+    @patch("os.path.exists")
+    def test_read_ssh_string(self, mock_run_command,read_ssh_string):
+        # Mocking the output of the run_command function
+        mock_run_command.return_value = (0, ['user@ip_address'], '')
+
+        ssh_string = read_ssh_string()  # Call the function to test
+        self.assertEqual(ssh_string, 'user@ip_address')
+
+    @patch('sonic_kdump_config.write_ssh_string')
+    def test_write_ssh_string(self, mock_run_command, write_ssh_string):
+        mock_run_command.return_value = (0, [], '')  # Mocking a successful command execution
+        
+        write_ssh_string('user@ip_address')  # Call the function to test
+        mock_run_command.assert_called_once()
+    
+    @patch('sonic_kdump_config.read_ssh_path')
+    @patch("os.path.exists")
+    def test_read_ssh_path(self, mock_run_command, read_ssh_path):
+        # Mocking the output of the run_command function
+        mock_run_command.return_value = (0, ['/path/to/keys'], '')
+
+        ssh_path = read_ssh_path()  # Call the function to test
+        self.assertEqual(ssh_path, '/path/to/keys')
+
+    @patch('sonic_kdump_config.write_ssh_path')
+    def test_write_ssh_path(self, mock_run_command, write_ssh_path):
+        # Mocking a successful command execution
+        mock_run_command.return_value = (0, [], '')
+
+        write_ssh_path('/path/to/keys')  # Call the function to test
+        mock_run_command.assert_called_once()
+
     @patch("sonic_kdump_config.write_use_kdump")
     @patch("os.path.exists")
     def test_kdump_disable(self, mock_path_exist, mock_write_kdump):

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -455,7 +455,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_remote(self, mock_locate, mock_search_kernel, mock_search_cmdline,
-            mock_rewrite, mock_write_kdump, mock_run, mock_open):
+            mock_rewrite, mock_write_kdump, mock_run, mock_open
+        ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -369,9 +369,9 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
         # Ensure the correct command is being run
         expected_cmd = (
-        "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s" 
-            % sonic_kdump_config.kdump_cfg
-        )
+    "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s"
+    % sonic_kdump_config.kdump_cfg
+)
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
 
         # Test case: SSH path in config doesn't match the provided one

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -246,7 +246,6 @@ class TestSonicKdumpConfig(unittest.TestCase):
     def test_cmd_kdump_ssh_string_update(self, mock_print, mock_write, mock_read, mock_run):
         # Mock read_ssh_string to return the current SSH string
         mock_read.return_value = 'old_ssh_string'
-        
         # Call the function with a new SSH string
         sonic_kdump_config.cmd_kdump_ssh_string(verbose=True, ssh_string='new_ssh_string')
 
@@ -417,8 +416,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
         # Ensure the correct command is being run
         expected_cmd = (
-        "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s"
-        % sonic_kdump_config.kdump_cfg
+            "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s"
+            % sonic_kdump_config.kdump_cfg
         )
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
 

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -369,8 +369,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
 
         # Ensure the correct command is being run
-        expected_cmd = (
-            "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"\\/path\\/to\\/keys\"/' %s" % 
+        expected_cmd = ("/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"\\/path\\/to\\/keys\"/' %s" % 
             sonic_kdump_config.kdump_cfg
         )
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -455,7 +455,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_remote(self, mock_locate, mock_search_kernel, mock_search_cmdline,
-                                  mock_rewrite, mock_write_kdump, mock_run, mock_open):
+        mock_rewrite, mock_write_kdump, mock_run, mock_open):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline
@@ -464,8 +464,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
 
         # Call the function with remote enabled
         changed = sonic_kdump_config.kdump_enable(verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
-                                image='myimage', cmdline_file='cmdline.txt',
-                                remote=True, ssh_string='user@remote', ssh_path='/path/to/keys')
+        image='myimage', cmdline_file='cmdline.txt',
+        remote=True, ssh_string='user@remote', ssh_path='/path/to/keys')
 
         # Assertions
         self.assertTrue(changed)  # Expect some changes to be made
@@ -489,8 +489,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
         # Expecting sys.exit to be called on failure
         with self.assertRaises(SystemExit):
             sonic_kdump_config.kdump_enable(verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
-                          image='myimage', cmdline_file='cmdline.txt',
-                          remote=True, ssh_string='user@remote', ssh_path='/path/to/keys')
+            image='myimage', cmdline_file='cmdline.txt',
+            remote=True, ssh_string='user@remote', ssh_path='/path/to/keys')
 
         # Check that the error message was printed
         mock_run.assert_called_once_with("/usr/sbin/kdump-config set-remote user@remote /path/to/keys", use_shell=False)
@@ -503,7 +503,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_local(self, mock_locate, mock_search_kernel, mock_search_cmdline,
-                                 mock_rewrite, mock_write_kdump, mock_run, mock_open):
+        mock_rewrite, mock_write_kdump, mock_run, mock_open):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline
@@ -511,8 +511,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
 
         # Call the function with remote disabled
         changed = sonic_kdump_config.kdump_enable(verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
-                                image='myimage', cmdline_file='cmdline.txt',
-                                remote=False, ssh_string='user@remote', ssh_path='/path/to/keys')
+        image='myimage', cmdline_file='cmdline.txt',
+        remote=False, ssh_string='user@remote', ssh_path='/path/to/keys')
 
         # Assertions
         self.assertTrue(changed)  # Expect some changes to be made
@@ -591,3 +591,4 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
+

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -463,10 +463,11 @@ class TestSonicKdumpConfig(unittest.TestCase):
         mock_run.return_value = (0, [], '')  # Simulate successful remote configuration
 
         # Call the function with remote enabled
-        changed = sonic_kdump_config.kdump_enable(verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
-            image='myimage', cmdline_file='cmdline.txt',
-            remote=True, ssh_string='user@remote', ssh_path='/path/to/keys'
-            )
+        changed = sonic_kdump_config.kdump_enable(
+                    verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
+                    image='myimage', cmdline_file='cmdline.txt',
+                    remote=True, ssh_string='user@remote', ssh_path='/path/to/keys'
+        )
 
         # Assertions
         self.assertTrue(changed)  # Expect some changes to be made
@@ -479,9 +480,10 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel_in_cmdline')
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
-    def test_kdump_enable_remote_error(self, mock_locate, mock_search_kernel, mock_search_cmdline,
+    def test_kdump_enable_remote_error(
+            self, mock_locate, mock_search_kernel, mock_search_cmdline,
             mock_rewrite, mock_write_kdump, mock_run, mock_open
-            ):
+        ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -456,7 +456,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_remote(self, mock_locate, mock_search_kernel, mock_search_cmdline,
             mock_rewrite, mock_write_kdump, mock_run, mock_open
-        ):
+            ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -488,9 +488,11 @@ class TestSonicKdumpConfig(unittest.TestCase):
 
         # Expecting sys.exit to be called on failure
         with self.assertRaises(SystemExit):
-            sonic_kdump_config.kdump_enable(verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
-            image='myimage', cmdline_file='cmdline.txt',
-            remote=True, ssh_string='user@remote', ssh_path='/path/to/keys')
+            sonic_kdump_config.kdump_enable(
+                verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
+                image='myimage', cmdline_file='cmdline.txt',
+                remote=True, ssh_string='user@remote', ssh_path='/path/to/keys'
+                )
 
         # Check that the error message was printed
         mock_run.assert_called_once_with("/usr/sbin/kdump-config set-remote user@remote /path/to/keys", use_shell=False)
@@ -502,7 +504,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel_in_cmdline')
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
-    def test_kdump_enable_local(self, mock_locate, mock_search_kernel, mock_search_cmdline,
+    def test_kdump_enable_local(
+        self, mock_locate, mock_search_kernel, mock_search_cmdline,
         mock_rewrite, mock_write_kdump, mock_run, mock_open):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
@@ -517,6 +520,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         # Assertions
         self.assertTrue(changed)  # Expect some changes to be made
         mock_run.assert_not_called()  # Ensure no remote commands were run
+
     @patch('sonic_kdump_config.run_command')
     @patch('sonic_kdump_config.read_ssh_path')
     @patch('sonic_kdump_config.write_ssh_path')
@@ -591,4 +595,3 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -284,7 +284,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
 
     @patch('sonic_kdump_config.read_ssh_string')
     @patch("os.path.exists")
-    def test_read_ssh_string(self, mock_run_command,read_ssh_string):
+    def test_read_ssh_string(self, mock_run_command, read_ssh_string):
         # Mocking the output of the run_command function
         mock_run_command.return_value = (0, ['user@ip_address'], '')
 
@@ -294,10 +294,10 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.write_ssh_string')
     def test_write_ssh_string(self, mock_run_command, write_ssh_string):
         mock_run_command.return_value = (0, [], '')  # Mocking a successful command execution
-        
+
         write_ssh_string('user@ip_address')  # Call the function to test
         mock_run_command.assert_called_once()
-    
+
     @patch('sonic_kdump_config.read_ssh_path')
     @patch("os.path.exists")
     def test_read_ssh_path(self, mock_run_command, read_ssh_path):

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import patch, mock_open, Mock
 from utilities_common.general import load_module_from_source
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../scripts')))
-from sonic_kdump_config import read_ssh_string, write_ssh_string, read_ssh_path, write_ssh_path
 
 from sonic_installer.common import IMAGE_PREFIX
 
@@ -286,12 +284,12 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch("sonic_kdump_config.run_command")
     def test_read_ssh_string(self, mock_run_cmd):
         """Tests the function `read_ssh_string(...)` in script `sonic-kdump-config`."""
-        
+
         # Test case for successful read
         mock_run_cmd.return_value = (0, ['user@ip_address'], None)  # Simulate successful command execution
         ssh_string = sonic_kdump_config.read_ssh_string()
         self.assertEqual(ssh_string, 'user@ip_address')
-        
+
         # Test case for non-integer output
         mock_run_cmd.return_value = (0, ['NotAString'], None)  # Simulate command execution returning a non-string
         ssh_string = sonic_kdump_config.read_ssh_string()
@@ -369,7 +367,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch("sonic_kdump_config.read_ssh_path")
     def test_write_ssh_path(self, mock_read_ssh_path, mock_run_cmd):
         """Tests the function `write_ssh_path(...)` in script `sonic-kdump-config`."""
-        
+
         # Test case for successful write
         mock_run_cmd.return_value = (0, [], None)  # Simulate successful command execution
         mock_read_ssh_path.return_value = '/path/to/keys'  # Return the same SSH_PATH

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -339,53 +339,50 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch("sonic_kdump_config.run_command")
     def test_read_ssh_path(self, mock_run_cmd):
         """Tests the function `read_ssh_path(...)` in script `sonic-kdump-config`."""
-        
+
         # Test successful case with valid SSH path
         mock_run_cmd.return_value = (0, ['/path/to/keys'], None)
         ssh_path = sonic_kdump_config.read_ssh_path()
         self.assertEqual(ssh_path, '/path/to/keys')
-        
+
         # Test case where SSH path is invalid
         mock_run_cmd.return_value = (0, ['NotAPath'], None)
         with self.assertRaises(SystemExit) as sys_exit:
             ssh_path = sonic_kdump_config.read_ssh_path()
         self.assertEqual(sys_exit.exception.code, 1)
-        
+
         # Test case where grep fails (no SSH path found)
         mock_run_cmd.return_value = (1, [], None)
         with self.assertRaises(SystemExit) as sys_exit:
             ssh_path = sonic_kdump_config.read_ssh_path()
         self.assertEqual(sys_exit.exception.code, 1)
 
-
     @patch("sonic_kdump_config.run_command")
     @patch("sonic_kdump_config.read_ssh_path")
     def test_write_ssh_path(self, mock_read_ssh_path, mock_run_cmd):
         """Tests the function `write_ssh_path(...)` in script `sonic-kdump-config`."""
-        
-        # Test writing a valid SSH path
-        mock_run_cmd.return_value = (0, [], None)
-        mock_read_ssh_path.return_value = '/path/to/keys'
-        
-        sonic_kdump_config.write_ssh_path('/path/to/keys')
-        
-        expected_cmd = (
-            '/bin/sed -i -e \'s/#*SSH_KEY=.*/SSH_KEY="\\/path\\/to\\/keys"/\' %s' % sonic_kdump_config.kdump_cfg
-        )
+
+        # Test case: Successfully write a valid SSH path
+        mock_run_cmd.return_value = (0, [], None)  # Simulate successful sed command
+        mock_read_ssh_path.return_value = '/path/to/keys'  # Simulate correct SSH path read
+
+        sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
+
+        # Ensure the correct command is being run
+        expected_cmd = "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"\\/path\\/to\\/keys\"/' %s" % sonic_kdump_config.kdump_cfg
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
-        
-        # Test case where the SSH path in the config doesn't match what was written
+
+        # Test case: SSH path in config doesn't match the provided one
         mock_read_ssh_path.return_value = '/wrong/path'
         with self.assertRaises(SystemExit) as sys_exit:
             sonic_kdump_config.write_ssh_path('/path/to/keys')
         self.assertEqual(sys_exit.exception.code, 1)
-        
-        # Test failure case for run_command
+
+        # Test case: Error during sed command execution
         mock_run_cmd.return_value = (1, [], "Error")
         with self.assertRaises(SystemExit) as sys_exit:
             sonic_kdump_config.write_ssh_path('/path/to/keys')
         self.assertEqual(sys_exit.exception.code, 1)
-
 
     @patch("sonic_kdump_config.write_use_kdump")
     @patch("os.path.exists")

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -378,7 +378,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         # Test case: Checking output messages
         with patch("builtins.print") as mock_print:
             sonic_kdump_config.cmd_kdump_remote(verbose=True)
-            mock_print.assert_called_with("SSH and SSH_KEY uncommented for remote configuration.")
+            mock_print.assert_called_with("SSH and SSH_KEY commented out for local configuration.")
 
             mock_read_remote.return_value = False
             sonic_kdump_config.cmd_kdump_remote(verbose=True)

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -370,7 +370,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         #/bin/sed -i -e \'s/#*SSH_KEY=.*/SSH_KEY="/path/to/keys"/\' /etc/default/kdump-tools
         # Ensure the correct command is being run
         expected_cmd = (
-            "/bin/sed -i -e \'s/#*SSH_KEY=.*/SSH_KEY="/path/to/keys"/\' %s" 
+            "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s" 
             % sonic_kdump_config.kdump_cfg
         )
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -455,7 +455,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_remote(self, mock_locate, mock_search_kernel, mock_search_cmdline,
-        mock_rewrite, mock_write_kdump, mock_run, mock_open):
+            mock_rewrite, mock_write_kdump, mock_run, mock_open):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline
@@ -464,8 +464,9 @@ class TestSonicKdumpConfig(unittest.TestCase):
 
         # Call the function with remote enabled
         changed = sonic_kdump_config.kdump_enable(verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
-        image='myimage', cmdline_file='cmdline.txt',
-        remote=True, ssh_string='user@remote', ssh_path='/path/to/keys')
+            image='myimage', cmdline_file='cmdline.txt',
+            remote=True, ssh_string='user@remote', ssh_path='/path/to/keys'
+            )
 
         # Assertions
         self.assertTrue(changed)  # Expect some changes to be made
@@ -479,7 +480,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_remote_error(self, mock_locate, mock_search_kernel, mock_search_cmdline,
-                                        mock_rewrite, mock_write_kdump, mock_run, mock_open):
+            mock_rewrite, mock_write_kdump, mock_run, mock_open
+            ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline
@@ -505,17 +507,20 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_local(
-        self, mock_locate, mock_search_kernel, mock_search_cmdline,
-        mock_rewrite, mock_write_kdump, mock_run, mock_open):
+            self, mock_locate, mock_search_kernel, mock_search_cmdline,
+            mock_rewrite, mock_write_kdump, mock_run, mock_open
+            ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline
         mock_search_kernel.return_value = None  # No crashkernel set in image line
 
         # Call the function with remote disabled
-        changed = sonic_kdump_config.kdump_enable(verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
-        image='myimage', cmdline_file='cmdline.txt',
-        remote=False, ssh_string='user@remote', ssh_path='/path/to/keys')
+        changed = sonic_kdump_config.kdump_enable(
+            verbose=True, kdump_enabled=True, memory='128M', num_dumps=3,
+            image='myimage', cmdline_file='cmdline.txt',
+            remote=False, ssh_string='user@remote', ssh_path='/path/to/keys'
+            )
 
         # Assertions
 

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -369,9 +369,9 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
         # Ensure the correct command is being run
         expected_cmd = (
-    "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s"
-    % sonic_kdump_config.kdump_cfg
-)
+        "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s"
+        % sonic_kdump_config.kdump_cfg
+        )
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
 
         # Test case: SSH path in config doesn't match the provided one

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -457,7 +457,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
     def test_kdump_enable_remote(
         self, mock_locate, mock_search_kernel, mock_search_cmdline,
         mock_rewrite, mock_write_kdump, mock_run, mock_open
-        ):
+    ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline
@@ -483,9 +483,9 @@ class TestSonicKdumpConfig(unittest.TestCase):
     @patch('sonic_kdump_config.search_for_crash_kernel')
     @patch('sonic_kdump_config.locate_image')
     def test_kdump_enable_remote_error(
-        self, mock_locate, mock_search_kernel, mock_search_cmdline,
-        mock_rewrite, mock_write_kdump, mock_run, mock_open
-        ):
+            self, mock_locate, mock_search_kernel, mock_search_cmdline,
+            mock_rewrite, mock_write_kdump, mock_run, mock_open
+            ):
         # Setup mocks
         mock_locate.return_value = 0  # Image found at index 0
         mock_search_cmdline.return_value = None  # No crashkernel set in cmdline

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -369,7 +369,10 @@ class TestSonicKdumpConfig(unittest.TestCase):
         sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
 
         # Ensure the correct command is being run
-        expected_cmd = "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"\\/path\\/to\\/keys\"/' %s" % sonic_kdump_config.kdump_cfg
+        expected_cmd = (
+            "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"\\/path\\/to\\/keys\"/' %s" % 
+            sonic_kdump_config.kdump_cfg
+        )
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
 
         # Test case: SSH path in config doesn't match the provided one

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -373,8 +373,8 @@ class TestSonicKdumpConfig(unittest.TestCase):
         mock_read_ssh_path.return_value = '/path/to/keys'  # Return the same SSH_PATH
         sonic_kdump_config.write_ssh_path('/path/to/keys')
         expected_cmd = (
-                    '/bin/sed -i -e \'s/#*SSH_PATH=.*/'
-                    'SSH_PATH="\\/path\\/to\\/keys"/\' %s'
+                    '/bin/sed -i -e \'s/#*SSH_KEY=.*/'
+                    'SSH_KEY="\\/path\\/to\\/keys"/\' %s'
                         ) % sonic_kdump_config.kdump_cfg
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
 

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -367,10 +367,9 @@ class TestSonicKdumpConfig(unittest.TestCase):
         mock_read_ssh_path.return_value = '/path/to/keys'  # Simulate correct SSH path read
 
         sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
-        #/bin/sed -i -e \'s/#*SSH_KEY=.*/SSH_KEY="/path/to/keys"/\' /etc/default/kdump-tools
         # Ensure the correct command is being run
         expected_cmd = (
-            "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s" 
+        "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"/path/to/keys\"/' %s" 
             % sonic_kdump_config.kdump_cfg
         )
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -367,10 +367,11 @@ class TestSonicKdumpConfig(unittest.TestCase):
         mock_read_ssh_path.return_value = '/path/to/keys'  # Simulate correct SSH path read
 
         sonic_kdump_config.write_ssh_path('/path/to/keys')  # Call function with valid path
-
+        #/bin/sed -i -e \'s/#*SSH_KEY=.*/SSH_KEY="/path/to/keys"/\' /etc/default/kdump-tools
         # Ensure the correct command is being run
-        expected_cmd = ("/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"\\/path\\/to\\/keys\"/' %s" % 
-            sonic_kdump_config.kdump_cfg
+        expected_cmd = (
+            "/bin/sed -i -e \'s/#*SSH_KEY=.*/SSH_KEY="/path/to/keys"/\' %s" 
+            % sonic_kdump_config.kdump_cfg
         )
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
 

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -518,6 +518,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         remote=False, ssh_string='user@remote', ssh_path='/path/to/keys')
 
         # Assertions
+
         self.assertTrue(changed)  # Expect some changes to be made
         mock_run.assert_not_called()  # Ensure no remote commands were run
 

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -447,7 +447,7 @@ class TestSonicKdumpConfig(unittest.TestCase):
         # Verify that the printed output is correct
         mock_print.assert_called_once_with('current_ssh_path')
 
-     @patch('builtins.open', new_callable=mock_open, read_data='loop=image-myimage crashkernel=128M')
+    @patch('builtins.open', new_callable=mock_open, read_data='loop=image-myimage crashkernel=128M')
     @patch('sonic_kdump_config.run_command')
     @patch('sonic_kdump_config.write_use_kdump')
     @patch('sonic_kdump_config.rewrite_cfg')

--- a/tests/sonic_kdump_config_test.py
+++ b/tests/sonic_kdump_config_test.py
@@ -315,10 +315,10 @@ class TestSonicKdumpConfig(unittest.TestCase):
         # Test successful case
         mock_run_cmd.return_value = (0, [], None)  # Simulate successful command execution
         mock_read_ssh_string.return_value = 'user@ip_address'  # Simulate reading existing SSH string
-        
+
         # Call the function to test
         sonic_kdump_config.write_ssh_string('user@ip_address')
-        
+
         # Verify that run_command was called with the correct command
         expected_cmd = '/bin/sed -i -e \'s/#*SSH=.*/SSH="user@ip_address"/\' %s' % sonic_kdump_config.kdump_cfg
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
@@ -372,7 +372,10 @@ class TestSonicKdumpConfig(unittest.TestCase):
         mock_run_cmd.return_value = (0, [], None)  # Simulate successful command execution
         mock_read_ssh_path.return_value = '/path/to/keys'  # Return the same SSH_PATH
         sonic_kdump_config.write_ssh_path('/path/to/keys')
-        expected_cmd = '/bin/sed -i -e \'s/#*SSH_PATH=.*/SSH_PATH="\\/path\\/to\\/keys"/\' %s' % sonic_kdump_config.kdump_cfg
+        expected_cmd = (
+                    '/bin/sed -i -e \'s/#*SSH_PATH=.*/'
+                    'SSH_PATH="\\/path\\/to\\/keys"/\' %s'
+                        ) % sonic_kdump_config.kdump_cfg
         mock_run_cmd.assert_called_once_with(expected_cmd, use_shell=True)
 
         # Test case for SSH_PATH not being written correctly
@@ -387,17 +390,6 @@ class TestSonicKdumpConfig(unittest.TestCase):
         with self.assertRaises(SystemExit) as sys_exit:
             sonic_kdump_config.write_ssh_path('/path/to/keys')
         self.assertEqual(sys_exit.exception.code, 1)
-
-    @patch('sonic_kdump_config.run_command')
-    @patch("os.path.exists")
-    def test_write_ssh_path(self, mock_path_exist, mock_run_command, write_ssh_path):
-        mock_path_exist.return_value = True
-        mock_run_command.return_value = (0, [], '')  # Mocking a successful command execution
-        kdump_cfg = '/etc/default/kdump-tools'
-        write_ssh_path('/path/to/keys')  # Call the function to test
-        # Verify that run_command was called with the correct command
-        expected_cmd = '/bin/sed -i -e \'s/#*SSH_PATH=.*/SSH_PATH="/path/to/keys"/\' %s' % kdump_cfg
-        mock_run_command.assert_called_once_with(expected_cmd, use_shell=True)
 
     @patch("sonic_kdump_config.write_use_kdump")
     @patch("os.path.exists")


### PR DESCRIPTION
**What I did**
Added remote kdump functionality using SSH in SONiC. 

**How I did it**
I added two new commands and two options to configure the kdump remote ssh feature.


**How to verify it**
Upon kernel crash, kdump will transfer the crash report files to the ssh server.
