### PR TITLE
[config] Exit with non-zero when qos reload fail

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -799,6 +799,7 @@ def _wait_until_clear(tables, interval=0.5, timeout=30, verbose=False):
 
 
 def _clear_qos(delay=False, verbose=False):
+    status = True
     QOS_TABLE_NAMES = [
             'PORT_QOS_MAP',
             'QUEUE',
@@ -838,7 +839,8 @@ def _clear_qos(delay=False, verbose=False):
         device_metadata = config_db.get_entry('DEVICE_METADATA', 'localhost')
         # Traditional buffer manager do not remove buffer tables in any case, no need to wait.
         timeout = 120 if device_metadata and device_metadata.get('buffer_model') == 'dynamic' else 0
-        return _wait_until_clear(["BUFFER_*_TABLE:*", "BUFFER_*_SET"], interval=0.5, timeout=timeout, verbose=verbose)
+        status = _wait_until_clear(["BUFFER_*_TABLE:*", "BUFFER_*_SET"], interval=0.5, timeout=timeout, verbose=verbose)
+    return status
 
 def _get_sonic_generated_services(num_asic):
     if not os.path.isfile(SONIC_GENERATED_SERVICE_PATH):

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9636,6 +9636,7 @@ Some of the example QOS configurations that users can modify are given below.
 
   In this example, it uses the buffers.json.j2 file and qos.json.j2 file from platform specific folders.
   When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
+  When an error occurs, such as "Operation not completed successfully, please save and reload configuration," the system will record the status, after executing all the latter commands, exit with code 1.
   ```
 
 **config qos reload --ports port_list**

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1607,6 +1607,32 @@ class TestConfigQos(object):
         _clear_qos(True, False)
         _wait_until_clear.assert_called_with(['BUFFER_*_TABLE:*', 'BUFFER_*_SET'], interval=0.5, timeout=0, verbose=False)
 
+    @mock.patch('config.main._wait_until_clear')
+    def test_clear_qos_without_delay(self, mock_wait_until_clear):
+        from config.main import _clear_qos
+
+        status = _clear_qos(False, False)
+        mock_wait_until_clear.assert_not_called()
+        assert status is True
+
+    @mock.patch('config.main._wait_until_clear')
+    def test_clear_qos_with_delay_returns_true(self, mock_wait_until_clear):
+        from config.main import _clear_qos
+        mock_wait_until_clear.return_value = True
+
+        status = _clear_qos(True, False)
+        mock_wait_until_clear.assert_called_once()
+        assert status is True
+
+    @mock.patch('config.main._wait_until_clear')
+    def test_clear_qos_with_delay_returns_false(self, mock_wait_until_clear):
+        from config.main import _clear_qos
+        mock_wait_until_clear.return_value = False
+
+        status = _clear_qos(True, False)
+        mock_wait_until_clear.assert_called_once()
+        assert status is False
+
     @patch('config.main._wait_until_clear')
     def test_qos_reload_not_empty_should_exit(self, mock_wait_until_clear):
         mock_wait_until_clear.return_value = False

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1607,17 +1607,6 @@ class TestConfigQos(object):
         _clear_qos(True, False)
         _wait_until_clear.assert_called_with(['BUFFER_*_TABLE:*', 'BUFFER_*_SET'], interval=0.5, timeout=0, verbose=False)
 
-    def test_qos_wait_until_clear_not_empty_should_exit(self):
-        from config.main import _wait_until_clear
-
-        with mock.patch('swsscommon.swsscommon.SonicV2Connector.keys',
-                        side_effect=TestConfigQos._keys):
-            TestConfigQos._keys_counter = 10
-            # timeout set to 0, will always timeout, and return val False
-            ret = _wait_until_clear(["BUFFER_POOL_TABLE:*"],
-                                    0.5, 0, verbose=False)
-            assert ret is False
-
     @patch('config.main._wait_until_clear')
     def test_qos_reload_not_empty_should_exit(self, mock_wait_until_clear):
         mock_wait_until_clear.return_value = False


### PR DESCRIPTION
Fix issue when 'config qos reload' operation unsuccessful, but returns exit code 0, when operation unsuccessful, now it will return code 1 after executing all the commands.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When config qos reload failed with error print "Operation not completed successfully", exit with code 1 finally, instead of exit with code 0.

#### How I did it
Check return value in function _wait_until_clear(), and after config qos reload command finish, check this flag, if it is none zero, then exit 1.

#### How to verify it
Test with command "config qos reload", will exit 1. Note that "config load_minigraph" is also verified, not impacted.

#### Previous command output (if the output of a command-line utility has changed)
```bash
# config qos reload
Operation not completed successfully, please save and reload configuration.
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Buffer calculation model updated, restarting swss is required to take effect
```

#### New command output (if the output of a command-line utility has changed)
```bash
# config qos reload
Operation not completed successfully, please save and reload configuration.
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Buffer calculation model updated, restarting swss is required to take effect
# echo $?
1
```
