### PR TITLE
Improve SONiC disk checker to handle disk full case and mount overlay fs to allow remote user login.

### DIFF
--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -77,7 +77,7 @@ def event_pub(event):
     event_publish(events_handle, EVENTS_PUBLISHER_TAG, param_dict)
 
 
-def test_disk_full(dirs): 
+def test_disk_full(dirs):
     for d in dirs:
         space = os.statvfs(d)
         if space.f_bavail < FREE_SPACE_THRESHOLD:
@@ -141,7 +141,7 @@ def do_mnt(dirs, overlay_prefix):
         os.mkdir(d_upper)
         os.mkdir(d_work)
 
-        ret = run_cmd(["mount", "-t", "overlay", "{}_{}".format(overlay_prefix, d_name),\
+        ret = run_cmd(["mount", "-t", "overlay", "{}_{}".format(overlay_prefix, d_name),
                 "-o", "lowerdir={},upperdir={},workdir={}".format(d, d_upper, d_work), d])
         if ret:
             break
@@ -152,9 +152,11 @@ def do_mnt(dirs, overlay_prefix):
         log_info("{} are mounted as Read-Write".format(dirs))
     return ret
 
+
 def do_unmnt(dirs, overlay_prefix):
     for d in dirs:
         d_name = get_dname(d)
+
         ret = run_cmd(["umount", "-l", "{}_{}".format(overlay_prefix, d_name)])
         if ret:
             break

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -169,7 +169,7 @@ def do_check(skip_mount, dirs):
     # Check if mounted
     if (not ret) and is_mounted(dirs):
         log_err("READ-ONLY: Mounted {} to make Read-Write".format(dirs))
-        event_pub()
+        event_pub("read_only")
 
     return ret
 

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -6,7 +6,7 @@ What:
     This utility is designed to address two specific issues:
     1. Disk becoming read-only due to kernel bugs.
     2. Disk running out of space.
-    When either of these issues occurs, the system prevents new remote user logins via TACACS. 
+    When either of these issues occurs, the system prevents new remote user logins via TACACS.
 
 How:
     Checks for read-write permissions and available disk space.

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -40,6 +40,8 @@ UPPER_DIR = "/run/mount/upper"
 WORK_DIR = "/run/mount/work"
 MOUNTS_FILE = "/proc/mounts"
 
+FREE_SPACE_THRESHOLD = 1024
+
 EVENTS_PUBLISHER_SOURCE = "sonic-events-host"
 EVENTS_PUBLISHER_TAG = "event-disk"
 events_handle = None
@@ -78,7 +80,13 @@ def test_writable(dirs):
             event_pub()
             return False
         else:
-            log_debug("{} is Read-Write".format(d))
+            print("{} is Read-Write".format(d))
+            space = os.statvfs(d)
+            if space.f_bavail < FREE_SPACE_THRESHOLD:
+                log_err("{} is no free space".format(d))
+                event_pub()
+                return False
+
     return True
 
 

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -80,7 +80,6 @@ def test_writable(dirs):
             event_pub()
             return False
         else:
-            print("{} is Read-Write".format(d))
             space = os.statvfs(d)
             if space.f_bavail < FREE_SPACE_THRESHOLD:
                 log_err("{} is no free space".format(d))

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -80,11 +80,14 @@ def test_writable(dirs):
             event_pub()
             return False
         else:
+            log_debug("{} is Read-Write".format(d))
             space = os.statvfs(d)
             if space.f_bavail < FREE_SPACE_THRESHOLD:
                 log_err("{} is no free space".format(d))
                 event_pub()
                 return False
+            else:
+                log_debug("{} has enough disk space".format(d))
 
     return True
 

--- a/scripts/disk_check.py
+++ b/scripts/disk_check.py
@@ -3,28 +3,34 @@
 
 """
 What:
-    There have been cases, where disk turns Read-only due to kernel bug.
-    In Read-only state, system blocks new remote user login via TACACS.
-    This utility is to check & make transient recovery as needed.
+    This utility is designed to address two specific issues:
+    1. Disk becoming read-only due to kernel bugs.
+    2. Disk running out of space.
+    When either of these issues occurs, the system prevents new remote user logins via TACACS. 
 
 How:
-    check for Read-Write permission. If Read-only, create writable overlay using tmpfs.
+    Checks for read-write permissions and available disk space.
+    If an issue is detected, create writable overlay using tmpfs.
 
-    By default "/etc" & "/home" are checked and if in Read-only state, make them Read-Write
+    By default "/etc" & "/home" are checked and if issue detected, make them Read-Write
     using overlay on top of tmpfs.
 
     Making /etc & /home as writable lets successful new remote user login.
 
-    If in Read-only state or in Read-Write state with the help of tmpfs overlay,
-    syslog ERR messages are written, to help raise alerts.
+    Write syslog ERR messages to help raise alerts in the following cases:
+    1. Disk in read-only state.
+    2. Disk out of space.
+    3. Mounted tmpfs overlay.
 
     Monit may be used to invoke it periodically, to help scan & fix and
     report via syslog.
 
 Tidbit:
-    If you would like to test this script, you could simulate a RO disk
-    with the following command. Reboot will revert the effect.
+    To test this script:
+    1. Simulate a RO disk with the following command. Reboot will revert the effect.
         sudo bash -c "echo u > /proc/sysrq-trigger"
+    2. Use up all disk space by create big file in /var/dump/:
+         dd if=/dev/zero of=/var/dump/sonic_dump_devicename_20241126_204132.tar bs=1G count=50
 
 """
 

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -177,6 +177,18 @@ class TestDiskCheck(object):
             
         assert max_log_lvl == syslog.LOG_ERR
 
+
+    @patch("disk_check.syslog.syslog")
+    @patch("disk_check.subprocess.run")
+    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 1394521, 971520, 883302, 883302, 0, 255)))
+    def test_diskfull(self, mock_proc, mock_log, os_statvfs):
+        mock_proc.side_effect = mock_subproc_run
+        mock_log.side_effect = report_err_msg
+
+        result = disk_check.test_writable(["/etc"])
+        assert result == False
+
+
     @classmethod
     def teardown_class(cls):
         subprocess.run("rm -rf /tmp/tmp*", shell=True)  # cleanup the temporary dirs

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -132,10 +132,9 @@ class TestDiskCheck(object):
 
     @patch("disk_check.syslog.syslog")
     @patch("disk_check.subprocess.run")
