### PR TITLE
[202405][wcmp]: Add W-ECMP CLI

### DIFF
--- a/config/bgp_cli.py
+++ b/config/bgp_cli.py
@@ -1,0 +1,192 @@
+import click
+import utilities_common.cli as clicommon
+
+from sonic_py_common import logger
+from utilities_common.bgp import (
+    CFG_BGP_DEVICE_GLOBAL,
+    BGP_DEVICE_GLOBAL_KEY,
+    SYSLOG_IDENTIFIER,
+    to_str,
+)
+
+
+log = logger.Logger(SYSLOG_IDENTIFIER)
+log.set_min_log_priority_info()
+
+
+#
+# BGP DB interface ----------------------------------------------------------------------------------------------------
+#
+
+
+def update_entry_validated(db, table, key, data, create_if_not_exists=False):
+    """ Update entry in table and validate configuration.
+    If attribute value in data is None, the attribute is deleted.
+
+    Args:
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
+        table (str): Table name to add new entry to.
+        key (Union[str, Tuple]): Key name in the table.
+        data (Dict): Entry data.
+        create_if_not_exists (bool):
+            In case entry does not exists already a new entry
+            is not created if this flag is set to False and
+            creates a new entry if flag is set to True.
+    Raises:
+        Exception: when cfg does not satisfy YANG schema.
+    """
+
+    cfg = db.get_config()
+    cfg.setdefault(table, {})
+
+    if not data:
+        raise click.ClickException(f"No field/values to update {key}")
+
+    if create_if_not_exists:
+        cfg[table].setdefault(key, {})
+
+    if key not in cfg[table]:
+        raise click.ClickException(f"{key} does not exist")
+
+    entry_changed = False
+    for attr, value in data.items():
+        if value == cfg[table][key].get(attr):
+            continue
+        entry_changed = True
+        if value is None:
+            cfg[table][key].pop(attr, None)
+        else:
+            cfg[table][key][attr] = value
+
+    if not entry_changed:
+        return
+
+    db.set_entry(table, key, cfg[table][key])
+
+
+#
+# BGP handlers --------------------------------------------------------------------------------------------------------
+#
+
+
+def tsa_handler(ctx, db, state):
+    """ Handle config updates for Traffic-Shift-Away (TSA) feature """
+
+    table = CFG_BGP_DEVICE_GLOBAL
+    key = BGP_DEVICE_GLOBAL_KEY
+    data = {
+        "tsa_enabled": state,
+    }
+
+    try:
+        update_entry_validated(db.cfgdb, table, key, data, create_if_not_exists=True)
+        log.log_notice("Configured TSA state: {}".format(to_str(state)))
+    except Exception as e:
+        log.log_error("Failed to configure TSA state: {}".format(str(e)))
+        ctx.fail(str(e))
+
+
+def wcmp_handler(ctx, db, state):
+    """ Handle config updates for Weighted-Cost Multi-Path (W-ECMP) feature """
+
+    table = CFG_BGP_DEVICE_GLOBAL
+    key = BGP_DEVICE_GLOBAL_KEY
+    data = {
+        "wcmp_enabled": state,
+    }
+
+    try:
+        update_entry_validated(db.cfgdb, table, key, data, create_if_not_exists=True)
+        log.log_notice("Configured W-ECMP state: {}".format(to_str(state)))
+    except Exception as e:
+        log.log_error("Failed to configure W-ECMP state: {}".format(str(e)))
+        ctx.fail(str(e))
+
+
+#
+# BGP device-global ---------------------------------------------------------------------------------------------------
+#
+
+
+@click.group(
+    name="device-global",
+    cls=clicommon.AliasedGroup
+)
+def DEVICE_GLOBAL():
+    """ Configure BGP device global state """
+
+    pass
+
+
+#
+# BGP device-global tsa -----------------------------------------------------------------------------------------------
+#
+
+
+@DEVICE_GLOBAL.group(
+    name="tsa",
+    cls=clicommon.AliasedGroup
+)
+def DEVICE_GLOBAL_TSA():
+    """ Configure Traffic-Shift-Away (TSA) feature """
+
+    pass
+
+
+@DEVICE_GLOBAL_TSA.command(
+    name="enabled"
+)
+@clicommon.pass_db
+@click.pass_context
+def DEVICE_GLOBAL_TSA_ENABLED(ctx, db):
+    """ Enable Traffic-Shift-Away (TSA) feature """
+
+    tsa_handler(ctx, db, "true")
+
+
+@DEVICE_GLOBAL_TSA.command(
+    name="disabled"
+)
+@clicommon.pass_db
+@click.pass_context
+def DEVICE_GLOBAL_TSA_DISABLED(ctx, db):
+    """ Disable Traffic-Shift-Away (TSA) feature """
+
+    tsa_handler(ctx, db, "false")
+
+
+#
+# BGP device-global w-ecmp --------------------------------------------------------------------------------------------
+#
+
+
+@DEVICE_GLOBAL.group(
+    name="w-ecmp",
+    cls=clicommon.AliasedGroup
+)
+def DEVICE_GLOBAL_WCMP():
+    """ Configure Weighted-Cost Multi-Path (W-ECMP) feature """
+
+    pass
+
+
+@DEVICE_GLOBAL_WCMP.command(
+    name="enabled"
+)
+@clicommon.pass_db
+@click.pass_context
+def DEVICE_GLOBAL_WCMP_ENABLED(ctx, db):
+    """ Enable Weighted-Cost Multi-Path (W-ECMP) feature """
+
+    wcmp_handler(ctx, db, "true")
+
+
+@DEVICE_GLOBAL_WCMP.command(
+    name="disabled"
+)
+@clicommon.pass_db
+@click.pass_context
+def DEVICE_GLOBAL_WCMP_DISABLED(ctx, db):
+    """ Disable Weighted-Cost Multi-Path (W-ECMP) feature """
+
+    wcmp_handler(ctx, db, "false")

