### PR TITLE
show ip interfaces: fix exception with BGP unnumbered

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -48,9 +48,14 @@ def get_bgp_peer():
     data = config_db.get_table('BGP_NEIGHBOR')
 
     for neighbor_ip in data.keys():
-        local_addr = data[neighbor_ip]['local_addr']
-        neighbor_name = data[neighbor_ip]['name']
-        bgp_peer.setdefault(local_addr, [neighbor_name, neighbor_ip])
+        # The data collected here will only work for manually defined neighbors
+        # so we need to ignore errors when using BGP Unnumbered.
+        try:
+            local_addr = data[neighbor_ip]['local_addr']
+            neighbor_name = data[neighbor_ip]['name']
+            bgp_peer.setdefault(local_addr, [neighbor_name, neighbor_ip])
+        except KeyError:
+            pass
     return bgp_peer
 
 

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -2059,6 +2059,14 @@
         "asn": "65200",
         "keepalive": "3"
     },
+    "BGP_NEIGHBOR|Vlan100": {
+        "rrclient": "0",
+        "peer_type": "external",
+        "nhopself": "0",
+        "admin_status": "up",
+        "holdtime": "10",
+        "keepalive": "3"
+    },
     "SCHEDULER|scheduler.0": {
         "type": "DWRR",
         "weight": "14"


### PR DESCRIPTION
#### What I did
Without this patch an exception is thrown when running `show ip interfaces` when BGP Unnumbered is configured:

```
root@sw1:~# show ip interfaces
Traceback (most recent call last):
  File "/usr/local/bin/ipintutil", line 280, in <module>
    main()
  File "/usr/local/bin/ipintutil", line 273, in main
    ip_intfs = get_ip_intfs(af, namespace, display)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/ipintutil", line 236, in get_ip_intfs
    ip_intfs_in_ns = get_ip_intfs_in_namespace(af, namespace, display)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/ipintutil", line 149, in get_ip_intfs_in_namespace
    bgp_peer = get_bgp_peer()
               ^^^^^^^^^^^^^^
  File "/usr/local/bin/ipintutil", line 51, in get_bgp_peer
    local_addr = data[neighbor_ip]['local_addr']
                 ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'local_addr'
```

This patch will allow the command to complete successfully.  It shouldn't be necessary to actually query FRR for neighbor details, the prior version didn't, it just echo'd back config details.

This is a slightly different patch to what #3565 does.  It does not add blank values to the output parameter, it skips due to exception handling.

#### How I did it

Added try / except logic block around optional key/values.

#### How to verify it

Configure BGP Unnumbered via FRR Management framework and observe 'show ip interfaces' fails with above error.  Apply patch and observe expected output.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Fixes #3565
Fixes https://github.com/sonic-net/sonic-buildimage/issues/19930
Signed-off-by: Brad House (@bradh352)
