### PR TITLE
kdump support for marvell-arm64

### DIFF
--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -24,6 +24,8 @@ import shlex
 import sys
 import syslog
 import subprocess
+import platform
+import tempfile
 
 from swsscommon.swsscommon import ConfigDBConnector
 from sonic_installer.bootloader import get_bootloader
@@ -378,7 +380,6 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file)
     img_index = locate_image(lines, "loop=image-"+image)
     if verbose:
         print("Image index in %s=%d" % (cmdline_file, img_index))
-
     changed = False
     crash_kernel_in_cmdline = search_for_crash_kernel_in_cmdline()
     if verbose:
@@ -412,7 +413,6 @@ def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file)
         if rc != 0:
             print_err("Error Unable to unload Kdump the kernel '%s'", err_str)
             sys.exit(1)
-
     return changed
 
 ## Read kdump configuration saved in the startup configuration file
@@ -438,6 +438,76 @@ def get_kdump_config_json(config_param):
             print_err("Error [%s] while reading startup configuration" % e)
             return None
 
+def kdump_disable_uboot(verbose, image, tmp_dir):
+    bootloader = get_bootloader()
+    installed_images = bootloader.get_installed_images()
+    if any(image in installed_image for installed_image in installed_images):
+        if image in installed_images[0]:
+            proc = subprocess.Popen(["/usr/bin/fw_printenv", "-n", "linuxargs"], text=True, stdout=subprocess.PIPE)
+            (out, _) = proc.communicate()
+            linuxargs = out.rstrip()
+            tmp_file_path = os.path.join(tmp_dir, "linuxargs.txt")
+            with open(tmp_file_path, 'w') as file:
+                file.write(linuxargs)
+            retval = kdump_disable(verbose, image, tmp_file_path)
+            if retval:
+                with open(tmp_file_path, 'r') as file:
+                    linuxargs = file.read().strip()
+                run_command(['/usr/bin/fw_setenv', 'linuxargs', linuxargs])
+            return retval
+
+        else:
+            proc = subprocess.Popen(["/usr/bin/fw_printenv", "-n", "linuxargs_old"], text=True, stdout=subprocess.PIPE)
+            (out, _) = proc.communicate()
+            linuxargs_old = out.rstrip()
+            tmp_file_path = os.path.join(tmp_dir, "linuxargs_old.txt")
+            with open(tmp_file_path, 'w') as file:
+                file.write(linuxargs_old)
+            retval = kdump_disable(verbose, image, tmp_file_path)
+            if retval:
+                with open(tmp_file_path, 'r') as file:
+                    linuxargs_old = file.read().strip()
+                run_command(['/usr/bin/fw_setenv', 'linuxargs_old', linuxargs_old])
+            return retval
+    else:
+        print("Current image is not part of any installed images")
+        return False
+
+def kdump_enable_uboot(verbose, kdump_enabled, memory, num_dumps, image, tmp_dir):
+    bootloader = get_bootloader()
+    installed_images = bootloader.get_installed_images()
+    if any(image in installed_image for installed_image in installed_images):
+        if image in installed_images[0]:
+            proc = subprocess.Popen(["/usr/bin/fw_printenv", "-n", "linuxargs"], text=True, stdout=subprocess.PIPE)
+            (out, _) = proc.communicate()
+            linuxargs = out.rstrip()
+            tmp_file_path = os.path.join(tmp_dir, "linuxargs.txt")
+            with open(tmp_file_path, 'w') as file:
+                file.write(linuxargs)
+            retval = kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, tmp_file_path)
+            if retval:
+                with open(tmp_file_path, 'r') as file:
+                    linuxargs = file.read().strip()
+                run_command(['/usr/bin/fw_setenv', 'linuxargs', linuxargs])
+            return retval
+
+        else:
+            proc = subprocess.Popen(["/usr/bin/fw_printenv", "-n", "linuxargs_old"], text=True, stdout=subprocess.PIPE)
+            (out, _) = proc.communicate()
+            linuxargs_old = out.rstrip()
+            tmp_file_path = os.path.join(tmp_dir, "linuxargs_old.txt")
+            with open(tmp_file_path, 'w') as file:
+                file.write(linuxargs_old)
+            retval = kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, tmp_file_path)
+            if retval:
+                with open(tmp_file_path, 'r') as file:
+                    linuxargs_old = file.read().strip()
+                run_command(['/usr/bin/fw_setenv', 'linuxargs_old', linuxargs_old])
+            return retval
+    else:
+        print("Current image is not part of any installed images")
+        return False
+
 ## Command: Enable kdump
 #
 #  @param verbose If True, the function will display a few additinal information
