### PR TITLE
[show][config] Add CLI support for configurable drop monitor feature

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -7526,6 +7526,11 @@ def dropcounters():
 @click.option("-a", "--alias", type=str, help="Alias for this counter")
 @click.option("-g", "--group", type=str, help="Group for this counter")
 @click.option("-d", "--desc",  type=str, help="Description for this counter")
+@click.option("-w", "--window", type=int, help="Window size in seconds")
+@click.option("-dct", "--drop-count-threshold",  type=int,
+              help="Minimum threshold for drop counts to be classified as an incident")
+@click.option('-ict', '--incident-count-threshold', type=int,
+              help="Minimum number of incidents to trigger a syslog entry")
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--namespace',
               '-n',
@@ -7535,7 +7540,8 @@ def dropcounters():
               show_default=True,
               help='Namespace name or all',
               callback=multi_asic_util.multi_asic_namespace_validation_callback)
-def install(counter_name, alias, group, counter_type, desc, reasons, verbose, namespace):
+def install(counter_name, alias, group, counter_type, desc, reasons, window,
+            incident_count_threshold, drop_count_threshold, verbose, namespace):
     """Install a new drop counter"""
     command = ['dropconfig', '-c', 'install', '-n', str(counter_name), '-t', str(counter_type), '-r', str(reasons)]
     if alias:
@@ -7546,7 +7552,73 @@ def install(counter_name, alias, group, counter_type, desc, reasons, verbose, na
         command += ['-d', str(desc)]
     if namespace:
         command += ['-ns', str(namespace)]
+    if window:
+        command += ['-w', str(window)]
+    if drop_count_threshold:
+        command += ['-dct', str(drop_count_threshold)]
+    if incident_count_threshold:
+        command += ['-ict', str(incident_count_threshold)]
 
+    clicommon.run_command(command, display_cmd=verbose)
+
+
+#
+# 'enable drop monitor' subcommand  ('config dropcounters enable_monitor')
+#
+@dropcounters.command()
+@click.option("-c", "--counter-name", type=str, help="Name of the counter", default=None)
+@click.option("-w", "--window", type=int, help="Window size in seconds")
+@click.option("-dct", "--drop-count-threshold",  type=int,
+              help="Minimum threshold for drop counts to be classified as an incident")
+@click.option('-ict', '--incident-count-threshold', type=int,
+              help="Minimum number of incidents to trigger a syslog entry")
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def enable_monitor(counter_name, window, incident_count_threshold, drop_count_threshold, verbose, namespace):
+    """Enable drop monitor feature. If no counter is provided, global feature status is set to enabled."""
+    command = ['dropconfig', '-c', 'enable_drop_monitor']
+    if counter_name:
+        command += ['-n', str(counter_name)]
+    if window:
+        command += ['-w', str(window)]
+    if drop_count_threshold:
+        command += ['-dct', str(drop_count_threshold)]
+    if incident_count_threshold:
+        command += ['-ict', str(incident_count_threshold)]
+    if namespace:
+        command += ['-ns', str(namespace)]
+
+    clicommon.run_command(command, display_cmd=verbose)
+
+
+#
+# 'disable drop monitor' subcommand  ('config dropcounters disable_monitor')
+#
+@dropcounters.command()
+@click.option("-c", "--counter-name", type=str, help="Name of the counter", default=None)
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def disable_monitor(counter_name, verbose, namespace):
+    """Disable drop monitor feature. If no counter is provided, gloabl feature status is set to disabled."""
+    command = ['dropconfig', '-c', 'disable_drop_monitor']
+    if counter_name:
+        command += ['-n', str(counter_name)]
+    if namespace:
+        command += ['-ns', str(namespace)]
     clicommon.run_command(command, display_cmd=verbose)
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -7530,7 +7530,7 @@ def dropcounters():
 @click.option("-dct", "--drop-count-threshold",  type=int,
               help="Minimum threshold for drop counts to be classified as an incident")
 @click.option('-ict', '--incident-count-threshold', type=int,
-              help="Minimum number of incidents to trigger a syslog entry")
+              help="Minimum number of incidents to trigger a persistent drop alert")
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--namespace',
               '-n',
@@ -7571,7 +7571,7 @@ def install(counter_name, alias, group, counter_type, desc, reasons, window,
 @click.option("-dct", "--drop-count-threshold",  type=int,
               help="Minimum threshold for drop counts to be classified as an incident")
 @click.option('-ict', '--incident-count-threshold', type=int,
-              help="Minimum number of incidents to trigger a syslog entry")
+              help="Minimum number of incidents to trigger a persistent drop alert")
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--namespace',
               '-n',
@@ -7613,7 +7613,7 @@ def enable_monitor(counter_name, window, incident_count_threshold, drop_count_th
               help='Namespace name or all',
               callback=multi_asic_util.multi_asic_namespace_validation_callback)
 def disable_monitor(counter_name, verbose, namespace):
-    """Disable drop monitor feature. If no counter is provided, gloabl feature status is set to disabled."""
+    """Disable drop monitor feature. If no counter is provided, global feature status is set to disabled."""
     command = ['dropconfig', '-c', 'disable_drop_monitor']
     if counter_name:
         command += ['-n', str(counter_name)]

--- a/scripts/dropconfig
+++ b/scripts/dropconfig
@@ -149,12 +149,12 @@ class DropConfig(object):
                 timestamp = datetime.utcfromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S')
                 print(f"{timestamp}: {message}")
 
-    def start_drop_monitor(self):
+    def start_global_drop_monitor(self):
         self.config_db.set_entry(DEBUG_DROP_MONITOR_TABLE,
                                  'CONFIG',
                                  {'status': 'enabled'})
 
-    def stop_drop_monitor(self):
+    def stop_global_drop_monitor(self):
         self.config_db.set_entry(DEBUG_DROP_MONITOR_TABLE,
                                  'CONFIG',
                                  {'status': 'disabled'})
@@ -165,11 +165,17 @@ class DropConfig(object):
             If no counter name is provided, we toggle the global feature status.
         """
         if not counter_name:
-            self.start_drop_monitor()
+            self.start_global_drop_monitor()
             print("Drop counter monitor is globally enabled.")
             return
         if not self.counter_name_in_use(counter_name):
             raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
+
+        # Check if drop monitor is globally enabled
+        global_drop_monitor_status = self.config_db.get_entry(DEBUG_DROP_MONITOR_TABLE, 'CONFIG')['status']
+        if global_drop_monitor_status == 'disabled':
+            print(f"Warning: Cannot enable monitoring for {counter_name}. The Global Persistent Drop Counter Monitor is currently disabled. Please enable global monitoring first.")
+            return
 
         drop_monitor_config = self.config_db.get_entry(DEBUG_COUNTER_CONFIG_TABLE,
                                                       counter_name)
@@ -194,23 +200,31 @@ class DropConfig(object):
                 raise InvalidArgumentError('Invalid drop count threshold. Drop count threshold should be non-negative, received: {}'.format(dct))
             drop_monitor_config['drop_count_threshold'] = str(dct)
 
-        # Start the drop monitor feature
-        self.start_drop_monitor()
-
         drop_monitor_config['drop_monitor_status'] = 'enabled'
         self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
                                  counter_name,
                                  drop_monitor_config)
-        print("Drop counter monitor is enabled for counter {}".format(counter_name))
+        print("Drop counter monitor is enabled for counter {}. The monitor is configured with:".format(counter_name))
+        print("window: {}".format(window))
+        print("drop_count_threshold: {}".format(dct))
+        print("incident_count_threshold: {}".format(ict))
 
     def disable_drop_monitor(self, counter_name):
         """
             The function to disable Debug Drop Monitor feature.
