### PR TITLE
[show][interface] Add changes for show interface errors command

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -434,8 +434,6 @@ def errors(ctx, interfacename):
     # Try to convert interface name from alias
     interfacename = try_convert_interfacename_from_alias(click.get_current_context(), interfacename)
 
-
-    # Ensure port_operr_table is a dictionary
     port_operr_table = get_all_port_errors()
 
     # Define a list of all potential errors

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -12,6 +12,7 @@ from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from portconfig import get_child_ports
 import sonic_platform_base.sonic_sfp.sfputilhelper
+
 from . import portchannel
 from collections import OrderedDict
 

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -414,7 +414,8 @@ def mpls(ctx, interfacename, namespace, display):
 
 interfaces.add_command(portchannel.portchannel)
 
-def get_all_port_errors():
+
+def get_all_port_errors(interfacename):
 
     port_operr_table = {}
     db = SonicV2Connector(host=REDIS_HOSTIP)
@@ -426,6 +427,7 @@ def get_all_port_errors():
 
     return port_operr_table
 
+
 @interfaces.command()
 @click.argument('interfacename', required=True)
 @click.pass_context
@@ -434,7 +436,7 @@ def errors(ctx, interfacename):
     # Try to convert interface name from alias
     interfacename = try_convert_interfacename_from_alias(click.get_current_context(), interfacename)
 
