### PR TITLE
Stop platform monitor service before fast/warm reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -846,6 +846,13 @@ then
   systemctl stop "$service_name"
 fi
 
+# Stop platform monitor sevice to prevent i2c access during warm/fast reboot
+services=$(systemctl list-units --plain --no-pager --no-legend --type=service | grep platform-monitor | cut -f 1 -d' ')
+for service_name in $services
+do
+  systemctl stop "$service_name"
+done
+
 # Update the reboot cause file to reflect that user issued this script
 # Upon next boot, the contents of this file will be used to determine the
 # cause of the previous reboot


### PR DESCRIPTION
Access i2c bus when fast/warm reboot would cause SMBus is busy and needs recover by power cycle.
```
i801_smbus 0000:00:1f.3: SMBus is busy, can't use it!
```

#### What I did
Stop platform monitor service before fast/warm reboot

#### How I did it

#### How to verify it
warm reboot for multiple times

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>