### PR TITLE
[Bug Fix] Fix disk check test and drops group test

### DIFF
--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -179,5 +179,5 @@ class TestDiskCheck(object):
 
     @classmethod
     def teardown_class(cls):
-        subprocess.run("rm -rf /tmp/tmp*", shell=True) # cleanup the temporary dirs
+        subprocess.run("rm -rf /tmp/tmp*", shell=True)  # cleanup the temporary dirs
         print("TEARDOWN")

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -1,7 +1,6 @@
 import sys
 import syslog
 from unittest.mock import patch
-import pytest
 import subprocess
 
 sys.path.append("scripts")
@@ -178,3 +177,7 @@ class TestDiskCheck(object):
             
         assert max_log_lvl == syslog.LOG_ERR
 
+    @classmethod
+    def teardown_class(cls):
+        subprocess.run(["rm", "-rf", "/tmp/tmp*"]) # cleanup the temporary dirs
+        print("TEARDOWN")

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -179,5 +179,5 @@ class TestDiskCheck(object):
 
     @classmethod
     def teardown_class(cls):
-        subprocess.run(["rm", "-rf", "/tmp/tmp*"]) # cleanup the temporary dirs
+        subprocess.run("rm -rf /tmp/tmp*", shell=True) # cleanup the temporary dirs
         print("TEARDOWN")

--- a/tests/drops_group_test.py
+++ b/tests/drops_group_test.py
@@ -3,6 +3,7 @@ import sys
 
 import shutil
 from click.testing import CliRunner
+from utilities_common.cli import UserCache
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -12,7 +13,6 @@ sys.path.insert(0, modules_path)
 
 import show.main as show
 import clear.main as clear
-from utilities_common.cli import UserCache
 
 expected_counter_capabilities = """\
 Counter Type           Total
@@ -97,6 +97,7 @@ Ethernet8      N/A         0           0         0           0          0       
 ----------------  --------------  -------------------
 sonic_drops_test               0                    0
 """
+
 
 def remove_tmp_dropstat_file():
     # remove the tmp portstat

--- a/tests/drops_group_test.py
+++ b/tests/drops_group_test.py
@@ -12,6 +12,7 @@ sys.path.insert(0, modules_path)
 
 import show.main as show
 import clear.main as clear
+from utilities_common.cli import UserCache
 
 expected_counter_capabilities = """\
 Counter Type           Total
@@ -97,14 +98,16 @@ Ethernet8      N/A         0           0         0           0          0       
 sonic_drops_test               0                    0
 """
 
-dropstat_path = "/tmp/dropstat-27"
+def remove_tmp_dropstat_file():
+    # remove the tmp portstat
+    cache = UserCache("dropstat")
+    cache.remove_all()
 
 class TestDropCounters(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
-        if os.path.exists(dropstat_path):
-            shutil.rmtree(dropstat_path)
+        remove_tmp_dropstat_file()
         os.environ["PATH"] += os.pathsep + scripts_path
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I fixed a problem that would cause disk_check_test and drops_group_test to fail when running the tests twice.

#### How I did it

tests/drop_groups_test.py: In the setup_class() of TestDropCounters class, I invoked a function to remove cache files.
tests/disk_check_test.py: In the teardown_class() of TestDiskCheck class, I run a command to remove /tmp/tmp* files.

#### How to verify it

Run the tests in the slave containers several times repeatedly and see if they passed. Before adding these fixes, the tests should fail starting from the second time.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

