### PR TITLE
[202405] Fix Backtrace in route-check during config reload/minigraph.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -886,9 +886,8 @@ def _get_disabled_services_list(config_db):
 def _stop_services():
     try:
         subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        click.echo("Disabling container and routeCheck monitoring ...")
+        click.echo("Disabling container monitoring ...")
         clicommon.run_command(['sudo', 'monit', 'unmonitor', 'container_checker'])
-        clicommon.run_command(['sudo', 'monit', 'unmonitor', 'routeCheck'])
     except subprocess.CalledProcessError as err:
         pass
 
@@ -947,17 +946,16 @@ def _restart_services():
     wait_service_restart_finish('interfaces-config', last_interface_config_timestamp)
     wait_service_restart_finish('networking', last_networking_timestamp)
 
+    try:
+        subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        click.echo("Enabling container monitoring ...")
+        clicommon.run_command(['sudo', 'monit', 'monitor', 'container_checker'])
+    except subprocess.CalledProcessError as err:
+        pass
+
     # Reload Monit configuration to pick up new hostname in case it changed
     click.echo("Reloading Monit configuration ...")
     clicommon.run_command(['sudo', 'monit', 'reload'])
-
-    try:
-        subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        click.echo("Enabling container and routeCheck monitoring ...")
-        clicommon.run_command(['sudo', 'monit', 'monitor', 'container_checker'])
-        clicommon.run_command(['sudo', 'monit', 'monitor', 'routeCheck'])
-    except subprocess.CalledProcessError as err:
-        pass
 
 def _per_namespace_swss_ready(service_name):
     out, _ = clicommon.run_command(['systemctl', 'show', str(service_name), '--property', 'ActiveState', '--value'], return_cmd=True)

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -331,9 +331,12 @@ def get_asicdb_routes(namespace):
 
 def is_bgp_suppress_fib_pending_enabled(namespace):
     """
-    On 202405 image this feature is not supported so always return False
+    Retruns True if FIB suppression is enabled in BGP config, False otherwise
     """
-    return False
+    show_run_cmd = ['show', 'runningconfiguration', 'bgp', '-n', namespace]
+
+    output = subprocess.check_output(show_run_cmd, text=True)
+    return 'bgp suppress-fib-pending' in output
 
 
 def is_suppress_fib_pending_enabled(namespace):

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -331,12 +331,9 @@ def get_asicdb_routes(namespace):
 
 def is_bgp_suppress_fib_pending_enabled(namespace):
     """
-    Retruns True if FIB suppression is enabled in BGP config, False otherwise
+    On 202405 image this feature is not supported so always return False
     """
-    show_run_cmd = ['show', 'runningconfiguration', 'bgp', '-n', namespace]
-
-    output = subprocess.check_output(show_run_cmd, text=True)
-    return 'bgp suppress-fib-pending' in output
+    return False
 
 
 def is_suppress_fib_pending_enabled(namespace):


### PR DESCRIPTION
What I did:

Fix below BT:

```
Program 'routeCheck'
  status                       Status ok
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  last exit value              1
  last output                  Exiting: failed to connect to any daemons.
                               Traceback (most recent call last):
                                 File "/usr/local/bin/route_check.py", line 878, in <module>
                                   sys.exit(main()[0])
                                            ^^^^^^
                                 File "/usr/local/bin/route_check.py", line 864, in main
                                   ret, res= check_routes(namespace)
                                             ^^^^^^^^^^^^^^^^^^^^^^^
                                 File "/usr/local/bin/route_check.py", line 794, in check_routes
                                   if is_bgp_suppress_fib_pending_enabled(namespace):
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                 File "/usr/local/bin/route_check.py", line 337, in is_bgp_suppress_fib_pending_enabled
                                   output = subprocess.check_output(show_run_cmd, text=True)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                 File "/usr/lib/python3.11/subprocess.py", line 466, in ch
  data collected               Mon, 16 Dec 2024 02:26:37
```

How I did:
Make API `is_bgp_suppress_fib_pending_enabled` always return False as on 202405 image this feature is not supported.