### PR TITLE
IP Assignment Issue

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4825,7 +4825,7 @@ def add_interface_ip(ctx, interface_name, ip_addr, gw, secondary):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
         # Add a validation to check this interface is not a member in vlan before
-        # changing it to a router port
+        # changing it to a router port mode
     vlan_member_table = config_db.get_table('VLAN_MEMBER')
 
     if (interface_is_in_vlan(vlan_member_table, interface_name)):

--- a/config/main.py
+++ b/config/main.py
@@ -4824,7 +4824,6 @@ def add_interface_ip(ctx, interface_name, ip_addr, gw, secondary):
         interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
-        
         # Add a validation to check this interface is not a member in vlan before
         # changing it to a router port
     vlan_member_table = config_db.get_table('VLAN_MEMBER')

--- a/config/main.py
+++ b/config/main.py
@@ -4824,6 +4824,15 @@ def add_interface_ip(ctx, interface_name, ip_addr, gw, secondary):
         interface_name = interface_alias_to_name(config_db, interface_name)
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
+        
+        # Add a validation to check this interface is not a member in vlan before
+        # changing it to a router port
+    vlan_member_table = config_db.get_table('VLAN_MEMBER')
+
+    if (interface_is_in_vlan(vlan_member_table, interface_name)):
+        click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))
+        return
+
 
     portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
 

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -1426,7 +1426,7 @@ class TestVlan(object):
                                ["Ethernet4", "10.10.10.1/24"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
-        assert 'Interface Ethernet4 is in trunk mode and needs to be in routed mode!' in result.output
+        assert 'Interface Ethernet4 is a member of vlan\nAborting!\n' in result.output
 
     def test_config_vlan_add_member_of_portchannel(self):
         runner = CliRunner()


### PR DESCRIPTION


#### What I did

Added Check for IP Assignment on Port when a Vlan is configured.
This PR is created in response to [Issue](https://github.com/sonic-net/sonic-buildimage/issues/19505)

#### How I did it

Modified config/main.py to add check for IP Assignment when Port has vlan membership 
#### How to verify it

After this, ip cannot be assigned on port which is configured to a VLAN.
