### PR TITLE
Fixed "ERR python3:- validateNamespace: Initialize global DB config" for sfpshow

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -15,6 +15,7 @@ from typing import Dict
 import click
 from natsort import natsorted
 from sonic_py_common import multi_asic
+from utilities_common.general import load_db_config
 from utilities_common.sfp_helper import covert_application_advertisement_to_output_string
 from utilities_common.sfp_helper import (
         QSFP_DATA_MAP,
@@ -647,6 +648,7 @@ def cli():
 @click.option('-n', '--namespace', default=None, help="Display interfaces for specific namespace")
 def eeprom(port, dump_dom, namespace):
     if port and multi_asic.is_multi_asic() and namespace is None:
+        load_db_config()
         try:
             namespace = multi_asic.get_namespace_for_port(port)
         except Exception:
@@ -664,6 +666,7 @@ def eeprom(port, dump_dom, namespace):
 @click.option('-n', '--namespace', default=None, help="Display interfaces for specific namespace")
 def info(port, namespace):
     if port and multi_asic.is_multi_asic() and namespace is None:
+        load_db_config()
         try:
             namespace = multi_asic.get_namespace_for_port(port)
         except Exception:
@@ -682,6 +685,7 @@ def info(port, namespace):
 @click.option('-n', '--namespace', default=None, help="Display interfaces for specific namespace")
 def presence(port, namespace):
     if port and multi_asic.is_multi_asic() and namespace is None:
+        load_db_config()
         try:
             namespace = multi_asic.get_namespace_for_port(port)
         except Exception:
@@ -700,6 +704,7 @@ def presence(port, namespace):
 @click.option('-n', '--namespace', default=None, help="Display interfaces for specific namespace")
 def pm(port, namespace):
     if port and multi_asic.is_multi_asic() and namespace is None:
+        load_db_config()
         try:
             namespace = multi_asic.get_namespace_for_port(port)
         except Exception:
@@ -718,6 +723,7 @@ def pm(port, namespace):
 @click.option('-n', '--namespace', default=None, help="Display interfaces for specific namespace")
 def status(port, namespace):
     if port and multi_asic.is_multi_asic() and namespace is None:
+        load_db_config()
         try:
             namespace = multi_asic.get_namespace_for_port(port)
         except Exception:

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -1023,6 +1023,34 @@ class Test_multiAsic_SFP(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "2"
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
 
+    def test_sfp_presence_without_ns(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ['Ethernet0'])
+        expected = """Port       Presence
+---------  ----------
+Ethernet0  Present
+"""
+        assert result.exit_code == 0
+        assert result.output == expected
+
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ['Ethernet4'])
+        expected = """Port       Presence
+---------  -----------
+Ethernet4  Not present
+"""
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == expected
+
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ['Ethernet200'])
+        expected = """Port         Presence
+-----------  -----------
+Ethernet200  Not present
+"""
+        assert result.exit_code == 1
+        assert result.output == expected
+
     @patch.object(show_module.interfaces.click.Choice, 'convert', MagicMock(return_value='asic0'))
     def test_sfp_presence_with_ns(self):
         runner = CliRunner()
@@ -1067,10 +1095,30 @@ Ethernet200  Not present
         expected = "Ethernet200: SFP EEPROM Not detected"
         assert result_lines == expected
 
+    def test_sfp_eeprom_without_ns(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ['Ethernet0'])
+        assert result.exit_code == 0
+        assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_sfp_eeprom_output
+
+        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ['Ethernet4'])
+        result_lines = result.output.strip('\n')
+        expected = "Ethernet4: SFP EEPROM Not detected"
+        assert result_lines == expected
+
     @patch.object(show_module.interfaces.click.Choice, 'convert', MagicMock(return_value='asic0'))
     def test_qsfp_dd_pm_with_ns(self):
         runner = CliRunner()
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["pm"], ['Ethernet0', '-n', 'asic0'])
+        result_lines = result.output.strip('\n')
+        expected = "Ethernet0: Transceiver performance monitoring not applicable"
+        assert result_lines == expected
+
+    def test_qsfp_dd_pm_without_ns(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["pm"], ['Ethernet0'])
         result_lines = result.output.strip('\n')
         expected = "Ethernet0: Transceiver performance monitoring not applicable"
         assert result_lines == expected
@@ -1083,10 +1131,25 @@ Ethernet200  Not present
         expected = "Ethernet0: Transceiver status info not applicable"
         assert result_lines == expected
 
+    def test_qsfp_dd_status_without_ns(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["status"], ['Ethernet0'])
+        result_lines = result.output.strip('\n')
+        expected = "Ethernet0: Transceiver status info not applicable"
+        assert result_lines == expected
+
     @patch.object(show_module.interfaces.click.Choice, 'convert', MagicMock(return_value='asic1'))
     def test_cmis_sfp_info_with_ns(self):
         runner = CliRunner()
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["info"], ['Ethernet64', '-n', 'asic1'])
+        assert result.exit_code == 0
+        assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_cmis_eeprom_output
+
+    def test_cmis_sfp_info_without_ns(self):
+        runner = CliRunner()
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["info"], ['Ethernet64'])
         assert result.exit_code == 0
         assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_cmis_eeprom_output
 

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -1034,7 +1034,8 @@ Ethernet0  Present
         assert result.exit_code == 0
         assert result.output == expected
 
-        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ['Ethernet4'])
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ['Ethernet4'])
         expected = """Port       Presence
 ---------  -----------
 Ethernet4  Not present
@@ -1043,7 +1044,8 @@ Ethernet4  Not present
         assert result.exit_code == 0
         assert result.output == expected
 
-        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ['Ethernet200'])
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["presence"], ['Ethernet200'])
         expected = """Port         Presence
 -----------  -----------
 Ethernet200  Not present
@@ -1100,9 +1102,10 @@ Ethernet200  Not present
         result = runner.invoke(
                 show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ['Ethernet0'])
         assert result.exit_code == 0
-        assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_sfp_eeprom_output
+        assert "\n".join([line.rstrip() for line in result.output.split('\n')]) == test_sfp_eeprom_output
 
-        result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ['Ethernet4'])
+        result = runner.invoke(
+                show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ['Ethernet4'])
         result_lines = result.output.strip('\n')
         expected = "Ethernet4: SFP EEPROM Not detected"
         assert result_lines == expected
@@ -1151,7 +1154,7 @@ Ethernet200  Not present
         result = runner.invoke(
                 show.cli.commands["interfaces"].commands["transceiver"].commands["info"], ['Ethernet64'])
         assert result.exit_code == 0
-        assert "\n".join([ l.rstrip() for l in result.output.split('\n')]) == test_cmis_eeprom_output
+        assert "\n".join([line.rstrip() for line in result.output.split('\n')]) == test_cmis_eeprom_output
 
     def test_sfp_eeprom_all(self):
         runner = CliRunner()


### PR DESCRIPTION
Signed-off-by: Anand Mehra anamehra@cisco.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed the "ERR python3: [ :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig]"
error when running 'show interfaces transceiver <>' commands.
e.g. show interfaces transceiver info Ethernet0

#### How I did it
Call load_db_config before multi-asic method calls.
Refacored the code to create a common function to be used inside multiple showsfc CLI commands.

#### How to verify it
Ruin commands like 'show interfaces transceiver info Ethernet0' on multi-asic system and check syslogs.
It should not generate the ERR logs as mentioned above.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

