### PR TITLE
Revert "enable pfcwd for backplane ports (#3759)"

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -105,17 +105,6 @@ def get_server_facing_ports(db):
     return server_facing_ports
 
 
-def get_bp_ports(db):
-    """    Get all the backplane ports.    """
-    candidates = db.get_table('PORT')
-    bp_ports = []
-    for port in candidates:
-        if candidates[port].get('admin_status') == 'up' \
-           and candidates[port].get('role') == 'Int':
-            bp_ports.append(port)
-    return bp_ports
-
-
 class PfcwdCli(object):
     def __init__(
         self, db=None, namespace=None, display=constants.DISPLAY_ALL
@@ -376,10 +365,9 @@ class PfcwdCli(object):
         )
 
         # Get active ports from Config DB
-        external_ports = list(self.config_db.get_table('DEVICE_NEIGHBOR').keys())
-        bp_ports = get_bp_ports(self.config_db)
-
-        active_ports = natsorted(list(set(external_ports + bp_ports)))
+        active_ports = natsorted(
+            list(self.config_db.get_table('DEVICE_NEIGHBOR').keys())
+        )
 
         if not enable or enable.lower() != "enable":
             return


### PR DESCRIPTION
This reverts commit 2866ccd9c20231bca87369b93f41f198ce55852b.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

After PFCWD is enabled on backplane in #3759, test_qos_sai failed with the following error:

```
======================================================================
ERROR: sai_qos_tests.PFCtest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "saitests/py3/sai_qos_tests.py", line 1789, in runTest
    pkt, int(self.test_params['pg']), asic_type, pkts_num_egr_mem)
  File "saitests/py3/sai_qos_tests.py", line 582, in fill_leakout_plus_one
    asic_type, int(pkts_num_egr_mem))
  File "saitests/py3/sai_qos_tests.py", line 626, in fill_egress_plus_one
    pkts_num_egr_mem + max_packets, pg_cntrs_base[queue], pg_cntrs[queue]))
RuntimeError: fill_egress_plus_one: Failure, sent 7884 packets, SQ occupancy bytes rose from 0 to 0

----------------------------------------------------------------------
```

as egress port is tx_disabled, PFC is generated from egress port back to backplane and triggered pfcwd on supervisor card. hence resulting in packet drop.

```
admin@sonic-sup-1:~$ show pfcwd stat -d all
            QUEUE       STATUS    STORM DETECTED/RESTORED     TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
-----------------  -----------  -------------------------  -------------  ------------  -----------------  -----------------
 Ethernet-BP448:3  operational                      11/11  35404/1018833           0/0             0/8880                0/0
Ethernet-BP2240:3  operational                        2/2    3601/980808           0/0        3601/979813                0/0
Ethernet-BP2240:4  operational                        1/1          0/997           0/0              0/997                0/0
Ethernet-BP2244:3  operational                        2/2      7465/1990           0/0           2055/995                0/0
Ethernet-BP2244:4  operational                        1/1          1/994           0/0              1/994                0/0
Ethernet-BP4560:3  operational                        1/1        968/989           0/0            968/989                0/0
Ethernet-BP4560:4  operational                        1/1          1/983           0/0              1/983                0/0
Ethernet-BP4564:3  operational                        2/2        12/1974           0/0              7/988                0/0
Ethernet-BP4564:4  operational                        1/1          7/982           0/0              7/982                0/0
admin@sonic-sup-1:~$
```

#### What I did

Reverted back PR #3759

#### How I did it

Reverted back PR #3759

#### How to verify it

test_qos_sai passed after applying the patch manually.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


