### PR TITLE
Add route_check.py support for IPv4-mapped IPv6 addresses

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -143,26 +143,36 @@ def print_message(lvl, *args, write_to_stdout=True):
     return msg
 
 
+def normalize_ip_network(ip):
+    """
+    Helper to normalize an IP network string using the ipaddress module.
+    For IPv4 mapped IPv6 addresses (e.g. "::ffff:a1b:bd10/128"), this will
+    return the canonical form (e.g. "::ffff:10.27.189.16/128").
+    """
+    net = ipaddress.ip_network(ip, strict=False)
+    return str(net)
+
+
 def add_prefix(ip):
     """
     helper add static prefix based on IP type
     :param ip: IP to add prefix as string.
-    :return ip + "/32 or /128"
+    :return ip + "/32 or /128" (normalized)
     """
     if ip.find(IPV6_SEPARATOR) == -1:
         ip = ip + PREFIX_SEPARATOR + "32"
     else:
         ip = ip + PREFIX_SEPARATOR + "128"
-    return str(ip_network(ip))
+    return normalize_ip_network(ip)
 
 
 def add_prefix_ifnot(ip):
     """
     helper add static prefix if absent
     :param ip: IP to add prefix as string.
-    :return ip with prefix
+    :return ip with prefix (normalized)
     """
-    return str(ip_network(ip)) if ip.find(PREFIX_SEPARATOR) != -1 else add_prefix(ip)
+    return normalize_ip_network(ip) if ip.find(PREFIX_SEPARATOR) != -1 else add_prefix(ip)
 
 
 def is_local(ip):
@@ -242,7 +252,7 @@ def checkout_rt_entry(k):
     if k.startswith(ASIC_KEY_PREFIX):
         e = k.lower().split("\"", -1)[3]
         if not is_local(e):
-            return True, e
+            return True, normalize_ip_network(e)
     return False, None
 
 

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -1108,4 +1108,40 @@ TEST_DATA = {
             },
         },
     },
+    "24": {
+        DESCR: "IPv4 mapped IPv6 address route check",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check",
+        PRE: {
+            DEFAULTNS: {
+                CONFIG_DB: {
+                    DEVICE_METADATA: {
+                        LOCALHOST: {"subtype": "DualToR"}
+                    },
+                    FEATURE_TABLE: {
+                        "bgp": {
+                            "state": "enabled"
+                        }
+                    }
+                },
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "::ffff:10.27.189.16/127": {"ifname": "Ethernet0"},
+                        "::ffff:10.27.189.17": {"ifname": "Ethernet0"}
+                    },
+                    INTF_TABLE: {
+                        "Ethernet0:::ffff:a1b:bd11/127": {},
+                        "Ethernet0": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "::ffff:10.27.189.17/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "::ffff:10.27.189.16/127" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                }
+            }
+        }
+    },
 }


### PR DESCRIPTION
The IPv4-mapped IPv6 address format differs between IP addresses and routes.

#### What I did
* For IP addresses, the format is represented in hexadecimal (e.g., ::ffff:a1b:bd11).
* For routes, the automated generation uses dotted decimal notation (e.g., ::ffff:10.27.189.17).

Previously, route_check.py would generate warning logs due to mismatches between the interface table and the route table caused by these format differences.

#### How I did it
This commit updates route_check.py to handle IPv4-mapped IPv6 addresses consistently, ensuring that both formats are treated as equivalent values.

#### How to verify it
Add new test data to verify the interface with IPv4-mapped IPv6 address

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

