### PR TITLE
Add scope to field validator.[redo PR: 3675]

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -191,7 +191,7 @@ class ConfigWrapper:
                 raise GenericConfigUpdaterError("Attempting to call invalid method {} in module {}. Module must be generic_config_updater.field_operation_validators, and method must be a defined validator".format(method_name, module_name))
             module = importlib.import_module(module_name, package=None)
             method_to_call = getattr(module, method_name)
-            return method_to_call(jsonpatch_element)
+            return method_to_call(self.scope, jsonpatch_element)
 
         if os.path.exists(GCU_FIELD_OP_CONF_FILE):
             with open(GCU_FIELD_OP_CONF_FILE, "r") as s:

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -1,5 +1,5 @@
-import unittest
 import mock
+import unittest
 import generic_config_updater
 import generic_config_updater.field_operation_validators as fov
 import generic_config_updater.gu_common as gu_common
@@ -14,32 +14,42 @@ class TestValidateFieldOperation(unittest.TestCase):
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_speed_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="40000,30000"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "xyz"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "234"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "235"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is False
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+    
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested(self):
@@ -48,7 +58,9 @@ class TestValidateFieldOperation(unittest.TestCase):
             "op": "add",
             "value": {"Ethernet3": {"alias": "Eth0", "speed": "235"}}
         }
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
@@ -61,8 +73,10 @@ class TestValidateFieldOperation(unittest.TestCase):
                 "Ethernet4": {"alias": "Eth4", "speed": "234"}
             }
         }
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+    
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested_2(self):
@@ -74,17 +88,23 @@ class TestValidateFieldOperation(unittest.TestCase):
                 "Ethernet4": {"alias": "Eth4", "speed": "236"}
             }
         }
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is False
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+    
     def test_port_config_update_validator_remove(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "asf"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
@@ -97,8 +117,10 @@ class TestValidateFieldOperation(unittest.TestCase):
                 "Ethernet4": {"alias": "Eth4", "fec": "fs"}
             }
         }
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is False
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+    
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested(self):
@@ -107,7 +129,9 @@ class TestValidateFieldOperation(unittest.TestCase):
             "op": "add",
             "value": {"Ethernet3": {"alias": "Eth0", "fec": "fc"}}
         }
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
     
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
@@ -120,25 +144,33 @@ class TestValidateFieldOperation(unittest.TestCase):
                 "Ethernet4": {"alias": "Eth4", "fec": "fc"}
             }
         }
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+    
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rs"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rs"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is True
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+    
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value=""))
     def test_port_config_update_validator_invalid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rsf"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) is False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
     
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
            mock.Mock(return_value="unknown"))
@@ -148,7 +180,9 @@ class TestValidateFieldOperation(unittest.TestCase):
             "op": "replace",
             "value": "234234"
         }
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) is False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
         
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -165,11 +199,14 @@ class TestValidateFieldOperation(unittest.TestCase):
             "op": "replace",
             "value": "234234"
         }
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) is False
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
+    
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
     @patch("builtins.open", mock_open(read_data='''{"tables": {"PFC_WD": {"validator_data": {
         "rdma_config_update_validator": {"PFCWD enable/disable": {"fields": [
@@ -177,7 +214,9 @@ class TestValidateFieldOperation(unittest.TestCase):
         ], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'''))
     def test_rdma_config_update_validator_spc_asic_valid_version_remove(self):
         patch_element = {"path": "/PFC_WD/Ethernet8/detection_time", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is True
 
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
@@ -198,11 +237,14 @@ class TestValidateFieldOperation(unittest.TestCase):
                 "restoration_time": "200"
             }
         }
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) is True
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is True
+   
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
     @patch("builtins.open", mock_open(read_data='''{"tables": {"PFC_WD": {"validator_data": {
         "rdma_config_update_validator": {"PFCWD enable/disable": {"fields": [
@@ -210,8 +252,10 @@ class TestValidateFieldOperation(unittest.TestCase):
         ], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'''))
     def test_rdma_config_update_validator_spc_asic_valid_version(self):
         patch_element = {"path": "/PFC_WD/Ethernet8", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) is True
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is True
+    
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
@@ -226,8 +270,10 @@ class TestValidateFieldOperation(unittest.TestCase):
             "path": "/BUFFER_POOL/ingress_lossless_pool/xoff",
             "op": "remove"
         }
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) is False
-
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
+    
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
@@ -243,7 +289,9 @@ class TestValidateFieldOperation(unittest.TestCase):
             "op": "add",
             "value": "sample_value"
         }
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) is False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
     
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
@@ -297,92 +345,6 @@ class TestValidateFieldOperation(unittest.TestCase):
             target_config
         )
 
