### PR TITLE
[sfputil] Configure the debug loopback mode only on the relevant lanes of the logical port

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3108,7 +3108,7 @@ This command is the standard CMIS diagnostic control used for troubleshooting li
   ```
   sfputil debug loopback PORT_NAME LOOPBACK_MODE <enable/disable>
 
-  Set the loopback mode
+  Valid values for loopback mode
   host-side-input: host side input loopback mode
   host-side-output: host side output loopback mode
   media-side-input: media side input loopback mode

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3106,23 +3106,19 @@ This command is the standard CMIS diagnostic control used for troubleshooting li
 
 - Usage:
   ```
-  sfputil debug loopback PORT_NAME LOOPBACK_MODE
+  sfputil debug loopback PORT_NAME LOOPBACK_MODE <enable/disable>
 
   Set the loopback mode
-  host-side-input: enable host side input loopback mode
-  host-side-output: enable host side output loopback mode
-  media-side-input: enable media side input loopback mode
-  media-side-output: enable media side output loopback mode
-  host-side-input-none: disable host side input loopback mode
-  host-side-output-none: disable host side output loopback mode
-  media-side-input-none: disable media side input loopback mode
-  media-side-output-none: disable media side output loopback mode
-  none: disable all loopback mode
+  host-side-input: host side input loopback mode
+  host-side-output: host side output loopback mode
+  media-side-input: media side input loopback mode
+  media-side-output: media side output loopback mode
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sfputil debug loopback Ethernet88 host-side-input
+  admin@sonic:~$ sfputil debug loopback Ethernet88 host-side-input enable
+  admin@sonic:~$ sfputil debug loopback Ethernet88 media-side-output disable
   ```
 
 ## DHCP Relay

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3109,11 +3109,15 @@ This command is the standard CMIS diagnostic control used for troubleshooting li
   sfputil debug loopback PORT_NAME LOOPBACK_MODE
 
   Set the loopback mode
-  host-side-input: host side input loopback mode
-  host-side-output: host side output loopback mode
-  media-side-input: media side input loopback mode
-  media-side-output: media side output loopback mode
-  none: disable loopback mode
+  host-side-input: enable host side input loopback mode
+  host-side-output: enable host side output loopback mode
+  media-side-input: enable media side input loopback mode
+  media-side-output: enable media side output loopback mode
+  host-side-input-none: disable host side input loopback mode
+  host-side-output-none: disable host side output loopback mode
+  media-side-input-none: disable media side input loopback mode
+  media-side-output-none: disable media side output loopback mode
+  none: disable all loopback mode
   ```
 
 - Example:

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -2032,9 +2032,9 @@ def loopback(port_name, loopback_mode, enable):
         sys.exit(EXIT_FAIL)
 
     if 'host-side' in loopback_mode:
-        lane_mask = ((1 << host_lane_count) - 1) << ((subport - 1) * host_lane_count)
+        lane_mask = get_subport_lane_mask(subport, host_lane_count)
     elif 'media-side' in loopback_mode:
-        lane_mask = ((1 << media_lane_count) - 1) << ((subport - 1) * media_lane_count)
+        lane_mask = get_subport_lane_mask(subport, media_lane_count)
     else:
         lane_mask = 0
 
@@ -2050,10 +2050,24 @@ def loopback(port_name, loopback_mode, enable):
         sys.exit(EXIT_FAIL)
 
     if status:
-        click.echo("{}: Set {} loopback".format(port_name, loopback_mode))
+        click.echo("{}: {} {} loopback".format(port_name, enable, loopback_mode))
     else:
-        click.echo("{}: Set {} loopback failed".format(port_name, loopback_mode))
+        click.echo("{}: {} {} loopback failed".format(port_name, enable, loopback_mode))
         sys.exit(EXIT_FAIL)
+
+
+def get_subport_lane_mask(subport, lane_count):
+    """Get the lane mask for the given subport and lane count
+
+    Args:
+        subport (int): Subport number
+        lane_count (int): Lane count for the subport
+
+    Returns:
+        int: Lane mask for the given subport and lane count
+    """
+    return ((1 << lane_count) - 1) << ((subport - 1) * lane_count)
+
 
 if __name__ == '__main__':
     cli()

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1469,10 +1469,10 @@ def is_fw_switch_done(port_name):
                 status = -1 # Abnormal status.
             elif (ImageARunning == 1) and (ImageACommitted == 0):   # ImageA is running, but not committed.
                 click.echo("FW images switch successful : ImageA is running")
