### PR TITLE
Fixes `show interface transceiver info Ethernet0` command failure for CMIS SFP.

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -19,6 +19,7 @@ from utilities_common.sfp_helper import covert_application_advertisement_to_outp
 from utilities_common.sfp_helper import (
         QSFP_DATA_MAP,
         CMIS_DATA_MAP,
+        C_CMIS_DATA_MAP,
         QSFP_STATUS_MAP,
         CMIS_STATUS_MAP,
         CCMIS_STATUS_MAP,
@@ -308,8 +309,15 @@ class SFPShow(object):
         indent = ' ' * 8
         output = ''
         is_sfp_cmis = 'cmis_rev' in sfp_info_dict
+        is_sfp_c_cmis = 'supported_max_tx_power' in sfp_info_dict
 
-        data_map = CMIS_DATA_MAP if is_sfp_cmis else QSFP_DATA_MAP
+        if is_sfp_c_cmis:
+            data_map = C_CMIS_DATA_MAP
+        elif is_sfp_c_cmis:
+            data_map = CMIS_DATA_MAP
+        else:
+            data_map = QSFP_DATA_MAP
+
         sorted_data_map_keys = sorted(data_map, key=data_map.get)
         for key in sorted_data_map_keys:
             if key == 'cable_type':

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -313,7 +313,7 @@ class SFPShow(object):
 
         if is_sfp_c_cmis:
             data_map = C_CMIS_DATA_MAP
-        elif is_sfp_c_cmis:
+        elif is_sfp_cmis:
             data_map = CMIS_DATA_MAP
         else:
             data_map = QSFP_DATA_MAP

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -35,10 +35,6 @@ QSFP_CMIS_DELTA_DATA_MAP = {
     'cmis_rev': 'CMIS Rev',
     'active_firmware': 'Active Firmware',
     'inactive_firmware': 'Inactive Firmware',
-    'supported_max_tx_power': 'Supported Max TX Power',
-    'supported_min_tx_power': 'Supported Min TX Power',
-    'supported_max_laser_freq': 'Supported Max Laser Frequency',
-    'supported_min_laser_freq': 'Supported Min Laser Frequency',
     'e1_active_firmware': 'E1 Active Firmware',
     'e1_inactive_firmware': 'E1 Inactive Firmware',
     'e1_server_firmware': 'E1 Server Firmware',
@@ -47,7 +43,15 @@ QSFP_CMIS_DELTA_DATA_MAP = {
     'e2_server_firmware': 'E2 Server Firmware'
 }
 
+C_CMIS_DELTA_DATA_MAP = {
+    'supported_max_tx_power': 'Supported Max TX Power',
+    'supported_min_tx_power': 'Supported Min TX Power',
+    'supported_max_laser_freq': 'Supported Max Laser Frequency',
+    'supported_min_laser_freq': 'Supported Min Laser Frequency',
+}
+
 CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP}
+C_CMIS_DATA_MAP = {**CMIS_DATA_MAP, **C_CMIS_DELTA_DATA_MAP}
 
 # Common fileds for all types:
 # For non-CMIS, only first 1 or 4 lanes are applicable.


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`show interface transceiver info Ethernet0` command was failing for CMIS SFP after this change: https://github.com/sonic-net/sonic-platform-daemons/pull/590/files#diff-fc70c43977a1ce57f3a6e9d7d09cb7ea5204f52b3adf3162936205e5680efb2f . Fixed the failing command. 
#### How I did it
Added a check for C-CMIS SFP to pick the right dict to generate data.
#### How to verify it
Run `show interface transceiver info Ethernet0` command on a CMIS SFP.
#### Previous command output (if the output of a command-line utility has changed)
```bash
root@str4-sn5600-2:/home/admin# show int transceiver info Ethernet0
Traceback (most recent call last):
  File "/usr/local/bin/sfpshow", line 733, in <module>
    cli()
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/sfpshow", line 674, in info
    sfp.get_eeprom()
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/multi_asic.py", line 156, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
  File "/usr/local/bin/sfpshow", line 556, in get_eeprom
    self.intf_eeprom[self.intf_name] = self.convert_interface_sfp_info_to_cli_output_string(
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/sfpshow", line 454, in convert_interface_sfp_info_to_cli_output_string
    sfp_info_output = self.convert_sfp_info_to_output_string(sfp_info_dict, sfp_firmware_info_dict)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/bin/sfpshow", line 341, in convert_sfp_info_to_output_string
    output += '{}{}: {}\n'.format(indent, data_map[key], sfp_info_dict[key])
                                                         ~~~~~~~~~~~~~^^^^^
KeyError: 'supported_max_laser_freq'
root@str4-sn5600-2:/home/admin#
```
#### New command output (if the output of a command-line utility has changed)
##### CMIS SFP:
```bash
admin@str4-sn5600-2:/usr$ show int transceiver info Ethernet4
Ethernet4: SFP EEPROM detected
        Active Firmware: 36.227.0
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: 100GAUI-1-L C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
                                   200GAUI-2-L C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   IB NDR - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   800G L C2M (placeholder) - Host Assign (0x1) - 800GBASE-DR8 (placeholder) - Media Assign (0x1)
                                   200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - 200GBASE-DR4 (Cl 121) - Media Assign (0x11)
                                   IB HDR (Arch.Spec.Vol.2) - Host Assign (0x11) - 200GBASE-DR4 (Cl 121) - Media Assign (0x11)
                                   100GAUI-1-S C2M (Annex 120G) - Host Assign (0xff) - 100GBASE-DR (Cl 140) - Media Assign (0xff)
                                   200GAUI-2-S C2M (Annex 120G) - Host Assign (0x55) - Undefined - Media Assign (0x55)
                                   400GAUI-4-S C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   800G S C2M (placeholder) - Host Assign (0x1) - 800GBASE-DR8 (placeholder) - Media Assign (0x1)
        CMIS Rev: 5.2
        Connector: MPO 2x12
        Encoding: N/A
        Extended Identifier: Power Class 8 (15.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 1
        Identifier: OSFP 8X Pluggable Transceiver
        Inactive Firmware: 36.227.0
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm DFB
        Media Lane Count: 1
        Module Hardware Rev: 1.10
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: sm_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2024-09-02   
        Vendor Name: PINEWAVE        
        Vendor OUI: 34-36-07
        Vendor PN: T-OH8CNT-NMT    
        Vendor Rev: 1A
        Vendor SN: IDOBIS130378    
```
##### C-CMIS SFP:
```bash
admin@sonic:~$ show int trans info Ethernet144                            
Ethernet144: SFP EEPROM detected
        Active Firmware: 3.3.37
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
        CMIS Rev: 5.0
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (18.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: 3.3.37
        Length Cable Assembly(m): 0.0
        Media Interface Technology: C-band tunable laser
        Media Lane Count: 1
        Module Hardware Rev: 0.0
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100
        Supported Max TX Power: -10.3
        Supported Min Laser Frequency: 191300
        Supported Min TX Power: -14.0
        Vendor Date Code(YYYY-MM-DD Lot): 2021-04-20 
        Vendor Name: INPHI CORP      
        Vendor OUI: 00-21-b8
        Vendor PN: IN-Q3JZ1-TC-M1  
        Vendor Rev: 01
        Vendor SN: L2116D0146      
```
##### QSFP Interface:
```bash
admin@sonic:~$ show int trans info Ethernet260
Ethernet260: SFP EEPROM detected
        Application Advertisement: N/A
        Connector: LC
        Encoding: 64B/66B
        Extended Identifier: GBIC/SFP defined by two-wire interface ID
        Extended RateSelect Compliance: Unknown
        Identifier: SFP/SFP+/SFP28
        Length OM3(10m): 30.0
        Nominal Bit Rate(100Mbs): 103
        Specification compliance:
                10G Ethernet Compliance: 10GBASE-SR
                ESCON Compliance: Unknown
                Ethernet Compliance: Unknown
                Fibre Channel Link Length: Unknown
                Fibre Channel Speed: Unknown
                Fibre Channel Transmission Media: Unknown
                Fibre Channel Transmitter Technology: Unknown
                Infiniband Compliance: Unknown
                SFP+CableTechnology: Unknown
                SONET Compliance Codes: Unknown
        Vendor Date Code(YYYY-MM-DD Lot): 2014-02-08   
        Vendor Name: FINISAR CORP.   
        Vendor OUI: 00-90-65
        Vendor PN: FTLX8571D3BCL   
        Vendor Rev: A   
        Vendor SN: AR62NDY 
```

##### 400ZR:
```bash
admin@sonic:/usr$ show int trans info Ethernet144                                                   
Ethernet144: SFP EEPROM detected
        Active Firmware: 3.3.37
        Active application selected code assigned to host lane 1: 1
        Active application selected code assigned to host lane 2: 1
        Active application selected code assigned to host lane 3: 1
        Active application selected code assigned to host lane 4: 1
        Active application selected code assigned to host lane 5: 1
        Active application selected code assigned to host lane 6: 1
        Active application selected code assigned to host lane 7: 1
        Active application selected code assigned to host lane 8: 1
        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
        CMIS Rev: 5.0
        Connector: LC
        Encoding: N/A
        Extended Identifier: Power Class 8 (18.0W Max)
        Extended RateSelect Compliance: N/A
        Host Lane Count: 8
        Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
        Inactive Firmware: 3.3.37
        Length Cable Assembly(m): 0.0
        Media Interface Technology: C-band tunable laser
        Media Lane Count: 1
        Module Hardware Rev: 0.0
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: sm_media_interface
        Supported Max Laser Frequency: 196100
        Supported Max TX Power: -10.3
        Supported Min Laser Frequency: 191300
        Supported Min TX Power: -14.0
        Vendor Date Code(YYYY-MM-DD Lot): 2021-04-20 
        Vendor Name: INPHI CORP      
        Vendor OUI: 00-21-b8
        Vendor PN: IN-Q3JZ1-TC-M1  
        Vendor Rev: 01
        Vendor SN: L2116D0146     
```