### PR TITLE
[ssdhealth] Check for default device before falling back to discovery

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -104,7 +104,21 @@ def psustatus(index, json, verbose):
 def ssdhealth(device, verbose, vendor):
     """Show SSD Health information"""
     if not device:
-        device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]
+        platform_data = device_info.get_platform_json_data()
+        # Check if there is any default disk for this platform
+        # {
+        #     "chassis": {
+        #         ..........
+        #         "disk": {
+        #             "device" : "/dev/nvme0n1"
+        #         }
+        #     }
+        # }
+        device = platform_data.get("chassis", {}).get("disk", {}).get("device", None)
+        if not device:
+            # Fallback to discovery
+            device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]
+
     cmd = ['sudo', 'ssdutil', '-d', str(device)]
     options = ["-v"] if verbose else []
     options += ["-e"] if vendor else []

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -87,3 +87,40 @@ class TestShowPlatformPsu(object):
             CliRunner().invoke(show.cli.commands['platform'].commands['psustatus'], ['--verbose'])
         assert mock_run_command.call_count == 1
         mock_run_command.assert_called_with(['psushow', '-s'], display_cmd=True)
+
+class TestShowPlatformSsdhealth(object):
+    # Test 'show platform ssdhealth'
+    @mock.patch('utilities_common.cli.run_command')
+    def test_ssdhealth(self, mock_run_command):
+        result = CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ["/dev/nvme0n1", '--verbose'])
+        assert result.exit_code == 0, result.output
+        assert mock_run_command.call_count == 1
+        mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)
+
+    @mock.patch('os.popen')
+    @mock.patch('utilities_common.cli.run_command')
+    @mock.patch('sonic_py_common.device_info.get_platform_json_data')
+    def test_ssdhealth_default_device(self, mock_plat_json, mock_run_command, mock_open):
+        mock_plat_json.return_value = {
+            "chassis" : {
+                 "name" : "mock_platform"
+            }
+        }
+        mock_fd = mock.MagicMock()
+        mock_fd.readline.return_value = "/dev/nvme0n1     disk\n"
+        mock_open.return_value = mock_fd
+        result = CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose'])
+        mock_open.assert_called_with("lsblk -o NAME,TYPE -p | grep disk")
+        mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)
+
+        mock_plat_json.return_value = {
+            "chassis" : {
+                "name" : "mock_platform2",
+                "disk" :  {
+                    "device" : "/dev/nvme0n1"
+                }
+            }
+        }
+        result = CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose'])
+        mock_plat_json.assert_called_with()
+        mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -91,36 +91,43 @@ class TestShowPlatformPsu(object):
 class TestShowPlatformSsdhealth(object):
     # Test 'show platform ssdhealth'
     @mock.patch('utilities_common.cli.run_command')
-    def test_ssdhealth(self, mock_run_command):
+    @mock.patch('sonic_py_common.device_info.get_platform_json_data')
+    def test_ssdhealth(self, mock_plat_json, mock_run_command):
+        mock_plat_json.return_value = {
+            "chassis": {
+                 "name": "mock_platform"
+            }
+        }
         result = CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ["/dev/nvme0n1", '--verbose'])
         assert result.exit_code == 0, result.output
         assert mock_run_command.call_count == 1
         mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)
+        mock_plat_json.assert_called_with()
 
     @mock.patch('os.popen')
     @mock.patch('utilities_common.cli.run_command')
     @mock.patch('sonic_py_common.device_info.get_platform_json_data')
     def test_ssdhealth_default_device(self, mock_plat_json, mock_run_command, mock_open):
         mock_plat_json.return_value = {
-            "chassis" : {
-                 "name" : "mock_platform"
+            "chassis": {
+                 "name": "mock_platform"
             }
         }
         mock_fd = mock.MagicMock()
         mock_fd.readline.return_value = "/dev/nvme0n1     disk\n"
         mock_open.return_value = mock_fd
-        result = CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose'])
+        CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose'])
         mock_open.assert_called_with("lsblk -o NAME,TYPE -p | grep disk")
         mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)
 
         mock_plat_json.return_value = {
-            "chassis" : {
-                "name" : "mock_platform2",
-                "disk" :  {
-                    "device" : "/dev/nvme0n1"
+            "chassis": {
+                "name": "mock_platform2",
+                "disk":  {
+                    "device": "/dev/nvme0n1"
                 }
             }
         }
-        result = CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose'])
+        CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose'])
         mock_plat_json.assert_called_with()
         mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -88,6 +88,7 @@ class TestShowPlatformPsu(object):
         assert mock_run_command.call_count == 1
         mock_run_command.assert_called_with(['psushow', '-s'], display_cmd=True)
 
+
 class TestShowPlatformSsdhealth(object):
     # Test 'show platform ssdhealth'
     @mock.patch('utilities_common.cli.run_command')

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -91,18 +91,11 @@ class TestShowPlatformPsu(object):
 class TestShowPlatformSsdhealth(object):
     # Test 'show platform ssdhealth'
     @mock.patch('utilities_common.cli.run_command')
-    @mock.patch('sonic_py_common.device_info.get_platform_json_data')
-    def test_ssdhealth(self, mock_plat_json, mock_run_command):
-        mock_plat_json.return_value = {
-            "chassis": {
-                 "name": "mock_platform"
-            }
-        }
+    def test_ssdhealth(self, mock_run_command):
         result = CliRunner().invoke(show.cli.commands['platform'].commands['ssdhealth'], ["/dev/nvme0n1", '--verbose'])
         assert result.exit_code == 0, result.output
         assert mock_run_command.call_count == 1
         mock_run_command.assert_called_with(['sudo', 'ssdutil', '-d', '/dev/nvme0n1', '-v'], display_cmd=True)
-        mock_plat_json.assert_called_with()
 
     @mock.patch('os.popen')
     @mock.patch('utilities_common.cli.run_command')

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -684,9 +684,15 @@ class TestShowPlatform(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['sudo', 'decode-syseeprom', '-d'], display_cmd=True)
 
+    @mock.patch('sonic_py_common.device_info.get_platform_json_data')
     @patch('utilities_common.cli.run_command')
     @patch('os.popen')
-    def test_ssdhealth(self, mock_popen, mock_run_command):
+    def test_ssdhealth(self, mock_popen, mock_run_command, mock_plat_json):
+        mock_plat_json.return_value = {
+            "chassis": {
+                 "name": "mock_platform"
+            }
+        }
         mock_popen.return_value.readline.return_value = '/dev/sda\n'
         runner = CliRunner()
         result = runner.invoke(show.cli.commands['platform'].commands['ssdhealth'], ['--verbose', '--vendor'])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Some platforms may have multiple primary disks which makes it ambiguous to determine the device when there is no device specific in the ssdhealth command

#### How I did it

Update the show platform command to check platform.json

#### How to verify it

1) UT's

```
vkarri@85964d14e169:/sonic/src/sonic-utilities$ pytest-3 tests/show_platform_test.py -k "ssdhealth" -v
collected 8 items / 6 deselected / 2 selected

tests/show_platform_test.py::TestShowPlatformSsdhealth::test_ssdhealth PASSED                                                                                                                                [ 50%]
tests/show_platform_test.py::TestShowPlatformSsdhealth::test_ssdhealth_default_device PASSED                                                                                                                 [100%]
```

2) Verified the CLI is printing the health output for expected device

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

