### PR TITLE
Adding cli to configure interface description

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4738,6 +4738,29 @@ def mtu(ctx, interface_name, interface_mtu, verbose):
         command += ["-vv"]
     clicommon.run_command(command, display_cmd=verbose)
 
+
+#
+# 'description' subcommand
+#
+
+@interface.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_description', metavar='<interface_description>', required=True)
+def description(ctx, interface_name, interface_description):
+    """Set interface description"""
+    # Get the config_db connector
+    config_db = ctx.obj['config_db']
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(config_db, interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    config_db.mod_entry("PORT", interface_name, {"description": interface_description})
+
 #
 # 'tpid' subcommand
 #

--- a/tests/config_int_description_test.py
+++ b/tests/config_int_description_test.py
@@ -1,0 +1,40 @@
+import config.main as config
+import os
+import pytest
+import sys
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, modules_path)
+
+
+@pytest.fixture(scope='module')
+def ctx(scope='module'):
+    db = Db()
+    obj = {'config_db': db.cfgdb, 'namespace': ''}
+    yield obj
+
+
+class TestConfigInterfaceDescription(object):
+    def test_interface_description(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(config.config.commands["interface"].commands["description"],
+                               ["Ethernet0", "To_server_0"], obj=db)
+        assert result.exit_code != 0
+
+    def test_interface_description_invalid_interface_name(self, ctx):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["interface"].commands["description"],
+                               ["", "test"], obj=ctx)
+        assert "Interface name is invalid" in result.output
+
+    def test_interface_description_valid_config(self, ctx):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["interface"].commands["description"],
+                               ["Ethernet0", "test"], obj=ctx)
+        assert result.exit_code == 0


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Adding CLI to configure interface description
#### How I did it
Adding new function under config/main to update the config db
#### How to verify it
1. put code change into lab device and tried to configure interface description.
admin@sw3:~$ sudo config interface description Ethernet0 "test interface description"
admin@sw3:~$ show interfaces description | grep Ethernet0
  Ethernet0      up       up   Ethernet1/1                      test interface description
#### Previous command output (if the output of a command-line utility has changed)
NA
#### New command output (if the output of a command-line utility has changed)
NA
