### PR TITLE
[broadcom] Add broadcom ASIC info to "show version" click command

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1480,6 +1480,18 @@ def version(verbose):
     platform_info = device_info.get_platform_info()
     chassis_info = platform.get_chassis_info()
 
+    if platform_info['asic_type'] == 'broadcom':
+        asic_info = _get_broadcom_info()
+        asic_info_str = []
+        asic_info_str.extend(
+            # NOTE: No ':' because that is in the output as well.
+            ["ASIC API {}".format(line) for line in asic_info['versions']])
+        asic_info_str.extend(
+            ["ASIC Model: {}".format(line) for line in asic_info['units']])
+        asic_info_str = '\n'.join(asic_info_str)
+    else:
+        asic_info = None
+
     sys_uptime_cmd = ["uptime"]
     sys_uptime = subprocess.Popen(sys_uptime_cmd, text=True, stdout=subprocess.PIPE)
 
@@ -1496,6 +1508,8 @@ def version(verbose):
     click.echo("HwSKU: {}".format(platform_info['hwsku']))
     click.echo("ASIC: {}".format(platform_info['asic_type']))
     click.echo("ASIC Count: {}".format(platform_info['asic_count']))
+    if asic_info:
+        click.echo(asic_info_str)
     click.echo("Serial Number: {}".format(chassis_info['serial']))
     click.echo("Model Number: {}".format(chassis_info['model']))
     click.echo("Hardware Revision: {}".format(chassis_info['revision']))
@@ -1505,6 +1519,31 @@ def version(verbose):
     cmd = ['sudo', 'docker', 'images', '--format', "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"]
     p = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
     click.echo(p.stdout.read())
+
+
+def _get_broadcom_info():
+    def _bcmcmd(command):
+        try:
+            res = subprocess.check_output(
+                # NOTE: There's also -n $UNIT in the bcmcmd shell script.
+                ['bcmcmd', '-t', '1', command],
+                stderr=subprocess.DEVNULL, text=True)
+        except (FileNotFoundError, PermissionError, subprocess.CalledProcessError) as e:
+            res = str(e)
+        lines = [
+            line.strip() for line in res.split('\n')
+            if line.strip() not in (
+                '', command, 'drivshell>')]
+        res = '\n'.join(lines)
+        return res
+
+    ret = {
+        # Slow: these calls easily take 2x300ms.
+        'versions': _bcmcmd('bsv').replace('\n', ' ').split(', '),
+        'units': _bcmcmd('show unit').split('\n'),
+        # 'monitor_version': _bcmcmd('ver'),
+    }
+    return ret
 
 #
 # 'environment' command ("show environment")


### PR DESCRIPTION
#### What I did

When the ASIC platform is broadcom, expand the "show version" output with additional versions. This helps keeping track of different versions when building/testing.

#### How I did it

Added _get_broadcom_info() function that calls 'bcmcmd' with 'bsv' and 'show unit'.

#### How to verify it

Run `show version` on a device with broadcom ASIC and observe how it now lists this:

```diff
 # show version

 SONiC Software Version: SONiC.master.0-123456789
 SONiC OS Version: 12
 Distribution: Debian 12.8
 Kernel: 6.1.0-22-2-amd64
 Build commit: 123456789
 Build date: Tue Nov 12 15:28:30 UTC 2024
 Built by: sonic-builder

 Platform: x86_64-accton_as9716_32d-r0
 HwSKU: Accton-AS9716-32D
 ASIC: broadcom
 ASIC Count: 1
+ASIC API BRCM SAI ver: [10.1.42.0]
+ASIC API OCP SAI ver: [1.13.2]
+ASIC API SDK ver: [sdk-6.5.29]
+ASIC Model: Unit 0 chip BCM56980_B0 (current)
 Serial Number: ...
```

#### Previous command output (if the output of a command-line utility has changed)

(see diff above)

#### New command output (if the output of a command-line utility has changed)

(see diff above)

#### Additional comments

I am aware that:

1. This is broadcom specific. I find it useful. Especially since the trouble I've been having with different versions working/not-working depending on libsaibcm.
2. The code might not be in the best location. I'll gladly move parts to a submodule/helper file. Please give me feedback on where you'd rather see it.
3. If syncd is down, the `show version` command takes slightly longer because of the timeouts. I think this is acceptable.

In my case, I could not get `master` from November 2024 to run on the Accton-AS7326-56X or Accton-AS9716-32D, except when I reverted ffb9bc021 and 433d039a4; reverting the BRCM SAI/SDK versions. While the BRCM/SAI versions will not get fetched if syncd is down (they will be in syslog), these clues are helpful when comparing output.

Another output:
```diff
 # show version

 SONiC Software Version: SONiC.202405.0-123456789
 SONiC OS Version: 12
 Distribution: Debian 12.8
 Kernel: 6.1.0-22-2-amd64
 Build commit: 123456789
 Build date: Mon Nov 18 15:56:07 UTC 2024
 Built by: sonic-builder

 Platform: x86_64-accton_as7326_56x-r0
 HwSKU: Accton-AS7326-56X
 ASIC: broadcom
 ASIC Count: 1
+ASIC API BRCM SAI ver: [11.2.13.1]
+ASIC API OCP SAI ver: [1.14.0]
+ASIC API SDK ver: [sdk-6.5.30-SP4]
+ASIC API CANCUN ver: [06.04.01]
+ASIC Model: Unit 0 chip BCM56873_A0 (current)
 Serial Number: ...
```