### PR TITLE
Add a command to update log level and refresh configuration

### DIFF
--- a/config/syslog.py
+++ b/config/syslog.py
@@ -658,8 +658,8 @@ def disable_rate_limit_feature(db, service_name, namespace):
               help="Program name to which the SIGHUP is sent (provided with --service)")
 @click.option("--pid",
               help="Process ID to which the SIGHUP is sent (provided with --service if PID is from container)")
-@click.option('--namespace', '-n', 'namespace', default=None, 
-              type=click.Choice(multi_asic_util.multi_asic_ns_choices()), 
+@click.option('--namespace', '-n', 'namespace', default=None,
+              type=click.Choice(multi_asic_util.multi_asic_ns_choices()),
               show_default=True, help='Namespace name')
 @clicommon.pass_db
 def level(db, component, level, service, program, pid, namespace):
@@ -676,7 +676,7 @@ def level(db, component, level, service, program, pid, namespace):
         asic_id = multi_asic.get_asic_id_from_name(namespace)
         service = f'{service}{asic_id}'
         cfg_db = db.cfgdb_clients[namespace]
-    
+
     cfg_db.mod_entry('LOGGER', component, {'LOGLEVEL': level})
     if not service and not program and not pid:
         return

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -10713,6 +10713,35 @@ This command is used to disable syslog rate limit feature.
   config syslog rate-limit-feature disable database -n asci0
   ```
 
+**config syslog level**
+
+This command is used to configure log level for a given log identifier.
+
+- Usage:
+  ```
+  config syslog level -c <log_identifier> -l <log_level> --service [<service_name>] --program [<program_name>]
+
+  config syslog level -c <log_identifier> -l <log_level> --service [<service_name>] --pid [<process_id>]
+
+  config syslog level -c <log_identifier> -l <log_level> ---pid [<process_id>]
+  ```
+
+- Example:
+
+  ```
+  # Update the log level without refresh the configuration
+  config syslog level -c xcvrd -l DEBUG
+
+  # Update the log level and send SIGHUP to xcvrd running in PMON
+  config syslog level -c xcvrd -l DEBUG --service pmon --program xcvrd
+
+  # Update the log level and send SIGHUP to PID 20 running in PMON
+  config syslog level -c xcvrd -l DEBUG --service pmon --pid 20
+
+  # Update the log level and send SIGHUP to PID 20 running in host
+  config syslog level -c xcvrd -l DEBUG --pid 20
+  ```
+
 Go Back To [Beginning of the document](#) or [Beginning of this section](#syslog)
 
 ## System State

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -10719,27 +10719,27 @@ This command is used to configure log level for a given log identifier.
 
 - Usage:
   ```
-  config syslog level -c <log_identifier> -l <log_level> --service [<service_name>] --program [<program_name>]
+  config syslog level -i <log_identifier> -l <log_level> --container [<container_name>] --program [<program_name>]
 
-  config syslog level -c <log_identifier> -l <log_level> --service [<service_name>] --pid [<process_id>]
+  config syslog level -i <log_identifier> -l <log_level> --container [<container_name>] --pid [<process_id>]
 
-  config syslog level -c <log_identifier> -l <log_level> ---pid [<process_id>]
+  config syslog level -i <log_identifier> -l <log_level> ---pid [<process_id>]
   ```
 
 - Example:
 
   ```
   # Update the log level without refresh the configuration
-  config syslog level -c xcvrd -l DEBUG
+  config syslog level -i xcvrd -l DEBUG
 
   # Update the log level and send SIGHUP to xcvrd running in PMON
-  config syslog level -c xcvrd -l DEBUG --service pmon --program xcvrd
+  config syslog level -i xcvrd -l DEBUG --container pmon --program xcvrd
 
   # Update the log level and send SIGHUP to PID 20 running in PMON
-  config syslog level -c xcvrd -l DEBUG --service pmon --pid 20
+  config syslog level -i xcvrd -l DEBUG --container pmon --pid 20
 
   # Update the log level and send SIGHUP to PID 20 running in host
-  config syslog level -c xcvrd -l DEBUG --pid 20
+  config syslog level -i xcvrd -l DEBUG --pid 20
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#syslog)

--- a/tests/syslog_multi_asic_test.py
+++ b/tests/syslog_multi_asic_test.py
@@ -289,7 +289,7 @@ class TestSyslogRateLimitMultiAsic:
         mock_run.return_value = ('something', 0)
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'component', '-l', 'DEBUG', '-n', 'asic0'], obj=db
+            ['-i', 'component', '-l', 'DEBUG', '-n', 'asic0'], obj=db
         )
         assert result.exit_code == 0
         cfg_db = db.cfgdb_clients['asic0']

--- a/tests/syslog_multi_asic_test.py
+++ b/tests/syslog_multi_asic_test.py
@@ -279,3 +279,19 @@ class TestSyslogRateLimitMultiAsic:
             ['database', '-n', 'asic0']
         )
         assert result.exit_code == 0
+        
+    @mock.patch('config.syslog.clicommon.run_command')
+    def test_config_log_level(self, mock_run, setup_cmd_module):
+        _, config = setup_cmd_module
+        db = Db()
+        runner = CliRunner()
+
+        mock_run.return_value = ('something', 0)
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'component', '-l', 'DEBUG', '-n', 'asic0'], obj=db
+        )
+        assert result.exit_code == 0
+        cfg_db = db.cfgdb_clients['asic0']
+        data = cfg_db.get_entry('LOGGER', 'component')
+        assert data.get('LOGLEVEL') == 'DEBUG'

