### PR TITLE
[chassis][cli] Fix config chassis module startup/shutdown command for fabric module

### DIFF
--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -72,7 +72,7 @@ def fabric_module_set_admin_status(db, chassis_module_name, state):
     if state == "down":
         for asic in asic_list:
             click.echo("Stop swss@{} and peer services".format(asic))
-            clicommon.run_command('sudo systemctl stop swss@{}.service'.format(asic))
+            clicommon.run_command(['sudo', 'systemctl', 'stop', 'swss@{}.service'.format(asic)])
 
         is_active = subprocess.call(["systemctl", "is-active", "--quiet", "swss@{}.service".format(asic)])
 
@@ -89,13 +89,13 @@ def fabric_module_set_admin_status(db, chassis_module_name, state):
         # without bring down the hardware
         for asic in asic_list:
             # To address systemd service restart limit by resetting the count
-            clicommon.run_command('sudo systemctl reset-failed swss@{}.service'.format(asic))
+            clicommon.run_command(['sudo', 'systemctl', 'reset-failed', 'swss@{}.service'.format(asic)])
             click.echo("Start swss@{} and peer services".format(asic))
-            clicommon.run_command('sudo systemctl start swss@{}.service'.format(asic))
+            clicommon.run_command(['sudo', 'systemctl', 'start', 'swss@{}.service'.format(asic)])
     elif state == "up":
         for asic in asic_list:
             click.echo("Start swss@{} and peer services".format(asic))
-            clicommon.run_command('sudo systemctl start swss@{}.service'.format(asic))
+            clicommon.run_command(['sudo', 'systemctl', 'start', 'swss@{}.service'.format(asic)])
 
 #
 # 'shutdown' subcommand ('config chassis_modules shutdown ...')

--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -126,7 +126,13 @@ Linecard4|Asic2|PortChannel0001         2           22  Linecard4|Asic2|Ethernet
 
 
 def mock_run_command_side_effect(*args, **kwargs):
-    return '', 0
+    print("command: {}".format(*args))
+    if isinstance(*args, list):
+        return '', 0
+    else:
+        print("Expected type of command is list. Actual type is {}".format(*args))
+        assert 0
+        return '', 0
 
 
 class TestChassisModules(object):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
MSFT ADO: 29166401

#### What I did
Executing CLI command "sudo config module shutdown FABRIC-CARD6" fails on latest Master and 202405 branch.  It cause back trace as below.  The "subprocess() has been modified with "sholl=False".  run_command() takes commands as list of string instead of a single line.   
```
admin@ixre-cpm-chassis7:~$ sudo config chassis modules shutdown FABRIC-CARD6
Shutting down chassis module FABRIC-CARD6
Stop swss@12 and peer services
Traceback (most recent call last):
  File "/usr/local/bin/config", line 8, in <module>
    sys.exit(config())
             ^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/config/chassis_modules.py", line 126, in shutdown_chassis_module
    fabric_module_set_admin_status(db, chassis_module_name, 'down')
  File "/usr/local/lib/python3.11/dist-packages/config/chassis_modules.py", line 75, in fabric_module_set_admin_status
    clicommon.run_command('sudo systemctl stop swss@{}.service'.format(asic))
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/cli.py", line 736, in run_command
    proc = subprocess.Popen(command, shell=shell, text=True, stdout=subprocess.PIPE)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1901, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'sudo systemctl stop swss@12.service'

``` 
#### How I did it
Change all single line commands to a list of string., such as "sudo systemctl stop swss{}.service".format(asic)  ["sudo", "systemctl", "stop", "swss{}.service".format(asic)]  to address the issue
#### How to verify it
Execute the following commands, there should not be any issue shown up:
"sudo config chassis module shutdown FABRIC-CARD6"
"sudo config chassis module startup FABRIC-CARD6"

#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A
