### PR TITLE
[EVPN MH][CLI config] add support for EVPN MH feature

### DIFF
--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -318,6 +318,42 @@ class TestPortChannel(object):
         assert result.exit_code != 0
         assert "Error: PortChannel0005 is not present." in result.output
 
+    def test_set_invalid_portchannel_mac_addr(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands["portchannel"].commands["mac-addr"].commands["set"],
+                               ["Ethernet48", "00:11:22:33:44:55"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Ethernet48 is invalid!" in result.output
+
+    def test_set_non_existing_portchannel_mac_addr(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands["portchannel"].commands["mac-addr"].commands["set"],
+                               ["PortChannel0005", "00:11:22:33:44:55"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Error: PortChannel0005 is not present." in result.output
+
+    def test_set_portchannel_mac_addr(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands["portchannel"].commands["mac-addr"].commands["set"],
+                               ["PortChannel1001", "00:11:22:33:44:55"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ""
+
     originalSubprocessPopen = subprocess.Popen
 
     class SubprocessMock:

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -415,9 +415,13 @@ def is_port_router_interface(config_db, port):
     """Check if port is a router interface"""
 
     interface_table = config_db.get_table('INTERFACE')
-    for intf in interface_table:
-        if port == intf:
+    for intf in interface_table.keys():
+        if is_ip_prefix_in_key(intf) and port == intf[0]:
             return True
+
+    entry = config_db.get_entry('INTERFACE', port)
+    if entry.get('ipv6_use_link_local_only') == 'enable':
+        return True
 
     return False
 
@@ -426,9 +430,13 @@ def is_pc_router_interface(config_db, pc):
     """Check if portchannel is a router interface"""
 
     pc_interface_table = config_db.get_table('PORTCHANNEL_INTERFACE')
-    for intf in pc_interface_table:
-        if pc == intf:
+    for intf in pc_interface_table.keys():
+        if is_ip_prefix_in_key(intf) and pc == intf[0]:
             return True
+
+    entry = config_db.get_entry('PORTCHANNEL_INTERFACE', pc)
+    if entry.get('ipv6_use_link_local_only') == 'enable':
+        return True
 
     return False
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added a command to change the mac address for portchannel interfaces

#### How I did it

- added `config portchannel mac-addr set` command

#### How to verify it

```
root@sonic:/# config portchannel add PortChannel11
root@sonic:/# ip a s PortChannel11
50: PortChannel11: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN group default qlen 1000
    link/ether 22:ef:3a:cc:22:bf brd ff:ff:ff:ff:ff:ff
root@sonic:/# config portchannel mac-addr set PortChannel11 00:11:22:33:44:55
root@sonic:/# ip a s PortChannel11
50: PortChannel11: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN group default qlen 1000
    link/ether 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