-            If no counter name is provided, we toggle the global feature status.
+            If no counter name is provided, we disable the global monitor control status.
+            If the Global Monitor Control is set to disabled, the monitoring status of each individual drop counter will also be set to disabled.
         """
         if not counter_name:
-            self.stop_drop_monitor()
+            # Disable global drop monitor feature
+            self.stop_global_drop_monitor()
             print("Drop counter monitor is globally disabled.")
+
+            # Disable drop monitor on all configured drop counters
+            drop_counter_list = self.config_db.get_keys(DEBUG_COUNTER_CONFIG_TABLE)
+            for counter_name in drop_counter_list:
+                self.disable_drop_monitor(counter_name)
+
             return
         if not self.counter_name_in_use(counter_name):
             raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
@@ -218,7 +232,7 @@ class DropConfig(object):
         drop_counter_entry = self.config_db.get_entry(DEBUG_COUNTER_CONFIG_TABLE,
                                                       counter_name)
 
-        if drop_counter_entry['drop_monitor_status'] == 'disabled':
+        if drop_counter_entry.get('drop_monitor_status', '') == 'disabled':
             print(f'Drop monitor is already disabled for {counter_name}')
             return
 
@@ -281,7 +295,6 @@ class DropConfig(object):
         if description or description == '':
             drop_counter_entry['desc'] = description
         if install_drop_monitor:
-            drop_counter_entry['drop_monitor_status'] = 'enabled'
             drop_counter_entry['window'] = str(window)
             drop_counter_entry['incident_count_threshold'] = str(ict)
             drop_counter_entry['drop_count_threshold'] = str(dct)

--- a/scripts/dropconfig
+++ b/scripts/dropconfig
@@ -13,6 +13,8 @@
 import argparse
 import os
 import sys
+import ast
+from datetime import datetime
 from utilities_common import constants
 from sonic_py_common import multi_asic
 from utilities_common import multi_asic as multi_asic_util
@@ -40,6 +42,8 @@ from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 # CONFIG_DB Tables
 DEBUG_COUNTER_CONFIG_TABLE = 'DEBUG_COUNTER'
 DROP_REASON_CONFIG_TABLE = 'DEBUG_COUNTER_DROP_REASON'
+DEBUG_DROP_MONITOR_TABLE = 'DEBUG_DROP_MONITOR'
+PERSISTENT_DROP_ALERTS_TABLE = 'PERSISTENT_DROP_ALERTS'
 
 # STATE_DB Tables
 DEBUG_COUNTER_CAPABILITY_TABLE = 'DEBUG_COUNTER_CAPABILITIES'
@@ -50,7 +54,11 @@ drop_counter_config_header = ['Counter',
                               'Group',
                               'Type',
                               'Reasons',
-                              'Description']
+                              'Description',
+                              'Drop Monitor',
+                              'Window',
+                              'Drop Count Threshold',
+                              'Incident Count Threshold']
 drop_counter_capability_header = ['Counter Type', 'Total']
 
 
@@ -63,6 +71,7 @@ class DropConfig(object):
         self.db = db
         self.config_db = config_db
         self.namespace = namespace
+        self.monitored_persistent_drops = []
 
     # -c show_config
     def print_counter_config(self, group):
@@ -78,7 +87,11 @@ class DropConfig(object):
                           counter.get('group', ''),
                           counter.get('type', ''),
                           counter.get('reason', ''),
-                          counter.get('description', '')))
+                          counter.get('description', ''),
+                          counter.get('drop_monitor_status', ''),
+                          counter.get('window', ''),
+                          counter.get('drop_count_threshold', ''),
+                          counter.get('incident_count_threshold', '')))
 
         if multi_asic.is_multi_asic():
             print("For namespace:", self.namespace)
@@ -118,8 +131,111 @@ class DropConfig(object):
                 for reason in supported_reasons:
                     print('        {}'.format(reason))
 
+    def print_drop_monitor_persistent_drops(self, counter_name):
+        """
+           Prints out the persistent drops recorded for drop counters
+        """
+        if not counter_name:
+            raise InvalidArgumentError('Counter name not provided')
+        if not self.counter_name_in_use(counter_name):
+            raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
+
+        print(f"The persistent drops recorded on {counter_name} are:")
+        data = self.db.get_all(self.db.COUNTERS_DB, PERSISTENT_DROP_ALERTS_TABLE)
+        for key, value in data.items():
+            counter, timestamp = key.split('|')
+            if (counter == counter_name):
+                timestamp = datetime.utcfromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S')
+                message = ast.literal_eval(value)['message']
+                print(f"{timestamp}: {message}")
+
+    def start_drop_monitor(self):
+        self.config_db.set_entry(DEBUG_DROP_MONITOR_TABLE,
+                                 'CONFIG',
+                                 {'status': 'enabled'})
+
+    def stop_drop_monitor(self):
+        self.config_db.set_entry(DEBUG_DROP_MONITOR_TABLE,
+                                 'CONFIG',
+                                 {'status': 'disabled'})
+
+    def enable_drop_monitor(self, counter_name, window, ict, dct):
+        """
+            The function to enable and configure Debug Drop Monitor feature.
+            If no counter name is provided, we toggle the global feature status.
+        """
+        if not counter_name:
+            start_drop_monitor()
+            print("Drop monitor feature is turned on for all counters")
+            return
+        if not self.counter_name_in_use(counter_name):
+            raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
+
+        drop_monitor_config = self.config_db.get_entry(DEBUG_COUNTER_CONFIG_TABLE,
+                                                      counter_name)
+
+        if not window and 'window' not in drop_monitor_config.keys():
+            raise InvalidArgumentError('Window is not provided, neither is it pre-configured')
+        if not ict and 'incident_count_threshold' not in drop_monitor_config.keys():
+            raise InvalidArgumentError('Incident count threshold is not provided, neither is it pre-configured')
+        if not dct and 'drop_count_threshold' not in drop_monitor_config.keys():
+            raise InvalidArgumentError('Drop count threshold is not provided, neither is it pre-configured')
+
+        if window:
+            if window <= 0:
+                raise InvalidArgumentError('Invalid window size. Window size should be positive, received: {}'.format(window))
+            drop_monitor_config['window'] = str(window)
+        if ict:
+            if ict < 0:
+                raise InvalidArgumentError('Invalid incident count threshold. Incident count threshold should be non-negative, received: {}'.format(ict))
+            drop_monitor_config['incident_count_threshold'] = str(ict)
+        if dct:
+            if dct < 0:
+                raise InvalidArgumentError('Invalid drop count threshold. Drop count threshold should be non-negative, received: {}'.format(dct))
+            drop_monitor_config['drop_count_threshold'] = str(dct)
+
+        # Start the drop monitor feature
+        self.start_drop_monitor()
+
+        # Update monitored_persistent_drops
+        self.monitored_persistent_drops.append(counter_name)
+
+        drop_monitor_config['drop_monitor_status'] = 'enabled'
+        self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
+                                 counter_name,
+                                 drop_monitor_config)
+
+    def disable_drop_monitor(self, counter_name):
+        """
+            The function to disable Debug Drop Monitor feature.
+            If no counter name is provided, we toggle the global feature status.
+        """
+        if not counter_name:
+            stop_drop_monitor()
+            print("Drop monitor feature is turned off for all counters")
+            return
+        if not self.counter_name_in_use(counter_name):
+            raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
+
+        drop_counter_entry = self.config_db.get_entry(DEBUG_COUNTER_CONFIG_TABLE,
+                                                      counter_name)
+
+        if drop_counter_entry['drop_monitor_status'] == 'disabled':
+            print(f'Drop monitor is already disabled for {counter_name}')
+            return
+
+        # Update monitored_persistent_drops
+        self.monitored_persistent_drops.remove(counter_name)
+        if len(self.monitored_persistent_drops) == 0:
+            self.stop_drop_monitor()
+
+        drop_counter_entry['drop_monitor_status'] = 'disabled'
+        self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
+                                 counter_name,
+                                 drop_counter_entry)
+
     def create_counter(self, counter_name, alias, group, counter_type,
-                       description, reasons):
+                       description, reasons, window, ict, dct):
         """
             Creates a new counter configuration
         """
@@ -132,6 +248,15 @@ class DropConfig(object):
 
         if not reasons:
             raise InvalidArgumentError('No drop reasons provided')
+
+        install_drop_monitor = False
+        if None in [window, dct, ict]:
+            if any(param is not None for param in [window, dct, ict]):
+                raise InvalidArgumentError('If a drop monitor is to be installed, \
+                    all three arguments (window, drop_count_threshold and \
+                    incident_count threshold) must be provided')
+        else:
+            install_drop_monitor = True
 
         if self.counter_name_in_use(counter_name):
             raise InvalidArgumentError('Counter name \'{}\' already in use'.format(counter_name))
@@ -152,6 +277,7 @@ class DropConfig(object):
             self.config_db.set_entry(DROP_REASON_CONFIG_TABLE, (counter_name, reason), {})
 
         drop_counter_entry = {'type': counter_type}
+        drop_counter_entry['drop_monitor_status'] = 'disabled'
 
         if alias:
             drop_counter_entry['alias'] = alias
@@ -159,6 +285,11 @@ class DropConfig(object):
             drop_counter_entry['group'] = group
         if description or description == '':
             drop_counter_entry['desc'] = description
+        if install_drop_monitor:
+            drop_counter_entry['drop_monitor_status'] = 'enabled'
+            drop_counter_entry['window'] = str(window)
+            drop_counter_entry['incident_count_threshold'] = str(ict)
+            drop_counter_entry['drop_count_threshold'] = str(dct)
 
         self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
                                  counter_name,
@@ -184,6 +315,11 @@ class DropConfig(object):
         # through and treat each drop reason as an entry to get the correct behavior.
         for reason in self.get_counter_drop_reasons(counter_name):
             self.config_db.set_entry(DROP_REASON_CONFIG_TABLE, reason, None)
+
+        # Delete the counter from monitored_persistent_drops list
+        self.monitored_persistent_drops.remove(counter_name)
+        if len(self.monitored_persistent_drops) == 0:
+            self.stop_drop_monitor()
 
     def add_reasons(self, counter_name, reasons):
         """
