### PR TITLE
enable pfcwd for backplane ports

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -105,6 +105,17 @@ def get_server_facing_ports(db):
     return server_facing_ports
 
 
+def get_bp_ports(db):
+    """    Get all the backplane ports.    """
+    candidates = db.get_table('PORT')
+    bp_ports = []
+    for port in candidates:
+        if candidates[port].get('admin_status') == 'up' \
+           and candidates[port].get('role') == 'Int':
+            bp_ports.append(port)
+    return bp_ports
+
+
 class PfcwdCli(object):
     def __init__(
         self, db=None, namespace=None, display=constants.DISPLAY_ALL
@@ -365,9 +376,10 @@ class PfcwdCli(object):
         )
 
         # Get active ports from Config DB
-        active_ports = natsorted(
-            list(self.config_db.get_table('DEVICE_NEIGHBOR').keys())
-        )
+        external_ports = list(self.config_db.get_table('DEVICE_NEIGHBOR').keys())
+        bp_ports = get_bp_ports(self.config_db)
+
+        active_ports = natsorted(list(set(external_ports + bp_ports)))
 
         if not enable or enable.lower() != "enable":
             return

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -379,7 +379,7 @@ class PfcwdCli(object):
         external_ports = list(self.config_db.get_table('DEVICE_NEIGHBOR').keys())
         bp_ports = get_bp_ports(self.config_db)
 
-        active_ports = natsorted(list(set(external_ports + bp_ports)))
+        active_ports = natsorted(set(external_ports + bp_ports))
 
         if not enable or enable.lower() != "enable":
             return


### PR DESCRIPTION
Currently, in Cisco 8800 chassis, PFCWD is only enabled for front end ports, not on backplane. As we have PFC enabled for backplane ports, need to enable pfcwd there too.

What I did.
Enable PFCWD for backplane ports.

How I did it
Include backplane ports into the port list to be enabled for pfcwd

How to verify it
manually copied the file to device, and run pfcwd start_default.

(cherry picked from commit 2866ccd9c20231bca87369b93f41f198ce55852b)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