--- a/tests/syslog_multi_asic_test.py
+++ b/tests/syslog_multi_asic_test.py
@@ -279,7 +279,7 @@ class TestSyslogRateLimitMultiAsic:
             ['database', '-n', 'asic0']
         )
         assert result.exit_code == 0
-        
+
     @mock.patch('config.syslog.clicommon.run_command')
     def test_config_log_level(self, mock_run, setup_cmd_module):
         _, config = setup_cmd_module

--- a/tests/syslog_test.py
+++ b/tests/syslog_test.py
@@ -495,7 +495,7 @@ class TestSyslog:
         mock_run.return_value = ('something', 0)
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'component', '-l', 'DEBUG'], obj=db
+            ['-i', 'component', '-l', 'DEBUG'], obj=db
         )
         assert result.exit_code == SUCCESS
         data = db.cfgdb.get_entry('LOGGER', 'component')
@@ -503,19 +503,19 @@ class TestSyslog:
 
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'component', '-l', 'DEBUG', '--pid', '123'], obj=db
+            ['-i', 'component', '-l', 'DEBUG', '--pid', '123'], obj=db
         )
         assert result.exit_code == SUCCESS
 
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'component', '-l', 'DEBUG', '--service', 'pmon', '--pid', '123'], obj=db
+            ['-i', 'component', '-l', 'DEBUG', '--container', 'pmon', '--pid', '123'], obj=db
         )
         assert result.exit_code == SUCCESS
 
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'component', '-l', 'DEBUG', '--service', 'pmon', '--program', 'xcvrd'], obj=db
+            ['-i', 'component', '-l', 'DEBUG', '--container', 'pmon', '--program', 'xcvrd'], obj=db
         )
         assert result.exit_code == SUCCESS
 
@@ -528,20 +528,20 @@ class TestSyslog:
         mock_run.return_value = ('something', 0)
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'log1', '-l', 'DEBUG', '--service', 'pmon'], obj=db
+            ['-i', 'log1', '-l', 'DEBUG', '--container', 'pmon'], obj=db
         )
         assert result.exit_code != SUCCESS
 
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'log1', '-l', 'DEBUG', '--program', 'xcvrd'], obj=db
+            ['-i', 'log1', '-l', 'DEBUG', '--program', 'xcvrd'], obj=db
         )
         assert result.exit_code != SUCCESS
 
         mock_run.reset_mock()
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'log1', '-l', 'DEBUG', '--service', 'swss', '--program', 'orchagent'], obj=db
+            ['-i', 'log1', '-l', 'DEBUG', '--container', 'swss', '--program', 'orchagent'], obj=db
         )
         assert result.exit_code == SUCCESS
         # Verify it does not send signal to orchagent if require_manual_refresh is not true
@@ -551,6 +551,6 @@ class TestSyslog:
         db.cfgdb.set_entry('LOGGER', 'log1', {'require_manual_refresh': 'true'})
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
-            ['-c', 'log1', '-l', 'DEBUG', '--service', 'pmon', '--program', 'xcvrd'], obj=db
+            ['-i', 'log1', '-l', 'DEBUG', '--container', 'pmon', '--program', 'xcvrd'], obj=db
         )
         assert result.exit_code != SUCCESS

--- a/tests/syslog_test.py
+++ b/tests/syslog_test.py
@@ -498,6 +498,8 @@ class TestSyslog:
             ['-c', 'component', '-l', 'DEBUG'], obj=db
         )
         assert result.exit_code == SUCCESS
+        data = db.cfgdb.get_entry('LOGGER', 'component')
+        assert data.get('LOGLEVEL') == 'DEBUG'
 
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],
@@ -543,17 +545,9 @@ class TestSyslog:
         )
         assert result.exit_code == SUCCESS
         # Verify it does not send signal to orchagent if require_manual_refresh is not true
-        assert mock_run.call_count == 1
+        assert mock_run.call_count == 0
 
         mock_run.return_value = ('something', -1)
-        result = runner.invoke(
-            config.config.commands["syslog"].commands["level"],
-            ['-c', 'log1', '-l', 'DEBUG'], obj=db
-        )
-
-        assert result.exit_code != SUCCESS
-
-        mock_run.side_effect = [('something', 0), ('something', -1)]
         db.cfgdb.set_entry('LOGGER', 'log1', {'require_manual_refresh': 'true'})
         result = runner.invoke(
             config.config.commands["syslog"].commands["level"],


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add a command "config syslog level" to set log level at runtime.

#### How I did it

Add a command "config syslog level" to set log level at runtime. This command shall update log level in CONFIG DB and send SIGHUP to relevant daemon if it requires a manual refresh

#### How to verify it

manual test
new unit test case

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

```
root@sonic:/home/admin# config syslog level --help
Usage: config syslog level [OPTIONS]

  Configure log level

Options:
  -c, --component TEXT            Component name in DB for which loglevel is
                                  applied (provided with -l)  [required]
  -l, --level [DEBUG|INFO|NOTICE|WARN|ERROR]
                                  Loglevel value  [required]
  --service TEXT                  Container name to which the SIGHUP is sent
                                  (provided with --pid or --program)
  --program TEXT                  Program name to which the SIGHUP is sent
                                  (provided with --service)
  --pid TEXT                      Process ID to which the SIGHUP is sent
                                  (provided with --service if PID is from
                                  container)
  -?, -h, --help                  Show this message and exit.
```