@@ -240,7 +376,11 @@ class DropConfig(object):
                 'alias':       counter_attributes.get('alias', counter_name),
                 'group':       counter_attributes.get('group', 'N/A'),
                 'type':        counter_attributes.get('type', 'N/A'),
-                'description': counter_attributes.get('desc', 'N/A')
+                'description': counter_attributes.get('desc', 'N/A'),
+                'drop_monitor_status': counter_attributes.get('drop_monitor_status', 'N/A'),
+                'window': counter_attributes.get('window', 'N/A'),
+                'drop_count_threshold': counter_attributes.get('drop_count_threshold', 'N/A'),
+                'incident_count_threshold': counter_attributes.get('incident_count_threshold', 'N/A'),
             }
 
             # Get the drop reasons for this counter
@@ -343,7 +483,10 @@ class DropConfigWrapper(object):
             group,
             counter_type,
             description,
-            reasons):
+            reasons,
+            window,
+            incident_count_threshold,
+            drop_count_threshold):
 
         dconfig = DropConfig(self.multi_asic.current_namespace, self.db, self.config_db)
 
@@ -354,7 +497,10 @@ class DropConfigWrapper(object):
                                        group,
                                        counter_type,
                                        description,
-                                       reasons)
+                                       reasons,
+                                       window,
+                                       incident_count_threshold,
+                                       drop_count_threshold)
             except InvalidArgumentError as err:
                 print('Encountered error trying to install counter: {}'.format(err.message))
                 sys.exit(1)
@@ -376,6 +522,23 @@ class DropConfigWrapper(object):
             except InvalidArgumentError as err:
                 print('Encountered error trying to remove reasons: {}'.format(err.message))
                 sys.exit(1)
+        elif command == 'enable_drop_monitor':
+            try:
+                dconfig.enable_drop_monitor(name,
+                                        window,
+                                        incident_count_threshold,
+                                        drop_count_threshold)
+            except InvalidArgumentError as err:
+                print('Encountered error trying to enable drop monitor: {}'.format(err.message))
+                sys.exit(1)
+        elif command == 'disable_drop_monitor':
+            try:
+                dconfig.disable_drop_monitor(name)
+            except InvalidArgumentError as err:
+                print('Encountered error trying to disable drop monitor: {}'.format(err.message))
+                sys.exit(1)
+        elif command == 'show_drop_monitor_persistent_drops':
+            dconfig.print_drop_monitor_persistent_drops(name)
         elif command == 'show_config':
             dconfig.print_counter_config(group)
         elif command == 'show_capabilities':
@@ -422,6 +585,9 @@ Examples:
     parser.add_argument('-t', '--type',    type=str, help='The type of the target drop counter',                   default=None)
     parser.add_argument('-d', '--desc',    type=str, help='The description for the target drop counter',           default=None)
     parser.add_argument('-r', '--reasons', type=str, help='The list of drop reasons for the target drop counter',  default=None)
