### PR TITLE
[202311] [Mellanox] Add CMIS Host Management Files to 'show techsupport' Dumps

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1209,6 +1209,16 @@ collect_mellanox() {
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local sai_dump_folder="/tmp/saisdkdump"
     local sai_dump_filename="${sai_dump_folder}/sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
+    local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
+    local platform_folder="/usr/share/sonic/device/${platform}"
+    local hwsku=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_hwsku())")
+    local sku_folder="/usr/share/sonic/device/${platform}/${hwsku}"
+    local cmis_host_mgmt_files=(
+        "sai.profile"
+        "pmon_daemon_control.json"
+        "media_settings.json"
+        "optics_si_settings.json"
+    )
 
     if [[ "$( docker container inspect -f '{{.State.Running}}' syncd )" == "true" ]]; then
         if [[ x"$(sonic-db-cli APPL_DB EXISTS PORT_TABLE:PortInitDone)" == x"1" ]]; then
@@ -1250,6 +1260,20 @@ collect_mellanox() {
       echo "HW Mgmt dump script $HW_DUMP_FILE does not exist"
     fi
 
+    # Save CMIS-host-management related files
+    local host_cmis_mgmt_path="cmis-host-mgmt"
+
+    for file in "${cmis_host_mgmt_files[@]}"; do
+        if [[ -f "${sku_folder}/${file}" ]]; then
+            ${CMD_PREFIX}save_file "${sku_folder}/${file}" "$host_cmis_mgmt_path" false true
+        fi
+    done
+
+    if [[ ! -f "${sku_folder}/pmon_daemon_control.json" && -f "${platform_folder}/pmon_daemon_control.json" ]]; then
+        ${CMD_PREFIX}save_file "${platform_folder}/pmon_daemon_control.json" "$host_cmis_mgmt_path" false true
+    fi
+
+    save_cmd "show interfaces autoneg status" "autoneg.status"
 }
 
 ###############################################################################
