### PR TITLE
Fix  slash in path. (#3573)

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -17,9 +17,11 @@ CHECKPOINT_EXT = ".cp.json"
 
 def extract_scope(path):
     if not path:
-        raise Exception("Wrong patch with empty path.")
+        raise GenericConfigUpdaterError("Wrong patch with empty path.")
     pointer = jsonpointer.JsonPointer(path)
-    parts = pointer.parts
+
+    # Re-escapes
+    parts = [jsonpointer.escape(part) for part in pointer.parts]
     if not parts:
         raise GenericConfigUpdaterError("Wrong patch with empty path.")
     if parts[0].startswith("asic"):

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -1,33 +1,101 @@
+import jsonpointer
 import unittest
 from importlib import reload
 from unittest.mock import patch, MagicMock
 from generic_config_updater.generic_updater import extract_scope
+from generic_config_updater.generic_updater import GenericConfigUpdaterError
 import generic_config_updater.change_applier
 import generic_config_updater.services_validator
 import generic_config_updater.gu_common
 
 
+def mock_get_running_config_side_effect(scope):
+    print(f"mocked_value_for_{scope}")
+    return {
+        "tables": {
+            "ACL_TABLE": {
+                "services_to_validate": ["aclservice"],
+                "validate_commands": ["acl_loader show table"]
+            },
+            "PORT": {
+                "services_to_validate": ["portservice"],
+                "validate_commands": ["show interfaces status"]
+            }
+        },
+        "services": {
+            "aclservice": {
+                "validate_commands": ["acl_loader show table"]
+            },
+            "portservice": {
+                "validate_commands": ["show interfaces status"]
+            }
+        }
+    }
+
+
 class TestMultiAsicChangeApplier(unittest.TestCase):
 
-    def test_extract_scope(self):
+    @patch('sonic_py_common.multi_asic.is_multi_asic')
+    def test_extract_scope_multiasic(self, mock_is_multi_asic):
+        mock_is_multi_asic.return_value = True
         test_paths_expectedresults = {
-            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status":  (True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"),
-            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
-            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"),
-            "/sometable/data": (True, "", "/sometable/data"),
-            "": (False, "", ""),
-            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (False, "", ""),
-            "/asic77": (False, "", ""),
-            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
-            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (False, "", ""),
+            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic1/PORTCHANNEL_INTERFACE/PortChannel106|10.0.0.6/31": (
+                True, "asic1", "/PORTCHANNEL_INTERFACE/PortChannel106|10.0.0.6/31"
+            ),
+            "/asic1/PORTCHANNEL_INTERFACE/PortChannel106|10.0.0.6~131": (
+                True, "asic1", "/PORTCHANNEL_INTERFACE/PortChannel106|10.0.0.6~131"
+            ),
+            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/sometable/data": (
+                False, "", "/sometable/data"
+            ),
+            "": (
+                False, "", ""
+            ),
+            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                False, "", ""
+            ),
+            "/asic77": (
+                False, "", ""
+            ),
+            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
         }
 
         for test_path, (result, expectedscope, expectedremainder) in test_paths_expectedresults.items():
@@ -35,10 +103,81 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
                 scope, remainder = extract_scope(test_path)
                 assert(scope == expectedscope)
                 assert(remainder == expectedremainder)
-            except Exception as e:
-                assert(result == False)
+            except AssertionError:
+                assert(not result)
+            except GenericConfigUpdaterError:
+                assert(not result)
+            except jsonpointer.JsonPointerException:
+                assert(not result)
 