+    parser.add_argument('-w', '--window', type=int, help='The window for drop counter monitor in seconds',  default=None)
+    parser.add_argument('-dct', '--drop-count-threshold', type=int, help='The minimum drops needed to classify a drop as an incident by the drop count monitor',  default=None)
+    parser.add_argument('-ict', '--incident-count-threshold', type=int, help='The minimum number of incidents needed to register a syslog by drop count monitor',  default=None)
     parser.add_argument('-ns', '--namespace', type=str, help='Perform operation on a specific namespace or skip for all',  default=None)
 
     args = parser.parse_args()
@@ -436,6 +602,12 @@ Examples:
     drop_reasons = args.reasons
     namespace = args.namespace
 
+    # These arguments are used to control the Drop Counter Monitor feature
+    # This is an optional feature and more details on its usage can be found at: https://github.com/sonic-net/SONiC/blob/master/doc/drop_counters/drop_counters_HLD.md
+    window = args.window
+    drop_count_threshold = args.drop_count_threshold
+    incident_count_threshold = args.incident_count_threshold
+
     reasons = deserialize_reason_list(drop_reasons)
 
     dropconfig_wrapper = DropConfigWrapper(namespace)
@@ -445,8 +617,10 @@ Examples:
                            group,
                            counter_type,
                            description,
-                           reasons)
-
+                           reasons,
+                           window,
+                           incident_count_threshold,
+                           drop_count_threshold)
 
 if __name__ == '__main__':
     main()

--- a/scripts/dropconfig
+++ b/scripts/dropconfig
@@ -13,7 +13,6 @@
 import argparse
 import os
 import sys
-import ast
 from datetime import datetime
 from utilities_common import constants
 from sonic_py_common import multi_asic
@@ -61,7 +60,6 @@ drop_counter_config_header = ['Counter',
                               'Incident Count Threshold']
 drop_counter_capability_header = ['Counter Type', 'Total']
 
-
 class InvalidArgumentError(RuntimeError):
     def __init__(self, msg):
         self.message = msg
@@ -71,7 +69,6 @@ class DropConfig(object):
         self.db = db
         self.config_db = config_db
         self.namespace = namespace
-        self.monitored_persistent_drops = []
 
     # -c show_config
     def print_counter_config(self, group):
@@ -140,13 +137,16 @@ class DropConfig(object):
         if not self.counter_name_in_use(counter_name):
             raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
 
-        print(f"The persistent drops recorded on {counter_name} are:")
         data = self.db.get_all(self.db.COUNTERS_DB, PERSISTENT_DROP_ALERTS_TABLE)
-        for key, value in data.items():
+        if data is None:
+            print("No persistent drop alerts have been recorded")
+            return
+
+        print(f"The persistent drops recorded on {counter_name} are:")
+        for key, message in data.items():
             counter, timestamp = key.split('|')
             if (counter == counter_name):
                 timestamp = datetime.utcfromtimestamp(int(timestamp)).strftime('%Y-%m-%d %H:%M:%S')
-                message = ast.literal_eval(value)['message']
                 print(f"{timestamp}: {message}")
 
     def start_drop_monitor(self):
@@ -165,7 +165,7 @@ class DropConfig(object):
             If no counter name is provided, we toggle the global feature status.
         """
         if not counter_name:
-            start_drop_monitor()
+            self.start_drop_monitor()
             print("Drop counter monitor is globally enabled.")
             return
         if not self.counter_name_in_use(counter_name):
@@ -197,9 +197,6 @@ class DropConfig(object):
         # Start the drop monitor feature
         self.start_drop_monitor()
 
-        # Update monitored_persistent_drops
-        self.monitored_persistent_drops.append(counter_name)
-
         drop_monitor_config['drop_monitor_status'] = 'enabled'
         self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
                                  counter_name,
@@ -212,7 +209,7 @@ class DropConfig(object):
             If no counter name is provided, we toggle the global feature status.
         """
         if not counter_name:
-            stop_drop_monitor()
+            self.stop_drop_monitor()
             print("Drop counter monitor is globally disabled.")
             return
         if not self.counter_name_in_use(counter_name):
@@ -224,11 +221,6 @@ class DropConfig(object):
         if drop_counter_entry['drop_monitor_status'] == 'disabled':
             print(f'Drop monitor is already disabled for {counter_name}')
             return
-
-        # Update monitored_persistent_drops
-        self.monitored_persistent_drops.remove(counter_name)
-        if len(self.monitored_persistent_drops) == 0:
-            self.stop_drop_monitor()
 
         drop_counter_entry['drop_monitor_status'] = 'disabled'
         self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
@@ -254,9 +246,10 @@ class DropConfig(object):
         install_drop_monitor = False
         if None in [window, dct, ict]:
             if any(param is not None for param in [window, dct, ict]):
-                raise InvalidArgumentError('If a drop monitor is to be installed, \
-                    all three arguments (window, drop_count_threshold and \
-                    incident_count threshold) must be provided')
+                message = ("If a drop monitor is to be installed, "
+                           "all three arguments (window, drop_count_threshold and "
+                           "incident_count threshold) must be provided")
+                raise InvalidArgumentError(message)
         else:
             install_drop_monitor = True
 
@@ -317,11 +310,6 @@ class DropConfig(object):
         # through and treat each drop reason as an entry to get the correct behavior.
         for reason in self.get_counter_drop_reasons(counter_name):
             self.config_db.set_entry(DROP_REASON_CONFIG_TABLE, reason, None)
-
-        # Delete the counter from monitored_persistent_drops list
-        self.monitored_persistent_drops.remove(counter_name)
-        if len(self.monitored_persistent_drops) == 0:
-            self.stop_drop_monitor()
 
     def add_reasons(self, counter_name, reasons):
         """

--- a/scripts/dropconfig
+++ b/scripts/dropconfig
@@ -166,7 +166,7 @@ class DropConfig(object):
         """
         if not counter_name:
             start_drop_monitor()
-            print("Drop monitor feature is turned on for all counters")
+            print("Drop counter monitor is globally enabled.")
             return
         if not self.counter_name_in_use(counter_name):
             raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
@@ -204,6 +204,7 @@ class DropConfig(object):
         self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
                                  counter_name,
                                  drop_monitor_config)
+        print("Drop counter monitor is enabled for counter {}".format(counter_name))
 
     def disable_drop_monitor(self, counter_name):
         """
@@ -212,7 +213,7 @@ class DropConfig(object):
         """
         if not counter_name:
             stop_drop_monitor()
-            print("Drop monitor feature is turned off for all counters")
+            print("Drop counter monitor is globally disabled.")
             return
         if not self.counter_name_in_use(counter_name):
             raise InvalidArgumentError('Counter \'{}\' not found'.format(counter_name))
@@ -233,6 +234,7 @@ class DropConfig(object):
         self.config_db.set_entry(DEBUG_COUNTER_CONFIG_TABLE,
                                  counter_name,
                                  drop_counter_entry)
+        print("Drop counter monitor is disabled for counter {}".format(counter_name))
 
     def create_counter(self, counter_name, alias, group, counter_type,
                        description, reasons, window, ict, dct):
