### PR TITLE
[202311] Set warn msg for list of tables which not covered by YANG

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2083,6 +2083,9 @@ def validate_config_by_cm_alerting(cm, config_json, jname):
     except Exception as ex:
         log.log_warning("Failed to validate {}. Alerting: {}".format(jname, ex))
 
+    if len(cm.tablesWithOutYang()):
+        log.log_warning("YANG failed to cover tables: {}.".format(list(cm.tablesWithOutYang().keys())))
+
 
 def override_config_db(config_db, config_input):
     # Deserialized golden config to DB recognized format


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
ADO: 29917681
#### What I did
Sent a warn syslog if there are tables not covered by yang. Only show the list of keys of table name
#### How I did it
Sent a warn syslog if there are tables not covered by yang.
#### How to verify it
Manual test


Improve output from
```
2024 Oct 23 07:43:20.293672 bjw-can-7260-12 WARNING config: YANG failed to cover tables: {'TABLE_NOT_COVRED_BY_YANG': {'mux_tunnel_egress_acl': {'status': 'disabled'}, 'tunnel_qos_remap': {'status': 'enabled'}}, 'bgpraw': 'aa', 'bgpraw1': 'aa', 'bgpraw2': 'aa'}.
```
to 
```
2024 Oct 23 07:45:21.755952 bjw-can-7260-12 WARNING config: YANG failed to cover tables: ['TABLE_NOT_COVRED_BY_YANG', 'bgpraw', 'bgpraw1', 'bgpraw2']
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

