### PR TITLE
[GCU] Bypass lanes default 0 value set in multiasic's host

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -239,6 +239,9 @@ class ConfigWrapper:
             for port in port_to_lanes_map:
                 lanes = port_to_lanes_map[port]
                 for lane in lanes:
+                    # Bypass default "0" set in lanes of multiasic's host
+                    if lane == "0":
+                        continue
                     if lane in existing:
                         return False, f"'{lane}' lane is used multiple times in PORT: {set([port, existing[lane]])}"
                     existing[lane] = port

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -343,6 +343,13 @@ class TestConfigWrapper(unittest.TestCase):
             }}
         self.validate_lanes(config)
 
+    def test_validate_lanes__valid_lanes_0_multi_ports__success(self):
+        config = {"PORT": {
+            "Ethernet0": {"lanes": "0,64,65", "speed":"10000"},
+            "Ethernet1": {"lanes": "0,66,68", "speed":"10000"},
+            }}
+        self.validate_lanes(config)
+
     def test_validate_lanes__same_valid_lanes_single_port__failure(self):
         config = {"PORT": {"Ethernet0": {"lanes": "65 \r\t\n, 65", "speed":"10000"}}}
         self.validate_lanes(config, '65')

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -345,8 +345,8 @@ class TestConfigWrapper(unittest.TestCase):
 
     def test_validate_lanes__valid_lanes_0_multi_ports__success(self):
         config = {"PORT": {
-            "Ethernet0": {"lanes": "0,64,65", "speed":"10000"},
-            "Ethernet1": {"lanes": "0,66,68", "speed":"10000"},
+            "Ethernet0": {"lanes": "0,64,65", "speed": "10000"},
+            "Ethernet1": {"lanes": "0,66,68", "speed": "10000"},
             }}
         self.validate_lanes(config)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Bypass lanes check if value is "0"
#### How I did it
Add a check
#### How to verify it
UT
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

