### PR TITLE
[reboot]: Allow reboot to happen regardless vendor hook errors

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -276,6 +276,10 @@ fi
 if [ -x ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK} ]; then
     debug "Executing the pre-reboot script"
     ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK}
+    EXIT_CODE="$?"
+    if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then
+        debug "WARNING: Failed to handle pre-reboot script: rc=${EXIT_CODE}"
+    fi
 fi
 
 if [ -x ${WATCHDOG_UTIL} ]; then

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -41,7 +41,6 @@ REBOOT_SCRIPT_NAME=$(basename $0)
 REBOOT_TYPE="${REBOOT_SCRIPT_NAME}"
 TAG_LATEST=no
 REBOOT_FLAGS=""
-FORCE_REBOOT="no"
 
 function debug()
 {
@@ -192,7 +191,6 @@ function parse_options()
                 ;;
             f )
                 REBOOT_FLAGS+=" -f"
-                FORCE_REBOOT="yes"
                 ;;
         esac
     done
@@ -278,13 +276,6 @@ fi
 if [ -x ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK} ]; then
     debug "Executing the pre-reboot script"
     ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK}
-    EXIT_CODE=$?
-    if [[ ${EXIT_CODE} != ${EXIT_SUCCESS} ]]; then
-        if [[ "${FORCE_REBOOT}" != "yes" ]]; then
-            echo "Reboot is interrupted: use -f (force) to override"
-            exit ${EXIT_ERROR}
-        fi
-    fi
 fi
 
 if [ -x ${WATCHDOG_UTIL} ]; then


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
The fix is aimed to resolve reboot issue when vendor reboot hook is executed during `syncd` service startup.

Relevant PRs:
1. https://github.com/sonic-net/sonic-utilities/pull/3203
2. https://github.com/sonic-net/sonic-utilities/pull/819

#### What I did
* Fixed reboot failure in case of vendor reboot hook error

#### How I did it
* Removed error validation

#### How to verify it
1. Execute `reboot` when `syncd` is starting and ASIC reset is in progress

#### Previous command output (if the output of a command-line utility has changed)
* N/A

#### New command output (if the output of a command-line utility has changed)
* N/A