### PR TITLE
Revert "[Mellanox] Update the save_file command in generate_dump to handle folders"

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1082,24 +1082,18 @@ save_file() {
     fi
 
     if $do_gzip; then
-        if [ ! -d "$path" ]; then
-          gz_path="${gz_path}.gz"
-          tar_path="${tar_path}.gz"
-
-          if $NOOP; then
+        gz_path="${gz_path}.gz"
+        tar_path="${tar_path}.gz"
+        if $NOOP; then
             echo "gzip -c $orig_path > $gz_path"
-          else
-            gzip -c $orig_path > $gz_path
-          fi
         else
-          gz_path="${gz_path}.tar.gz"
-          tar_path="${tar_path}.tar.gz"
-
-          if $NOOP; then
-              echo "tar -czvf $gz_path -C $(dirname $orig_path) $(basename $orig_path)"
-          else
-              tar -czvf "$gz_path" -C "$(dirname "$orig_path")" "$(basename "$orig_path")"
-          fi
+            gzip -c $orig_path > $gz_path
+        fi
+    else
+        if $NOOP; then
+            echo "cp $orig_path $gz_path"
+        else
+            cp $orig_path $gz_path
         fi
     fi
 


### PR DESCRIPTION
Reverts sonic-net/sonic-utilities#3631 since this change would cause PR test failure in show_techsupport/test_auto_techsupport.py test, error message:
```
11:05:39 __init__.pytest_runtest_call             L0040 ERROR  | Traceback (most recent call last):
  File "/var/src/sonic-mgmt/tests/show_techsupport/test_auto_techsupport.py", line 945, in validate_techsupport_generation
    validate_core_files_inside_techsupport(duthost, techsupport_folder_path,
  File "/var/src/sonic-mgmt/tests/show_techsupport/test_auto_techsupport.py", line 690, in validate_core_files_inside_techsupport
    assert core_file in core_files_inside_techsupport, 'Core file: {} not found in techsupport core ' \
AssertionError: Core file: bash.1733310266.1792.core.gz not found in techsupport core files: []

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 1788, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/usr/local/lib/python3.8/dist-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/usr/local/lib/python3.8/dist-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/var/src/sonic-mgmt/tests/show_techsupport/test_auto_techsupport.py", line 311, in test_sanity
    validate_techsupport_generation(self.duthost, self.dut_cli, is_techsupport_expected=True,
  File "/var/src/sonic-mgmt/tests/show_techsupport/test_auto_techsupport.py", line 957, in validate_techsupport_generation
    raise AssertionError(err)
AssertionError: Core file: bash.1733310266.1792.core.gz not found in techsupport core files: []
```