@@ -587,7 +589,7 @@ Examples:
     parser.add_argument('-r', '--reasons', type=str, help='The list of drop reasons for the target drop counter',  default=None)
     parser.add_argument('-w', '--window', type=int, help='The window for drop counter monitor in seconds',  default=None)
     parser.add_argument('-dct', '--drop-count-threshold', type=int, help='The minimum drops needed to classify a drop as an incident by the drop count monitor',  default=None)
-    parser.add_argument('-ict', '--incident-count-threshold', type=int, help='The minimum number of incidents needed to register a syslog by drop count monitor',  default=None)
+    parser.add_argument('-ict', '--incident-count-threshold', type=int, help='The minimum number of incidents needed to trigger a persistent drop alert',  default=None)
     parser.add_argument('-ns', '--namespace', type=str, help='Perform operation on a specific namespace or skip for all',  default=None)
 
     args = parser.parse_args()

--- a/show/dropcounters.py
+++ b/show/dropcounters.py
@@ -17,9 +17,20 @@ def dropcounters():
 @dropcounters.command()
 @click.argument("counter_name", type=str, required=True)
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def persistent_drops(counter_name, verbose):
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def persistent_drops(counter_name, verbose, namespace):
     """Show device drop counter persistent drops"""
     cmd = ['dropconfig', '-c', 'show_drop_monitor_persistent_drops', '-n', str(counter_name)]
+
+    if namespace:
+        cmd += ['-ns', str(namespace)]
 
     clicommon.run_command(cmd, display_cmd=verbose)
 

--- a/show/dropcounters.py
+++ b/show/dropcounters.py
@@ -13,6 +13,16 @@ def dropcounters():
     pass
 
 
+# 'persistent_drops' subcommand ("show dropcounters persistent_drops counter_name")
+@dropcounters.command()
+@click.argument("counter_name", type=str, required=True)
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def persistent_drops(counter_name, verbose):
+    """Show device drop counter persistent drops"""
+    cmd = ['dropconfig', '-c', 'show_drop_monitor_persistent_drops', '-n', str(counter_name)]
+
+    clicommon.run_command(cmd, display_cmd=verbose)
+
 # 'configuration' subcommand ("show dropcounters configuration")
 @dropcounters.command()
 @click.option('-g', '--group', required=False)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -3352,15 +3352,24 @@ class TestConfigDropcounters(object):
         counter_type = 'PORT_INGRESS_DROPS'
         reasons = '[EXCEEDS_L2_MTU,DECAP_ERROR]'
         alias = 'BAD_DROPS'
+        dct = '10'  # Drop count threshold
         group = 'BAD'
         desc = 'more port ingress drops'
 
         runner = CliRunner()
-        result = runner.invoke(config.config.commands['dropcounters'].commands['install'], [counter_name, counter_type, reasons, '-d', desc, '-g', group, '-a', alias])
+        result = runner.invoke(config.config.commands['dropcounters'].commands['install'],
+                               [counter_name, counter_type, reasons, '-d', desc, '-g', group,
+                               '-a', alias, '-dct', dct])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'install', '-n', str(counter_name), '-t', str(counter_type), '-r', str(reasons), '-a', str(alias), '-g', str(group), '-d', str(desc)], display_cmd=False)
+        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'install',
+                                                  '-n', str(counter_name),
+                                                  '-t', str(counter_type),
+                                                  '-r', str(reasons), '-a', str(alias),
+                                                  '-g', str(group), '-d', str(desc),
+                                                  '-dct', str(dct)],
+                                                 display_cmd=False)
 
     @patch('utilities_common.cli.run_command')
     def test_delete(self, mock_run_command):
@@ -3377,11 +3386,41 @@ class TestConfigDropcounters(object):
         counter_name = 'DEBUG_2'
         reasons = '[EXCEEDS_L2_MTU,DECAP_ERROR]'
         runner = CliRunner()
-        result = runner.invoke(config.config.commands['dropcounters'].commands['add-reasons'], [counter_name, reasons, '-v'])
+        result = runner.invoke(config.config.commands['dropcounters'].commands['add-reasons'],
+                               [counter_name, reasons, '-v'])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'add', '-n', str(counter_name), '-r', str(reasons)], display_cmd=True)
+        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'add', '-n', str(counter_name),
+                                                  '-r', str(reasons)], display_cmd=True)
+
+    @patch('utilities_common.cli.run_command')
+    def test_enable_drop_monitor(self, mock_run_command):
+        counter_name = 'DEBUG_2'
+        dct = '10'  # Drop count threshold
+        ict = '2'  # Incident count threshold
+        window = '300'
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands['dropcounters'].commands['enable-monitor'],
+                               ['-c', counter_name, '-w', window, '-dct', dct, '-ict', ict, '-v'])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'enable_drop_monitor', '-n',
+                                                  str(counter_name), '-w', str(window), '-dct', str(dct),
+                                                  '-ict', str(ict)], display_cmd=True)
+
+    @patch('utilities_common.cli.run_command')
+    def test_disable_drop_monitor(self, mock_run_command):
+        counter_name = 'DEBUG_2'
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands['dropcounters'].commands['disable-monitor'],
+                               ['-c', counter_name, '-v'])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'disable_drop_monitor',
+                                                  '-n', str(counter_name)], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')
     def test_remove_reasons(self, mock_run_command):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -3352,14 +3352,18 @@ class TestConfigDropcounters(object):
         counter_type = 'PORT_INGRESS_DROPS'
         reasons = '[EXCEEDS_L2_MTU,DECAP_ERROR]'
         alias = 'BAD_DROPS'
-        dct = '10'  # Drop count threshold
         group = 'BAD'
         desc = 'more port ingress drops'
+
+        # Parameters for configurable drop monitor
+        dct = '10'  # Drop count threshold
+        ict = '2'  # Incident count threshold
+        window = '300'
 
         runner = CliRunner()
         result = runner.invoke(config.config.commands['dropcounters'].commands['install'],
                                [counter_name, counter_type, reasons, '-d', desc, '-g', group,
-                               '-a', alias, '-dct', dct])
+                               '-a', alias, '-w', window, '-dct', dct, '-ict', ict])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
@@ -3368,7 +3372,8 @@ class TestConfigDropcounters(object):
                                                   '-t', str(counter_type),
                                                   '-r', str(reasons), '-a', str(alias),
                                                   '-g', str(group), '-d', str(desc),
-                                                  '-dct', str(dct)],
+                                                  '-w', str(window), '-dct', str(dct),
+                                                  '-ict', str(ict)],
                                                  display_cmd=False)
 
     @patch('utilities_common.cli.run_command')
@@ -3393,34 +3398,6 @@ class TestConfigDropcounters(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['dropconfig', '-c', 'add', '-n', str(counter_name),
                                                   '-r', str(reasons)], display_cmd=True)
