### PR TITLE
[Arista] Add 7060X6-64 to GCU Validator

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -30,7 +30,7 @@
                 "th2": [ "Arista-7260CX3-D108C10", "Arista-7260CX3-D108C8",  "Arista-7260CX3-C64", "Arista-7260CX3-Q64" ],
                 "th3": [ "Nokia-IXR7220-H3" ],
                 "th4": [ "Nokia-IXR7220-H4-64D", "Nokia-IXR7220-H4-32D" ],
-                "th5": [ "Nokia-IXR7220-H5-64D" ],
+                "th5": [ "Nokia-IXR7220-H5-64D", "Arista-7060X6-64DE", "Arista-7060X6-64PE" ],
                 "td2": [ "Force10-S6000", "Force10-S6000-Q24S32", "Arista-7050-QX32", "Arista-7050-QX-32S", "Nexus-3164", "Arista-7050QX32S-Q32" ],
                 "td3": [ "Arista-7050CX3-32S-C32", "Arista-7050CX3-32S-D48C8" ],
                 "j2c+": [ "Nokia-IXR7250E-36x100G", "Nokia-IXR7250E-36x400G" ]


### PR DESCRIPTION
Add Arista 7060X6-64 to gcu validator file.

#### What I did
Added the Arista-7060X6-64DE and Arista-7060X6-64PE hwsku platforms to the th5 entry in the gcu_field_operation_validators.conf.json file.

#### How to verify it
Run the sonic-mgmt gcu tests and confirm that apply-patch now works for hwskus under these platforms.

### Applicable Backport Branches
202405
202411