### PR TITLE
Revise RJ45 Port Type Check

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -103,6 +103,9 @@ class portconfig(object):
             port_transceiver_info = self.state_db.get_all(self.state_db.STATE_DB, "TRANSCEIVER_INFO|{}".format(port))
             if port_transceiver_info:
                 self.is_rj45_port = True if port_transceiver_info.get("type") == "RJ45" else False
+            else:
+                from utilities_common.platform_sfputil_helper import is_rj45_port
+                self.is_rj45_port = is_rj45_port(port)
             for key in lag_mbr_tables:
                 if port == key[1]:
                     self.parent = key[0]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
For the RJ45 port, the port_transceiver_info is None. This is because that the XCVRD will not update TRANSCEIVER_INFO into STATE DB for the RJ45 port.

#### How I did it
If port_transceiver_info is None,
apply the same method used in intfutil.
#### How to verify it
Set link-training on RJ45 port, the error msg "Setting RJ45 ports' link-training is not supported" must be displayed.
Set interface type on RJ45 port, the error msg "Setting RJ45 ports' type is not supported" must be displayed.
Set advertised-types on RJ45 port, the error msg "Setting RJ45 ports' advertised types is not supported" must be displayed.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

