### PR TITLE
Add port FEC BER show changes

### DIFF
--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -35,11 +35,11 @@ Ethernet8      N/A        6  1350.00 KB/s    9000.00/s        N/A       100     
 """
 
 intf_fec_counters = """\
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR
----------  -------  ----------  ------------  ----------------
-Ethernet0        D     130,402             3                 4
-Ethernet4      N/A     110,412             1                 0
-Ethernet8      N/A     100,317             0                 0
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER
+---------  -------  ----------  ------------  ----------------  -------------  --------------
+Ethernet0        D     130,402             3                 4            N/A             N/A
+Ethernet4      N/A     110,412             1                 0            N/A             N/A
+Ethernet8      N/A     100,317             0                 0            N/A             N/A
 """
 
 intf_fec_counters_fec_hist = """\

--- a/utilities_common/netstat.py
+++ b/utilities_common/netstat.py
@@ -107,6 +107,15 @@ def format_prate(rate):
     else:
         return "{:.2f}".format(float(rate))+'/s'
 
+def format_fec_ber(rate):
+    """
+    Show the ber rate.
+    """
+    if rate == STATUS_NA:
+        return STATUS_NA
+    else:
+        return "{:.2e}".format(float(rate))
+
 
 def format_util(brate, port_rate):
     """

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -11,7 +11,8 @@ from swsscommon.swsscommon import SonicV2Connector, CounterTable, PortCounter
 from utilities_common import constants
 import utilities_common.multi_asic as multi_asic_util
 from utilities_common.netstat import ns_diff, table_as_json, format_brate, format_prate, \
-                                     format_util, format_number_with_comma, format_util_directly
+                                     format_util, format_number_with_comma, format_util_directly, \
+                                     format_fec_ber
 
 """
 The order and count of statistics mentioned below needs to be in sync with the values in portstat script
@@ -32,11 +33,11 @@ header_all = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'RX_ERR'
 header_std = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP', 'RX_OVR',
               'TX_OK', 'TX_BPS', 'TX_UTIL', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_errors_only = ['IFACE', 'STATE', 'RX_ERR', 'RX_DRP', 'RX_OVR', 'TX_ERR', 'TX_DRP', 'TX_OVR']
-header_fec_only = ['IFACE', 'STATE', 'FEC_CORR', 'FEC_UNCORR', 'FEC_SYMBOL_ERR']
+header_fec_only = ['IFACE', 'STATE', 'FEC_CORR', 'FEC_UNCORR', 'FEC_SYMBOL_ERR', 'FEC_PRE_BER', 'FEC_POST_BER']
 header_rates_only = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_OK', 'TX_BPS', 'TX_PPS', 'TX_UTIL']
 
-rates_key_list = ['RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_BPS', 'TX_PPS', 'TX_UTIL']
-ratestat_fields = ("rx_bps",  "rx_pps", "rx_util", "tx_bps", "tx_pps", "tx_util")
+rates_key_list = ['RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_BPS', 'TX_PPS', 'TX_UTIL', 'FEC_PRE_BER', 'FEC_POST_BER']
+ratestat_fields = ("rx_bps",  "rx_pps", "rx_util", "tx_bps", "tx_pps", "tx_util", "fec_pre_ber", "fec_post_ber")
 RateStats = namedtuple("RateStats", ratestat_fields)
 
 """
@@ -194,10 +195,12 @@ class Portstat(object):
             tx_err = self.db.get(self.db.CHASSIS_STATE_DB, key, "tx_err")
             tx_drop = self.db.get(self.db.CHASSIS_STATE_DB, key, "tx_drop")
             tx_ovr = self.db.get(self.db.CHASSIS_STATE_DB, key, "tx_ovr")
+            fec_pre_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_pre_ber")
+            fec_post_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_post_ber")
             port_alias = key.split("|")[-1]
             cnstat_dict[port_alias] = NStats._make([rx_ok, rx_err, rx_drop, rx_ovr, tx_ok, tx_err, tx_drop, tx_ovr] +
                                                    [STATUS_NA] * (len(NStats._fields) - 8))._asdict()
-            ratestat_dict[port_alias] = RateStats._make([rx_bps, rx_pps, rx_util, tx_bps, tx_pps, tx_util])
+            ratestat_dict[port_alias] = RateStats._make([rx_bps, rx_pps, rx_util, tx_bps, tx_pps, tx_util, fec_post_ber, fec_post_ber])
         self.cnstat_dict.update(cnstat_dict)
         self.ratestat_dict.update(ratestat_dict)
 
@@ -238,7 +241,7 @@ class Portstat(object):
             """
                 Get the rates from specific table.
             """
-            fields = ["0", "0", "0", "0", "0", "0"]
+            fields = ["0", "0", "0", "0", "0", "0", "0", "0"]
             for pos, name in enumerate(rates_key_list):
                 full_table_id = RATES_TABLE_PREFIX + table_id
                 counter_data = self.db.get(self.db.COUNTERS_DB, full_table_id, name)
@@ -363,7 +366,9 @@ class Portstat(object):
                 table.append((key, self.get_port_state(key),
                               format_number_with_comma(data['fec_corr']),
                               format_number_with_comma(data['fec_uncorr']),
-                              format_number_with_comma(data['fec_symbol_err'])))
+                              format_number_with_comma(data['fec_symbol_err']),
+                              format_fec_ber(rates.fec_pre_ber),
+                              format_fec_ber(rates.fec_post_ber)))
             elif rates_only:
                 header = header_rates_only
                 table.append((key, self.get_port_state(key),


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This is to add the utilities changes for the feature port FEC BER.
This change the cli output as describled in the HLD#1829, Port FEC BER

Two additonal PR(s) will address the swss ( sonic-swss) and the sonic-mgmt changes
#### How I did it
This is to add two additional column for the cli "show interface counters fec-stat".
The new new colums are FEC_PRE_BER    FEC_POST_BER

#### How to verify it
using the following two cli, one can verify the output
(1) show interface counters fec-stat
(2) portstat -f

#### Previous command output (if the output of a command-line utility has changed)
portstat -f
      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    

#### New command output (if the output of a command-line utility has changed)
portstat -f
      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER
