### PR TITLE
[ARM64][Warm-Reboot]: Get boot arguments from uboot environment

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -415,7 +415,23 @@ function setup_reboot_variables()
         # Handle architectures supporting Device Tree
         elif [ -f /sys/firmware/devicetree/base/chosen/bootargs ]; then
             KERNEL_IMAGE="$(ls $IMAGE_PATH/boot/vmlinuz-*)"
-            BOOT_OPTIONS="$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$//') ${KEXEC_LOAD_EXTRA_CMDLINE_LINUX} SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+            # Fetch next_boot variable
+            SONIC_IMAGE_NAME="$( fw_printenv boot_next | cut -d '=' -f 2- )"
+            SUFFIX=""
+            if [[ ${SONIC_IMAGE_NAME} == "run sonic_image_2" ]]; then
+                SUFFIX="_old"
+            fi
+            SONIC_BOOTARGS="$(fw_printenv sonic_bootargs${SUFFIX} | cut -d '=' -f 2- )"
+            if [[ ! -z "${SONIC_BOOTARGS}" ]]; then
+                LINUX_BOOTARGS="$( fw_printenv linuxargs${SUFFIX} | cut -d '=' -f 2- )"
+                BAUDRATE="$( fw_printenv baudrate | cut -d '=' -f 2- )"
+                BOOT_OPTIONS="$(echo $SONIC_BOOTARGS | sed -e "s/\${baudrate}/$BAUDRATE/g")"
+                BOOT_OPTIONS="$(echo $BOOT_OPTIONS | sed -e "s@\${linuxargs$SUFFIX}@$LINUX_BOOTARGS@g")"
+                BOOT_OPTIONS="$(echo $BOOT_OPTIONS | sed -e 's/.$//') ${KEXEC_LOAD_EXTRA_CMDLINE_LINUX} SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+            else
+                # Fetch bootargs from device tree of the current image
+                BOOT_OPTIONS="$(cat /sys/firmware/devicetree/base/chosen/bootargs | sed 's/.$//') ${KEXEC_LOAD_EXTRA_CMDLINE_LINUX} SONIC_BOOT_TYPE=${BOOT_TYPE_ARG}"
+            fi
             INITRD=$(echo $KERNEL_IMAGE | sed 's/vmlinuz/initrd.img/g')
 
             # If initrd is a U-Boot uImage, remove the uImage header


### PR DESCRIPTION
Fetch boot arguments from the next boot image by reading it from uboot environment variables.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
In current scenario, during warm-reboot for arm64, boot arguments are fetched from device tree of the current image. This causes an issue during upgrade/downgrade with warm-reboot.

#### How I did it
With the change, boot arguments for arm64 is fetched from uboot environment variables. The logic relies on creation of
"sonic_bootargs" environment variable to fetch the right boot argument.

#### How to verify it
Tested by sonic to sonic install followed by warm-reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

