### PR TITLE
Fix call for spanning-tree commands in dump script

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2209,10 +2209,10 @@ main() {
     wait
 
  	save_cmd "stpctl all" "stp.log"
-    save_cmd "show spanning_tree" "stp.show"
-    save_cmd "show spanning_tree statistics" "stp.stats"
-    save_cmd "show spanning_tree bpdu_guard" "stp.bg"
-    save_cmd "show spanning_tree root_guard" "stp.rg"
+    save_cmd "show spanning-tree" "stp.show"
+    save_cmd "show spanning-tree statistics" "stp.stats"
+    save_cmd "show spanning-tree bpdu_guard" "stp.bg"
+    save_cmd "show spanning-tree root_guard" "stp.rg"
 
     save_cmd "ps aux" "ps.aux" &
     save_cmd "top -b -n 1" "top" &


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix the calls for spanning-tree commands in dump script.
During call to generate techsupport, we can see that the spanning tree commands fail:
```
.
Error: No such command "spanning_tree".
timeout --foreground 5m bash -c "dummy_cleanup_method ()
.
```
#### How I did it
Change from show spanning_tree to the actual command show spanning-tree
#### How to verify it
Call show techsupport

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