-    @patch('os.access', return_value=True)
     @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 4096,
                                                          971520, 883302, 883302, 4096, 255)))
-    def test_readonly(self, mock_os_statvfs, mock_os_access, mock_proc, mock_log):
+    def test_readonly(self, mock_os_statvfs, mock_proc, mock_log):
         global err_data, cmds, max_log_lvl
 
         mock_proc.side_effect = mock_subproc_run

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -183,7 +183,7 @@ class TestDiskCheck(object):
     @patch('os.access', return_value=True)
     @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 0,
                                                          971520, 883302, 883302, 4096, 255)))
-    def test_diskfull(self, mock_proc, mock_log, os_access, os_statvfs):
+    def test_diskfull(self, mock_os_statvfs, mock_os_access, mock_proc, mock_log):
         global max_log_lvl
         max_log_lvl = -1
         mock_proc.side_effect = mock_subproc_run

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -184,6 +184,8 @@ class TestDiskCheck(object):
     @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 0,
                                                          971520, 883302, 883302, 4096, 255)))
     def test_diskfull(self, mock_proc, mock_log, os_access, os_statvfs):
+        global max_log_lvl
+        max_log_lvl = -1
         mock_proc.side_effect = mock_subproc_run
         mock_log.side_effect = report_err_msg
 

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -202,19 +202,22 @@ class TestDiskCheck(object):
 
     @patch("disk_check.syslog.syslog")
     @patch("disk_check.subprocess.run")
+    @patch('shutil.rmtree')
     @patch('os.access', return_value=True)
     @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 4096,
                                                          971520, 883302, 883302, 4096, 255)))
