### PR TITLE
Fix show interface counters for Chassis Packet Supervisor

### DIFF
--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -133,7 +133,7 @@ class Portstat(object):
         self.cnstat_dict = OrderedDict()
         self.cnstat_dict['time'] = datetime.datetime.now()
         self.ratestat_dict = OrderedDict()
-        if device_info.is_supervisor():
+        if device_info.is_supervisor() and not device_info.is_packet_chassis():
             if device_info.is_voq_chassis() or (self.namespace is None and self.display_option != 'all'):
                 self.collect_stat_from_lc()
         else:


### PR DESCRIPTION
Signed-off-by: Anand Mehra anamehra@cisco.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
On Chassis-packet supervisor, show interface counter -d all returns no data

#### How I did it
Fixed the condition in portstat.py to use right path for Chassis Packet RP to collect counters.

#### How to verify it
Run 'show interface counters -d all' on Chassis-Packet Supervisor

#### Previous command output (if the output of a command-line utility has changed)

```
root@aaa14-rp:/home/cisco# show interface counters  -d all 

Reminder: Please execute 'show interface counters -d all' to include internal links
```
#### New command output (if the output of a command-line utility has changed)
```
root@aaa14-rp:/home/cisco# show int co  -d all 
          IFACE    STATE        RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR        TX_OK        TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
---------------  -------  -----------  ------------  ---------  --------  --------  --------  -----------  ------------  ---------  --------  --------  --------
   Ethernet-BP0                     0      0.00 B/s      0.00%         0         0         0            0      0.00 B/s      0.00%         0         0         0
.
.
.
Ethernet-BP4592                     0      0.00 B/s      0.00%         0         0         0            0      0.00 B/s      0.00%         0         0         0
Ethernet-BP4596                     0      0.00 B/s      0.00%         0         0         0            0      0.00 B/s      0.00%         0         0         0

Reminder: Please execute 'show interface counters -d all' to include internal links

root@aaa14-rp:/home/cisco# show interfaces counters -n asic0 -d all
         IFACE    STATE        RX_OK        RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR        TX_OK        TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
--------------  -------  -----------  ------------  ---------  --------  --------  --------  -----------  ------------  ---------  --------  --------  --------
  Ethernet-BP0                     0      0.00 B/s      0.00%         0         0         0            0      0.00 B/s      0.00%         0         0         0
  Ethernet-BP4                     0      0.00 B/s      0.00%         0         0         0            0      0.00 B/s      0.00%         0         0         0
  Ethernet-BP8                     0      0.00 B/s      0.00%         0         0         0            0      0.00 B/s      0.00%         0         0         0
.
.
.
Ethernet-BP244           106,613,381  1511.24 KB/s      0.01%         0       950         0  141,593,632  1255.56 KB/s      0.01%         0         0         0

Reminder: Please execute 'show interface counters -d all' to include internal links

```
