### PR TITLE
 [fast/warm-reboot] Improve retry mechanism to check if SAI_OBJECT_TYPE_ACL_ENTRY entries are in redis

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -304,17 +304,23 @@ function check_mirror_session_acls()
     ACL_ND="missing"
     start_time=${SECONDS}
     elapsed_time=$((${SECONDS} - ${start_time}))
+    retry_count=0
     while [[ ${elapsed_time} -lt 10 ]]; do
 	CHECK_ACL_ENTRIES=0
+        retry_count=$((retry_count + 1))
         ACL_OUTPUT=$(sonic-db-cli ASIC_DB KEYS "*" | grep SAI_OBJECT_TYPE_ACL_ENTRY) || CHECK_ACL_ENTRIES=$?
 	if [[ ${CHECK_ACL_ENTRIES} -ne 0 ]]; then
-	    error "Failed to retrieve SAI_OBJECT_TYPE_ACL_ENTRY from redis"
-	    exit ${EXIT_NO_MIRROR_SESSION_ACLS}
+	    error "Failed to retrieve SAI_OBJECT_TYPE_ACL_ENTRY from redis, retrying... (Attempt: ${retry_count})"
+	    sleep 0.1
+	    elapsed_time=$((${SECONDS} - ${start_time}))
+	    continue
 	fi
 	ACL_ENTRIES=( ${ACL_OUTPUT} )
 	if [[ ${#ACL_ENTRIES[@]} -eq 0 ]]; then
-	    error "NO SAI_OBJECT_TYPE_ACL_ENTRY objects found"
-	    exit ${EXIT_NO_MIRROR_SESSION_ACLS}
+	    error "NO SAI_OBJECT_TYPE_ACL_ENTRY objects found, retrying... (Attempt: ${retry_count})"
+	    sleep 0.1
+	    elapsed_time=$((${SECONDS} - ${start_time}))
+	    continue
 	fi
         for ACL_ENTRY in ${ACL_ENTRIES[@]}; do
             ACL_PRIORITY=$(sonic-db-cli ASIC_DB HGET ${ACL_ENTRY} SAI_ACL_ENTRY_ATTR_PRIORITY)
@@ -332,7 +338,7 @@ function check_mirror_session_acls()
         elapsed_time=$((${SECONDS} - ${start_time}))
     done
     if [[ "${ACL_ARP}" != "found" || "${ACL_ND}" != "found" ]]; then
-        debug "Failed to program mirror session ACLs on ASIC. ACLs: ARP=${ACL_ARP} ND=${ACL_ND}"
+        error "Failed to program mirror session ACLs on ASIC. ACLs: ARP=${ACL_ARP} ND=${ACL_ND}"
         exit ${EXIT_NO_MIRROR_SESSION_ACLS}
     fi
     debug "Mirror session ACLs (arp, nd) programmed to ASIC successfully"

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -310,14 +310,14 @@ function check_mirror_session_acls()
         retry_count=$((retry_count + 1))
         ACL_OUTPUT=$(sonic-db-cli ASIC_DB KEYS "*" | grep SAI_OBJECT_TYPE_ACL_ENTRY) || CHECK_ACL_ENTRIES=$?
 	if [[ ${CHECK_ACL_ENTRIES} -ne 0 ]]; then
-	    error "Failed to retrieve SAI_OBJECT_TYPE_ACL_ENTRY from redis, retrying... (Attempt: ${retry_count})"
+	    debug "Failed to retrieve SAI_OBJECT_TYPE_ACL_ENTRY from redis, retrying... (Attempt: ${retry_count})"
 	    sleep 0.1
 	    elapsed_time=$((${SECONDS} - ${start_time}))
 	    continue
 	fi
 	ACL_ENTRIES=( ${ACL_OUTPUT} )
 	if [[ ${#ACL_ENTRIES[@]} -eq 0 ]]; then
-	    error "NO SAI_OBJECT_TYPE_ACL_ENTRY objects found, retrying... (Attempt: ${retry_count})"
+	    debug "NO SAI_OBJECT_TYPE_ACL_ENTRY objects found, retrying... (Attempt: ${retry_count})"
 	    sleep 0.1
 	    elapsed_time=$((${SECONDS} - ${start_time}))
 	    continue


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Sometimes during `/usr/local/bin/neighbor_advertiser` script execution, ACL entries are added to redis database with delay.
So during execution of function `check_mirror_session_acls() ` script can't find ACL entries.
Retry mechanism was added for this check in https://github.com/sonic-net/sonic-utilities/pull/3333
But the script will return error and exit with failure after first try.
Need to improve this algorithm.

#### How I did it
add sleep 0.1 and 'continue' instead of 'exit'

#### How to verify it
run wr_arp test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

