### PR TITLE
Vnet_route_check TCP socket for DB connection.

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -74,7 +74,7 @@ def print_message(lvl, *args):
 def check_vnet_cfg():
     ''' Returns True if VNET is configured in APP_DB or False if no VNET configuration.
     '''
-    db = swsscommon.DBConnector('APPL_DB', 0)
+    db = swsscommon.DBConnector('APPL_DB', 0, True)
 
     vnet_db_keys = swsscommon.Table(db, 'VNET_TABLE').getKeys()
 
@@ -85,7 +85,7 @@ def get_vnet_intfs():
     ''' Returns dictionary of VNETs and related VNET interfaces.
     Format: { <vnet_name>: [ <vnet_rif_name> ] }
     '''
-    db = swsscommon.DBConnector('APPL_DB', 0)
+    db = swsscommon.DBConnector('APPL_DB', 0, True)
 
     intfs_table = swsscommon.Table(db, 'INTF_TABLE')
     intfs_keys = swsscommon.Table(db, 'INTF_TABLE').getKeys()
@@ -109,7 +109,7 @@ def get_all_rifs_oids():
     ''' Returns dictionary of all router interfaces and their OIDs.
     Format: { <rif_name>: <rif_oid> }
     '''
-    db = swsscommon.DBConnector('COUNTERS_DB', 0)
+    db = swsscommon.DBConnector('COUNTERS_DB', 0, True)
     rif_table = swsscommon.Table(db, 'COUNTERS_RIF_NAME_MAP')
 
     rif_name_oid_map = dict(rif_table.get('')[1])
@@ -140,7 +140,7 @@ def get_vrf_entries():
     ''' Returns dictionary of VNET interfaces and corresponding VRF OIDs.
     Format: { <vnet_rif_name>: <vrf_oid> }
     '''
-    db = swsscommon.DBConnector('ASIC_DB', 0)
+    db = swsscommon.DBConnector('ASIC_DB', 0, True)
     rif_table = swsscommon.Table(db, 'ASIC_STATE')
 
     vnet_rifs_oids = get_vnet_rifs_oids()
@@ -162,7 +162,7 @@ def filter_out_vnet_ip2me_routes(vnet_routes):
     ''' Filters out IP2ME routes from the provided dictionary with VNET routes
     Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
     '''
-    db = swsscommon.DBConnector('APPL_DB', 0)
+    db = swsscommon.DBConnector('APPL_DB', 0, True)
 
     all_rifs_db_keys = swsscommon.Table(db, 'INTF_TABLE').getKeys()
     vnet_intfs = get_vnet_intfs()
@@ -198,7 +198,7 @@ def get_vnet_routes_from_app_db():
     ''' Returns dictionary of VNET routes configured per each VNET in APP_DB.
     Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
     '''
-    db = swsscommon.DBConnector('APPL_DB', 0)
+    db = swsscommon.DBConnector('APPL_DB', 0, True)
 
     vnet_intfs = get_vnet_intfs()
     vnet_vrfs = get_vrf_entries()
@@ -245,7 +245,7 @@ def get_vnet_routes_from_asic_db():
     ''' Returns dictionary of VNET routes configured per each VNET in ASIC_DB.
     Format: { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
     '''
-    db = swsscommon.DBConnector('ASIC_DB', 0)
+    db = swsscommon.DBConnector('ASIC_DB', 0, True)
 
     tbl = swsscommon.Table(db, 'ASIC_STATE')
 
@@ -363,7 +363,7 @@ def main():
     # Don't run VNET routes consistancy logic if there is no VNET configuration
     if not check_vnet_cfg():
         return rc
-    asic_db = swsscommon.DBConnector('ASIC_DB', 0)
+    asic_db = swsscommon.DBConnector('ASIC_DB', 0, True)
     virtual_router = swsscommon.Table(asic_db, 'ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER')
     if virtual_router.getKeys() != []:
         global default_vrf_oid

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -341,7 +341,7 @@ class Table:
 
 
 db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB, "COUNTERS_DB": CNTR_DB}
-def conn_side_effect(arg, _):
+def conn_side_effect(arg, _, __):
     return db_conns[arg]
 
 

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -341,6 +341,8 @@ class Table:
 
 
 db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB, "COUNTERS_DB": CNTR_DB}
+
+
 def conn_side_effect(arg, _, __):
     return db_conns[arg]
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Currently the Vnet_route_check fails if a user calls it witout sudo with the following error.

```
Traceback (most recent call last):
  File "/usr/local/bin/vnet_route_check.py", line 401, in <module>
    sys.exit(main())
  File "/usr/local/bin/vnet_route_check.py", line 364, in main
    if not check_vnet_cfg():
  File "/usr/local/bin/vnet_route_check.py", line 77, in check_vnet_cfg
    db = swsscommon.DBConnector('APPL_DB', 0)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1656, in __init__
    _swsscommon.DBConnector_swiginit(self, _swsscommon.new_DBConnector(*args))
RuntimeError: Unable to connect to redis (unix-socket): Cannot assign requested address

```
#### What I did
The **route_check** script accesses the same DB tables but is able to run without the sudo rights.  To solve this problem I have changed the **Vnet_route_check** to use a TCP socket to connect to the DB as done in **route_check**. As a result the script doesn't fail with a run time error.

#### How I did it

#### How to verify it
create a new user on a T1 device which has no docker or sudoers privilage. run vnet_route check. it should fail.
#### Previous command output (if the output of a command-line utility has changed)
```
Traceback (most recent call last):
  File "/usr/local/bin/vnet_route_check.py", line 401, in <module>
    sys.exit(main())
  File "/usr/local/bin/vnet_route_check.py", line 364, in main
    if not check_vnet_cfg():
  File "/usr/local/bin/vnet_route_check.py", line 77, in check_vnet_cfg
    db = swsscommon.DBConnector('APPL_DB', 0)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1656, in __init__
    _swsscommon.DBConnector_swiginit(self, _swsscommon.new_DBConnector(*args))
RuntimeError: Unable to connect to redis (unix-socket): Cannot assign requested address

```

#### New command output (if the output of a command-line utility has changed)
None
