### PR TITLE
Fix KeyError in pfc config command

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -28,7 +28,7 @@ class Pfc(object):
         This function dumps the current config in a JSON file for unit testing.
         """
         # Only dump files in unit testing mode
-        if os.environ["UTILITIES_UNIT_TESTING"] != "2":
+        if os.getenv("UTILITIES_UNIT_TESTING") != "2":
             return
 
         if namespace not in self.updated_port_tables.keys():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Used `getenv` to return `None` if the env variable is missing instead of key error. Fixes https://github.com/sonic-net/sonic-buildimage/issues/20398

#### How I did it
Same as above

#### How to verify it
Run the `pfc config asymmetric on EthernetX` command on a T2 topology linecard

#### Previous command output (if the output of a command-line utility has changed)
`KeyError: 'UTILITIES_UNIT_TESTING'`

#### New command output (if the output of a command-line utility has changed)
No output (as expected). Config commands change attributes as expected
