### PR TITLE
[202205] Backport: Add the pre_reboot_hook script execution, add the watchdog arm before the reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -179,7 +179,7 @@ function check_conflict_boot_in_fw_update()
 
 function parse_options()
 {
-    while getopts "h?v" opt; do
+    while getopts "h?vtf" opt; do
         case ${opt} in
             h|\? )
                 show_help_and_exit

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+declare -r EXIT_SUCCESS=0
+declare -r EXIT_ERROR=1
+declare -r WATCHDOG_UTIL="/usr/local/bin/watchdogutil"
+declare -r PRE_REBOOT_HOOK="pre_reboot_hook"
+
 DEVPATH="/usr/share/sonic/device"
 PLAT_REBOOT="platform_reboot"
 PLATFORM_UPDATE_REBOOT_CAUSE="platform_update_reboot_cause"
@@ -34,6 +40,8 @@ PLATFORM_FWUTIL_AU_REBOOT_HANDLE="platform_fw_au_reboot_handle"
 REBOOT_SCRIPT_NAME=$(basename $0)
 REBOOT_TYPE="${REBOOT_SCRIPT_NAME}"
 TAG_LATEST=no
+REBOOT_FLAGS=""
+FORCE_REBOOT="no"
 
 function debug()
 {
@@ -122,7 +130,7 @@ function show_help_and_exit()
     echo "    Available options:"
     echo "        -h, -? : getting this help"
 
-    exit 0
+    exit ${EXIT_SUCCESS}
 }
 
 function setup_reboot_variables()
@@ -165,7 +173,7 @@ function check_conflict_boot_in_fw_update()
     FW_AU_TASK_FILE=$(compgen -G ${FW_AU_TASK_FILE_REGEX}) || true
     if [[ -n "${FW_AU_TASK_FILE}" ]] && [[ ! -f "${FW_AU_TASK_FILE_EXP}" ]]; then
         VERBOSE=yes debug "Firmware auto update scheduled for a different reboot: ${FW_AU_TASK_FILE}"
-        exit 1
+        exit ${EXIT_ERROR}
     fi
 }
 
@@ -182,6 +190,10 @@ function parse_options()
             t )
                 TAG_LATEST=no
                 ;;
+            f )
+                REBOOT_FLAGS+=" -f"
+                FORCE_REBOOT="yes"
+                ;;
         esac
     done
 }
@@ -191,7 +203,7 @@ parse_options $@
 # Exit if not superuser
 if [[ "$EUID" -ne 0 ]]; then
     echo "This command must be run as root" >&2
-    exit 1
+    exit ${EXIT_ERROR}
 fi
 
 debug "User requested rebooting device ..."
@@ -241,6 +253,23 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_UPDATE_REBOOT_CAUSE} ]; then
     ${DEVPATH}/${PLATFORM}/${PLATFORM_UPDATE_REBOOT_CAUSE}
 fi
 
+if [ -x ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK} ]; then
+    debug "Executing the pre-reboot script"
+    ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK}
+    EXIT_CODE=$?
+    if [[ ${EXIT_CODE} != ${EXIT_SUCCESS} ]]; then
+        if [[ "${FORCE_REBOOT}" != "yes" ]]; then
+            echo "Reboot is interrupted: use -f (force) to override"
+            exit ${EXIT_ERROR}
+        fi
+    fi
+fi
+
+if [ -x ${WATCHDOG_UTIL} ]; then
+    debug "Enabling the Watchdog before reboot"
+    ${WATCHDOG_UTIL} arm
+fi
+
 if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
     VERBOSE=yes debug "Rebooting with platform ${PLATFORM} specific tool ..."
     ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} $@
@@ -259,4 +288,4 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then
 fi
 
 VERBOSE=yes debug "Issuing OS-level reboot ..." >&2
-exec /sbin/reboot $@
+exec /sbin/reboot ${REBOOT_FLAGS}


### PR DESCRIPTION
DEPENDS ON: https://github.com/sonic-net/sonic-buildimage/pull/21686

Backport commits https://github.com/sonic-net/sonic-utilities/pull/3492 and https://github.com/sonic-net/sonic-utilities/pull/3203.
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add back the support to call reboot -f.
The support for this option was accidentally removed as part of this PR #3203.
The same PR for 202311 doesn't have this mistake - #3204.
Add the pre_reboot_hook script execution, add the watchdog arm before the reboot, in order to support the graceful reboot instead of the sysfs power cycle, to avoid filesystem corruption.

#### How I did it
Add back option -f for reboot script.
Modify the scripts/reboot.

#### How to verify it
Call reboot -f.
Start watching logs by using show log -f and journalctl -p debug -f.
Execute the reboot command from the switch CLI.
Check in logs that all systemd services terminated correctly.

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202205

Because 202205 branch is missing this change.

#### Tested branch (Please provide the tested image version)
SONiC.202205_5_rc.7-3349088e1