### PR TITLE
[show_tech] modify generate_dump to includes BERT data and also the platform specified hw-mgmt info

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -875,6 +875,42 @@ save_proc() {
 }
 
 ###############################################################################
+# Given list of proc files, saves proc files to tar.
+# Globals:
+#  V
+#  TARDIR
+#  MKDIR
+#  CP
+#  DUMPDIR
+#  TAR
+#  RM
+#  BASE
+#  TARFILE
+#  NOOP
+# Arguments:
+#  *procfiles: variable-length list of proc file paths to save
+# Returns:
+#  None
+###############################################################################
+save_proc() {
+    trap 'handle_error $? $LINENO' ERR
+    local procfiles="$@"
+    $MKDIR $V -p $TARDIR/proc
+    for f in $procfiles
+    do
+        if $NOOP; then
+            if [ -e $f ]; then
+                echo "$CP $V -r $f $TARDIR/proc"
+            fi
+        else
+            ( [ -e $f ] && $CP $V -r $f $TARDIR/proc ) || echo "$f not found" > $TARDIR/$f
+        fi
+    done
+
+    chmod ugo+rw -R $DUMPDIR/$BASE/proc
+}
+
+###############################################################################
 # Dump io stats for processes
 # Globals:
 #  V
@@ -1469,6 +1505,7 @@ collect_marvell_prestera() {
 ###############################################################################
 collect_broadcom() {
     trap 'handle_error $? $LINENO' ERR
+    local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local platform=$(show platform summary --json | python -c 'import sys, json; \
         print(json.load(sys.stdin)["platform"])')
     local hwsku=$(show platform summary --json | python -c 'import sys, json; \
@@ -1597,6 +1634,25 @@ collect_broadcom() {
 
     copy_from_masic_docker "syncd" "/var/log/diagrun.log" "/var/log/diagrun.log"
     copy_from_masic_docker "syncd" "/var/log/bcm_diag_post" "/var/log/bcm_diag_post"
+
+    # run 'hw-management-generate-dump.sh' script and save the result file
+    HW_DUMP_FILE=/usr/bin/hw-management-generate-dump.sh
+    if [ -f "$HW_DUMP_FILE" ]; then
+      ${CMD_PREFIX}${timeout_cmd} /usr/bin/hw-management-generate-dump.sh $ALLOW_PROCESS_STOP
+      ret=$?
+      if [ $ret -ne 0 ]; then
+        if [ $ret -eq $TIMEOUT_EXIT_CODE ]; then
+          echo "hw-management dump timedout after ${TIMEOUT_MIN} minutes."
+        else
+          echo "hw-management dump failed ..."
+        fi
+      else
+        save_file "/tmp/hw-mgmt-dump*" "hw-mgmt" false
+        rm -f /tmp/hw-mgmt-dump*
+      fi
+    else
+      echo "HW Mgmt dump script $HW_DUMP_FILE does not exist"
+    fi  
 }
 
 ###############################################################################
@@ -1805,6 +1861,12 @@ save_log_files() {
         file_list="${file_list} ${file_list_2}"
     fi
 
+    # save log files creation info
+    files_ts_info=/tmp/files.timestamp.info
+    ls --time-style='+%d-%m-%Y %H:%M:%S' -last /var/log/* > $files_ts_info
+    save_file $files_ts_info "log" true
+    rm -f $files_ts_info
+    
     # gzip up all log files individually before placing them in the incremental tarball
     for file in $file_list; do
         dest_dir="log"
@@ -2071,6 +2133,11 @@ main() {
     echo "[ Capture Proc State ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
     wait
 
+    # capture /sys info - include acpi info
+    save_sys /sys/firmware/acpi/tables & 
+    end_t2=$(date +%s%3N)
+    echo "[ Capture Sys info ] : $(($end_t2-$end_t)) msec" >> $TECHSUPPORT_TIME_INFO
+    
     # Save all the processes within each docker
     save_cmd "show services" services.summary &
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -875,7 +875,7 @@ save_proc() {
 }
 
 ###############################################################################
-# Given list of proc files, saves proc files to tar.
+# Given list of sys files, saves sys files to tar.
 # Globals:
 #  V
 #  TARDIR
@@ -888,26 +888,26 @@ save_proc() {
 #  TARFILE
 #  NOOP
 # Arguments:
-#  *procfiles: variable-length list of proc file paths to save
+#  *sysfiles: variable-length list of sys file paths to save
 # Returns:
 #  None
 ###############################################################################
-save_proc() {
+save_sys() {
     trap 'handle_error $? $LINENO' ERR
-    local procfiles="$@"
-    $MKDIR $V -p $TARDIR/proc
-    for f in $procfiles
+    local sysfiles="$@"
+    $MKDIR $V -p $TARDIR/sys
+    for f in $sysfiles
     do
         if $NOOP; then
             if [ -e $f ]; then
-                echo "$CP $V -r $f $TARDIR/proc"
+                echo "$CP $V -r $f $TARDIR/sys"
             fi
         else
-            ( [ -e $f ] && $CP $V -r $f $TARDIR/proc ) || echo "$f not found" > $TARDIR/$f
+            ( [ -e $f ] && $CP $V -r $f $TARDIR/sys ) || echo "$f not found" > $TARDIR/$f
         fi
     done
 
-    chmod ugo+rw -R $DUMPDIR/$BASE/proc
+    chmod ugo+rw -R $DUMPDIR/$BASE/sys
 }
 
 ###############################################################################

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2134,10 +2134,11 @@ main() {
     wait
 
     # capture /sys info - include acpi info
-    save_sys /sys/firmware/acpi/tables & 
+    save_sys /sys/firmware/acpi/tables &
     end_t2=$(date +%s%3N)
     echo "[ Capture Sys info ] : $(($end_t2-$end_t)) msec" >> $TECHSUPPORT_TIME_INFO
-    
+    wait
+
     # Save all the processes within each docker
     save_cmd "show services" services.summary &
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modify the generate_dump to include the BERT data and the platform specified hw-mgmt info

#### How I did it
1) Introduced a new function save_sys() which save the /sys/firmware/acpi/tables folder which container the BERT info.  
2) Follow the consistency to modify the collect_broadcom to the platform specified script hw-management-generate_dump.sh if this script exists.   
3) Enhance generate_dump to create log/files.timestamp.info to gather modification timestamp of all log files in the /var/log directory.

#### How to verify it
1) Execute the "show techsupport" on both Supervisor and Linecard
2) Download and open the show_tech file to verify the following info
  - folder hw-mgmt exists and contains the platform specified info
  - folder sys/   exists and contains the BERT info
  - file log/files.timestamp.info.gz should exist.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

