### PR TITLE
Consolidate the get running config way.

### DIFF
--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from swsscommon.swsscommon import ConfigDBConnector
 from sonic_py_common import multi_asic
 from .gu_common import GenericConfigUpdaterError, genericUpdaterLogging
+from .gu_common import get_config_db_as_json
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 UPDATER_CONF_FILE = f"{SCRIPT_DIR}/gcu_services_validator.conf.json"
@@ -161,29 +162,4 @@ class ChangeApplier:
             data.pop(key, None)
 
     def _get_running_config(self):
-        _, fname = tempfile.mkstemp(suffix="_changeApplier")
-
-        if self.scope:
-            cmd = ['sonic-cfggen', '-d', '--print-data', '-n', self.scope]
-        else:
-            cmd = ['sonic-cfggen', '-d', '--print-data']
-
-        with open(fname, "w") as file:
-            result = subprocess.Popen(cmd, stdout=file, stderr=subprocess.PIPE, text=True)
-            _, err = result.communicate()
-
-        return_code = result.returncode
-        if return_code:
-            os.remove(fname)
-            raise GenericConfigUpdaterError(
-                f"Failed to get running config for scope: {self.scope}," +
-                f"Return code: {return_code}, Error: {err}")
-
-        run_data = {}
-        try:
-            with open(fname, "r") as file:
-                run_data = json.load(file)
-        finally:
-            if os.path.isfile(fname):
-                os.remove(fname)
-        return run_data
+        return get_config_db_as_json(self.scope)

--- a/generic_config_updater/change_applier.py
+++ b/generic_config_updater/change_applier.py
@@ -138,7 +138,7 @@ class ChangeApplier:
             str(jsondiff.diff(run_data, upd_data))[0:40]))
 
     def apply(self, change):
-        run_data = self._get_running_config()
+        run_data = get_config_db_as_json(self.scope)
         upd_data = prune_empty_table(change.apply(copy.deepcopy(run_data)))
         upd_keys = defaultdict(dict)
 
@@ -147,7 +147,7 @@ class ChangeApplier:
 
         ret = self._services_validate(run_data, upd_data, upd_keys)
         if not ret:
-            run_data = self._get_running_config()
+            run_data = get_config_db_as_json(self.scope)
             self.remove_backend_tables_from_config(upd_data)
             self.remove_backend_tables_from_config(run_data)
             if upd_data != run_data:
@@ -160,6 +160,3 @@ class ChangeApplier:
     def remove_backend_tables_from_config(self, data):
         for key in self.backend_tables:
             data.pop(key, None)
