### PR TITLE
[COPP:Yang-changes] Fix for config replace issues seen with COPP configurations

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -864,8 +864,8 @@ class DBMigrator():
         """
         copp_group_def = self.configDB.get_entry('COPP_GROUP', 'default')
         if 'trap_action' not in copp_group_def:
-           copp_group_def['trap_action'] = 'trap'
-           self.configDB.set_entry('COPP_GROUP', 'default', copp_group_def)
+            copp_group_def['trap_action'] = 'trap'
+            self.configDB.set_entry('COPP_GROUP', 'default', copp_group_def)
 
     def version_unknown(self):
         """

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -1242,6 +1242,10 @@ class DBMigrator():
         Version 202405_01.
         """
         log.log_info('Handling version_202405_01')
+
+        if self.configDB.keys(self.configDB.CONFIG_DB, "COPP_GROUP|default"):
+            self.migrate_config_db_copp_group_trap_action_mandatory_node()
+
         self.set_version('version_202411_01')
         return 'version_202411_01'
 
@@ -1251,10 +1255,6 @@ class DBMigrator():
         master branch until 202411 branch is created.
         """
         log.log_info('Handling version_202411_01')
-
-        if self.configDB.keys(self.configDB.CONFIG_DB, "COPP_GROUP|default"):
-            self.migrate_config_db_copp_group_trap_action_mandatory_node()
-
         return None
 
     def get_version(self):

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -856,6 +856,17 @@ class DBMigrator():
             if keys:
                 self.configDB.delete(self.configDB.CONFIG_DB, authorization_key)
 
+    def migrate_config_db_copp_group_trap_action_mandatory_node(self):
+        """
+        Migrate COPP_GROUP table, for 'default' group Yang mandatory node
+        'trap_action' was missing, so add the same so that Yang validation
+        will go through
+        """
+        copp_group_def = self.configDB.get_entry('COPP_GROUP', 'default')
+        if 'trap_action' not in copp_group_def:
+           copp_group_def['trap_action'] = 'trap'
+           self.configDB.set_entry('COPP_GROUP', 'default', copp_group_def)
+
     def version_unknown(self):
         """
         version_unknown tracks all SONiC versions that doesn't have a version
@@ -1240,6 +1251,10 @@ class DBMigrator():
         master branch until 202411 branch is created.
         """
         log.log_info('Handling version_202411_01')
+
+        if self.configDB.keys(self.configDB.CONFIG_DB, "COPP_GROUP|default"):
+            self.migrate_config_db_copp_group_trap_action_mandatory_node()
+
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/copp_group_table_expected.json
+++ b/tests/db_migrator_input/config_db/copp_group_table_expected.json
@@ -114,5 +114,5 @@
 	"COPP_TRAP|sflow": {
 	    "trap_group": "queue2_group1",
 	    "trap_ids": "sample_packet"
-	},
+	}
 }

