### PR TITLE
[CLI] Fix the error of running "show storm-control interface"

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -493,6 +493,7 @@ def storm_control(ctx, namespace, display):
             click.echo(tabulate(body, header, tablefmt="grid"))
 
 @storm_control.command('interface')
+@multi_asic_util.multi_asic_click_options
 @click.argument('interface', metavar='<interface>',required=True)
 def interface(interface, namespace, display):
     if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
CLI shows an error when trying to show the storm control configuration. 
`TypeError: interface() missing 2 required positional arguments: 'namespace' and 'display' `
This PR fixes the error of running "show storm-control interface". 

#### How I did it
Added the default value for the arguments to fix this bug.

#### How to verify it
Execute the "show storm-control interface <interface_name>"

#### Previous command output (if the output of a command-line utility has changed)
```shell
admin@sonic:~$ show storm-control interface Ethernet0
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
TypeError: interface() missing 2 required positional arguments: 'namespace' and 'display' 
```

#### New command output (if the output of a command-line utility has changed)
```shell
admin@sonic:~$ show storm-control interface Ethernet0
+------------------+--------------+---------------+---------------------+
| Interface Name   | Storm Type   |   Rate (kbps) | Burst Size(kbits)   |
+==================+==============+===============+=====================+
| Ethernet0        | broadcast    |         10000 | default             |
+------------------+--------------+---------------+---------------------+
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [X] 202211: Feature storm control is supported, but CLI got the error. 
- [X] 202305: Feature storm control is supported, but CLI got the error. 
- [X] 202311: Feature storm control is supported, but CLI got the error. 