-
-    @patch('utilities_common.cli.run_command')
-    def test_enable_drop_monitor(self, mock_run_command):
-        counter_name = 'DEBUG_2'
-        dct = '10'  # Drop count threshold
-        ict = '2'  # Incident count threshold
-        window = '300'
-        runner = CliRunner()
-        result = runner.invoke(config.config.commands['dropcounters'].commands['enable-monitor'],
-                               ['-c', counter_name, '-w', window, '-dct', dct, '-ict', ict, '-v'])
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
-        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'enable_drop_monitor', '-n',
-                                                  str(counter_name), '-w', str(window), '-dct', str(dct),
-                                                  '-ict', str(ict)], display_cmd=True)
-
-    @patch('utilities_common.cli.run_command')
-    def test_disable_drop_monitor(self, mock_run_command):
-        counter_name = 'DEBUG_2'
-        runner = CliRunner()
-        result = runner.invoke(config.config.commands['dropcounters'].commands['disable-monitor'],
-                               ['-c', counter_name, '-v'])
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
-        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'disable_drop_monitor',
-                                                  '-n', str(counter_name)], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')
     def test_remove_reasons(self, mock_run_command):
@@ -3470,6 +3447,39 @@ class TestConfigDropcountersMasic(object):
         mock_run_command.assert_called_once_with(['dropconfig', '-c', 'install', '-n', str(counter_name),
                                                   '-t', str(counter_type), '-r', str(reasons), '-a', str(alias),
                                                   '-g', str(group), '-d', str(desc),
+                                                  '-ns', str(namespace)], display_cmd=False)
+
+    @patch('utilities_common.cli.run_command')
+    def test_enable_monitor_multi_asic(self, mock_run_command):
+        counter_name = 'DEBUG_2'
+        window = '300'
+        dct = '10'  # Drop count threshold
+        ict = '5'  # Incident count threshold
+        namespace = 'asic0'
+
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands['dropcounters'].commands['enable-monitor'],
+                               ['-c', counter_name, '-w', window, '-dct', dct, '-ict', ict,
+                               '-n', namespace])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'enable_drop_monitor', '-n', str(counter_name),
+                                                  '-w', str(window), '-dct', str(dct), '-ict', str(ict),
+                                                  '-ns', str(namespace)], display_cmd=False)
+
+    @patch('utilities_common.cli.run_command')
+    def test_disable_monitor_multi_asic(self, mock_run_command):
+        counter_name = 'DEBUG_2'
+        namespace = 'asic0'
+
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands['dropcounters'].commands['disable-monitor'],
+                               ['-c', counter_name, '-n', namespace])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(['dropconfig', '-c', 'disable_drop_monitor', '-n', str(counter_name),
                                                   '-ns', str(namespace)], display_cmd=False)
 
     @patch('utilities_common.cli.run_command')

--- a/tests/dropconfig_test.py
+++ b/tests/dropconfig_test.py
@@ -94,7 +94,6 @@ class TestDropConfig(object):
             dropconfig.main()
         except SystemExit as e:
             assert e.code == 0
-        mock_print.assert_called_once_with('Drop counter monitor is globally enabled.')
 
     @patch('builtins.print')
     @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor', '-n', 'DEBUG_0'])
@@ -103,7 +102,6 @@ class TestDropConfig(object):
             dropconfig.main()
         except SystemExit as e:
             assert e.code == 0
-        mock_print.assert_called_once_with('Drop counter monitor is enabled for counter DEBUG_0')
 
     @patch('builtins.print')
     @patch('sys.argv', ['dropconfig', '-c', 'disable_drop_monitor'])
@@ -112,7 +110,6 @@ class TestDropConfig(object):
             dropconfig.main()
         except SystemExit as e:
             assert e.code == 0
-        mock_print.assert_called_once_with('Drop counter monitor is globally disabled.')
 
     @patch('builtins.print')
     @patch('sys.argv', ['dropconfig', '-c', 'disable_drop_monitor', '-n', 'DEBUG_0'])
@@ -121,7 +118,6 @@ class TestDropConfig(object):
             dropconfig.main()
         except SystemExit as e:
             assert e.code == 0
-        mock_print.assert_called_once_with('Drop counter monitor is disabled for counter DEBUG_0')
 
     @patch('builtins.print')
     @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor', '-n', 'INVALID'])
@@ -175,4 +171,3 @@ class TestDropConfig(object):
 
     def teardown(self):
         print('TEARDOWN')
-

--- a/tests/dropconfig_test.py
+++ b/tests/dropconfig_test.py
@@ -23,6 +23,31 @@ class TestDropConfig(object):
         assert e.value.code == 1
 
     @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'install',
+                        '-n', 'DEBUG_2', '-t', 'PORT_INGRESS_DROPS',
+                        '-r', '[EXCEEDS_L2_MTU]', '-w', '300'])
+    def test_install_insufficient_arg_error(self, mock_print):
+        with pytest.raises(SystemExit) as e:
+            dropconfig.main()
+        err_msg = ("Encountered error trying to install counter: "
+                   "If a drop monitor is to be installed, "
+                   "all three arguments (window, drop_count_threshold and "
+                   "incident_count threshold) must be provided")
+        mock_print.assert_called_once_with(err_msg)
+        assert e.value.code == 1
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'install',
+                        '-n', 'DEBUG_10', '-t', 'PORT_INGRESS_DROPS',
+                        '-r', '[IP_HEADER_ERROR]', '-w', '300',
+                        '-ict', '2', '-dct', '10'])
+    def test_install_debug_monitor(self, mock_print):
+        try:
+            dropconfig.main()
+        except SystemExit as e:
+            assert e.code == 0
+
+    @patch('builtins.print')
     @patch('sys.argv', ['dropconfig', '-c', 'uninstall'])
     def test_delete_error(self, mock_print):
         with pytest.raises(SystemExit) as e:
@@ -44,6 +69,108 @@ class TestDropConfig(object):
         with pytest.raises(SystemExit) as e:
             dropconfig.main()
         mock_print.assert_called_once_with('Encountered error trying to remove reasons: No counter name provided')