@@ -448,6 +518,7 @@ def cmd_kdump_enable(verbose, image):
     kdump_enabled = get_kdump_administrative_mode()
     memory = get_kdump_memory()
     num_dumps = get_kdump_num_dumps()
+    arch = platform.machine()
     if verbose:
         print("configDB: kdump_enabled=%d memory=[%s] num_nums=%d" % (kdump_enabled, memory, num_dumps))
 
@@ -456,6 +527,11 @@ def cmd_kdump_enable(verbose, image):
     elif open(machine_cfg, 'r').read().find('aboot_platform') >= 0:
         aboot_cfg = aboot_cfg_template % image
         return kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, aboot_cfg)
+    elif ("aarch64" in arch):
+        tmp_dir_obj = tempfile.TemporaryDirectory()
+        tmp_dir = tmp_dir_obj.name
+        return kdump_enable_uboot(verbose, kdump_enabled, memory, num_dumps, image, tmp_dir)
+        tmp_dir_obj.cleanup()
     else:
         print("Feature not supported on this platform")
         return False
@@ -527,6 +603,7 @@ def cmd_kdump_disable(verbose):
     kdump_enabled = get_kdump_administrative_mode()
     memory = get_kdump_memory()
     num_dumps = get_kdump_num_dumps()
+    arch = platform.machine()
 
     if verbose:
         print("configDB: kdump_enabled=%d memory=[%s] num_nums=%d" % (kdump_enabled, memory, num_dumps))
@@ -536,6 +613,11 @@ def cmd_kdump_disable(verbose):
     elif open(machine_cfg, 'r').read().find('aboot_platform') >= 0:
         aboot_cfg = aboot_cfg_template % image
         return kdump_disable(verbose, image, aboot_cfg)
+    elif ("aarch64" in arch):
+        tmp_dir_obj = tempfile.TemporaryDirectory()
+        tmp_dir = tmp_dir_obj.name
+        return kdump_disable_uboot(verbose, image, tmp_dir)
+        tmp_dir_obj.cleanup()
     else:
         print("Feature not supported on this platform")
         return False


### PR DESCRIPTION
#### What I did
Enable kdump configurability for arm64 marvell platform

#### How I did it
This change is one of the two part changes to be done to enable kdump utility for arm64 marvell platform.
1. sonic-buildimage - https://github.com/sonic-net/sonic-buildimage/pull/20661

#### How to verify it
Verify basic "config kdump enable/disable" options in marvell platform device.

#### Previous command output (if the output of a command-line utility has changed)
admin@ixs-7215-pizza-GA-4:~$ show kdump config
Traceback (most recent call last):
 File "/usr/local/bin/show", line 8, in <module>
  sys.exit(cli())
 File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in __call__
  return self.main(*args, **kwargs)
 File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
  rv = self.invoke(ctx)
 File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
  return _process_result(sub_ctx.command.invoke(sub_ctx))
 File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
  return _process_result(sub_ctx.command.invoke(sub_ctx))
 File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
  return ctx.invoke(self.callback, **ctx.params)
 File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
  return callback(*args, **kwargs)
 File "/usr/local/lib/python3.9/dist-packages/show/kdump.py", line 72, in config
  oper_mode = get_kdump_oper_mode()
 File "/usr/local/lib/python3.9/dist-packages/show/kdump.py", line 52, in get_kdump_oper_mode
  command_stdout, _ = clicommon.run_command(['/usr/sbin/kdump-config', 'status'], return_cmd=True)
 File "/usr/local/lib/python3.9/dist-packages/utilities_common/cli.py", line 545, in run_command
  proc = subprocess.Popen(command, shell=shell, text=True, stdout=subprocess.PIPE)
 File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
  self._execute_child(args, executable, preexec_fn, close_fds,
 File "/usr/lib/python3.9/subprocess.py", line 1823, in _execute_child
  raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/kdump-config'


#### New command output (if the output of a command-line utility has changed)
root@str-mxx-1:/home/admin# show kdump config
Kdump administrative mode: Enabled
Kdump operational mode: Ready
Kdump memory reservation: 448M
Maximum number of Kdump files: 3
root@str-marvell-acs-1:/home/admin#