-
-    def _get_running_config(self):
-        return get_config_db_as_json(self.scope)

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -69,9 +69,10 @@ def get_config_db_as_text(scope=None):
     result = subprocess.Popen(cmd, shell=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     text, err = result.communicate()
     return_code = result.returncode
-    if return_code: # non-zero means failure
+    if return_code:
         raise GenericConfigUpdaterError(f"Failed to get running config for namespace: {scope},"
                                         f" Return code: {return_code}, Error: {err}")
+    return text
 
 
 class ConfigWrapper:

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -53,6 +53,27 @@ class JsonChange:
             return self.patch == other.patch
         return False
 
+
+def get_config_db_as_json(scope=None):
+    text = get_config_db_as_text(scope=scope)
+    config_db_json = json.loads(text)
+    config_db_json.pop("bgpraw", None)
+    return config_db_json
+
+
+def get_config_db_as_text(scope=None):
+    if scope is not None and scope != multi_asic.DEFAULT_NAMESPACE:
+        cmd = ['sonic-cfggen', '-d', '--print-data', '-n', scope]
+    else:
+        cmd = ['sonic-cfggen', '-d', '--print-data']
+    result = subprocess.Popen(cmd, shell=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    text, err = result.communicate()
+    return_code = result.returncode
+    if return_code: # non-zero means failure
+        raise GenericConfigUpdaterError(f"Failed to get running config for namespace: {scope},"
+                                        f" Return code: {return_code}, Error: {err}")
+
+
 class ConfigWrapper:
     def __init__(self, yang_dir=YANG_DIR, scope=multi_asic.DEFAULT_NAMESPACE):
         self.scope = scope
@@ -60,24 +81,10 @@ class ConfigWrapper:
         self.sonic_yang_with_loaded_models = None
 
     def get_config_db_as_json(self):
-        text = self._get_config_db_as_text()
-        config_db_json = json.loads(text)
-        config_db_json.pop("bgpraw", None)
-        return config_db_json
+        return get_config_db_as_json(self.scope)
 
     def _get_config_db_as_text(self):
-        if self.scope is not None and self.scope != multi_asic.DEFAULT_NAMESPACE:
-            cmd = ['sonic-cfggen', '-d', '--print-data', '-n', self.scope]
-        else:
-            cmd = ['sonic-cfggen', '-d', '--print-data']
-
-        result = subprocess.Popen(cmd, shell=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        text, err = result.communicate()
-        return_code = result.returncode
-        if return_code: # non-zero means failure
-            raise GenericConfigUpdaterError(f"Failed to get running config for namespace: {self.scope},"
-                                            f" Return code: {return_code}, Error: {err}")
-        return text
+        return get_config_db_as_text(self.scope)
 
     def get_sonic_yang_as_json(self):
         config_db_json = self.get_config_db_as_json()

--- a/tests/generic_config_updater/change_applier_test.py
+++ b/tests/generic_config_updater/change_applier_test.py
@@ -200,7 +200,7 @@ def vlan_validate(old_cfg, new_cfg, keys):
 
 class TestChangeApplier(unittest.TestCase):
 
-    @patch("gu_common.get_config_db_as_json")
+    @patch("generic_config_updater.gu_common.get_config_db_as_json")
     @patch("generic_config_updater.change_applier.get_config_db")
     @patch("generic_config_updater.change_applier.set_config")
     def test_change_apply(self, mock_set, mock_db, mock_get_config_json):

--- a/tests/generic_config_updater/change_applier_test.py
+++ b/tests/generic_config_updater/change_applier_test.py
@@ -8,7 +8,6 @@ from unittest.mock import patch, Mock, call
 
 import generic_config_updater.change_applier
 import generic_config_updater.services_validator
-import generic_config_updater.gu_common
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 DATA_FILE =  os.path.join(SCRIPT_DIR, "files", "change_applier_test.data.json")
@@ -200,7 +199,7 @@ def vlan_validate(old_cfg, new_cfg, keys):
 
 class TestChangeApplier(unittest.TestCase):
 
-    @patch("generic_config_updater.gu_common.get_config_db_as_json")
+    @patch("generic_config_updater.change_applier.ChangeApplier._get_running_config")
     @patch("generic_config_updater.change_applier.get_config_db")
     @patch("generic_config_updater.change_applier.set_config")
     def test_change_apply(self, mock_set, mock_db, mock_get_config_json):

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -56,7 +56,6 @@ class TestFeaturePatchApplication(unittest.TestCase):
                 self.run_single_success_case_applier(data[test_case_name])
 
     @patch("generic_config_updater.field_operation_validators.rdma_config_update_validator", mock.Mock(return_value=True))
-    @patch('generic_config_updater.gu_common.get_config_db_as_json', side_effect=get_running_config)
     def test_feature_patch_application_failure(self):
         # Fromat of the JSON file containing the test-cases:
         #
@@ -94,7 +93,8 @@ class TestFeaturePatchApplication(unittest.TestCase):
     
     @patch("generic_config_updater.change_applier.get_config_db")
     @patch("generic_config_updater.change_applier.set_config")
-    def run_single_success_case_applier(self, data, mock_set, mock_db):
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
+    def run_single_success_case_applier(self, data, mock_set, mock_db, mock_get_config_db_as_json):
         current_config = data["current_config"]
         expected_config = data["expected_config"]
         patch = jsonpatch.JsonPatch(data["patch"])
@@ -122,7 +122,8 @@ class TestFeaturePatchApplication(unittest.TestCase):
         self.assertEqual(simulated_config, expected_config)
     
     @patch("generic_config_updater.change_applier.get_config_db")
-    def run_single_failure_case_applier(self, data, mock_db):
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
+    def run_single_failure_case_applier(self, data, mock_db, mock_get_config_db_as_json):
         current_config = data["current_config"]
         patch = jsonpatch.JsonPatch(data["patch"])
         expected_error_substrings = data["expected_error_substrings"]

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -91,9 +91,9 @@ class TestFeaturePatchApplication(unittest.TestCase):
         patch_wrapper = PatchWrapper(config_wrapper)
         return gu.PatchApplier(config_wrapper=config_wrapper, patch_wrapper=patch_wrapper, changeapplier=change_applier)
     
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
     @patch("generic_config_updater.change_applier.get_config_db")
     @patch("generic_config_updater.change_applier.set_config")
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
     def run_single_success_case_applier(self, data, mock_set, mock_db, mock_get_config_db_as_json):
         current_config = data["current_config"]
         expected_config = data["expected_config"]

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock
 from mock import patch
 
 import generic_config_updater.change_applier
+import generic_config_updater.gu_common
 import generic_config_updater.patch_sorter as ps
 import generic_config_updater.generic_updater as gu
 from .gutest_helpers import Files
@@ -81,7 +82,7 @@ class TestFeaturePatchApplication(unittest.TestCase):
         patch_wrapper = PatchWrapper(config_wrapper)
         return ps.StrictPatchSorter(config_wrapper, patch_wrapper)
 
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', side_effect=get_running_config)
     def create_patch_applier(self, config, mock_get_config_db_as_json):
         global running_config
         running_config = copy.deepcopy(config)

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -81,13 +81,13 @@ class TestFeaturePatchApplication(unittest.TestCase):
         patch_wrapper = PatchWrapper(config_wrapper)
         return ps.StrictPatchSorter(config_wrapper, patch_wrapper)
 
-    def create_patch_applier(self, config):
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
+    def create_patch_applier(self, config, mock_get_config_db_as_json):
         global running_config
         running_config = copy.deepcopy(config)
         config_wrapper = self.config_wrapper
         config_wrapper.get_config_db_as_json = MagicMock(side_effect=get_running_config)
         change_applier = generic_config_updater.change_applier.ChangeApplier()
-        change_applier._get_running_config = MagicMock(side_effect=get_running_config)
         patch_wrapper = PatchWrapper(config_wrapper)
         return gu.PatchApplier(config_wrapper=config_wrapper, patch_wrapper=patch_wrapper, changeapplier=change_applier)
     

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -27,7 +27,7 @@ def set_entry(config_db, tbl, key, data):
         if not running_config[tbl]:
             running_config.pop(tbl)
 
-def get_running_config():
+def get_running_config(scope="localhost"):
     return running_config
 
 class TestFeaturePatchApplication(unittest.TestCase):

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -13,7 +13,8 @@ from .gutest_helpers import Files
 from generic_config_updater.gu_common import ConfigWrapper, PatchWrapper
 
 running_config = {}
-    
+
+
 def set_entry(config_db, tbl, key, data):
     global running_config
     if data != None:
@@ -27,8 +28,10 @@ def set_entry(config_db, tbl, key, data):
         if not running_config[tbl]:
             running_config.pop(tbl)
 
+
 def get_running_config(scope="localhost"):
     return running_config
+
 
 class TestFeaturePatchApplication(unittest.TestCase):
     def setUp(self):

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -56,6 +56,7 @@ class TestFeaturePatchApplication(unittest.TestCase):
                 self.run_single_success_case_applier(data[test_case_name])
 
     @patch("generic_config_updater.field_operation_validators.rdma_config_update_validator", mock.Mock(return_value=True))
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', side_effect=get_running_config)
     def test_feature_patch_application_failure(self):
         # Fromat of the JSON file containing the test-cases:
         #
@@ -82,8 +83,7 @@ class TestFeaturePatchApplication(unittest.TestCase):
         patch_wrapper = PatchWrapper(config_wrapper)
         return ps.StrictPatchSorter(config_wrapper, patch_wrapper)
 
-    @patch('generic_config_updater.gu_common.get_config_db_as_json', side_effect=get_running_config)
-    def create_patch_applier(self, config, mock_get_config_db_as_json):
+    def create_patch_applier(self, config):
         global running_config
         running_config = copy.deepcopy(config)
         config_wrapper = self.config_wrapper

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -161,7 +161,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
             except Exception:
                 assert(not result)
 
-    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_default_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -183,7 +183,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct namespace
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="")
 
-    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_given_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -203,7 +203,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct scope
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="asic0")
 
-    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -225,7 +225,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
 
         self.assertTrue('Failed to get running config' in str(context.exception))
 
-    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_patch_with_empty_tables_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -161,7 +161,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
             except Exception:
                 assert(not result)
 
-    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_default_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -183,7 +183,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct namespace
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="")
 
