### PR TITLE
 Fix for integer overflow of counter value if its too large

### DIFF
--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -229,7 +229,7 @@ class Portstat(object):
                     if counter_name not in fvs:
                         fields[pos] = STATUS_NA
                     elif fields[pos] != STATUS_NA:
-                        fields[pos] = str(int(fields[pos]) + int(fvs[counter_name]))
+                        fields[pos] = str(int(fields[pos]) + int(float(fvs[counter_name])))
 
             cntr = NStats._make(fields)._asdict()
             return cntr


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Changed the data type casting to float if count coming is too large or in scientific notation .

#### How I did it
made it float then type cast to int for display purpose

#### How to verify it
Manually passed big value and see the count output if it breaks or works 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

