### PR TITLE
[sfputil] use EXIT_FAIL instead of ERROR_NOT_IMPLEMENTED exit code

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1880,7 +1880,7 @@ def write_eeprom(port, page, offset, data, wire_addr, verify):
         success = sfp.write_eeprom(overall_offset, len(bytes), bytes)
         if not success:
             click.echo("Error: Failed to write EEPROM!")
-            sys.exit(ERROR_NOT_IMPLEMENTED)
+            sys.exit(EXIT_FAIL)
         if verify:
             read_data = sfp.read_eeprom(overall_offset, len(bytes))
             if read_data != bytes:

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1395,7 +1395,7 @@ EEPROM hexdump for port Ethernet4
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '0', '-o', '0', '-d', '10'])
         print(result.output)
-        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        assert result.exit_code == EXIT_FAIL
 
         # write success
         mock_sfp.write_eeprom.return_value = True


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it
change the exit code while write eeprom not success

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