-    def test_unmount_disk_full(self, mock_os_statvfs, mock_os_access, mock_proc, mock_log):
+    def test_unmount_disk_full(self, mock_os_statvfs, mock_os_access, mock_rmtree, mock_proc, mock_log):
         global max_log_lvl
         max_log_lvl = -1
         mock_proc.side_effect = mock_subproc_run
         mock_log.side_effect = report_err_msg
 
         tc = {
-            "upperdir": "/tmp",
+            "upperdir": "/tmp/tmpx",
+            "workdir": "/tmp/tmpy"
         }
         swap_upper(tc)
+        swap_work(tc)
 
         with patch('sys.argv', ["", "-d", "/tmpx"]):
             disk_check.main()
@@ -232,16 +235,6 @@ class TestDiskCheck(object):
 
         result = disk_check.test_disk_full(["/etc"])
         assert result is True
-
-    @patch("disk_check.syslog.syslog")
-    @patch("disk_check.subprocess.run")
-    def test_do_unmnt(self, mock_proc, mock_log):
-        global max_log_lvl
-        max_log_lvl = -1
-        mock_proc.side_effect = mock_subproc_run
-        mock_log.side_effect = report_err_msg
-
-        disk_check.do_unmnt(["/etc"])
 
     @patch("disk_check.syslog.syslog")
     @patch("disk_check.subprocess.run")

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -180,8 +180,8 @@ class TestDiskCheck(object):
 
     @patch("disk_check.syslog.syslog")
     @patch("disk_check.subprocess.run")
-    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 1394521,
-                                                         971520, 883302, 883302, 0, 255)))
+    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 0,
+                                                         971520, 883302, 883302, 4096, 255)))
     def test_diskfull(self, mock_proc, mock_log, os_statvfs):
         mock_proc.side_effect = mock_subproc_run
         mock_log.side_effect = report_err_msg

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -178,16 +178,16 @@ class TestDiskCheck(object):
             
         assert max_log_lvl == syslog.LOG_ERR
 
-
     @patch("disk_check.syslog.syslog")
     @patch("disk_check.subprocess.run")
-    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 1394521, 971520, 883302, 883302, 0, 255)))
+    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 1394521,
+                                                         971520, 883302, 883302, 0, 255)))
     def test_diskfull(self, mock_proc, mock_log, os_statvfs):
         mock_proc.side_effect = mock_subproc_run
         mock_log.side_effect = report_err_msg
 
         result = disk_check.test_writable(["/etc"])
-        assert result == False
+        assert result is False
 
 
     @classmethod

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 import syslog
 from unittest.mock import patch
@@ -185,6 +186,44 @@ class TestDiskCheck(object):
     @patch('os.access', return_value=True)
     @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 0,
                                                          971520, 883302, 883302, 4096, 255)))
+    def test_mount_disk_full(self, mock_os_statvfs, mock_os_access, mock_proc, mock_log):
+        global max_log_lvl
+        max_log_lvl = -1
+        mock_proc.side_effect = mock_subproc_run
+        mock_log.side_effect = report_err_msg
+
+        tc = {
+            "upperdir": "/tmp",
+        }
+        swap_upper(tc)
+
+        with patch('sys.argv', ["", "-d", "/tmpx"]):
+            disk_check.main()
+
+    @patch("disk_check.syslog.syslog")
+    @patch("disk_check.subprocess.run")
+    @patch('os.access', return_value=True)
+    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 4096,
+                                                         971520, 883302, 883302, 4096, 255)))
+    def test_unmount_disk_full(self, mock_os_statvfs, mock_os_access, mock_proc, mock_log):
+        global max_log_lvl
+        max_log_lvl = -1
+        mock_proc.side_effect = mock_subproc_run
+        mock_log.side_effect = report_err_msg
+
+        tc = {
+            "upperdir": "/tmp",
+        }
+        swap_upper(tc)
+
+        with patch('sys.argv', ["", "-d", "/tmpx"]):
+            disk_check.main()
+
+    @patch("disk_check.syslog.syslog")
+    @patch("disk_check.subprocess.run")
+    @patch('os.access', return_value=True)
+    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 0,
+                                                         971520, 883302, 883302, 4096, 255)))
     def test_diskfull(self, mock_os_statvfs, mock_os_access, mock_proc, mock_log):
         global max_log_lvl
         max_log_lvl = -1