+        assert e.value.code == 1
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor'])
+    def test_enable_monitor(self, mock_print):
+        try:
+            dropconfig.main()
+        except SystemExit as e:
+            assert e.code == 0
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'disable_drop_monitor'])
+    def test_disable_monitor(self, mock_print):
+        try:
+            dropconfig.main()
+        except SystemExit as e:
+            assert e.code == 0
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor'])
+    def test_enable_global_monitor(self, mock_print):
+        try:
+            dropconfig.main()
+        except SystemExit as e:
+            assert e.code == 0
+        mock_print.assert_called_once_with('Drop counter monitor is globally enabled.')
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor', '-n', 'DEBUG_0'])
+    def test_enable_specific_monitor(self, mock_print):
+        try:
+            dropconfig.main()
+        except SystemExit as e:
+            assert e.code == 0
+        mock_print.assert_called_once_with('Drop counter monitor is enabled for counter DEBUG_0')
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'disable_drop_monitor'])
+    def test_disable_global_monitor(self, mock_print):
+        try:
+            dropconfig.main()
+        except SystemExit as e:
+            assert e.code == 0
+        mock_print.assert_called_once_with('Drop counter monitor is globally disabled.')
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'disable_drop_monitor', '-n', 'DEBUG_0'])
+    def test_disable_specific_monitor(self, mock_print):
+        try:
+            dropconfig.main()
+        except SystemExit as e:
+            assert e.code == 0
+        mock_print.assert_called_once_with('Drop counter monitor is disabled for counter DEBUG_0')
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor', '-n', 'INVALID'])
+    def test_invalid_counter_enable_monitor_error(self, mock_print):
+        with pytest.raises(SystemExit) as e:
+            dropconfig.main()
+        error_message = ("Encountered error trying to enable drop monitor: "
+                         "Counter 'INVALID' not found")
+        mock_print.assert_called_once_with(error_message)
+        assert e.value.code == 1
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'disable_drop_monitor', '-n', 'INVALID'])
+    def test_invalid_counter_disable_monitor_error(self, mock_print):
+        with pytest.raises(SystemExit) as e:
+            dropconfig.main()
+        error_message = ("Encountered error trying to disable drop monitor: "
+                         "Counter 'INVALID' not found")
+        mock_print.assert_called_once_with(error_message)
+        assert e.value.code == 1
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor', '-n', 'DEBUG_0', '-w', '-1'])
+    def test_invalid_window_enable_monitor_error(self, mock_print):
+        with pytest.raises(SystemExit) as e:
+            dropconfig.main()
+        err_msg = ("Encountered error trying to enable drop monitor: Invalid window size. "
+                   "Window size should be positive, received: -1")
+        mock_print.assert_called_once_with(err_msg)
+        assert e.value.code == 1
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor', '-n', 'DEBUG_0', '-ict', '-1'])
+    def test_invalid_ict_enable_monitor_error(self, mock_print):
+        with pytest.raises(SystemExit) as e:
+            dropconfig.main()
+        err_msg = ("Encountered error trying to enable drop monitor: Invalid incident count threshold. "
+                   "Incident count threshold should be non-negative, received: -1")
+        mock_print.assert_called_once_with(err_msg)
+        assert e.value.code == 1
+
+    @patch('builtins.print')
+    @patch('sys.argv', ['dropconfig', '-c', 'enable_drop_monitor', '-n', 'DEBUG_0', '-dct', '-1'])
+    def test_invalid_dct_enable_monitor_error(self, mock_print):
+        with pytest.raises(SystemExit) as e:
+            dropconfig.main()
+        err_msg = ("Encountered error trying to enable drop monitor: Invalid drop count threshold. "
+                   "Drop count threshold should be non-negative, received: -1")
+        mock_print.assert_called_once_with(err_msg)
         assert e.value.code == 1
 
     def teardown(self):

--- a/tests/drops_group_test.py
+++ b/tests/drops_group_test.py
@@ -32,18 +32,36 @@ SWITCH_EGRESS_DROPS
 """
 
 expected_counter_configuration = """\
-Counter            Alias              Group         Type                 Reasons    Description
------------------  -----------------  ------------  -------------------  ---------  --------------------------------------------------
-DEBUG_0            DEBUG_0            N/A           PORT_INGRESS_DROPS   None       N/A
-DEBUG_1            SWITCH_DROPS       PACKET_DROPS  SWITCH_EGRESS_DROPS  None       Outgoing packet drops, tracked at the switch level
-DEBUG_2            DEBUG_2            N/A           PORT_INGRESS_DROPS   None
-lowercase_counter  lowercase_counter  N/A           SWITCH_EGRESS_DROPS  None       N/A
+Counter            Alias              Group         Type                 \
+Reasons    Description                                         Drop Monitor    \
+Window    Drop Count Threshold    Incident Count Threshold
+-----------------  -----------------  ------------  -------------------  \
+---------  --------------------------------------------------  --------------  \
+--------  ----------------------  --------------------------
+DEBUG_0            DEBUG_0            N/A           PORT_INGRESS_DROPS   None       \
+N/A                                                 enabled         300       \
+5                       2
+DEBUG_1            SWITCH_DROPS       PACKET_DROPS  SWITCH_EGRESS_DROPS  None       \
+Outgoing packet drops, tracked at the switch level  N/A             N/A       \
+N/A                     N/A
+DEBUG_2            DEBUG_2            N/A           PORT_INGRESS_DROPS   \
+None                                                           N/A             \
+N/A       N/A                     N/A
+lowercase_counter  lowercase_counter  N/A           SWITCH_EGRESS_DROPS  None       \
+N/A                                                 N/A             N/A       \
+N/A                     N/A
 """
 
 expected_counter_configuration_with_group = """\
-Counter    Alias         Group         Type                 Reasons    Description
----------  ------------  ------------  -------------------  ---------  --------------------------------------------------
-DEBUG_1    SWITCH_DROPS  PACKET_DROPS  SWITCH_EGRESS_DROPS  None       Outgoing packet drops, tracked at the switch level
+Counter    Alias         Group         Type                 Reasons    \
+Description                                         Drop Monitor    \
+Window    Drop Count Threshold    Incident Count Threshold
+---------  ------------  ------------  -------------------  ---------  \
+--------------------------------------------------  --------------  \
+--------  ----------------------  --------------------------
+DEBUG_1    SWITCH_DROPS  PACKET_DROPS  SWITCH_EGRESS_DROPS  None       \
+Outgoing packet drops, tracked at the switch level  N/A             \
+N/A       N/A                     N/A
 """
 
 expected_counts = """\
@@ -97,6 +115,12 @@ Ethernet8      N/A         0           0         0           0          0       
           DEVICE    SWITCH_DROPS    lowercase_counter
 ----------------  --------------  -------------------
 sonic_drops_test               0                    0