-    def test_validate_field_operation_illegal__dataacl_table_type_update_and_rule_change(self):
-        old_config = {
-            "ACL_TABLE": {
-                "TEST_INGRESS": {
-                    "type": "L2"
-                }
-            },
-            "ACL_RULE": {
-                "TEST_INGRESS|RULE_1": {
-                    "ETHER_TYPE": "2048"
-                }
-            }
-        }
-        target_config = {
-            "ACL_TABLE": {
-                "TEST_INGRESS": {
-                    "type": "L3V6"
-                }
-            },
-            "ACL_RULE": {
-                "TEST_INGRESS|RULE_1": {
-                    "IP_TYPE": "IPV6ANY"
-                }
-            }
-        }
-        config_wrapper = gu_common.ConfigWrapper()
-        self.assertRaises(gu_common.IllegalPatchOperationError,
-                          config_wrapper.validate_field_operation, old_config, target_config)
-
-    def test_validate_field_operation_legal__only_dataacl_table_type_update(self):
-        old_config = {
-            "ACL_TABLE": {
-                "TEST_INGRESS": {
-                    "type": "L3"
-                }
-            },
-            "ACL_RULE": {
-                "TEST_INGRESS|RULE_1": {
-                    "IP_TYPE": "IPV6ANY"
-                }
-            }
-        }
-        target_config = {
-            "ACL_TABLE": {
-                "TEST_INGRESS": {
-                    "type": "L3V6"
-                }
-            },
-            "ACL_RULE": {
-                "TEST_INGRESS|RULE_1": {
-                    "IP_TYPE": "IPV6ANY"
-                }
-            }
-        }
-        config_wrapper = gu_common.ConfigWrapper()
-        config_wrapper.validate_field_operation(old_config, target_config)
-
-    def test_validate_field_operation_legal__only_dataacl_rule_update(self):
-        old_config = {
-            "ACL_TABLE": {
-                "TEST_INGRESS": {
-                    "type": "L3"
-                }
-            },
-            "ACL_RULE": {
-                "TEST_INGRESS|RULE_1": {
-                    "IP_TYPE": "IPV6ANY"
-                }
-            }
-        }
-        target_config = {
-            "ACL_TABLE": {
-                "TEST_INGRESS": {
-                    "type": "L3"
-                }
-            },
-            "ACL_RULE": {
-                "TEST_INGRESS|RULE_1": {
-                    "IP_TYPE": "IPV4ANY"
-                }
-            }
-        }
-        config_wrapper = gu_common.ConfigWrapper()
-        config_wrapper.validate_field_operation(old_config, target_config)
-
-
 class TestGetAsicName(unittest.TestCase):
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
@@ -391,7 +353,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-D48C8", 0]
-        self.assertEqual(fov.get_asic_name(), "spc1")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc1")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -399,7 +362,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-MSN3800", 0]
-        self.assertEqual(fov.get_asic_name(), "spc2")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc2")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -407,7 +371,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN4600C-C64", 0]
-        self.assertEqual(fov.get_asic_name(), "spc3")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc3")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -415,7 +380,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-SN5600", 0]
-        self.assertEqual(fov.get_asic_name(), "spc4")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc4")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -423,7 +389,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-A1", 0]
-        self.assertEqual(fov.get_asic_name(), "spc1")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc1")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -431,7 +398,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN5640-C512S2", 0]
-        self.assertEqual(fov.get_asic_name(), "spc5")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "spc5")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -439,7 +407,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6100", 0]
-        self.assertEqual(fov.get_asic_name(), "th")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "th")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -447,7 +416,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7260CX3-D108C8", 0]
-        self.assertEqual(fov.get_asic_name(), "th2")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "th2")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -455,7 +425,8 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6000", 0]
-        self.assertEqual(fov.get_asic_name(), "td2")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "td2")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -463,10 +434,12 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7050CX3-32S-C32", 0]
-        self.assertEqual(fov.get_asic_name(), "td3")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "td3")
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_cisco(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'cisco-8000'}
-        self.assertEqual(fov.get_asic_name(), "cisco-8000")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(scope), "cisco-8000")

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -17,7 +17,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is True
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="40000,30000"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
@@ -25,7 +25,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
@@ -41,7 +41,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is True
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
@@ -49,7 +49,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested(self):
@@ -61,7 +61,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db_nested(self):
@@ -76,7 +76,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is True
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested_2(self):
@@ -91,7 +91,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
-    
+
     def test_port_config_update_validator_remove(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "remove"}
         for scope in ["localhost", "asic0"]:
@@ -105,7 +105,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db_nested(self):
@@ -120,7 +120,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested(self):
@@ -132,7 +132,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is True
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested_2(self):
@@ -147,7 +147,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is True
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db(self):
@@ -163,7 +163,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is True
-    
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value=""))
     def test_port_config_update_validator_invalid_fec_no_state_db(self):
@@ -171,7 +171,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
-    
+
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
            mock.Mock(return_value="unknown"))
     def test_rdma_config_update_validator_unknown_asic(self):
