### PR TITLE
[fast-reboot] Fix delaying counters: apply config to running CONFIG_DB

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -14,9 +14,15 @@ DEFLT_60_SEC= "default (60000)"
 DEFLT_10_SEC= "default (10000)"
 DEFLT_1_SEC = "default (1000)"
 
+
 @click.group()
-def cli():
+@click.pass_context
+def cli(ctx):
     """ SONiC Static Counter Poll configurations """
+
+    ctx.obj = ConfigDBConnector()
+    ctx.obj.connect()
+
 
 # Queue counter commands
 @cli.group()
@@ -381,6 +387,19 @@ def disable(ctx):
     fc_info = {}
     fc_info['FLEX_COUNTER_STATUS'] = 'disable'
     ctx.obj.mod_entry("FLEX_COUNTER_TABLE", "FLOW_CNT_ROUTE", fc_info)
+
+
+@cli.command()
+@click.pass_context
+def delay(ctx):
+    """ Delays all counters for next boot """
+    config_db = ctx.obj
+
+    for key in config_db.get_keys('FLEX_COUNTER_TABLE'):
+        entry = config_db.get_entry('FLEX_COUNTER_TABLE', key)
+        entry['FLEX_COUNTER_DELAY_STATUS'] = 'true'
+        config_db.mod_entry('FLEX_COUNTER_TABLE', key, entry)
+
 
 @cli.command()
 def show():

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -5,7 +5,6 @@ REBOOT_TIME=$(date)
 REBOOT_CAUSE_FILE="/host/reboot-cause/reboot-cause.txt"
 WARM_DIR=/host/warmboot
 REDIS_FILE=dump.rdb
-CONFIG_DB_FILE=/etc/sonic/config_db.json
 REBOOT_SCRIPT_NAME=$(basename $0)
 REBOOT_TYPE="${REBOOT_SCRIPT_NAME}"
 SHUTDOWN_ORDER_FILE="/etc/sonic/${REBOOT_TYPE}_order"
@@ -722,8 +721,8 @@ fi
 
 if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
     COUNTERPOLL_DELAY_RC=0
-    # Delay counters in config_db.json
-    /usr/local/bin/counterpoll config-db delay $CONFIG_DB_FILE || COUNTERPOLL_DELAY_RC=$?
+    # Delay counters in CONFIG_DB
+    /usr/local/bin/counterpoll delay || COUNTERPOLL_DELAY_RC=$?
     if [[ COUNTERPOLL_DELAY_RC -ne 0 ]]; then
         error "Failed to delay counterpoll. Exit code: $COUNTERPOLL_DELAY_RC"
         unload_kernel

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -221,6 +221,21 @@ class TestCounterpoll(object):
         assert result.exit_code == 2
         assert expected in result.output
 
+    def test_delay(self):
+        runner = CliRunner()
+        db = Db()
+
+        for key in db.cfgdb.get_keys('FLEX_COUNTER_TABLE'):
+            entry = db.cfgdb.get_entry('FLEX_COUNTER_TABLE', key)
+            assert 'FLEX_COUNTER_DELAY_STATUS' not in entry
+
+        result = runner.invoke(counterpoll.cli.commands["delay"], [], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        for key in db.cfgdb.get_keys('FLEX_COUNTER_TABLE'):
+            entry = db.cfgdb.get_entry('FLEX_COUNTER_TABLE', key)
+            assert entry['FLEX_COUNTER_DELAY_STATUS'] == 'true'
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Delay flag was set to config_db.json, however, now fast reboot uses running config_db DB dump instead of config_db.json, therefore the delay wasn't set to the right place and didn't have any effect.

Otherwise, orchagent is busy for a long time queries objects before sending APPLY_VIEW.

#### How I did it

Set delay flag to running config_db.

#### How to verify it

Do fast-reboot, check that delay flag is set, orchagent does not init counters yet, after some time, delay flag is unset.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

