### PR TITLE
Add Unit Test for portstat

### DIFF
--- a/tests/portstat_db/on_sup_na/chassis_state_db.json
+++ b/tests/portstat_db/on_sup_na/chassis_state_db.json
@@ -1,0 +1,68 @@
+{
+    "CHASSIS_MODULE_HOSTNAME_TABLE|LINE-CARD0": {
+        "module_hostname": "sonic-lc1"
+    }, 
+    "CHASSIS_MODULE_HOSTNAME_TABLE|LINE-CARD1": {
+        "module_hostname": "sonic-lc2"
+    },
+    "CHASSIS_MODULE_HOSTNAME_TABLE|LINE-CARD2": {
+        "module_hostname": "sonic-lc3"
+    },
+    "LINECARD_PORT_STAT_MARK_TABLE|sonic-lc1": {
+        "timestamp": "2020-07-01 00:00:00"
+    },
+    "LINECARD_PORT_STAT_MARK_TABLE|sonic-lc3": {
+        "timestamp": "2020-07-01 00:00:00"
+    },
+    "LINECARD_PORT_STAT_TABLE|Ethernet1/1": {
+        "state": "U",
+        "rx_ok": 100,
+        "rx_bps": 10,
+        "rx_pps": 1,
+        "rx_util": 0,
+        "rx_err": 0,
+        "rx_drop": 0,
+        "rx_ovr": 0,
+        "tx_ok": 100,
+        "tx_bps": 10,
+        "tx_pps": 1,
+        "tx_util": 0,
+        "tx_err": 0,
+        "tx_drop": 0,
+        "tx_ovr": 0
+    },
+    "LINECARD_PORT_STAT_TABLE|Ethernet2/1": {
+        "state": "U",
+        "rx_ok": 100,
+        "rx_bps": 10,
+        "rx_pps": 1,
+        "rx_util": 0,
+        "rx_err": 0,
+        "rx_drop": 0,
+        "rx_ovr": 0,
+        "tx_ok": 100,
+        "tx_bps": 10,
+        "tx_pps": 1,
+        "tx_util": 0,
+        "tx_err": 0,
+        "tx_drop": 0,
+        "tx_ovr": 0
+    },
+    "LINECARD_PORT_STAT_TABLE|Ethernet11/1": {
+        "state": "N/A",
+        "rx_ok": "N/A",
+        "rx_bps": "N/A",
+        "rx_pps": "N/A",
+        "rx_util": "N/A",
+        "rx_err": "N/A",
+        "rx_drop": "N/A",
+        "rx_ovr": "N/A",
+        "tx_ok": "N/A",
+        "tx_bps": "N/A",
+        "tx_pps": "N/A",
+        "tx_util": "N/A",
+        "tx_err": "N/A",
+        "tx_drop": "N/A",
+        "tx_ovr": "N/A"
+    }
+}

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -524,7 +524,7 @@ class TestPortStat(object):
         os.environ["UTILITIES_UNIT_TESTING_IS_SUP"] = "0"
         os.system("cp /tmp/chassis_state_db.json {}"
                   .format(os.path.join(test_path, "mock_tables/chassis_state_db.json")))
-        
+
     def test_show_intf_counters_on_sup_na(self):
         remove_tmp_cnstat_file()
         os.system("cp {} /tmp/".format(os.path.join(test_path, "mock_tables/chassis_state_db.json")))

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -272,6 +272,19 @@ intf_counters_on_sup_no_counters = "Linecard Counter Table is not available.\n"
 
 intf_counters_on_sup_partial_lc = "Not all linecards have published their counter values.\n"
 
+intf_counters_on_sup_na = """\
+       IFACE    STATE    RX_OK     RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK     TX_BPS    TX_UTIL\
+    TX_ERR    TX_DRP    TX_OVR
+------------  -------  -------  ---------  ---------  --------  --------  --------  -------  ---------  ---------\
+  --------  --------  --------
+ Ethernet1/1        U      100  10.00 B/s      0.00%         0         0         0      100  10.00 B/s      0.00%\
+         0         0         0
+ Ethernet2/1        U      100  10.00 B/s      0.00%         0         0         0      100  10.00 B/s      0.00%\
+         0         0         0
+Ethernet11/1      N/A      N/A        N/A        N/A       N/A       N/A       N/A      N/A        N/A        N/A\
+       N/A       N/A       N/A
+"""
+
 TEST_PERIOD = 3
 
 
@@ -507,6 +520,31 @@ class TestPortStat(object):
         print("result = {}".format(result))
         assert return_code == 0
         assert result == intf_counters_on_sup_partial_lc
+
+        os.environ["UTILITIES_UNIT_TESTING_IS_SUP"] = "0"
+        os.system("cp /tmp/chassis_state_db.json {}"
+                  .format(os.path.join(test_path, "mock_tables/chassis_state_db.json")))
+        
+    def test_show_intf_counters_on_sup_na(self):
+        remove_tmp_cnstat_file()
+        os.system("cp {} /tmp/".format(os.path.join(test_path, "mock_tables/chassis_state_db.json")))
+        os.system("cp {} {}".format(os.path.join(test_path, "portstat_db/on_sup_na/chassis_state_db.json"),
+                                    os.path.join(test_path, "mock_tables/chassis_state_db.json")))
+        os.environ["UTILITIES_UNIT_TESTING_IS_SUP"] = "1"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == intf_counters_on_sup_na
+
+        return_code, result = get_result_and_return_code(['portstat'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == intf_counters_on_sup_na
 
         os.environ["UTILITIES_UNIT_TESTING_IS_SUP"] = "0"
         os.system("cp /tmp/chassis_state_db.json {}"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I added a unit test for scenarios where a LC's counter DB is N/A.

#### How I did it

#### How to verify it

Run the unit test suite.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