-    port_operr_table = get_all_port_errors()
+    port_operr_table = get_all_port_errors(interfacename)
 
     # Define a list of all potential errors
     ALL_PORT_ERRORS = [

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -465,8 +465,12 @@ def errors(ctx, interfacename):
         count_key = f"{error}_count"
         time_key = f"{error}_time"
 
-        count = port_operr_table.get(count_key, "0")  # Default count to '0'
-        timestamp = port_operr_table.get(time_key, "Never")  # Default timestamp to 'Never'
+        if port_operr_table is not None:
+            count = port_operr_table.get(count_key, "0")  # Default count to '0'
+            timestamp = port_operr_table.get(time_key, "Never")  # Default timestamp to 'Never'
+        else:
+            count = "0"
+            timestamp = "Never"
 
         # Add to table
         body.append([error.replace('_', ' '), count, timestamp])

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -414,6 +414,7 @@ def mpls(ctx, interfacename, namespace, display):
 
 interfaces.add_command(portchannel.portchannel)
 
+
 @interfaces.command()
 @click.argument('interfacename', required=True)
 @click.pass_context

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -12,7 +12,6 @@ from sonic_py_common import multi_asic
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from portconfig import get_child_ports
-import sonic_platform_base.sonic_sfp.sfputilhelper
 
 from . import portchannel
 from collections import OrderedDict

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -5,14 +5,13 @@ import subprocess
 import click
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
-from utilities_common import platform_sfputil_helper
 from natsort import natsorted
 from tabulate import tabulate
 from sonic_py_common import multi_asic
 from sonic_py_common import device_info
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from portconfig import get_child_ports
-
+import sonic_platform_base.sonic_sfp.sfputilhelper
 from . import portchannel
 from collections import OrderedDict
 

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -581,8 +581,7 @@ class TestInterfaces(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert result.output == intf_errors_Ethernet64 
-
+        assert result.output == intf_errors_Ethernet64
 
     def test_show_intf_errors_empty_data():
         """Test case for an interface with no error data."""
@@ -593,8 +592,7 @@ class TestInterfaces(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert result.output == intf_errors_Ethernet16 
-
+        assert result.output == intf_errors_Ethernet16
 
     def test_show_intf_errors_partial_data():
         """Test case for an interface with partial error data."""
@@ -605,8 +603,7 @@ class TestInterfaces(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert result.output == intf_errors_Ethernet32 
-
+        assert result.output == intf_errors_Ethernet32
 
     def test_show_intf_errors_default_values():
         """Test case for an interface with default values."""
@@ -616,8 +613,8 @@ class TestInterfaces(object):
         )
         print(result.exit_code)
         print(result.output)
-        assert result.exit_code == 0 
-        assert result.output == intf_errors_Ethernet48 
+        assert result.exit_code == 0
+        assert result.output == intf_errors_Ethernet48
 
     @classmethod
     def teardown_class(cls):

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -573,50 +573,50 @@ class TestInterfaces(object):
         assert result.output == show_interfaces_switchport_config_in_alias_mode_output
 
     def test_show_intf_errors_filled_data():
-	"""Test case for an interface with filled error data."""
-	runner = CliRunner()
-	result = runner.invoke(
-	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet64"]
-	)
-	print(result.exit_code)
-	print(result.output)
-	assert result.exit_code == 0
+        """Test case for an interface with filled error data."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["errors"], ["Ethernet64"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
         assert result.output == intf_errors_Ethernet64 
 
 
     def test_show_intf_errors_empty_data():
-	"""Test case for an interface with no error data."""
-	runner = CliRunner()
-	result = runner.invoke(
-	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet16"]
-	)
-	print(result.exit_code)
-	print(result.output)
-	assert result.exit_code == 0
+        """Test case for an interface with no error data."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["errors"], ["Ethernet16"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
         assert result.output == intf_errors_Ethernet16 
 
 
     def test_show_intf_errors_partial_data():
-	"""Test case for an interface with partial error data."""
-	runner = CliRunner()
-	result = runner.invoke(
-	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet32"]
-	)
-	print(result.exit_code)
-	print(result.output)
-	assert result.exit_code == 0
+        """Test case for an interface with partial error data."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["errors"], ["Ethernet32"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
         assert result.output == intf_errors_Ethernet32 
 
 
     def test_show_intf_errors_default_values():
-	"""Test case for an interface with default values."""
-	runner = CliRunner()
-	result = runner.invoke(
-	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet48"]
-	)
-	print(result.exit_code)
-	print(result.output)
-	assert result.exit_code == 0 
+        """Test case for an interface with default values."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["errors"], ["Ethernet48"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0 
         assert result.output == intf_errors_Ethernet48 
 
     @classmethod

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -572,7 +572,7 @@ class TestInterfaces(object):
         assert result.exit_code == 0
         assert result.output == show_interfaces_switchport_config_in_alias_mode_output
 
-    def test_show_intf_errors_filled_data():
+    def test_show_intf_errors_filled_data(self):
         """Test case for an interface with filled error data."""
         runner = CliRunner()
         result = runner.invoke(
@@ -583,7 +583,7 @@ class TestInterfaces(object):
         assert result.exit_code == 0
         assert result.output == intf_errors_Ethernet64
 
-    def test_show_intf_errors_empty_data():
+    def test_show_intf_errors_empty_data(self):
         """Test case for an interface with no error data."""
         runner = CliRunner()
         result = runner.invoke(
@@ -594,7 +594,7 @@ class TestInterfaces(object):
         assert result.exit_code == 0
         assert result.output == intf_errors_Ethernet16
 
-    def test_show_intf_errors_partial_data():
+    def test_show_intf_errors_partial_data(self):
         """Test case for an interface with partial error data."""
         runner = CliRunner()
         result = runner.invoke(
@@ -605,7 +605,7 @@ class TestInterfaces(object):
         assert result.exit_code == 0
         assert result.output == intf_errors_Ethernet32
 
-    def test_show_intf_errors_default_values():
+    def test_show_intf_errors_default_values(self):
         """Test case for an interface with default values."""
         runner = CliRunner()
         result = runner.invoke(

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -300,7 +300,7 @@ oper error status                  0    Never
 signal local error                 0    Never
 """
 
-ntf_errors_Ethernet32 = """\
+intf_errors_Ethernet32 = """\
 Port Errors                     Count  Last timestamp(UTC)
 -----------------------------  -------  ---------------------
 code group error                   0    Never

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -265,77 +265,77 @@ PortChannel1001  trunk               4000
 
 intf_errors_Ethernet64 = """\
 Port Errors                     Count  Last timestamp(UTC)
------------------------------  -------  ---------------------
-code group error                   0    Never
-crc rate                           0    Never
-data unit crc error                0    Never
-data unit misalignment error       0    Never
-data unit size                     0    Never
-fec alignment loss                 0    Never
-fec sync loss                      0    Never
-high ber error                     0    Never
-high ser error                     0    Never
-mac local fault                   26    2025-01-17 18:40:56
-mac remote fault               14483    2025-01-17 19:51:12
-no rx reachability                 0    Never
-oper error status                  2    2025-01-17 19:51:12
-signal local error                 0    Never
+----------------------------  -------  ---------------------
+code group error                    0  Never
+crc rate                            0  Never
+data unit crc error                 0  Never
+data unit misalignment error        0  Never
+data unit size                      0  Never
+fec alignment loss                  0  Never
+fec sync loss                       0  Never
+high ber error                      0  Never
+high ser error                      0  Never
+mac local fault                    26  2025-01-17 18:40:56
+mac remote fault                14483  2025-01-17 19:51:12
+no rx reachability                  0  Never
+oper error status                   0  Never
+signal local error                  0  Never
 """
 intf_errors_Ethernet16 = """\
 Port Errors                     Count  Last timestamp(UTC)
------------------------------  -------  ---------------------
-code group error                   0    Never
-crc rate                           0    Never
-data unit crc error                0    Never
-data unit misalignment error       0    Never
-data unit size                     0    Never
-fec alignment loss                 0    Never
-fec sync loss                      0    Never
-high ber error                     0    Never
-high ser error                     0    Never
-mac local fault                    0    Never
-mac remote fault                   0    Never
-no rx reachability                 0    Never
-oper error status                  0    Never
-signal local error                 0    Never
+----------------------------  -------  ---------------------
+code group error                    0  Never
+crc rate                            0  Never
+data unit crc error                 0  Never
+data unit misalignment error        0  Never
+data unit size                      0  Never
+fec alignment loss                  0  Never
+fec sync loss                       0  Never
+high ber error                      0  Never
+high ser error                      0  Never
+mac local fault                     0  Never
+mac remote fault                    0  Never
+no rx reachability                  0  Never
+oper error status                   0  Never
+signal local error                  0  Never
 """
 
 intf_errors_Ethernet32 = """\
 Port Errors                     Count  Last timestamp(UTC)
------------------------------  -------  ---------------------
-code group error                   0    Never
-crc rate                           0    Never
-data unit crc error                0    Never
-data unit misalignment error       0    Never
-data unit size                     0    Never
-fec alignment loss                 0    Never
-fec sync loss                      3    2025-01-16 13:45:20
-high ber error                     1    2025-01-16 14:30:10
-high ser error                     0    Never
-mac local fault                    5    2025-01-16 12:05:34
-mac remote fault                   0    Never
-no rx reachability                 0    Never
-oper error status                  0    Never
-signal local error                 0    Never
+----------------------------  -------  ---------------------
+code group error                    0  Never
+crc rate                            0  Never
+data unit crc error                 0  Never
+data unit misalignment error        0  Never
+data unit size                      0  Never
+fec alignment loss                  0  Never
+fec sync loss                       3  2025-01-16 13:45:20
+high ber error                      1  2025-01-16 14:30:10
+high ser error                      0  Never
+mac local fault                     5  2025-01-16 12:05:34
+mac remote fault                    0
+no rx reachability                  0  Never
+oper error status                   0  Never
+signal local error                  0  Never
 """
 
 intf_errors_Ethernet48 = """\
 Port Errors                     Count  Last timestamp(UTC)
------------------------------  -------  ---------------------
-code group error                   0    Never
-crc rate                           0    Never
-data unit crc error                0    Never
-data unit misalignment error       0    Never
-data unit size                     0    Never
-fec alignment loss                 0    Never
-fec sync loss                      0    Never
-high ber error                     0    Never
-high ser error                     0    Never
-mac local fault                    0    Never
-mac remote fault                   0    Never
-no rx reachability                 0    Never
-oper error status                  0    Never
-signal local error                 0    Never
+----------------------------  -------  ---------------------
+code group error                    0  Never
+crc rate                            0  Never
+data unit crc error                 0  Never
+data unit misalignment error        0  Never
+data unit size                      0  Never
+fec alignment loss                  0  Never
+fec sync loss                       0  Never
+high ber error                      0  Never
+high ser error                      0  Never
+mac local fault                     0
+mac remote fault                    0
+no rx reachability                  0  Never
+oper error status                   0  Never
+signal local error                  0  Never
 """
 
 

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -263,6 +263,82 @@ PortChannel0004  routed
 PortChannel1001  trunk               4000
 """
 
+intf_errors_Ethernet64 = """\
+Port Errors                     Count  Last timestamp(UTC)
+-----------------------------  -------  ---------------------
+code group error                   0    Never
+crc rate                           0    Never
+data unit crc error                0    Never
+data unit misalignment error       0    Never
+data unit size                     0    Never
+fec alignment loss                 0    Never
+fec sync loss                      0    Never
+high ber error                     0    Never
+high ser error                     0    Never
+mac local fault                   26    2025-01-17 18:40:56
+mac remote fault               14483    2025-01-17 19:51:12
+no rx reachability                 0    Never
+oper error status                  2    2025-01-17 19:51:12
+signal local error                 0    Never
+"""
+intf_errors_Ethernet16 = """\
+Port Errors                     Count  Last timestamp(UTC)
+-----------------------------  -------  ---------------------
+code group error                   0    Never
+crc rate                           0    Never
+data unit crc error                0    Never
+data unit misalignment error       0    Never
+data unit size                     0    Never
+fec alignment loss                 0    Never
+fec sync loss                      0    Never
+high ber error                     0    Never
+high ser error                     0    Never
+mac local fault                    0    Never
+mac remote fault                   0    Never
+no rx reachability                 0    Never
+oper error status                  0    Never
+signal local error                 0    Never
+"""
+
+ntf_errors_Ethernet32 = """\
+Port Errors                     Count  Last timestamp(UTC)
+-----------------------------  -------  ---------------------
+code group error                   0    Never
+crc rate                           0    Never
+data unit crc error                0    Never
+data unit misalignment error       0    Never
+data unit size                     0    Never
+fec alignment loss                 0    Never
+fec sync loss                      3    2025-01-16 13:45:20
+high ber error                     1    2025-01-16 14:30:10
+high ser error                     0    Never
+mac local fault                    5    2025-01-16 12:05:34
+mac remote fault                   0    Never
+no rx reachability                 0    Never
+oper error status                  0    Never
+signal local error                 0    Never
+"""
+
+intf_errors_Ethernet48 = """\
+Port Errors                     Count  Last timestamp(UTC)
+-----------------------------  -------  ---------------------
+code group error                   0    Never
+crc rate                           0    Never
+data unit crc error                0    Never
+data unit misalignment error       0    Never
+data unit size                     0    Never
+fec alignment loss                 0    Never
+fec sync loss                      0    Never
+high ber error                     0    Never
+high ser error                     0    Never
+mac local fault                    0    Never
+mac remote fault                   0    Never
+no rx reachability                 0    Never
+oper error status                  0    Never
+signal local error                 0    Never
+"""
+
+
 
 class TestInterfaces(object):
     @classmethod
@@ -495,6 +571,53 @@ class TestInterfaces(object):
 
         assert result.exit_code == 0
         assert result.output == show_interfaces_switchport_config_in_alias_mode_output
+
+    def test_show_intf_errors_filled_data():
+	"""Test case for an interface with filled error data."""
+	runner = CliRunner()
+	result = runner.invoke(
+	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet64"]
+	)
+	print(result.exit_code)
+	print(result.output)
+	assert result.exit_code == 0
+        assert result.output == intf_errors_Ethernet64 
+
+
+    def test_show_intf_errors_empty_data():
+	"""Test case for an interface with no error data."""
+	runner = CliRunner()
+	result = runner.invoke(
+	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet16"]
+	)
+	print(result.exit_code)
+	print(result.output)
+	assert result.exit_code == 0
+        assert result.output == intf_errors_Ethernet16 
+
+
+    def test_show_intf_errors_partial_data():
+	"""Test case for an interface with partial error data."""
+	runner = CliRunner()
+	result = runner.invoke(
+	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet32"]
+	)
+	print(result.exit_code)
+	print(result.output)
+	assert result.exit_code == 0
+        assert result.output == intf_errors_Ethernet32 
+
+
+    def test_show_intf_errors_default_values():
+	"""Test case for an interface with default values."""
+	runner = CliRunner()
+	result = runner.invoke(
+	    show.cli.commands["interfaces"].commands["errors"], ["Ethernet48"]
+	)
+	print(result.exit_code)
+	print(result.output)
+	assert result.exit_code == 0 
+        assert result.output == intf_errors_Ethernet48 
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1684,5 +1684,32 @@
     },
     "STP_TABLE|GLOBAL": {
         "max_stp_inst": "510"
+    },
+    "PORT_OPERR_TABLE|Ethernet72": {
+    },
+    "PORT_OPERR_TABLE|Ethernet64": {
+        "oper_error_status": "2",
+        "mac_remote_fault_count": "14483",
+        "mac_remote_fault_time": "2025-01-17 19:51:12",
+        "mac_local_fault_count": "26",
+        "mac_local_fault_time": "2025-01-17 18:40:56"
+    },
+    "PORT_OPERR_TABLE|Ethernet32": {
+        "oper_error_status": "0",
+        "mac_remote_fault_count": "0",
+        "mac_remote_fault_time": "",
+        "mac_local_fault_count": "5",
+        "mac_local_fault_time": "2025-01-16 12:05:34",
+        "fec_sync_loss_count": "3",
+        "fec_sync_loss_time": "2025-01-16 13:45:20",
+        "high_ber_error_count": "1",
+        "high_ber_error_time": "2025-01-16 14:30:10"
+    },
+    "PORT_OPERR_TABLE|Ethernet48": {
+        "oper_error_status": "0",
+        "mac_remote_fault_count": "0",
+        "mac_remote_fault_time": "",
+        "mac_local_fault_count": "0",
+        "mac_local_fault_time": ""
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This pull request introduces a new subcommand to the show interfaces command, allowing users to view error statistics for network interfaces. The new errors subcommand displays a table of potential interface errors, including error types, counts, and the last timestamp (in UTC) when the error occurred. If an error has not been encountered, the count defaults to 0, and the timestamp is displayed as Never. This change helps users easily identify any issues with their network interfaces and track error occurrences.

#### How I did it

To implement the errors subcommand, added a new command handler to the show/interfaces/__init__.py file. The handler retrieves the error data for a specified interface from the PORT_OPERR_TABLE in the database. The error types are predefined in a list, and for each type, the count and timestamp are pulled from the table.  The results are then formatted into a table using the tabulate library, sorted alphabetically by error type.

#### How to verify it
UT and running the changes on a testbed

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

```

admin@sonic$ show int errors Ethernet76
Port Errors                     Count  Last timestamp(UTC)
----------------------------  -------  ---------------------
code group error                    0  Never
crc rate                            0  Never
data unit crc error                 0  Never
data unit misalignment error        0  Never
data unit size                      0  Never
fec alignment loss                  0  Never
fec sync loss                       0  Never
high ber error                      0  Never
high ser error                      0  Never
mac local fault                     0  Never
mac remote fault                 7908  2025-01-17 19:34:13
no rx reachability                  0  Never
oper error status                   0  Never
signal local error                  0  Never
```
