### PR TITLE
Added retry for docker execution in warm-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -475,7 +475,7 @@ function check_docker_exec()
         for ((i=1; i<=max_retries; i++)); do
             STATE=$(timeout $timeout docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
             if [[ x"${STATE}" != x"timed out" ]]; then
-                debug "docker exec for $container succeeeded in $i tries"
+                debug "docker exec for $container succeeded in $i tries"
                 success=true
                 break
             fi

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -468,10 +468,20 @@ function setup_reboot_variables()
 function check_docker_exec()
 {
     containers="radv bgp lldp swss database teamd syncd"
+    timeout=1s
+    max_retries=5
     for container in $containers; do
-        STATE=$(timeout 1s docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
-        if [[ x"${STATE}" == x"timed out" ]]; then
-            error "Docker exec on $container timedout"
+        success=false
+        for ((i=1; i<=max_retries; i++)); do
+            STATE=$(timeout $timeout docker exec $container echo "success"; if [[ $? == 124 ]]; then echo "timed out"; fi)
+            if [[ x"${STATE}" != x"timed out" ]]; then
+                debug "docker exec for $container succeeeded in $i tries"
+                success=true
+                break
+            fi
+        done
+        if [[ $success == false ]]; then
+            error "Docker exec on $container timed out after $max_retries retries"
             exit "${EXIT_FAILURE}"
         fi
     done


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added retry for `docker exec` since there are failures on systems after utilization increased from previous releases during warm-reboot execution (Test failures in test_wr_arp_advance)

#### How I did it
Added retry mechanism in the bash script, if there is a failure there are 5 retries attempted for the docker exec command

#### How to verify it
Run `warm-reboot` command


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)