### PR TITLE
Fix multi-asic behaviour for PFC

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6284,8 +6284,9 @@ def pfc(ctx):
 @pfc.command()
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('status', type=click.Choice(['on', 'off']))
+@multi_asic_util.multi_asic_click_option_namespace
 @click.pass_context
-def asymmetric(ctx, interface_name, status):
+def asymmetric(ctx, interface_name, status, namespace):
     """Set asymmetric PFC configuration."""
     # Get the config_db connector
     config_db = ctx.obj['config_db']
@@ -6295,7 +6296,11 @@ def asymmetric(ctx, interface_name, status):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    clicommon.run_command(['pfc', 'config', 'asymmetric', str(status), str(interface_name)])
+    cmd = ['pfc', 'config', 'asymmetric', str(status), str(interface_name)]
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
+
+    clicommon.run_command(cmd)
 
 #
 # 'pfc priority' command ('config interface pfc priority ...')
@@ -6305,8 +6310,9 @@ def asymmetric(ctx, interface_name, status):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('priority', type=click.Choice([str(x) for x in range(8)]))
 @click.argument('status', type=click.Choice(['on', 'off']))
+@multi_asic_util.multi_asic_click_option_namespace
 @click.pass_context
-def priority(ctx, interface_name, priority, status):
+def priority(ctx, interface_name, priority, status, namespace):
     """Set PFC priority configuration."""
     # Get the config_db connector
     config_db = ctx.obj['config_db']
@@ -6316,7 +6322,11 @@ def priority(ctx, interface_name, priority, status):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    clicommon.run_command(['pfc', 'config', 'priority', str(status), str(interface_name), str(priority)])
+    cmd = ['pfc', 'config', 'priority', str(status), str(interface_name), str(priority)]
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
+
+    clicommon.run_command(cmd)
 
 #
 # 'buffer' group ('config buffer ...')

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -8,153 +8,161 @@ from natsort import natsorted
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
 
-def configPfcAsym(interface, pfc_asym):
-    """
-    PFC handler to configure asymmentric PFC.
-    """
-    configdb = ConfigDBConnector()
-    configdb.connect()
+class Pfc(object):
+    def configPfcAsym(self, interface, pfc_asym):
+        """
+        PFC handler to configure asymmentric PFC.
+        """
+        configdb = ConfigDBConnector()
+        configdb.connect()
 
-    configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
+        configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
 
 
-def showPfcAsym(interface):
-    """
-    PFC handler to display asymmetric PFC information.
-    """
-    header = ('Interface', 'Asymmetric')
+    def showPfcAsym(self, interface):
+        """
+        PFC handler to display asymmetric PFC information.
+        """
+        header = ('Interface', 'Asymmetric')
 
-    configdb = ConfigDBConnector()
-    configdb.connect()
+        configdb = ConfigDBConnector()
+        configdb.connect()
 
-    if interface:
-        db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|{0}'.format(interface))
-    else:
-        db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|*')
+        if interface:
+            db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|{0}'.format(interface))
+        else:
+            db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|*')
 
-    table = []
+        table = []
+
+        for i in db_keys or [None]:
+            key = None
+            if i:
+                key = i.split('|')[-1]
+
+            if key and key.startswith('Ethernet'):
+                entry = configdb.get_entry('PORT', key)
+                table.append([key, entry.get('pfc_asym', 'N/A')])
+
+        sorted_table = natsorted(table)
+
+        click.echo()
+        click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
+        click.echo()
+
+    def configPfcPrio(self, status, interface, priority):
+        configdb = ConfigDBConnector()
+        configdb.connect()
+
+        if interface not in configdb.get_keys('PORT_QOS_MAP'):
+            click.echo('Cannot find interface {0}'.format(interface))
+            return
+
+        """Current lossless priorities on the interface"""
+        entry = configdb.get_entry('PORT_QOS_MAP', interface)
+        enable_prio = entry.get('pfc_enable').split(',')
+
+        """Avoid '' in enable_prio"""
+        enable_prio = [x.strip() for x in enable_prio if x.strip()]
+
+        if status == 'on' and priority in enable_prio:
+            click.echo('Priority {0} has already been enabled on {1}'.format(priority, interface))
+            return
+
+        if status == 'off' and priority not in enable_prio:
+            click.echo('Priority {0} is not enabled on {1}'.format(priority, interface))
+            return
+
+        if status == 'on':
+            enable_prio.append(priority)
+
+        else:
+            enable_prio.remove(priority)
+
+        enable_prio.sort()
+        configdb.mod_entry("PORT_QOS_MAP", interface, {'pfc_enable': ','.join(enable_prio)})
+
+        """Show the latest PFC configuration"""
+        self.showPfcPrio(interface)
         
-    for i in db_keys or [None]:
-        key = None 
-        if i:
-            key = i.split('|')[-1]
+    def showPfcPrio(self, interface):
+        """
+        PFC handler to display PFC enabled priority information.
+        """
+        header = ('Interface', 'Lossless priorities')
+        table = []
 
-        if key and key.startswith('Ethernet'):
-            entry = configdb.get_entry('PORT', key)
-            table.append([key, entry.get('pfc_asym', 'N/A')])
+        configdb = ConfigDBConnector()
+        configdb.connect()
 
-    sorted_table = natsorted(table)
+        """Get all the interfaces with QoS map information"""
+        intfs = configdb.get_keys('PORT_QOS_MAP')
 
-    click.echo()
-    click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
-    click.echo()
+        """The user specifies an interface but we cannot find it"""
+        if interface and interface not in intfs:
+            click.echo('Cannot find interface {0}'.format(interface))
+            return
 
-def configPfcPrio(status, interface, priority):
-    configdb = ConfigDBConnector()
-    configdb.connect()
+        if interface:
+            intfs = [interface]
 
-    if interface not in configdb.get_keys('PORT_QOS_MAP'):
-        click.echo('Cannot find interface {0}'.format(interface))
-        return 
+        for intf in intfs:
+            entry = configdb.get_entry('PORT_QOS_MAP', intf)
+            table.append([intf, entry.get('pfc_enable', 'N/A')])
 
-    """Current lossless priorities on the interface""" 
-    entry = configdb.get_entry('PORT_QOS_MAP', interface)
-    enable_prio = entry.get('pfc_enable').split(',')
-    
-    """Avoid '' in enable_prio"""
-    enable_prio = [x.strip() for x in enable_prio if x.strip()]
-    
-    if status == 'on' and priority in enable_prio:
-        click.echo('Priority {0} has already been enabled on {1}'.format(priority, interface))
-        return
-    
-    if status == 'off' and priority not in enable_prio:
-        click.echo('Priority {0} is not enabled on {1}'.format(priority, interface))
-        return
-    
-    if status == 'on':
-        enable_prio.append(priority)
-    
-    else:
-        enable_prio.remove(priority)
-     
-    enable_prio.sort()    
-    configdb.mod_entry("PORT_QOS_MAP", interface, {'pfc_enable': ','.join(enable_prio)})
-    
-    """Show the latest PFC configuration"""
-    showPfcPrio(interface)
-     
-def showPfcPrio(interface):
-    """
-    PFC handler to display PFC enabled priority information.
-    """
-    header = ('Interface', 'Lossless priorities')
-    table = []
-        
-    configdb = ConfigDBConnector()
-    configdb.connect()
-    
-    """Get all the interfaces with QoS map information"""
-    intfs = configdb.get_keys('PORT_QOS_MAP')
-    
-    """The user specifies an interface but we cannot find it"""    
-    if interface and interface not in intfs:
-        click.echo('Cannot find interface {0}'.format(interface))
-        return 
-    
-    if interface:
-        intfs = [interface]
-    
-    for intf in intfs: 
-        entry = configdb.get_entry('PORT_QOS_MAP', intf)
-        table.append([intf, entry.get('pfc_enable', 'N/A')])
-    
-    sorted_table = natsorted(table)
-    click.echo()
-    click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
-    click.echo()
+        sorted_table = natsorted(table)
+        click.echo()
+        click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
+        click.echo()
     
 @click.group()
