### PR TITLE
Enable show ip bgp on sup and -n all for show ip bgp network

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A convenient alternative is to let the SONiC build system configure a build envi
 ```
 python3 setup.py bdist_wheel
 ```
+Note: This command by default will not update the wheel package in target/. To specify the destination location of wheel package, use "-d" option.
 
 #### To run unit tests
 
@@ -73,6 +74,12 @@ python3 setup.py bdist_wheel
 python3 setup.py test
 ```
 
+#### To install the package on a SONiC machine
+```
+sudo pip uninstall sonic-utilities
+sudo pip install YOUR_WHEEL_PACKAGE
+```
+Note: Don't use "--force-reinstall".
 
 ### sonic-utilities-data
 

--- a/rcli/linecard.py
+++ b/rcli/linecard.py
@@ -41,7 +41,7 @@ class Linecard:
             # the user has passed linecard hostname
             self.hostname = linecard_name
             self.module_name = module_name
-            
+
         self.username = username
         self.password = password
 

--- a/rcli/linecard.py
+++ b/rcli/linecard.py
@@ -8,7 +8,7 @@ import sys
 import termios
 import tty
 
-from .utils import get_linecard_ip
+from .utils import get_linecard_ip, get_linecard_hostname_from_module_name, get_linecard_module_name_from_hostname
 from paramiko.py3compat import u
 from paramiko import Channel
 
@@ -31,7 +31,17 @@ class Linecard:
         if not self.ip:
             sys.exit(1)
 
-        self.linecard_name = linecard_name
+        # if the user passes linecard hostname, then try to get the module name for that linecard
+        module_name = get_linecard_module_name_from_hostname(linecard_name)
+        if module_name is None:
+            # if the module name cannot be found from host, assume the user has passed module name
+            self.module_name = linecard_name
+            self.hostname = get_linecard_hostname_from_module_name(linecard_name)
+        else:
+            # the user has passed linecard hostname
+            self.hostname = linecard_name
+            self.module_name = module_name
+            
         self.username = username
         self.password = password
 

--- a/rcli/rexec.py
+++ b/rcli/rexec.py
@@ -30,7 +30,7 @@ def cli(linecard_names, command, username):
 
     if list(linecard_names) == ["all"]:
         # Get all linecard names using autocompletion helper
-        linecard_names = rcli_utils.get_all_linecards(None, None, "")
+        linecard_names = sorted(rcli_utils.get_all_linecards(None, None, ""))
 
     linecards = []
     # Iterate through each linecard, check if the login was successful

--- a/rcli/rexec.py
+++ b/rcli/rexec.py
@@ -30,14 +30,16 @@ def cli(linecard_names, command, username):
 
     if list(linecard_names) == ["all"]:
         # Get all linecard names using autocompletion helper
-        linecard_names = sorted(rcli_utils.get_all_linecards(None, None, ""))
+        module_names = sorted(rcli_utils.get_all_linecards(None, None, ""))
+    else:
+        module_names = linecard_names
 
     linecards = []
     # Iterate through each linecard, check if the login was successful
-    for linecard_name in linecard_names:
-        linecard = Linecard(linecard_name, username, password)
+    for module_name in module_names:
+        linecard = Linecard(module_name, username, password)
         if not linecard.connection:
-            click.echo(f"Failed to connect to {linecard_name} with username {username}")
+            click.echo(f"Failed to connect to {module_name} with username {username}")
             sys.exit(1)
         linecards.append(linecard)
 

--- a/rcli/rexec.py
+++ b/rcli/rexec.py
@@ -43,7 +43,7 @@ def cli(linecard_names, command, username):
 
     for linecard in linecards:
         if linecard.connection:
-            click.echo(f"======== {linecard.linecard_name} output: ========")
+            click.echo(f"======== {linecard.linecard_name}|{linecard.hostname} output: ========")
             click.echo(linecard.execute_cmd(command))
 
 

--- a/rcli/rexec.py
+++ b/rcli/rexec.py
@@ -43,7 +43,7 @@ def cli(linecard_names, command, username):
 
     for linecard in linecards:
         if linecard.connection:
-            click.echo(f"======== {linecard.linecard_name}|{linecard.hostname} output: ========")
+            click.echo(f"======== {linecard.module_name}|{linecard.hostname} output: ========")
             click.echo(linecard.execute_cmd(command))
 
 

--- a/rcli/rshell.py
+++ b/rcli/rshell.py
@@ -28,14 +28,14 @@ def cli(linecard_name, username):
     try:
         linecard = Linecard(linecard_name, username, password)
         if linecard.connection:
-            click.echo(f"Connecting to {linecard.linecard_name}")
+            click.echo(f"Connecting to {linecard.module_name}")
             # If connection was created, connection exists.
             # Otherwise, user will see an error message.
             linecard.start_shell()
             click.echo("Connection Closed")
     except paramiko.ssh_exception.AuthenticationException:
         click.echo(
-            f"Login failed on '{linecard.linecard_name}' with username '{linecard.username}'")
+            f"Login failed on '{linecard.module_name}' with username '{linecard.username}'")
 
 
 if __name__=="__main__":

--- a/rcli/utils.py
+++ b/rcli/utils.py
@@ -43,6 +43,20 @@ def get_linecard_module_name_from_hostname(linecard_name: str):
 
     return None
 
+
+def get_linecard_hostname_from_module_name(linecard_name: str):
+
+    chassis_state_db = connect_to_chassis_state_db()
+    keys = chassis_state_db.keys(chassis_state_db.CHASSIS_STATE_DB , '{}|{}'.format(CHASSIS_MODULE_HOSTNAME_TABLE, '*'))
+    for key in keys:
+        module_name = key.split('|')[1]
+        if module_name.replace('-', '').lower() == linecard_name.replace('-', '').lower():
+            hostname = chassis_state_db.get(chassis_state_db.CHASSIS_STATE_DB, key, CHASSIS_MODULE_HOSTNAME)
+            return hostname
+
+    return None
+
+
 def get_linecard_ip(linecard_name: str):
     """
     Given a linecard name, lookup its IP address in the midplane table
@@ -68,6 +82,7 @@ def get_linecard_ip(linecard_name: str):
         click.echo('Linecard {} not accessible'.format(linecard_name))
         return None
     return module_ip
+
 
 def get_module_ip_and_access_from_state_db(module_name):
     state_db = connect_state_db()

--- a/rcli/utils.py
+++ b/rcli/utils.py
@@ -47,7 +47,7 @@ def get_linecard_module_name_from_hostname(linecard_name: str):
 def get_linecard_hostname_from_module_name(linecard_name: str):
 
     chassis_state_db = connect_to_chassis_state_db()
-    keys = chassis_state_db.keys(chassis_state_db.CHASSIS_STATE_DB , '{}|{}'.format(CHASSIS_MODULE_HOSTNAME_TABLE, '*'))
+    keys = chassis_state_db.keys(chassis_state_db.CHASSIS_STATE_DB, '{}|{}'.format(CHASSIS_MODULE_HOSTNAME_TABLE, '*'))
     for key in keys:
         module_name = key.split('|')[1]
         if module_name.replace('-', '').lower() == linecard_name.replace('-', '').lower():

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -1,11 +1,14 @@
 import click
+import sys
+import subprocess
 
-from sonic_py_common import multi_asic
+from sonic_py_common import multi_asic, device_info
 from show.main import ip
 import utilities_common.bgp_util as bgp_util
 import utilities_common.cli as clicommon
 import utilities_common.constants as constants
 import utilities_common.multi_asic as multi_asic_util
+import rcli.rexec
 
 ###############################################################################
 #
@@ -17,6 +20,12 @@ import utilities_common.multi_asic as multi_asic_util
 @ip.group(cls=clicommon.AliasedGroup)
 def bgp():
     """Show IPv4 BGP (Border Gateway Protocol) information"""
+    if device_info.is_supervisor():
+        # if the device is a chassis, the command need to be executed by rexec
+        click.echo("Since the current device is a chassis supervisor, " +
+                   "this command will be executed remotely on all linecards")
+        proc = subprocess.run(["rexec", "all"] + ["-c", " ".join(sys.argv)])
+        sys.exit(proc.returncode)
     pass
 
 
@@ -102,10 +111,16 @@ def neighbors(ipaddress, info_type, namespace):
 def network(ipaddress, info_type, namespace):
     """Show IP (IPv4) BGP network"""
 
-    if multi_asic.is_multi_asic() and namespace not in multi_asic.get_namespace_list():
-        ctx = click.get_current_context()
-        ctx.fail('-n/--namespace option required. provide namespace from list {}'\
-            .format(multi_asic.get_namespace_list()))
+    namespace = namespace.strip()
+    if multi_asic.is_multi_asic():
+        if namespace == multi_asic.DEFAULT_NAMESPACE:
+            ctx = click.get_current_context()
+            ctx.fail('-n/--namespace option required. provide namespace from list {}'
+                .format(multi_asic.get_namespace_list()))
+        if namespace != "all" and namespace not in multi_asic.get_namespace_list():
+            ctx = click.get_current_context()
+            ctx.fail('invalid namespace {}. provide namespace from list {}'
+                .format(namespace, multi_asic.get_namespace_list()))
 
     command = 'show ip bgp'
     if ipaddress is not None:
@@ -125,5 +140,15 @@ def network(ipaddress, info_type, namespace):
         if info_type is not None:
             command += ' {}'.format(info_type)
 
-    output  =  bgp_util.run_bgp_show_command(command, namespace)
-    click.echo(output.rstrip('\n'))
+    if namespace == "all":
+        if multi_asic.is_multi_asic():
+            for ns in multi_asic.get_namespace_list():
+                click.echo("\n======== namespace {} ========".format(ns))
+                output = bgp_util.run_bgp_show_command(command, ns)
+                click.echo(output.rstrip('\n'))
+        else:
+            output = bgp_util.run_bgp_show_command(command, "")
+            click.echo(output.rstrip('\n'))
+    else:
+        output = bgp_util.run_bgp_show_command(command, namespace)
+        click.echo(output.rstrip('\n'))

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -115,11 +115,11 @@ def network(ipaddress, info_type, namespace):
         if namespace == multi_asic.DEFAULT_NAMESPACE:
             ctx = click.get_current_context()
             ctx.fail('-n/--namespace option required. provide namespace from list {}'
-                    .format(multi_asic.get_namespace_list()))
+                     .format(multi_asic.get_namespace_list()))
         if namespace != "all" and namespace not in multi_asic.get_namespace_list():
             ctx = click.get_current_context()
             ctx.fail('invalid namespace {}. provide namespace from list {}'
-                    .format(namespace, multi_asic.get_namespace_list()))
+                     .format(namespace, multi_asic.get_namespace_list()))
 
     command = 'show ip bgp'
     if ipaddress is not None:

--- a/show/bgp_frr_v4.py
+++ b/show/bgp_frr_v4.py
@@ -8,7 +8,6 @@ import utilities_common.bgp_util as bgp_util
 import utilities_common.cli as clicommon
 import utilities_common.constants as constants
 import utilities_common.multi_asic as multi_asic_util
-import rcli.rexec
 
 ###############################################################################
 #
@@ -116,11 +115,11 @@ def network(ipaddress, info_type, namespace):
         if namespace == multi_asic.DEFAULT_NAMESPACE:
             ctx = click.get_current_context()
             ctx.fail('-n/--namespace option required. provide namespace from list {}'
-                .format(multi_asic.get_namespace_list()))
+                    .format(multi_asic.get_namespace_list()))
         if namespace != "all" and namespace not in multi_asic.get_namespace_list():
             ctx = click.get_current_context()
             ctx.fail('invalid namespace {}. provide namespace from list {}'
-                .format(namespace, multi_asic.get_namespace_list()))
+                    .format(namespace, multi_asic.get_namespace_list()))
 
     command = 'show ip bgp'
     if ipaddress is not None:

--- a/show/main.py
+++ b/show/main.py
@@ -1190,7 +1190,11 @@ elif routing_stack == "frr":
     ip.add_command(bgp)
     from .bgp_frr_v6 import bgp
     ipv6.add_command(bgp)
-
+elif device_info.is_supervisor():
+    from .bgp_frr_v4 import bgp
+    ip.add_command(bgp)
+    from .bgp_frr_v6 import bgp
+    ipv6.add_command(bgp)
 #
 # 'link-local-mode' subcommand ("show ipv6 link-local-mode")
 #

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -227,6 +227,9 @@ Paths: (4 available, best #4, table default)
 multi_asic_bgp_network_err = \
 """Error: -n/--namespace option required. provide namespace from list ['asic0', 'asic1']"""
 
+multi_asic_bgp_network_asic_unknown_err = \
+"""Error: invalid namespace asic_unknown. provide namespace from list ['asic0', 'asic1']"""
+
 bgp_v4_network_asic0 = \
 """
 BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
@@ -309,6 +312,111 @@ Paths: (2 available, best #2, table default, not advertised outside local AS)
       Community: local-AS
       Originator: 8.0.0.4, Cluster list: 8.0.0.4
       Last update: Thu Apr 22 02:13:30 2021 
+"""
+
+bgp_v4_network_all_asic = \
+"""
+======== namespace asic0 ========
+
+BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+* i0.0.0.0/0        10.1.0.2                      100      0 65200 6666 6667 i
+* i                 10.1.0.0                      100      0 65200 6666 6667 i
+*=                  10.0.0.5                               0 65200 6666 6667 i
+*>                  10.0.0.1                               0 65200 6666 6667 i
+* i8.0.0.0/32       10.1.0.2                 0    100      0 i
+* i                 10.1.0.0                 0    100      0 i
+*                   0.0.0.0                  0         32768 ?
+*>                  0.0.0.0                  0         32768 i
+*=i8.0.0.1/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.2/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.3/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*>i8.0.0.4/32       10.1.0.0                 0    100      0 i
+*>i8.0.0.5/32       10.1.0.2                 0    100      0 i
+* i10.0.0.0/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+* i10.0.0.4/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+*=i10.0.0.8/31      10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.12/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.32/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.34/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.36/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.38/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.40/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ? 
+
+======== namespace asic1 ========
+
+BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
+Default local pref 100, local AS 65100
+Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+* i0.0.0.0/0        10.1.0.2                      100      0 65200 6666 6667 i
+* i                 10.1.0.0                      100      0 65200 6666 6667 i
+*=                  10.0.0.5                               0 65200 6666 6667 i
+*>                  10.0.0.1                               0 65200 6666 6667 i
+* i8.0.0.0/32       10.1.0.2                 0    100      0 i
+* i                 10.1.0.0                 0    100      0 i
+*                   0.0.0.0                  0         32768 ?
+*>                  0.0.0.0                  0         32768 i
+*=i8.0.0.1/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.2/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*=i8.0.0.3/32       10.1.0.2                 0    100      0 i
+*>i                 10.1.0.0                 0    100      0 i
+*>i8.0.0.4/32       10.1.0.0                 0    100      0 i
+*>i8.0.0.5/32       10.1.0.2                 0    100      0 i
+* i10.0.0.0/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+* i10.0.0.4/31      10.1.0.2                 0    100      0 ?
+* i                 10.1.0.0                 0    100      0 ?
+*>                  0.0.0.0                  0         32768 ?
+*=i10.0.0.8/31      10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.12/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.32/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.34/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.36/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.38/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.40/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ?
+*=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
+*>i                 10.1.0.0                 0    100      0 ? 
 """
 
 bgp_v6_network_asic0 = \
@@ -429,6 +537,9 @@ def mock_show_bgp_network_multi_asic(param):
         return bgp_v6_network_ip_address_asic0
     elif param == 'bgp_v6_network_bestpath_asic0':
         return bgp_v6_network_ip_address_asic0_bestpath
+    elif param == "bgp_v4_network_all_asic":
+        # this is mocking the output of a single LC
+        return bgp_v4_network_asic0
     else:
         return ''
 
@@ -453,6 +564,11 @@ testData = {
         'args': [' 193.11.248.128', 'longer-prefixes'],
         'rc': 1,
         'rc_output': bgp_v4_network_longer_prefixes_error
+    },
+    'bgp_v4_network_all_asic_on_single_asic': {
+        'args': ['-nall'],
+        'rc': 0,
+        'rc_output': bgp_v4_network
     },
     'bgp_v6_network': {
         'args': [],
@@ -498,6 +614,16 @@ testData = {
         'args': ['-nasic0', '10.0.0.44', 'bestpath'],
         'rc': 0,
         'rc_output': bgp_v4_network_bestpath_asic0
+    },
+    'bgp_v4_network_all_asic': {
+        'args': ['-nall'],
+        'rc': 0,
+        'rc_output': bgp_v4_network_all_asic
+    },
+    'bgp_v4_network_asic_unknown': {
+        'args': ['-nasic_unknown'],
+        'rc': 2,
+        'rc_err_msg': multi_asic_bgp_network_asic_unknown_err
     },
     'bgp_v6_network_multi_asic': {
         'args': [],

--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -228,7 +228,7 @@ multi_asic_bgp_network_err = \
 """Error: -n/--namespace option required. provide namespace from list ['asic0', 'asic1']"""
 
 multi_asic_bgp_network_asic_unknown_err = \
-"""Error: invalid namespace asic_unknown. provide namespace from list ['asic0', 'asic1']"""
+  """Error: invalid namespace asic_unknown. provide namespace from list ['asic0', 'asic1']"""
 
 bgp_v4_network_asic0 = \
 """
@@ -279,7 +279,7 @@ Origin codes:  i - IGP, e - EGP, ? - incomplete
 *=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
 *>i                 10.1.0.0                 0    100      0 ?
 *=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
-*>i                 10.1.0.0                 0    100      0 ? 
+*>i                 10.1.0.0                 0    100      0 ?
 """
 
 bgp_v4_network_ip_address_asic0 = \
@@ -315,7 +315,7 @@ Paths: (2 available, best #2, table default, not advertised outside local AS)
 """
 
 bgp_v4_network_all_asic = \
-"""
+  """
 ======== namespace asic0 ========
 
 BGP table version is 11256, local router ID is 10.1.0.32, vrf id 0
@@ -365,7 +365,7 @@ Origin codes:  i - IGP, e - EGP, ? - incomplete
 *=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
 *>i                 10.1.0.0                 0    100      0 ?
 *=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
-*>i                 10.1.0.0                 0    100      0 ? 
+*>i                 10.1.0.0                 0    100      0 ?
 
 ======== namespace asic1 ========
 
@@ -416,7 +416,7 @@ Origin codes:  i - IGP, e - EGP, ? - incomplete
 *=i10.0.0.42/31     10.1.0.2                 0    100      0 ?
 *>i                 10.1.0.0                 0    100      0 ?
 *=i10.0.0.44/31     10.1.0.2                 0    100      0 ?
-*>i                 10.1.0.0                 0    100      0 ? 
+*>i                 10.1.0.0                 0    100      0 ?
 """
 
 bgp_v6_network_asic0 = \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,6 +386,13 @@ def setup_multi_asic_bgp_instance(request):
         else:
             return ""
 
+    def mock_multi_asic_list():
+        return ["asic0", "asic1"]
+
+    # mock multi-asic list
+    if request.param == "bgp_v4_network_all_asic":
+        multi_asic.get_namespace_list = mock_multi_asic_list
+
     _old_run_bgp_command = bgp_util.run_bgp_command
     if request.param == 'ip_route_for_int_ip':
         bgp_util.run_bgp_command = mock_run_bgp_command_for_static

--- a/tests/mock_tables/chassis_state_db.json
+++ b/tests/mock_tables/chassis_state_db.json
@@ -4,6 +4,9 @@
     }, 
     "CHASSIS_MODULE_HOSTNAME_TABLE|LINE-CARD1": {
         "module_hostname": "sonic-lc2"
+    },
+    "CHASSIS_MODULE_HOSTNAME_TABLE|LINE-CARD2": {
+        "module_hostname": "sonic-lc3"
     }
 
 }

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -12,9 +12,9 @@ import select
 import socket
 import termios
 
-MULTI_LC_REXEC_OUTPUT = '''======== sonic-lc1 output: ========
+MULTI_LC_REXEC_OUTPUT = '''======== LINE-CARD0|sonic-lc1 output: ========
 hello world
-======== LINE-CARD2 output: ========
+======== LINE-CARD2|sonic-lc3 output: ========
 hello world
 '''
 REXEC_HELP = '''Usage: cli [OPTIONS] LINECARD_NAMES...
@@ -152,12 +152,12 @@ class TestRemoteExec(object):
     @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_invalid_lc(self):
         runner = CliRunner()
-        LINECARD_NAME = "sonic-lc-3"
+        LINECARD_NAME = "sonic-lc-100"
         result = runner.invoke(
             rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 1, result.output
-        assert "Linecard sonic-lc-3 not found\n" == result.output
+        assert "Linecard sonic-lc-100 not found\n" == result.output
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -1,0 +1,56 @@
+import mock
+import subprocess
+from io import BytesIO
+from click.testing import CliRunner
+
+
+def mock_rexec_command(*args):
+    mock_stdout = BytesIO(b"""hello world""")
+    print(mock_stdout.getvalue().decode())
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_stdout, stderr=BytesIO())
+
+
+def mock_rexec_error_cmd(*args):
+    mock_stderr = BytesIO(b"""Error""")
+    print(mock_stderr.getvalue().decode())
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout=BytesIO(), stderr=mock_stderr)
+
+
+MULTI_LC_REXEC_OUTPUT = '''Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
+hello world
+'''
+
+MULTI_LC_ERR_OUTPUT = '''Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
+Error
+'''
+
+class TestRexecBgp(object):
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    def test_show_ip_bgp_rexec(self, setup_bgp_commands):
+        show = setup_bgp_commands
+        runner = CliRunner()
+
+        _old_subprocess_run = subprocess.run
+        subprocess.run = mock_rexec_command
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
+        print(result.output)
+        subprocess.run = _old_subprocess_run
+        assert result.exit_code == 0
+        assert MULTI_LC_REXEC_OUTPUT == result.output
+
+    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    def test_show_ip_bgp_error_rexec(self, setup_bgp_commands):
+        show = setup_bgp_commands
+        runner = CliRunner()
+
+        _old_subprocess_run = subprocess.run
+        subprocess.run = mock_rexec_error_cmd
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["summary"])
+        print(result.output)
+        subprocess.run = _old_subprocess_run
+        assert result.exit_code == 1
+        assert MULTI_LC_ERR_OUTPUT == result.output

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -24,6 +24,7 @@ MULTI_LC_ERR_OUTPUT = '''Since the current device is a chassis supervisor, this 
 Error
 '''
 
+
 class TestRexecBgp(object):
     @classmethod
     def setup_class(cls):

--- a/tests/show_bgp_network_test.py
+++ b/tests/show_bgp_network_test.py
@@ -57,7 +57,8 @@ class TestBgpNetwork(object):
          ('bgp_v4_network_bestpath', 'bgp_v4_network_bestpath'),
          ('bgp_v6_network_longer_prefixes', 'bgp_v6_network_longer_prefixes'),
          ('bgp_v4_network', 'bgp_v4_network_longer_prefixes_error'),
-         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes_error')],
+         ('bgp_v4_network', 'bgp_v6_network_longer_prefixes_error'),
+         ('bgp_v4_network', 'bgp_v4_network_all_asic_on_single_asic')],
         indirect=['setup_single_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_single_bgp_instance):
@@ -84,7 +85,9 @@ class TestMultiAsicBgpNetwork(object):
          ('bgp_v4_network_bestpath_asic0', 'bgp_v4_network_bestpath_asic0'),
         ('bgp_v6_network_asic0', 'bgp_v6_network_asic0'),
          ('bgp_v6_network_ip_address_asic0', 'bgp_v6_network_ip_address_asic0'),
-         ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0')],
+         ('bgp_v6_network_bestpath_asic0', 'bgp_v6_network_bestpath_asic0'),
+         ('bgp_v4_network_all_asic', 'bgp_v4_network_all_asic'),
+         ('bgp_v4_network', 'bgp_v4_network_asic_unknown')],
         indirect=['setup_multi_asic_bgp_instance'])
     def test_bgp_network(self, setup_bgp_commands, test_vector,
                          setup_multi_asic_bgp_instance):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

1. Enable "show ip bgp" on sup and "-n all" for show ip bgp network.
2. Modify README.doc to make the instructions of building and installing the wheel package more clear.
3. Improve the output format of rexec command

#### How I did it

Modify the code in show/main.py to enable "show ip bgp ..." on supervisors and modify show/bgp_frr_v4.py to add support for the new features.
Update README.md.
Modify the rexec implementation to improve the output format.
Add unit tests for the above change.

#### How to verify it

Run on a SONiC chassis

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

