### PR TITLE
[db_migrator][telemetry] Remove the telemetry from the feature table

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -641,6 +641,13 @@ class DBMigrator():
             if certs:
                 self.configDB.set_entry("GNMI", "certs", certs)
 
+    def migrate_remove_feature(self, feature):
+        if self.configDB.get_entry('FEATURE', feature):
+            log.log_notice('Migrate remove {}'.format(feature))
+            self.configDB.mod_entry('FEATURE', feature, None)
+        if self.configDB.get_entry('AUTO_TECHSUPPORT_FEATURE', feature):
+            self.configDB.mod_entry('AUTO_TECHSUPPORT_FEATURE', feature, None)
+
     def migrate_console_switch(self):
         # CONSOLE_SWITCH - add missing key
         if not self.config_src_data or 'CONSOLE_SWITCH' not in self.config_src_data:
@@ -1231,6 +1238,7 @@ class DBMigrator():
         Version 202405_01.
         """
         log.log_info('Handling version_202405_01')
+        self.migrate_remove_feature('telemetry')
         self.set_version('version_202411_01')
         return 'version_202411_01'
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Feature telemetry has been replaced by GNMI. This PR removes the telemetry feature from FEATURE table to avoid the logging message shown up every minute when upgrade a platform from 202205 to 202405 image.  It fixes https://github.com/sonic-net/sonic-buildimage/issues/20056. 

The following is the log message:
```
2024 Aug 28 15:35:12.219750 Linecard WARNING Chassis: Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
```

#### How I did it
Modified the db_migrator  by adding function migrate_remove_feature() to remove the telemetry related configuration in the CONFIG_DB if telemetry config exists.  Configuration includes "FEATURE|telemetry" and "AUTO_TECHSUPPORT|telemetry"

#### How to verify it
1) Upgrade a platform which is running 202205 image.
2) Using the following command to verify the telemetry is no longer in the CONFIG_BD
```
admin@ixre-egl-board25:~$ sonic-db-dump -n CONFIG_DB -y -k "FEATURE|telemetry"
{}
admin@ixre-egl-board25:~$ sonic-db-dump -n CONFIG_DB -y -k "AUTO_TECHSUPPORT_FEATURE|telemetry"
{}
```
3) Check the syslog. The following message should not be shown
```
Linecard WARNING Chassis: Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