@@ -1264,17 +1288,9 @@ collect_mellanox() {
 collect_mellanox_dfw_dumps() {
     trap 'handle_error $? $LINENO' ERR
     local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
-    local platform_folder="/usr/share/sonic/device/${platform}"
     local hwsku=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_hwsku())")
-    local sku_folder="/usr/share/sonic/device/${platform}/${hwsku}"
     local def_dump_path="/var/log/mellanox/sdk-dumps"
     local sdk_dump_path=`cat /usr/share/sonic/device/${platform}/${hwsku}/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
-    local cmis_host_mgmt_files=(
-        "sai.profile"
-        "pmon_daemon_control.json"
-        "media_settings.json"
-        "optics_si_settings.json"
-    )
 
     if [ -z $sdk_dump_path ]; then
         # If the SAI_DUMP_STORE_PATH is not found in device specific sai profile, check in common sai profile
@@ -1316,26 +1332,6 @@ collect_mellanox_dfw_dumps() {
             fi
         fi
     done
-
-    # Save CMIS-host-management related files
-    local host_cmis_mgmt_path="etc/cmis-host-mgmt"
-
-    for file in "${cmis_host_mgmt_files[@]}"; do
-        if [[ -f "${sku_folder}/${file}" ]]; then
-            ${CMD_PREFIX}save_file "${sku_folder}/${file}" "$host_cmis_mgmt_path" false true
-        fi
-    done
-
-    if [[ ! -f "${sku_folder}/pmon_daemon_control.json" && -f "${platform_folder}/pmon_daemon_control.json" ]]; then
-        ${CMD_PREFIX}save_file "${platform_folder}/pmon_daemon_control.json" "$host_cmis_mgmt_path" false true
-    fi
-
-    local autoneg_status_file="/tmp/autoneg.status"
-    if show interfaces autoneg status > "$autoneg_status_file"; then
-        ${CMD_PREFIX}save_file "$autoneg_status_file" "$host_cmis_mgmt_path" false true
-    else
-        echo "ERROR: Failed to save autoneg.status"
-    fi
 }
 
 ###############################################################################

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1264,9 +1264,17 @@ collect_mellanox() {
 collect_mellanox_dfw_dumps() {
     trap 'handle_error $? $LINENO' ERR
     local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
+    local platform_folder="/usr/share/sonic/device/${platform}"
     local hwsku=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_hwsku())")
+    local sku_folder="/usr/share/sonic/device/${platform}/${hwsku}"
     local def_dump_path="/var/log/mellanox/sdk-dumps"
     local sdk_dump_path=`cat /usr/share/sonic/device/${platform}/${hwsku}/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
+    local cmis_host_mgmt_files=(
+        "sai.profile"
+        "pmon_daemon_control.json"
+        "media_settings.json"
+        "optics_si_settings.json"
+    )
 
     if [ -z $sdk_dump_path ]; then
         # If the SAI_DUMP_STORE_PATH is not found in device specific sai profile, check in common sai profile
@@ -1310,14 +1318,7 @@ collect_mellanox_dfw_dumps() {
     done
 
     # Save CMIS-host-management related files
-    cmis_host_mgmt_files=(
-        "sai.profile"
-        "pmon_daemon_control.json"
-        "media_settings.json"
-        "optics_si_settings.json"
-    )
-    sku_folder="/usr/share/sonic/device/${platform}/${hwsku}"
-    host_cmis_mgmt_path="etc/cmis-host-mgmt"
+    local host_cmis_mgmt_path="etc/cmis-host-mgmt"
 
     for file in "${cmis_host_mgmt_files[@]}"; do
         if [[ -f "${sku_folder}/${file}" ]]; then
@@ -1325,16 +1326,15 @@ collect_mellanox_dfw_dumps() {
         fi
     done
 
-    platform_folder="/usr/share/sonic/device/${platform}"
     if [[ ! -f "${sku_folder}/pmon_daemon_control.json" && -f "${platform_folder}/pmon_daemon_control.json" ]]; then
         ${CMD_PREFIX}save_file "${platform_folder}/pmon_daemon_control.json" "$host_cmis_mgmt_path" false true
     fi
 
-    autoneg_status_file="/tmp/autoneg.status"
-    if show int autoneg sta > "$autoneg_status_file"; then
+    local autoneg_status_file="/tmp/autoneg.status"
+    if show interfaces autoneg status > "$autoneg_status_file"; then
         ${CMD_PREFIX}save_file "$autoneg_status_file" "$host_cmis_mgmt_path" false true
     else
-        echo "ERROR: Failed to save autoneg.status."
+        echo "ERROR: Failed to save autoneg.status"
     fi
 }
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1308,6 +1308,34 @@ collect_mellanox_dfw_dumps() {
             fi
         fi
     done
+
+    # Save CMIS-host-management related files
+    cmis_host_mgmt_files=(
+        "sai.profile"
+        "pmon_daemon_control.json"
+        "media_settings.json"
+        "optics_si_settings.json"
+    )
+    sku_folder="/usr/share/sonic/device/${platform}/${hwsku}"
+    host_cmis_mgmt_path="etc/cmis-host-mgmt"
+
+    for file in "${cmis_host_mgmt_files[@]}"; do
+        if [[ -f "${sku_folder}/${file}" ]]; then
+            ${CMD_PREFIX}save_file "${sku_folder}/${file}" "$host_cmis_mgmt_path" false true
+        fi
+    done
+
+    platform_folder="/usr/share/sonic/device/${platform}"
+    if [[ ! -f "${sku_folder}/pmon_daemon_control.json" && -f "${platform_folder}/pmon_daemon_control.json" ]]; then
+        ${CMD_PREFIX}save_file "${platform_folder}/pmon_daemon_control.json" "$host_cmis_mgmt_path" false true
+    fi
+
+    autoneg_status_file="/tmp/autoneg.status"
+    if show int autoneg sta > "$autoneg_status_file"; then
+        ${CMD_PREFIX}save_file "$autoneg_status_file" "$host_cmis_mgmt_path" false true
+    else
+        echo "ERROR: Failed to save autoneg.status."
+    fi
 }
 
 ###############################################################################

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1261,16 +1261,16 @@ collect_mellanox() {
     fi
 
     # Save CMIS-host-management related files
-    local host_cmis_mgmt_path="cmis-host-mgmt"
+    local cmis_host_mgmt_path="cmis-host-mgmt"
 
     for file in "${cmis_host_mgmt_files[@]}"; do
         if [[ -f "${file}" ]]; then
-            ${CMD_PREFIX}save_file "${file}" "$host_cmis_mgmt_path" false true
+            ${CMD_PREFIX}save_file "${file}" "$cmis_host_mgmt_path" false true
         fi
     done
 
     if [[ ! -f "${sku_folder}/pmon_daemon_control.json" && -f "${platform_folder}/pmon_daemon_control.json" ]]; then
-        ${CMD_PREFIX}save_file "${platform_folder}/pmon_daemon_control.json" "$host_cmis_mgmt_path" false true
+        ${CMD_PREFIX}save_file "${platform_folder}/pmon_daemon_control.json" "$cmis_host_mgmt_path" false true
     fi
 
     save_cmd "show interfaces autoneg status" "autoneg.status"

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1214,10 +1214,10 @@ collect_mellanox() {
     local hwsku=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_hwsku())")
     local sku_folder="/usr/share/sonic/device/${platform}/${hwsku}"
     local cmis_host_mgmt_files=(
-        "sai.profile"
-        "pmon_daemon_control.json"
-        "media_settings.json"
-        "optics_si_settings.json"
+        "/tmp/nv-syncd-shared/sai.profile"
+        "${sku_folder}/pmon_daemon_control.json"
+        "${sku_folder}/media_settings.json"
+        "${sku_folder}/optics_si_settings.json"
     )
 
     if [[ "$( docker container inspect -f '{{.State.Running}}' syncd )" == "true" ]]; then
@@ -1264,8 +1264,8 @@ collect_mellanox() {
     local host_cmis_mgmt_path="cmis-host-mgmt"
 
     for file in "${cmis_host_mgmt_files[@]}"; do
-        if [[ -f "${sku_folder}/${file}" ]]; then
-            ${CMD_PREFIX}save_file "${sku_folder}/${file}" "$host_cmis_mgmt_path" false true
+        if [[ -f "${file}" ]]; then
+            ${CMD_PREFIX}save_file "${file}" "$host_cmis_mgmt_path" false true
         fi
     done
 


### PR DESCRIPTION
Resolving 202311 conflicts for  https://github.com/sonic-net/sonic-utilities/pull/3501

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
For Mellanox platforms, I added the following CMIS host management-related files to the 'show techsupport' dumps (if they exist): sai.profile, pmon_daemon_control.json, media_settings.json, optics_si_settings.json, and autoneg.status.

#### How I did it
I copied the relevant files from the SKU/platform folder and ran the 'show interface autoneg status' command to store the auto-negotiation status for all ports.

#### How to verify it
Run 'show techsupport' and verify that autoneg.status is located in the 'dumps' directory and that the other files are present in the cmis-host-mgmt path within the generated dump.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