@@ -183,7 +183,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 rdma_config_update_validator(scope, patch_element) is False
-        
+
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
@@ -202,7 +202,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 rdma_config_update_validator(scope, patch_element) is False
-    
+
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
@@ -240,7 +240,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 rdma_config_update_validator(scope, patch_element) is True
-   
+
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
@@ -255,7 +255,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 rdma_config_update_validator(scope, patch_element) is True
-    
+
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
@@ -273,7 +273,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 rdma_config_update_validator(scope, patch_element) is False
-    
+
     @patch("sonic_py_common.device_info.get_sonic_version_info",
            mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
@@ -292,7 +292,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         for scope in ["localhost", "asic0"]:
             assert generic_config_updater.field_operation_validators.\
                 rdma_config_update_validator(scope, patch_element) is False
-    
+
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
         target_config = {"PFC_WD": {"GLOBAL": {}}}
@@ -303,7 +303,7 @@ class TestValidateFieldOperation(unittest.TestCase):
             old_config,
             target_config
         )
-    
+
     def test_validate_field_operation_legal__rm_loopback1(self):
         old_config = {
             "LOOPBACK_INTERFACE": {
@@ -321,7 +321,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         config_wrapper = gu_common.ConfigWrapper()
         config_wrapper.validate_field_operation(old_config, target_config)
-        
+
     def test_validate_field_operation_illegal__rm_loopback0(self):
         old_config = {
             "LOOPBACK_INTERFACE": {
@@ -355,7 +355,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-D48C8", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "spc1")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc2(self, mock_popen, mock_get_sonic_version_info):
@@ -364,7 +364,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["ACS-MSN3800", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "spc2")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc3(self, mock_popen, mock_get_sonic_version_info):
@@ -373,7 +373,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN4600C-C64", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "spc3")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc4(self, mock_popen, mock_get_sonic_version_info):
@@ -382,7 +382,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["ACS-SN5600", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "spc4")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc4(self, mock_popen, mock_get_sonic_version_info):
@@ -409,7 +409,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["Force10-S6100", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "th")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_th2(self, mock_popen, mock_get_sonic_version_info):
@@ -418,7 +418,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["Arista-7260CX3-D108C8", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "th2")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_td2(self, mock_popen, mock_get_sonic_version_info):
@@ -427,7 +427,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["Force10-S6000", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "td2")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_td3(self, mock_popen, mock_get_sonic_version_info):
@@ -436,7 +436,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = ["Arista-7050CX3-32S-C32", 0]
         for scope in ["localhost", "asic0"]:
             self.assertEqual(fov.get_asic_name(scope), "td3")
-    
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_cisco(self, mock_popen, mock_get_sonic_version_info):

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -354,7 +354,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-D48C8", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "spc1")
+            self.assertEqual(fov.get_asic_name(), "spc1")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -363,7 +363,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-MSN3800", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "spc2")
+            self.assertEqual(fov.get_asic_name(), "spc2")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -372,7 +372,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN4600C-C64", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "spc3")
+            self.assertEqual(fov.get_asic_name(), "spc3")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -381,7 +381,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-SN5600", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "spc4")
+            self.assertEqual(fov.get_asic_name(), "spc4")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -390,7 +390,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-A1", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "spc1")
+            self.assertEqual(fov.get_asic_name(), "spc1")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -399,7 +399,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN5640-C512S2", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "spc5")
+            self.assertEqual(fov.get_asic_name(), "spc5")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -408,7 +408,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6100", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "th")
+            self.assertEqual(fov.get_asic_name(), "th")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -417,7 +417,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7260CX3-D108C8", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "th2")
+            self.assertEqual(fov.get_asic_name(), "th2")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -426,7 +426,7 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6000", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "td2")
+            self.assertEqual(fov.get_asic_name(), "td2")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -435,11 +435,11 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7050CX3-32S-C32", 0]
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "td3")
+            self.assertEqual(fov.get_asic_name(), "td3")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_cisco(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'cisco-8000'}
         for scope in ["localhost", "asic0"]:
-            self.assertEqual(fov.get_asic_name(scope), "cisco-8000")
+            self.assertEqual(fov.get_asic_name(), "cisco-8000")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This is for fix issue:https://github.com/sonic-net/sonic-buildimage/issues/20379. It was done by [PR 3675](https://github.com/sonic-net/sonic-utilities/pull/3675). and it was reverted by https://github.com/sonic-net/sonic-utilities/pull/3689.

This is redo by removing unnecessary change that caused PR test failure.

#### How I did it

For field_operation_validators, add scope if need read state_db.

#### How to verify it

```shell
admin@str2-7250-lc1-2:~$ sonic-db-cli STATE_DB -n asic0 hget "PORT_TABLE|Ethernet0" supported_fecs
none,rs

admin@str2-7250-lc1-2:~$ cat fec.json 
[
    {
        "op": "add",
        "path": "/asic0/PORT/Ethernet0/fec",
        "value": "fc"
    }
]

admin@str2-7250-lc1-2:~$ sudo config apply-patch fec.json 
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: [{"op": "add", "path": "/PORT/Ethernet0/fec", "value": "fc"}]
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Failed to apply patch due to: Failed to apply patch on the following scopes:
- asic0: Modification of PORT table is illegal- validating function generic_config_updater.field_operation_validators.port_config_update_validator returned False
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Failed to apply patch on the following scopes:
- asic0: Modification of PORT table is illegal- validating function generic_config_updater.field_operation_validators.port_config_update_validator returned False
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

