### PR TITLE
Add golden config check

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1396,15 +1396,15 @@ def config_file_yang_validation(filename):
     # Check if the config is empty
     if not config:
         return
-    
+
     # Check if the config is not a dictionary
     if not isinstance(config, dict):
         return
-    
+
     # Check if the config is an empty dictionary
     if not config:
         return
-    
+
     # If the device is multi-ASIC, check if all required namespaces exist
     if multi_asic.is_multi_asic():
         required_namespaces = [HOST_NAMESPACE, *multi_asic.get_namespace_list()]

--- a/config/main.py
+++ b/config/main.py
@@ -1392,6 +1392,27 @@ def multiasic_write_to_db(filename, load_sysinfo):
 
 def config_file_yang_validation(filename):
     config = read_json_file(filename)
+
+    # Check if the config is empty
+    if not config:
+        return
+    
+    # Check if the config is not a dictionary
+    if not isinstance(config, dict):
+        return
+    
+    # Check if the config is an empty dictionary
+    if not config:
+        return
+    
+    # If the device is multi-ASIC, check if all required namespaces exist
+    if multi_asic.is_multi_asic():
+        required_namespaces = [HOST_NAMESPACE, *multi_asic.get_namespace_list()]
+        for ns in required_namespaces:
+            asic_name = HOST_NAMESPACE if ns == DEFAULT_NAMESPACE else ns
+            if asic_name not in config:
+                return
+
     sy = sonic_yang.SonicYang(YANG_DIR)
     sy.loadYangModel()
     asic_list = [HOST_NAMESPACE]

--- a/config/main.py
+++ b/config/main.py
@@ -1394,11 +1394,7 @@ def config_file_yang_validation(filename):
     config = read_json_file(filename)
 
     # Check if the config is empty
-    if not config:
-        return False
-
-    # Check if the config is not a dictionary
-    if not isinstance(config, dict):
+    if not config or not isinstance(config, dict):
         return False
 
     # If the device is multi-ASIC, check if all required namespaces exist

--- a/config/main.py
+++ b/config/main.py
@@ -1412,7 +1412,7 @@ def config_file_yang_validation(filename):
         asic_list.extend(multi_asic.get_namespace_list())
     for scope in asic_list:
         config_to_check = config.get(scope) if multi_asic.is_multi_asic() else config
-        if not config_to_check:
+        if config_to_check:
             try:
                 sy.loadData(configdbJson=config_to_check)
                 sy.validate_data_tree()
@@ -2075,7 +2075,7 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
             asic_list.extend(multi_asic.get_namespace_list())
         for scope in asic_list:
             host_config = config_to_check.get(scope) if multi_asic.is_multi_asic() else config_to_check
-            if not host_config:
+            if host_config:
                 table_hard_dependency_check(host_config)
 
     # Stop services before config push

--- a/config/main.py
+++ b/config/main.py
@@ -1412,13 +1412,14 @@ def config_file_yang_validation(filename):
         asic_list.extend(multi_asic.get_namespace_list())
     for scope in asic_list:
         config_to_check = config.get(scope) if multi_asic.is_multi_asic() else config
-        try:
-            sy.loadData(configdbJson=config_to_check)
-            sy.validate_data_tree()
-        except sonic_yang.SonicYangException as e:
-            click.secho("{} fails YANG validation! Error: {}".format(filename, str(e)),
-                        fg='magenta')
-            raise click.Abort()
+        if not config_to_check:
+            try:
+                sy.loadData(configdbJson=config_to_check)
+                sy.validate_data_tree()
+            except sonic_yang.SonicYangException as e:
+                click.secho("{} fails YANG validation! Error: {}".format(filename, str(e)),
+                            fg='magenta')
+                raise click.Abort()
 
         sy.tablesWithOutYang.pop('bgpraw', None)
         if len(sy.tablesWithOutYang):
@@ -2074,7 +2075,8 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
             asic_list.extend(multi_asic.get_namespace_list())
         for scope in asic_list:
             host_config = config_to_check.get(scope) if multi_asic.is_multi_asic() else config_to_check
-            table_hard_dependency_check(host_config)
+            if not host_config:
+                table_hard_dependency_check(host_config)
 
     # Stop services before config push
     if not no_service_restart:

--- a/config/main.py
+++ b/config/main.py
@@ -1393,8 +1393,8 @@ def multiasic_write_to_db(filename, load_sysinfo):
 def config_file_yang_validation(filename):
     config = read_json_file(filename)
 
-    # Check if the config is empty
-    if not config or not isinstance(config, dict):
+    # Check if the config is not a dictionary
+    if not isinstance(config, dict):
         return False
 
     # If the device is multi-ASIC, check if all required namespaces exist

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1306,7 +1306,7 @@ class TestLoadMinigraph(object):
             mock_load_data.assert_called_once_with(configdbJson=valid_config)
             mock_validate_data_tree.assert_called_once()
 
-        valid_config = {
+        valid_multi_asic_config = {
             'localhost': {
                 'DEVICE_METADATA': {
                     'localhost': {
@@ -1332,16 +1332,18 @@ class TestLoadMinigraph(object):
                 }
             }
         }
-        with mock.patch('config.main.read_json_file', return_value=valid_config) as mock_read_json_file, \
+        with mock.patch('config.main.read_json_file', return_value=valid_multi_asic_config) \
+                as mock_multiasic_read_json_file, \
                 mock.patch('config.main.multi_asic.is_multi_asic', return_value=True), \
-                mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model, \
-                mock.patch('config.main.sonic_yang.SonicYang.loadData') as mock_load_data, \
-                mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree') as mock_validate_data_tree:
+                mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_multiasic_load_yang_model, \
+                mock.patch('config.main.sonic_yang.SonicYang.loadData') as mock_multiasic_load_data, \
+                mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree') \
+                as mock_multiasic_validate_data_tree:
             assert config_file_yang_validation('dummy_file.json')
-            mock_read_json_file.assert_called_once_with('dummy_file.json')
-            mock_load_yang_model.assert_called_once()
-            mock_load_data.assert_called_once_with(configdbJson=valid_config)
-            mock_validate_data_tree.assert_called_once()
+            mock_multiasic_read_json_file.assert_called_once_with('dummy_file.json')
+            mock_multiasic_load_yang_model.assert_called_once()
+            mock_multiasic_load_data.assert_called_once_with(configdbJson=valid_config)
+            mock_multiasic_validate_data_tree.assert_called_once()
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1342,7 +1342,7 @@ class TestLoadMinigraph(object):
             assert config_file_yang_validation('dummy_file.json')
             mock_multiasic_read_json_file.assert_called_once_with('dummy_file.json')
             mock_multiasic_load_yang_model.assert_called_once()
-            mock_multiasic_load_data.assert_called_once_with(configdbJson=valid_config)
+            mock_multiasic_load_data.assert_called_once_with(configdbJson=valid_multi_asic_config)
             mock_multiasic_validate_data_tree.assert_called_once()
 
     @classmethod

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1179,7 +1179,7 @@ class TestLoadMinigraph(object):
         with mock.patch("utilities_common.cli.run_command",
                         mock.MagicMock(side_effect=mock_run_command_side_effect)), \
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
-                mock.patch('config.main.read_json_file', mock.MagicMock(return_value={})):
+                mock.patch('config.main.read_json_file', mock.MagicMock(return_value=[])):
             (config, show) = get_cmd_module
             runner = CliRunner()
             result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "-y"])

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1169,12 +1169,15 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
-    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
+    @mock.patch(
+            'sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
+            mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_with_invalid_golden_config(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False
 
-        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
+        with mock.patch("utilities_common.cli.run_command",
+                        mock.MagicMock(side_effect=mock_run_command_side_effect)), \
                 mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
                 mock.patch('config.main.read_json_file', mock.MagicMock(return_value={})):
             (config, show) = get_cmd_module

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1306,6 +1306,8 @@ class TestLoadMinigraph(object):
             mock_load_data.assert_called_once_with(configdbJson=valid_config)
             mock_validate_data_tree.assert_called_once()
 
+        mock_load_data.reset_mock()
+
         valid_multi_asic_config = {
             'localhost': {
                 'DEVICE_METADATA': {

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -967,7 +967,7 @@ class TestLoadMinigraph(object):
         import config.main
         importlib.reload(config.main)
 
-    def read_json_file_side_effect(filename):
+    def read_json_file_side_effect(self, filename):
         return {
             'DEVICE_METADATA': {
                 'localhost': {

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1342,7 +1342,7 @@ class TestLoadMinigraph(object):
             assert config_file_yang_validation('dummy_file.json')
             mock_multiasic_read_json_file.assert_called_once_with('dummy_file.json')
             mock_multiasic_load_yang_model.assert_called()
-            mock_multiasic_load_data.assert_called_once_with(configdbJson=valid_multi_asic_config)
+            mock_multiasic_load_data.assert_called_with(configdbJson=valid_multi_asic_config)
             mock_multiasic_validate_data_tree.assert_called()
 
     @classmethod

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1240,7 +1240,8 @@ class TestLoadMinigraph(object):
                 return True if 'golden_config' in filename else False
 
             with mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
-                    mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=self.read_json_file_side_effect)):
+                    mock.patch('config.main.read_json_file', mock.MagicMock(
+                        side_effect=self.read_json_file_side_effect)):
                 (config, show) = get_cmd_module
                 db = Db()
                 golden_config = {}
@@ -1304,7 +1305,6 @@ class TestLoadMinigraph(object):
             mock_load_yang_model.assert_called_once()
             mock_load_data.assert_called_once_with(configdbJson=valid_config)
             mock_validate_data_tree.assert_called_once()
-
 
         valid_config = {
             'localhost': {

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1169,6 +1169,20 @@ class TestLoadMinigraph(object):
             assert result.exit_code == 0
             assert "config override-config-table /etc/sonic/golden_config_db.json" in result.output
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=("dummy_path", None)))
+    def test_load_minigraph_with_invalid_golden_config(self, get_cmd_module):
+        def is_file_side_effect(filename):
+            return True if 'golden_config' in filename else False
+
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
+                mock.patch('config.main.read_json_file', mock.MagicMock(return_value={})):
+            (config, show) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "-y"])
+            assert result.exit_code != 0
+            assert "Invalid golden config file:" in result.output
+
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
                 mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_hard_dependency_check(self, get_cmd_module):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1254,23 +1254,23 @@ class TestLoadMinigraph(object):
 
     def test_config_file_yang_validation(self):
         # Test with empty config
-        with mock.patch('config.main.read_json_file', return_value={}) as mock_read_json_file:
+        with mock.patch('config.main.read_json_file', return_value="") as mock_read_json_file:
             with mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model:
-                config_file_yang_validation('dummy_file.json')
+                assert not config_file_yang_validation('dummy_file.json')
                 mock_read_json_file.assert_called_once_with('dummy_file.json')
                 mock_load_yang_model.assert_not_called()
 
         # Test with non-dict config
         with mock.patch('config.main.read_json_file', return_value=[]) as mock_read_json_file:
             with mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model:
-                config_file_yang_validation('dummy_file.json')
+                assert not config_file_yang_validation('dummy_file.json')
                 mock_read_json_file.assert_called_once_with('dummy_file.json')
                 mock_load_yang_model.assert_not_called()
 
         # Test with empty dict config
         with mock.patch('config.main.read_json_file', return_value={}) as mock_read_json_file:
             with mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model:
-                config_file_yang_validation('dummy_file.json')
+                assert not config_file_yang_validation('dummy_file.json')
                 mock_read_json_file.assert_called_once_with('dummy_file.json')
                 mock_load_yang_model.assert_not_called()
 
@@ -1279,7 +1279,7 @@ class TestLoadMinigraph(object):
             with mock.patch('config.main.multi_asic.is_multi_asic', return_value=True):
                 with mock.patch('config.main.multi_asic.get_namespace_list', return_value=['asic0', 'asic1']):
                     with mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model:
-                        config_file_yang_validation('dummy_file.json')
+                        assert not config_file_yang_validation('dummy_file.json')
                         mock_read_json_file.assert_called_once_with('dummy_file.json')
                         mock_load_yang_model.assert_not_called()
 
@@ -1314,7 +1314,7 @@ class TestLoadMinigraph(object):
             with mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model:
                 with mock.patch('config.main.sonic_yang.SonicYang.loadData') as mock_load_data:
                     with mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree') as mock_validate_data_tree:
-                        config_file_yang_validation('dummy_file.json')
+                        assert config_file_yang_validation('dummy_file.json')
                         mock_read_json_file.assert_called_once_with('dummy_file.json')
                         mock_load_yang_model.assert_called_once()
                         mock_load_data.assert_called_once_with(configdbJson=valid_config)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1306,8 +1306,6 @@ class TestLoadMinigraph(object):
             mock_load_data.assert_called_once_with(configdbJson=valid_config)
             mock_validate_data_tree.assert_called_once()
 
-        mock_load_data.reset_mock()
-
         valid_multi_asic_config = {
             'localhost': {
                 'DEVICE_METADATA': {
@@ -1343,9 +1341,9 @@ class TestLoadMinigraph(object):
                 as mock_multiasic_validate_data_tree:
             assert config_file_yang_validation('dummy_file.json')
             mock_multiasic_read_json_file.assert_called_once_with('dummy_file.json')
-            mock_multiasic_load_yang_model.assert_called_once()
+            mock_multiasic_load_yang_model.assert_called()
             mock_multiasic_load_data.assert_called_once_with(configdbJson=valid_multi_asic_config)
-            mock_multiasic_validate_data_tree.assert_called_once()
+            mock_multiasic_validate_data_tree.assert_called()
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1306,45 +1306,6 @@ class TestLoadMinigraph(object):
             mock_load_data.assert_called_once_with(configdbJson=valid_config)
             mock_validate_data_tree.assert_called_once()
 
-        valid_multi_asic_config = {
-            'localhost': {
-                'DEVICE_METADATA': {
-                    'localhost': {
-                        'platform': 'x86_64-mlnx_msn2700-r0',
-                        'mac': '00:02:03:04:05:06'
-                    }
-                }
-            },
-            'asic0': {
-                'DEVICE_METADATA': {
-                    'localhost': {
-                        'platform': 'x86_64-mlnx_msn2700-r0',
-                        'mac': '00:02:03:04:05:07'
-                    }
-                }
-            },
-            'asic1': {
-                'DEVICE_METADATA': {
-                    'localhost': {
-                        'platform': 'x86_64-mlnx_msn2700-r0',
-                        'mac': '00:02:03:04:05:08'
-                    }
-                }
-            }
-        }
-        with mock.patch('config.main.read_json_file', return_value=valid_multi_asic_config) \
-                as mock_multiasic_read_json_file, \
-                mock.patch('config.main.multi_asic.is_multi_asic', return_value=True), \
-                mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_multiasic_load_yang_model, \
-                mock.patch('config.main.sonic_yang.SonicYang.loadData') as mock_multiasic_load_data, \
-                mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree') \
-                as mock_multiasic_validate_data_tree:
-            assert config_file_yang_validation('dummy_file.json')
-            mock_multiasic_read_json_file.assert_called_once_with('dummy_file.json')
-            mock_multiasic_load_yang_model.assert_called()
-            mock_multiasic_load_data.assert_called_with(configdbJson=valid_multi_asic_config)
-            mock_multiasic_validate_data_tree.assert_called()
-
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1286,13 +1286,6 @@ class TestLoadMinigraph(object):
                 mock_read_json_file.assert_called_once_with('dummy_file.json')
                 mock_load_yang_model.assert_not_called()
 
-        # Test with empty dict config
-        with mock.patch('config.main.read_json_file', return_value={}) as mock_read_json_file:
-            with mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model:
-                assert not config_file_yang_validation('dummy_file.json')
-                mock_read_json_file.assert_called_once_with('dummy_file.json')
-                mock_load_yang_model.assert_not_called()
-
         # Test with missing namespaces in multi-ASIC config
         with mock.patch('config.main.read_json_file', return_value={'localhost': {}}) as mock_read_json_file:
             with mock.patch('config.main.multi_asic.is_multi_asic', return_value=True):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added golden config file content check in config_file_yang_validation.

#### How I did it
The function reads a JSON configuration file.
It checks if the configuration is empty or not a dictionary.
If the device is multi-ASIC, it verifies that all required namespaces exist in the configuration.

#### How to verify it

Patch change into testbed, given below cases to verify
1. Empty file
2. Not dictionary
3. Empty dictionary
4. Missing namespace if platform is multi asic.
5. Normal golden config.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

