### PR TITLE
Add timeout for rexec's get_password

### DIFF
--- a/rcli/utils.py
+++ b/rcli/utils.py
@@ -1,5 +1,5 @@
 import click
-from getpass import getpass
+import getpass
 import os
 import signal
 
@@ -159,7 +159,7 @@ def get_password(username=None):
 
     signal.signal(signal.SIGALRM, get_password_timeout)
     signal.alarm(GET_PASSWORD_TIMEOUT)  # Set a timeout of 60 seconds
-    password = getpass(
+    password = getpass.getpass(
         "Password for username '{}': ".format(username),
         # Pass in click stdout stream - this is similar to using click.echo
         stream=click.get_text_stream('stdout')

--- a/rcli/utils.py
+++ b/rcli/utils.py
@@ -1,7 +1,7 @@
 import click
 from getpass import getpass
 import os
-import sys
+import signal
 
 from swsscommon.swsscommon import SonicV2Connector
 
@@ -18,6 +18,8 @@ CHASSIS_MIDPLANE_INFO_ACCESS_FIELD = 'access'
 
 CHASSIS_MODULE_HOSTNAME_TABLE = 'CHASSIS_MODULE_HOSTNAME_TABLE'
 CHASSIS_MODULE_HOSTNAME = 'module_hostname'
+
+GET_PASSWORD_TIMEOUT = 10
 
 def connect_to_chassis_state_db():
     chassis_state_db = SonicV2Connector(host="127.0.0.1")
@@ -151,8 +153,17 @@ def get_password(username=None):
     if username is None:
         username = os.getlogin()
 
-    return getpass(
+    def get_password_timeout(*args):
+        print("Timeout when waiting for password input")
+        exit(1)
+
+    signal.signal(signal.SIGALRM, get_password_timeout)
+    signal.alarm(GET_PASSWORD_TIMEOUT)  # Set a timeout of 60 seconds
+    password = getpass(
         "Password for username '{}': ".format(username),
         # Pass in click stdout stream - this is similar to using click.echo
         stream=click.get_text_stream('stdout')
     )
+    signal.alarm(0)  # Cancel the alarm
+
+    return password

--- a/rcli/utils.py
+++ b/rcli/utils.py
@@ -154,7 +154,7 @@ def get_password(username=None):
         username = os.getlogin()
 
     def get_password_timeout(*args):
-        print("Timeout when waiting for password input")
+        print("\nAborted! Timeout when waiting for password input.")
         exit(1)
 
     signal.signal(signal.SIGALRM, get_password_timeout)

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -223,7 +223,7 @@ class TestRemoteExec(object):
             rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 1, result.output
-        assert "Timeout when waiting for password input" in result.output
+        assert "Aborted" in result.output
 
 
 class TestRemoteCLI(object):

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -76,7 +76,7 @@ def mock_paramiko_connection(channel):
     return conn
 
 
-def mock_getpass(prompt = "Password:", stream = None):
+def mock_getpass(prompt="Password:", stream=None):
     return "dummy"
 
 
@@ -220,9 +220,11 @@ class TestRemoteExec(object):
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     def test_rexec_without_password_input(self):
         runner = CliRunner()
+        getpass.getpass = self.getpass
         LINECARD_NAME = "all"
         result = runner.invoke(
             rexec.cli, [LINECARD_NAME, "-c", "show version"])
+        getpass.getpass = mock_getpass
         print(result.output)
         assert result.exit_code == 1, result.output
         assert "Aborted" in result.output

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -214,6 +214,17 @@ class TestRemoteExec(object):
         assert result.exit_code == 1, result.output
         assert "Failed to connect to sonic-lc1 with username testuser\n" == result.output
 
+    @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
+    @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
+    def test_rexec_with_password_timeout(self):
+        runner = CliRunner()
+        LINECARD_NAME = "all"
+        result = runner.invoke(
+            rexec.cli, [LINECARD_NAME, "-c", "show version"])
+        print(result.output)
+        assert result.exit_code == 1, result.output
+        assert "Timeout when waiting for password input" in result.output
+
 
 class TestRemoteCLI(object):
     @classmethod

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -84,7 +84,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     # @mock.patch.object(linecard.Linecard, '_get_password', mock.MagicMock(return_value='dummmy'))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_command()))
@@ -98,7 +98,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_command()))
     def test_rexec_with_hostname(self):
@@ -111,7 +111,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(paramiko.SSHClient, 'exec_command', mock.MagicMock(return_value=mock_exec_error_cmd()))
     def test_rexec_error_with_module_name(self):
@@ -133,7 +133,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_all(self):
@@ -147,7 +147,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_invalid_lc(self):
@@ -161,7 +161,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_unreachable_lc(self):
@@ -175,7 +175,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock())
     @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
     def test_rexec_help(self):
