### PR TITLE
Enhance next image detection for Aboot in sonic-installer

### DIFF
--- a/sonic_installer/bootloader/aboot.py
+++ b/sonic_installer/bootloader/aboot.py
@@ -71,6 +71,8 @@ class AbootBootloader(Bootloader):
 
     def _boot_config_read(self, path=BOOT_CONFIG_PATH):
         config = collections.OrderedDict()
+        if not os.path.exists(path):
+            return config
         with open(path) as f:
             for line in f.readlines():
                 line = line.strip()
@@ -112,7 +114,10 @@ class AbootBootloader(Bootloader):
 
     def get_next_image(self):
         config = self._boot_config_read()
-        match = re.search(r"flash:/*(\S+)/", config['SWI'])
+        swi = config.get('SWI', '')
+        match = re.search(r"flash:/*(\S+)/", swi)
+        if not match:
+            return swi.split(':', 1)[-1]
         return match.group(1).replace(IMAGE_DIR_PREFIX, IMAGE_PREFIX, 1)
 
     def set_default_image(self, image):


### PR DESCRIPTION
#### What I did

Fix a crash of sonic-installer for Aboot bootloaders when the next image is not exactly an installed sonic image. 

#### How I did it

The Aboot bootloader relies of the SWI= keyword argument in the boot-config file to know which image to boot.
This value is also used by sonic-installer to figure to extract the next image that will be executed.
The current code has an issue as it only expects the next image to match the installation path of a SONiC image but not anything else.

This means that `SWI=flash:sonic-aboot-broadcom.swi` is not valid and can therefore be a problem when trying to install a new image via cold reboot.

#### How to verify it

Try `sonic-installer list` with the following values in `boot-config`
```
SWI=flash:image-something-expected/.sonic-boot.swi
SWI=flash:sonic-aboot-broadcom.swi
SWI=
```
