### PR TITLE
Fix for config replace issues seen with COPP configurations

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -856,6 +856,17 @@ class DBMigrator():
             if keys:
                 self.configDB.delete(self.configDB.CONFIG_DB, authorization_key)
 
+    def migrate_config_db_copp_group_trap_action_mandatory_node(self):
+        """
+        Migrate COPP_GROUP table, for 'default' group Yang mandatory node
+        'trap_action' was missing, so add the same so that Yang validation
+        will go through
+        """
+        copp_group_def = self.configDB.get_entry('COPP_GROUP', 'default')
+        if 'trap_action' not in copp_group_def:
+           copp_group_def['trap_action'] = 'trap'
+           self.configDB.set_entry('COPP_GROUP', 'default', copp_group_def)
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -1240,6 +1251,10 @@ class DBMigrator():
         master branch until 202411 branch is created.
         """
         log.log_info('Handling version_202411_01')
+
+        if self.configDB.keys(self.configDB.CONFIG_DB, "COPP_GROUP|default"):
+            self.migrate_config_db_copp_group_trap_action_mandatory_node()
+
         return None
 
     def get_version(self):


### PR DESCRIPTION
• Issue: config replace/yang-validation fails for COPP configurations.

• Root cause: 
   • COPP's device initial config **copp_cfg.json** has missing yang mandatory leaf "trap_action" for "default" COPP_GROUP. 
   • "genetlink_name" & "genetlink_mcgrp_name" nodes are not added in sonic-copp.yang, which are used for "queue2_group1" in copp_cfg.json

• Fix: 
   •  In copp_cfg.json, mandatory leaf  "trap_action" is added for "default" COPP_GROUP.

  "COPP_GROUP": {
        "default": {
     + "trap_action":"trap", <<< this node needs to be added
        "queue": "0",
        "meter_type":"packets",

   •  "genetlink_name" and "genetlink_mcgrp_name" leaves are added in sonic-copp.yang.
		
   •  DB Migration script is updated to upgrade the DB config automatically.

Tests :
Config replace -> 
	i. Config load copp_cfg.json
	ii. Config save
	iii. Config replace -> Ensure no error seen

Upgrade -> 
         i.  Save config in build without the fix
         ii. upgrade to build with changes and ensure configurations are reflected in new config_db.json

PRs :
Sonic-buildimage :  https://github.com/sonic-net/sonic-buildimage/pull/19816
Sonic-utilities :  https://github.com/sonic-net/sonic-utilities/pull/3472