### PR TITLE
Make 'show ip bgp summary' work even when we don't have any peer groups

### DIFF
--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -483,8 +483,7 @@ class TestBgpCommandsSingleAsic(object):
         assert result.output == show_error_no_v6_neighbor_single_asic
 
     @pytest.mark.parametrize('setup_single_bgp_instance',
-                            ['v4'],
-                            indirect=['setup_single_bgp_instance'])
+                             ['v4'], indirect=['setup_single_bgp_instance'])
     def test_bgp_summary_raw_missing_peergroup_count(
             self,
             setup_bgp_commands,
@@ -506,23 +505,23 @@ class TestBgpCommandsSingleAsic(object):
                 "peerMemory": 2048,
                 "ribCount": 10,
                 "ribMemory": 1024,
-                "peers":{
-                    "10.0.0.33":{
-                        "remoteAs":64001,
-                        "version":4,
-                        "msgRcvd":0,
-                        "msgSent":0,
-                        "tableVersion":0,
-                        "outq":0,
-                        "inq":0,
-                        "peerUptime":"never",
-                        "peerUptimeMsec":0,
-                        "prefixReceivedCount":0,
-                        "pfxRcd":0,
-                        "state":"Active",
-                        "connectionsEstablished":0,
-                        "connectionsDropped":0,
-                        "idType":"ipv4"
+                "peers": {
+                    "10.0.0.33": {
+                        "remoteAs": 64001,
+                        "version": 4,
+                        "msgRcvd": 0,
+                        "msgSent": 0,
+                        "tableVersion": 0,
+                        "outq": 0,
+                        "inq": 0,
+                        "peerUptime": "never",
+                        "peerUptimeMsec": 0,
+                        "prefixReceivedCount": 0,
+                        "pfxRcd": 0,
+                        "state": "Active",
+                        "connectionsEstablished": 0,
+                        "connectionsDropped": 0,
+                        "idType": "ipv4"
                     }
                 }
             }
@@ -536,8 +535,7 @@ class TestBgpCommandsSingleAsic(object):
             assert "Peer groups 0, using 0 bytes of memory" in result.output
 
     @pytest.mark.parametrize('setup_single_bgp_instance',
-                        ['v6'],
-                        indirect=['setup_single_bgp_instance'])
+                             ['v6'], indirect=['setup_single_bgp_instance'])
     def test_bgp_summary_raw_missing_peergroup_count_v6(
             self,
             setup_bgp_commands,
@@ -559,23 +557,23 @@ class TestBgpCommandsSingleAsic(object):
                 "peerMemory": 2048,
                 "ribCount": 10,
                 "ribMemory": 1024,
-                "peers":{
-                    "fc00::42":{
-                        "remoteAs":64001,
-                        "version":4,
-                        "msgRcvd":0,
-                        "msgSent":0,
-                        "tableVersion":0,
-                        "outq":0,
-                        "inq":0,
-                        "peerUptime":"never",
-                        "peerUptimeMsec":0,
-                        "prefixReceivedCount":0,
-                        "pfxRcd":0,
-                        "state":"Active",
-                        "connectionsEstablished":0,
-                        "connectionsDropped":0,
-                        "idType":"ipv6"
+                "peers": {
+                    "fc00::42": {
+                        "remoteAs": 64001,
+                        "version": 4,
+                        "msgRcvd": 0,
+                        "msgSent": 0,
+                        "tableVersion": 0,
+                        "outq": 0,
+                        "inq": 0,
+                        "peerUptime": "never",
+                        "peerUptimeMsec": 0,
+                        "prefixReceivedCount": 0,
+                        "pfxRcd": 0,
+                        "state": "Active",
+                        "connectionsEstablished": 0,
+                        "connectionsDropped": 0,
+                        "idType": "ipv6"
                     }
                 }
             }

--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -480,6 +481,112 @@ class TestBgpCommandsSingleAsic(object):
         print("{}".format(result.output))
         assert result.exit_code == 0
         assert result.output == show_error_no_v6_neighbor_single_asic
+
+    @pytest.mark.parametrize('setup_single_bgp_instance',
+                            ['v4'],
+                            indirect=['setup_single_bgp_instance'])
+    def test_bgp_summary_raw_missing_peergroup_count(
+            self,
+            setup_bgp_commands,
+            setup_single_bgp_instance):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        # mock vtysh cli output that does not have peergroup count
+        mock_json = {
+            "ipv4Unicast": {
+                "routerId": "10.1.0.32",
+                "as": 65100,
+                "localAS": 65100,
+                "vrfId": 0,
+                "tableVersion": 1,
+                "totalPeers": 0,
+                "dynamicPeers": 0,
+                "bestPaths": 0,
+                "peerCount": 2,
+                "peerMemory": 2048,
+                "ribCount": 10,
+                "ribMemory": 1024,
+                "peers":{
+                    "10.0.0.33":{
+                        "remoteAs":64001,
+                        "version":4,
+                        "msgRcvd":0,
+                        "msgSent":0,
+                        "tableVersion":0,
+                        "outq":0,
+                        "inq":0,
+                        "peerUptime":"never",
+                        "peerUptimeMsec":0,
+                        "prefixReceivedCount":0,
+                        "pfxRcd":0,
+                        "state":"Active",
+                        "connectionsEstablished":0,
+                        "connectionsDropped":0,
+                        "idType":"ipv4"
+                    }
+                }
+            }
+        }
+
+        with patch('utilities_common.bgp_util.run_bgp_command', return_value=json.dumps(mock_json)):
+            result = runner.invoke(
+                show.cli.commands["ip"].commands["bgp"].commands["summary"], [])
+            # verify that the CLI handles missing peergroup count gracefully
+            assert result.exit_code == 0
+            assert "Peer groups 0, using 0 bytes of memory" in result.output
+
+    @pytest.mark.parametrize('setup_single_bgp_instance',
+                        ['v6'],
+                        indirect=['setup_single_bgp_instance'])
+    def test_bgp_summary_raw_missing_peergroup_count_v6(
+            self,
+            setup_bgp_commands,
+            setup_single_bgp_instance):
+        show = setup_bgp_commands
+        runner = CliRunner()
+        # mock vtysh cli output that does not have peergroup count
+        mock_json = {
+            "ipv6Unicast": {
+                "routerId": "10.1.0.32",
+                "as": 65100,
+                "localAS": 65100,
+                "vrfId": 0,
+                "tableVersion": 1,
+                "totalPeers": 0,
+                "dynamicPeers": 0,
+                "bestPaths": 0,
+                "peerCount": 2,
+                "peerMemory": 2048,
+                "ribCount": 10,
+                "ribMemory": 1024,
+                "peers":{
+                    "fc00::42":{
+                        "remoteAs":64001,
+                        "version":4,
+                        "msgRcvd":0,
+                        "msgSent":0,
+                        "tableVersion":0,
+                        "outq":0,
+                        "inq":0,
+                        "peerUptime":"never",
+                        "peerUptimeMsec":0,
+                        "prefixReceivedCount":0,
+                        "pfxRcd":0,
+                        "state":"Active",
+                        "connectionsEstablished":0,
+                        "connectionsDropped":0,
+                        "idType":"ipv6"
+                    }
+                }
+            }
+        }
+
+        with patch('utilities_common.bgp_util.run_bgp_command', return_value=json.dumps(mock_json)):
+            result = runner.invoke(
+                show.cli.commands["ipv6"].commands["bgp"].commands["summary"], [])
+            # verify that the CLI handles missing peergroup count gracefully
+            assert result.exit_code == 0
+            assert "Peer groups 0, using 0 bytes of memory" in result.output
 
     @classmethod
     def teardown_class(cls):

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -357,10 +357,13 @@ def process_bgp_summary_json(bgp_summary, cmd_output, device, has_bgp_neighbors=
                 'ribCount', 0) + cmd_output['ribCount']
             bgp_summary['ribMemory'] = bgp_summary.get(
                 'ribMemory', 0) + cmd_output['ribMemory']
+            # Handle the case when we have peers but no peer-groups are configured.
+            # We still want to display peer information without just showing
+            # Error: peerGroupCount missing in the bgp_summary
             bgp_summary['peerGroupCount'] = bgp_summary.get(
-                'peerGroupCount', 0) + cmd_output['peerGroupCount']
+                'peerGroupCount', 0) + cmd_output.get('peerGroupCount', 0)
             bgp_summary['peerGroupMemory'] = bgp_summary.get(
-                'peerGroupMemory', 0) + cmd_output['peerGroupMemory']
+                'peerGroupMemory', 0) + cmd_output.get('peerGroupMemory', 0)
         else:
             # when there are no bgp neighbors, all values are zero
             bgp_summary['peerCount'] = bgp_summary.get(


### PR DESCRIPTION
Fix `show ip bgp summary` output when no peer groups are configured

fixes #3737 
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Currently when we don't have any peer groups configured, `show ip bgp summary` fails
```
sonic(bash)$ show ip bgp summary
Usage: show ip bgp summary [OPTIONS]
Try "show ip bgp summary -h" for help.

Error: peerGroupCount missing in the bgp_summary
```
vtysh gives more meaningful output in this case:

```
sonic(bash)$ vtysh

Hello, this is FRRouting (version 10.0.1).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

2025/01/27 20:21:52 [YDG3W-JND95] FD Limit set: 1048576 is stupidly large.  Is this what you intended?  Consider using
 --limit-fds also limiting size to 100000
sonic# show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 10.0.0.3, local AS number 65001 VRF default vrf-id 0
BGP table version 48
RIB entries 3, using 384 bytes of memory
Peers 1, using 20 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
rtr1(10.1.0.1)  4      65100     14459     14624       48    0    0 3d18h59m            0        2 rtr1

Total number of neighbors 1
```

Changing `show ip bgp summary` to give such meaningful output in this case as well.

#### How I did it
Avoid getting `KeyError` while accessing `cmd_output['peerGroupCount']` by using `cmd_output.get('peerGroupCount', 0)`. 

#### How to verify it
1. Manually verified it on a SONiC dut.

2. The unit tests fail without my changes and pass with them.

Please note that I'm printing 0 peer groups (`Peer groups 0, using 0 bytes of memory`) instead of removing the entire line, just in case some existing user scripts always expect this line to be present in the output.

#### Previous command output (if the output of a command-line utility has changed)
```
sonic(bash)$ show ip bgp summary
Usage: show ip bgp summary [OPTIONS]
Try "show ip bgp summary -h" for help.

Error: peerGroupCount missing in the bgp_summary
```

#### New command output (if the output of a command-line utility has changed)
```
sonic(bash)$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.0.0.3, local AS number 65001 vrf-id 0
BGP table version 48
RIB entries 3, using 384 bytes of memory
Peers 1, using 20592 KiB of memory
Peer groups 0, using 0 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.1.0.1       4  65100      14691      14856        48      0       0  3d22h51m                0

Total number of neighbors 1
sonic(bash)$
```