--- a/tests/db_migrator_input/config_db/copp_group_table_expected.json
+++ b/tests/db_migrator_input/config_db/copp_group_table_expected.json
@@ -1,122 +1,118 @@
 {
-    "COPP_GROUP": {
-	    "default": {
-		    "queue": "0",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"600",
-		    "cbs":"600",
-		    "red_action":"drop",
-                    "trap_action":"trap"
-	    },
-	    "queue4_group1": {
-		    "trap_action":"trap",
-		    "trap_priority":"4",
-		    "queue": "4",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"6000",
-		    "cbs":"6000",
-		    "red_action":"drop"
-	    },
-	    "queue4_group2": {
-		    "trap_action":"copy",
-		    "trap_priority":"4",
-		    "queue": "4",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"600",
-		    "cbs":"600",
-		    "red_action":"drop"
-	    },
-	    "queue4_group3": {
-		    "trap_action":"trap",
-		    "trap_priority":"4",
-		    "queue": "4",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"300",
-		    "cbs":"300",
-		    "red_action":"drop"
-	    },
-	    "queue1_group1": {
-		    "trap_action":"trap",
-		    "trap_priority":"1",
-		    "queue": "1",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"6000",
-		    "cbs":"6000",
-		    "red_action":"drop"
-	    },
-	    "queue1_group2": {
-		    "trap_action":"trap",
-		    "trap_priority":"1",
-		    "queue": "1",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"600",
-		    "cbs":"600",
-		    "red_action":"drop"
-	    },
-	    "queue2_group1": {
-		    "cbs": "1000",
-		    "cir": "1000",
-		    "genetlink_mcgrp_name": "packets",
-		    "genetlink_name": "psample",
-		    "meter_type": "packets",
-		    "mode": "sr_tcm",
-		    "queue": "2",
-		    "red_action": "drop",
-		    "trap_action": "trap",
-		    "trap_priority": "1"
-
-	    }
+    "COPP_GROUP|default": {
+	"queue": "0",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"600",
+	    "cbs":"600",
+	    "red_action":"drop",
+            "trap_action":"trap"
     },
-    "COPP_TRAP": {
-	    "bgp": {
-		    "trap_ids": "bgp,bgpv6",
-		    "trap_group": "queue4_group1"
-	    },
-	    "lacp": {
-		    "trap_ids": "lacp",
-		    "trap_group": "queue4_group1",
-		    "always_enabled": "true"
-	    },
-	    "arp": {
-		    "trap_ids": "arp_req,arp_resp,neigh_discovery",
-		    "trap_group": "queue4_group2",
-		    "always_enabled": "true"
-	    },
-	    "lldp": {
-		    "trap_ids": "lldp",
-		    "trap_group": "queue4_group3"
-	    },
-	    "dhcp_relay": {
-		    "trap_ids": "dhcp,dhcpv6",
-		    "trap_group": "queue4_group3"
-	    },
-	    "udld": {
-		    "trap_ids": "udld",
-		    "trap_group": "queue4_group3",
-		    "always_enabled": "true"
-	    },
-	    "ip2me": {
-		    "trap_ids": "ip2me",
-		    "trap_group": "queue1_group1",
-		    "always_enabled": "true"
-	    },
-	    "macsec": {
-		    "trap_ids": "eapol",
-		    "trap_group": "queue4_group1"
-	    },
-	    "nat": {
-		    "trap_ids": "src_nat_miss,dest_nat_miss",
-		    "trap_group": "queue1_group2"
-	    },
-	    "sflow": {
-		    "trap_group": "queue2_group1",
-		    "trap_ids": "sample_packet"
-	    }
-    }
+	"COPP_GROUP|queue4_group1": {
+	    "trap_action":"trap",
+	    "trap_priority":"4",
+	    "queue": "4",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"6000",
+	    "cbs":"6000",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue4_group2": {
+	    "trap_action":"copy",
+	    "trap_priority":"4",
+	    "queue": "4",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"600",
+	    "cbs":"600",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue4_group3": {
+	    "trap_action":"trap",
+	    "trap_priority":"4",
+	    "queue": "4",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"300",
+	    "cbs":"300",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue1_group1": {
+	    "trap_action":"trap",
+	    "trap_priority":"1",
+	    "queue": "1",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"6000",
+	    "cbs":"6000",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue1_group2": {
+	    "trap_action":"trap",
+	    "trap_priority":"1",
+	    "queue": "1",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"600",
+	    "cbs":"600",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue2_group1": {
+	    "cbs": "1000",
+	    "cir": "1000",
+	    "genetlink_mcgrp_name": "packets",
+	    "genetlink_name": "psample",
+	    "meter_type": "packets",
+	    "mode": "sr_tcm",
+	    "queue": "2",
+	    "red_action": "drop",
+	    "trap_action": "trap",
+	    "trap_priority": "1"
+
+	},
+	"COPP_TRAP|bgp": {
+	    "trap_ids": "bgp,bgpv6",
+	    "trap_group": "queue4_group1"
+	},
+	"COPP_TRAP|lacp": {
+	    "trap_ids": "lacp",
+	    "trap_group": "queue4_group1",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|arp": {
+	    "trap_ids": "arp_req,arp_resp,neigh_discovery",
+	    "trap_group": "queue4_group2",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|lldp": {
+	    "trap_ids": "lldp",
+	    "trap_group": "queue4_group3"
+	},
+	"COPP_TRAP|dhcp_relay": {
+	    "trap_ids": "dhcp,dhcpv6",
+	    "trap_group": "queue4_group3"
+	},
+	"COPP_TRAP|udld": {
+	    "trap_ids": "udld",
+	    "trap_group": "queue4_group3",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|ip2me": {
+	    "trap_ids": "ip2me",
+	    "trap_group": "queue1_group1",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|macsec": {
+	    "trap_ids": "eapol",
+	    "trap_group": "queue4_group1"
+	},
+	"COPP_TRAP|nat": {
+	    "trap_ids": "src_nat_miss,dest_nat_miss",
+	    "trap_group": "queue1_group2"
+	},
+	"COPP_TRAP|sflow": {
+	    "trap_group": "queue2_group1",
+	    "trap_ids": "sample_packet"
+	},
 }

--- a/tests/db_migrator_input/config_db/copp_group_table_expected.json
+++ b/tests/db_migrator_input/config_db/copp_group_table_expected.json
@@ -1,0 +1,122 @@
+{
+    "COPP_GROUP": {
+	    "default": {
+		    "queue": "0",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"600",
+		    "cbs":"600",
+		    "red_action":"drop",
+                    "trap_action":"trap"
+	    },
+	    "queue4_group1": {
+		    "trap_action":"trap",
+		    "trap_priority":"4",
+		    "queue": "4",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"6000",
+		    "cbs":"6000",
+		    "red_action":"drop"
+	    },
+	    "queue4_group2": {
+		    "trap_action":"copy",
+		    "trap_priority":"4",
+		    "queue": "4",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"600",
+		    "cbs":"600",
+		    "red_action":"drop"
+	    },
+	    "queue4_group3": {
+		    "trap_action":"trap",
+		    "trap_priority":"4",
+		    "queue": "4",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"300",
+		    "cbs":"300",
+		    "red_action":"drop"
+	    },
+	    "queue1_group1": {
+		    "trap_action":"trap",
+		    "trap_priority":"1",
+		    "queue": "1",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"6000",
+		    "cbs":"6000",
+		    "red_action":"drop"
+	    },
+	    "queue1_group2": {
+		    "trap_action":"trap",
+		    "trap_priority":"1",
+		    "queue": "1",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"600",
+		    "cbs":"600",
+		    "red_action":"drop"
+	    },
+	    "queue2_group1": {
+		    "cbs": "1000",
+		    "cir": "1000",
+		    "genetlink_mcgrp_name": "packets",
+		    "genetlink_name": "psample",
+		    "meter_type": "packets",
+		    "mode": "sr_tcm",
+		    "queue": "2",
+		    "red_action": "drop",
+		    "trap_action": "trap",
+		    "trap_priority": "1"
+
+	    }
+    },
+    "COPP_TRAP": {
+	    "bgp": {
+		    "trap_ids": "bgp,bgpv6",
+		    "trap_group": "queue4_group1"
+	    },
+	    "lacp": {
+		    "trap_ids": "lacp",
+		    "trap_group": "queue4_group1",
+		    "always_enabled": "true"
+	    },
+	    "arp": {
+		    "trap_ids": "arp_req,arp_resp,neigh_discovery",
+		    "trap_group": "queue4_group2",
+		    "always_enabled": "true"
+	    },
+	    "lldp": {
+		    "trap_ids": "lldp",
+		    "trap_group": "queue4_group3"
+	    },
+	    "dhcp_relay": {
+		    "trap_ids": "dhcp,dhcpv6",
+		    "trap_group": "queue4_group3"
+	    },
+	    "udld": {
+		    "trap_ids": "udld",
+		    "trap_group": "queue4_group3",
+		    "always_enabled": "true"
+	    },
+	    "ip2me": {
+		    "trap_ids": "ip2me",
+		    "trap_group": "queue1_group1",
+		    "always_enabled": "true"
+	    },
+	    "macsec": {
+		    "trap_ids": "eapol",
+		    "trap_group": "queue4_group1"
+	    },
+	    "nat": {
+		    "trap_ids": "src_nat_miss,dest_nat_miss",
+		    "trap_group": "queue1_group2"
+	    },
+	    "sflow": {
+		    "trap_group": "queue2_group1",
+		    "trap_ids": "sample_packet"
+	    }
+    }
+}

--- a/tests/db_migrator_input/config_db/copp_group_table_input.json
+++ b/tests/db_migrator_input/config_db/copp_group_table_input.json
@@ -1,124 +1,120 @@
 {
-    "COPP_GROUP": {
-	    "default": {
-		    "queue": "0",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"600",
-		    "cbs":"600",
-		    "red_action":"drop"
-	    },
-	    "queue4_group1": {
-		    "trap_action":"trap",
-		    "trap_priority":"4",
-		    "queue": "4",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"6000",
-		    "cbs":"6000",
-		    "red_action":"drop"
-	    },
-	    "queue4_group2": {
-		    "trap_action":"copy",
-		    "trap_priority":"4",
-		    "queue": "4",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"600",
-		    "cbs":"600",
-		    "red_action":"drop"
-	    },
-	    "queue4_group3": {
-		    "trap_action":"trap",
-		    "trap_priority":"4",
-		    "queue": "4",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"300",
-		    "cbs":"300",
-		    "red_action":"drop"
-	    },
-	    "queue1_group1": {
-		    "trap_action":"trap",
-		    "trap_priority":"1",
-		    "queue": "1",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"6000",
-		    "cbs":"6000",
-		    "red_action":"drop"
-	    },
-	    "queue1_group2": {
-		    "trap_action":"trap",
-		    "trap_priority":"1",
-		    "queue": "1",
-		    "meter_type":"packets",
-		    "mode":"sr_tcm",
-		    "cir":"600",
-		    "cbs":"600",
-		    "red_action":"drop"
-	    },
-	    "queue2_group1": {
-		    "cbs": "1000",
-		    "cir": "1000",
-		    "genetlink_mcgrp_name": "packets",
-		    "genetlink_name": "psample",
-		    "meter_type": "packets",
-		    "mode": "sr_tcm",
-		    "queue": "2",
-		    "red_action": "drop",
-		    "trap_action": "trap",
-		    "trap_priority": "1"
+    "COPP_GROUP|default": {
+	"queue": "0",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"600",
+	    "cbs":"600",
+	    "red_action":"drop"
+    },
+	"COPP_GROUP|queue4_group1": {
+	    "trap_action":"trap",
+	    "trap_priority":"4",
+	    "queue": "4",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"6000",
+	    "cbs":"6000",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue4_group2": {
+	    "trap_action":"copy",
+	    "trap_priority":"4",
+	    "queue": "4",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"600",
+	    "cbs":"600",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue4_group3": {
+	    "trap_action":"trap",
+	    "trap_priority":"4",
+	    "queue": "4",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"300",
+	    "cbs":"300",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue1_group1": {
+	    "trap_action":"trap",
+	    "trap_priority":"1",
+	    "queue": "1",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"6000",
+	    "cbs":"6000",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue1_group2": {
+	    "trap_action":"trap",
+	    "trap_priority":"1",
+	    "queue": "1",
+	    "meter_type":"packets",
+	    "mode":"sr_tcm",
+	    "cir":"600",
+	    "cbs":"600",
+	    "red_action":"drop"
+	},
+	"COPP_GROUP|queue2_group1": {
+	    "cbs": "1000",
+	    "cir": "1000",
+	    "genetlink_mcgrp_name": "packets",
+	    "genetlink_name": "psample",
+	    "meter_type": "packets",
+	    "mode": "sr_tcm",
+	    "queue": "2",
+	    "red_action": "drop",
+	    "trap_action": "trap",
+	    "trap_priority": "1"
 
-	    }
-    },
-    "COPP_TRAP": {
-	    "bgp": {
-		    "trap_ids": "bgp,bgpv6",
-		    "trap_group": "queue4_group1"
-	    },
-	    "lacp": {
-		    "trap_ids": "lacp",
-		    "trap_group": "queue4_group1",
-		    "always_enabled": "true"
-	    },
-	    "arp": {
-		    "trap_ids": "arp_req,arp_resp,neigh_discovery",
-		    "trap_group": "queue4_group2",
-		    "always_enabled": "true"
-	    },
-	    "lldp": {
-		    "trap_ids": "lldp",
-		    "trap_group": "queue4_group3"
-	    },
-	    "dhcp_relay": {
-		    "trap_ids": "dhcp,dhcpv6",
-		    "trap_group": "queue4_group3"
-	    },
-	    "udld": {
-		    "trap_ids": "udld",
-		    "trap_group": "queue4_group3",
-		    "always_enabled": "true"
-	    },
-	    "ip2me": {
-		    "trap_ids": "ip2me",
-		    "trap_group": "queue1_group1",
-		    "always_enabled": "true"
-	    },
-	    "macsec": {
-		    "trap_ids": "eapol",
-		    "trap_group": "queue4_group1"
-	    },
-	    "nat": {
-		    "trap_ids": "src_nat_miss,dest_nat_miss",
-		    "trap_group": "queue1_group2"
-	    },
-	    "sflow": {
-		    "trap_group": "queue2_group1",
-		    "trap_ids": "sample_packet"
-	    }
-    },
-    "VERSIONS|DATABASE": {
-        "VERSION": "version_202311_03"
-    }
+	},
+	"COPP_TRAP|bgp": {
+	    "trap_ids": "bgp,bgpv6",
+	    "trap_group": "queue4_group1"
+	},
+	"COPP_TRAP|lacp": {
+	    "trap_ids": "lacp",
+	    "trap_group": "queue4_group1",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|arp": {
+	    "trap_ids": "arp_req,arp_resp,neigh_discovery",
+	    "trap_group": "queue4_group2",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|lldp": {
+	    "trap_ids": "lldp",
+	    "trap_group": "queue4_group3"
+	},
+	"COPP_TRAP|dhcp_relay": {
+	    "trap_ids": "dhcp,dhcpv6",
+	    "trap_group": "queue4_group3"
+	},
+	"COPP_TRAP|udld": {
+	    "trap_ids": "udld",
+	    "trap_group": "queue4_group3",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|ip2me": {
+	    "trap_ids": "ip2me",
+	    "trap_group": "queue1_group1",
+	    "always_enabled": "true"
+	},
+	"COPP_TRAP|macsec": {
+	    "trap_ids": "eapol",
+	    "trap_group": "queue4_group1"
+	},
+	"COPP_TRAP|nat": {
+	    "trap_ids": "src_nat_miss,dest_nat_miss",
+	    "trap_group": "queue1_group2"
+	},
+	"COPP_TRAP|sflow": {
+	    "trap_group": "queue2_group1",
+	    "trap_ids": "sample_packet"
+	},
+	"VERSIONS|DATABASE": {
+	    "VERSION": "version_202405_01"
+	}
 }

--- a/tests/db_migrator_input/config_db/copp_group_table_input.json
+++ b/tests/db_migrator_input/config_db/copp_group_table_input.json
@@ -119,6 +119,6 @@
 	    }
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_202405_01"
+        "VERSION": "version_202311_03"
     }
 }

