### PR TITLE
Fix show techsupport date issue

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1120,7 +1120,6 @@ save_file() {
 find_files() {
     trap 'handle_error $? $LINENO' ERR
     local -r directory=$1
-    $TOUCH --date="${SINCE_DATE}" "${REFERENCE_FILE}"
     local -r find_command="find -L $directory -type f -newer ${REFERENCE_FILE}"
 
     echo $($find_command)
@@ -1914,6 +1913,8 @@ main() {
     ${CMD_PREFIX}renice +5 -p $$ >> /dev/null
     ${CMD_PREFIX}ionice -c 2 -n 5 -p $$ >> /dev/null
 
+    # Created file as a reference to compare modification time
+    $TOUCH --date="${SINCE_DATE}" "${REFERENCE_FILE}"
     $MKDIR $V -p $TARDIR
 
     # Start with this script so its obvious what code is responsible


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Show techsupport is designed to collect logs and core files since given date.
I find that some core files are missing when given date is relative, for example "5 minutes ago".
Microsoft ADO: 28737486

#### How I did it
Create the reference file at the start of the script, and don't update it in find_files.

#### How to verify it
Run end to end test: show_techsupport/test_auto_techsupport.py

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