--- a/config/main.py
+++ b/config/main.py
@@ -61,6 +61,7 @@ from . import mclag
 from . import syslog
 from . import switchport
 from . import dns
+from . import bgp_cli
 
 
 # mock masic APIs for unit test
@@ -4046,6 +4047,10 @@ def del_user(db, user):
 def bgp():
     """BGP-related configuration tasks"""
     pass
+
+
+# BGP module extensions
+config.commands['bgp'].add_command(bgp_cli.DEVICE_GLOBAL)
 
 #
 # 'shutdown' subgroup ('config bgp shutdown ...')

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2630,6 +2630,26 @@ When enabled, BGP will not advertise routes which aren't yet offloaded.
   Disabled
   ```
 
+**show bgp device-global**
+
+This command displays BGP device global configuration.
+
+- Usage:
+  ```bash
+  show bgp device-global
+  ```
+
+- Options:
+  - _-j,--json_: display in JSON format
+
+- Example:
+  ```bash
+  admin@sonic:~$ show bgp device-global
+  TSA      W-ECMP
+  -------  -------
+  enabled  enabled
+  ```
+
 Go Back To [Beginning of the document](#) or [Beginning of this section](#bgp)
 
 ### BGP config commands
@@ -2738,6 +2758,26 @@ Once enabled, BGP will not advertise routes which aren't yet offloaded.
   ```
   ```
   admin@sonic:~$ sudo config suppress-fib-pending disabled 
+  ```
+
+**config bgp device-global tsa/w-ecmp**
+
+This command is used to manage BGP device global configuration.
+
+Feature list:
+1. TSA - Traffic-Shift-Away
+2. W-ECMP - Weighted-Cost Multi-Path
+
+- Usage:
+  ```bash
+  config bgp device-global tsa <enabled|disabled>
+  config bgp device-global w-ecmp <enabled|disabled>
+  ```
+
+- Examples:
+  ```bash
+  admin@sonic:~$ config bgp device-global tsa enabled
+  admin@sonic:~$ config bgp device-global w-ecmp enabled
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#bgp)

--- a/show/bgp_cli.py
+++ b/show/bgp_cli.py
@@ -1,0 +1,128 @@
+import click
+import tabulate
+import json
+import utilities_common.cli as clicommon
+
+from utilities_common.bgp import (
+    CFG_BGP_DEVICE_GLOBAL,
+    BGP_DEVICE_GLOBAL_KEY,
+    to_str,
+)
+
+
+#
+# BGP helpers ---------------------------------------------------------------------------------------------------------
+#
+
+
+def format_attr_value(entry, attr):
+    """ Helper that formats attribute to be presented in the table output.
+
+    Args:
+        entry (Dict[str, str]): CONFIG DB entry configuration.
+        attr (Dict): Attribute metadata.
+
+    Returns:
+        str: formatted attribute value.
+    """
+
+    if attr["is-leaf-list"]:
+        value = entry.get(attr["name"], [])
+        return "\n".join(value) if value else "N/A"
+    return entry.get(attr["name"], "N/A")
+
+
+#
+# BGP CLI -------------------------------------------------------------------------------------------------------------
+#
+
+
+@click.group(
+    name="bgp",
+    cls=clicommon.AliasedGroup
+)
+def BGP():
+    """ Show BGP configuration """
+
+    pass
+
+
+#
+# BGP device-global ---------------------------------------------------------------------------------------------------
+#
+
+
+@BGP.command(
+    name="device-global"
+)
+@click.option(
+    "-j", "--json", "json_format",
+    help="Display in JSON format",
+    is_flag=True,
+    default=False
+)
+@clicommon.pass_db
+@click.pass_context
+def DEVICE_GLOBAL(ctx, db, json_format):
+    """ Show BGP device global state """
+
+    header = [
+        "TSA",
+        "W-ECMP",
+    ]
+    body = []
+
+    table = db.cfgdb.get_table(CFG_BGP_DEVICE_GLOBAL)
+    entry = table.get(BGP_DEVICE_GLOBAL_KEY, {})
+
+    if not entry:
+        click.echo("No configuration is present in CONFIG DB")
+        ctx.exit(0)
+
+    if json_format:
+        json_dict = {
+            "tsa": to_str(
+                format_attr_value(
+                    entry,
+                    {
+                        'name': 'tsa_enabled',
+                        'is-leaf-list': False
+                    }
+                )
+            ),
+            "w-ecmp": to_str(
+                format_attr_value(
+                    entry,
+                    {
+                        'name': 'wcmp_enabled',
+                        'is-leaf-list': False
+                    }
+                )
+            )
+        }
+        click.echo(json.dumps(json_dict, indent=4))
+        ctx.exit(0)
+
+    row = [
+        to_str(
+            format_attr_value(
+                entry,
+                {
+                    'name': 'tsa_enabled',
+                    'is-leaf-list': False
+                }
+            )
+        ),
+        to_str(
+            format_attr_value(
+                entry,
+                {
+                    'name': 'wcmp_enabled',
+                    'is-leaf-list': False
+                }
+            )
+        )
+    ]
+    body.append(row)
+
+    click.echo(tabulate.tabulate(body, header))

--- a/show/main.py
+++ b/show/main.py
@@ -66,6 +66,7 @@ from . import warm_restart
 from . import plugins
 from . import syslog
 from . import dns
+from . import bgp_cli
 
 # Global Variables
 PLATFORM_JSON = 'platform.json'
@@ -325,6 +326,8 @@ cli.add_command(syslog.syslog)
 if is_gearbox_configured():
     cli.add_command(gearbox.gearbox)
 
+# bgp module
+cli.add_command(bgp_cli.BGP)
 
 #
 # 'vrf' command ("show vrf")

--- a/tests/bgp_input/assert_show_output.py
+++ b/tests/bgp_input/assert_show_output.py
@@ -1,0 +1,55 @@
+"""
+Module holding the correct values for show CLI command outputs for the bgp_test.py
+"""
+
+show_device_global_empty = """\
+No configuration is present in CONFIG DB
+"""
+
+show_device_global_all_disabled = """\
+TSA       W-ECMP
+--------  --------
+disabled  disabled
+"""
+show_device_global_all_disabled_json = """\
+{
+    "tsa": "disabled",
+    "w-ecmp": "disabled"
+}
+"""
+
+show_device_global_all_enabled = """\
+TSA      W-ECMP
+-------  --------
+enabled  enabled
+"""
+show_device_global_all_enabled_json = """\
+{
+    "tsa": "enabled",
+    "w-ecmp": "enabled"
+}
+"""
+
+show_device_global_tsa_enabled = """\
+TSA      W-ECMP
+-------  --------
+enabled  disabled
+"""
+show_device_global_tsa_enabled_json = """\
+{
+    "tsa": "enabled",
+    "w-ecmp": "disabled"
+}
+"""
+
+show_device_global_wcmp_enabled = """\
+TSA       W-ECMP
+--------  --------
+disabled  enabled
+"""
+show_device_global_wcmp_enabled_json = """\
+{
+    "tsa": "disabled",
+    "w-ecmp": "enabled"
+}
+"""

--- a/tests/bgp_input/mock_config/all_disabled.json
+++ b/tests/bgp_input/mock_config/all_disabled.json
@@ -1,0 +1,6 @@
+{
+    "BGP_DEVICE_GLOBAL|STATE": {
+        "tsa_enabled": "false",
+        "wcmp_enabled": "false"
+    }
+}

--- a/tests/bgp_input/mock_config/all_enabled.json
+++ b/tests/bgp_input/mock_config/all_enabled.json
@@ -1,0 +1,6 @@
+{
+    "BGP_DEVICE_GLOBAL|STATE": {
+        "tsa_enabled": "true",
+        "wcmp_enabled": "true"
+    }
+}

--- a/tests/bgp_input/mock_config/empty.json
+++ b/tests/bgp_input/mock_config/empty.json
@@ -1,0 +1,5 @@
+{
+    "BGP_DEVICE_GLOBAL|STATE": {
+        "NULL": "NULL"
+    }
+}

--- a/tests/bgp_input/mock_config/tsa_enabled.json
+++ b/tests/bgp_input/mock_config/tsa_enabled.json
@@ -1,0 +1,6 @@
+{
+    "BGP_DEVICE_GLOBAL|STATE": {
+        "tsa_enabled": "true",
+        "wcmp_enabled": "false"
+    }
+}

--- a/tests/bgp_input/mock_config/wcmp_enabled.json
+++ b/tests/bgp_input/mock_config/wcmp_enabled.json
@@ -1,0 +1,6 @@
+{
+    "BGP_DEVICE_GLOBAL|STATE": {
+        "tsa_enabled": "false",
+        "wcmp_enabled": "true"
+    }
+}

--- a/tests/bgp_test.py
+++ b/tests/bgp_test.py
@@ -1,0 +1,130 @@
+import pytest
+import os
+import logging
+import show.main as show
+import config.main as config
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+from .mock_tables import dbconnector
+from .bgp_input import assert_show_output
+
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+input_path = os.path.join(test_path, "bgp_input")
+mock_config_path = os.path.join(input_path, "mock_config")
+
+logger = logging.getLogger(__name__)
+
+
+SUCCESS = 0
+
+
+class TestBgp:
+    @classmethod
+    def setup_class(cls):
+        logger.info("Setup class: {}".format(cls.__name__))
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        logger.info("Teardown class: {}".format(cls.__name__))
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs.clear()
+
+    # ---------- CONFIG BGP ---------- #
+
+    @pytest.mark.parametrize(
+        "feature", [
+            "tsa",
+            "w-ecmp"
+        ]
+    )
+    @pytest.mark.parametrize(
+        "state", [
+            "enabled",
+            "disabled"
+        ]
+    )
+    def test_config_device_global(self, feature, state):
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(
+            config.config.commands["bgp"].commands["device-global"].
+            commands[feature].commands[state], obj=db
+        )
+
+        logger.debug("\n" + result.output)
+        logger.debug(result.exit_code)
+
+        assert result.exit_code == SUCCESS
+
+    # ---------- SHOW BGP ---------- #
+
+    @pytest.mark.parametrize(
+        "cfgdb,output", [
+            pytest.param(
+                os.path.join(mock_config_path, "empty"),
+                {
+                    "plain": assert_show_output.show_device_global_empty,
+                    "json": assert_show_output.show_device_global_empty
+                },
+                id="empty"
+            ),
+            pytest.param(
+                os.path.join(mock_config_path, "all_disabled"),
+                {
+                    "plain": assert_show_output.show_device_global_all_disabled,
+                    "json": assert_show_output.show_device_global_all_disabled_json
+                },
+                id="all-disabled"
+            ),
+            pytest.param(
+                os.path.join(mock_config_path, "all_enabled"),
+                {
+                    "plain": assert_show_output.show_device_global_all_enabled,
+                    "json": assert_show_output.show_device_global_all_enabled_json
+                },
+                id="all-enabled"
+            ),
+            pytest.param(
+                os.path.join(mock_config_path, "tsa_enabled"),
+                {
+                    "plain": assert_show_output.show_device_global_tsa_enabled,
+                    "json": assert_show_output.show_device_global_tsa_enabled_json
+                },
+                id="tsa-enabled"
+            ),
+            pytest.param(
+                os.path.join(mock_config_path, "wcmp_enabled"),
+                {
+                    "plain": assert_show_output.show_device_global_wcmp_enabled,
+                    "json": assert_show_output.show_device_global_wcmp_enabled_json
+                },
+                id="w-ecmp-enabled"
+            )
+        ]
+    )
+    @pytest.mark.parametrize(
+        "format", [
+            "plain",
+            "json",
+        ]
+    )
+    def test_show_device_global(self, cfgdb, output, format):
+        dbconnector.dedicated_dbs["CONFIG_DB"] = cfgdb
+
+        db = Db()
+        runner = CliRunner()
+
+        result = runner.invoke(
+            show.cli.commands["bgp"].commands["device-global"],
+            [] if format == "plain" else ["--json"], obj=db
+        )
+
+        logger.debug("\n" + result.output)
+        logger.debug(result.exit_code)
+
+        assert result.output == output[format]
+        assert result.exit_code == SUCCESS

--- a/utilities_common/bgp.py
+++ b/utilities_common/bgp.py
@@ -1,0 +1,23 @@
+from swsscommon.swsscommon import CFG_BGP_DEVICE_GLOBAL_TABLE_NAME as CFG_BGP_DEVICE_GLOBAL # noqa
+
+#
+# BGP constants -------------------------------------------------------------------------------------------------------
+#
+
+BGP_DEVICE_GLOBAL_KEY = "STATE"
+
+SYSLOG_IDENTIFIER = "bgp-cli"
+
+
+#
+# BGP helpers ---------------------------------------------------------------------------------------------------------
+#
+
+
+def to_str(state):
+    """ Convert boolean to string representation """
+    if state == "true":
+        return "enabled"
+    elif state == "false":
+        return "disabled"
+    return state


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn [nazariig@nvidia.com](mailto:nazariig@nvidia.com)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

**HLD:** https://github.com/sonic-net/SONiC/pull/1629

#### What I did
* Implemented CLI for Weighted-Cost Multi-Path feature

#### How I did it
* Integrated Weighted-Cost Multi-Path interface into `config` and `show` CLI root

#### How to verify it
1. Run Weighted-Cost Multi-Path CLI UTs

#### Details if related
* Backport from `master`: https://github.com/sonic-net/sonic-utilities/pull/3253

#### Previous command output (if the output of a command-line utility has changed)
* N/A

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:/home/admin# show bgp device-global
TSA      WCMP
-------  -------
enabled  enabled
admin@sonic:/home/admin# show bgp device-global --json
{
    "tsa": "enabled",
    "wcmp": "enabled"
}
```