-    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_given_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -203,7 +203,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct scope
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="asic0")
 
-    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -225,7 +225,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
 
         self.assertTrue('Failed to get running config' in str(context.exception))
 
-    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_patch_with_empty_tables_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -7,6 +7,30 @@ import generic_config_updater.services_validator
 import generic_config_updater.gu_common
 
 
+def mock_get_running_config_side_effect(scope):
+    print(f"mocked_value_for_{scope}")
+    return {
+        "tables": {
+            "ACL_TABLE": {
+                "services_to_validate": ["aclservice"],
+                "validate_commands": ["acl_loader show table"]
+            },
+            "PORT": {
+                "services_to_validate": ["portservice"],
+                "validate_commands": ["show interfaces status"]
+            }
+        },
+        "services": {
+            "aclservice": {
+                "validate_commands": ["acl_loader show table"]
+            },
+            "portservice": {
+                "validate_commands": ["show interfaces status"]
+            }
+        }
+    }
+
+
 class TestMultiAsicChangeApplier(unittest.TestCase):
 
     @patch('sonic_py_common.multi_asic.is_multi_asic')
@@ -137,7 +161,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
             except Exception:
                 assert(not result)
 
-    @patch('generic_config_updater.change_applier.ChangeApplier._get_running_config', autospec=True)
+    @patch('generic_config_updater.change_applier.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_default_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -145,26 +169,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         mock_ConfigDBConnector.return_value = mock_db
 
         # Setup mock for json.load to return some running configuration
-        mock_get_running_config.return_value = {
-            "tables": {
-                "ACL_TABLE": {
-                    "services_to_validate": ["aclservice"],
-                    "validate_commands": ["acl_loader show table"]
-                },
-                "PORT": {
-                    "services_to_validate": ["portservice"],
-                    "validate_commands": ["show interfaces status"]
-                }
-            },
-            "services": {
-                "aclservice": {
-                    "validate_commands": ["acl_loader show table"]
-                },
-                "portservice": {
-                    "validate_commands": ["show interfaces status"]
-                }
-            }
-        }
+        mock_get_running_config.side_effect = mock_get_running_config_side_effect
 
         # Instantiate ChangeApplier with the default scope
         applier = generic_config_updater.change_applier.ChangeApplier()
@@ -178,34 +183,13 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct namespace
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="")
 