-                status = 1  # run_firmware is done. 
+                status = 1  # run_firmware is done.
             elif (ImageBRunning == 1) and (ImageBCommitted == 0):   # ImageB is running, but not committed.
                 click.echo("FW images switch successful : ImageB is running")
-                status = 1  # run_firmware is done. 
+                status = 1  # run_firmware is done.
             else:                                                   # No image is running, or running and committed image is same.
                 click.echo("FW info error : Failed to switch into uncommitted image!")
                 status = -1 # Failure for Switching images.
@@ -1970,7 +1970,9 @@ def debug():
 @click.argument('port_name', required=True, default=None)
 @click.argument('loopback_mode', required=True, default="none",
                 type=click.Choice(["none", "host-side-input", "host-side-output",
-                                   "media-side-input", "media-side-output"]))
+                                   "media-side-input", "media-side-output",
+                                   "host-side-input-none", "host-side-output-none",
+                                   "media-side-input-none", "media-side-output-none"]))
 def loopback(port_name, loopback_mode):
     """Set module diagnostic loopback mode
     """
@@ -1998,7 +2000,7 @@ def loopback(port_name, loopback_mode):
         subport = int(config_db.get(config_db.CONFIG_DB,
                                     'PORT|{}'.format(port_name), 'subport'))
 
-        # If it is not defined (None) or if it is set to 0, assign a default value of 1
+        # If subport is not defined (None) or set to 0, assign a default value of 1
         # to ensure valid subport configuration.
         if subport is None or subport == 0:
             subport = 1
@@ -2019,9 +2021,11 @@ def loopback(port_name, loopback_mode):
         click.echo("Failed to connect to STATE_DB")
         sys.exit(EXIT_FAIL)
 
-    if loopback_mode in ("host-side-input", "host-side-output"):
+    if loopback_mode in ("host-side-input", "host-side-output",
+                         "host-side-input-none", "host-side-output-none"):
         lane_mask = ((1 << host_lane_count) - 1) << ((subport - 1) * host_lane_count)
-    elif loopback_mode in ("media-side-input", "host-side-output"):
+    elif loopback_mode in ("media-side-input", "media-side-output",
+                           "media-side-input-none", "media-side-output-none"):
         lane_mask = ((1 << media_lane_count) - 1) << ((subport - 1) * media_lane_count)
     else:
         lane_mask = 0

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1997,6 +1997,11 @@ def loopback(port_name, loopback_mode):
         config_db.connect()
         subport = int(config_db.get(config_db.CONFIG_DB,
                                     'PORT|{}'.format(port_name), 'subport'))
+
+        # If it is not defined (None) or if it is set to 0, assign a default value of 1
+        # to ensure valid subport configuration.
+        if subport is None or subport == 0:
+            subport = 1
     else:
         click.echo("Failed to connect to CONFIG_DB")
         sys.exit(EXIT_FAIL)

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1991,29 +1991,28 @@ def loopback(port_name, loopback_mode):
         click.echo("{}: This functionality is not implemented".format(port_name))
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
-    namespaces = multi_asic.get_front_end_namespaces()
-    for namespace in namespaces:
-        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        if config_db is not None:
-            config_db.connect()
-            subport = int(config_db.get(config_db.CONFIG_DB,
-                                        'PORT|{}'.format(port_name), 'subport'))
-        else:
-            click.echo("Failed to connect to CONFIG_DB")
-            sys.exit(EXIT_FAIL)
+    namespace = multi_asic.get_namespace_for_port(port_name)
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    if config_db is not None:
+        config_db.connect()
+        subport = int(config_db.get(config_db.CONFIG_DB,
+                                    'PORT|{}'.format(port_name), 'subport'))
+    else:
+        click.echo("Failed to connect to CONFIG_DB")
+        sys.exit(EXIT_FAIL)
 
