### PR TITLE
Add scope to field validator.

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -4,15 +4,16 @@ import json
 import jsonpointer
 import subprocess
 from sonic_py_common import device_info
-from .gu_common import GenericConfigUpdaterError
+from .gu_common import GenericConfigUpdaterError, HOST_NAMESPACE
 from swsscommon import swsscommon
 from utilities_common.constants import DEFAULT_SUPPORTED_FECS_LIST
 
+APPL_DB_NAME = 'APPL_DB'
+REDIS_TIMEOUT_MSECS = 0
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 GCU_TABLE_MOD_CONF_FILE = f"{SCRIPT_DIR}/gcu_field_operation_validators.conf.json"
-GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
 
-def get_asic_name():
+def get_asic_name(scope):
     asic = "unknown"
     
     if os.path.exists(GCU_TABLE_MOD_CONF_FILE):
@@ -27,7 +28,12 @@ def get_asic_name():
     if asic_type == 'cisco-8000':
         asic = "cisco-8000"
     elif asic_type == 'mellanox' or asic_type == 'vs' or asic_type == 'broadcom':
-        proc = subprocess.Popen(GET_HWSKU_CMD, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        get_hwsku_cmds = []
+        if scope == HOST_NAMESPACE:
+            get_hwsku_cmds = ["sonic-cfggen", "-d", "-v", "DEVICE_METADATA.localhost.hwsku"]
+        else:
+            get_hwsku_cmds = ["sonic-cfggen", "-d", "-n", scope, "-v", "DEVICE_METADATA.localhost.hwsku"]
+        proc = subprocess.Popen(get_hwsku_cmds, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
         output, err = proc.communicate()
         hwsku = output.rstrip('\n')
         if asic_type == 'mellanox' or asic_type == 'vs':
@@ -60,8 +66,8 @@ def get_asic_name():
     return asic
 
 
-def rdma_config_update_validator(patch_element):
-    asic = get_asic_name()
+def rdma_config_update_validator(scope, patch_element):
+    asic = get_asic_name(scope)
     if asic == "unknown":
         return False
     version_info = device_info.get_sonic_version_info()
@@ -133,17 +139,17 @@ def rdma_config_update_validator(patch_element):
     return True
 
 
-def read_statedb_entry(table, key, field):
-    state_db = swsscommon.DBConnector("STATE_DB", 0)
+def read_statedb_entry(scope, table, key, field):
+    state_db = swsscommon.DBConnector(APPL_DB_NAME, REDIS_TIMEOUT_MSECS, True, scope)
     tbl = swsscommon.Table(state_db, table)
     return tbl.hget(key, field)[1]
 
 
-def port_config_update_validator(patch_element):
+def port_config_update_validator(scope, patch_element):
 
     def _validate_field(field, port, value):
         if field == "fec":
-            supported_fecs_str = read_statedb_entry("PORT_TABLE", port, "supported_fecs")
+            supported_fecs_str = read_statedb_entry(scope, "PORT_TABLE", port, "supported_fecs")
             if supported_fecs_str:
                 if supported_fecs_str != 'N/A':
                     supported_fecs_list = [element.strip() for element in supported_fecs_str.split(',')]
@@ -155,7 +161,7 @@ def port_config_update_validator(patch_element):
                 return False
             return True
         if field == "speed":
-            supported_speeds_str = read_statedb_entry("PORT_TABLE", port, "supported_speeds") or ''
+            supported_speeds_str = read_statedb_entry(scope, "PORT_TABLE", port, "supported_speeds") or ''
             try:
                 supported_speeds = [int(s) for s in supported_speeds_str.split(',') if s]
                 if supported_speeds and int(value) not in supported_speeds:

--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -34,7 +34,7 @@ def get_asic_name(scope):
             get_hwsku_cmds = ["sonic-cfggen", "-d", "-v", "DEVICE_METADATA.localhost.hwsku"]
         else:
             get_hwsku_cmds = ["sonic-cfggen", "-d", "-n", scope, "-v", "DEVICE_METADATA.localhost.hwsku"]
-        proc = subprocess.Popen(get_hwsku_cmds, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        proc = subprocess.Popen(get_hwsku_cmds, shell=False, universal_newlines=True, stdout=subprocess.PIPE)
         output, err = proc.communicate()
         hwsku = output.rstrip('\n')
         if asic_type == 'mellanox' or asic_type == 'vs':

--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -8,7 +8,7 @@ from .gu_common import GenericConfigUpdaterError, HOST_NAMESPACE
 from swsscommon import swsscommon
 from utilities_common.constants import DEFAULT_SUPPORTED_FECS_LIST
 
-APPL_DB_NAME = 'APPL_DB'
+STATE_DB_NAME = 'STATE_DB'
 REDIS_TIMEOUT_MSECS = 0
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 GCU_TABLE_MOD_CONF_FILE = f"{SCRIPT_DIR}/gcu_field_operation_validators.conf.json"
@@ -141,7 +141,7 @@ def rdma_config_update_validator(scope, patch_element):
 
 
 def read_statedb_entry(scope, table, key, field):
-    state_db = swsscommon.DBConnector(APPL_DB_NAME, REDIS_TIMEOUT_MSECS, True, scope)
+    state_db = swsscommon.DBConnector(STATE_DB_NAME, REDIS_TIMEOUT_MSECS, True, scope)
     tbl = swsscommon.Table(state_db, table)
     return tbl.hget(key, field)[1]
 

--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -13,6 +13,7 @@ REDIS_TIMEOUT_MSECS = 0
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 GCU_TABLE_MOD_CONF_FILE = f"{SCRIPT_DIR}/gcu_field_operation_validators.conf.json"
 
+
 def get_asic_name(scope):
     asic = "unknown"
     

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -189,7 +189,7 @@ class ConfigWrapper:
                 raise GenericConfigUpdaterError("Attempting to call invalid method {} in module {}. Module must be generic_config_updater.field_operation_validators, and method must be a defined validator".format(method_name, module_name))
             module = importlib.import_module(module_name, package=None)
             method_to_call = getattr(module, method_name)
-            return method_to_call(jsonpatch_element)
+            return method_to_call(self.scope, jsonpatch_element)
 
         if os.path.exists(GCU_FIELD_OP_CONF_FILE):
             with open(GCU_FIELD_OP_CONF_FILE, "r") as s:

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -16,7 +16,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="40000,30000"))
@@ -24,7 +24,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "xyz"}}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == False
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
@@ -32,7 +32,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
@@ -40,7 +40,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "234"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
@@ -48,7 +48,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "235"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == False
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
@@ -60,7 +60,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == False
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
@@ -75,7 +75,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
@@ -90,13 +90,13 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == False
+                port_config_update_validator(scope, patch_element) is False
     
     def test_port_config_update_validator_remove(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "remove"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
@@ -104,7 +104,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "asf"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == False
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
@@ -119,7 +119,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == False
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
@@ -131,7 +131,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
@@ -146,7 +146,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
@@ -154,7 +154,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rs"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value=""))
@@ -162,7 +162,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rs"}}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == True
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value=""))
@@ -170,7 +170,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rsf"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                port_config_update_validator(scope, patch_element) == False
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
            mock.Mock(return_value="unknown"))
