### PR TITLE
Combine multiple database write operations into one for ecnconfig

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -168,25 +168,17 @@ class EcnConfig(object):
 
         return result
 
-    def set_wred_threshold(self, profile, threshold, value):
+    def set_wred_attributes(self, profile, attributes):
         chk_exec_privilege()
 
-        field = WRED_CONFIG_FIELDS[threshold]
-        if self.verbose:
-            print("Setting %s value to %s" % (field, value))
-        self.db.mod_entry(WRED_PROFILE_TABLE_NAME, profile, {field: value})
-        if self.filename is not None:
-            prof_table = self.db.get_table(WRED_PROFILE_TABLE_NAME)
-            with open(self.filename, "w") as fd:
-                json.dump(prof_table, fd)
-
-    def set_wred_prob(self, profile, drop_color, value):
-        chk_exec_privilege()
-
-        field = WRED_CONFIG_FIELDS[drop_color]
-        if self.verbose:
-            print("Setting %s value to %s%%" % (field, value))
-        self.db.mod_entry(WRED_PROFILE_TABLE_NAME, profile, {field: value})
+        attribute_info = {}
+        for f in attributes:
+            field = WRED_CONFIG_FIELDS[f]
+            value = attributes[f]
+            if self.verbose:
+                print("Setting %s value to %s%%" % (field, value))
+            attribute_info[field] = value
+        self.db.mod_entry(WRED_PROFILE_TABLE_NAME, profile, attribute_info)
         if self.filename is not None:
             prof_table = self.db.get_table(WRED_PROFILE_TABLE_NAME)
             with open(self.filename, "w") as fd:
@@ -352,24 +344,27 @@ def main():
 
                 # apply new configuration
                 # the following parameters can be combined in one run
+                new_attributes = {}
                 if args.green_max:
-                    prof_cfg.set_wred_threshold(args.profile, "gmax", args.green_max)
+                    new_attributes["gmax"] = args.green_max
                 if args.green_min:
-                    prof_cfg.set_wred_threshold(args.profile, "gmin", args.green_min)
+                    new_attributes["gmin"] = args.green_min
                 if args.yellow_max:
-                    prof_cfg.set_wred_threshold(args.profile, "ymax", args.yellow_max)
+                    new_attributes["ymax"] = args.yellow_max
                 if args.yellow_min:
-                    prof_cfg.set_wred_threshold(args.profile, "ymin", args.yellow_min)
+                    new_attributes["ymin"] = args.yellow_min
                 if args.red_max:
-                    prof_cfg.set_wred_threshold(args.profile, "rmax", args.red_max)
+                    new_attributes["rmax"] = args.red_max
                 if args.red_min:
-                    prof_cfg.set_wred_threshold(args.profile, "rmin", args.red_min)
+                    new_attributes["rmin"] = args.red_min
                 if args.green_drop_prob:
-                    prof_cfg.set_wred_prob(args.profile, "gdrop", args.green_drop_prob)
+                    new_attributes["gdrop"] = args.green_drop_prob
                 if args.yellow_drop_prob:
-                    prof_cfg.set_wred_prob(args.profile, "ydrop", args.yellow_drop_prob)
+                    new_attributes["ydrop"] = args.yellow_drop_prob
                 if args.red_drop_prob:
-                    prof_cfg.set_wred_prob(args.profile, "rdrop", args.red_drop_prob)
+                    new_attributes["rdrop"] = args.red_drop_prob
+                if new_attributes:
+                    prof_cfg.set_wred_attributes(args.profile, new_attributes)
 
         elif args.queue:
             arg_len_min = 3


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update the ecnconfig to optimize the configuration by not having to update per attribute configured.

#### How I did it
Combine multiple database write operations into one.

#### How to verify it
Verified it on testbed.
Reduce the time from 7 seconds to 3 seconds according to file sairedis.asic0.rec.

Old log:
```
sudo ip netns exec asic0 ecnconfig -p AZURE_LOSSLESS -gmin 1048576 -gmax 4194304 -gdrop 5 // 7 seconds

2024-07-25.22:56:32.456074|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_ECN_MARK_MODE=SAI_ECN_MARK_MODE_GREEN_YELLOW
2024-07-25.22:56:32.956405|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_DROP_PROBABILITY=100
2024-07-25.22:56:33.460428|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_MAX_THRESHOLD=4194304
2024-07-25.22:56:34.020608|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_MIN_THRESHOLD=1048576
2024-07-25.22:56:34.537116|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_ENABLE=true
2024-07-25.22:56:34.596754|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_ENABLE=true
2024-07-25.22:56:34.597617|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_DROP_PROBABILITY=0
2024-07-25.22:56:35.127506|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_MAX_THRESHOLD=6144000
2024-07-25.22:56:35.674162|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_MIN_THRESHOLD=0

2024-07-25.22:56:36.357615|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_ECN_MARK_MODE=SAI_ECN_MARK_MODE_GREEN_YELLOW
2024-07-25.22:56:36.918050|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_DROP_PROBABILITY=5
2024-07-25.22:56:37.564106|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_MAX_THRESHOLD=4194304
2024-07-25.22:56:38.064905|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_MIN_THRESHOLD=1048576
2024-07-25.22:56:38.676530|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_ENABLE=true
2024-07-25.22:56:38.695258|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_ENABLE=true
2024-07-25.22:56:38.696198|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_DROP_PROBABILITY=0
2024-07-25.22:56:39.193380|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_MAX_THRESHOLD=6144000
2024-07-25.22:56:39.733325|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_MIN_THRESHOLD=0
```

New log:
```
sudo ip netns exec asic0 ecnconfig -p AZURE_LOSSLESS -gmin 1048576 -gmax 4194304 -gdrop 5 // 3 seconds

2024-07-26.00:23:21.509712|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_ECN_MARK_MODE=SAI_ECN_MARK_MODE_GREEN_YELLOW
2024-07-26.00:23:21.985441|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_DROP_PROBABILITY=5
2024-07-26.00:23:22.473747|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_MAX_THRESHOLD=4194304
2024-07-26.00:23:23.054270|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_MIN_THRESHOLD=1048576
2024-07-26.00:23:23.603101|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_GREEN_ENABLE=true
2024-07-26.00:23:23.657349|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_ENABLE=true
2024-07-26.00:23:23.657825|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_DROP_PROBABILITY=0
2024-07-26.00:23:24.155250|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_MAX_THRESHOLD=6144000
2024-07-26.00:23:24.682135|s|SAI_OBJECT_TYPE_WRED:oid:0x130000000006ae|SAI_WRED_ATTR_YELLOW_MIN_THRESHOLD=0
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

