### PR TITLE
[db_migrator] Migrate tunnel table

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -664,6 +664,26 @@ class DBMigrator():
             metadata['synchronous_mode'] = device_metadata_data.get("synchronous_mode")
             self.configDB.set_entry('DEVICE_METADATA', 'localhost', metadata)
 
+    def migrate_ipinip_tunnel(self):
+        """Migrate TUNNEL_DECAP_TABLE to add decap terms with TUNNEL_DECAP_TERM_TABLE."""
+        tunnel_decap_table = self.appDB.get_table('TUNNEL_DECAP_TABLE')
+        app_db_separator = self.appDB.get_db_separator(self.appDB.APPL_DB)
+        for key, attrs in tunnel_decap_table.items():
+            if "dst_ip" in attrs:
+                dst_ips = attrs["dst_ip"].split(",")
+                src_ip = attrs.get("src_ip")
+                for dst_ip in dst_ips:
+                    decap_term_table_key = app_db_separator.join(["TUNNEL_DECAP_TERM_TABLE", key, dst_ip])
+                    if src_ip:
+                        self.appDB.set(self.appDB.APPL_DB, decap_term_table_key, "src_ip", src_ip)
+                        self.appDB.set(self.appDB.APPL_DB, decap_term_table_key, "term_type", "P2P")
+                    else:
+                        self.appDB.set(self.appDB.APPL_DB, decap_term_table_key, "term_type", "P2MP")
+
+            attrs.pop("dst_ip", None)
+            attrs.pop("src_ip", None)
+            self.appDB.set_entry("TUNNEL_DECAP_TABLE", key, attrs)
+
     def migrate_port_qos_map_global(self):
         """
         Generate dscp_to_tc_map for switch.
@@ -1232,6 +1252,9 @@ class DBMigrator():
         Version 202405_01.
         """
         log.log_info('Handling version_202405_01')
+
+        self.migrate_ipinip_tunnel()
+
         self.set_version('version_202411_01')
         return 'version_202411_01'
 

--- a/tests/db_migrator_input/appl_db/tunnel_table_expected.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_expected.json
@@ -1,0 +1,61 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL": {
+        "dscp_mode": "uniform",
+        "ecn_mode": "copy_from_outer",
+        "ttl_mode": "pipe",
+        "tunnel_type": "IPINIP"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL": {
+        "dscp_mode": "uniform",
+        "ecn_mode": "copy_from_outer",
+        "ttl_mode": "pipe",
+        "tunnel_type": "IPINIP"
+    },
+    "TUNNEL_DECAP_TABLE:MuxTunnel0": {
+        "dscp_mode": "uniform",
+        "ecn_mode": "copy_from_outer",
+        "encap_ecn_mode": "standard",
+        "ttl_mode": "pipe",
+        "tunnel_type": "IPINIP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.56": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.58": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.60": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.62": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.1.0.32": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.0.1": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00:1::32": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::71": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::75": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::79": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc00::7d": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:IPINIP_V6_TUNNEL:fc02:1000::1": {
+        "term_type": "P2MP"
+    },
+    "TUNNEL_DECAP_TERM_TABLE:MuxTunnel0:10.1.0.32": {
+        "term_type": "P2P",
+        "src_ip": "10.1.0.33"
+    }
+}

--- a/tests/db_migrator_input/appl_db/tunnel_table_input.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_input.json
@@ -1,0 +1,25 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL": {
+        "dscp_mode": "uniform",
+        "dst_ip": "10.0.0.56,10.0.0.58,10.0.0.60,10.0.0.62,10.1.0.32,192.168.0.1",
+        "ecn_mode": "copy_from_outer",
+        "ttl_mode": "pipe",
+        "tunnel_type": "IPINIP"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL": {
+        "dscp_mode": "uniform",
+        "dst_ip": "fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d,fc02:1000::1",
+        "ecn_mode": "copy_from_outer",
+        "ttl_mode": "pipe",
+        "tunnel_type": "IPINIP"
+    },
+    "TUNNEL_DECAP_TABLE:MuxTunnel0": {
+        "dscp_mode": "uniform",
+        "dst_ip": "10.1.0.32",
+        "ecn_mode": "copy_from_outer",
+        "encap_ecn_mode": "standard",
+        "ttl_mode": "pipe",
+        "tunnel_type": "IPINIP",
+        "src_ip": "10.1.0.33"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1020,3 +1020,35 @@ class TestAAAMigrator(object):
 
         diff = DeepDiff(resulting_table, expected_table, ignore_order=True)
         assert not diff
+
+
+class TestIPinIPTunnelMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['APPL_DB'] = None
+
+    def test_tunnel_migrator(self):
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_input')
+
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate()
+
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_expected')
+        expected_appl_db = SonicV2Connector(host='127.0.0.1')
+        expected_appl_db.connect(expected_appl_db.APPL_DB)
+        expected_keys = expected_appl_db.keys(expected_appl_db.APPL_DB, "*")
+        resulting_keys = dbmgtr.appDB.keys(dbmgtr.appDB.APPL_DB, "*")
+        expected_keys.sort()
+        resulting_keys.sort()
+        assert expected_keys == resulting_keys
+        for key in expected_keys:
+            resulting_keys = dbmgtr.appDB.get_all(dbmgtr.appDB.APPL_DB, key)
+            expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
+            diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
+            assert not diff


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Let's migrate the `TUNNEL_DECAP_TABLE` based on the db schema change introduced in 202405.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How I did it
* before migration:
```
{
    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL": {
        "dscp_mode": "uniform",
        "dst_ip": "10.0.0.56,10.0.0.58,10.0.0.60,10.0.0.62,10.1.0.32,192.168.0.1",
        "ecn_mode": "copy_from_outer",
        "ttl_mode": "pipe",
        "tunnel_type": "IPINIP"
    }
}
```
* after migration:
```
{
    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL": {
        "dscp_mode": "uniform",
        "ecn_mode": "copy_from_outer",
        "ttl_mode": "pipe",
        "tunnel_type": "IPINIP"
    },
    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.56": {
        "term_type": "P2MP"
    },
    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.58": {
        "term_type": "P2MP"
    },
    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.60": {
        "term_type": "P2MP"
    },
    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.0.0.62": {
        "term_type": "P2MP"
    },
    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:10.1.0.32": {
        "term_type": "P2MP"
    },
    "TUNNEL_DECAP_TERM_TABLE:IPINIP_TUNNEL:192.168.0.1": {
        "term_type": "P2MP"
    }
}
```

#### How to verify it
1. UT
2. warm reboot from 202311 to 202405.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

