### PR TITLE
Remove Multi ASIC namespace Check.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1397,14 +1397,6 @@ def config_file_yang_validation(filename):
     if not isinstance(config, dict):
         return False
 
-    # If the device is multi-ASIC, check if all required namespaces exist
-    if multi_asic.is_multi_asic():
-        required_namespaces = [HOST_NAMESPACE, *multi_asic.get_namespace_list()]
-        for ns in required_namespaces:
-            asic_name = HOST_NAMESPACE if ns == DEFAULT_NAMESPACE else ns
-            if asic_name not in config:
-                return False
-
     sy = sonic_yang.SonicYang(YANG_DIR)
     sy.loadYangModel()
     asic_list = [HOST_NAMESPACE]

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1286,15 +1286,6 @@ class TestLoadMinigraph(object):
                 mock_read_json_file.assert_called_once_with('dummy_file.json')
                 mock_load_yang_model.assert_not_called()
 
-        # Test with missing namespaces in multi-ASIC config
-        with mock.patch('config.main.read_json_file', return_value={'localhost': {}}) as mock_read_json_file:
-            with mock.patch('config.main.multi_asic.is_multi_asic', return_value=True):
-                with mock.patch('config.main.multi_asic.get_namespace_list', return_value=['asic0', 'asic1']):
-                    with mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model:
-                        assert not config_file_yang_validation('dummy_file.json')
-                        mock_read_json_file.assert_called_once_with('dummy_file.json')
-                        mock_load_yang_model.assert_not_called()
-
         # Test with valid config
         valid_config = {
                 'DEVICE_METADATA': {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The multiasic golden config is a empty dict, which does not have namespace: [generate](https://github.com/sonic-net/sonic-mgmt/blob/master/ansible/library/generate_golden_config_db.py#L399)

![image](https://github.com/user-attachments/assets/86f8ef17-9f4c-47b1-aae4-4488a51e33f0)

#### How I did it

Remove multi asic namespace check.

#### How to verify it

Multi Asic KVM and Testbed

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

