### PR TITLE
Add namespace check for multiasic

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -31,6 +31,9 @@ def extract_scope(path):
         scope = HOST_NAMESPACE
         remainder = "/" + "/".join(parts[1:])
     else:
+        if multi_asic.is_multi_asic():
+            raise GenericConfigUpdaterError(f"Multi ASIC must have namespace prefix in path: '{path}'.")
+
         scope = ""
         remainder = path
     return scope, remainder

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -13,23 +13,57 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
     def test_extract_scope_multiasic(self, mock_is_multi_asic):
         mock_is_multi_asic.return_value = True
         test_paths_expectedresults = {
-            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status":  (True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
-            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
-            "/sometable/data": (False, "", "/sometable/data"),
-            "": (False, "", ""),
-            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (False, "", ""),
-            "/asic77": (False, "", ""),
-            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/sometable/data": (
+                False, "", "/sometable/data"
+            ),
+            "": (
+                False, "", ""
+            ),
+            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                False, "", ""
+            ),
+            "/asic77": (
+                False, "", ""
+            ),
+            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
         }
 
         for test_path, (result, expectedscope, expectedremainder) in test_paths_expectedresults.items():
@@ -37,30 +71,62 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
                 scope, remainder = extract_scope(test_path)
                 assert(scope == expectedscope)
                 assert(remainder == expectedremainder)
-            except Exception as e:
+            except Exception:
                 assert(not result)
 
     @patch('sonic_py_common.multi_asic.is_multi_asic')
     def test_extract_scope_singleasic(self, mock_is_multi_asic):
         mock_is_multi_asic.return_value = False
         test_paths_expectedresults = {
-            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status":  (True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
-            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
-            "/sometable/data": (True, "", "/sometable/data"),
-            "": (False, "", ""),
-            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (False, "", ""),
+            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status":  (
+                True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/sometable/data": (
+                True, "", "/sometable/data"
+            ),
+            "": (
+                False, "", ""
+            ),
+            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                False, "", ""
+            ),
             "/asic77": (False, "", ""),
-            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
         }
 
         for test_path, (result, expectedscope, expectedremainder) in test_paths_expectedresults.items():
@@ -68,7 +134,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
                 scope, remainder = extract_scope(test_path)
                 assert(scope == expectedscope)
                 assert(remainder == expectedremainder)
-            except Exception as e:
+            except Exception:
                 assert(not result)
 
     @patch('generic_config_updater.change_applier.ChangeApplier._get_running_config', autospec=True)

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -9,7 +9,40 @@ import generic_config_updater.gu_common
 
 class TestMultiAsicChangeApplier(unittest.TestCase):
 
-    def test_extract_scope(self):
+    @patch('sonic_py_common.multi_asic.is_multi_asic')
+    def test_extract_scope_multiasic(self, mock_is_multi_asic):
+        mock_is_multi_asic.return_value = True
+        test_paths_expectedresults = {
+            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"),
+            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"),
+            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status":  (True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
+            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
+            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
+            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
+            "/sometable/data": (False, "", "/sometable/data"),
+            "": (False, "", ""),
+            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (False, "", ""),
+            "/asic77": (False, "", ""),
+            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+        }
+
+        for test_path, (result, expectedscope, expectedremainder) in test_paths_expectedresults.items():
+            try:
+                scope, remainder = extract_scope(test_path)
+                assert(scope == expectedscope)
+                assert(remainder == expectedremainder)
+            except Exception as e:
+                assert(not result)
+
+    @patch('sonic_py_common.multi_asic.is_multi_asic')
+    def test_extract_scope_singleasic(self, mock_is_multi_asic):
+        mock_is_multi_asic.return_value = False
         test_paths_expectedresults = {
             "/asic0/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"),
             "/asic01/PORTCHANNEL/PortChannel102/admin_status": (True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"),
@@ -36,7 +69,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
                 assert(scope == expectedscope)
                 assert(remainder == expectedremainder)
             except Exception as e:
-                assert(result == False)
+                assert(not result)
 
     @patch('generic_config_updater.change_applier.ChangeApplier._get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add namespace check for multiasic

#### How I did it
If device is multi asic, check whether namespace appear.

#### How to verify it

1. Multi ASIC
```
admin@str2-7250-lc1-2:~$ cat badpatch.json 
[
    {
        "op": "add",
        "path": "/AAA",
        "value": {
            "accounting": {
                "login": "tacacs+,local"
            },
            "authentication": {
                "debug": "True",
                "failthrough": "True",
                "fallback": "True",
                "login": "tacacs+",
                "trace": "True"
            },
            "authorization": {
                "login": "tacacs+,local"
            }
        }
    }
]

admin@str2-7250-lc1-2:~$ sudo config apply-patch badpatch.json 
sonic_yang(6):Note: Below table(s) have no YANG models: DHCP_SERVER
Failed to apply patch due to: Multi ASIC must have namespace prefix in path: '/AAA'.
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Multi ASIC must have namespace prefix in path: '/AAA'.
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

