### PR TITLE
add sonic_asic_platform in the render context when rendering docker_image_ctl.j2

### DIFF
--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -29,6 +29,8 @@ from sonic_package_manager.service_creator.feature import FeatureRegistry
 from sonic_package_manager.service_creator.sonic_db import SonicDB
 from sonic_package_manager.service_creator.utils import in_chroot
 
+from sonic_py_common import device_info
+
 
 SERVICE_FILE_TEMPLATE = 'sonic.service.j2'
 
@@ -254,6 +256,9 @@ class ServiceCreator:
         script_path = os.path.join(DOCKER_CTL_SCRIPT_LOCATION, f'{name}.sh')
         script_template = get_tmpl_path(DOCKER_CTL_SCRIPT_TEMPLATE)
         run_opt = []
+        sonic_asic_platform = os.environ.get("CONFIGURED_PLATFORM")
+        if sonic_asic_platform == None:
+            sonic_asic_platform = device_info.get_platform_info().get('asic_type', None)
 
         if container_spec['privileged']:
             run_opt.append('--privileged')
@@ -278,6 +283,7 @@ class ServiceCreator:
             'docker_container_name': name,
             'docker_image_id': image_id,
             'docker_image_run_opt': run_opt,
+            'sonic_asic_platform': sonic_asic_platform
         }
         render_template(script_template, script_path, render_ctx, executable=True)
         log.info(f'generated {script_path}')

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -257,7 +257,7 @@ class ServiceCreator:
         script_template = get_tmpl_path(DOCKER_CTL_SCRIPT_TEMPLATE)
         run_opt = []
         sonic_asic_platform = os.environ.get("CONFIGURED_PLATFORM")
-        if sonic_asic_platform == None:
+        if sonic_asic_platform is None:
             sonic_asic_platform = device_info.get_platform_info().get('asic_type', None)
 
         if container_spec['privileged']:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did

Now, when the service-creator in sonic-package-manager renders the docker_image_ctl.j2 template, it does not include the sonic_asic_platform info in the render context. The sonic_asic_platform variable is crucial for the manipulation of template rendering, so I added the code to supplement it in the render context.

#### What I did

I added code to acquire sonic_asic_platform info and added it in the render context of docker_image_ctl.j2.

Microsoft ADO: 30477799

#### How I did it

Add additional code in the service creator of sonic package manager.

#### How to verify it

Use the updated sonic-utilities code to build a new VS image.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

