### PR TITLE
Fix ssdhealth failure on multi-asic VS platform

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -114,7 +114,9 @@ def ssdhealth(device, verbose, vendor):
         #         }
         #     }
         # }
-        device = platform_data.get("chassis", {}).get("disk", {}).get("device", None)
+        if platform_data:
+            device = platform_data.get("chassis", {}).get("disk", {}).get("device", None)
+
         if not device:
             # Fallback to discovery
             device = os.popen("lsblk -o NAME,TYPE -p | grep disk").readline().strip().split()[0]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

show platform ssdhealth is failing on multi asic vs platform

```
E sys.exit(cli())
E ^^^^^
E File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in call
E return self.main(*args, **kwargs)
E ^^^^^^^^^^^^^^^^^^^^^^^^^^
E File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
E rv = self.invoke(ctx)
E ^^^^^^^^^^^^^^^^
E File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
E return _process_result(sub_ctx.command.invoke(sub_ctx))
E ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
E return _process_result(sub_ctx.command.invoke(sub_ctx))
E ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
E return ctx.invoke(self.callback, **ctx.params)
E ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
E return callback(*args, **kwargs)
E ^^^^^^^^^^^^^^^^^^^^^^^^^
E File "/usr/local/lib/python3.11/dist-packages/show/platform.py", line 117, in ssdhealth
E device = platform_data.get("chassis", {}).get("disk", {}).get("device", None)
E ^^^^^^^^^^^^^^^^^
E AttributeError: 'NoneType' object has no attribute 'get'
```

