### PR TITLE
[show][interfaces] Add proposal for show interface errors {port}

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5121,47 +5121,33 @@ This command is to display the link-training status of the selected interfaces. 
     Ethernet8      trained          on      up       up
   ```
 
-**show interfaces mac-statistics**
+**show interfaces errors**
 
 The show interface mac-stats command provides detailed statistics and error counters for MAC-level operations on an interface. It displays the status of various operational parameters, error counts, and timestamps for when these errors occurred.
 
 - Usage:
   ```
-  show interfaces mac_statistics [<interface_name>]
+  show interfaces errors [<interface_name>]
   ```
 
 - Example:
-  ```
-  admin@sonic:~$ show interfaces mac_statistics Ethernet4
-  Field                             Value
-  --------------------------------  -------------------
-  oper_error_status                 5442
-  mac_local_fault_count             2
-  mac_local_fault_time              2024-11-02 04:00:05
-  fec_sync_loss_count               2
-  fec_sync_loss_time                2024-11-02 04:00:05
-  fec_alignment_loss_count          2
-  fec_alignment_loss_time           2024-11-02 04:00:05
-  high_ser_error_count              2
-  high_ser_error_time               2024-11-02 04:00:05
-  high ber_error_count              2
-  high ber_error_time               2024-11-02 04:00:05
-  data_unit_crc_error_count         2
-  data_unit_crc_error_time          2024-11-02 04:00:05
-  data_unit_misalignment_error_count 2
-  data_unit_misalignment_error_time 2024-11-02 04:00:05
-  signal_local_error_count          2
-  signal_local_error_time           2024-11-02 04:00:05
-  mac_remote_fault_count            2
-  mac_remote_fault_time             2024-11-02 04:00:50
-  crc_rate_count                    2
-  crc_rate_time                     2024-11-02 04:00:50
-  data_unit_size_count              2
-  data_unit_size_time               2024-11-02 04:00:50
-  code_group_error_count            2
-  code_group_error_time             2024-11-02 04:00:50
-  no_rx_reachability_count          2
-  no_rx_reachability_time           2024-11-02 04:00:50
+  admin@sonic:~$ show interfaces errors Ethernet4
+  Port Errors                        Count           Last timestamp(UTC)
+  ---------------------------------- -----           -------------------
+  oper_error_status                  5442            2024-11-02 04:00:05
+  mac_local_fault_count              2               2024-11-02 04:00:05
+  fec_sync_loss_count                2               2024-11-02 04:00:05
+  fec_alignment_loss_count           2               2024-11-02 04:00:05
+  high_ser_error_count               2               2024-11-02 04:00:05
+  high ber_error_count               2               2024-11-02 04:00:05
+  data_unit_crc_error_count          2               2024-11-02 04:00:05
+  data_unit_misalignment_error_count 2               2024-11-02 04:00:05
+  signal_local_error_count           2               2024-11-02 04:00:05
+  mac_remote_fault_count             2               2024-11-02 04:00:50
+  crc_rate_count                     2               2024-11-02 04:00:50
+  data_unit_size_count               2               2024-11-02 04:00:50
+  code_group_error_count             0               Never
+  no_rx_reachability_count           0               Never
   ```
 
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5136,19 +5136,19 @@ The show interface errors command provides detailed statistics and error counter
   Port Errors                        Count           Last timestamp(UTC)
   ---------------------------------- -----           -------------------
   oper_error_status                  5442            2024-11-02 04:00:05
-  mac_local_fault_count              2               2024-11-02 04:00:05
-  fec_sync_loss_count                2               2024-11-02 04:00:05
-  fec_alignment_loss_count           2               2024-11-02 04:00:05
-  high_ser_error_count               2               2024-11-02 04:00:05
-  high ber_error_count               2               2024-11-02 04:00:05
-  data_unit_crc_error_count          2               2024-11-02 04:00:05
-  data_unit_misalignment_error_count 2               2024-11-02 04:00:05
-  signal_local_error_count           2               2024-11-02 04:00:05
-  mac_remote_fault_count             2               2024-11-02 04:00:50
-  crc_rate_count                     2               2024-11-02 04:00:50
-  data_unit_size_count               2               2024-11-02 04:00:50
-  code_group_error_count             0               Never
-  no_rx_reachability_count           0               Never
+  mac_local_fault                    2               2024-11-02 04:00:05
+  fec_sync_loss                      2               2024-11-02 04:00:05
+  fec_alignment_loss                 2               2024-11-02 04:00:05
+  high_ser_error                     2               2024-11-02 04:00:05
+  high ber_error                     2               2024-11-02 04:00:05
+  data_unit_crc_error                2               2024-11-02 04:00:05
+  data_unit_misalignment_error       2               2024-11-02 04:00:05
+  signal_local_error                 2               2024-11-02 04:00:05
+  mac_remote_fault                   2               2024-11-02 04:00:50
+  crc_rate                           2               2024-11-02 04:00:50
+  data_unit_size                     2               2024-11-02 04:00:50
+  code_group_error                   0               Never
+  no_rx_reachability                 0               Never
   ```
 
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5123,7 +5123,7 @@ This command is to display the link-training status of the selected interfaces. 
 
 **show interfaces errors**
 