--- a/tests/db_migrator_input/config_db/copp_group_table_input.json
+++ b/tests/db_migrator_input/config_db/copp_group_table_input.json
@@ -117,5 +117,8 @@
 		    "trap_group": "queue2_group1",
 		    "trap_ids": "sample_packet"
 	    }
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_202405_01"
     }
 }

--- a/tests/db_migrator_input/config_db/copp_group_table_input.json
+++ b/tests/db_migrator_input/config_db/copp_group_table_input.json
@@ -1,0 +1,121 @@
+{
+    "COPP_GROUP": {
+	    "default": {
+		    "queue": "0",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"600",
+		    "cbs":"600",
+		    "red_action":"drop"
+	    },
+	    "queue4_group1": {
+		    "trap_action":"trap",
+		    "trap_priority":"4",
+		    "queue": "4",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"6000",
+		    "cbs":"6000",
+		    "red_action":"drop"
+	    },
+	    "queue4_group2": {
+		    "trap_action":"copy",
+		    "trap_priority":"4",
+		    "queue": "4",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"600",
+		    "cbs":"600",
+		    "red_action":"drop"
+	    },
+	    "queue4_group3": {
+		    "trap_action":"trap",
+		    "trap_priority":"4",
+		    "queue": "4",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"300",
+		    "cbs":"300",
+		    "red_action":"drop"
+	    },
+	    "queue1_group1": {
+		    "trap_action":"trap",
+		    "trap_priority":"1",
+		    "queue": "1",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"6000",
+		    "cbs":"6000",
+		    "red_action":"drop"
+	    },
+	    "queue1_group2": {
+		    "trap_action":"trap",
+		    "trap_priority":"1",
+		    "queue": "1",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"600",
+		    "cbs":"600",
+		    "red_action":"drop"
+	    },
+	    "queue2_group1": {
+		    "cbs": "1000",
+		    "cir": "1000",
+		    "genetlink_mcgrp_name": "packets",
+		    "genetlink_name": "psample",
+		    "meter_type": "packets",
+		    "mode": "sr_tcm",
+		    "queue": "2",
+		    "red_action": "drop",
+		    "trap_action": "trap",
+		    "trap_priority": "1"
+
+	    }
+    },
+    "COPP_TRAP": {
+	    "bgp": {
+		    "trap_ids": "bgp,bgpv6",
+		    "trap_group": "queue4_group1"
+	    },
+	    "lacp": {
+		    "trap_ids": "lacp",
+		    "trap_group": "queue4_group1",
+		    "always_enabled": "true"
+	    },
+	    "arp": {
+		    "trap_ids": "arp_req,arp_resp,neigh_discovery",
+		    "trap_group": "queue4_group2",
+		    "always_enabled": "true"
+	    },
+	    "lldp": {
+		    "trap_ids": "lldp",
+		    "trap_group": "queue4_group3"
+	    },
+	    "dhcp_relay": {
+		    "trap_ids": "dhcp,dhcpv6",
+		    "trap_group": "queue4_group3"
+	    },
+	    "udld": {
+		    "trap_ids": "udld",
+		    "trap_group": "queue4_group3",
+		    "always_enabled": "true"
+	    },
+	    "ip2me": {
+		    "trap_ids": "ip2me",
+		    "trap_group": "queue1_group1",
+		    "always_enabled": "true"
+	    },
+	    "macsec": {
+		    "trap_ids": "eapol",
+		    "trap_group": "queue4_group1"
+	    },
+	    "nat": {
+		    "trap_ids": "src_nat_miss,dest_nat_miss",
+		    "trap_group": "queue1_group2"
+	    },
+	    "sflow": {
+		    "trap_group": "queue2_group1",
+		    "trap_ids": "sample_packet"
+	    }
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1013,3 +1013,27 @@ class TestAAAMigrator(object):
 
         diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
         assert not diff
+
+class TestCoppGroupTrapAction(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['CONFIG_DB'] = None
+
+    def test_copp_group_trap_action_migrator(self):
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'copp_group_table_input')
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+        dbconnector.dedicated_dbs['CONFIG_DB'] = os.path.join(mock_db_path, 'config_db', 'copp_group_table_expected')
+        expected_db = Db()
+
+        resulting_table = dbmgtr.configDB.get_table('COPP_GROUP')
+        expected_table = expected_db.cfgdb.get_table('COPP_GROUP')
+
+        diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
+        assert not diff

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1014,6 +1014,7 @@ class TestAAAMigrator(object):
         diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
         assert not diff
 
+
 class TestCoppGroupTrapAction(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
==> Issue: 
       config replace/yang-validation fails for COPP configurations.

==> Root cause:
• COPP's device initial config copp_cfg.json has missing yang mandatory leaf "trap_action" for "default" COPP_GROUP.
• "genetlink_name" & "genetlink_mcgrp_name" nodes are not added in sonic-copp.yang, which are used for "queue2_group1" in copp_cfg.json

==> Fix:
• In copp_cfg.json, mandatory leaf "trap_action" is added for "default" COPP_GROUP.

"COPP_GROUP": {
"default": {
+ "trap_action":"trap", <<< this node needs to be added
"queue": "0",
"meter_type":"packets",

• "genetlink_name" and "genetlink_mcgrp_name" leaves are added in sonic-copp.yang.

• DB Migration script is updated to upgrade the DB config automatically.

==> Tests :
Config replace ->
i. Config load copp_cfg.json
ii. Config save
iii. Config replace -> Ensure no error seen

Upgrade ->
i. Save config in build without the fix
ii. upgrade to build with changes and ensure configurations are reflected in new config_db.json

==> PRs :
Sonic-buildimage : https://github.com/sonic-net/sonic-buildimage/pull/19817
Sonic-utilities : https://github.com/sonic-net/sonic-utilities/pull/3473
SONiC (docs) : https://github.com/sonic-net/SONiC/pull/1773

Signed-off-by: Anukul Verma <anukverm@cisco.com>