### PR TITLE
Fixing 'show ip bgp neighbor <ip>' in frr unified config mode

### DIFF
--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -228,7 +228,7 @@
     "VLAN_MEMBER|Vlan1000|PortChannel1002": {
         "tagging_mode": "tagged"
     },
-    "BGP_NEIGHBOR|10.0.0.1": {
+    "BGP_NEIGHBOR|default|10.0.0.1": {
         "rrclient": "0",
         "name": "ARISTA01T2",
         "local_addr": "10.0.0.0",
@@ -238,7 +238,7 @@
         "asn": "65200",
         "keepalive": "3"
     },
-    "BGP_NEIGHBOR|fc00::2": {
+    "BGP_NEIGHBOR|default|fc00::2": {
         "rrclient": "0",
         "name": "ARISTA01T2",
         "local_addr": "fc00::1",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1277,7 +1277,7 @@
             "bank": "1",
             "link": "Ethernet12"
         },
-    "BGP_NEIGHBOR|10.0.0.1": {
+    "BGP_NEIGHBOR|default|10.0.0.1": {
         "asn": "65200",
         "holdtime": "10",
         "keepalive": "3",
@@ -1457,7 +1457,7 @@
         "nhopself": "0",
         "rrclient": "0"
     },
-    "BGP_NEIGHBOR|10.0.0.57": {
+    "BGP_NEIGHBOR|default|10.0.0.57": {
         "asn": "64013",
         "holdtime": "10",
         "keepalive": "3",
@@ -1682,7 +1682,7 @@
         "nhopself": "0",
         "rrclient": "0"
     },
-    "BGP_NEIGHBOR|fc00::72": {
+    "BGP_NEIGHBOR|default|fc00::72": {
         "asn": "64013",
         "holdtime": "10",
         "keepalive": "3",

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -149,8 +149,18 @@ def get_bgp_neighbor_ip_to_name(ip, static_neighbors, dynamic_neighbors):
     :param dynamic_neighbors: subnet of dynamically defined neighbors dict
     :return: name of neighbor
     """
+    # Direct IP match
     if ip in static_neighbors:
         return static_neighbors[ip]
+    # Try to find the key where IP is the second element of any tuple key.
+    # This is to handle the case where the key is a tuple like (vrfname, IP)
+    # when unified routing config mode is enabled
+    elif matching_key := next(
+        (key for key in static_neighbors.keys()
+         if isinstance(key, tuple) and len(key) == 2 and key[1] == ip),
+        None
+    ):
+        return static_neighbors[matching_key]
     elif is_ipv4_address(ip):
         for subnet in dynamic_neighbors[constants.IPV4]:
             if ipaddress.IPv4Address(ip) in ipaddress.IPv4Network(subnet):


### PR DESCRIPTION
Fixing `show ip bgp neighbor neighbor_ip` command in frr unified config mode.

fixes #3736 
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Currently this Cli fails for a valid neighbor in frr unified config mode, even when `show ip bgp neighbors` shows this neighbor correctly.
```
rtr1(bash)$ show ip bgp neighbor 10.1.0.2
Usage: show ip bgp neighbor [OPTIONS] [IPADDRESS] [[routes|advertised-
                            routes|received-routes]]
Try "show ip bgp neighbor -h" for help.

Error:  Bgp neighbor 10.1.0.2 not configured
```

The reason for this is that while trying to make sure neighbor exists in config_db, the code looks at BGP_NEIGHBOR table with key as neighbor_ip, whereas in frr unified config mode, the key is `vrfname|neighbor_ip`. I'm fixing this behavior.

A nice side effect of this fix is that neighbor name now shows up in `show ip bgp summary` output, which was previously missing when frr unified config mode was enabled.

#### How I did it

This PR fixes this issue by making sure if neighbor_ip is not present in the BGP_NEIGHBOR table, then it also checks for the entry using `*|neighbor_ip` as the key.
The modified config_db.json mock table forced me to fix another issue in `show ip bgp summary` where neighbor name was not being shown in unified config mgmt mode. I couldn't segregate that fix as otherwise the unit tests won't pass.

#### How to verify it

- Verified manually that the changes work both with and without frr unified config mode.
- Also verified in unit test by modifying the mocked config_db. The `tests/mock_tables` has mocked config_db json files, and I modified one v4 and one v6 neighbor (for both single and multi asic case) to have the key as `default|ip`. This makes sure that unit tests work in both the cases, when neighbor is present with `neighbor_ip` as the key, as well as when it is present with `vrfname|neighbor_ip` as the key.
- The `show_bgp_neighbor_test.py` testcases fail without my change (with the new modified mock_tables/config_db.json) and pass with them.

#### Previous command output (if the output of a command-line utility has changed)
```
rtr1(bash)$ show ip bgp neighbor 10.1.0.2
Usage: show ip bgp neighbor [OPTIONS] [IPADDRESS] [[routes|advertised-
                            routes|received-routes]]
Try "show ip bgp neighbor -h" for help.

Error:  Bgp neighbor 10.1.0.2 not configured

rtr1(bash)$ show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 10.0.0.1, local AS number 65100 vrf-id 0
BGP table version 5
RIB entries 5, using 640 bytes of memory
Peers 1, using 20592 KiB of memory
Peer groups 1, using 64 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.1.0.2       4  65001       7168       7167         5      0       0  4d23h24m                2

Total number of neighbors 1
```

#### New command output (if the output of a command-line utility has changed)
```
rtr1(bash)$ show ip bgp neighbors 10.1.0.2

BGP neighbor is 10.1.0.2, remote AS 65001, local AS 65100, external link
  Local Role: undefined
  Remote Role: undefined
 Description: rtr2
Hostname: sonic
 Member of peer-group peer4 for session parameters
  BGP version 4, remote router ID 10.0.0.3, local router ID 10.0.0.1
  BGP state = Established, up for 18:09:16
  Last read 00:00:16, Last write 00:00:16
  Hold time is 180 seconds, keepalive interval is 60 seconds
  Configured hold time is 180 seconds, keepalive interval is 60 seconds
  Configured tcp-mss is 0, synced tcp-mss is 1496
  Configured conditional advertisements interval is 60 seconds
...
...

rtr1(bash)$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.0.0.1, local AS number 65100 vrf-id 0
BGP table version 5
RIB entries 5, using 640 bytes of memory
Peers 1, using 20592 KiB of memory
Peer groups 1, using 64 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.1.0.2       4  65001       7204       7203         5      0       0  5d00h00m                2  rtr2

Total number of neighbors 1
```
