### PR TITLE
[show] Fix exception error for "show ip route vrf all"

### DIFF
--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -77,7 +77,10 @@ def get_nexthop_info_str(nxhp_info, filterByIp):
             str_2_return = " (blackhole)"
 
     if "vrf" in nxhp_info:
-        str_2_return += "(vrf {}, {},".format(nxhp_info['vrf'], nxhp_info['interfaceName'])
+        str_2_return += " (vrf {}".format(nxhp_info['vrf'])
+        if 'interfaceName' in nxhp_info:
+            str_2_return += ", {}".format(nxhp_info['interfaceName'])
+        str_2_return += ")"
     if "active" not in nxhp_info:
         str_2_return += " inactive"
     if "onLink" in nxhp_info:

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -111,7 +111,7 @@ Codes: K - kernel route, C - connected, S - static, R - RIP,
        F - PBR, f - OpenFabric,
        > - selected route, * - FIB route, q - queued route, r - rejected route
 
-C>*10.3.0.4/31 (blackhole)(vrf 2, PortChannel1014, inactive (recursive) 2d22h02m
+C>*10.3.0.4/31 (blackhole) (vrf 2, PortChannel1014) inactive (recursive) 2d22h02m
 C>*10.5.0.4/31 (ICMP unreachable) inactive 2d22h02m
 C>*10.5.0.8/31 (ICMP admin-prohibited) inactive onlink, src 10.2.3.4 2d22h02m
 C> 10.6.0.8/31 inactive 2d22h02m


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix the unexpected exception error that appears when the interface is not resolved, causing the key for `interfaceName` to be missing in the case of static route configuration.

#### How I did it
Handle the case where `interface_name` is missing.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
VRF Vrf1:
C>*192.168.1.0/24 is directly connected, Vlan1, 00:02:36
K>*192.168.1.254/32 [0/0] is directly connected, Vlan1, 00:04:54
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/show/main.py", line 1043, in route
    bgp_common.show_routes(args, namespace, display, verbose, "ip")
  File "/usr/local/lib/python3.9/dist-packages/show/bgp_common.py", line 474, in show_routes
    print_ip_routes(combined_route, filter_by_ip)
  File "/usr/local/lib/python3.9/dist-packages/show/bgp_common.py", line 189, in print_ip_routes
    str_2_print += get_nexthop_info_str(info[i]['nexthops'][j], False)
  File "/usr/local/lib/python3.9/dist-packages/show/bgp_common.py", line 80, in get_nexthop_info_str
    str_2_return += "(vrf {}, {},".format(nxhp_info['vrf'], nxhp_info['interfaceName'])
KeyError: 'interfaceName'
```

#### New command output (if the output of a command-line utility has changed)
```
VRF Vrf1:
C>*192.168.1.0/24 is directly connected, Vlan1, 00:00:42
K>*192.168.1.254/32 [0/0] is directly connected, Vlan1, 00:01:45
S 192.168.2.0/24 [1/0] via 192.168.2.1 (vrf Vrf2) inactive, 00:00:28
```

