### PR TITLE
[dualtor] Support reset heartbeat suspend timer on active-standby ports

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -1269,3 +1269,75 @@ def telemetry(db, state):
     else:
         click.echo("ERR: Unable to set ycabled telemetry state to {}".format(state))
         sys.exit(CONFIG_FAIL)
+
+
+# 'muxcable' command ("config muxcable reset-heartbeat-suspend <port|all>")
+@muxcable.command()
+@click.argument('port', metavar='<port_name>', required=True, default=None)
+@clicommon.pass_db
+def reset_heartbeat_suspend(db, port):
+    """Reset the mux port heartbeat suspend."""
+
+    if port is None:
+        click.echo("no port provided")
+        sys.exit(CONFIG_FAIL)
+
+    port = platform_sfputil_helper.get_interface_name(port, db)
+    asic_index = multi_asic.get_asic_index_from_namespace(EMPTY_NAMESPACE)
+    config_dbs = {}
+    mux_linkmgrd_tables = {}
+    mux_config_tables = {}
+
+    # Getting all front asic namespace and correspding config DB connector
+    namespaces = multi_asic.get_front_end_namespaces()
+    for namespace in namespaces:
+        asic_index = multi_asic.get_asic_index_from_namespace(namespace)
+        config_dbs[asic_index] = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_dbs[asic_index].connect()
+        mux_linkmgrd_tables[asic_index] = config_dbs[asic_index].get_table("MUX_LINKMGR")
+        mux_config_tables[asic_index] = config_dbs[asic_index].get_table("MUX_CABLE")
+
+    if port == "all":
+        for asic_index, mux_config_table in mux_config_tables.items():
+            config_db = config_dbs[asic_index]
+            mux_linkmgrd_table = mux_linkmgrd_tables[asic_index]
+            mux_ports = [p for p, c in mux_config_table.items()
+                         if c.get("cable_type", "active-standby") == "active-standby"]
+            if mux_ports:
+                # trigger one-shot heartbeat suspend reset
+                config_db.mod_entry("MUX_LINKMGR", "LINK_PROBER", {"reset_suspend_timer": ",".join(mux_ports)})
+                # restore config db to the original
+                config_db.set_entry("MUX_LINKMGR", "LINK_PROBER", mux_linkmgrd_table.get("LINK_PROBER", None))
+    else:
+        asic_index = None
+        if platform_sfputil is not None:
+            asic_index = platform_sfputil.get_asic_id_for_logical_port(port)
+        if asic_index is None:
+            # TODO this import is only for unit test purposes, and should be removed once sonic_platform_base
+            # is fully mocked
+            import sonic_platform_base.sonic_sfp.sfputilhelper
+            asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
+            if asic_index is None:
+                click.echo("Got invalid asic index for port {}, can't reset heartbeat suspend".format(port))
+                sys.exit(CONFIG_FAIL)
+        if asic_index in config_dbs:
+            config_db = config_dbs[asic_index]
+            mux_linkmgrd_table = mux_linkmgrd_tables[asic_index]
+            mux_config_table = mux_config_tables[asic_index]
+            if port not in mux_config_table:
+                click.echo("Got invalid port {}, can't reset heartbeat suspend'".format(port))
+                sys.exit(CONFIG_FAIL)
+            else:
+                if mux_config_table[port].get("cable_type", "active-standby") != "active-standby":
+                    click.echo(
+                        "Got invalid port {}, can't reset heartbeat suspend on active-active mux port".format(port)
+                    )
+                    sys.exit(CONFIG_FAIL)
+
+            # trigger one-shot heartbeat suspend reset
+            config_db.mod_entry("MUX_LINKMGR", "LINK_PROBER", {"reset_suspend_timer": port})
+            # restore config db to the original
+            config_db.set_entry("MUX_LINKMGR", "LINK_PROBER", mux_linkmgrd_table.get("LINK_PROBER", None))
+        else:
+            click.echo("Got invalid asic index for port {}, can't reset heartbeat suspend'".format(port))
+            sys.exit(CONFIG_FAIL)

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -2126,6 +2126,57 @@ class TestMuxcable(object):
         assert result.output == show_muxcable_resetcause_expected_port_output_json
 
 
