### PR TITLE
Revert "Optimize techsupport reducing number of vtysh calls in scale sceario"

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -524,42 +524,27 @@ save_bgp_neighbor() {
     local ns=$(get_vtysh_namespace $asic_id)
 
     neighbor_list_v4=$(${timeout_cmd} bash -c "vtysh $ns -c 'show ip bgp neighbors' | grep 'BGP neighbor is' | awk -F '[, ]' '{print \$4}' | awk /\\\./")
-    if [ ! -z "$neighbor_list_v4" ]; then
-        v4_cmd="vtysh "
-        for word in $neighbor_list_v4; do
-            v4_cmd="${v4_cmd} $ns -Ec 'show bgp ipv4 neighbors $word advertised-routes' "
-            v4_cmd="${v4_cmd} $ns -Ec 'show bgp ipv4 neighbors $word routes' "
-        done
-        save_cmd "$v4_cmd" "ip.bgp.neigh.adv.rcv.routes"
-    fi
-
+    for word in $neighbor_list_v4; do
+        save_cmd "vtysh $ns -c \"show ip bgp neighbors $word advertised-routes\"" "ip.bgp.neighbor.$word.adv$asic_id"
+        save_cmd "vtysh $ns -c \"show ip bgp neighbors $word routes\"" "ip.bgp.neighbor.$word.rcv$asic_id"
+    done
     neighbor_list_v6=$(${timeout_cmd} bash -c "vtysh $ns -c 'show bgp ipv6 neighbors' | grep 'BGP neighbor is' | awk -F '[, ]' '{print \$4}' | awk /:/")
-    if [ ! -z "$neighbor_list_v6" ]; then
-        v6_cmd="vtysh "
-        for word in $neighbor_list_v6; do
-            v6_cmd="${v6_cmd} $ns -Ec 'show bgp ipv6 neighbors $word advertised-routes' "
-            v6_cmd="${v6_cmd} $ns -Ec 'show bgp ipv6 neighbors $word routes' "
-        done
-        save_cmd "$v6_cmd" "ipv6.bgp.neigh.adv.rcv.routes"
-    fi
-
+    for word in $neighbor_list_v6; do
+        save_cmd "vtysh $ns -c \"show bgp ipv6 neighbors $word advertised-routes\"" "ipv6.bgp.neighbor.$word.adv$asic_id"
+        save_cmd "vtysh $ns -c \"show bgp ipv6 neighbors $word routes\"" "ipv6.bgp.neighbor.$word.rcv$asic_id"
+    done
     vrf_list=""
     vrf_output=$(${timeout_cmd} bash -c "vtysh $ns -c 'show vrf'")
     if [ ! -z $vrf_output]; then
         vrf_list= echo $vrf_output | awk -F" " '{print $2}'
     fi
-
-    if [ ! -z "$vrf_list" ]; then
-        vrf_cmd="vtysh "
-        for vrf in $vrf_list; do
-            neighbor_list=`${timeout_cmd} bash -c "vtysh $ns -c 'show ip bgp vrf $vrf neighbors' | grep 'BGP neighbor is' | awk -F '[, ]' '{print \$4}'"`
-            for word in $neighbor_list; do
-                vrf_cmd="${vrf_cmd} $ns -Ec 'show ip bgp vrf $vrf neighbors $word advertised-routes' "
-                vrf_cmd="${vrf_cmd} $ns -Ec 'show ip bgp vrf $vrf neighbors $word routes' "
-            done
+    for vrf in $vrf_list; do
+        neighbor_list=`${timeout_cmd} bash -c "vtysh $ns -c 'show ip bgp vrf $vrf neighbors' | grep 'BGP neighbor is' | awk -F '[, ]' '{print \$4}'"`
+        for word in $neighbor_list; do
+            save_cmd "vtysh $ns -c \"show ip bgp vrf $vrf neighbors $word advertised-routes\"" "ip.bgp.neighbor.$vrf.$word.adv$asic_id"
+            save_cmd "vtysh $ns -c \"show ip bgp vrf $vrf neighbors $word routes\"" "ip.bgp.neighbor.$vrf.$word.rcv$asic_id"
         done
-        save_cmd "$vrf_cmd" "ip.bgp.neigh.vrf.adv.rcv.routes"
-    fi
+    done
 }
 
 ###############################################################################


