### PR TITLE
Use the disk currently in use by SONiC for the 'show platform ssdhealth' command.

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -104,7 +104,15 @@ def psustatus(index, json, verbose):
 def ssdhealth(device, verbose, vendor):
     """Show SSD Health information"""
     if not device:
-        device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]
+        # Looking for the SSD disk currently used by the SONiC.
+
+        base_device = os.popen("lsblk -l -o NAME,TYPE,MOUNTPOINT -p | grep -w '/host'").readline().strip().split()[0]
+
+        # Extract the base device name, handling both 'p' and non-'p' partitioning schemes
+        # Example : /dev/sda1 => /dev/sda
+        #           /dev/nvme0n1p2 => /dev/nvme0n1
+        #           /dev/mmcblk0p1 => /dev/mmcblk0
+        device = base_device.rstrip("0123456789").split("p")[0]
     cmd = ['sudo', 'ssdutil', '-d', str(device)]
     options = ["-v"] if verbose else []
     options += ["-e"] if vendor else []

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -693,7 +693,7 @@ class TestShowPlatform(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        mock_popen.assert_called_once_with('lsblk -o NAME,TYPE -p | grep disk')
+        mock_popen.assert_called_once_with("lsblk -l -o NAME,TYPE,MOUNTPOINT -p | grep -w '/host'")
         mock_run_command.assert_called_once_with(['sudo', 'ssdutil', '-d', '/dev/sda', '-v', '-e'], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Due to a USB flash drive being plugged in, the SONiC command 'show platform ssdhealth' does not display correctly.
```
admin@sonic:~$ show platform ssdhealth
[Error] Cannot read device /dev/sda
Device Model : N/A
Health : N/A
Temperature : N/A
```

dmesg log : 
```
[10609.931754] sd 4:0:0:0: [sda] 121241600 512-byte logical blocks: (62.1 GB/57.8 GiB)
[10609.931904] sd 4:0:0:0: [sda] Write Protect is off
[10609.931908] sd 4:0:0:0: [sda] Mode Sense: 43 00 00 00
[10609.932037] sd 4:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
[10609.968964]  sda: sda1
[10610.004083] sd 4:0:0:0: [sda] Attached SCSI removable disk
```
 

lsblk log :
```
admin@sonic:~$ lsblk -o NAME,TYPE -p | grep disk
/dev/sda         disk
/dev/nvme0n1     disk
```
#### How I did it
Use the SSD disk currently in use by SONiC as the default argument for the 'ssdutil' command.

#### How to verify it
1. Plugging in a USB flash drive.
2. "show platform ssdhealth"
```
admin@sonic:~$ show platform ssdhealth
Device Model : MPT160-M8240GCB5ACT-E132
Health       : 100.0%
Temperature  : 27.0C
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