-def cli():
+@click.pass_context
+def cli(ctx):
     """PFC Command Line"""
-    pass
+    ctx.obj = { 'pfc': Pfc() }
 
 @cli.group()
-def config():
+@click.pass_context
+def config(ctx):
     """Config PFC"""
     pass
 
 @cli.group()
-def show():
+@click.pass_context
+def show(ctx):
     """Show PFC information"""
     pass
 
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
-def configAsym(status, interface):
+@click.pass_context
+def configAsym(ctx, status, interface):
     """Configure asymmetric PFC on a given port."""
-    configPfcAsym(interface, status)
+    ctx.obj['pfc'].configPfcAsym(interface, status)
 
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
 @click.argument('priority', type=click.Choice(ALL_PRIORITIES))
-def configPrio(status, interface, priority):
+@click.pass_context
+def configPrio(ctx, status, interface, priority):
     """Configure PFC on a given priority."""
-    configPfcPrio(status, interface, priority)
-    
-@click.command()
-@click.argument('interface', type=click.STRING, required=False)
-def showAsym(interface):
-    """Show asymmetric PFC information"""
-    showPfcAsym(interface)
+    ctx.obj['pfc'].configPfcPrio(status, interface, priority)
 
 @click.command()
 @click.argument('interface', type=click.STRING, required=False)
-def showPrio(interface):
+@click.pass_context
+def showAsym(ctx, interface):
+    """Show asymmetric PFC information"""
+    ctx.obj['pfc'].showPfcAsym(interface)
+
+@click.command()
+@click.argument('interface', type=click.STRING, required=False)
+@click.pass_context
+def showPrio(ctx, interface):
     """Show PFC priority information"""
-    showPfcPrio(interface)
+    ctx.obj['pfc'].showPfcPrio(interface)
 
 config.add_command(configAsym, "asymmetric")
 config.add_command(configPrio, "priority")

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -5,8 +5,6 @@ import click
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted
-from importlib import reload
-from utilities_common import multi_asic as multi_asic_util
 
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
@@ -22,10 +20,10 @@ except KeyError:
     pass
 
 class Pfc(object):
+
     def __init__(self, db=None):
         self.db = None
         self.cfgdb = db
-        self.multi_asic = multi_asic_util.MultiAsic()
 
     def configPfcAsym(self, interface, pfc_asym):
         """
@@ -34,10 +32,7 @@ class Pfc(object):
 
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
@@ -53,10 +48,7 @@ class Pfc(object):
 
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         if interface:
@@ -84,10 +76,7 @@ class Pfc(object):
     def configPfcPrio(self, status, interface, priority):
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         if interface not in configdb.get_keys('PORT_QOS_MAP'):
@@ -130,10 +119,7 @@ class Pfc(object):
 
         configdb = self.cfgdb
         if configdb is None:
-            # Get the namespace list
-            namespaces = multi_asic.get_namespace_list()
-
-            configdb = ConfigDBConnector(namespace=namespaces[0])
+            configdb = ConfigDBConnector()
             configdb.connect()
 
         """Get all the interfaces with QoS map information"""
@@ -162,7 +148,7 @@ def cli(ctx):
     # Use the db object if given as input.
     db = None if ctx.obj is None else ctx.obj.cfgdb
     """PFC Command Line"""
-    ctx.obj = { 'pfc': Pfc(db) }
+    ctx.obj = {'pfc': Pfc(db)}
 
 @cli.group()
 @click.pass_context

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,23 +1,11 @@
 #!/usr/bin/env python3
 import click
-import os
-import sys
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted
 
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
-
-# mock the redis for unit test purposes #
-try:
-    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
-        modules_path = os.path.join(os.path.dirname(__file__), "..")
-        tests_path = os.path.join(modules_path, "tests")
-        sys.path.insert(0, modules_path)
-        sys.path.insert(0, tests_path)
-except KeyError:
-    pass
 
 
 class Pfc(object):
@@ -32,9 +20,6 @@ class Pfc(object):
         configdb.connect()
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
-
-        if "UTILITIES_UNIT_TESTING" in os.environ and os.environ["UTILITIES_UNIT_TESTING"] == "2":
-            self.showPfcAsym(interface)
 
     def showPfcAsym(self, interface):
         """

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -21,6 +21,7 @@ except KeyError:
 
 class Pfc(object):
 
+
     def __init__(self, db=None):
         self.db = None
         self.cfgdb = db

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -21,20 +21,15 @@ except KeyError:
 
 
 class Pfc(object):
-
-    def __init__(self, db=None):
-        self.db = None
-        self.cfgdb = db
+    def __init__(self, cfgdb=None):
+        self.cfgdb = cfgdb
 
     def configPfcAsym(self, interface, pfc_asym):
         """
         PFC handler to configure asymmetric PFC.
         """
-
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
 