@@ -182,7 +182,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                rdma_config_update_validator(scope, patch_element) == False
+                rdma_config_update_validator(scope, patch_element) is False
         
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -201,7 +201,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                rdma_config_update_validator(scope, patch_element) == False
+                rdma_config_update_validator(scope, patch_element) is False
     
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -216,7 +216,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PFC_WD/Ethernet8/detection_time", "op": "remove"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                rdma_config_update_validator(scope, patch_element) == True
+                rdma_config_update_validator(scope, patch_element) is True
 
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -239,7 +239,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                rdma_config_update_validator(scope, patch_element) == True
+                rdma_config_update_validator(scope, patch_element) is True
    
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -254,7 +254,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PFC_WD/Ethernet8", "op": "remove"}
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                rdma_config_update_validator(scope, patch_element) == True
+                rdma_config_update_validator(scope, patch_element) is True
     
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -272,7 +272,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                rdma_config_update_validator(scope, patch_element) == False
+                rdma_config_update_validator(scope, patch_element) is False
     
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -291,7 +291,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
-                rdma_config_update_validator(scope, patch_element) == False
+                rdma_config_update_validator(scope, patch_element) is False
     
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -1,5 +1,4 @@
 import mock
-import pytest
 import unittest
 import generic_config_updater
 import generic_config_updater.field_operation_validators as fov
