### PR TITLE
Add YANG validation for config reload if file is given

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1810,6 +1810,22 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
+    if filename is not None:
+        if multi_asic.is_multi_asic():
+            # Multiasic has not 100% fully validated. Thus pass here.
+            pass
+        else:
+            config_to_check = read_json_file(filename)
+            sy = sonic_yang.SonicYang(YANG_DIR)
+            sy.loadYangModel()
+            try:
+                sy.loadData(configdbJson=config_to_check)
+                sy.validate_data_tree()
+            except sonic_yang.SonicYangException as e:
+                click.secho("{} fails YANG validation! Error: {}".format(filename, str(e)),
+                            fg='magenta')
+                raise click.Abort()
+
     #Stop services before config push
     if not no_service_restart:
         log.log_notice("'reload' stopping services...")

--- a/config/main.py
+++ b/config/main.py
@@ -1828,7 +1828,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             # Multiasic has not 100% fully validated. Thus pass here.
             pass
         else:
-            config_file_yang_validation(filename):
+            config_file_yang_validation(filename)
 
     #Stop services before config push
     if not no_service_restart:

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -422,6 +422,12 @@ function setup_reboot_variables()
         local fstype=$(blkid -o value -s TYPE ${sonic_dev})
         BOOT_OPTIONS="${BOOT_OPTIONS} ssd-upgrader-part=${sonic_dev},${fstype}"
     fi
+
+    if [[ "$sonic_asic_type" == "mellanox" ]]; then
+        # Set governor to performance to speed up boot process.
+        # The governor is reset back to kernel default in warmboot-finalizer script.
+        BOOT_OPTIONS="${BOOT_OPTIONS} cpufreq.default_governor=performance"
+    fi
 }
 
 function check_docker_exec()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add constraint for YANG when config reload, which is already enabled in load_minigraph
#### How I did it
Check YANG vaidation for the config
#### How to verify it
Unit test
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

