### PR TITLE
Merge changes introduced in PR#3447 into branch 202405

### DIFF
--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -595,10 +595,10 @@ testData = {
         'rc': 0,
         'rc_output': bgp_v6_network_longer_prefixes
     },
-    'bgp_v4_network_multi_asic': {
+    'bgp_v4_network_default_multi_asic': {
         'args': [],
-        'rc': 2,
-        'rc_err_msg': multi_asic_bgp_network_err
+        'rc': 0,
+        'rc_output': bgp_v4_network_all_asic
     },
     'bgp_v4_network_asic0': {
         'args': ['-nasic0'],

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -31,6 +31,7 @@ class TestRexecBgp(object):
         pass
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "ip", "bgp", "summary"])
     def test_show_ip_bgp_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
@@ -44,6 +45,7 @@ class TestRexecBgp(object):
         assert MULTI_LC_REXEC_OUTPUT == result.output
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "ip", "bgp", "summary"])
     def test_show_ip_bgp_error_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
@@ -55,3 +57,17 @@ class TestRexecBgp(object):
         subprocess.run = _old_subprocess_run
         assert result.exit_code == 1
         assert MULTI_LC_ERR_OUTPUT == result.output
+
+    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "ip", "bgp", "network", "10.0.0.0/24"])
+    def test_show_ip_bgp_network_rexec(self, setup_bgp_commands):
+        show = setup_bgp_commands
+        runner = CliRunner()
+
+        _old_subprocess_run = subprocess.run
+        subprocess.run = mock_rexec_command
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["network", "10.0.0.0/24"])
+        print(result.output)
+        subprocess.run = _old_subprocess_run
+        assert result.exit_code == 0
+        assert MULTI_LC_REXEC_OUTPUT == result.output