@@ -16,194 +15,294 @@ class TestValidateFieldOperation(unittest.TestCase):
     def test_port_config_update_validator_valid_speed_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="40000,30000"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="40000,30000"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "xyz"}}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
 
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "234"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "235"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested(self):
-        patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "speed": "235"}}}
+        patch_element = {
+            "path": "/PORT",
+            "op": "add",
+            "value": {"Ethernet3": {"alias": "Eth0", "speed": "235"}}
+        }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db_nested(self):
         patch_element = {
             "path": "/PORT",
             "op": "add",
-            "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "234"}}
+            "value": {
+                "Ethernet3": {"alias": "Eth0", "speed": "234"},
+                "Ethernet4": {"alias": "Eth4", "speed": "234"}
+            }
         }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested_2(self):
         patch_element = {
             "path": "/PORT",
             "op": "add",
-            "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "236"}}
+            "value": {
+                "Ethernet3": {"alias": "Eth0", "speed": "234"},
+                "Ethernet4": {"alias": "Eth4", "speed": "236"}
+            }
         }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
     
     def test_port_config_update_validator_remove(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "remove"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
 
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "asf"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db_nested(self):
         patch_element = {
             "path": "/PORT",
             "op": "add",
-            "value": {"Ethernet3": {"alias": "Eth0", "fec": "none"}, "Ethernet4": {"alias": "Eth4", "fec": "fs"}}
+            "value": {
+                "Ethernet3": {"alias": "Eth0", "fec": "none"},
+                "Ethernet4": {"alias": "Eth4", "fec": "fs"}
+            }
         }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested(self):
-        patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "fec": "fc"}}}
+        patch_element = {
+            "path": "/PORT",
+            "op": "add",
+            "value": {"Ethernet3": {"alias": "Eth0", "fec": "fc"}}
+        }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested_2(self):
         patch_element = {
             "path": "/PORT",
             "op": "add",
-            "value": {"Ethernet3": {"alias": "Eth0", "fec": "rs"}, "Ethernet4": {"alias": "Eth4", "fec": "fc"}}
+            "value": {
+                "Ethernet3": {"alias": "Eth0", "fec": "rs"},
+                "Ethernet4": {"alias": "Eth4", "fec": "fc"}
+            }
         }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rs"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
 
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rs"}}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
     
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value=""))
     def test_port_config_update_validator_invalid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rsf"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
     
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="unknown"))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="unknown"))
     def test_rdma_config_update_validator_unknown_asic(self):
-        patch_element = {"path": "/PFC_WD/Ethernet4/restoration_time", "op": "replace", "value": "234234"}
+        patch_element = {
+            "path": "/PFC_WD/Ethernet4/restoration_time",
+            "op": "replace",
+            "value": "234234"
+        }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) == False
         
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="td3"))
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "SONiC.20220530"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="td3"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": \
-        {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "ingress_lossless_pool/size", \
-        "egress_lossy_pool/size"], "operations": ["replace"], "platforms": {"td3": "20221100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='''{"tables": {"BUFFER_POOL": {"validator_data": {
+        "rdma_config_update_validator": {"Shared/headroom pool size changes": {"fields": [
+            "ingress_lossless_pool/xoff", "ingress_lossless_pool/size", "egress_lossy_pool/size"
+        ], "operations": ["replace"], "platforms": {"td3": "20221100"}}}}}}}'''))
     def test_rdma_config_update_validator_td3_asic_invalid_version(self):
