### PR TITLE
Added post commands for enabling fifos

### DIFF
--- a/scripts/dpu-tty.py
+++ b/scripts/dpu-tty.py
@@ -45,7 +45,10 @@ def get_dpu_tty(dpu, tty, baud):
 
     if baud is None:
         baud = dpus[dpu]["serial-console"]["baud-rate"]
-    return dev, baud
+
+    post_cmds = dpus[dpu].get("tty-post-cmds")
+
+    return dev, baud, post_cmds
 
 
 def main():
@@ -56,7 +59,7 @@ def main():
     parser.add_argument('-b', '--baud')
     args = parser.parse_args()
 
-    dpu_tty, dpu_baud = get_dpu_tty(args.name, args.tty, args.baud)
+    dpu_tty, dpu_baud, post_cmds = get_dpu_tty(args.name, args.tty, args.baud)
     # Use UART console utility for error checking of dpu_tty and dpu_baud.
 
     p = subprocess.run([UART_CON, '-b', dpu_baud, '/dev/%s' % dpu_tty])
@@ -66,8 +69,16 @@ def main():
             print(p.stdout)
         if p.stderr:
             print(p.stderr)
-    return p.returncode
+        return p.returncode
 
+    # Execute tty-post-cmds only if it exists
+    if post_cmds:
+        print(f"Executing post commands: {post_cmds}")
+        for cmd in post_cmds:
+            if cmd:
+                subprocess.run(cmd, shell=True, check=False)
+
+    return 0
 
 if __name__ == "__main__":
     exit(main())

--- a/scripts/dpu-tty.py
+++ b/scripts/dpu-tty.py
@@ -75,9 +75,10 @@ def main():
     if post_cmds:
         print(f"Executing post commands: {post_cmds}")
         for cmd in post_cmds:
-            if cmd:
-                subprocess.run(cmd, shell=True, check=False)
-
+            if 'echo' in cmd:
+                subprocess.run(['bash', '-c', cmd])
+            else:
+                subprocess.run(cmd.split())
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

         - Updated dpu-tty.py to run fifo enable configuration commands after exiting from dpu console.

#### How I did it
 
         - Read the command lists from platform.json if present and execute it.
         - Command to Write to fifos_enable in Sysfs path

#### How to verify it

         - Added the steps in UT

#### Previous command output (if the output of a command-line utility has changed)

         - No change

#### New command output (if the output of a command-line utility has changed)



Sample DPU content in Platform.json:

```
    "DPUS": {
        "dpu0": {
	    "bus_info": "[0000:]1A:00.0",
            "midplane_interface":  "dpu0",
            "serial-console": {
                "device": "ttyS4",
                "baud-rate": "115200"
            },
	    "tty-post-cmds": ["stty -F /dev/ttyS4 115200 cs8 ignpar -cstopb -clocal",
		              "echo 1 > /sys/bus/platform/devices/uxbar/modem0/fifos_enable"]
        },
        "dpu1": {
	    "bus_info": "[0000:]16:00.0",
            "midplane_interface":  "dpu1",
            "serial-console": {
                "device": "ttyS5",
                "baud-rate": "115200"
            },
	    "tty-post-cmds": ["stty -F /dev/ttyS5 115200 cs8 ignpar -cstopb -clocal",
		              "echo 1 > /sys/bus/platform/devices/uxbar/modem1/fifos_enable"]
        },

```
