### PR TITLE
Remove debug dump import by default

### DIFF
--- a/utilities_common/helper.py
+++ b/utilities_common/helper.py
@@ -1,5 +1,3 @@
-from dump.match_infra import MatchEngine, MatchRequest, ConnectionPool
-from dump.match_helper import get_matched_keys
 from .db import Db
 import copy
 
@@ -20,18 +18,19 @@ def get_port_acl_binding(db_wrap, port, ns):
     if not isinstance(db_wrap, Db):
         raise Exception("db_wrap object is not of type utilities_common.Db")
 
-    conn_pool = ConnectionPool()
+    from dump import match_infra, match_helper
+    conn_pool = match_infra.ConnectionPool()
     conn_pool.fill(ns, db_wrap.db_clients[ns], db_wrap.db_list)
-    m_engine = MatchEngine(conn_pool)
-    req = MatchRequest(db="CONFIG_DB",
-                      table=ACL,
-                      key_pattern="*",
-                      field="ports@",
-                      value=port,
-                      ns=ns,
-                      match_entire_list=False)
+    m_engine = match_infra.MatchEngine(conn_pool)
+    req = match_infra.MatchRequest(db="CONFIG_DB",
+                                    table=ACL,
+                                    key_pattern="*",
+                                    field="ports@",
+                                    value=port,
+                                    ns=ns,
+                                    match_entire_list=False)
     ret = m_engine.fetch(req)
-    acl_tables, _ = get_matched_keys(ret)
+    acl_tables, _ = match_helper.get_matched_keys(ret)
     return acl_tables
 
 
@@ -51,19 +50,20 @@ def get_port_pbh_binding(db_wrap, port, ns):
     PBH = "PBH_TABLE" # Table to look for port bindings
     if not isinstance(db_wrap, Db):
         raise Exception("db_wrap object is not of type utilities_common.Db")
-
-    conn_pool = ConnectionPool()
+    
+    from dump import match_infra, match_helper
+    conn_pool = match_infra.ConnectionPool()
     conn_pool.fill(ns, db_wrap.db_clients[ns], db_wrap.db_list)
-    m_engine = MatchEngine(conn_pool)
-    req = MatchRequest(db="CONFIG_DB",
-                      table=PBH,
-                      key_pattern="*",
-                      field="interface_list@",
-                      value=port,
-                      ns=ns,
-                      match_entire_list=False)
+    m_engine = match_infra.MatchEngine(conn_pool)
+    req = match_infra.MatchRequest(db="CONFIG_DB",
+                                    table=PBH,
+                                    key_pattern="*",
+                                    field="interface_list@",
+                                    value=port,
+                                    ns=ns,
+                                    match_entire_list=False)
     ret = m_engine.fetch(req)
-    pbh_tables, _ = get_matched_keys(ret)
+    pbh_tables, _ = match_helper.get_matched_keys(ret)
     return pbh_tables
 
 

--- a/utilities_common/helper.py
+++ b/utilities_common/helper.py
@@ -23,12 +23,12 @@ def get_port_acl_binding(db_wrap, port, ns):
     conn_pool.fill(ns, db_wrap.db_clients[ns], db_wrap.db_list)
     m_engine = match_infra.MatchEngine(conn_pool)
     req = match_infra.MatchRequest(db="CONFIG_DB",
-                                    table=ACL,
-                                    key_pattern="*",
-                                    field="ports@",
-                                    value=port,
-                                    ns=ns,
-                                    match_entire_list=False)
+                                   table=ACL,
+                                   key_pattern="*",
+                                   field="ports@",
+                                   value=port,
+                                   ns=ns,
+                                   match_entire_list=False)
     ret = m_engine.fetch(req)
     acl_tables, _ = match_helper.get_matched_keys(ret)
     return acl_tables
@@ -50,18 +50,18 @@ def get_port_pbh_binding(db_wrap, port, ns):
     PBH = "PBH_TABLE" # Table to look for port bindings
     if not isinstance(db_wrap, Db):
         raise Exception("db_wrap object is not of type utilities_common.Db")
-    
+
     from dump import match_infra, match_helper
     conn_pool = match_infra.ConnectionPool()
     conn_pool.fill(ns, db_wrap.db_clients[ns], db_wrap.db_list)
     m_engine = match_infra.MatchEngine(conn_pool)
     req = match_infra.MatchRequest(db="CONFIG_DB",
-                                    table=PBH,
-                                    key_pattern="*",
-                                    field="interface_list@",
-                                    value=port,
-                                    ns=ns,
-                                    match_entire_list=False)
+                                   table=PBH,
+                                   key_pattern="*",
+                                   field="interface_list@",
+                                   value=port,
+                                   ns=ns,
+                                   match_entire_list=False)
     ret = m_engine.fetch(req)
     pbh_tables, _ = match_helper.get_matched_keys(ret)
     return pbh_tables


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Remove debug dump import by default, Starting 202411, debug dump started to import libdashapi to parse DASH objects. 

Keeping this in default import path is causing CLI execution time to increase. 

#### How I did it

Make the import on-demand

#### How to verify it

UT and verified on the image

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