-    @patch('generic_config_updater.change_applier.ChangeApplier._get_running_config', autospec=True)
+    @patch('sonic_py_common.multi_asic.is_multi_asic')
+    def test_extract_scope_singleasic(self, mock_is_multi_asic):
+        mock_is_multi_asic.return_value = False
+        test_paths_expectedresults = {
+            "/asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic01/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic01", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic123456789/PORTCHANNEL/PortChannel102/admin_status":  (
+                True, "asic123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/asic0123456789/PORTCHANNEL/PortChannel102/admin_status": (
+                True, "asic0123456789", "/PORTCHANNEL/PortChannel102/admin_status"
+            ),
+            "/localhost/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "localhost", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/asic1/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                True, "asic1", "/BGP_DEVICE_GLOBAL/STATE/tsa_enabled"
+            ),
+            "/sometable/data": (
+                True, "", "/sometable/data"
+            ),
+            "": (
+                False, "", ""
+            ),
+            "localhostabc/BGP_DEVICE_GLOBAL/STATE/tsa_enabled": (
+                False, "", ""
+            ),
+            "/asic77": (False, "", ""),
+            "/Asic0/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/ASIC1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/Localhost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/LocalHost/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asci1/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asicx/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+            "/asic-12/PORTCHANNEL/PortChannel102/admin_status": (
+                False, "", ""
+            ),
+        }
+
+        for test_path, (result, expectedscope, expectedremainder) in test_paths_expectedresults.items():
+            try:
+                scope, remainder = extract_scope(test_path)
+                assert(scope == expectedscope)
+                assert(remainder == expectedremainder)
+            except AssertionError:
+                assert(not result)
+            except GenericConfigUpdaterError:
+                assert(not result)
+            except jsonpointer.JsonPointerException:
+                assert(not result)
+
+    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_default_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -46,26 +185,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         mock_ConfigDBConnector.return_value = mock_db
 
         # Setup mock for json.load to return some running configuration
-        mock_get_running_config.return_value = {
-            "tables": {
-                "ACL_TABLE": {
-                    "services_to_validate": ["aclservice"],
-                    "validate_commands": ["acl_loader show table"]
-                },
-                "PORT": {
-                    "services_to_validate": ["portservice"],
-                    "validate_commands": ["show interfaces status"]
-                }
-            },
-            "services": {
-                "aclservice": {
-                    "validate_commands": ["acl_loader show table"]
-                },
-                "portservice": {
-                    "validate_commands": ["show interfaces status"]
-                }
-            }
-        }
+        mock_get_running_config.side_effect = mock_get_running_config_side_effect
 
         # Instantiate ChangeApplier with the default scope
         applier = generic_config_updater.change_applier.ChangeApplier()


### PR DESCRIPTION
#### What I did

Addressing issue [#20377](https://github.com/sonic-net/sonic-buildimage/issues/20377). The issue caused by unescape in JsonPointer implementation which followed [RFC 6901](https://www.rfc-editor.org/rfc/rfc6901)

```python
pointer = jsonpointer.JsonPointer(path)

...

class JsonPointer(object):
    """A JSON Pointer that can reference parts of a JSON document"""

    # Array indices must not contain:
    # leading zeros, signs, spaces, decimals, etc
    _RE_ARRAY_INDEX = re.compile('0|[1-9][0-9]*$')
    _RE_INVALID_ESCAPE = re.compile('(~[^01]|~$)')

    def __init__(self, pointer):

        # validate escapes
        invalid_escape = self._RE_INVALID_ESCAPE.search(pointer)
        if invalid_escape:
            raise JsonPointerException('Found invalid escape {}'.format(
                invalid_escape.group()))

        parts = pointer.split('/')
        if parts.pop(0) != '':
            raise JsonPointerException('Location must start with /')

        parts = [unescape(part) for part in parts]
        self.parts = parts
```

#### How I did it

Re-escape `/` to `~1` to match the real key in json, and [JsonPatch](https://www.rfc-editor.org/rfc/rfc6902#appendix-A.14) will handle it correctly.

#### How to verify it

```shell
admin@str2-7250-lc1-2:~$ cat link.json
[
    {
        "op": "add",
        "path": "/asic1/PORTCHANNEL_INTERFACE/PortChannel106|10.0.0.6~131",
        "value": {}
    }
]
admin@str2-7250-lc1-2:~$ sudo config apply-patch link.json
sonic_yang(6):Note: Below table(s) have no YANG models: DHCP_SERVER
sonic_yang(6):Note: Below table(s) have no YANG models: LOGGER
sonic_yang(6):Note: Below table(s) have no YANG models: LOGGER
Patch Applier: asic1: Patch application starting.
Patch Applier: asic1: Patch: [{"op": "add", "path": "/PORTCHANNEL_INTERFACE/PortChannel106|10.0.0.6~131", "value": {}}]
Patch Applier: asic1 getting current config db.
Patch Applier: asic1: simulating the target full config after applying the patch.
Patch Applier: asic1: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic1: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: asic1: sorting patch updates.
Patch Applier: The asic1 patch was converted into 0 changes.
Patch Applier: asic1: applying 0 changes in order.
Patch Applier: asic1: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic1 patch application completed.
Patch applied successfully.
```

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