@@ -47,10 +42,8 @@ class Pfc(object):
         """
         header = ('Interface', 'Asymmetric')
 
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         if interface:
             db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|{0}'.format(interface))
@@ -75,10 +68,8 @@ class Pfc(object):
         click.echo()
 
     def configPfcPrio(self, status, interface, priority):
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         if interface not in configdb.get_keys('PORT_QOS_MAP'):
             click.echo('Cannot find interface {0}'.format(interface))
@@ -118,10 +109,8 @@ class Pfc(object):
         header = ('Interface', 'Lossless priorities')
         table = []
 
-        configdb = self.cfgdb
-        if configdb is None:
-            configdb = ConfigDBConnector()
-            configdb.connect()
+        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
+        configdb.connect()
 
         """Get all the interfaces with QoS map information"""
         intfs = configdb.get_keys('PORT_QOS_MAP')
@@ -146,10 +135,11 @@ class Pfc(object):
 @click.group()
 @click.pass_context
 def cli(ctx):
-    # Use the db object if given as input.
-    db = None if ctx.obj is None else ctx.obj.cfgdb
     """PFC Command Line"""
-    ctx.obj = {'pfc': Pfc(db)}
+    # Use the cfgdb object if given as input.
+    cfgdb = None if ctx.obj is None else ctx.obj.cfgdb
+
+    ctx.obj = {'pfc': Pfc(cfgdb)}
 
 @cli.group()
 @click.pass_context

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -19,8 +19,8 @@ try:
 except KeyError:
     pass
 
-class Pfc(object):
 
+class Pfc(object):
 
     def __init__(self, db=None):
         self.db = None

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,39 +1,63 @@
 #!/usr/bin/env python3
+import os
 import click
-from swsscommon.swsscommon import ConfigDBConnector
+import json
+from sonic_py_common import multi_asic
 from tabulate import tabulate
 from natsort import natsorted
+from utilities_common import multi_asic as multi_asic_util
 
+# Constants
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
+PORT_TABLE_NAME = "PORT"
+PORT_QOS_MAP_TABLE_NAME = "PORT_QOS_MAP"
 
 
 class Pfc(object):
-    def __init__(self, cfgdb=None):
-        self.cfgdb = cfgdb
+    def __init__(self, namespace=None):
+        self.multi_asic = multi_asic_util.MultiAsic(namespace_option=namespace)
+        self.config_db = None
 
+        # For unit testing
+        self.updated_port_tables = {}
+        self.test_filename = '/tmp/pfc_testdata.json'
+
+    def dump_config_to_json(self, table_name, namespace):
+        """
+        This function dumps the current config in a JSON file for unit testing.
+        """
+        # Only dump files in unit testing mode
+        if os.environ["UTILITIES_UNIT_TESTING"] != "2":
+            return
+
+        if namespace not in self.updated_port_tables.keys():
+            self.updated_port_tables[namespace] = {}
+
+        self.updated_port_tables[namespace][table_name] = self.config_db.get_table(table_name)
+        with open(self.test_filename, "w") as fd:
+            json.dump(self.updated_port_tables, fd)
+
+    @multi_asic_util.run_on_multi_asic
     def configPfcAsym(self, interface, pfc_asym):
         """
         PFC handler to configure asymmetric PFC.
         """
-        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
-        configdb.connect()
+        self.config_db.mod_entry(PORT_TABLE_NAME, interface, {'pfc_asym': pfc_asym})
+        self.dump_config_to_json(PORT_TABLE_NAME, self.multi_asic.current_namespace)
 
-        configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
-
+    @multi_asic_util.run_on_multi_asic
     def showPfcAsym(self, interface):
         """
         PFC handler to display asymmetric PFC information.
         """
+        namespace_str = f"Namespace {self.multi_asic.current_namespace}" if multi_asic.is_multi_asic() else ''
         header = ('Interface', 'Asymmetric')
 
-        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
-        configdb.connect()
-
         if interface:
-            db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|{0}'.format(interface))
+            db_keys = self.config_db.keys(self.config_db.CONFIG_DB, 'PORT|{0}'.format(interface))
         else:
-            db_keys = configdb.keys(configdb.CONFIG_DB, 'PORT|*')
+            db_keys = self.config_db.keys(self.config_db.CONFIG_DB, 'PORT|*')
 
         table = []
 
@@ -43,36 +67,35 @@ class Pfc(object):
                 key = i.split('|')[-1]
 
             if key and key.startswith('Ethernet'):
-                entry = configdb.get_entry('PORT', key)
+                entry = self.config_db.get_entry(PORT_TABLE_NAME, key)
                 table.append([key, entry.get('pfc_asym', 'N/A')])
 
         sorted_table = natsorted(table)
 
-        click.echo()
+        click.echo(namespace_str)
         click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
         click.echo()
 
+    @multi_asic_util.run_on_multi_asic
     def configPfcPrio(self, status, interface, priority):
-        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
-        configdb.connect()
-
-        if interface not in configdb.get_keys('PORT_QOS_MAP'):
+        if interface not in self.config_db.get_keys(PORT_QOS_MAP_TABLE_NAME):
             click.echo('Cannot find interface {0}'.format(interface))
             return
 
         """Current lossless priorities on the interface"""
-        entry = configdb.get_entry('PORT_QOS_MAP', interface)
+        entry = self.config_db.get_entry('PORT_QOS_MAP', interface)
         enable_prio = entry.get('pfc_enable').split(',')
 
         """Avoid '' in enable_prio"""
         enable_prio = [x.strip() for x in enable_prio if x.strip()]
 
+        namespace_str = f" for namespace {self.multi_asic.current_namespace}" if multi_asic.is_multi_asic() else ''
         if status == 'on' and priority in enable_prio:
-            click.echo('Priority {0} has already been enabled on {1}'.format(priority, interface))
+            click.echo('Priority {0} has already been enabled on {1}{2}'.format(priority, interfacei, namespace_str))
             return
 
         if status == 'off' and priority not in enable_prio:
-            click.echo('Priority {0} is not enabled on {1}'.format(priority, interface))
+            click.echo('Priority {0} is not enabled on {1}{2}'.format(priority, interface, namespace_str))
             return
 
         if status == 'on':
@@ -82,11 +105,10 @@ class Pfc(object):
             enable_prio.remove(priority)
 
         enable_prio.sort()
-        configdb.mod_entry("PORT_QOS_MAP", interface, {'pfc_enable': ','.join(enable_prio)})
+        self.config_db.mod_entry(PORT_QOS_MAP_TABLE_NAME, interface, {'pfc_enable': ','.join(enable_prio)})
+        self.dump_config_to_json(PORT_QOS_MAP_TABLE_NAME, self.multi_asic.current_namespace)
 
-        """Show the latest PFC configuration"""
-        self.showPfcPrio(interface)
-        
+    @multi_asic_util.run_on_multi_asic
     def showPfcPrio(self, interface):
         """
         PFC handler to display PFC enabled priority information.
@@ -94,82 +116,82 @@ class Pfc(object):
         header = ('Interface', 'Lossless priorities')
         table = []
 
-        configdb = ConfigDBConnector() if self.cfgdb is None else self.cfgdb
-        configdb.connect()
-
         """Get all the interfaces with QoS map information"""
-        intfs = configdb.get_keys('PORT_QOS_MAP')
+        intfs = self.config_db.get_keys('PORT_QOS_MAP')
 
         """The user specifies an interface but we cannot find it"""
+        namespace_str = f"Namespace {self.multi_asic.current_namespace}" if multi_asic.is_multi_asic() else ''
         if interface and interface not in intfs:
-            click.echo('Cannot find interface {0}'.format(interface))
+            click.echo('Cannot find interface {0} for {1}'.format(interface, namespace_str))
             return
 
         if interface:
             intfs = [interface]
 
         for intf in intfs:
-            entry = configdb.get_entry('PORT_QOS_MAP', intf)
+            entry = self.config_db.get_entry('PORT_QOS_MAP', intf)
             table.append([intf, entry.get('pfc_enable', 'N/A')])
 
         sorted_table = natsorted(table)
-        click.echo()
+        click.echo(namespace_str)
         click.echo(tabulate(sorted_table, headers=header, tablefmt="simple", missingval=""))
         click.echo()
-    
-@click.group()
-@click.pass_context
-def cli(ctx):
-    """PFC Command Line"""
-    # Use the cfgdb object if given as input.
-    cfgdb = None if ctx.obj is None else ctx.obj.cfgdb
 
-    ctx.obj = {'pfc': Pfc(cfgdb)}
+
+@click.group()
+def cli():
+    """PFC Command Line"""
+
 
 @cli.group()
-@click.pass_context
-def config(ctx):
+def config():
     """Config PFC"""
     pass
 
+
 @cli.group()
-@click.pass_context
-def show(ctx):
+def show():
     """Show PFC information"""
     pass
+
 
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
-@click.pass_context
-def configAsym(ctx, status, interface):
+@multi_asic_util.multi_asic_click_option_namespace
+def configAsym(status, interface, namespace):
     """Configure asymmetric PFC on a given port."""
-    ctx.obj['pfc'].configPfcAsym(interface, status)
+    Pfc(namespace).configPfcAsym(interface, status)
+
 
 @click.command()
 @click.argument('status', type=click.Choice(PRIORITY_STATUS))
 @click.argument('interface', type=click.STRING)
 @click.argument('priority', type=click.Choice(ALL_PRIORITIES))