@@ -193,6 +232,26 @@ class TestDiskCheck(object):
 
         result = disk_check.test_disk_full(["/etc"])
         assert result is True
+
+    @patch("disk_check.syslog.syslog")
+    @patch("disk_check.subprocess.run")
+    def test_do_unmnt(self, mock_proc, mock_log):
+        global max_log_lvl
+        max_log_lvl = -1
+        mock_proc.side_effect = mock_subproc_run
+        mock_log.side_effect = report_err_msg
+
+        disk_check.do_unmnt(["/etc"])
+
+    @patch("disk_check.syslog.syslog")
+    @patch("disk_check.subprocess.run")
+    def test_do_unmnt(self, mock_proc, mock_log):
+        global max_log_lvl
+        max_log_lvl = -1
+        mock_proc.side_effect = mock_subproc_run
+        mock_log.side_effect = report_err_msg
+
+        disk_check.do_unmnt(["/etc"])
 
 
     @classmethod

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -183,7 +183,7 @@ class TestDiskCheck(object):
     @patch('os.access', return_value=True)
     @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 0,
                                                          971520, 883302, 883302, 4096, 255)))
-    def test_diskfull(self, mock_proc, mock_log, os_statvfs):
+    def test_diskfull(self, mock_proc, mock_log, os_access, os_statvfs):
         mock_proc.side_effect = mock_subproc_run
         mock_log.side_effect = report_err_msg
 

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import syslog
 from unittest.mock import patch

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 import syslog
 from unittest.mock import patch
@@ -244,7 +243,7 @@ class TestDiskCheck(object):
         mock_proc.side_effect = mock_subproc_run
         mock_log.side_effect = report_err_msg
 
-        disk_check.do_unmnt(["/etc"])
+        disk_check.do_unmnt(["/etc"], "overlay_prefix")
 
 
     @classmethod

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -132,7 +132,10 @@ class TestDiskCheck(object):
 
     @patch("disk_check.syslog.syslog")
     @patch("disk_check.subprocess.run")
-    def test_readonly(self, mock_proc, mock_log):
+    @patch('os.access', return_value=True)
+    @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 4096,
+                                                         971520, 883302, 883302, 4096, 255)))
+    def test_readonly(self, mock_os_statvfs, mock_os_access, mock_proc, mock_log):
         global err_data, cmds, max_log_lvl
 
         mock_proc.side_effect = mock_subproc_run
@@ -189,8 +192,8 @@ class TestDiskCheck(object):
         mock_proc.side_effect = mock_subproc_run
         mock_log.side_effect = report_err_msg
 
-        result = disk_check.test_writable(["/etc"])
-        assert result is False
+        result = disk_check.test_disk_full(["/etc"])
+        assert result is True
 
 
     @classmethod

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -180,6 +180,7 @@ class TestDiskCheck(object):
 
     @patch("disk_check.syslog.syslog")
     @patch("disk_check.subprocess.run")
+    @patch('os.access', return_value=True)
     @patch('os.statvfs', return_value=os.statvfs_result((4096, 4096, 1909350, 1491513, 0,
                                                          971520, 883302, 883302, 4096, 255)))
     def test_diskfull(self, mock_proc, mock_log, os_statvfs):


### PR DESCRIPTION
Improve SONiC disk checker to handle disk full case and mount overlay fs to allow remote user login.

This PR depends on DB schema change: https://github.com/sonic-net/sonic-buildimage/pull/21351

#### What I did
    Currently disk checker only handle RO disk case, but when disk no free space, remote user also can't login.

#### How I did it
    Check disk free space and mount overlay fs to allow TACACS login.

#### How to verify it
    Create big file on device, make device no free space. then login with remote user should success.

##### Work item tracking
- Microsoft ADO: 30608100

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

