### PR TITLE
[QOS] Skip showing unnecessary warning message

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -793,7 +793,7 @@ def _wait_until_clear(tables, interval=0.5, timeout=30, verbose=False):
                     click.echo("Some entries matching {} still exist: {}".format(table, keys[0]))
                 time.sleep(interval)
         empty = (non_empty_table_count == 0)
-    if not empty:
+    if not empty and timeout:
         click.echo("Operation not completed successfully, please save and reload configuration.")
     return empty
 

--- a/config/main.py
+++ b/config/main.py
@@ -793,7 +793,9 @@ def _wait_until_clear(tables, interval=0.5, timeout=30, verbose=False):
                     click.echo("Some entries matching {} still exist: {}".format(table, keys[0]))
                 time.sleep(interval)
         empty = (non_empty_table_count == 0)
-    if not empty and timeout:
+    if timeout == 0:
+        empty = True
+    if not empty:
         click.echo("Operation not completed successfully, please save and reload configuration.")
     return empty
 

--- a/config/main.py
+++ b/config/main.py
@@ -778,6 +778,8 @@ def storm_control_delete_entry(port_name, storm_type):
 
 
 def _wait_until_clear(tables, interval=0.5, timeout=30, verbose=False):
+    if timeout == 0:
+        return True
     start = time.time()
     empty = False
     app_db = SonicV2Connector(host='127.0.0.1')
@@ -793,8 +795,7 @@ def _wait_until_clear(tables, interval=0.5, timeout=30, verbose=False):
                     click.echo("Some entries matching {} still exist: {}".format(table, keys[0]))
                 time.sleep(interval)
         empty = (non_empty_table_count == 0)
-    if timeout == 0:
-        empty = True
+
     if not empty:
         click.echo("Operation not completed successfully, please save and reload configuration.")
     return empty

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1601,6 +1601,14 @@ class TestConfigQos(object):
             empty = _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5,2)
         assert not empty
 
+    @patch('click.echo')
+    @patch('swsscommon.swsscommon.SonicV2Connector.keys')
+    def test_qos_wait_until_clear_no_timeout(self, mock_keys, mock_echo):
+        from config.main import _wait_until_clear
+        _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5, 0) # timeout is zero
+        mock_keys.assert_not_called()
+        mock_echo.assert_not_called()
+
     @mock.patch('config.main._wait_until_clear')
     def test_qos_clear_no_wait(self, _wait_until_clear):
         from config.main import _clear_qos

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1605,7 +1605,7 @@ class TestConfigQos(object):
     @patch('swsscommon.swsscommon.SonicV2Connector.keys')
     def test_qos_wait_until_clear_no_timeout(self, mock_keys, mock_echo):
         from config.main import _wait_until_clear
-        _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5, 0)
+        assert _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5, 0)
         mock_keys.assert_not_called()
         mock_echo.assert_not_called()
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1605,7 +1605,7 @@ class TestConfigQos(object):
     @patch('swsscommon.swsscommon.SonicV2Connector.keys')
     def test_qos_wait_until_clear_no_timeout(self, mock_keys, mock_echo):
         from config.main import _wait_until_clear
-        _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5, 0) # timeout is zero
+        _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5, 0)
         mock_keys.assert_not_called()
         mock_echo.assert_not_called()
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Don't show an unnecessary warning message (`Operation not completed successfully, please save and reload configuration.`) during config qos reload

**To repro:**
```
root@sonic:/home/admin# sonic-cfggen -H -k Mellanox-SN4700-O8V48 --preset t1 > /tmp/default_config.json

root@sonic:/home/admin# config qos reload
Operation not completed successfully, please save and reload configuration.

Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db

Buffer calculation model updated, restarting swss is required to take effect
```

#### How I did it

When in traditional buffer mode, qos reload will not wait for tables to be cleared, so it will set the timeout to 0 in the _wait_until_clear call. But today, this prints an error log and exits.

Thus fixed to not print the error log when the timeout is zero.

#### How to verify it

UT and manual testing

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

