### PR TITLE
Update PR checker pipeline to point to bookworm

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,7 @@ stages:
         sudo apt-get update
         sudo apt-get install -y python3-pip
         sudo pip3 install requests==2.31.0
+        sudo apt-get install -y python3-protobuf
       displayName: "Install dependencies"
 
     - script: |
@@ -84,7 +85,6 @@ stages:
         sudo dpkg -i libyang_1.0.73_amd64.deb
         sudo dpkg -i libyang-cpp_1.0.73_amd64.deb
         sudo dpkg -i python3-yang_1.0.73_amd64.deb
-        sudo dpkg -i libprotobuf*.deb
       workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
       displayName: 'Install Debian dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ stages:
       vmImage: ubuntu-20.04
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye:$(BUILD_BRANCH)
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)
 
     steps:
     - script: |
@@ -85,7 +85,7 @@ stages:
         sudo dpkg -i libyang-cpp_1.0.73_amd64.deb
         sudo dpkg -i python3-yang_1.0.73_amd64.deb
         sudo dpkg -i libprotobuf*.deb
-      workingDirectory: $(Pipeline.Workspace)/target/debs/bullseye/
+      workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
       displayName: 'Install Debian dependencies'
 
     - task: DownloadPipelineArtifact@2
@@ -134,7 +134,7 @@ stages:
         sudo pip3 install sonic_yang_models-1.0-py3-none-any.whl
         sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
         sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
-      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bullseye/
+      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bookworm/
       displayName: 'Install Python dependencies'
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
         source: specific
         project: build
         pipeline: 9
-        artifact: sonic-swss-common
+        artifact: sonic-swss-common-bookworm
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/$(sourceBranch)'
       displayName: "Download sonic swss common deb packages"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,9 +169,9 @@ stages:
 
     - script: |
         set -e
-        python3 -m build -n
+        python3 setup.py bdist_wheel
       displayName: 'Build Python 3 wheel'
 
     - publish: '$(System.DefaultWorkingDirectory)/dist/'
       artifact: wheels
-      displayName: "Publish Python wheels"
+      displayName: "oublish Python wheels"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
         set -ex
         sudo apt-get update
         sudo apt-get install -y python3-pip
-        pip3 install requests==2.31.0
+        sudo pip3 install requests==2.31.0
         sudo apt-get install -y python3-protobuf
       displayName: "Install dependencies"
 
@@ -128,12 +128,12 @@ stages:
 
     - script: |
         set -xe
-        pip3 install swsssdk-2.0.1-py3-none-any.whl
-        pip3 install sonic_py_common-1.0-py3-none-any.whl
-        pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl
-        pip3 install sonic_yang_models-1.0-py3-none-any.whl
-        pip3 install sonic_config_engine-1.0-py3-none-any.whl
-        pip3 install sonic_platform_common-1.0-py3-none-any.whl
+        sudo pip3 install swsssdk-2.0.1-py3-none-any.whl
+        sudo pip3 install sonic_py_common-1.0-py3-none-any.whl
+        sudo pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl
+        sudo pip3 install sonic_yang_models-1.0-py3-none-any.whl
+        sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
+        sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
       workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bookworm/
       displayName: 'Install Python dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,9 @@ stages:
       displayName: "Install .NET CORE"
 
     - script: |
-        python3 setup.py test
+        sudo pip3 install ".[testing]"
+        sudo pip3 uninstall --yes sonic-utilities
+        pytest
       displayName: 'Test Python 3'
 
     - task: PublishTestResults@2
@@ -167,7 +169,7 @@ stages:
 
     - script: |
         set -e
-        python3 setup.py bdist_wheel
+        python3 -m build -n
       displayName: 'Build Python 3 wheel'
 
     - publish: '$(System.DefaultWorkingDirectory)/dist/'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,7 +141,7 @@ stages:
         set -ex
         # Install .NET CORE
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/11/prod
+        sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
         set -ex
         sudo apt-get update
         sudo apt-get install -y python3-pip
-        sudo pip3 install requests==2.31.0
+        pip3 install requests==2.31.0
         sudo apt-get install -y python3-protobuf
       displayName: "Install dependencies"
 
@@ -128,12 +128,12 @@ stages:
 
     - script: |
         set -xe
-        sudo pip3 install swsssdk-2.0.1-py3-none-any.whl
-        sudo pip3 install sonic_py_common-1.0-py3-none-any.whl
-        sudo pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl
-        sudo pip3 install sonic_yang_models-1.0-py3-none-any.whl
-        sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
-        sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
+        pip3 install swsssdk-2.0.1-py3-none-any.whl
+        pip3 install sonic_py_common-1.0-py3-none-any.whl
+        pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl
+        pip3 install sonic_yang_models-1.0-py3-none-any.whl
+        pip3 install sonic_config_engine-1.0-py3-none-any.whl
+        pip3 install sonic_platform_common-1.0-py3-none-any.whl
       workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bookworm/
       displayName: 'Install Python dependencies'
 
@@ -147,8 +147,8 @@ stages:
       displayName: "Install .NET CORE"
 
     - script: |
-        sudo pip3 install ".[testing]"
-        sudo pip3 uninstall --yes sonic-utilities
+        pip3 install ".[testing]"
+        pip3 uninstall --yes sonic-utilities
         pytest
       displayName: 'Test Python 3'
 
@@ -169,9 +169,9 @@ stages:
 
     - script: |
         set -e
-        python3 setup.py bdist_wheel
+        python3 -m build -n
       displayName: 'Build Python 3 wheel'
 
     - publish: '$(System.DefaultWorkingDirectory)/dist/'
       artifact: wheels
-      displayName: "oublish Python wheels"
+      displayName: "Publish Python wheels"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR is to fix the PR checker failure due to migration in dependency.

#### How I did it
1. Change dependency from bullseye to bookworm
2. Change building command accordingly

#### How to verify it
The change is verified by running the PR checker pipeline.

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A