--- a/tests/show_bgp_network_test.py
+++ b/tests/show_bgp_network_test.py
@@ -78,7 +78,7 @@ class TestMultiAsicBgpNetwork(object):
 
     @pytest.mark.parametrize(
         'setup_multi_asic_bgp_instance, test_vector',
-        [('bgp_v4_network', 'bgp_v4_network_multi_asic'),
+        [('bgp_v4_network_all_asic', 'bgp_v4_network_default_multi_asic'),
          ('bgp_v6_network', 'bgp_v6_network_multi_asic'),
          ('bgp_v4_network_asic0', 'bgp_v4_network_asic0'),
          ('bgp_v4_network_ip_address_asic0', 'bgp_v4_network_ip_address_asic0'),


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I changed the default behaviors of "show ip bgp network" command on multi-asic chassis.

Microsoft ADO: 28897424

#### How I did it

I modified the implementation of "bgp" command group and "network" subcommand in show/bgp_frr_v4.py and updated the relevant unit tests. The changes are listed below.

1. Now, by default "show ip bgp network" will display results from all namespaces. Meanwhile, it will not forcefully require "-n" option any more.
2. "show ip bgp network" now will require ip-address/ip-prefix option to be executed on chassis supervisors. This is to avoid getting excessive routes from such command on the supervisors.

#### How to verify it

Install and run it on a SONiC T2 chassis.

#### Previous command output (if the output of a command-line utility has changed)

Previously, if you run `show ip bgp network` on a chassis supervisor you will get something similar to below:
```
======== LINE-CARD0|lc1-hostname output: ========
Usage: show ip bgp network [OPTIONS] [<ipv4-address>|<ipv4-prefix>]
                           [bestpath|json|longer-prefixes|multipath]
Try "show ip bgp network -h" for help.

Error: -n/--namespace option required. provide namespace from list ['asic0', 'asic1']

======== LINE-CARD1|lc2-hostname output: ========
Usage: show ip bgp network [OPTIONS] [<ipv4-address>|<ipv4-prefix>]
                           [bestpath|json|longer-prefixes|multipath]
Try "show ip bgp network -h" for help.

Error: -n/--namespace option required. provide namespace from list ['asic0', 'asic1']

```

#### New command output (if the output of a command-line utility has changed)

Now, running `show ip bgp network` on a chassis supervisor will display:
```
Usage: show ip bgp network [OPTIONS] [<ipv4-address>|<ipv4-prefix>]
                           [bestpath|json|longer-prefixes|multipath]
Try "show ip bgp network -h" for help.

Error: Missing argument "[<ipv4-address>|<ipv4-prefix>]".
```
After you specify an ipv4 prefix or ipv4 address, then you will get:
```
======== LINE-CARD0|lc1-hostname output: ========

======== namespace asic0 ========
BGP routing table entry for 192.170.99.0/25, version 6085
Paths: (4 available, best #4, table default)
  65000 65506
    10.0.0.13 from 3.3.3.6 (192.0.0.6)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 229, TX-All 207 TX-Best-Per-AS 0
      Last update: Thu Jul 25 22:00:44 2024
  65003 65506
    10.0.0.23 from 3.3.3.8 (192.0.0.8)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 117, TX-All 726 TX-Best-Per-AS 0
      Last update: Thu Jul 25 00:15:58 2024
  65002 65506
    10.0.0.19 from 3.3.3.8 (192.0.0.8)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 375, TX-All 727 TX-Best-Per-AS 0
      Last update: Thu Jul 25 00:15:58 2024
  65001 65506
    10.0.0.17 from 3.3.3.6 (192.0.0.6)
      Origin IGP, localpref 100, valid, internal, multipath, best (Router ID)
      AddPath ID: RX 228, TX-All 206 TX-Best-Per-AS 0
      Advertised to: 10.0.0.1
      Last update: Thu Jul 25 00:15:57 2024

======== namespace asic1 ========
BGP routing table entry for 192.170.99.0/25, version 6087
Paths: (4 available, best #4, table default)
  65000 65506
    10.0.0.13 from 3.3.3.6 (192.0.0.6)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 229, TX-All 207 TX-Best-Per-AS 0
      Last update: Thu Jul 25 22:00:44 2024
  65003 65506
    10.0.0.23 from 3.3.3.8 (192.0.0.8)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 117, TX-All 727 TX-Best-Per-AS 0
      Last update: Thu Jul 25 00:15:58 2024
  65002 65506
    10.0.0.19 from 3.3.3.8 (192.0.0.8)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 375, TX-All 728 TX-Best-Per-AS 0
      Last update: Thu Jul 25 00:15:58 2024
  65001 65506
    10.0.0.17 from 3.3.3.6 (192.0.0.6)
      Origin IGP, localpref 100, valid, internal, multipath, best (Router ID)
      AddPath ID: RX 228, TX-All 206 TX-Best-Per-AS 0
      Advertised to: 10.0.0.7
      Last update: Thu Jul 25 00:15:57 2024

======== LINE-CARD1|lc2 output: ========

======== namespace asic0 ========
BGP routing table entry for 192.170.99.0/25, version 16554
Paths: (4 available, best #4, table default)
  65000 65506
    10.0.0.13 from 10.0.0.13 (100.1.0.7)
      Origin IGP, valid, external, multipath
      AddPath ID: RX 0, TX-All 229 TX-Best-Per-AS 0
      Advertised to: 3.3.3.1 3.3.3.2 3.3.3.8
      Last update: Thu Jul 25 22:00:45 2024
  65003 65506
    10.0.0.23 from 3.3.3.8 (192.0.0.8)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 117, TX-All 733 TX-Best-Per-AS 0
      Last update: Tue Jul 23 07:40:44 2024
  65002 65506
    10.0.0.19 from 3.3.3.8 (192.0.0.8)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 375, TX-All 734 TX-Best-Per-AS 0
      Last update: Tue Jul 23 07:40:44 2024
  65001 65506
    10.0.0.17 from 10.0.0.17 (100.1.0.9)
      Origin IGP, valid, external, multipath, best (Peer Type)
      AddPath ID: RX 0, TX-All 228 TX-Best-Per-AS 0
      Advertised to: 3.3.3.1 3.3.3.2 3.3.3.8
      Last update: Tue Jul 23 07:40:44 2024

======== namespace asic1 ========
BGP routing table entry for 192.170.99.0/25, version 16795
Paths: (4 available, best #4, table default)
  65000 65506
    10.0.0.13 from 3.3.3.6 (192.0.0.6)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 229, TX-All 733 TX-Best-Per-AS 0
      Last update: Thu Jul 25 22:00:44 2024
  65001 65506
    10.0.0.17 from 3.3.3.6 (192.0.0.6)
      Origin IGP, localpref 100, valid, internal, multipath
      AddPath ID: RX 228, TX-All 734 TX-Best-Per-AS 0
      Last update: Tue Jul 23 07:40:43 2024
  65002 65506
    10.0.0.19 from 10.0.0.19 (100.1.0.10)
      Origin IGP, valid, external, multipath
      AddPath ID: RX 0, TX-All 375 TX-Best-Per-AS 0
      Advertised to: 3.3.3.1 3.3.3.2 3.3.3.6
      Last update: Tue Jul 23 07:39:34 2024
  65003 65506
    10.0.0.23 from 10.0.0.23 (100.1.0.12)
      Origin IGP, valid, external, multipath, best (Older Path)
      AddPath ID: RX 0, TX-All 117 TX-Best-Per-AS 0
      Advertised to: 3.3.3.1 3.3.3.2 3.3.3.6
      Last update: Tue Jul 23 07:39:34 2024
```