-@click.pass_context
-def configPrio(ctx, status, interface, priority):
+@multi_asic_util.multi_asic_click_option_namespace
+def configPrio(status, interface, priority, namespace):
     """Configure PFC on a given priority."""
-    ctx.obj['pfc'].configPfcPrio(status, interface, priority)
+    Pfc(namespace).configPfcPrio(status, interface, priority)
+
 
 @click.command()
 @click.argument('interface', type=click.STRING, required=False)
-@click.pass_context
-def showAsym(ctx, interface):
+@multi_asic_util.multi_asic_click_option_namespace
+def showAsym(interface, namespace):
     """Show asymmetric PFC information"""
-    ctx.obj['pfc'].showPfcAsym(interface)
+    Pfc(namespace).showPfcAsym(interface)
+
 
 @click.command()
 @click.argument('interface', type=click.STRING, required=False)
-@click.pass_context
-def showPrio(ctx, interface):
+@multi_asic_util.multi_asic_click_option_namespace
+def showPrio(interface, namespace):
     """Show PFC priority information"""
-    ctx.obj['pfc'].showPfcPrio(interface)
+    Pfc(namespace).showPfcPrio(interface)
+
 
 config.add_command(configAsym, "asymmetric")
 config.add_command(configPrio, "priority")
 show.add_command(showAsym, "asymmetric")
 show.add_command(showPrio, "priority")
+

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,12 +1,24 @@
 #!/usr/bin/env python3
-
+import os
+import sys
 import click
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted
+from importlib import reload
 
 ALL_PRIORITIES = [str(x) for x in range(8)]
 PRIORITY_STATUS = ['on', 'off']
+
+# mock the redis for unit test purposes #
+try:
+    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
+        modules_path = os.path.join(os.path.dirname(__file__), "..")
+        tests_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, tests_path)
+except KeyError:
+    pass
 
 class Pfc(object):
     def configPfcAsym(self, interface, pfc_asym):
@@ -18,6 +30,8 @@ class Pfc(object):
 
         configdb.mod_entry("PORT", interface, {'pfc_asym': pfc_asym})
 
+        if "UTILITIES_UNIT_TESTING" in os.environ and os.environ["UTILITIES_UNIT_TESTING"] == "2":
+            self.showPfcAsym(interface)
 
     def showPfcAsym(self, interface):
         """

--- a/pfc/main.py
+++ b/pfc/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import click
 import os
 import sys
-import click
 from swsscommon.swsscommon import ConfigDBConnector
 from tabulate import tabulate
 from natsort import natsorted

--- a/show/main.py
+++ b/show/main.py
@@ -645,7 +645,8 @@ def counters(namespace, display, verbose):
 
 @pfc.command()
 @click.argument('interface', type=click.STRING, required=False)
-def priority(interface):
+@multi_asic_util.multi_asic_click_option_namespace
+def priority(interface, namespace):
     """Show pfc priority"""
     cmd = ['pfc', 'show', 'priority']
     if interface is not None and clicommon.get_interface_naming_mode() == "alias":
@@ -653,12 +654,15 @@ def priority(interface):
 
     if interface is not None:
         cmd += [str(interface)]
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
 
     run_command(cmd)
 
 @pfc.command()
 @click.argument('interface', type=click.STRING, required=False)
-def asymmetric(interface):
+@multi_asic_util.multi_asic_click_option_namespace
+def asymmetric(interface, namespace):
     """Show asymmetric pfc"""
     cmd = ['pfc', 'show', 'asymmetric']
     if interface is not None and clicommon.get_interface_naming_mode() == "alias":
@@ -666,6 +670,8 @@ def asymmetric(interface):
 
     if interface is not None:
         cmd += [str(interface)]
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
 
     run_command(cmd)
 

--- a/tests/multi_asic_pfc_test.py
+++ b/tests/multi_asic_pfc_test.py
@@ -1,0 +1,134 @@
+import os
+import sys
+import json
+import importlib
+import pfc.main as pfc
+from .pfc_test import TestPfcBase
+from click.testing import CliRunner
+from .pfc_input.pfc_test_vectors import testData
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "pfc")
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+
+class TestPfcMultiAsic(TestPfcBase):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+
+        # Multi-asic utils rely on the database that is loaded
+        # We reload the multi_asic database and update the multi-asic utils
+        # Pfc uses click cmds that use multi_asic utils, hence we reload pfc too
+
+        import mock_tables.mock_multi_asic
+        importlib.reload(mock_tables.mock_multi_asic)
+        mock_tables.dbconnector.load_namespace_config()
+
+        import utilities_common
+        importlib.reload(utilities_common.multi_asic)
+        importlib.reload(pfc)
+
+    def executor(self, input):
+        runner = CliRunner()
+        result = runner.invoke(pfc.cli, input['cmd'])
+        exit_code = result.exit_code
+        output = result.output
+
+        print(exit_code)
+        print(output)
+
+        assert exit_code == input['rc']
+
+        # For config commands we dump modified value in a tmp JSON file for testing
+        if 'cmp_args' in input:
+            fd = open('/tmp/pfc_testdata.json', 'r')
+            cmp_data = json.load(fd)
+
+            # Verify assignments
+            for args in input['cmp_args']:
+                namespace, table, key, field, expected_val = args
+                assert(cmp_data[namespace][table][key][field] == expected_val)
+            fd.close()
+
+        if 'rc_msg' in input:
+            assert input['rc_msg'] in output
+
+        if 'rc_output' in input:
+            assert output == input['rc_output']
+
+    def test_pfc_show_asymmetric_all_asic0_masic(self):
+        self.executor(testData['pfc_show_asymmetric_all_asic0_masic'])
+
+    def test_pfc_show_asymmetric_all_asic1_masic(self):
+        self.executor(testData['pfc_show_asymmetric_all_asic1_masic'])
+
+    def test_pfc_show_asymmetric_all_masic(self):
+        self.executor(testData['pfc_show_asymmetric_all_masic'])
+
+    def test_pfc_show_asymmetric_intf_one_masic(self):
+        self.executor(testData['pfc_show_asymmetric_intf_one_masic'])
+
+    def test_pfc_show_asymmetric_intf_all_masic(self):
+        self.executor(testData['pfc_show_asymmetric_intf_all_masic'])
+
+    def test_pfc_show_asymmetric_intf_fake_one_masic(self):
+        self.executor(testData['pfc_show_asymmetric_intf_fake_one_masic'])
+
+    def test_pfc_show_priority_all_asic0_masic(self):
+        self.executor(testData['pfc_show_priority_all_asic0_masic'])
+
+    def test_pfc_show_priority_all_asic1_masic(self):
+        self.executor(testData['pfc_show_priority_all_asic1_masic'])
+
+    def test_pfc_show_priority_all_masic(self):
+        self.executor(testData['pfc_show_priority_all_masic'])
+
+    def test_pfc_show_priority_intf_one_masic(self):
+        self.executor(testData['pfc_show_priority_intf_one_masic'])
+
+    def test_pfc_show_priority_intf_all_masic(self):
+        self.executor(testData['pfc_show_priority_intf_all_masic'])
+
+    def test_pfc_show_priority_intf_fake_one_masic(self):
+        self.executor(testData['pfc_show_priority_intf_fake_one_masic'])
+
+    def test_pfc_show_priority_intf_fake_all_masic(self):
+        self.executor(testData['pfc_show_priority_intf_fake_all_masic'])
+
+    def test_pfc_config_asymmetric_one_masic(self):
+        self.executor(testData['pfc_config_asymmetric_one_masic'])
+
+    def test_pfc_config_asymmetric_invalid_one_masic(self):
+        self.executor(testData['pfc_config_asymmetric_invalid_one_masic'])
+
+    def test_pfc_config_asymmetric_all_masic(self):
+        self.executor(testData['pfc_config_asymmetric_all_masic'])
+
+    def test_pfc_config_asymmetric_invalid_all_masic(self):
+        self.executor(testData['pfc_config_asymmetric_invalid_all_masic'])
+
+    def test_pfc_config_priority_one_masic(self):
+        self.executor(testData['pfc_config_priority_one_masic'])
+
+    def test_pfc_config_priority_invalid_one_masic(self):
+        self.executor(testData['pfc_config_priority_invalid_one_masic'])
+
+    def test_pfc_config_priority_all_masic(self):
+        self.executor(testData['pfc_config_priority_all_masic'])
+
+    def test_pfc_config_priority_invalid_all_masic(self):
+        self.executor(testData['pfc_config_priority_invalid_all_masic'])
+
+    @classmethod
+    def teardown_class(cls):
+        # Reset the database to mock single-asic state
+        import mock_tables.mock_single_asic
+        mock_tables.dbconnector.load_database_config()
+
+        super().teardown_class()
+        os.environ.pop("UTILITIES_UNIT_TESTING_TOPOLOGY")
+

--- a/tests/pfc_input/assert_show_output.py
+++ b/tests/pfc_input/assert_show_output.py
@@ -6,7 +6,7 @@ Interface    Asymmetric
 """
 
 pfc_cannot_find_intf = """\
-Cannot find interface Ethernet1234
+Cannot find interface Ethernet1234 for 
 """
 
 pfc_show_asymmetric_all = """\

--- a/tests/pfc_input/assert_show_output.py
+++ b/tests/pfc_input/assert_show_output.py
@@ -1,3 +1,10 @@
+pfc_asym_cannot_find_intf = """\
+
+Interface    Asymmetric
+-----------  ------------
+
+"""
+
 pfc_cannot_find_intf = """\
 Cannot find interface Ethernet1234
 """

--- a/tests/pfc_input/assert_show_output.py
+++ b/tests/pfc_input/assert_show_output.py
@@ -73,14 +73,6 @@ Ethernet0    3,4
 
 """
 
