### PR TITLE
Enforce table without YANG check in both load_minigraph and reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1384,6 +1384,9 @@ def config_file_yang_validation(filename):
                     fg='magenta')
         raise click.Abort()
 
+    if len(sy.tablesWithOutYang):
+        log.log_warning("YANG failed to cover tables: {}.".format(list(sy.tablesWithOutYang.keys())))
+
 
 # This is our main entrypoint - the main 'config' command
 @click.group(cls=clicommon.AbbreviationGroup, context_settings=CONTEXT_SETTINGS)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 29917681
#### What I did
Enforece log warning message for non YANG covered table
#### How I did it
Add log warning message
#### How to verify it
Manual test

Sample output:
```
2024 Oct 23 08:21:04.851705 bjw-can-7260-12 WARNING config: YANG failed to cover tables: ['TABLE_NOT_COVRED_BY_YANG', 'bgpraw', 'bgpraw1', 'bgpraw2'].
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

