### PR TITLE
Added support for TLV_CODE_VENDOR_NAME

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -206,6 +206,23 @@ def print_model(use_db=False):
     print(model)
 
 
+def print_vendor(use_db=False):
+    vendor = None
+    if use_db:
+        vendor = get_tlv_value_from_db(TlvInfoDecoder._TLV_CODE_VENDOR_NAME)
+    else:
+        eeprom = instantiate_eeprom_object()
+        if not eeprom:
+            print('Failed to read system EEPROM info')
+            return
+
+        try:
+            vendor = eeprom.vendorstr()
+        except TypeError:
+            vendor = eeprom.vendorstr(eeprom.read_eeprom())
+
+    print(vendor)
+
 #-------------------------------------------------------------------------------
 #
 # sets global variable "optcfg"
@@ -220,6 +237,9 @@ def get_cmdline_opts():
                       help='print the device product name')
     optcfg.add_option('-m', dest='mgmtmac', action='store_true', default=False,
                       help='print the base mac address for management interfaces')
+    optcfg.add_option('-v', dest='vendorstr', action='store_true', default=False,
+                      help='print the vendor string for the platform')
+    
     return optcfg.parse_args()
 
 
@@ -253,6 +273,8 @@ def main():
         print_serial(use_db)
     elif opts.modelstr:
         print_model(use_db)
+    elif opts.vendorstr:
+        print_vendor(use_db)
     else:
         if use_db:
             tlv_dict = read_eeprom_from_db()

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -192,6 +192,11 @@ CRC-32               0xFE        4  0xAC518FB3
         captured = capsys.readouterr()
         assert captured.out == 'S6100-ON\n'
 
+    def test_print_vendor(self, capsys):
+        decode_syseeprom.print_vendor(True)
+        captured = capsys.readouterr()
+        assert captured.out == 'DELL\n'
+
     @mock.patch('os.geteuid', lambda: 0)
     @mock.patch('sonic_py_common.device_info.get_platform', lambda: 'arista')
     @mock.patch.object(sys, 'argv', ["decode-syseeprom"])

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -221,3 +221,30 @@ CRC-32               0xFE        4  0xAC518FB3
         eeprom = decode_syseeprom.instantiate_eeprom_object()
         # Since sonic_platform is mocked, this should return the mocked eeprom object
         assert eeprom is not None
+
+    @mock.patch('decode_syseeprom.instantiate_eeprom_object')
+    def test_print_vendor_eeprom_success(self, mock_instantiate, capsys):
+        mock_eeprom = mock.MagicMock()
+        mock_eeprom.vendorstr.return_value = 'MOCK_VENDOR'
+        mock_instantiate.return_value = mock_eeprom
+        decode_syseeprom.print_vendor(use_db=False)
+        captured = capsys.readouterr()
+        assert captured.out == 'MOCK_VENDOR\n'
+
+    @mock.patch('decode_syseeprom.instantiate_eeprom_object')
+    def test_print_vendor_eeprom_none(self, mock_instantiate, capsys):
+        mock_instantiate.return_value = None
+        decode_syseeprom.print_vendor(use_db=False)
+        captured = capsys.readouterr()
+        assert 'Failed to read system EEPROM info' in captured.out
+
+    @mock.patch('decode_syseeprom.instantiate_eeprom_object')
+    def test_print_vendor_typeerror_fallback(self, mock_instantiate, capsys):
+        mock_eeprom = mock.MagicMock()
+        # Simulate vendorstr() raising TypeError when called with no args
+        mock_eeprom.vendorstr.side_effect = [TypeError(), 'FALLBACK_VENDOR']
+        mock_eeprom.read_eeprom.return_value = 'dummy'
+        mock_instantiate.return_value = mock_eeprom
+        decode_syseeprom.print_vendor(use_db=False)
+        captured = capsys.readouterr()
+        assert captured.out == 'FALLBACK_VENDOR\n'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
	• Fix Option 60 encoding.
		Update dhclient.conf.j2 templated to add "\0x00" as first character in the string to indicate that included id is a string
	• Add support for Option 61
		To add vendor-class unconditionally in each message, updated the dhclient.conf.j2 to included vendor-name:product-name. The value for these variables is retrieved from eeprom. Product name is already available and added the option to retrieve vendor name through decode-syseeprom utility.

#### Required PRs:
https://github.com/sonic-net/sonic-platform-common/pull/542
https://github.com/sonic-net/sonic-buildimage/pull/21722

Logs:
```
# =============== Managed by SONiC Config Engine DO NOT EDIT! ===============
# generated from /usr/share/sonic/templates/dhclient.conf.j2 using sonic-cfggen
# file: /etc/dhcp/dhclient.conf
#
# Configuration file for /sbin/dhclient, which is included in Debian's
#       dhcp3-client package.
#
# This is a sample configuration file for dhclient. See dhclient.conf's
#       man page for more information about the syntax of this file
#       and a more comprehensive list of the parameters understood by
#       dhclient.
#
# Normally, if the DHCP server provides reasonable information and does
#       not leave anything out (like the domain name, for example), then
#       few changes must be made to this file, if any.
#

option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
option snmp-community code 224 = text;
option minigraph-url code 225 = text;
option acl-url code 226 = text;
option tftp-server-name code 66 = text;
option bootfile-name code 67 = text;
option user-class code 77 = text;
option provisioning-script-url code 239 = text;
option dhcp6.user-class code 15 = text;
option dhcp6.provisioning-script-url code 239 = text;
option dhcp6.boot-file-url code 59 = text;
option vendor-class code 60 = text;

send host-name = gethostname();
request subnet-mask, broadcast-address, time-offset, routers,
        domain-name, domain-name-servers, domain-search, host-name,
        dhcp6.name-servers, dhcp6.domain-search, interface-mtu, dhcp6.fqdn,
        rfc3442-classless-static-routes, ntp-servers, log-servers,snmp-community, minigraph-url, acl-url;

send vendor-class "Cisco:{MODEL-XXXX}"; 


18:31:56.604658 IP (tos 0x0, ttl 64, id 58732, offset 0, flags [DF], proto UDP (17), length 338)
    10.29.XXX.XXX.bootpc > hostname.example.com.bootps: [udp sum ok] BOOTP/DHCP, Request from 34:73:YY:YY:YY:YY (oui Unknown), length 310, xid 0xff8d9300, Flags [none] (0x0000)
          Client-IP 10.29.XXX.XXX
          Client-Ethernet-Address 34:73:YY:YY:YY:YY (oui Unknown)
          Vendor-rfc1048 Extensions
            Magic Cookie 0x63825363
            DHCP-Message Option 53, length 1: Release
            Server-ID Option 54, length 4: hostname.example.com
            Hostname Option 12, length 5: "sonic"
            Vendor-Class Option 60, length 18: "Cisco:{MODEL-XXXX}"
            Client-ID Option 61, length 31: "SONiC##MODEL-XXXX##XYZ" 
            
            
            
root@sonic:/home/cisco# ifconfig eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::3673:2dff:fe30:70d8  prefixlen 64  scopeid 0x20<link>
        ether 34:73:YY:YY:YY:YY  txqueuelen 1000  (Ethernet)
        RX packets 9939  bytes 2618950 (2.4 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 1219  bytes 203002 (198.2 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device memory 0x95000000-9501ffff 
        ```