-The show interface mac-stats command provides detailed statistics and error counters for MAC-level operations on an interface. It displays the status of various operational parameters, error counts, and timestamps for when these errors occurred.
+The show interface errors command provides detailed statistics and error counters for MAC-level operations on an interface. It displays the status of various operational parameters, error counts, and timestamps for when these errors occurred.
 
 - Usage:
   ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5121,6 +5121,50 @@ This command is to display the link-training status of the selected interfaces. 
     Ethernet8      trained          on      up       up
   ```
 
+**show interfaces mac-statistics**
+
+The show interface mac-stats command provides detailed statistics and error counters for MAC-level operations on an interface. It displays the status of various operational parameters, error counts, and timestamps for when these errors occurred.
+
+- Usage:
+  ```
+  show interfaces mac_statistics [<interface_name>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show interfaces mac_statistics Ethernet4
+  Field                             Value
+  --------------------------------  -------------------
+  oper_error_status                 5442
+  mac_local_fault_count             2
+  mac_local_fault_time              2024-11-02 04:00:05
+  fec_sync_loss_count               2
+  fec_sync_loss_time                2024-11-02 04:00:05
+  fec_alignment_loss_count          2
+  fec_alignment_loss_time           2024-11-02 04:00:05
+  high_ser_error_count              2
+  high_ser_error_time               2024-11-02 04:00:05
+  high ber_error_count              2
+  high ber_error_time               2024-11-02 04:00:05
+  data_unit_crc_error_count         2
+  data_unit_crc_error_time          2024-11-02 04:00:05
+  data_unit_misalignment_error_count 2
+  data_unit_misalignment_error_time 2024-11-02 04:00:05
+  signal_local_error_count          2
+  signal_local_error_time           2024-11-02 04:00:05
+  mac_remote_fault_count            2
+  mac_remote_fault_time             2024-11-02 04:00:50
+  crc_rate_count                    2
+  crc_rate_time                     2024-11-02 04:00:50
+  data_unit_size_count              2
+  data_unit_size_time               2024-11-02 04:00:50
+  code_group_error_count            2
+  code_group_error_time             2024-11-02 04:00:50
+  no_rx_reachability_count          2
+  no_rx_reachability_time           2024-11-02 04:00:50
+  ```
+
+
 **show interfaces mpls**
 
 This command is used to display the configured MPLS state for the list of configured interfaces.

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5131,6 +5131,7 @@ The show interface mac-stats command provides detailed statistics and error coun
   ```
 
 - Example:
+  ```
   admin@sonic:~$ show interfaces errors Ethernet4
   Port Errors                        Count           Last timestamp(UTC)
   ---------------------------------- -----           -------------------


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
introduces the show interfaces mac-statistics command. This command provides detailed statistics and error counters related to MAC-level operations for network interfaces.
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

