### PR TITLE
Refresh showtech dump file modify timestamp before cleanup call 

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2223,6 +2223,9 @@ finalize() {
         else
             echo "WARNING: gzip operation appears to have failed." >&2
         fi
+        # sometimes gzip takes more than 20 sec to finish, causing file time create validation
+        # to fail. touching the tarfile created to refresh modify time.
+        touch ${TARFILE}
     fi
 
     # Invoke the TechSupport Cleanup Hook


### PR DESCRIPTION
Signed-off-by: Anand Mehra anamehra@cisco.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/20693

#### What I did
During the show techsupport, generate_dump calls techsupport_cleanup with current generated file. The techsupport_cleanup verifies the file path provided for file last modification timestamp and on success only proceeds to cleanup. It expects the file to be modified within last 20 secs. Sometimes when file is big, gzip takes more that 20 sec. Due to this, the last modify timestamp to current time stamp diff is greater than 20 and verify_recent_file_creation fails causing cleanup to fail.

#### How I did it
touch the tarfile after finishing the gzip to refresh modify timestamp.

#### How to verify it
run show techsupport

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

