### PR TITLE
[fast/warm-reboot] add cpufreq.default_governor=performance to BOOT_OPTIONS

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -417,9 +417,11 @@ function setup_reboot_variables()
         BOOT_OPTIONS="${BOOT_OPTIONS} ssd-upgrader-part=${sonic_dev},${fstype}"
     fi
 
-    # Set governor to performance to speed up boot process.
-    # The governor is reset back to kernel default in warmboot-finalizer script.
-    BOOT_OPTIONS="${BOOT_OPTIONS} cpufreq.default_governor=performance"
+    if [[ "$sonic_asic_type" == "mellanox" ]]; then
+        # Set governor to performance to speed up boot process.
+        # The governor is reset back to kernel default in warmboot-finalizer script.
+        BOOT_OPTIONS="${BOOT_OPTIONS} cpufreq.default_governor=performance"
+    fi
 }
 
 function check_docker_exec()

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -416,6 +416,10 @@ function setup_reboot_variables()
         local fstype=$(blkid -o value -s TYPE ${sonic_dev})
         BOOT_OPTIONS="${BOOT_OPTIONS} ssd-upgrader-part=${sonic_dev},${fstype}"
     fi
+
+    # Set governor to performance to speed up boot process.
+    # The governor is reset back to kernel default in warmboot-finalizer script.
+    BOOT_OPTIONS="${BOOT_OPTIONS} cpufreq.default_governor=performance"
 }
 
 function check_docker_exec()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Set cpufreq.default_governor to *performance* for faster boot time. We observe consistent 1 sec improvement across several devices.

**NOTE**: This will apply to upgrades starting from 202405 since this is set in shutdown path to avoid any extra scripts running at boot time. Upgrade from older versions/branches will require a runtime patch to fast-reboot and warm-reboot script.

DEPENDS ON: https://github.com/sonic-net/sonic-buildimage/pull/19634

#### How I did it

Append this option to BOOT_OPTIONS variable.

#### How to verify it

Run fast-reboot or warm-reboot. Check:
```
admin@sonic:~$ cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
performance
```

After boot is finalized check that it is reset back to default:
```
admin@sonic:~$ cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
schedutil
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

