### PR TITLE
[LT] Not allow configuring link-training at RJ45 ports

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -160,6 +160,9 @@ class portconfig(object):
         if self.is_lag:
             raise Exception("Invalid port %s" % (port))
 
+        if self.is_rj45_port:
+            raise Exception("Setting RJ45 ports' link-training is not supported")
+
         if self.verbose:
             print("Setting link-training %s on port %s" % (mode, port))
         lt_modes = ['on', 'off']

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -161,7 +161,8 @@ class portconfig(object):
             raise Exception("Invalid port %s" % (port))
 
         if self.is_rj45_port:
-            raise Exception("Setting RJ45 ports' link-training is not supported")
+            print("Setting RJ45 ports' link-training is not supported")
+            exit(1)
 
         if self.verbose:
             print("Setting link-training %s on port %s" % (mode, port))

--- a/tests/config_lt_test.py
+++ b/tests/config_lt_test.py
@@ -38,6 +38,11 @@ class TestConfigInterface(object):
         result = self.basic_check("link-training", ["PortChannel0001", "on"], ctx, operator.ne)
         assert 'Invalid port PortChannel0001' in result.output
 
+        result = self.basic_check("link-training", ["Ethernet16", "on"], ctx, operator.ne)
+        assert "Setting RJ45 ports' link-training is not supported" in result.output
+        result = self.basic_check("link-training", ["Ethernet16", "off"], ctx, operator.ne)
+        assert "Setting RJ45 ports' link-training is not supported" in result.output
+
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):
         runner = CliRunner()
         result = runner.invoke(config.config.commands["interface"].commands[command_name], para_list, obj = ctx)


### PR DESCRIPTION
* Skip RJ-45 interfaces

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Skip setting link-training on RJ-45 interfaces
#### How I did it
Check the interface type. If the interface is RJ-45, just return error.
#### How to verify it
Enable link-training or disable link-training on RJ45 interfaces, error message shall be shown.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