-        state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
-        if state_db is not None:
-            state_db.connect(state_db.STATE_DB)
-            host_lane_count = int(state_db.get(state_db.STATE_DB,
-                                               'TRANSCEIVER_INFO|{}'.format(port_name),
-                                               'host_lane_count'))
-            media_lane_count = int(state_db.get(state_db.STATE_DB,
-                                                'TRANSCEIVER_INFO|{}'.format(port_name),
-                                                'media_lane_count'))
-        else:
-            click.echo("Failed to connect to STATE_DB")
-            sys.exit(EXIT_FAIL)
+    state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+    if state_db is not None:
+        state_db.connect(state_db.STATE_DB)
+        host_lane_count = int(state_db.get(state_db.STATE_DB,
+                                           'TRANSCEIVER_INFO|{}'.format(port_name),
+                                           'host_lane_count'))
+        media_lane_count = int(state_db.get(state_db.STATE_DB,
+                                            'TRANSCEIVER_INFO|{}'.format(port_name),
+                                            'media_lane_count'))
+    else:
+        click.echo("Failed to connect to STATE_DB")
+        sys.exit(EXIT_FAIL)
 
     if loopback_mode in ("host-side-input", "host-side-output"):
         lane_mask = ((1 << host_lane_count) - 1) << ((subport - 1) * host_lane_count)

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1469,10 +1469,10 @@ def is_fw_switch_done(port_name):
                 status = -1 # Abnormal status.
             elif (ImageARunning == 1) and (ImageACommitted == 0):   # ImageA is running, but not committed.
                 click.echo("FW images switch successful : ImageA is running")
-                status = 1  # run_firmware is done.
+                status = 1  # run_firmware is done. 
             elif (ImageBRunning == 1) and (ImageBCommitted == 0):   # ImageB is running, but not committed.
                 click.echo("FW images switch successful : ImageB is running")
-                status = 1  # run_firmware is done.
+                status = 1  # run_firmware is done. 
             else:                                                   # No image is running, or running and committed image is same.
                 click.echo("FW info error : Failed to switch into uncommitted image!")
                 status = -1 # Failure for Switching images.
@@ -2021,11 +2021,9 @@ def loopback(port_name, loopback_mode):
         click.echo("Failed to connect to STATE_DB")
         sys.exit(EXIT_FAIL)
 
-    if loopback_mode in ("host-side-input", "host-side-output",
-                         "host-side-input-none", "host-side-output-none"):
+    if 'host-side' in loopback_mode:
         lane_mask = ((1 << host_lane_count) - 1) << ((subport - 1) * host_lane_count)
-    elif loopback_mode in ("media-side-input", "media-side-output",
-                           "media-side-input-none", "media-side-output-none"):
+    elif 'media-side' in loopback_mode:
         lane_mask = ((1 << media_lane_count) - 1) << ((subport - 1) * media_lane_count)
     else:
         lane_mask = 0

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1967,13 +1967,12 @@ def debug():
 
 # 'loopback' subcommand
 @debug.command()
-@click.argument('port_name', required=True, default=None)
-@click.argument('loopback_mode', required=True, default="none",
-                type=click.Choice(["none", "host-side-input", "host-side-output",
-                                   "media-side-input", "media-side-output",
-                                   "host-side-input-none", "host-side-output-none",
-                                   "media-side-input-none", "media-side-output-none"]))
-def loopback(port_name, loopback_mode):
+@click.argument('port_name', required=True)
+@click.argument('loopback_mode', required=True,
+                type=click.Choice(["host-side-input", "host-side-output",
+                                   "media-side-input", "media-side-output"]))
+@click.argument('enable', required=True, type=click.Choice(["enable", "disable"]))
+def loopback(port_name, loopback_mode, enable):
     """Set module diagnostic loopback mode
     """
     physical_port = logical_port_to_physical_port_index(port_name)
@@ -2040,12 +2039,15 @@ def loopback(port_name, loopback_mode):
         lane_mask = 0
 
     try:
-        status = api.set_loopback_mode(loopback_mode, lane_mask=lane_mask)
+        status = api.set_loopback_mode(loopback_mode,
+                                       lane_mask=lane_mask,
+                                       enable=enable == 'enable')
     except AttributeError:
         click.echo("{}: Set loopback mode is not applicable for this module".format(port_name))
         sys.exit(ERROR_NOT_IMPLEMENTED)
     except TypeError:
