### PR TITLE
Fix enable ipv6-link-local-only fail on VLAN interface without IP

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5829,8 +5829,12 @@ def enable_use_link_local_only(ctx, interface_name):
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     if (interface_type == "VLAN_INTERFACE"):
-        if not clicommon.is_valid_vlan_interface(db, interface_name):
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
+        if not clicommon.check_if_vlanid_exist(db, interface_name):
+            ctx.fail("{} is nonexistent. Please create vlan first!!"
+                     .format(interface_name))
+        if not clicommon.has_vlan_member(db, interface_name):
+            ctx.fail("{} has no member joined. Please make sure at least one vlan member joined the vlan!!"
+                     .format(interface_name))
 
     portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
 
@@ -5882,8 +5886,12 @@ def disable_use_link_local_only(ctx, interface_name):
             ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
 
     if (interface_type == "VLAN_INTERFACE"):
-        if not clicommon.is_valid_vlan_interface(db, interface_name):
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
+        if not clicommon.check_if_vlanid_exist(db, interface_name):
+            ctx.fail("{} is nonexistent. Please create vlan first!!"
+                     .format(interface_name))
+        if not clicommon.has_vlan_member(db, interface_name):
+            ctx.fail("{} has no member joined. Please make sure at least one vlan member joined the vlan!!"
+                     .format(interface_name))
 
     portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
 

--- a/tests/ipv6_link_local_test.py
+++ b/tests/ipv6_link_local_test.py
@@ -190,7 +190,7 @@ class TestIPv6LinkLocal(object):
         runner = CliRunner()
         db = Db()
         obj = {'db':db.cfgdb}
-        
+
         # Enable ipv6 link local on Ethernet32
         result = runner.invoke(config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"], ["Ethernet32"], obj=obj)
         print(result.exit_code)
@@ -233,6 +233,54 @@ class TestIPv6LinkLocal(object):
         print(result.output)
         assert result.exit_code != 0
         assert 'Error: Ethernet40 is a router interface!' in result.output
+
+    def test_config_enable_disable_ipv6_link_local_on_nonexistent_vlan(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # Enable ipv6 link local on nonexistent Vlan10
+        result = runner.invoke(
+            config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"],
+            ["Vlan10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Vlan10 is nonexistent. Please create vlan first!!' in result.output
+
+        # Disable ipv6 link local on nonexistent Vlan10
+        result = runner.invoke(
+            config.config.commands["interface"].commands["ipv6"].commands["disable"].commands["use-link-local-only"],
+            ["Vlan10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Vlan10 is nonexistent. Please create vlan first!!' in result.output
+
+    def test_config_enable_disable_ipv6_link_local_on_vlan_no_member_joined(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # Enable ipv6 link local on Vlan3000 no member joined
+        result = runner.invoke(
+            config.config.commands["interface"].commands["ipv6"].commands["enable"].commands["use-link-local-only"],
+            ["Vlan3000"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Vlan3000 has no member joined. Please make sure at least one vlan member joined the vlan!!' \
+               in result.output
+
+        # Disable ipv6 link local on Vlan3000 no member joined
+        result = runner.invoke(
+            config.config.commands["interface"].commands["ipv6"].commands["disable"].commands["use-link-local-only"],
+            ["Vlan3000"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Error: Vlan3000 has no member joined. Please make sure at least one vlan member joined the vlan!!' \
+               in result.output
 
     @classmethod
     def teardown_class(cls):

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -262,10 +262,21 @@ def is_vlanid_in_range(vid):
 
 
 def check_if_vlanid_exist(config_db, vlan, table_name='VLAN'):
-    """Check if vlan id exits in the config db or ot"""
+    """Check if vlan id exists in the config db or not"""
 
     if len(config_db.get_entry(table_name, vlan)) != 0:
         return True
+
+    return False
+
+
+def has_vlan_member(config_db, vlan):
+    """Check if vlan has any member joined"""
+
+    vlan_ports_data = config_db.get_table('VLAN_MEMBER')
+    for key in vlan_ports_data:
+        if key[0] == vlan:
+            return True
 
     return False
 


### PR DESCRIPTION
#### What I did
Change the condition to be check VLAN exist and has VLAN member joined instead of VLAN interface with IP to enable ipv6-link-local-only on VLAN.

#### Why I did it
The ipv6-link-local-only function works even if the VLAN interface without IP.

#### How to verify it
Unit test