### PR TITLE
feat: add support for scientific get_counters

### DIFF
--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -229,7 +229,11 @@ class Portstat(object):
                     if counter_name not in fvs:
                         fields[pos] = STATUS_NA
                     elif fields[pos] != STATUS_NA:
-                        fields[pos] = str(int(fields[pos]) + int(fvs[counter_name]))
+                        # fvs[counter_name] will be a string. To support scientific number, we convert it to float
+                        # first since scientific number internally is a float.
+                        # https://stackoverflow.com/questions/32861429/converting-number-in-scientific-notation-to-int
+                        counter_value = int(float(fvs[counter_name]))
+                        fields[pos] = str(int(fields[pos]) + counter_value)
 
             cntr = NStats._make(fields)._asdict()
             return cntr


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix [#19192](https://github.com/sonic-net/sonic-buildimage/issues/19192) happens when the counters value gets too big and turns into scientific number

#### How I did it
Since value getting from counters_db will be serialise to string. The scientific number will be serialised to something like `1e+1`.

As a result, doing `int("1e+1")` directly will throw an error. Since natural of scientific number is float. A fix is to convert `"1e+1"` to `10.0` first and then do `int(10.0)`


#### How to verify it

1. Sending large volume of traffic using traffic generator.
2. run "portstat" or "show interface count" or "sonic-clear counter" without seeing [#19192](https://github.com/sonic-net/sonic-buildimage/issues/19192)

#### Previous command output (if the output of a command-line utility has changed)
```
$ sudo ip netns exec asic2 portstat | grep -E 'IFACE|Ethernet256|Ethernet264'

Traceback (most recent call last):
  File "/usr/local/bin/portstat", line 675, in <module>
    main()
  File "/usr/local/bin/portstat", line 635, in main
    cnstat_dict, ratestat_dict = portstat.get_cnstat_dict()
  File "/usr/local/bin/portstat", line 151, in get_cnstat_dict
    self.collect_stat()
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/multi_asic.py", line 157, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
  File "/usr/local/bin/portstat", line 161, in collect_stat
    cnstat_dict, ratestat_dict = self.get_cnstat()
  File "/usr/local/bin/portstat", line 215, in get_cnstat
    cnstat_dict[port] = get_counters(port)
  File "/usr/local/bin/portstat", line 182, in get_counters
    fields[pos] = str(int(fields[pos]) + int(fvs[counter_name]))
ValueError: invalid literal for int() with base 10: '1.8342735403386e+14'
```
#### New command output (if the output of a command-line utility has changed)
TBD
