### PR TITLE
Add support of the pensando-dpu platform to generate-dump utility.

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1677,6 +1677,45 @@ collect_nvidia_bluefield() {
 }
 
 ###############################################################################
+# Collect Pensando specific information
+# Globals:
+#  MKDIR
+#  V
+#  NOOP
+#  RM
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+collect_pensando() {
+    trap 'handle_error $? $LINENO' ERR
+    platform=$(grep 'onie_platform=' /host/machine.conf | cut -d '=' -f 2)
+    pipeline=`cat /usr/share/sonic/device/${platform}/default_pipeline`
+    if [ ${pipeline} = "polaris" ]; then
+        dpu_container_name="polaris"
+    else
+        dpu_container_name="dpu"
+    fi
+    local dpu_dump_folder="/root/dpu_dump"
+    $MKDIR $V -p $dpu_dump_folder
+    if $NOOP; then
+        echo "docker exec ${dpu_container_name} /nic/tools/collect_techsupport.sh"
+    else
+        output=$(docker exec ${dpu_container_name} /nic/tools/collect_techsupport.sh 2>&1)
+        if echo "${output}" | grep -q "Techsupport collected at"; then
+            file_path=$(echo "${output}" | grep -oP '(?<=Techsupport collected at ).*')
+            file_name=$(basename "${file_path}")
+            copy_from_docker ${dpu_container_name} ${file_path} ${dpu_dump_folder}
+            save_file ${dpu_dump_folder}/${file_name} ${dpu_container_name}_techsupport false
+        else
+            echo "Failed to collect ${dpu_container_name} container techsupport..."
+        fi
+    fi
+    $RM $V -rf $dpu_dump_folder
+}
+
+###############################################################################
 # Save log file
 # Globals:
 #  TAR, TARFILE, DUMPDIR, BASE, TARDIR, TECHSUPPORT_TIME_INFO
@@ -2108,6 +2147,10 @@ main() {
 
     if [ "$asic" = "marvell" ]; then
         collect_marvell
+    fi
+
+    if [ "$asic" = "pensando" ]; then
+        collect_pensando
     fi
 
 


### PR DESCRIPTION
#### What I did
Add support of the pensando-dpu platform to generate-dump utility to collect platform-specific dumps on Pensando DPU.
#### How I did it
Extend platform-specific section of generate-dump utility
#### How to verify it
Run "show techsupport" command to generate dump file. Verify that `{dpu_container}_techsupport` directory exists in the created dump file.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

#### show techsupport command output logs:-
```
{
    cat
}; docker exec syncd saidump | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20240910_045531/dump/saidump'"
mkdir: created directory '/root/dpu_dump'
timeout --foreground 5m sudo docker exec polaris touch /data/techsupport//DSC_TechSupport_b08d.57cd.360f_2024-09-10_04-57-04_1725944224.tar.gz
timeout --foreground 5m sudo docker cp polaris:/data/techsupport//DSC_TechSupport_b08d.57cd.360f_2024-09-10_04-57-04_1725944224.tar.gz /root/dpu_dump
mkdir: created directory '/var/dump/sonic_dump_sonic_20240910_045531/polaris_techsupport'
removed '/root/dpu_dump/DSC_TechSupport_b08d.57cd.360f_2024-09-10_04-57-04_1725944224.tar.gz'
removed directory '/root/dpu_dump'
timeout --foreground 5m bash -c "dummy_cleanup_method ()
{
    cat
}; echo 10/09/2024 04:57:43:857701 | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20240910_045531/dump/date.counter_2'"
```
```
sonic_dump_sonic_20240910_045531/proc/iomem
sonic_dump_sonic_20240910_045531/polaris_techsupport/
sonic_dump_sonic_20240910_045531/polaris_techsupport/DSC_TechSupport_b08d.57cd.360f_2024-09-10_04-57-04_1725944224.tar.gz
sonic_dump_sonic_20240910_045531/core/
```
```
root@sonic:/home/admin# cd /var/dump/
root@sonic:/var/dump# ls
sonic_dump_sonic_20240910_045531.tar.gz
root@sonic:/var/dump# tar -xzf sonic_dump_sonic_20240910_045531.tar.gz
root@sonic:/var/dump# cd sonic_dump_sonic_20240910_045531/
root@sonic:/var/dump/sonic_dump_sonic_20240910_045531# cd polaris_techsupport/
root@sonic:/var/dump/sonic_dump_sonic_20240910_045531/polaris_techsupport# ls
DSC_TechSupport_b08d.57cd.360f_2024-09-10_04-57-04_1725944224.tar.gz
root@sonic:/var/dump/sonic_dump_sonic_20240910_045531/polaris_techsupport#
```
#### /usr/local/bin/generate_dump -n output
```
{
    cat
}; docker exec syncd saidump | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20240910_050411/dump/saidump'"
mkdir -p /root/dpu_dump
docker exec polaris /nic/tools/collect_techsupport.sh
rm -rf /root/dpu_dump
mkdir -p /var/dump/sonic_dump_sonic_20240910_050411/dump
timeout --foreground 5m bash -c "dummy_cleanup_method ()
{
    cat
}; echo 10/09/2024 05:04:40:130209 | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20240910_050411/dump/date.counter_2'"
```
