### PR TITLE
Support empty golden config file for multi-asic

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -128,7 +128,7 @@ class DBMigrator():
                             config_namespace = "localhost"
                         else:
                             config_namespace = ns
-                        golden_config_data = golden_data[config_namespace]
+                        golden_config_data = golden_data.get(config_namespace, None)
         except Exception as e:
             log.log_error('Caught exception while trying to load golden config: ' + str(e))
             pass

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -856,6 +856,11 @@ class TestGoldenConfig(object):
         # hostname is from golden_config_db.json
         assert hostname == 'SONiC-Golden-Config'
 
+    def test_golden_config_ns(self):
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator("asic0")
+        assert dbmgtr.config_src_data is None
+
 class TestGoldenConfigInvalid(object):
     @classmethod
     def setup_class(cls):

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -857,9 +857,11 @@ class TestGoldenConfig(object):
         assert hostname == 'SONiC-Golden-Config'
 
     def test_golden_config_ns(self):
+        # golden_config_db.json.test has no namespace
         import db_migrator
         dbmgtr = db_migrator.DBMigrator("asic0")
-        assert dbmgtr.config_src_data is None
+        config = json.dumps(dbmgtr.config_src_data)
+        assert 'SONiC-Golden-Config' not in config
 
 class TestGoldenConfigInvalid(object):
     @classmethod

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -860,8 +860,8 @@ class TestGoldenConfig(object):
         # golden_config_db.json.test has no namespace
         import db_migrator
         dbmgtr = db_migrator.DBMigrator("asic0")
-        config = json.dumps(dbmgtr.config_src_data)
-        assert 'SONiC-Golden-Config' not in config
+        result = json.dumps(dbmgtr.config_src_data)
+        assert 'SONiC-Golden-Config' not in result
 
 class TestGoldenConfigInvalid(object):
     @classmethod


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
config_sonic_basedon_testbed.yml creates an empty golden_config_db.json file under /etc/sonic for non mx platforms.
When this empty file exist db_migration fails for all asics for non mx platforms.

#### How I did it
Update db_migrator to support empty golden config file.

#### How to verify it
Run unit test and end to end test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