-        status = api.set_loopback_mode(loopback_mode)
+        click.echo("{}: Set loopback mode failed. Parameter is not supported".format(port_name))
+        sys.exit(EXIT_FAIL)
 
     if status:
         click.echo("{}: Set {} loopback".format(port_name, loopback_mode))

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -18,7 +18,7 @@ import click
 import sonic_platform
 import sonic_platform_base.sonic_sfp.sfputilhelper
 from sonic_platform_base.sfp_base import SfpBase
-from swsscommon.swsscommon import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from natsort import natsorted
 from sonic_py_common import device_info, logger, multi_asic
 from utilities_common.sfp_helper import covert_application_advertisement_to_output_string
@@ -1991,11 +1991,44 @@ def loopback(port_name, loopback_mode):
         click.echo("{}: This functionality is not implemented".format(port_name))
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        if config_db is not None:
+            config_db.connect()
+            subport = int(config_db.get(config_db.CONFIG_DB,
+                                        'PORT|{}'.format(port_name), 'subport'))
+        else:
+            click.echo("Failed to connect to CONFIG_DB")
+            sys.exit(EXIT_FAIL)
+
+        state_db = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+        if state_db is not None:
+            state_db.connect(state_db.STATE_DB)
+            host_lane_count = int(state_db.get(state_db.STATE_DB,
+                                               'TRANSCEIVER_INFO|{}'.format(port_name),
+                                               'host_lane_count'))
+            media_lane_count = int(state_db.get(state_db.STATE_DB,
+                                                'TRANSCEIVER_INFO|{}'.format(port_name),
+                                                'media_lane_count'))
+        else:
+            click.echo("Failed to connect to STATE_DB")
+            sys.exit(EXIT_FAIL)
+
+    if loopback_mode in ("host-side-input", "host-side-output"):
+        lane_mask = ((1 << host_lane_count) - 1) << ((subport - 1) * host_lane_count)
+    elif loopback_mode in ("media-side-input", "host-side-output"):
+        lane_mask = ((1 << media_lane_count) - 1) << ((subport - 1) * media_lane_count)
+    else:
+        lane_mask = 0
+
     try:
-        status = api.set_loopback_mode(loopback_mode)
+        status = api.set_loopback_mode(loopback_mode, lane_mask=lane_mask)
     except AttributeError:
         click.echo("{}: Set loopback mode is not applicable for this module".format(port_name))
         sys.exit(ERROR_NOT_IMPLEMENTED)
+    except TypeError:
+        status = api.set_loopback_mode(loopback_mode)
 
     if status:
         click.echo("{}: Set {} loopback".format(port_name, loopback_mode))

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1661,19 +1661,19 @@ EEPROM hexdump for port Ethernet4
         mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
                                ["Ethernet0", "host-side-input", "enable"])
-        assert result.output == 'Ethernet0: Set host-side-input loopback\n'
+        assert result.output == 'Ethernet0: enable host-side-input loopback\n'
         assert result.exit_code != ERROR_NOT_IMPLEMENTED
 
         mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
                                ["Ethernet0", "media-side-input", "enable"])
-        assert result.output == 'Ethernet0: Set media-side-input loopback\n'
+        assert result.output == 'Ethernet0: enable media-side-input loopback\n'
         assert result.exit_code != ERROR_NOT_IMPLEMENTED
 
         mock_api.set_loopback_mode.return_value = False
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
                                ["Ethernet0", "media-side-output", "enable"])
-        assert result.output == 'Ethernet0: Set media-side-output loopback failed\n'
+        assert result.output == 'Ethernet0: enable media-side-output loopback failed\n'
         assert result.exit_code == EXIT_FAIL
 
         mock_api.set_loopback_mode.return_value = True
@@ -1709,3 +1709,14 @@ EEPROM hexdump for port Ethernet4
                                ["Ethernet0", "media-side-input", "enable"])
         assert result.output == 'Ethernet0: Failed to connect to STATE_DB\n'
         assert result.exit_code == EXIT_FAIL
