### PR TITLE
Extra delay between running firmware and updating firmware version

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1591,8 +1591,9 @@ def download_firmware(port_name, filepath):
                                                                1 = Hitless Reset to Inactive Image (Default)\n \
                                                                2 = Attempt non-hitless Reset to Running Image\n \
                                                                3 = Attempt Hitless Reset to Running Image\n")
-@click.option('--delay', metavar='<delay>', type=click.IntRange(0, 10), help="Delay time before updating firmware information to STATE_DB")
-def run(port_name, mode):
+@click.option('--delay', metavar='<delay>', type=click.IntRange(0, 10), default=5,
+              help="Delay time before updating firmware information to STATE_DB")
+def run(port_name, mode, delay):
     """Run the firmware with default mode=0"""
 
     if is_port_type_rj45(port_name):
@@ -1608,6 +1609,8 @@ def run(port_name, mode):
         click.echo('Failed to run firmware in mode={}! CDB status: {}'.format(mode, status))
         sys.exit(EXIT_FAIL)
 
+    # The cable firmware can be still under initialization immediately after run_firmware
+    # We put a delay here to avoid potential error message in accessing the cable EEPROM
     if delay:
         time.sleep(delay)
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1591,6 +1591,7 @@ def download_firmware(port_name, filepath):
                                                                1 = Hitless Reset to Inactive Image (Default)\n \
                                                                2 = Attempt non-hitless Reset to Running Image\n \
                                                                3 = Attempt Hitless Reset to Running Image\n")
+@click.option('--delay', metavar='<delay>', type=click.IntRange(0, 10), help="Delay time before updating firmware information to STATE_DB")
 def run(port_name, mode):
     """Run the firmware with default mode=0"""
 
@@ -1606,6 +1607,9 @@ def run(port_name, mode):
     if status != 1:
         click.echo('Failed to run firmware in mode={}! CDB status: {}'.format(mode, status))
         sys.exit(EXIT_FAIL)
+
+    if delay:
+        time.sleep(delay)
 
     update_firmware_info_to_state_db(port_name)
     click.echo("Firmware run in mode={} success".format(mode))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Introduce a delay in "sfputil firmware run" between running firmware and updating the cable firmware version info.

The flow of "sfputil firmware run" is the following

1. Issue CMIS CDB command "run cable firmware" (0x109) to the cable to switch to the inactive firmware.
2. Fetch the version of the cable's running firmware

It takes time for the cable to get ready after switching firmware, which can cause an error message in step 2.
We introduce a CLI option to specify a delay between step 1 and 2 to avoid error message.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