+"""
+
+expected_drop_monitor_persistent_drops = """\
+The persistent drops recorded on DEBUG_0 are:
+2025-05-06 01:39:03: Persistent packet drops detected on Ethernet0
+2025-05-06 01:42:47: Persistent packet drops detected on Ethernet1
 """
 
 
@@ -163,6 +187,12 @@ class TestDropCounters(object):
         result = runner.invoke(show.cli.commands["dropcounters"].commands["counts"], [])
         print(result.output)
         assert result.output == expected_counts_with_clear
+
+    def test_show_drop_monitor_persistent_drops(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["dropcounters"].commands["persistent-drops"], ['DEBUG_0'])
+        print(result.output)
+        assert result.output == expected_drop_monitor_persistent_drops
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -347,7 +347,11 @@
         "size": "0"
     },
     "DEBUG_COUNTER|DEBUG_0": {
-        "type": "PORT_INGRESS_DROPS"
+        "type": "PORT_INGRESS_DROPS",
+        "drop_monitor_status": "enabled",
+        "window": "300",
+        "drop_count_threshold": "5",
+        "incident_count_threshold": "2"
     },
     "DEBUG_COUNTER|DEBUG_1": {
         "type": "SWITCH_EGRESS_DROPS",

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -346,6 +346,9 @@
         "pool": "ingress_lossless_pool_hbm",
         "size": "0"
     },
+    "DEBUG_DROP_MONITOR|CONFIG": {
+        "status": "enabled"
+    },
     "DEBUG_COUNTER|DEBUG_0": {
         "type": "PORT_INGRESS_DROPS",
         "drop_monitor_status": "enabled",

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -114,7 +114,7 @@
     },
     "DEBUG_COUNTER_CAPABILITIES|PORT_INGRESS_DROPS": {
         "reasons": "[IP_HEADER_ERROR,NO_L3_HEADER]",
-        "count": "4"
+        "count": "5"
     },
     "DEBUG_COUNTER_CAPABILITIES|SWITCH_EGRESS_DROPS": {
         "reasons": "[ACL_ANY,L2_ANY,L3_ANY]",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -827,7 +827,11 @@
         "ipv6_use_link_local_only": "enable"
     },
     "DEBUG_COUNTER|DEBUG_0": {
-        "type": "PORT_INGRESS_DROPS"
+        "type": "PORT_INGRESS_DROPS",
+        "drop_monitor_status": "enabled",
+        "window": "300",
+        "drop_count_threshold": "5",
+        "incident_count_threshold": "2"
     },
     "DEBUG_COUNTER|DEBUG_1": {
         "type": "SWITCH_EGRESS_DROPS",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -826,6 +826,9 @@
     "INTERFACE|Ethernet40": {
         "ipv6_use_link_local_only": "enable"
     },
+    "DEBUG_DROP_MONITOR|CONFIG": {
+        "status": "enabled"
+    },
     "DEBUG_COUNTER|DEBUG_0": {
         "type": "PORT_INGRESS_DROPS",
         "drop_monitor_status": "enabled",

--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -2873,5 +2873,13 @@
     "COUNTERS:oid:0x17000000002000":{
         "SAI_COUNTER_STAT_PACKETS": 200,
         "SAI_COUNTER_STAT_BYTES": 204800
+    },
+    "PERSISTENT_DROP_ALERTS":{
+        "DEBUG_0|1746495543": {
+            "message": "Persistent packet drops detected on Ethernet0"
+        },
+        "DEBUG_0|1746495767": {
+            "message": "Persistent packet drops detected on Ethernet1"
+        }
     }
 }

--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -2875,11 +2875,7 @@
         "SAI_COUNTER_STAT_BYTES": 204800
     },
     "PERSISTENT_DROP_ALERTS":{
-        "DEBUG_0|1746495543": {
-            "message": "Persistent packet drops detected on Ethernet0"
-        },
-        "DEBUG_0|1746495767": {
-            "message": "Persistent packet drops detected on Ethernet1"
-        }
+        "DEBUG_0|1746495543": "Persistent packet drops detected on Ethernet0",
+        "DEBUG_0|1746495767": "Persistent packet drops detected on Ethernet1"
     }
 }

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1061,7 +1061,7 @@
     },
     "DEBUG_COUNTER_CAPABILITIES|PORT_INGRESS_DROPS": {
         "reasons": "[IP_HEADER_ERROR,NO_L3_HEADER]",
-        "count": "4"
+        "count": "5"
     },
     "DEBUG_COUNTER_CAPABILITIES|SWITCH_EGRESS_DROPS": {
         "reasons": "[ACL_ANY,L2_ANY,L3_ANY]",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
This PR enables users to proactively monitor and identify persistent packet drops in their SONiC environment, improving network stability and troubleshooting capabilities.

Fixes https://github.com/sonic-net/sonic-utilities/issues/3757

#### What I did
*   Implements commands to configure persistent drop monitor thresholds.
*   Adds support for setting monitoring window size, drop count threshold, and incident count threshold.
*   Includes `show dropcounters persistent-drops` command to display persistent drop alerts.
*   Provides `config dropcounters enable-monitor/disbale-monitor` command to enable/disable the feature.
*   Adds unit tests to cover the new CLI functionality.

##### Key Features:

*   Configurable monitoring window: Users can specify the time window (in seconds) for detecting persistent drops.
*   Adjustable thresholds: Users can set the minimum number of drops required to trigger an incident and the minimum number of incidents to trigger a persistent drop alert.
*   Per dropcounter configuration: The drop monitor can be enabled/disabled per drop counter
*   Global feature toggle: The feature can be enabled/disabled globally.

#### How I did it
*   Modified the existing dropconfig script
*   Modified show and config scripts

#### How to verify it
*   Added unit tests to cover the new CLI functionality.
*   Manual testing performed on a SONiC device to verify configuration

#### Previous command output (if the output of a command-line utility has changed)
NA

#### New command output (if the output of a command-line utility has changed)

Snapshots from an Arista switch running SONiC.

> #### Per Drop Counter Configuration
```
root@up322:~# config dropcounters enable-monitor -c DEBUG_0 -w 120 -dct 5 -ict 2
Drop counter monitor is enabled for counter DEBUG_0
root@up322:~# show dropcounters configuration
Counter    Alias      Group    Type                Reasons         Description              Drop Monitor      Window    Drop Count Threshold    Incident Count Threshold
---------  ---------  -------  ------------------  --------------  -----------------------  --------------  --------  ----------------------  --------------------------
DEBUG_0    BAD_DROPS  BAD      PORT_INGRESS_DROPS  SIP_LINK_LOCAL  More port ingress drops  enabled              120                       5                           2
```

```
root@up322:~# config dropcounters disable-monitor -c DEBUG_0
Drop counter monitor is disabled for counter DEBUG_0
root@up322:~# show dropcounters configuration
Counter    Alias      Group    Type                Reasons         Description              Drop Monitor      Window    Drop Count Threshold    Incident Count Threshold
---------  ---------  -------  ------------------  --------------  -----------------------  --------------  --------  ----------------------  --------------------------
DEBUG_0    BAD_DROPS  BAD      PORT_INGRESS_DROPS  SIP_LINK_LOCAL  More port ingress drops  disabled             120                       5                           2

```
> #### Global configuration
```
root@up322:~# config dropcounters disable-monitor
Drop counter monitor is globally disabled.
```
```
root@up322:~# config dropcounters enable-monitor
Drop counter monitor is globally enabled.
```

> #### Show commands

```
root@up322:~# show dropcounters configuration
Counter    Alias      Group    Type                Reasons         Description              Drop Monitor      Window    Drop Count Threshold    Incident Count Threshold
---------  ---------  -------  ------------------  --------------  -----------------------  --------------  --------  ----------------------  --------------------------
DEBUG_0    BAD_DROPS  BAD      PORT_INGRESS_DROPS  SIP_LINK_LOCAL  More port ingress drops  enabled              300                       5                           1
```

```
root@up322:~# show dropcounters persistent-drops DEBUG_0
The persistent drops recorded on DEBUG_0 are:
2025-05-14 15:56:58: Persistent packet drops detected on Ethernet0
```

#### Documentation
Details are discussed in the HLD: https://github.com/sonic-net/SONiC/pull/1912