### PR TITLE
Fix handling of optional fields in get_bgp_peer function

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -48,8 +48,8 @@ def get_bgp_peer():
     data = config_db.get_table('BGP_NEIGHBOR')
 
     for neighbor_ip in data.keys():
-        local_addr = data[neighbor_ip]['local_addr']
-        neighbor_name = data[neighbor_ip]['name']
+        local_addr = data[neighbor_ip].get('local_addr', "")
+        neighbor_name = data[neighbor_ip].get('name', "")
         bgp_peer.setdefault(local_addr, [neighbor_name, neighbor_ip])
     return bgp_peer
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This commit fixes an issue in get_bgp_peer function where `local_addr` and `name` were treated as mandatory. However, `local_addr` and `name` fields are not required in BGP neighbor configuration.

#### How I did it

The local_addr and name fields are no longer mandatory in the get_bgp_peer function.

#### How to verify it

Apply BGP neighbor configuration like below (utilizing BGP_PEER_GROUP), where fields such as local_addr or name are omitted:

```json
{ 
    "BGP_GLOBALS": {
        "default": {
            "local_asn": "65001",
            "log_nbr_state_changes": "true",
            "router_id": "10.0.0.1"
        }
    },
   "BGP_PEER_GROUP": {
        "default|core": {
          "peer_group_name": "core",
          "admin_status": "true",
          "asn": "65002",
          "peer_type": "external"
        }
     },
    "BGP_NEIGHBOR": {
        "default|Ethernet4": {
            "peer_group_name": "core"
        }
    },
    "BGP_NEIGHBOR_AF": {
        "default|core|ipv4_unicast": {
            "admin_status": "true",
            "route_map_in": [
                "ALLOW"
            ],
            "route_map_out": [
                "ALLOW"
            ]
        }
    },
    "ROUTE_MAP": {
        "ALLOW|1": {
            "route_operation": "permit"
        }
    }
}
```

#### Previous command output (if the output of a command-line utility has changed)

```bash
root@sw1:~# show ip interfaces 
Traceback (most recent call last):
  File "/usr/local/bin/ipintutil", line 280, in <module>
    main()
  File "/usr/local/bin/ipintutil", line 273, in main
    ip_intfs = get_ip_intfs(af, namespace, display)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/ipintutil", line 236, in get_ip_intfs
    ip_intfs_in_ns = get_ip_intfs_in_namespace(af, namespace, display)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/ipintutil", line 149, in get_ip_intfs_in_namespace
    bgp_peer = get_bgp_peer()
               ^^^^^^^^^^^^^^
  File "/usr/local/bin/ipintutil", line 51, in get_bgp_peer
    local_addr = data[neighbor_ip]['local_addr']
                 ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'local_addr'
```

#### New command output (if the output of a command-line utility has changed)

```bash
root@sw1:~# show ip interfaces 
Interface    Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  -------------------  ------------  --------------  -------------
Ethernet4              1.1.1.0/31           up/up         N/A             N/A
```


Fixes [#19930](https://github.com/sonic-net/sonic-buildimage/issues/19930)