### PR TITLE
Fix typo in route_check_script

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -840,8 +840,8 @@ def check_routes(namespace):
     if results:
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
         print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
-        print_message(syslog.LOG_WARNING, "add: ", json.dumps(adds, indent=4))
-        print_message(syslog.LOG_WARNING, "del: ", json.dumps(deletes, indent=4))
+        print_message(syslog.LOG_WARNING, "add: ", json.dumps(all_adds, indent=4))
+        print_message(syslog.LOG_WARNING, "del: ", json.dumps(all_deletes, indent=4))
         return -1, results
     else:
         print_message(syslog.LOG_INFO, "All good!")


### PR DESCRIPTION

#### What I did
Fixed a typo in route_check script. If result is not empty, script might fail due to undefined variable.

#### How I did it
Corrected the typo. 

#### How to verify it
NA
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

