### PR TITLE
[Draft] Add remote compatible show ip bgp and -n all for show ip bgp network

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A convenient alternative is to let the SONiC build system configure a build envi
 ```
 python3 setup.py bdist_wheel
 ```
+Note: This command by default will not update the wheel package in target/. To specify the destination location of wheel package, use "-d" option.
 
 #### To run unit tests
 
@@ -73,6 +74,12 @@ python3 setup.py bdist_wheel
 python3 setup.py test
 ```
 
+#### To install the package on a SONiC machine
+```
+sudo pip uninstall sonic-utilities
+sudo pip install YOUR_WHEEL_PACKAGE
+```
+Note: Don't use "--force-reinstall".
 
 ### sonic-utilities-data
 

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -142,7 +142,7 @@ def network(ipaddress, info_type, namespace):
     if namespace == "all":
         if multi_asic.is_multi_asic():
             for ns in multi_asic.get_namespace_list():
-                click.echo("======== namespace {} ========".format(ns))
+                click.echo("\n======== namespace {} ========".format(ns))
                 output = bgp_util.run_bgp_show_command(command, ns)
                 click.echo(output.rstrip('\n'))
         else:

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -21,7 +21,8 @@ def bgp():
     """Show IPv4 BGP (Border Gateway Protocol) information"""
     if device_info.is_supervisor():
         # if the device is a chassis, the command need to be executed by rexec
-        click.echo("Since the current device is a chassis supervisor, this command will be executed remotely on all linecards")
+        click.echo("Since the current device is a chassis supervisor, " +
+                   "this command will be executed remotely on all linecards")
         rcli.rexec.cli("all", " ".join(sys.argv))
         sys.exit(0)
     pass
@@ -112,11 +113,11 @@ def network(ipaddress, info_type, namespace):
     if multi_asic.is_multi_asic():
         if namespace == multi_asic.DEFAULT_NAMESPACE:
             ctx = click.get_current_context()
-            ctx.fail('-n/--namespace option required. provide namespace from list {}'\
+            ctx.fail('-n/--namespace option required. provide namespace from list {}'
                 .format(multi_asic.get_namespace_list()))
         if namespace != "all" and namespace not in multi_asic.get_namespace_list():
             ctx = click.get_current_context()
-            ctx.fail('invalid namespace. provide namespace from list {}'\
+            ctx.fail('invalid namespace. provide namespace from list {}'
                 .format(multi_asic.get_namespace_list()))
 
     command = 'show ip bgp'

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -117,8 +117,8 @@ def network(ipaddress, info_type, namespace):
                 .format(multi_asic.get_namespace_list()))
         if namespace != "all" and namespace not in multi_asic.get_namespace_list():
             ctx = click.get_current_context()
-            ctx.fail('invalid namespace. provide namespace from list {}'
-                .format(multi_asic.get_namespace_list()))
+            ctx.fail('invalid namespace {}. provide namespace from list {}'
+                .format(namespace, multi_asic.get_namespace_list()))
 
     command = 'show ip bgp'
     if ipaddress is not None:

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -1,11 +1,13 @@
 import click
+import sys
 
-from sonic_py_common import multi_asic
+from sonic_py_common import multi_asic, device_info
 from show.main import ip
 import utilities_common.bgp_util as bgp_util
 import utilities_common.cli as clicommon
 import utilities_common.constants as constants
 import utilities_common.multi_asic as multi_asic_util
+import rcli.rexec
 
 ###############################################################################
 #
@@ -17,6 +19,11 @@ import utilities_common.multi_asic as multi_asic_util
 @ip.group(cls=clicommon.AliasedGroup)
 def bgp():
     """Show IPv4 BGP (Border Gateway Protocol) information"""
+    if device_info.is_supervisor():
+        # if the device is a chassis, the command need to be executed by rexec
+        click.echo("Since the current device is a chassis supervisor, this command will be executed remotely on all linecards")
+        rcli.rexec.cli("all", " ".join(sys.argv))
+        sys.exit(0)
     pass
 
 
@@ -102,10 +109,15 @@ def neighbors(ipaddress, info_type, namespace):
 def network(ipaddress, info_type, namespace):
     """Show IP (IPv4) BGP network"""
 
-    if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():
-        ctx = click.get_current_context()
-        ctx.fail('-n/--namespace option required. provide namespace from list {}'\
-            .format(multi_asic.get_namespace_list()))
+    if multi_asic.is_multi_asic():
+        if namespace == multi_asic.DEFAULT_NAMESPACE:
+            ctx = click.get_current_context()
+            ctx.fail('-n/--namespace option required. provide namespace from list {}'\
+                .format(multi_asic.get_namespace_list()))
+        if namespace != "all" and namespace not in multi_asic.get_namespace_list():
+            ctx = click.get_current_context()
+            ctx.fail('invalid namespace. provide namespace from list {}'\
+                .format(multi_asic.get_namespace_list()))
 
     command = 'show ip bgp'
     if ipaddress is not None:
@@ -125,5 +137,15 @@ def network(ipaddress, info_type, namespace):
         if info_type is not None:
             command += ' {}'.format(info_type)
 
-    output  =  bgp_util.run_bgp_show_command(command, namespace)
-    click.echo(output.rstrip('\n'))
+    if namespace == "all":
+        if multi_asic.is_multi_asic():
+            for ns in multi_asic.get_namespace_list():
+                click.echo("======== namespace {} ========".format(ns))
+                output = bgp_util.run_bgp_show_command(command, ns)
+                click.echo(output.rstrip('\n'))
+        else:
+            output = bgp_util.run_bgp_show_command(command, "")
+            click.echo(output.rstrip('\n'))
+    else:
+        output = bgp_util.run_bgp_show_command(command, namespace)
+        click.echo(output.rstrip('\n'))

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -1,5 +1,6 @@
 import click
 import sys
+import subprocess
 
 from sonic_py_common import multi_asic, device_info
 from show.main import ip
@@ -23,8 +24,8 @@ def bgp():
         # if the device is a chassis, the command need to be executed by rexec
         click.echo("Since the current device is a chassis supervisor, " +
                    "this command will be executed remotely on all linecards")
-        rcli.rexec.cli("all", " ".join(sys.argv))
-        sys.exit(0)
+        proc = subprocess.run(["rexec", "all"] + ["-c", " ".join(sys.argv)])
+        sys.exit(proc.returncode)
     pass
 
 

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -110,6 +110,7 @@ def neighbors(ipaddress, info_type, namespace):
 def network(ipaddress, info_type, namespace):
     """Show IP (IPv4) BGP network"""
 
+    namespace = namespace.strip()
     if multi_asic.is_multi_asic():
         if namespace == multi_asic.DEFAULT_NAMESPACE:
             ctx = click.get_current_context()

--- a/show/main.py
+++ b/show/main.py
@@ -1187,7 +1187,11 @@ elif routing_stack == "frr":
     ip.add_command(bgp)
     from .bgp_frr_v6 import bgp
     ipv6.add_command(bgp)
-
+elif device_info.is_chassis():
+    from .bgp_frr_v4 import bgp
+    ip.add_command(bgp)
+    from .bgp_frr_v6 import bgp
+    ipv6.add_command(bgp)
 #
 # 'link-local-mode' subcommand ("show ipv6 link-local-mode")
 #

--- a/show/main.py
+++ b/show/main.py
@@ -1187,7 +1187,7 @@ elif routing_stack == "frr":
     ip.add_command(bgp)
     from .bgp_frr_v6 import bgp
     ipv6.add_command(bgp)
-elif device_info.is_chassis():
+elif device_info.is_supervisor():
     from .bgp_frr_v4 import bgp
     ip.add_command(bgp)
     from .bgp_frr_v6 import bgp

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -311,7 +311,7 @@ Paths: (2 available, best #2, table default, not advertised outside local AS)
       Last update: Thu Apr 22 02:13:30 2021 
 """
 
-bgp_v4_network_all = \
+bgp_v4_network_all_asic = \
 """
 ======== namespace asic0 ========
 BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
@@ -531,7 +531,7 @@ def mock_show_bgp_network_multi_asic(param):
         return bgp_v6_network_ip_address_asic0
     elif param == 'bgp_v6_network_bestpath_asic0':
         return bgp_v6_network_ip_address_asic0_bestpath
-    elif param == "bgp_v4_network_all":
+    elif param == "bgp_v4_network_all_asic":
         # this is mocking the output of a single LC
         return bgp_v4_network_asic0
     else:
@@ -604,10 +604,10 @@ testData = {
         'rc': 0,
         'rc_output': bgp_v4_network_bestpath_asic0
     },
-    'bgp_v4_network_all': {
+    'bgp_v4_network_all_asic': {
         'args': ['-n all'],
         'rc': 0,
-        'rc_output': bgp_v4_network_all
+        'rc_output': bgp_v4_network_all_asic
     },
     'bgp_v6_network_multi_asic': {
         'args': [],

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -314,6 +314,7 @@ Paths: (2 available, best #2, table default, not advertised outside local AS)
 bgp_v4_network_all_asic = \
 """
 ======== namespace asic0 ========
+
 BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
 Default local pref 100, local AS 65100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
@@ -362,7 +363,9 @@ Origin codes:  i - IGP, e - EGP, ? - incomplete
 *>i                 10.1.0.0                 0    100      0 ?
 *=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
 *>i                 10.1.0.0                 0    100      0 ? 
+
 ======== namespace asic1 ========
+
 BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
 Default local pref 100, local AS 65100
 Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -227,7 +227,7 @@ Paths: (4 available, best #4, table default)
 multi_asic_bgp_network_err = \
 """Error: -n/--namespace option required. provide namespace from list ['asic0', 'asic1']"""
 
-multi_asic_bgp_network_err = \
+multi_asic_bgp_network_asic_unknown_err = \
 """Error: invalid namespace asic_unknown. provide namespace from list ['asic0', 'asic1']"""
 
 bgp_v4_network_asic0 = \
@@ -621,9 +621,9 @@ testData = {
         'rc_output': bgp_v4_network_all_asic
     },
     'bgp_v4_network_asic_unknown': {
-        'args': ['-nasic_unkown'],
+        'args': ['-nasic_unknown'],
         'rc': 2,
-        'rc_err_msg': multi_asic_bgp_network_err
+        'rc_err_msg': multi_asic_bgp_network_asic_unknown_err
     },
     'bgp_v6_network_multi_asic': {
         'args': [],

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -227,6 +227,9 @@ Paths: (4 available, best #4, table default)
 multi_asic_bgp_network_err = \
 """Error: -n/--namespace option required. provide namespace from list ['asic0', 'asic1']"""
 
+multi_asic_bgp_network_err = \
+"""Error: invalid namespace asic_unknown. provide namespace from list ['asic0', 'asic1']"""
+
 bgp_v4_network_asic0 = \
 """
 BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
@@ -562,6 +565,11 @@ testData = {
         'rc': 1,
         'rc_output': bgp_v4_network_longer_prefixes_error
     },
+    'bgp_v4_network_all_asic_on_single_asic': {
+        'args': ['-nall'],
+        'rc': 0,
+        'rc_output': bgp_v4_network
+    },
     'bgp_v6_network': {
         'args': [],
         'rc': 0,
@@ -611,6 +619,11 @@ testData = {
         'args': ['-nall'],
         'rc': 0,
         'rc_output': bgp_v4_network_all_asic
+    },
+    'bgp_v4_network_asic_unknown': {
+        'args': ['-nasic_unkown'],
+        'rc': 2,
+        'rc_err_msg': multi_asic_bgp_network_err
     },
     'bgp_v6_network_multi_asic': {
         'args': [],

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -311,6 +311,108 @@ Paths: (2 available, best #2, table default, not advertised outside local AS)
       Last update: Thu Apr 22 02:13:30 2021 
 """
 
+bgp_v4_network_all = \
+"""
+======== namespace asic0 ========
+BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+* i0.0.0.0/0        10.1.0.2                      100      0 65200 6666 6667 i
+* i                 10.1.0.0                      100      0 65200 6666 6667 i
+*=                  10.0.0.5                               0 65200 6666 6667 i
+*>                  10.0.0.1                               0 65200 6666 6667 i
+* i8.0.0.0/32       10.1.0.2                 0    100      0 i
+* i                 10.1.0.0                 0    100      0 i
+*                   0.0.0.0                  0         32768 ?
+*>                  0.0.0.0                  0         32768 i
+*=i8.0.0.1/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.2/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.3/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*>i8.0.0.4/32       10.1.0.0                 0    100      0 i
+*>i8.0.0.5/32       10.1.0.2                 0    100      0 i
+* i10.0.0.0/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+* i10.0.0.4/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+*=i10.0.0.8/31      10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.12/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.32/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.34/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.36/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.38/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.40/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ? 
+======== namespace asic1 ========
+BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+* i0.0.0.0/0        10.1.0.2                      100      0 65200 6666 6667 i
+* i                 10.1.0.0                      100      0 65200 6666 6667 i
+*=                  10.0.0.5                               0 65200 6666 6667 i
+*>                  10.0.0.1                               0 65200 6666 6667 i
+* i8.0.0.0/32       10.1.0.2                 0    100      0 i
+* i                 10.1.0.0                 0    100      0 i
+*                   0.0.0.0                  0         32768 ?
+*>                  0.0.0.0                  0         32768 i
+*=i8.0.0.1/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.2/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.3/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*>i8.0.0.4/32       10.1.0.0                 0    100      0 i
+*>i8.0.0.5/32       10.1.0.2                 0    100      0 i
+* i10.0.0.0/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+* i10.0.0.4/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+*=i10.0.0.8/31      10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.12/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.32/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.34/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.36/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.38/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.40/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ? 
+"""
+
 bgp_v6_network_asic0 = \
 """
 BGP table version is 12849, local router ID is 10.1.0.32, vrf id 0
@@ -429,6 +531,9 @@ def mock_show_bgp_network_multi_asic(param):
         return bgp_v6_network_ip_address_asic0
     elif param == 'bgp_v6_network_bestpath_asic0':
         return bgp_v6_network_ip_address_asic0_bestpath
+    elif param == "bgp_v4_network_all":
+        # this is mocking the output of a single LC
+        return bgp_v4_network_asic0
     else:
         return ''
 
@@ -498,6 +603,11 @@ testData = {
         'args': ['-nasic0', '10.0.0.44', 'bestpath'],
         'rc': 0,
         'rc_output': bgp_v4_network_bestpath_asic0
+    },
+    'bgp_v4_network_all': {
+        'args': ['-n all'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_all
     },
     'bgp_v6_network_multi_asic': {
         'args': [],

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -605,7 +605,7 @@ testData = {
         'rc_output': bgp_v4_network_bestpath_asic0
     },
     'bgp_v4_network_all_asic': {
-        'args': ['-n all'],
+        'args': ['-nall'],
         'rc': 0,
         'rc_output': bgp_v4_network_all_asic
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,7 +390,7 @@ def setup_multi_asic_bgp_instance(request):
         return ["asic0", "asic1"]
 
     # mock multi-asic list
-    if request.param.endswith("all_asic"):
+    if request.param == "bgp_v4_network_all_asic":
         multi_asic.get_namespace_list = mock_multi_asic_list
 
     _old_run_bgp_command = bgp_util.run_bgp_command

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,7 +390,8 @@ def setup_multi_asic_bgp_instance(request):
         return ["asic0", "asic1"]
 
     # mock multi-asic list
-    multi_asic.get_namespace_list = mock_multi_asic_list
+    if request.param.endswith("all_asic"):
+        multi_asic.get_namespace_list = mock_multi_asic_list
 
     _old_run_bgp_command = bgp_util.run_bgp_command
     if request.param == 'ip_route_for_int_ip':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,6 +386,12 @@ def setup_multi_asic_bgp_instance(request):
         else:
             return ""
 
+    def mock_multi_asic_list():
+        return ["asic0", "asic1"]
+
+    # mock multi-asic list
+    multi_asic.get_namespace_list = mock_multi_asic_list
+
     _old_run_bgp_command = bgp_util.run_bgp_command
     if request.param == 'ip_route_for_int_ip':
         bgp_util.run_bgp_command = mock_run_bgp_command_for_static

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -38,7 +38,7 @@ class TestRexecBgpNetwork(object):
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
-    @mock.patch("rcli_utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
+    @mock.patch("rcli.utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_command()))
     def test_show_ip_bgp_rexec(self, setup_bgp_commands):
@@ -53,7 +53,7 @@ class TestRexecBgpNetwork(object):
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
-    @mock.patch("rcli_utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
+    @mock.patch("rcli.utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_error_cmd()))
     def test_show_ip_bgp_error_rexec(self, setup_bgp_commands):

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -4,21 +4,22 @@ from io import BytesIO
 from click.testing import CliRunner
 
 
-def mock_rexec_command():
+def mock_rexec_command(*args):
     mock_stdout = BytesIO(b"""hello world""")
     print(mock_stdout.getvalue().decode())
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_stdout, stderr=BytesIO())
 
-def mock_rexec_error_cmd():
-
+def mock_rexec_error_cmd(*args):
     mock_stderr = BytesIO(b"""Error""")
     print(mock_stderr.getvalue().decode())
     return subprocess.CompletedProcess(args=[], returncode=1, stdout=BytesIO(), stderr=mock_stderr)
 
 
-MULTI_LC_REXEC_OUTPUT = '''hello world'''
+MULTI_LC_REXEC_OUTPUT = '''Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
+hello world'''
 
-MULTI_LC_ERR_OUTPUT = '''Error'''
+MULTI_LC_ERR_OUTPUT = '''Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
+Error'''
 
 class TestRexecBgpNetwork(object):
     @classmethod

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -39,7 +39,7 @@ class TestRexecBgpNetwork(object):
         show = setup_bgp_commands
         runner = CliRunner()
 
-        result = runner.invoke(show.cli.commands["ip"].commands["bgp"].commands["summary"])
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert MULTI_LC_REXEC_OUTPUT == result.output
@@ -54,7 +54,7 @@ class TestRexecBgpNetwork(object):
         show = setup_bgp_commands
         runner = CliRunner()
 
-        result = runner.invoke(show.cli.commands["ip"].commands["bgp"].commands["summary"])
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert MULTI_LC_ERR_OUTPUT == result.output

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -1,28 +1,21 @@
 import mock
-import paramiko
+import subprocess
 from io import BytesIO
 from click.testing import CliRunner
 
-def mock_exec_command():
+def mock_rexec_command():
     mock_stdout = BytesIO(b"""hello world""")
-    return '', mock_stdout, None
+    print(mock_stdout.getvalue().decode())
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_stdout, stderr=BytesIO())
 
-def mock_exec_error_cmd():
-    mock_stdout = BytesIO()
+def mock_rexec_error_cmd():
     mock_stderr = BytesIO(b"""Error""")
-    return '', mock_stdout, mock_stderr
+    print(mock_stderr.getvalue().decode())
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout=BytesIO(), stderr=mock_stderr)
 
-MULTI_LC_REXEC_OUTPUT = '''======== LINE-CARD0 output: ========
-hello world
-======== LINE-CARD1 output: ========
-hello world
-'''
+MULTI_LC_REXEC_OUTPUT = '''hello world'''
 
-MULTI_LC_ERR_OUTPUT = '''======== LINE-CARD0 output: ========
-Error
-======== LINE-CARD1 output: ========
-Error
-'''
+MULTI_LC_ERR_OUTPUT = '''Error'''
 
 class TestRexecBgpNetwork(object):
     @classmethod
@@ -30,31 +23,23 @@ class TestRexecBgpNetwork(object):
         pass
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
-    @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
-    @mock.patch("rcli.utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
-    @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_command()))
     def test_show_ip_bgp_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
 
+        subprocess.run = mock_rexec_command
         result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
         print(result.output)
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == 0
         assert MULTI_LC_REXEC_OUTPUT == result.output
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
-    @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
-    @mock.patch("rcli.utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
-    @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
-    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_error_cmd()))
     def test_show_ip_bgp_error_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
 
+        subprocess.run = mock_rexec_error_cmd
         result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
         print(result.output)
-        assert result.exit_code == 0, result.output
+        assert result.exit_code == 1
         assert MULTI_LC_ERR_OUTPUT == result.output

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -30,13 +30,6 @@ class TestRexecBgpNetwork(object):
         pass
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
-    @mock.patch("show.main.get_routing_stack", mock.MagicMock(return_value=""))
-    def test_bgp_setup_in_show_main(self):
-        import show.main as main
-        assert main.ip.commands["bgp"] is not None
-        assert main.ipv6.commands["bgp"] is not None
-
-    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
     def test_show_ip_bgp_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -3,15 +3,18 @@ import subprocess
 from io import BytesIO
 from click.testing import CliRunner
 
+
 def mock_rexec_command():
     mock_stdout = BytesIO(b"""hello world""")
     print(mock_stdout.getvalue().decode())
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_stdout, stderr=BytesIO())
 
 def mock_rexec_error_cmd():
+
     mock_stderr = BytesIO(b"""Error""")
     print(mock_stderr.getvalue().decode())
     return subprocess.CompletedProcess(args=[], returncode=1, stdout=BytesIO(), stderr=mock_stderr)
+
 
 MULTI_LC_REXEC_OUTPUT = '''hello world'''
 
@@ -27,9 +30,11 @@ class TestRexecBgpNetwork(object):
         show = setup_bgp_commands
         runner = CliRunner()
 
+        _old_subprocess_run = subprocess.run
         subprocess.run = mock_rexec_command
         result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
         print(result.output)
+        subprocess.run = _old_subprocess_run
         assert result.exit_code == 0
         assert MULTI_LC_REXEC_OUTPUT == result.output
 
@@ -38,8 +43,10 @@ class TestRexecBgpNetwork(object):
         show = setup_bgp_commands
         runner = CliRunner()
 
+        _old_subprocess_run = subprocess.run
         subprocess.run = mock_rexec_error_cmd
         result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
         print(result.output)
+        subprocess.run = _old_subprocess_run
         assert result.exit_code == 1
         assert MULTI_LC_ERR_OUTPUT == result.output

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -1,0 +1,66 @@
+import importlib
+import pytest
+import mock
+import paramiko
+from io import BytesIO, StringIO
+from click.testing import CliRunner
+
+from rcli import rexec
+
+def mock_exec_command():
+
+    mock_stdout = BytesIO(b"""hello world""")
+    mock_stderr = BytesIO()
+    return '', mock_stdout, None
+
+def mock_exec_error_cmd():
+    mock_stdout = BytesIO()
+    mock_stderr = BytesIO(b"""Error""")
+    return '', mock_stdout, mock_stderr
+
+MULTI_LC_REXEC_OUTPUT = '''======== LINE-CARD0 output: ========
+hello world
+======== LINE-CARD1 output: ========
+hello world
+'''
+
+MULTI_LC_ERR_OUTPUT = '''======== LINE-CARD0 output: ========
+Error
+======== LINE-CARD1 output: ========
+Error
+'''
+
+class TestRexecBgpNetwork(object):
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
+    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("rcli_utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
+    @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
+    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_command()))
+    def test_show_ip_bgp_rexec(self, setup_bgp_commands):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        
+        result = runner.invoke(show.commands["ip"].commands["bgp"])
+        print(result.output)
+        assert result.exit_code == 0, result.output
+        assert MULTI_LC_REXEC_OUTPUT == result.output
+
+    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
+    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("rcli_utils.get_all_linecards", mock.MagicMock(return_value=["LINE-CARD0", "LINE-CARD1"]))
+    @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
+    @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_error_cmd()))
+    def test_show_ip_bgp_error_rexec(self, setup_bgp_commands):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        
+        result = runner.invoke(show.commands["ip"].commands["bgp"])
+        print(result.output)
+        assert result.exit_code == 0, result.output
+        assert MULTI_LC_ERR_OUTPUT == result.output

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -39,7 +39,7 @@ class TestRexecBgpNetwork(object):
         show = setup_bgp_commands
         runner = CliRunner()
 
-        result = runner.invoke(show.cli.commands["ip"].commands["bgp"])
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"].commands["summary"])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert MULTI_LC_REXEC_OUTPUT == result.output
@@ -54,7 +54,7 @@ class TestRexecBgpNetwork(object):
         show = setup_bgp_commands
         runner = CliRunner()
 
-        result = runner.invoke(show.cli.commands["ip"].commands["bgp"])
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"].commands["summary"])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert MULTI_LC_ERR_OUTPUT == result.output

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -9,6 +9,7 @@ def mock_rexec_command(*args):
     print(mock_stdout.getvalue().decode())
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_stdout, stderr=BytesIO())
 
+
 def mock_rexec_error_cmd(*args):
     mock_stderr = BytesIO(b"""Error""")
     print(mock_stderr.getvalue().decode())
@@ -16,10 +17,12 @@ def mock_rexec_error_cmd(*args):
 
 
 MULTI_LC_REXEC_OUTPUT = '''Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
-hello world'''
+hello world
+'''
 
 MULTI_LC_ERR_OUTPUT = '''Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
-Error'''
+Error
+'''
 
 class TestRexecBgpNetwork(object):
     @classmethod

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -30,6 +30,13 @@ class TestRexecBgpNetwork(object):
         pass
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("show.main.get_routing_stack", mock.MagicMock(return_value=""))
+    def test_bgp_setup_in_show_main(self):
+        import show.main as main
+        assert main.ip.commands["bgp"] is not None
+        assert main.ipv6.commands["bgp"] is not None
+
+    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
     def test_show_ip_bgp_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -1,16 +1,10 @@
-import importlib
-import pytest
 import mock
 import paramiko
-from io import BytesIO, StringIO
+from io import BytesIO
 from click.testing import CliRunner
 
-from rcli import rexec
-
 def mock_exec_command():
-
     mock_stdout = BytesIO(b"""hello world""")
-    mock_stderr = BytesIO()
     return '', mock_stdout, None
 
 def mock_exec_error_cmd():
@@ -44,8 +38,8 @@ class TestRexecBgpNetwork(object):
     def test_show_ip_bgp_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
-        
-        result = runner.invoke(show.commands["ip"].commands["bgp"])
+
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert MULTI_LC_REXEC_OUTPUT == result.output
@@ -59,8 +53,8 @@ class TestRexecBgpNetwork(object):
     def test_show_ip_bgp_error_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
-        
-        result = runner.invoke(show.commands["ip"].commands["bgp"])
+
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"])
         print(result.output)
         assert result.exit_code == 0, result.output
         assert MULTI_LC_ERR_OUTPUT == result.output

--- a/tests/show_bgp_network_test.py
+++ b/tests/show_bgp_network_test.py
@@ -84,7 +84,8 @@ class TestMultiAsicBgpNetwork(object):
          ('bgp_v4_network_bestpath_asic0', 'bgp_v4_network_bestpath_asic0'),
         ('bgp_v6_network_asic0', 'bgp_v6_network_asic0'),
          ('bgp_v6_network_ip_address_asic0', 'bgp_v6_network_ip_address_asic0'),
-         ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0')],
+         ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0'),
+         ('bgp_v4_network_all', 'bgp_v4_network_all')],
         indirect=['setup_multi_asic_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_multi_asic_bgp_instance):

--- a/tests/show_bgp_network_test.py
+++ b/tests/show_bgp_network_test.py
@@ -57,7 +57,8 @@ class TestBgpNetwork(object):
          ('bgp_v4_network_bestpath', 'bgp_v4_network_bestpath'),
          ('bgp_v6_network_longer_prefixes', 'bgp_v6_network_longer_prefixes'),
          ('bgp_v4_network', 'bgp_v4_network_longer_prefixes_error'),
-         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes_error')],
+         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes_error')
+         ('bgp_v4_network', 'bgp_v4_network_all_asic_on_single_asic')],
         indirect=['setup_single_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_single_bgp_instance):
@@ -85,7 +86,8 @@ class TestMultiAsicBgpNetwork(object):
         ('bgp_v6_network_asic0', 'bgp_v6_network_asic0'),
          ('bgp_v6_network_ip_address_asic0', 'bgp_v6_network_ip_address_asic0'),
          ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0'),
-         ('bgp_v4_network_all_asic', 'bgp_v4_network_all_asic')],
+         ('bgp_v4_network_all_asic', 'bgp_v4_network_all_asic'),
+         ('bgp_v4_network', 'bgp_v4_network_asic_unknown'),],
         indirect=['setup_multi_asic_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_multi_asic_bgp_instance):

--- a/tests/show_bgp_network_test.py
+++ b/tests/show_bgp_network_test.py
@@ -85,7 +85,7 @@ class TestMultiAsicBgpNetwork(object):
         ('bgp_v6_network_asic0', 'bgp_v6_network_asic0'),
          ('bgp_v6_network_ip_address_asic0', 'bgp_v6_network_ip_address_asic0'),
          ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0'),
-         ('bgp_v4_network_all', 'bgp_v4_network_all')],
+         ('bgp_v4_network_all_asic', 'bgp_v4_network_all_asic')],
         indirect=['setup_multi_asic_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_multi_asic_bgp_instance):

--- a/tests/show_bgp_network_test.py
+++ b/tests/show_bgp_network_test.py
@@ -57,7 +57,7 @@ class TestBgpNetwork(object):
          ('bgp_v4_network_bestpath', 'bgp_v4_network_bestpath'),
          ('bgp_v6_network_longer_prefixes', 'bgp_v6_network_longer_prefixes'),
          ('bgp_v4_network', 'bgp_v4_network_longer_prefixes_error'),
-         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes_error')
+         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes_error'),
          ('bgp_v4_network', 'bgp_v4_network_all_asic_on_single_asic')],
         indirect=['setup_single_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
@@ -87,7 +87,7 @@ class TestMultiAsicBgpNetwork(object):
          ('bgp_v6_network_ip_address_asic0', 'bgp_v6_network_ip_address_asic0'),
          ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0'),
          ('bgp_v4_network_all_asic', 'bgp_v4_network_all_asic'),
-         ('bgp_v4_network', 'bgp_v4_network_asic_unknown'),],
+         ('bgp_v4_network', 'bgp_v4_network_asic_unknown')],
         indirect=['setup_multi_asic_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_multi_asic_bgp_instance):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I enable the direct execution of "show ip bgp" on chassis supervisor and "-n all" option for "show ip bgp network" on multi-asic machine

#### How I did it
1. I modified the show ip bgp command to detect whether the current machine is a supervisor. If so, it will invoke rexec.cli to remotely exec the command on all linecards.
2. I add code in show ip bgp network command to pull the list of namespaces of the current device and run the command for each namespace.

#### How to verify it
On chassis supervisor, run "show ip bgp ..."
On a multi-asic device, run "show ip bgp network -n all"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