+    def test_config_muxcable_reset_heartbeat_suspend_all(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["all"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+
+        assert result.exit_code == 0
+        assert result.output == "Success in resetting heartbeat suspend for mux ports: Ethernet0, Ethernet4, Ethernet8, Ethernet12, Ethernet16, Ethernet28\n"
+
+
+    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    def test_config_muxcable_reset_heartbeat_suspend_active_standby_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["Ethernet28"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+
+        assert result.exit_code == 0
+        assert result.output == "Success in resetting heartbeat suspend for mux ports: Ethernet28\n"
+
+
+    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    def test_config_muxcable_reset_heartbeat_suspend_active_active_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["Ethernet32"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+
+        assert result.exit_code == 1
+        assert result.output == "Got invalid port Ethernet32, can't reset heartbeat suspend on active-active mux port\n"
+
+
+    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    def test_config_muxcable_reset_heartbeat_suspend_invalid_port(self):
+        runner = CliRunner()
+        db = Db()
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["Ethernet40"], obj=db)
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+
+        assert result.exit_code == 1
+        assert result.output == "Got invalid port Ethernet40, can't reset heartbeat suspend'\n"
+
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -2125,57 +2125,61 @@ class TestMuxcable(object):
                                ["Ethernet0", "--json"], obj=db)
         assert result.output == show_muxcable_resetcause_expected_port_output_json
 
-
     def test_config_muxcable_reset_heartbeat_suspend_all(self):
         runner = CliRunner()
         db = Db()
 
         os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
-        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["all"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"],
+                               ["all"], obj=db)
         os.environ['SONIC_CLI_IFACE_MODE'] = "default"
 
         assert result.exit_code == 0
-        assert result.output == "Success in resetting heartbeat suspend for mux ports: Ethernet0, Ethernet4, Ethernet8, Ethernet12, Ethernet16, Ethernet28\n"
+        assert result.output == ("Success in resetting heartbeat suspend for mux ports: "
+                                 "Ethernet0, Ethernet4, Ethernet8, Ethernet12, Ethernet16, Ethernet28\n")
 
-
-    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port',
+                mock.MagicMock(return_value=0))
     def test_config_muxcable_reset_heartbeat_suspend_active_standby_port(self):
         runner = CliRunner()
         db = Db()
 
         os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
-        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["Ethernet28"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"],
+                               ["Ethernet28"], obj=db)
         os.environ['SONIC_CLI_IFACE_MODE'] = "default"
 
         assert result.exit_code == 0
         assert result.output == "Success in resetting heartbeat suspend for mux ports: Ethernet28\n"
 
-
-    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port',
+                mock.MagicMock(return_value=0))
     def test_config_muxcable_reset_heartbeat_suspend_active_active_port(self):
         runner = CliRunner()
         db = Db()
 
         os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
-        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["Ethernet32"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"],
+                               ["Ethernet32"], obj=db)
         os.environ['SONIC_CLI_IFACE_MODE'] = "default"
 
         assert result.exit_code == 1
-        assert result.output == "Got invalid port Ethernet32, can't reset heartbeat suspend on active-active mux port\n"
+        assert result.output == \
+            "Got invalid port Ethernet32, can't reset heartbeat suspend on active-active mux port\n"
 
-
-    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port', mock.MagicMock(return_value=0))
+    @mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper.get_asic_id_for_logical_port',
+                mock.MagicMock(return_value=0))
     def test_config_muxcable_reset_heartbeat_suspend_invalid_port(self):
         runner = CliRunner()
         db = Db()
 
         os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
-        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"], ["Ethernet40"], obj=db)
+        result = runner.invoke(config.config.commands["muxcable"].commands["reset-heartbeat-suspend"],
+                               ["Ethernet40"], obj=db)
         os.environ['SONIC_CLI_IFACE_MODE'] = "default"
 
         assert result.exit_code == 1
         assert result.output == "Got invalid port Ethernet40, can't reset heartbeat suspend'\n"
-
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Support reset heartbeat suspend timer on active-standby dualtor mux ports.
This depends on https://github.com/sonic-net/sonic-linkmgrd/pull/286.

* Microsoft ADO (number only): 31520887

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How I did it
Add sub CLI `config muxcable reset-heartbeat-suspend` to write the reset port list to `MUX_LINKMGR|LINK_PROBER`.
The DB operations of `config muxcable reset-heartbeat-suspend all`:
```
1740387788.261626 [4 unix:/var/run/redis/redis.sock] "HSET" "MUX_LINKMGR|LINK_PROBER" "reset_suspend_timer" "Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96"
1740387788.264557 [4 unix:/var/run/redis/redis.sock] "HDEL" "MUX_LINKMGR|LINK_PROBER" "reset_suspend_timer"
```

#### How to verify it
UT and on DUT.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
# config muxcable
Usage: config muxcable [OPTIONS] COMMAND [ARGS]...

  Show muxcable information

Options:
  -h, -?, --help  Show this message and exit.

Commands:
  firmware                 Configure muxcable firmware command
  hwmode                   Configure muxcable hardware directly
  kill-radv                Kill radv service when it is meant to be stopped,
                           so no good-bye packet is sent for ceasing To Be an
                           Advertising Interface
  loopback                 Enable/disable loopback mode on a port
  mode                     Config muxcable mode
  packetloss               config muxcable packetloss reset
  prbs                     Enable/disable PRBS mode on a port
  reset                    reset a target on the cable NIC TORA TORB Local
  reset-heartbeat-suspend  Reset the mux port heartbeat suspend.
  set-anlt                 Enable anlt mode on a port args port <target>
                           NIC...
  set-fec                  Enable fec mode on a port args port <target> NIC...
  telemetry                Enable/Disable Telemetry for ycabled
# config muxcable reset-heartbeat-suspend all
Success in resetting heartbeat suspend for mux ports: Ethernet4, Ethernet8
# config muxcable reset-heartbeat-suspend Ethernet4
Success in resetting heartbeat suspend for mux ports: Ethernet4
```