@@ -188,7 +188,7 @@ class TestRemoteExec(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock(side_effect=paramiko.ssh_exception.NoValidConnectionsError({('192.168.0.1',
                                                                                                                                   22): "None"})))
     @mock.patch.object(linecard.Linecard, 'execute_cmd', mock.MagicMock(return_value="hello world"))
@@ -202,7 +202,7 @@ class TestRemoteExec(object):
         assert "Failed to connect to sonic-lc1 with username admin\n" == result.output
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(paramiko.SSHClient, 'connect', mock.MagicMock(side_effect=paramiko.ssh_exception.NoValidConnectionsError({('192.168.0.1',
                                                                                                                                   22): "None"})))
     def test_rexec_with_user_param(self):
@@ -235,7 +235,7 @@ class TestRemoteCLI(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(linecard.Linecard, '_set_tty_params', mock.MagicMock())
     @mock.patch.object(termios, 'tcsetattr', mock.MagicMock())
     @mock.patch.object(termios, 'tcgetattr', mock.MagicMock(return_value=[]))
@@ -253,7 +253,7 @@ class TestRemoteCLI(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(linecard.Linecard, '_set_tty_params', mock.MagicMock())
     @mock.patch.object(termios, 'tcsetattr', mock.MagicMock())
     @mock.patch.object(termios, 'tcgetattr', mock.MagicMock(return_value=[]))
@@ -271,7 +271,7 @@ class TestRemoteCLI(object):
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
-    @mock.patch("rcli.utils.get_password", mock.MagicMock(return_value="dummy"))
+    @mock.patch("getpass.getpass", mock.MagicMock(return_value="dummy"))
     @mock.patch.object(linecard.Linecard, '_set_tty_params', mock.MagicMock())
     @mock.patch.object(termios, 'tcsetattr', mock.MagicMock())
     @mock.patch.object(termios, 'tcgetattr', mock.MagicMock(return_value=[]))

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -81,18 +81,19 @@ def mock_getpass(prompt="Password:", stream=None):
 
 
 class TestRemoteExec(object):
+    __getpass = getpass.getpass
+
     @classmethod
     def setup_class(cls):
         print("SETUP")
         from .mock_tables import dbconnector
         dbconnector.load_database_config()
-        cls.getpass = getpass.getpass
         getpass.getpass = mock_getpass
 
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-        getpass.getpass = cls.getpass
+        getpass.getpass = TestRemoteExec.__getpass
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
@@ -220,7 +221,7 @@ class TestRemoteExec(object):
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
     def test_rexec_without_password_input(self):
         runner = CliRunner()
-        getpass.getpass = self.getpass
+        getpass.getpass = TestRemoteExec.__getpass
         LINECARD_NAME = "all"
         result = runner.invoke(
             rexec.cli, [LINECARD_NAME, "-c", "show version"])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I added a timeout setting for the get_password function in rexec module so that automatic pipelines that does not expect password input will not get blocked. The current timeout setting is 10 sec.

#### How I did it

Add a SIGALRM signal before waiting for password input. 

#### How to verify it

Run a "show ip bgp summary" on SONiC Chassis Supversior and does not input password until it times out.

#### Previous command output (if the output of a command-line utility has changed)

Before adding such a mechanism, if you do not input password when run "rexec -c <cmd>" you will be blocked at the following output:
```
Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
Password for username 'XXX':
```

#### New command output (if the output of a command-line utility has changed)
After adding such a mechanism, if you do not input password when run "rexec -c <cmd>" you will see a timeout message after 10 seconds.
```
Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
Password for username 'XXX': 
Aborted! Timeout when waiting for password input.
```
