### PR TITLE
Fix kexec_unload failure on secure boot enabled platforms

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -147,7 +147,7 @@ function clear_boot()
     # common_clear
     debug "${REBOOT_TYPE} failure ($?) cleanup ..."
 
-    /sbin/kexec -u || /bin/true
+    /sbin/kexec -u -a || /bin/true
 
     teardown_control_plane_assistant
 
@@ -519,7 +519,7 @@ function unload_kernel()
 {
     # Unload the previously loaded kernel if any loaded
     if [[ "$(cat /sys/kernel/kexec_loaded)" -eq 1 ]]; then
-        /sbin/kexec -u
+        /sbin/kexec -u -a
     fi
 }
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did

kexec -u on systems with SB enabled is failing

Fixes https://github.com/sonic-net/sonic-buildimage/issues/18007

```
root@sn5600:/home/admin# mokutil --sb-state
SecureBoot enabled
root@sn5600:/home/admin# kexec -u
kexec unload failed: Permission denied

[ 3443.199576] ima: impossible to appraise a kernel image without a file descriptor; try using kexec_file_load syscall.
```

#### How I did it

#### How to verify it

Use the -a argument with kexec 

```
 -a, --kexec-syscall-auto  Use file based syscall for kexec and fall
                      back to the compatibility syscall when file based
                      syscall is not supported or the kernel did not
                      understand the image
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