-        patch_element = {"path": "/BUFFER_POOL/ingress_lossless_pool/xoff", "op": "replace", "value": "234234"}
+        patch_element = {
+            "path": "/BUFFER_POOL/ingress_lossless_pool/xoff",
+            "op": "replace",
+            "value": "234234"
+        }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) == False
     
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "SONiC.20220530"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
-        {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], \
-        "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='''{"tables": {"PFC_WD": {"validator_data": {
+        "rdma_config_update_validator": {"PFCWD enable/disable": {"fields": [
+            "detection_time", "action"
+        ], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'''))
     def test_rdma_config_update_validator_spc_asic_valid_version_remove(self):
         patch_element = {"path": "/PFC_WD/Ethernet8/detection_time", "op": "remove"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) == True
 
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "SONiC.20220530"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
-        {"PFCWD enable/disable": {"fields": ["detection_time", "restoration_time", "action"], "operations": \
-        ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='''{"tables": {"PFC_WD": {"validator_data": {
+        "rdma_config_update_validator": {"PFCWD enable/disable": {"fields": [
+            "detection_time", "restoration_time", "action"
+        ], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'''))
     def test_rdma_config_update_validator_spc_asic_valid_version_add_pfcwd(self):
         patch_element = {
             "path": "/PFC_WD/Ethernet8",
             "op": "add",
-            "value": {"action": "drop", "detection_time": "300", "restoration_time": "200"}
+            "value": {
+                "action": "drop",
+                "detection_time": "300",
+                "restoration_time": "200"
+            }
         }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) == True
    
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "SONiC.20220530"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
-        {"PFCWD enable/disable": {"fields": ["detection_time", "action", ""], "operations": ["remove", "replace", "add"], \
-        "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='''{"tables": {"PFC_WD": {"validator_data": {
+        "rdma_config_update_validator": {"PFCWD enable/disable": {"fields": [
+            "detection_time", "action", ""
+        ], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'''))
     def test_rdma_config_update_validator_spc_asic_valid_version(self):
         patch_element = {"path": "/PFC_WD/Ethernet8", "op": "remove"}
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == True
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) == True
     
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "SONiC.20220530"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": \
-        {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "egress_lossy_pool/size"], \
-        "operations": ["replace"], "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='''{"tables": {"BUFFER_POOL": {"validator_data": {
+        "rdma_config_update_validator": {"Shared/headroom pool size changes": {"fields": [
+            "ingress_lossless_pool/xoff", "egress_lossy_pool/size"
+        ], "operations": ["replace"], "platforms": {"spc1": "20181100"}}}}}}}'''))
     def test_rdma_config_update_validator_spc_asic_invalid_op(self):
-        patch_element = {"path": "/BUFFER_POOL/ingress_lossless_pool/xoff", "op": "remove"}
+        patch_element = {
+            "path": "/BUFFER_POOL/ingress_lossless_pool/xoff",
+            "op": "remove"
+        }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) == False
     
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "SONiC.20220530"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
-        {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], \
-        "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='''{"tables": {"PFC_WD": {"validator_data": {
+        "rdma_config_update_validator": {"PFCWD enable/disable": {"fields": [
+            "detection_time", "action"
+        ], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'''))
     def test_rdma_config_update_validator_spc_asic_other_field(self):
-        patch_element = {"path": "/PFC_WD/Ethernet8/other_field", "op": "add", "value": "sample_value"}
+        patch_element = {
+            "path": "/PFC_WD/Ethernet8/other_field",
+            "op": "add",
+            "value": "sample_value"
+        }
         for scope in ["localhost", "asic0"]:
-            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) == False
     
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
         target_config = {"PFC_WD": {"GLOBAL": {}}}
         config_wrapper = gu_common.ConfigWrapper()
-        self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
+        self.assertRaises(
+            gu_common.IllegalPatchOperationError,
+            config_wrapper.validate_field_operation,
+            old_config,
+            target_config
+        )
     
     def test_validate_field_operation_legal__rm_loopback1(self):
         old_config = {
@@ -239,7 +338,12 @@ class TestValidateFieldOperation(unittest.TestCase):
             }
         }
         config_wrapper = gu_common.ConfigWrapper()
-        self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
+        self.assertRaises(
+            gu_common.IllegalPatchOperationError,
+            config_wrapper.validate_field_operation,
+            old_config,
+            target_config
+        )
 
 class TestGetAsicName(unittest.TestCase):
 

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -1,8 +1,6 @@
-import io
-import unittest
 import mock
-import json
-import subprocess
+import pytest
+import unittest
 import generic_config_updater
 import generic_config_updater.field_operation_validators as fov
 import generic_config_updater.gu_common as gu_common
@@ -17,134 +15,189 @@ class TestValidateFieldOperation(unittest.TestCase):
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_speed_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="40000,30000"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "xyz"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "234"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "235"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "speed": "235"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db_nested(self):
-        patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "234"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        patch_element = {
+            "path": "/PORT",
+            "op": "add",
+            "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "234"}}
+        }
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested_2(self):
-        patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "236"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
+        patch_element = {
+            "path": "/PORT",
+            "op": "add",
+            "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "236"}}
+        }
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
     
     def test_port_config_update_validator_remove(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "asf"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db_nested(self):
-        patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "fec": "none"}, "Ethernet4": {"alias": "Eth4", "fec": "fs"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
+        patch_element = {
+            "path": "/PORT",
+            "op": "add",
+            "value": {"Ethernet3": {"alias": "Eth0", "fec": "none"}, "Ethernet4": {"alias": "Eth4", "fec": "fs"}}
+        }
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "fec": "fc"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested_2(self):
-        patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "fec": "rs"}, "Ethernet4": {"alias": "Eth4", "fec": "fc"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        patch_element = {
+            "path": "/PORT",
+            "op": "add",
+            "value": {"Ethernet3": {"alias": "Eth0", "fec": "rs"}, "Ethernet4": {"alias": "Eth4", "fec": "fc"}}
+        }
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rs"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rs"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_invalid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rsf"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.port_config_update_validator(scope, patch_element) == False
     
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="unknown"))
     def test_rdma_config_update_validator_unknown_asic(self):
         patch_element = {"path": "/PFC_WD/Ethernet4/restoration_time", "op": "replace", "value": "234234"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
         
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="td3"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "ingress_lossless_pool/size", "egress_lossy_pool/size"], "operations": ["replace"], "platforms": {"td3": "20221100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": \
+        {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "ingress_lossless_pool/size", \
+        "egress_lossy_pool/size"], "operations": ["replace"], "platforms": {"td3": "20221100"}}}}}}}'))
     def test_rdma_config_update_validator_td3_asic_invalid_version(self):
         patch_element = {"path": "/BUFFER_POOL/ingress_lossless_pool/xoff", "op": "replace", "value": "234234"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
     
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
+        {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], \
+        "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_valid_version_remove(self):
         patch_element = {"path": "/PFC_WD/Ethernet8/detection_time", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == True
 
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "restoration_time", "action"], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
+        {"PFCWD enable/disable": {"fields": ["detection_time", "restoration_time", "action"], "operations": \
+        ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_valid_version_add_pfcwd(self):
-        patch_element = {"path": "/PFC_WD/Ethernet8", "op": "add", "value": {"action": "drop", "detection_time": "300", "restoration_time": "200"}}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == True
+        patch_element = {
+            "path": "/PFC_WD/Ethernet8",
+            "op": "add",
+            "value": {"action": "drop", "detection_time": "300", "restoration_time": "200"}
+        }
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == True
    
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "action", ""], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
+        {"PFCWD enable/disable": {"fields": ["detection_time", "action", ""], "operations": ["remove", "replace", "add"], \
+        "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_valid_version(self):
         patch_element = {"path": "/PFC_WD/Ethernet8", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == True
     
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "egress_lossy_pool/size"], "operations": ["replace"], "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": \
+        {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "egress_lossy_pool/size"], \
+        "operations": ["replace"], "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_invalid_op(self):
         patch_element = {"path": "/BUFFER_POOL/ingress_lossless_pool/xoff", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
     
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
+    @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": \
+        {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], \
+        "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_other_field(self):
         patch_element = {"path": "/PFC_WD/Ethernet8/other_field", "op": "add", "value": "sample_value"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.rdma_config_update_validator(scope, patch_element) == False
     
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
@@ -196,7 +249,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-D48C8", 0]
-        self.assertEqual(fov.get_asic_name(), "spc1")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc1")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -204,7 +258,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-MSN3800", 0]
-        self.assertEqual(fov.get_asic_name(), "spc2")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc2")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -212,7 +267,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN4600C-C64", 0]
-        self.assertEqual(fov.get_asic_name(), "spc3")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc3")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -220,7 +276,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-SN5600", 0]
-        self.assertEqual(fov.get_asic_name(), "spc4")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc4")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -228,7 +285,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-A1", 0]
-        self.assertEqual(fov.get_asic_name(), "spc1")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc1")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -236,7 +294,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6100", 0]
-        self.assertEqual(fov.get_asic_name(), "th")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "th")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -244,7 +303,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7260CX3-D108C8", 0]
-        self.assertEqual(fov.get_asic_name(), "th2")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "th2")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -252,7 +312,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6000", 0]
-        self.assertEqual(fov.get_asic_name(), "td2")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "td2")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -260,10 +321,12 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7050CX3-32S-C32", 0]
-        self.assertEqual(fov.get_asic_name(), "td3")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "td3")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_cisco(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'cisco-8000'}
-        self.assertEqual(fov.get_asic_name(), "cisco-8000")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "cisco-8000")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This is for fix issue:https://github.com/sonic-net/sonic-buildimage/issues/20379

#### How I did it

For field_operation_validators, add scope if need read state_db.

#### How to verify it

```shell
admin@str2-7250-lc1-2:~$ sonic-db-cli STATE_DB -n asic0 hget "PORT_TABLE|Ethernet0" supported_fecs
none,rs

admin@str2-7250-lc1-2:~$ cat fec.json 
[
    {
        "op": "add",
        "path": "/asic0/PORT/Ethernet0/fec",
        "value": "fc"
    }
]

admin@str2-7250-lc1-2:~$ sudo config apply-patch fec.json 
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: [{"op": "add", "path": "/PORT/Ethernet0/fec", "value": "fc"}]
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Failed to apply patch due to: Failed to apply patch on the following scopes:
- asic0: Modification of PORT table is illegal- validating function generic_config_updater.field_operation_validators.port_config_update_validator returned False
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Failed to apply patch on the following scopes:
- asic0: Modification of PORT table is illegal- validating function generic_config_updater.field_operation_validators.port_config_update_validator returned False
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

