### PR TITLE
Revert config reload with YANG validation

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1372,19 +1372,6 @@ def multiasic_write_to_db(filename, load_sysinfo):
         migrate_db_to_lastest(ns)
 
 
-def config_file_yang_validation(filename):
-    config_to_check = read_json_file(filename)
-    sy = sonic_yang.SonicYang(YANG_DIR)
-    sy.loadYangModel()
-    try:
-        sy.loadData(configdbJson=config_to_check)
-        sy.validate_data_tree()
-    except sonic_yang.SonicYangException as e:
-        click.secho("{} fails YANG validation! Error: {}".format(filename, str(e)),
-                    fg='magenta')
-        raise click.Abort()
-
-
 # This is our main entrypoint - the main 'config' command
 @click.group(cls=clicommon.AbbreviationGroup, context_settings=CONTEXT_SETTINGS)
 @click.pass_context
@@ -1826,13 +1813,6 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
-    if filename is not None:
-        if multi_asic.is_multi_asic():
-            # Multiasic has not 100% fully validated. Thus pass here.
-            pass
-        else:
-            config_file_yang_validation(filename)
-
     #Stop services before config push
     if not no_service_restart:
         log.log_notice("'reload' stopping services...")
@@ -2023,7 +2003,15 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
             # Multiasic has not 100% fully validated. Thus pass here.
             pass
         else:
-            config_file_yang_validation(golden_config_path)
+            sy = sonic_yang.SonicYang(YANG_DIR)
+            sy.loadYangModel()
+            try:
+                sy.loadData(configdbJson=config_to_check)
+                sy.validate_data_tree()
+            except sonic_yang.SonicYangException as e:
+                click.secho("{} fails YANG validation! Error: {}".format(golden_config_path, str(e)),
+                            fg='magenta')
+                raise click.Abort()
 
         # Dependency check golden config json
         if multi_asic.is_multi_asic():

--- a/config/main.py
+++ b/config/main.py
@@ -1826,7 +1826,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
-    if filename is not None and filename != "/dev/stdin":
+    if filename is not None:
         if multi_asic.is_multi_asic():
             # Multiasic has not 100% fully validated. Thus pass here.
             pass

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1432,34 +1432,6 @@ class TestReloadConfig(object):
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
                 == RELOAD_YANG_CFG_OUTPUT.format(config.SYSTEM_RELOAD_LOCK)
 
-    def test_reload_config_fails_yang_validation(self, get_cmd_module, setup_single_broadcom_asic):
-        with open(self.dummy_cfg_file, 'w') as f:
-            device_metadata = {
-                "DEVICE_METADATA": {
-                    "localhost": {
-                        "invalid_hwsku": "some_hwsku"
-                    }
-                }
-            }
-            f.write(json.dumps(device_metadata))
-
-        with mock.patch(
-                "utilities_common.cli.run_command",
-                mock.MagicMock(side_effect=mock_run_command_side_effect)
-        ):
-            (config, _) = get_cmd_module
-            runner = CliRunner()
-
-            result = runner.invoke(
-                config.config.commands["reload"],
-                [self.dummy_cfg_file, '-y', '-f'])
-
-            print(result.exit_code)
-            print(result.output)
-            traceback.print_tb(result.exc_info[2])
-            assert result.exit_code != 0
-            assert "fails YANG validation! Error" in result.output
-
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The sonic vm image has yang validation issue with default config setup. Limit YANG check to golden config only before fix default factory config.
#### How I did it
Restrict YANG validation to golden config only.
#### How to verify it
Unit test and integration test.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

