### PR TITLE
[show_techsupport][pstore] Archive /var/lib/systemd/pstore info to techsupport (#3745)

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -860,6 +860,87 @@ save_proc() {
 }
 
 ###############################################################################
+# Given list of sys files, saves sys files to tar.
+# Globals:
+#  V
+#  TARDIR
+#  MKDIR
+#  CP
+#  DUMPDIR
+#  TAR
+#  RM
+#  BASE
+#  TARFILE
+#  NOOP
+# Arguments:
+#  *sysfiles: variable-length list of sys file paths to save
+# Returns:
+#  None
+###############################################################################
+save_sys() {
+    trap 'handle_error $? $LINENO' ERR
+    local sysfiles="$@"
+    local cp_cmd="sudo cp"
+    
+    $MKDIR $V -p $TARDIR/sys
+    for f in $sysfiles
+    do
+        if $NOOP; then
+            if [ -e $f ]; then
+                echo "$cp_cmd $V -r -p $f $TARDIR/sys"
+            fi
+        else
+            ( [ -e $f ] && $cp_cmd $V -r -p $f $TARDIR/sys ) || echo "$f not found" > $TARDIR/$f
+        fi
+    done
+
+    chmod ugo+rw -R $DUMPDIR/$BASE/sys
+}
+
+###############################################################################
+# Given list of pstore directories or files, saves subdirectories and files to tar.
+# Globals:
+#  V
+#  TARDIR
+#  MKDIR
+#  CP
+#  DUMPDIR
+#  TAR
+#  RM
+#  BASE
+#  TARFILE
+#  NOOP
+# Arguments:
+#  *pstorefiles: variable-length list of pstore file paths to save
+# Returns:
+#  None
+###############################################################################
+save_pstore() {
+    trap 'handle_error $? $LINENO' ERR
+    local pstorefiles="$@"
+    PSTORE_DIR_LIST_INFO_FILE="techsupport_pstore_dir_listing_info"
+    $MKDIR $V -p $TARDIR/pstore
+    
+    echo "==================================" > $TARDIR/pstore/$PSTORE_DIR_LIST_INFO_FILE
+    echo "/var/lib/systemd/pstore files info" >> $TARDIR/pstore/$PSTORE_DIR_LIST_INFO_FILE
+    echo "==================================" >> $TARDIR/pstore/$PSTORE_DIR_LIST_INFO_FILE
+    for f in $pstorefiles
+    do
+        if $NOOP; then
+            if [ -e $f ]; then
+                echo "$CP $V -r -p $f/* $TARDIR/pstore"
+            fi
+        else
+            ls --time-style='+%d-%m-%Y %H:%M:%S' -last $f >> $TARDIR/pstore/$PSTORE_DIR_LIST_INFO_FILE
+            ls --time-style='+%d-%m-%Y %H:%M:%S' -last $f/* >> $TARDIR/pstore/$PSTORE_DIR_LIST_INFO_FILE
+            ( [ -e $f ] && $CP $V -r -p $f/* $TARDIR/pstore ) || echo "$f not found" > $TARDIR/$f
+        fi
+    done
+
+    chmod ugo+rw -R $DUMPDIR/$BASE/pstore
+}
+
+###############################################################################
 # Dump io stats for processes
 # Globals:
 #  V
@@ -2005,6 +2086,19 @@ main() {
     echo "[ Capture Proc State ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
     wait
 
+    # capture /sys info - include acpi info and pre-process pstore info
+    save_sys /sys/firmware/acpi/tables /sys/fs/pstore &
+    end_t2=$(date +%s%3N)
+    echo "[ Capture Sys info ] : $(($end_t2-$end_t)) msec" >> $TECHSUPPORT_TIME_INFO
+    wait
+
+    # capture /var/lib/systemd/pstore info
+    start_t=$(date +%s%3N)
+    save_pstore /var/lib/systemd/pstore &
+    end_t=$(date +%s%3N)
+    echo "[ Capture pstore info ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
+    wait
+    
     # Save all the processes within each docker
     save_cmd "show services" services.summary &
 


### PR DESCRIPTION
(cherry picked from commit 5fa85027d7cdc581d85ad9305a9c52230ab87098)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
(cherry picked from commit 5fa85027d7cdc581d85ad9305a9c52230ab87098)
Modify the generate_dump to archive the /var/lib/systemd/pstore info for the show techsupport. Fixes https://github.com/sonic-net/sonic-buildimage/issues/21526
#### How I did it
Add function save_pstore() to generrate_dump script to collect the /var/lib/systemd/pstore info for the show techsupport. Also call the save_sys() function to collect /sys/fs/pstore directory info.
#### How to verify it
1) executes "show techsupport"
2) download the techsupport tra file
3) extract the techSupport tar file. and verify the following 2 directories should exist under sonic-dump 
    pstore/
   sys/pstore/

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