-    @patch('generic_config_updater.change_applier.ChangeApplier._get_running_config', autospec=True)
+    @patch('generic_config_updater.change_applier.ChangeApplier.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_given_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
         mock_db = MagicMock()
         mock_ConfigDBConnector.return_value = mock_db
-
-        # Setup mock for json.load to return some running configuration
-        mock_get_running_config.return_value = {
-            "tables": {
-                "ACL_TABLE": {
-                    "services_to_validate": ["aclservice"],
-                    "validate_commands": ["acl_loader show table"]
-                },
-                "PORT": {
-                    "services_to_validate": ["portservice"],
-                    "validate_commands": ["show interfaces status"]
-                }
-            },
-            "services": {
-                "aclservice": {
-                    "validate_commands": ["acl_loader show table"]
-                },
-                "portservice": {
-                    "validate_commands": ["show interfaces status"]
-                }
-            }
-        }
+        mock_get_running_config.side_effect = mock_get_running_config_side_effect
 
         # Instantiate ChangeApplier with the default scope
         applier = generic_config_updater.change_applier.ChangeApplier(scope="asic0")
@@ -219,7 +203,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct scope
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="asic0")
 
-    @patch('generic_config_updater.change_applier.ChangeApplier._get_running_config', autospec=True)
+    @patch('generic_config_updater.change_applier.ChangeApplier.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -241,7 +225,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
 
         self.assertTrue('Failed to get running config' in str(context.exception))
 
-    @patch('generic_config_updater.change_applier.ChangeApplier._get_running_config', autospec=True)
+    @patch('generic_config_updater.change_applier.ChangeApplier.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_patch_with_empty_tables_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -249,14 +233,17 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         mock_ConfigDBConnector.return_value = mock_db
 
         # Setup mock for json.load to simulate configuration where crucial tables are unexpectedly empty
-        mock_get_running_config.return_value = {
-            "tables": {
-                # Simulate empty tables or missing crucial configuration
-            },
-            "services": {
-                # Normally, services would be listed here
+        def mock_get_empty_running_config_side_effect():
+            return {
+                "tables": {
+                    # Simulate empty tables or missing crucial configuration
+                },
+                "services": {
+                    # Normally, services would be listed here
+                }
             }
-        }
+
+        mock_get_running_config.side_effect = mock_get_empty_running_config_side_effect
 
         # Instantiate ChangeApplier with a specific scope to simulate applying changes in a multi-asic environment
         applier = generic_config_updater.change_applier.ChangeApplier(scope="asic0")

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -161,7 +161,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
             except Exception:
                 assert(not result)
 
-    @patch('generic_config_updater.change_applier.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_default_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -183,7 +183,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct namespace
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="")
 
-    @patch('generic_config_updater.change_applier.ChangeApplier.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_given_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -203,7 +203,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Assert ConfigDBConnector called with the correct scope
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="asic0")
 
-    @patch('generic_config_updater.change_applier.ChangeApplier.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -225,7 +225,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
 
         self.assertTrue('Failed to get running config' in str(context.exception))
 
-    @patch('generic_config_updater.change_applier.ChangeApplier.get_running_config', autospec=True)
+    @patch('generic_config_updater.gu_common.get_running_config', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_patch_with_empty_tables_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Addressing the [issue 20508](https://github.com/sonic-net/sonic-buildimage/issues/20508).

ADO: 29979987

#### How I did it

Remove temp file as intermediate steps.

#### How to verify it

```
admin@str2-7250-lc1-2:~$ cat test.json 

[
 {
        "op": "add",
        "path": "/asic0/BGP_DEVICE_GLOBAL/STATE/idf_isolation_state",
        "value": "unisolated"
    }
]

admin@str2-7250-lc1-2:~$ sudo config apply-patch test.json 
sonic_yang(6):Note: Below table(s) have no YANG models: DHCP_SERVER
sonic_yang(6):Note: Below table(s) have no YANG models: LOGGER
sonic_yang(6):Note: Below table(s) have no YANG models: LOGGER
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: [{"op": "add", "path": "/BGP_DEVICE_GLOBAL/STATE/idf_isolation_state", "value": "unisolated"}]
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic0: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: asic0: sorting patch updates.
Patch Applier: The asic0 patch was converted into 1 change:
Patch Applier: asic0: applying 1 change in order:
Patch Applier:   * [{"op": "replace", "path": "/BGP_DEVICE_GLOBAL/STATE/idf_isolation_state", "value": "unisolated"}]
Patch Applier: asic0: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic0 patch application completed.
Patch applied successfully.


admin@str2-7250-lc1-2:~$ show ver

SONiC Software Version: SONiC.20220532.72
SONiC OS Version: 11
Distribution: Debian 11.9
Kernel: 5.10.0-23-2-amd64
Build commit: 7766169087
Build date: Fri Oct  4 00:15:40 UTC 2024
Built by: azureuser@98b2318ac000000

Platform: x86_64-nokia_ixr7250e_36x400g-r0
HwSKU: Nokia-IXR7250E-36x100G
ASIC: broadcom
ASIC Count: 2
Serial Number: NS220304200
Model Number: 3HE12578AARA01
Hardware Revision: 56
Uptime: 05:08:45 up 2 days, 10:16,  1 user,  load average: 1.64, 1.82, 1.74
Date: Fri 25 Oct 2024 05:08:45

Docker images:
REPOSITORY                 TAG           IMAGE ID       SIZE
docker-mux                 20220532.72   a27de04f0900   375MB
docker-mux                 latest        a27de04f0900   375MB
docker-macsec              latest        9cad4ac054db   372MB
docker-sonic-restapi       20220532.72   2dc9b6c42cdb   345MB
docker-sonic-restapi       latest        2dc9b6c42cdb   345MB
docker-orchagent           20220532.72   560867c70e69   360MB
docker-orchagent           latest        560867c70e69   360MB
docker-fpm-frr             20220532.72   525aad3b1670   367MB
docker-fpm-frr             latest        525aad3b1670   367MB
docker-teamd               20220532.72   9bc2875ba21c   343MB
docker-teamd               latest        9bc2875ba21c   343MB
docker-syncd-brcm-dnx      20220532.72   58ee35f9df5b   674MB
docker-syncd-brcm-dnx      latest        58ee35f9df5b   674MB
docker-gbsyncd-credo       20220532.72   5084ec39b3fc   346MB
docker-gbsyncd-credo       latest        5084ec39b3fc   346MB
docker-gbsyncd-broncos     20220532.72   f1011e5ed75c   374MB
docker-gbsyncd-broncos     latest        f1011e5ed75c   374MB
docker-dhcp-relay          latest        137faf5f4038   337MB
docker-platform-monitor    20220532.72   41d6954ab85a   452MB
docker-platform-monitor    latest        41d6954ab85a   452MB
docker-snmp                20220532.72   916f66a40a77   376MB
docker-snmp                latest        916f66a40a77   376MB
docker-sonic-telemetry     20220532.72   e8037e0fd00c   407MB
docker-sonic-telemetry     latest        e8037e0fd00c   407MB
docker-router-advertiser   20220532.72   a5afbccec5da   327MB
docker-router-advertiser   latest        a5afbccec5da   327MB
docker-lldp                20220532.72   01386dd544cf   369MB
docker-lldp                latest        01386dd544cf   369MB
docker-database            20220532.72   2da62f2abd04   327MB
docker-database            latest        2da62f2abd04   327MB
docker-acms                20220532.72   264a51a7a259   374MB
docker-acms                latest        264a51a7a259   374MB
k8s.gcr.io/pause           3.5           ed210e3e4a5b   683kB
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