### PR DESCRIPTION
Reverts sonic-net/sonic-utilities#3605 for it's causing PR test failure:
```
=================================== FAILURES ===================================
______________________ test_techsupport_commands[vlab-01] ______________________

duthosts = [<MultiAsicSonicHost vlab-01>]
enum_rand_one_per_hwsku_frontend_hostname = 'vlab-01'
commands_to_check = {'bfd_cmds': ["vtysh -c 'show bfd peers'", "vtysh -c 'show bfd peers counters'", "vtysh -c 'show bfd peers json'", "vt... ['/proc/buddyinfo', '/proc/cmdline', '/proc/consoles', '/proc/cpuinfo', '/proc/devices', '/proc/diskstats', ...], ...}
skip_on_dpu = None

    def test_techsupport_commands(
            duthosts, enum_rand_one_per_hwsku_frontend_hostname, commands_to_check, skip_on_dpu):  # noqa F811
        """
        This test checks list of commands that will be run when executing
        'show techsupport' CLI against a standard expected list of commands
        to run.
    
        The test invokes show techsupport with noop option, which just
        returns the list of commands that will be run when collecting
        tech support data.
    
        Args:
        commands_to_check: contains a dict of command groups with each
        group containing a list of related commands.
        """
    
        cmd_not_found = defaultdict(list)
        duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
    
        stdout = duthost.shell(r'sudo generate_dump -n | grep -v "^mkdir\|^rm\|^tar\|^gzip"')
    
        pytest_assert(stdout['rc'] == 0, 'generate_dump command failed')
    
        cmd_list = stdout["stdout_lines"]
    
        strbash_in_cmdlist = False
        for command in cmd_list:
            if "bash -c" in command:
                strbash_in_cmdlist = True
                break
    
        for cmd_group_name, cmd_group_to_check in list(commands_to_check.items()):
            cmd_not_found.update(
                check_cmds(cmd_group_name, cmd_group_to_check, cmd_list, strbash_in_cmdlist)
            )
    
        error_message = ''
        for key, commands in cmd_not_found.items():
            error_message += "Commands not found for '{}': ".format(key) + '; '.join(commands) + '\n'
    
>       pytest_assert(len(cmd_not_found) == 0, error_message)
E       Failed: Commands not found for 'bgp_cmds': vtysh\s+-c "show ip bgp neighbors .* advertised-routes"; vtysh\s+-c "show ip bgp neighbors .* routes"; vtysh\s+-c "show bgp ipv6 neighbors .* advertised-routes"; vtysh\s+-c "show bgp ipv6 neighbors .* routes"

cmd_group_name = 'docker_cmds'
cmd_group_to_check = ['docker exec syncd saidump', 'docker stats --no-stream', 'docker ps -a', 'docker top pmon', 'docker exec lldp lldpcli show statistics', 'docker logs bgp', ...]
cmd_list   = ['Lock succesfully accquired and installed signal handlers', 'touch --date=@0 /tmp/reference', 'ln -s /usr/local/bin/g...ump_vlab-01_20241220_065209/proc', 'echo cp  -r /proc/consoles /var/dump/sonic_dump_vlab-01_20241220_065209/proc', ...]
cmd_not_found = defaultdict(<class 'list'>, {'bgp_cmds': ['vtysh\\s+-c "show ip bgp neighbors .* advertised-routes"', 'vtysh\\s+-c "sh...s"', 'vtysh\\s+-c "show bgp ipv6 neighbors .* advertised-routes"', 'vtysh\\s+-c "show bgp ipv6 neighbors .* routes"']})
command    = 'timeout --foreground 5m bash -c "dummy_cleanup_method () '
commands   = ['vtysh\\s+-c "show ip bgp neighbors .* advertised-routes"', 'vtysh\\s+-c "show ip bgp neighbors .* routes"', 'vtysh\\s+-c "show bgp ipv6 neighbors .* advertised-routes"', 'vtysh\\s+-c "show bgp ipv6 neighbors .* routes"']
commands_to_check = {'bfd_cmds': ["vtysh -c 'show bfd peers'", "vtysh -c 'show bfd peers counters'", "vtysh -c 'show bfd peers json'", "vt... ['/proc/buddyinfo', '/proc/cmdline', '/proc/consoles', '/proc/cpuinfo', '/proc/devices', '/proc/diskstats', ...], ...}
duthost    = <MultiAsicSonicHost vlab-01>
duthosts   = [<MultiAsicSonicHost vlab-01>]
enum_rand_one_per_hwsku_frontend_hostname = 'vlab-01'
error_message = 'Commands not found for \'bgp_cmds\': vtysh\\s+-c "show ip bgp neighbors .* advertised-routes"; vtysh\\s+-c "show ip b...routes"; vtysh\\s+-c "show bgp ipv6 neighbors .* advertised-routes"; vtysh\\s+-c "show bgp ipv6 neighbors .* routes"\n'
key        = 'bgp_cmds'
skip_on_dpu = None
stdout     = {'changed': True, 'stdout': 'Lock succesfully accquired and installed signal handlers\ntouch --date=@0 /tmp/reference\...or directory', 'ERR: RC:-1 observed on line 2250', 'Removing lock. Exit: 0'], '_ansible_no_log': None, 'failed': False}
strbash_in_cmdlist = True
```