### PR TITLE
sfputil: skip displaying the values that are not supported.

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -335,7 +335,7 @@ def convert_sfp_info_to_output_string(sfp_info_dict):
     if sfp_type.startswith('QSFP-DD') or sfp_type.startswith('OSFP'):
         sorted_qsfp_data_map_keys = sorted(QSFP_DD_DATA_MAP, key=QSFP_DD_DATA_MAP.get)
         for key in sorted_qsfp_data_map_keys:
-            #Skip the keys with N/A value
+            # Skip the keys with N/A value
             if sfp_info_dict.get(key) == 'N/A':
                 continue
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -335,6 +335,10 @@ def convert_sfp_info_to_output_string(sfp_info_dict):
     if sfp_type.startswith('QSFP-DD') or sfp_type.startswith('OSFP'):
         sorted_qsfp_data_map_keys = sorted(QSFP_DD_DATA_MAP, key=QSFP_DD_DATA_MAP.get)
         for key in sorted_qsfp_data_map_keys:
+            #Skip the keys with N/A value
+            if sfp_info_dict.get(key) == 'N/A':
+                continue
+
             if key == 'cable_type':
                 output += '{}{}: {}\n'.format(indent, sfp_info_dict['cable_type'], sfp_info_dict['cable_length'])
             elif key == 'cable_length':
@@ -1469,10 +1473,10 @@ def is_fw_switch_done(port_name):
                 status = -1 # Abnormal status.
             elif (ImageARunning == 1) and (ImageACommitted == 0):   # ImageA is running, but not committed.
                 click.echo("FW images switch successful : ImageA is running")
-                status = 1  # run_firmware is done. 
+                status = 1  # run_firmware is done.
             elif (ImageBRunning == 1) and (ImageBCommitted == 0):   # ImageB is running, but not committed.
                 click.echo("FW images switch successful : ImageB is running")
-                status = 1  # run_firmware is done. 
+                status = 1  # run_firmware is done.
             else:                                                   # No image is running, or running and committed image is same.
                 click.echo("FW info error : Failed to switch into uncommitted image!")
                 status = -1 # Failure for Switching images.

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1473,10 +1473,10 @@ def is_fw_switch_done(port_name):
                 status = -1 # Abnormal status.
             elif (ImageARunning == 1) and (ImageACommitted == 0):   # ImageA is running, but not committed.
                 click.echo("FW images switch successful : ImageA is running")
-                status = 1  # run_firmware is done.
+                status = 1  # run_firmware is done. 
             elif (ImageBRunning == 1) and (ImageBCommitted == 0):   # ImageB is running, but not committed.
                 click.echo("FW images switch successful : ImageB is running")
-                status = 1  # run_firmware is done.
+                status = 1  # run_firmware is done. 
             else:                                                   # No image is running, or running and committed image is same.
                 click.echo("FW info error : Failed to switch into uncommitted image!")
                 status = -1 # Failure for Switching images.


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Skip displaying the fields which are unsupported for CMIS specific transceivers.

#### How I did it
Skip the key with "N/A" value in convert_sfp_info_to_output_string()

#### How to verify it
Verified 'show interfaces transceiver info' and 'sfputil show eeprom -p' outputs on an Arista testbed.

#### Previous command output (if the output of a command-line utility has changed)
# sfputil show eeprom -d -p Ethernet0

Ethernet0: SFP EEPROM detected
        Active App Selection Host Lane 1: 5
        Active App Selection Host Lane 2: 5
        Active App Selection Host Lane 3: 5
        Active App Selection Host Lane 4: 5
        Active App Selection Host Lane 5: 5
        Active App Selection Host Lane 6: 5
        Active App Selection Host Lane 7: 5
        Active App Selection Host Lane 8: 5
        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
                                   100GAUI-1-S C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
                                   200GAUI-2-L C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   200GAUI-2-S C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   800G L C2M (placeholder) - Host Assign (0x1) - 800GBASE-DR8 (placeholder) - Media Assign (0x1)
        CMIS Revision: 5.1
        Connector: MPO 2x12
        Encoding: N/A
        Extended Identifier: Power Class 8 (16.0W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 1.0
        Host Electrical Interface: 400GAUI-4-L C2M (Annex 120G)
        Host Lane Assignment Options: 17
        Host Lane Count: 4
        Identifier: OSFP 8X Pluggable Transceiver
        Length Cable Assembly(m): 0.0
        Media Interface Code: 400GBASE-DR4 (Cl 124)
        Media Interface Technology: 1310 nm EML
        Media Lane Assignment Options: 17
        Media Lane Count: 4
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        **Supported Max Laser Frequency: N/AGHz
        Supported Max TX Power: N/AdBm
        Supported Min Laser Frequency: N/AGHz
        Supported Min TX Power: N/AdBm**
        Vendor Date Code(YYYY-MM-DD Lot): 2024-04-25   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTCE4517E1PCA-2F
        Vendor Rev: A0
        Vendor SN: XACB0QQ

#### New command output (if the output of a command-line utility has changed)
# sfputil show eeprom -p Ethernet0
Ethernet0: SFP EEPROM detected
        Active App Selection Host Lane 1: 5
        Active App Selection Host Lane 2: 5
        Active App Selection Host Lane 3: 5
        Active App Selection Host Lane 4: 5
        Active App Selection Host Lane 5: 5
        Active App Selection Host Lane 6: 5
        Active App Selection Host Lane 7: 5
        Active App Selection Host Lane 8: 5
        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
                                   100GAUI-1-S C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
                                   200GAUI-2-L C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   200GAUI-2-S C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   800G L C2M (placeholder) - Host Assign (0x1) - 800GBASE-DR8 (placeholder) - Media Assign (0x1)
        CMIS Revision: 5.1
        Connector: MPO 2x12
        Extended Identifier: Power Class 8 (16.0W Max)
        Hardware Revision: 1.0
        Host Electrical Interface: 400GAUI-4-L C2M (Annex 120G)
        Host Lane Assignment Options: 17
        Host Lane Count: 4
        Identifier: OSFP 8X Pluggable Transceiver
        Length Cable Assembly(m): 0.0
        Media Interface Code: 400GBASE-DR4 (Cl 124)
        Media Interface Technology: 1310 nm EML
        Media Lane Assignment Options: 17
        Media Lane Count: 4
        Nominal Bit Rate(100Mbs): 0
        Specification compliance: sm_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2024-04-25   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTCE4517E1PCA-2F
        Vendor Rev: A0
        Vendor SN: XACB0QQ 