-pfc_config_asymmetric = """\
-
-Interface    Asymmetric
------------  ------------
-Ethernet0    on
-
-"""
-
 pfc_config_priority_on = """\
 
 Interface    Lossless priorities

--- a/tests/pfc_input/assert_show_output.py
+++ b/tests/pfc_input/assert_show_output.py
@@ -1,0 +1,83 @@
+pfc_cannot_find_intf = """\
+Cannot find interface Ethernet1234
+"""
+
+pfc_show_asymmetric_all = """\
+
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    off
+Ethernet4    off
+Ethernet8    off
+Ethernet12   off
+Ethernet16   off
+Ethernet20   off
+Ethernet24   off
+Ethernet28   off
+Ethernet32   off
+Ethernet36   off
+Ethernet40   off
+Ethernet44   off
+Ethernet48   off
+Ethernet52   off
+Ethernet56   off
+Ethernet60   off
+Ethernet64   off
+Ethernet68   off
+Ethernet72   off
+Ethernet76   off
+Ethernet80   off
+Ethernet84   off
+Ethernet88   off
+Ethernet92   off
+Ethernet96   off
+Ethernet100  off
+Ethernet104  off
+Ethernet108  off
+Ethernet112  off
+Ethernet116  off
+Ethernet120  off
+Ethernet124  off
+
+"""
+
+pfc_show_asymmetric_intf = """\
+
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    off
+
+"""
+
+pfc_show_priority_all = """\
+
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4
+Ethernet4    3,4
+
+"""
+
+pfc_show_priority_intf = """\
+
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4
+
+"""
+
+pfc_config_asymmetric = """\
+
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    on
+
+"""
+
+pfc_config_priority_on = """\
+
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4,5
+
+"""

--- a/tests/pfc_input/pfc_test_vectors.py
+++ b/tests/pfc_input/pfc_test_vectors.py
@@ -1,0 +1,283 @@
+# Golden outputs
+show_asym_all_asic0_masic = """\
+Namespace asic0
+Interface     Asymmetric
+------------  ------------
+Ethernet0     off
+Ethernet4     off
+Ethernet16    off
+Ethernet-BP0  off
+Ethernet-BP4  off
+
+"""
+
+show_asym_all_asic1_masic = """\
+Namespace asic1
+Interface       Asymmetric
+--------------  ------------
+Ethernet64      off
+Ethernet-BP256  off
+Ethernet-BP260  off
+
+"""
+
+show_asym_all_masic = """\
+Namespace asic0
+Interface     Asymmetric
+------------  ------------
+Ethernet0     off
+Ethernet4     off
+Ethernet16    off
+Ethernet-BP0  off
+Ethernet-BP4  off
+
+Namespace asic1
+Interface       Asymmetric
+--------------  ------------
+Ethernet64      off
+Ethernet-BP256  off
+Ethernet-BP260  off
+
+"""
+
+show_asym_intf_one_masic = """\
+Namespace asic0
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    off
+
+"""
+
+show_asym_intf_all_masic = """\
+Namespace asic0
+Interface    Asymmetric
+-----------  ------------
+Ethernet0    off
+
+Namespace asic1
+Interface    Asymmetric
+-----------  ------------
+
+"""
+
+show_asym_intf_fake_one_masic = """\
+Namespace asic0
+Interface    Asymmetric
+-----------  ------------
+
+"""
+
+show_prio_all_asic0_masic = """\
+Namespace asic0
+Interface       Lossless priorities
+--------------  ---------------------
+Ethernet0       3,4
+Ethernet4       3,4
+Ethernet8       3,4
+Ethernet-BP0    3,4
+Ethernet-BP4    3,4
+Ethernet-BP256  3,4
+Ethernet-BP260  3,4
+
+"""
+
+show_prio_all_asic1_masic = """\
+Namespace asic1
+Interface       Lossless priorities
+--------------  ---------------------
+Ethernet0       3,4
+Ethernet4       3,4
+Ethernet8       3,4
+Ethernet-BP0    3,4
+Ethernet-BP4    3,4
+Ethernet-BP256  3,4
+
+"""
+
+show_prio_all_masic = """\
+Namespace asic0
+Interface       Lossless priorities
+--------------  ---------------------
+Ethernet0       3,4
+Ethernet4       3,4
+Ethernet8       3,4
+Ethernet-BP0    3,4
+Ethernet-BP4    3,4
+Ethernet-BP256  3,4
+Ethernet-BP260  3,4
+
+Namespace asic1
+Interface       Lossless priorities
+--------------  ---------------------
+Ethernet0       3,4
+Ethernet4       3,4
+Ethernet8       3,4
+Ethernet-BP0    3,4
+Ethernet-BP4    3,4
+Ethernet-BP256  3,4
+
+"""
+
+show_prio_intf_one_masic = """\
+Namespace asic0
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4
+
+"""
+
+show_prio_intf_all_masic = """\
+Namespace asic0
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4
+
+Namespace asic1
+Interface    Lossless priorities
+-----------  ---------------------
+Ethernet0    3,4
+
+"""
+
+show_prio_intf_fake_one_masic = """\
+Cannot find interface Ethernet1234 for Namespace asic0
+"""
+
+show_prio_intf_fake_all_masic = """\
+Cannot find interface Ethernet1234 for Namespace asic0
+Cannot find interface Ethernet1234 for Namespace asic1
+"""
+
+testData = {
+             'pfc_show_asymmetric_all_asic0_masic': {'cmd': ['show', 'asymmetric',
+                                                             '--namespace', 'asic0'],
+                                                     'rc': 0,
+                                                     'rc_output': show_asym_all_asic0_masic
+                                                     },
+             'pfc_show_asymmetric_all_asic1_masic': {'cmd': ['show', 'asymmetric',
+                                                             '--namespace', 'asic1'],
+                                                     'rc': 0,
+                                                     'rc_output': show_asym_all_asic1_masic
+                                                     },
+             'pfc_show_asymmetric_all_masic': {'cmd': ['show', 'asymmetric'],
+                                               'rc': 0,
+                                               'rc_output': show_asym_all_masic
+                                               },
+             'pfc_show_asymmetric_intf_one_masic': {'cmd': ['show', 'asymmetric',
+                                                            'Ethernet0', '--namespace',
+                                                            'asic0'],
+                                                    'rc': 0,
+                                                    'rc_output': show_asym_intf_one_masic
+                                                     },
+             'pfc_show_asymmetric_intf_all_masic': {'cmd': ['show', 'asymmetric',
+                                                            'Ethernet0'],
+                                                    'rc': 0,
+                                                    'rc_output': show_asym_intf_all_masic
+                                                     },
+             'pfc_show_asymmetric_intf_fake_one_masic': {'cmd': ['show', 'asymmetric',
+                                                             'Ethernet1234', '--namespace',
+                                                             'asic0'],
+                                                    'rc': 0,
+                                                    'rc_output': show_asym_intf_fake_one_masic
+                                                     },
+             'pfc_show_priority_all_asic0_masic': {'cmd': ['show', 'priority',
+                                                           '--namespace', 'asic0'],
+                                                     'rc': 0,
+                                                     'rc_output': show_prio_all_asic0_masic
+                                                     },
+             'pfc_show_priority_all_asic1_masic': {'cmd': ['show', 'priority',
+                                                             '--namespace', 'asic1'],
+                                                     'rc': 0,
+                                                     'rc_output': show_prio_all_asic1_masic
+                                                     },
+             'pfc_show_priority_all_masic': {'cmd': ['show', 'priority'],
+                                               'rc': 0,
+                                               'rc_output': show_prio_all_masic
+                                               },
+             'pfc_show_priority_intf_one_masic': {'cmd': ['show', 'priority',
+                                                            'Ethernet0', '--namespace',
+                                                            'asic0'],
+                                                  'rc': 0,
+                                                  'rc_output': show_prio_intf_one_masic
+                                                  },
+             'pfc_show_priority_intf_all_masic': {'cmd': ['show', 'priority',
+                                                          'Ethernet0'],
+                                                  'rc': 0,
+                                                  'rc_output': show_prio_intf_all_masic
+                                                  },
+             'pfc_show_priority_intf_fake_one_masic': {'cmd': ['show', 'priority',
+                                                             'Ethernet1234', '--namespace',
+                                                             'asic0'],
+                                                    'rc': 0,
+                                                    'rc_output': show_prio_intf_fake_one_masic
+                                                     },
+             'pfc_show_priority_intf_fake_all_masic': {'cmd': ['show', 'priority',
+                                                             'Ethernet1234'],
+                                                       'rc': 0,
+                                                       'rc_output': show_prio_intf_fake_all_masic
+                                                     },
+             'pfc_config_asymmetric_one_masic': {'cmd': ['config', 'asymmetric',
+                                                         'on', 'Ethernet0', '--namespace',
+                                                         'asic0'],
+                                                 'rc': 0,
+                                                 'cmp_args': [['asic0','PORT','Ethernet0','pfc_asym','on']]
+                                                 },
+             'pfc_config_asymmetric_invalid_one_masic': {'cmd': ['config', 'asymmetric',
+                                                                 'onn', 'Ethernet0', '--namespace',
+                                                                 'asic0'],
+                                                         'rc': 2,
+                                                         'rc_msg': ('Usage: cli config asymmetric [OPTIONS] '
+                                                                    '[on|off] INTERFACE\nTry "cli config '
+                                                                    'asymmetric --help" for help.\n\n'
+                                                                    'Error: Invalid value for "[on|off]": '
+                                                                    'invalid choice: onn. (choose from on, off)')
+                                                 },
+             'pfc_config_asymmetric_all_masic': {'cmd': ['config', 'asymmetric',
+                                                         'on', 'Ethernet0'],
+                                                 'rc': 0,
+                                                 'cmp_args': [['asic0','PORT','Ethernet0','pfc_asym','on'],
+                                                              ['asic1','PORT','Ethernet0','pfc_asym','on']]
+                                                 },
+             'pfc_config_asymmetric_invalid_all_masic': {'cmd': ['config', 'asymmetric',
+                                                                 'onn', 'Ethernet0'],
+                                                         'rc': 2,
+                                                         'rc_msg': ('Usage: cli config asymmetric [OPTIONS] '
+                                                                    '[on|off] INTERFACE\nTry "cli config '
+                                                                    'asymmetric --help" for help.\n\n'
+                                                                    'Error: Invalid value for "[on|off]": '
+                                                                    'invalid choice: onn. (choose from on, off)')
+                                                        },
+             'pfc_config_priority_one_masic': {'cmd': ['config', 'priority',
+                                                       'on', 'Ethernet0', '5',
+                                                       '--namespace', 'asic0'],
+                                               'rc': 0,
+                                               'cmp_args': [['asic0','PORT_QOS_MAP','Ethernet0','pfc_enable','3,4,5']]
+                                               },
+             'pfc_config_priority_invalid_one_masic': {'cmd': ['config', 'priority',
+                                                               'onn', 'Ethernet0', '5',
+                                                               '--namespace', 'asic0'],
+                                                         'rc': 2,
+                                                         'rc_msg': ('Usage: cli config priority [OPTIONS] '
+                                                                    '[on|off] INTERFACE [0|1|2|3|4|5|6|7]\n'
+                                                                    'Try "cli config priority --help" for '
+                                                                    'help.\n\nError: Invalid value for '
+                                                                    '"[on|off]": invalid choice: onn. '
+                                                                    '(choose from on, off)')
+                                                 },
+             'pfc_config_priority_all_masic': {'cmd': ['config', 'priority',
+                                                         'on', 'Ethernet0', '5'],
+                                                 'rc': 0,
+                                                 'cmp_args': [['asic0','PORT_QOS_MAP','Ethernet0','pfc_enable','3,4,5'],
+                                                              ['asic1','PORT_QOS_MAP','Ethernet0', 'pfc_enable', '3,4,5']]
+                                                 },
+             'pfc_config_priority_invalid_all_masic': {'cmd': ['config', 'priority',
+                                                                 'onn', 'Ethernet0', '5'],
+                                                         'rc': 2,
+                                                         'rc_msg': ('Usage: cli config priority [OPTIONS] '
+                                                                    '[on|off] INTERFACE [0|1|2|3|4|5|6|7]\n'
+                                                                    'Try "cli config priority --help" for '
+                                                                    'help.\n\nError: Invalid value for '
+                                                                    '"[on|off]": invalid choice: onn. '
+                                                                    '(choose from on, off)')
+                                                        },
+}

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,10 +1,10 @@
 import os
 import sys
+import json
 import pfc.main as pfc
 from .pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
    pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, \
    pfc_config_priority_on, pfc_asym_cannot_find_intf
-from utilities_common.db import Db
 
 from click.testing import CliRunner
 from importlib import reload
@@ -17,11 +17,15 @@ sys.path.insert(0, modules_path)
 
 
 class TestPfcBase(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ["UTILITIES_UNIT_TESTING"] = "2"
 
-    def executor(self, cliobj, command, expected_rc=0, expected_output=None, expected_cfgdb_entry=None,
+    def executor(self, cliobj, command, expected_rc=0, expected_output=None, expected_cfgdb_entries=None,
                  runner=CliRunner()):
-        db = Db()
-        result = runner.invoke(cliobj, command, obj=db)
+        result = runner.invoke(cliobj, command)
         print(result.exit_code)
         print(result.output)
 
@@ -32,21 +36,37 @@ class TestPfcBase(object):
         if expected_output:
             assert result.output == expected_output
 
-        if expected_cfgdb_entry:
-            (table, key, field, expected_val) = expected_cfgdb_entry
-            configdb = db.cfgdb
-            entry = configdb.get_entry(table, key)
-            assert entry.get(field) == expected_val
-
-
-class TestPfc(TestPfcBase):
+        if expected_cfgdb_entries:
+            fd = open('/tmp/pfc_testdata.json', 'r')
+            cmp_data = json.load(fd)
+            for expected_cfgdb_entry in expected_cfgdb_entries:
+                (namespace, table, key, field, expected_val) = expected_cfgdb_entry
+                entry = cmp_data[namespace][table][key][field]
+                assert entry == expected_val
 
     @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(
+            os.environ["PATH"].split(os.pathsep)[:-1]
+        )
+        os.environ.pop("UTILITIES_UNIT_TESTING")
+        if os.path.isfile('/tmp/pfc_testdata.json'):
+            os.remove('/tmp/pfc_testdata.json')
+
+class TestPfc(TestPfcBase):
+    @classmethod
     def setup_class(cls):
+        super().setup_class()
+
         from mock_tables import dbconnector
         from mock_tables import mock_single_asic
         reload(mock_single_asic)
-        dbconnector.load_namespace_config()
+        dbconnector.load_database_config()
+
+        import utilities_common
+        reload(utilities_common.multi_asic)
+        reload(pfc)
 
     def test_pfc_show_asymmetric_all(self):
         self.executor(pfc.cli, ['show', 'asymmetric'],
@@ -74,8 +94,10 @@ class TestPfc(TestPfcBase):
 
     def test_pfc_config_asymmetric(self):
         self.executor(pfc.cli, ['config', 'asymmetric', 'on', 'Ethernet0'],
-                      expected_cfgdb_entry=('PORT', 'Ethernet0', 'pfc_asym', 'on'))
+                      # namespace, table, key, field, expected_val
+                      expected_cfgdb_entries=[('', 'PORT', 'Ethernet0', 'pfc_asym', 'on')])
 
     def test_pfc_config_priority(self):
         self.executor(pfc.cli, ['config', 'priority', 'on', 'Ethernet0', '5'],
-                      expected_output=pfc_config_priority_on)
+                      # namespace, table, key, field, expected_val
+                      expected_cfgdb_entries=[('', 'PORT_QOS_MAP', 'Ethernet0', 'pfc_enable', '3,4,5')])

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import pfc.main as pfc
+from pfc_input.assert_show_output import *
+
+from click.testing import CliRunner
+from importlib import reload
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "pfc")
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+class TestPfcBase(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
+        result = runner.invoke(command, args)
+        print(result.exit_code)
+        print(result.output)
+
+        if result.exit_code != expected_rc:
+            print(result.exception)
+
+        assert result.exit_code == expected_rc
+        if expected_output:
+            assert result.output == expected_output
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        print("TEARDOWN")
+
+class TestPfc(TestPfcBase):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        from mock_tables import dbconnector
+        from mock_tables import mock_single_asic
+        reload(mock_single_asic)
+        dbconnector.load_namespace_config()
+
+    def test_pfc_show_asymmetric_all(self):
+        self.executor(pfc.cli, ['show', 'asymmetric'],
+                      expected_output=pfc_show_asymmetric_all)
+
+    def test_pfc_show_asymmetric_intf(self):
+        self.executor(pfc.cli, ['show', 'asymmetric', 'Ethernet0'],
+                      expected_output=pfc_show_asymmetric_intf)
+
+    def test_pfc_show_asymmetric_intf_fake(self):
+        self.executor(pfc.cli, ['show', 'asymmetric', 'Ethernet1234'],
+                      expected_output=pfc_cannot_find_intf)
+
+    def test_pfc_show_priority_all(self):
+        self.executor(pfc.cli, ['show', 'priority'],
+                      expected_output=pfc_show_priority_all)
+
+    def test_pfc_show_priority_intf(self):
+        self.executor(pfc.cli, ['show', 'priority', 'Ethernet0'],
+                      expected_output=pfc_show_priority_intf)
+
+    def test_pfc_show_asymmetric_intf_fake(self):
+        self.executor(pfc.cli, ['show', 'priority', 'Ethernet1234'],
+                      expected_output=pfc_cannot_find_intf)
+
+    def test_pfc_config_asymmetric(self):
+        self.executor(pfc.cli, ['config', 'asymmetric', 'on', 'Ethernet0'],
+                      expected_output=pfc_config_asymmetric)
+
+    def test_pfc_config_priority(self):
+        self.executor(pfc.cli, ['config', 'priority', 'on', 'Ethernet0', '5'],
+                      expected_output=pfc_config_priority_on)

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -2,6 +2,7 @@ import os
 import sys
 import pfc.main as pfc
 from pfc_input.assert_show_output import *
+from utilities_common.db import Db
 
 from click.testing import CliRunner
 from importlib import reload
@@ -20,7 +21,9 @@ class TestPfcBase(object):
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
 
     def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
-        result = runner.invoke(command, args)
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        result = runner.invoke(command, args, obj=db)
         print(result.exit_code)
         print(result.output)
 

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,7 +1,9 @@
 import os
 import sys
 import pfc.main as pfc
-from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, pfc_config_asymmetric, pfc_config_priority_on
+from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
+   pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, \
+   pfc_config_asymmetric, pfc_config_priority_on
 from utilities_common.db import Db
 
 from click.testing import CliRunner
@@ -14,6 +16,7 @@ sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
 class TestPfcBase(object):
+
 
     @classmethod
     def setup_class(cls):
@@ -41,6 +44,7 @@ class TestPfcBase(object):
         print("TEARDOWN")
 
 class TestPfc(TestPfcBase):
+
 
     @classmethod
     def setup_class(cls):

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pfc.main as pfc
-from pfc_input.assert_show_output import *
+from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, pfc_config_asymmetric, pfc_config_priority_on
 from utilities_common.db import Db
 
 from click.testing import CliRunner
@@ -14,6 +14,7 @@ sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
 class TestPfcBase(object):
+
     @classmethod
     def setup_class(cls):
         print("SETUP")
@@ -22,7 +23,6 @@ class TestPfcBase(object):
 
     def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
         db = Db()
-        obj = {'config_db':db.cfgdb}
         result = runner.invoke(command, args, obj=db)
         print(result.exit_code)
         print(result.output)
@@ -41,6 +41,7 @@ class TestPfcBase(object):
         print("TEARDOWN")
 
 class TestPfc(TestPfcBase):
+
     @classmethod
     def setup_class(cls):
         super().setup_class()
@@ -69,7 +70,7 @@ class TestPfc(TestPfcBase):
         self.executor(pfc.cli, ['show', 'priority', 'Ethernet0'],
                       expected_output=pfc_show_priority_intf)
 
-    def test_pfc_show_asymmetric_intf_fake(self):
+    def test_pfc_show_priority_intf_fake(self):
         self.executor(pfc.cli, ['show', 'priority', 'Ethernet1234'],
                       expected_output=pfc_cannot_find_intf)
 

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -15,8 +15,8 @@ scripts_path = os.path.join(modules_path, "pfc")
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
 
-class TestPfcBase(object):
 
+class TestPfcBase(object):
 
     @classmethod
     def setup_class(cls):
@@ -43,8 +43,8 @@ class TestPfcBase(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
         print("TEARDOWN")
 
-class TestPfc(TestPfcBase):
 
+class TestPfc(TestPfcBase):
 
     @classmethod
     def setup_class(cls):

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -3,7 +3,7 @@ import sys
 import pfc.main as pfc
 from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
    pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, \
-   pfc_config_asymmetric, pfc_config_priority_on
+   pfc_config_asymmetric, pfc_config_priority_on, pfc_asym_cannot_find_intf
 from utilities_common.db import Db
 
 from click.testing import CliRunner

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -24,9 +24,9 @@ class TestPfcBase(object):
         os.environ["PATH"] += os.pathsep + scripts_path
         os.environ['UTILITIES_UNIT_TESTING'] = "2"
 
-    def executor(self, command, args, expected_rc=0, expected_output=None, runner=CliRunner()):
+    def executor(self, cliobj, command, expected_rc=0, expected_output=None, runner=CliRunner()):
         db = Db()
-        result = runner.invoke(command, args, obj=db)
+        result = runner.invoke(cliobj, command, obj=db)
         print(result.exit_code)
         print(result.output)
 

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import pfc.main as pfc
-from pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
+from .pfc_input.assert_show_output import pfc_cannot_find_intf, pfc_show_asymmetric_all, \
    pfc_show_asymmetric_intf, pfc_show_priority_all, pfc_show_priority_intf, \
-   pfc_config_asymmetric, pfc_config_priority_on, pfc_asym_cannot_find_intf
+   pfc_config_priority_on, pfc_asym_cannot_find_intf
 from utilities_common.db import Db
 
 from click.testing import CliRunner
@@ -18,13 +18,8 @@ sys.path.insert(0, modules_path)
 
 class TestPfcBase(object):
 
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
-        os.environ["PATH"] += os.pathsep + scripts_path
-        os.environ['UTILITIES_UNIT_TESTING'] = "2"
-
-    def executor(self, cliobj, command, expected_rc=0, expected_output=None, runner=CliRunner()):
+    def executor(self, cliobj, command, expected_rc=0, expected_output=None, expected_cfgdb_entry=None,
+                 runner=CliRunner()):
         db = Db()
         result = runner.invoke(cliobj, command, obj=db)
         print(result.exit_code)
@@ -32,23 +27,22 @@ class TestPfcBase(object):
 
         if result.exit_code != expected_rc:
             print(result.exception)
-
         assert result.exit_code == expected_rc
+
         if expected_output:
             assert result.output == expected_output
 
-    @classmethod
-    def teardown_class(cls):
-        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
-        os.environ["UTILITIES_UNIT_TESTING"] = "0"
-        print("TEARDOWN")
+        if expected_cfgdb_entry:
+            (table, key, field, expected_val) = expected_cfgdb_entry
+            configdb = db.cfgdb
+            entry = configdb.get_entry(table, key)
+            assert entry.get(field) == expected_val
 
 
 class TestPfc(TestPfcBase):
 
     @classmethod
     def setup_class(cls):
-        super().setup_class()
         from mock_tables import dbconnector
         from mock_tables import mock_single_asic
         reload(mock_single_asic)
@@ -80,7 +74,7 @@ class TestPfc(TestPfcBase):
 
     def test_pfc_config_asymmetric(self):
         self.executor(pfc.cli, ['config', 'asymmetric', 'on', 'Ethernet0'],
-                      expected_output=pfc_config_asymmetric)
+                      expected_cfgdb_entry=('PORT', 'Ethernet0', 'pfc_asym', 'on'))
 
     def test_pfc_config_priority(self):
         self.executor(pfc.cli, ['config', 'priority', 'on', 'Ethernet0', '5'],

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -64,7 +64,7 @@ class TestPfc(TestPfcBase):
 
     def test_pfc_show_asymmetric_intf_fake(self):
         self.executor(pfc.cli, ['show', 'asymmetric', 'Ethernet1234'],
-                      expected_output=pfc_cannot_find_intf)
+                      expected_output=pfc_asym_cannot_find_intf)
 
     def test_pfc_show_priority_all(self):
         self.executor(pfc.cli, ['show', 'priority'],


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added multi-asic support to PFC by:
- [x] Add namespace arg for show and config cmds for pfc
- [x] Replace test DB with JSON to support verification of multiple namespaces in unit test
- [x] Add unit tests for multi-asic behaviour
- [x] Added a test vector file for better test organization

This is a logical successor of #3057 and is a part of the larger efforts to add multi-asic functionality tracked in [#15148](https://github.com/sonic-net/sonic-buildimage/issues/15148)

#### How I did it
I used the multi_asic helper functions from `sonic_py_common` and `utilities_common` to handle multiple namespaces

#### How to verify it
There were three stages of verification:
- [x] Verify the single-asic and multi-asic unit tests for pfc pass
- [x] Verify the behaviour on a single-asic linecard on a DUT
- [x] Verify the behaviour on a multi-asic linecard on a DUT

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
The namespace argument is the new addition to the pfc command.

Case 1: If namespace is specified in a multi-asic device
Behaviour: We will run the command only on the specified namespace
e.g: `pfc show asymmetric --namespace asic0`
![image](https://github.com/user-attachments/assets/ba734724-2ddc-43d1-82fc-98ca61e41fb1)

Case 2: If no namespace is specified in a multi-asic device
Behaviour: We will run the command on all namespaces
e.g: `pfc show priority`
![pfc show priority](https://github.com/user-attachments/assets/a67c7cf6-083e-4e4f-a105-e38f711797eb)

Case 3: If a namespace is specified in single-asic device (other than default '')
Behaviour: We will raise an invalid argument error
e.g: `pfc show asymmetric --namespace asic0`
![pfc invalid namespace cw](https://github.com/user-attachments/assets/63ac2638-2b5e-49c0-ada5-bd9612695a97)

Case 4: If no namespace is specified in single-asic device
Behaviour: We will run it on the only valid namespace - default namespace
e.g: `pfc show priority`
![pfc config prio cw](https://github.com/user-attachments/assets/dba3f8dd-773e-4da1-8fee-8e0fd222a310)