+
+    @pytest.mark.parametrize("subport, lane_count, expected_mask", [
+        (1, 1, 0x1),
+        (1, 4, 0xf),
+        (2, 1, 0x2),
+        (2, 4, 0xf0),
+        (3, 2, 0x30),
+        (4, 1, 0x8),
+    ])
+    def test_get_subport_lane_mask(self, subport, lane_count, expected_mask):
+        assert sfputil.get_subport_lane_mask(subport, lane_count) == expected_mask

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1648,63 +1648,64 @@ EEPROM hexdump for port Ethernet4
         runner = CliRunner()
         mock_sfp.get_presence.return_value = False
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "host-side-input"])
+                               ["Ethernet0", "host-side-input", "enable"])
         assert result.output == 'Ethernet0: SFP EEPROM not detected\n'
         mock_sfp.get_presence.return_value = True
 
         mock_sfp.get_xcvr_api = MagicMock(side_effect=NotImplementedError)
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "host-side-input"])
+                               ["Ethernet0", "host-side-input", "enable"])
         assert result.output == 'Ethernet0: This functionality is not implemented\n'
         assert result.exit_code == ERROR_NOT_IMPLEMENTED
 
         mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "host-side-input"])
+                               ["Ethernet0", "host-side-input", "enable"])
         assert result.output == 'Ethernet0: Set host-side-input loopback\n'
         assert result.exit_code != ERROR_NOT_IMPLEMENTED
 
         mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "media-side-input"])
+                               ["Ethernet0", "media-side-input", "enable"])
         assert result.output == 'Ethernet0: Set media-side-input loopback\n'
         assert result.exit_code != ERROR_NOT_IMPLEMENTED
 
         mock_api.set_loopback_mode.return_value = False
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "none"])
-        assert result.output == 'Ethernet0: Set none loopback failed\n'
+                               ["Ethernet0", "media-side-output", "enable"])
+        assert result.output == 'Ethernet0: Set media-side-output loopback failed\n'
         assert result.exit_code == EXIT_FAIL
 
         mock_api.set_loopback_mode.return_value = True
         mock_api.set_loopback_mode.side_effect = AttributeError
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "none"])
+                               ["Ethernet0", "host-side-input", "enable"])
         assert result.output == 'Ethernet0: Set loopback mode is not applicable for this module\n'
         assert result.exit_code == ERROR_NOT_IMPLEMENTED
 
         mock_api.set_loopback_mode.side_effect = [TypeError, True]
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "none"])
-        assert result.output == 'Ethernet0: Set none loopback\n'
+                               ["Ethernet0", "host-side-input", "enable"])
+        assert result.output == 'Ethernet0: Set loopback mode failed. Parameter is not supported\n'
+        assert result.exit_code == EXIT_FAIL
 
         mock_config_db = MagicMock()
         mock_config_db.get.side_effect = TypeError
         mock_config_db_connector.return_value = mock_config_db
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "none"])
+                               ["Ethernet0", "media-side-input", "enable"])
         assert result.output == 'Ethernet0: subport is not present in CONFIG_DB\n'
         assert result.exit_code == EXIT_FAIL
 
         mock_config_db_connector.return_value = None
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "none"])
+                               ["Ethernet0", "media-side-input", "enable"])
         assert result.output == 'Ethernet0: Failed to connect to CONFIG_DB\n'
         assert result.exit_code == EXIT_FAIL
 
         mock_config_db_connector.return_value = MagicMock()
         mock_sonic_v2_connector.return_value = None
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "none"])
+                               ["Ethernet0", "media-side-input", "enable"])
         assert result.output == 'Ethernet0: Failed to connect to STATE_DB\n'
         assert result.exit_code == EXIT_FAIL


### PR DESCRIPTION
#### What I did
This update enhances the loopback command functionality to support configuring the loopback mode for specific logical ports, instead of applying the configuration to the entire physical port.

#### How I did it
By calculating the lane mask according to the port's configuration and state data, the loopback mode can now be accurately set for the specified port, ensuring that other unrelated logical ports are not affected during diagnostic operations.

#### How to verify it
Tested under Cisco8111 with Credo C1 cable.

The sfputil debug loopback command will now only affect the relevant lanes of the logical port.

Set **host input** loopback mode on logical port **Ethernet80**, the expected value of **page 0x13, byte 0xB7= 0x0F**
![image](https://github.com/user-attachments/assets/161a2df9-9ba7-4029-842d-e0d9957d0c52)

Set **media input** loopback mode on logical port **Ethernet84**, the expected value of **page 0x13, byte 0xB5= 0xF0**
![image](https://github.com/user-attachments/assets/6c135120-a2a7-40ce-923d-7585592a07af)

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)