### PR TITLE
Revert "Skip default lanes dup check"

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -239,8 +239,7 @@ class ConfigWrapper:
             for port in port_to_lanes_map:
                 lanes = port_to_lanes_map[port]
                 for lane in lanes:
-                    # default lane would be 0, it does not need validate duplication.
-                    if lane in existing and lane != '0':
+                    if lane in existing:
                         return False, f"'{lane}' lane is used multiple times in PORT: {set([port, existing[lane]])}"
                     existing[lane] = port
         return True, None

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -361,13 +361,6 @@ class TestConfigWrapper(unittest.TestCase):
             }}
         self.validate_lanes(config, '67')
 
-    def test_validate_lanes_default_value_duplicate_check(self):
-        config = {"PORT": {
-            "Ethernet0": {"lanes": "0", "speed": "10000"},
-            "Ethernet1": {"lanes": "0", "speed": "10000"},
-            }}
-        self.validate_lanes(config)
-
     def validate_lanes(self, config_db, expected_error=None):
         # Arrange
         config_wrapper = gu_common.ConfigWrapper()


### PR DESCRIPTION
Reverts sonic-net/sonic-utilities#3489 since the PR: https://github.com/sonic-net/sonic-buildimage/pull/19968 has merged.