### PR TITLE
Add namespace support for show interface neighbor expected

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5435,7 +5435,7 @@ This command is used to display the list of expected neighbors for all interface
 
 - Usage:
   ```
-  show interfaces neighbor expected [<interface_name>]
+  show interfaces neighbor expected [<interface_name>] -n [<namespace>]
   ```
 
 - Example:

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -281,16 +281,19 @@ def neighbor():
 # 'expected' subcommand ("show interface neighbor expected")
 @neighbor.command()
 @click.argument('interfacename', required=False)
+@click.option('--namespace', '-n', 'namespace', default='',
+              type=str, show_default=True, help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
 @clicommon.pass_db
-def expected(db, interfacename):
+def expected(db, interfacename, namespace):
     """Show expected neighbor information by interfaces"""
 
-    neighbor_dict = db.cfgdb.get_table("DEVICE_NEIGHBOR")
+    neighbor_dict = db.cfgdb_clients[namespace].get_table("DEVICE_NEIGHBOR")
     if neighbor_dict is None:
         click.echo("DEVICE_NEIGHBOR information is not present.")
         return
 
-    neighbor_metadata_dict = db.cfgdb.get_table("DEVICE_NEIGHBOR_METADATA")
+    neighbor_metadata_dict = db.cfgdb_clients[namespace].get_table("DEVICE_NEIGHBOR_METADATA")
     if neighbor_metadata_dict is None:
         click.echo("DEVICE_NEIGHBOR_METADATA information is not present.")
         return

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -281,12 +281,13 @@ def neighbor():
 # 'expected' subcommand ("show interface neighbor expected")
 @neighbor.command()
 @click.argument('interfacename', required=False)
-@click.option('--namespace', '-n', 'namespace', default='',
-              type=str, show_default=True, help='Namespace name or all',
-              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+@multi_asic_util.multi_asic_click_option_namespace
 @clicommon.pass_db
 def expected(db, interfacename, namespace):
     """Show expected neighbor information by interfaces"""
+
+    if not namespace:
+        namespace = multi_asic_util.constants.DEFAULT_NAMESPACE
 
     neighbor_dict = db.cfgdb_clients[namespace].get_table("DEVICE_NEIGHBOR")
     if neighbor_dict is None:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Adding namespace support for `show interface neighbor expected`. So that we can use

```
show interface neighbor expected -n asic0
```

#### How I did it

#### How to verify it
Verified on T2 testbed

#### Previous command output (if the output of a command-line utility has changed)
```
admin@somehost:/var/log$ show interfaces neighbor expected -n asic1
Usage: show interfaces neighbor expected [OPTIONS] [INTERFACENAME]
Try "show interfaces neighbor expected -h" for help.

Error: no such option: -n
```

#### New command output (if the output of a command-line utility has changed)
```
admin@somehost:/var/log$ show interfaces neighbor expected -n asic1
LocalPort    Neighbor    NeighborPort    NeighborLoopback    NeighborMgmt    NeighborType
-----------  ----------  --------------  ------------------  --------------  --------------
Ethernet96   ARISTAXXTX  Ethernet1       None                XXX.XX.XXX.XX   someHub
Ethernet104  ARISTAXXTX Ethernet1       None                XXX.XX.XXX.XX   otherHub
...
```
