### PR TITLE
[202405] Fix `vnet_route_check` for active and inactive routes, add `--all` option

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -4,6 +4,7 @@ import sys
 import json
 import syslog
 import subprocess
+import argparse
 from swsscommon import swsscommon
 
 ''' vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
@@ -356,7 +357,40 @@ def get_sdk_vnet_routes_diff(routes):
     return routes_diff
 
 
+def filter_active_vnet_routes(vnet_routes: dict):
+    """ Filters a dictionary containing VNet routes configured for each VNet in APP_DB.
+    For each VNet in "vnet_routes", only active routes are included in the returned dictionary.
+    Format (for both input and output):
+    { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
+    """
+    state_db = swsscommon.DBConnector("STATE_DB", 0, True)
+    vnet_route_tunnel_table = swsscommon.Table(state_db, "VNET_ROUTE_TUNNEL_TABLE")
+
+    vnet_active_routes = {}
+    for vnet_name, vnet_info in vnet_routes.items():
+        active_routes = []
+        for prefix in vnet_info["routes"]:
+            key = f"{vnet_name}|{prefix}"
+            exists, fvs = vnet_route_tunnel_table.get(key)
+            if not exists:
+                print_message(syslog.LOG_WARNING, f"VNET_ROUTE_TUNNEL_TABLE|{key} does not exist in STATE DB.")
+                active_routes.append(prefix)  # Treating "prefix" as an active route
+                continue
+            fvs_dict = dict(fvs)
+            if fvs_dict.get("state") == "active":
+                active_routes.append(prefix)
+        if len(active_routes) > 0:
+            vnet_active_routes[vnet_name] = {"routes": active_routes, "vrf_oid": vnet_info["vrf_oid"]}
+
+    return vnet_active_routes
+
+
 def main():
+    parser = argparse.ArgumentParser(
+        description="A script that checks for VNet route mismatches between APP DB, ASIC DB, and SDK.")
+    parser.add_argument("-a", "--all", action="store_true",
+                        help="Find routes missed in ASIC DB by checking both active and inactive routes in APP DB.")
+    args = parser.parse_args()
 
     rc = RC_OK
 
@@ -365,14 +399,20 @@ def main():
         return rc
     asic_db = swsscommon.DBConnector('ASIC_DB', 0)
     virtual_router = swsscommon.Table(asic_db, 'ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER')
-    if virtual_router.getKeys() != []:
-        global default_vrf_oid
-        default_vrf_oid = virtual_router.getKeys()[0]
+    global default_vrf_oid
+    default_vrf_oid = ""
+    vr_keys = virtual_router.getKeys()
+    if vr_keys:
+        default_vrf_oid = vr_keys[0]
 
     app_db_vnet_routes = get_vnet_routes_from_app_db()
+    active_app_db_vnet_routes = filter_active_vnet_routes(app_db_vnet_routes)
     asic_db_vnet_routes = get_vnet_routes_from_asic_db()
 
-    missed_in_asic_db_routes = get_vnet_routes_diff(asic_db_vnet_routes, app_db_vnet_routes,True)
+    if args.all:
+        missed_in_asic_db_routes = get_vnet_routes_diff(asic_db_vnet_routes, app_db_vnet_routes, True)
+    else:
+        missed_in_asic_db_routes = get_vnet_routes_diff(asic_db_vnet_routes, active_app_db_vnet_routes, True)
     missed_in_app_db_routes = get_vnet_routes_diff(app_db_vnet_routes, asic_db_vnet_routes)
     missed_in_sdk_routes = get_sdk_vnet_routes_diff(asic_db_vnet_routes)
 

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -363,7 +363,7 @@ def filter_active_vnet_routes(vnet_routes: dict):
     Format (for both input and output):
     { <vnet_name>: { 'routes': [ <pfx/pfx_len> ], 'vrf_oid': <oid> } }
     """
-    state_db = swsscommon.DBConnector("STATE_DB", 0, True)
+    state_db = swsscommon.DBConnector("STATE_DB", 0)
     vnet_route_tunnel_table = swsscommon.Table(state_db, "VNET_ROUTE_TUNNEL_TABLE")
 
     vnet_active_routes = {}

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -15,6 +15,7 @@ RET = "return"
 APPL_DB = 0
 ASIC_DB = 1
 CNTR_DB = 2
+STATE_DB = 6
 PRE = "pre-value"
 UPD = "update"
 RESULT = "res"
@@ -40,23 +41,23 @@ tables_returned = {}
 test_data = {
     "0": {
         DESCR: "All VNET routes are configured in both APP and ASIC DBs",
-        ARGS: "vnet_route_check",
+        ARGS: "vnet_route_check --all",
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
-                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
                 },
                 VNET_TABLE: {
-                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
                 },
                 INTF_TABLE: {
-                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001": {"vnet_name": "Vnet1"},
                     "Vlan3001:30.1.10.1/24": {}
                 },
                 VNET_ROUTE_TABLE: {
-                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
-                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
-                    "Vnet1:50.2.2.0/24": { "ifname": "Vlan3001" }
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.2.2.0/24": {"ifname": "Vlan3001"}
                 }
             },
             ASIC_DB: {
@@ -70,30 +71,37 @@ test_data = {
                 }
             },
             CNTR_DB: {
-                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|30.1.10.0/24": [("active_endpoints", ""), ("state", "inactive")],
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", ""), ("state", "inactive")],
+                    "Vnet1|50.2.2.0/24": [("active_endpoints", ""), ("state", "inactive")]
+                }
             }
         }
     },
     "1": {
         DESCR: "VNET route is missed in ASIC DB",
-        ARGS: "vnet_route_check",
+        ARGS: "vnet_route_check -a",
         RET: -1,
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
-                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
                 },
                 VNET_TABLE: {
-                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
                 },
                 INTF_TABLE: {
-                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001": {"vnet_name": "Vnet1"},
                     "Vlan3001:30.1.10.1/24": {}
                 },
                 VNET_ROUTE_TABLE: {
-                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
-                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
-                    "Vnet1:50.2.2.0/24": { "ifname": "Vlan3001" }
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.2.2.0/24": {"ifname": "Vlan3001"}
                 }
             },
             ASIC_DB: {
@@ -106,7 +114,14 @@ test_data = {
                 }
             },
             CNTR_DB: {
-                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|30.1.10.0/24": [("active_endpoints", ""), ("state", "inactive")],
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", "30.1.10.10"), ("state", "active")],
+                    "Vnet1|50.2.2.0/24": [("active_endpoints", ""), ("state", "inactive")]
+                }
             }
         },
         RESULT: {
@@ -123,23 +138,23 @@ test_data = {
     },
     "2": {
         DESCR: "VNET route is missed in APP DB",
-        ARGS: "vnet_route_check",
+        ARGS: "vnet_route_check -a",
         RET: -1,
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
-                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
                 },
                 VNET_TABLE: {
-                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
                 },
                 INTF_TABLE: {
-                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001": {"vnet_name": "Vnet1"},
                     "Vlan3001:30.1.10.1/24": {}
                 },
                 VNET_ROUTE_TABLE: {
-                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
-                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
                 }
             },
             ASIC_DB: {
@@ -153,7 +168,13 @@ test_data = {
                 }
             },
             CNTR_DB: {
-                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|30.1.10.0/24": [("active_endpoints", "30.1.10.5"), ("state", "active")],
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", "30.1.10.10"), ("state", "active")]
+                }
             }
         },
         RESULT: {
@@ -170,23 +191,23 @@ test_data = {
     },
     "3": {
         DESCR: "VNET routes are missed in both ASIC and APP DB",
-        ARGS: "vnet_route_check",
+        ARGS: "vnet_route_check -a",
         RET: -1,
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
-                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
                 },
                 VNET_TABLE: {
-                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
                 },
                 INTF_TABLE: {
-                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001": {"vnet_name": "Vnet1"},
                     "Vlan3001:30.1.10.1/24": {}
                 },
                 VNET_ROUTE_TABLE: {
-                    "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
-                    "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
                 }
             },
             ASIC_DB: {
@@ -199,7 +220,13 @@ test_data = {
                 }
             },
             CNTR_DB: {
-                "COUNTERS_RIF_NAME_MAP": { "Vlan3001": "oid:0x6000000000d76" }
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|30.1.10.0/24": [("active_endpoints", ""), ("state", "inactive")],
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", ""), ("state", "inactive")]
+                }
             }
         },
         RESULT: {
@@ -223,12 +250,12 @@ test_data = {
     },
     "4": {
         DESCR: "All tunnel routes are configured in both APP and ASIC DB",
-        ARGS: "vnet_route_check",
+        ARGS: "vnet_route_check --all",
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
-                    "tunnel_v4": { "src_ip": "10.1.0.32" },
-                    "tunnel_v6": { "src_ip": "3001:2000::1" }
+                    "tunnel_v4": {"src_ip": "10.1.0.32"},
+                    "tunnel_v6": {"src_ip": "3001:2000::1"}
                 },
                 VNET_TABLE: {
                     "Vnet_v4_in_v4-0": [("vxlan_tunnel", "tunnel_v4"), ("scope", "default"), ("vni", "10000"), ("peer_list", "")],
@@ -236,43 +263,54 @@ test_data = {
 
                 },
                 VNET_ROUTE_TUNNEL_TABLE: {
-                    "Vnet_v4_in_v4-0:150.62.191.1/32" : { "endpoint" : "100.251.7.1,100.251.7.2" },
-                    "Vnet_v6_in_v6-0:fd01:fc00::1/128" : { "endpoint" : "fc02:1000::1,fc02:1000::2" }
+                    "Vnet_v4_in_v4-0:150.62.191.1/32": {"endpoint": "100.251.7.1,100.251.7.2"},
+                    "Vnet_v6_in_v6-0:fd01:fc00::1/128": {"endpoint": "fc02:1000::1,fc02:1000::2"}
 
                 }
             },
             ASIC_DB: {
                 "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER": {
-                         "oid:0x3000000000d4b" : { "":"" }
+                         "oid:0x3000000000d4b": {"": ""}
                 },
                 ASIC_STATE: {
                     RT_ENTRY_KEY_PREFIX + "150.62.191.1/32" + RT_ENTRY_KEY_SUFFIX: {},
                     RT_ENTRY_KEY_PREFIX + "fd01:fc00::1/128" + RT_ENTRY_KEY_SUFFIX: {}
+                }
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet_v4_in_v4-0|150.62.191.1/32": [("active_endpoints", "100.251.7.1"), ("state", "active")],
+                    "Vnet_v6_in_v6-0|fd01:fc00::1/128": [("active_endpoints", "fc02:1000::1"), ("state", "active")]
                 }
             }
         }
     },
     "5": {
         DESCR: "Tunnel route present in APP DB but mssing in ASIC DB",
-        ARGS: "vnet_route_check",
+        ARGS: "vnet_route_check -a",
         RET: -1,
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
-                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
                 },
                 VNET_TABLE: {
                     "Vnet_v4_in_v4-0": [("vxlan_tunnel", "tunnel_v4"), ("scope", "default"), ("vni", "10000"), ("peer_list", "")]
                 },
                 VNET_ROUTE_TUNNEL_TABLE: {
-                   "Vnet_v4_in_v4-0:150.62.191.1/32" : { "endpoint" : "100.251.7.1,100.251.7.2" }
+                   "Vnet_v4_in_v4-0:150.62.191.1/32": {"endpoint": "100.251.7.1,100.251.7.2"}
                 }
             },
             ASIC_DB: {
                 "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER": {
-                         "oid:0x3000000000d4b" : { "":"" }
+                         "oid:0x3000000000d4b": {"": ""}
                 },
                 ASIC_STATE: {
+                }
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet_v4_in_v4-0|150.62.191.1/32": [("active_endpoints", "100.251.7.2"), ("state", "active")]
                 }
             }
         },
@@ -290,20 +328,318 @@ test_data = {
     },
     "6": {
         DESCR: "Only Vxlan tunnel configured, No routes.",
+        ARGS: "vnet_route_check --all",
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
+                },
+                VNET_TABLE: {
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
+                },
+                INTF_TABLE: {
+                    "Vlan3001": {"vnet_name": "Vnet1"},
+                    "Vlan3001:30.1.10.1/24": {}
+                },
+            },
+        }
+    },
+    "7": {
+        DESCR: "VNET routes are missed in both ASIC and APP DB, but routes in APP DB are inactive",
+        ARGS: "vnet_route_check",
+        RET: -1,
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
+                },
+                VNET_TABLE: {
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
+                },
+                INTF_TABLE: {
+                    "Vlan3001": {"vnet_name": "Vnet1"},
+                    "Vlan3001:30.1.10.1/24": {}
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    RT_ENTRY_KEY_PREFIX + "50.2.2.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|30.1.10.0/24": [("active_endpoints", ""), ("state", "inactive")],
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", ""), ("state", "inactive")]
+                }
+            }
+        },
+        RESULT: {
+            "results": {
+                "missed_in_app_db_routes": {
+                    "Vnet1": {
+                        "routes": [
+                            "50.2.2.0/24"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "8": {
+        DESCR: "A VNET route is missed in ASIC DB, but it is inactive",
         ARGS: "vnet_route_check",
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
-                    "tunnel_v4": { "src_ip": "10.1.0.32" }
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
                 },
                 VNET_TABLE: {
-                    "Vnet1": { "vxlan_tunnel": "tunnel_v4", "vni": "10001" }
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
                 },
                 INTF_TABLE: {
-                    "Vlan3001": { "vnet_name": "Vnet1" },
+                    "Vlan3001": {"vnet_name": "Vnet1"},
                     "Vlan3001:30.1.10.1/24": {}
                 },
+                VNET_ROUTE_TABLE: {
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
+                }
             },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|30.1.10.0/24": [("active_endpoints", "30.1.10.5"), ("state", "active")],
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", ""), ("state", "inactive")]
+                }
+            }
+        }
+    },
+    "9": {
+        DESCR: "A VNET route is missed in ASIC DB and it is active",
+        ARGS: "vnet_route_check",
+        RET: -1,
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
+                },
+                VNET_TABLE: {
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
+                },
+                INTF_TABLE: {
+                    "Vlan3001": {"vnet_name": "Vnet1"},
+                    "Vlan3001:30.1.10.1/24": {}
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|30.1.10.0/24": [("active_endpoints", ""), ("state", "inactive")],
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", "30.1.10.10"), ("state", "active")]
+                }
+            }
+        },
+        RESULT: {
+            "results": {
+                "missed_in_asic_db_routes": {
+                    "Vnet1": {
+                        "routes": [
+                            "50.1.1.0/24"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "10": {
+        DESCR: "An IPv6 VNET route is missed in ASIC DB, but it is inactive",
+        ARGS: "vnet_route_check",
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v6": {"src_ip": "3001:2000::1"}
+                },
+                VNET_TABLE: {
+                    "Vnet_v6": [("vxlan_tunnel", "tunnel_v6"), ("scope", "default"), ("vni", "10002"),
+                                ("peer_list", "")]
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet_v6:fd01:fc00::1/128": {"endpoint": "fc02:1000::1,fc02:1000::2"}
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    },
+                    "SAI_OBJECT_TYPE_VIRTUAL_ROUTER": {
+                         "oid:0x3000000000d4b": {"": ""}
+                    },
+                }
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet_v6|fd01:fc00::1/128": [("active_endpoints", ""), ("state", "inactive")]
+                }
+            }
+        }
+    },
+    "11": {
+        DESCR: "An IPv6 VNET route is missed in ASIC DB and it is active",
+        ARGS: "vnet_route_check",
+        RET: -1,
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v6": {"src_ip": "3001:2000::1"}
+                },
+                VNET_TABLE: {
+                    "Vnet_v6": [("vxlan_tunnel", "tunnel_v6"), ("scope", "default"), ("vni", "10002"),
+                                ("peer_list", "")]
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet_v6:fd01:fc00::1/128": {"endpoint": "fc02:1000::1,fc02:1000::2"}
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    },
+                    "SAI_OBJECT_TYPE_VIRTUAL_ROUTER": {
+                         "oid:0x3000000000d4b": {"": ""}
+                    },
+                }
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet_v6|fd01:fc00::1/128": [("active_endpoints", "fc02:1000::2"), ("state", "active")]
+                }
+            }
+        },
+        RESULT: {
+            "results": {
+                "missed_in_asic_db_routes": {
+                    "Vnet_v6": {
+                        "routes": [
+                            "fd01:fc00::1/128"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "12": {
+        DESCR: "An IPv6 VNET route that is missing in STATE DB and ASIC DB",
+        ARGS: "vnet_route_check",
+        RET: -1,
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v6": {"src_ip": "3001:2000::1"}
+                },
+                VNET_TABLE: {
+                    "Vnet_v6": [("vxlan_tunnel", "tunnel_v6"), ("scope", "default"), ("vni", "10002"),
+                                ("peer_list", "")]
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet_v6:fd01:fc00::1/128": {"endpoint": "fc02:1000::1,fc02:1000::2"}
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    },
+                    "SAI_OBJECT_TYPE_VIRTUAL_ROUTER": {
+                         "oid:0x3000000000d4b": {"": ""}
+                    },
+                }
+            }
+        },
+        RESULT: {
+            "results": {
+                "missed_in_asic_db_routes": {
+                    "Vnet_v6": {
+                        "routes": [
+                            "fd01:fc00::1/128"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "13": {
+        DESCR: "A VNET route is missing in STATE DB and another inactive route is missing in ASIC DB",
+         ARGS: "vnet_route_check",
+         PRE: {
+             APPL_DB: {
+                 VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
+                 },
+                 VNET_TABLE: {
+                    "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
+                 },
+                 INTF_TABLE: {
+                    "Vlan3001": {"vnet_name": "Vnet1"},
+                    "Vlan3001:30.1.10.1/24": {}
+                 },
+                VNET_ROUTE_TABLE: {
+                    "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                    "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
+                }
+             },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    }
+                }
+            },
+            CNTR_DB: {
+                "COUNTERS_RIF_NAME_MAP": {"Vlan3001": "oid:0x6000000000d76"}
+            },
+            STATE_DB: {
+                VNET_ROUTE_TUNNEL_TABLE: {
+                    "Vnet1|50.1.1.0/24": [("active_endpoints", ""), ("state", "inactive")]
+                }
+            }
         }
     }
 }
@@ -336,11 +672,16 @@ class Table:
         return list(self.data.keys())
 
     def get(self, key):
-        ret = copy.deepcopy(self.data.get(key, self.data))
-        return (True, ret)
+        result = self.data.get(key)
+        if result:
+            ret = copy.deepcopy(result)
+            return (True, ret)
+        else:
+            ret = copy.deepcopy(self.data)
+            return (False, ret)
 
 
-db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB, "COUNTERS_DB": CNTR_DB}
+db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB, "COUNTERS_DB": CNTR_DB, "STATE_DB": STATE_DB}
 def conn_side_effect(arg, _):
     return db_conns[arg]
 
@@ -363,14 +704,6 @@ class mock_db_conn:
 
     def getDbName(self):
         return self.db_name
-
-
-def table_side_effect(db, tbl):
-    if not db in tables_returned:
-        tables_returned[db] = {}
-    if not tbl in tables_returned[db]:
-        tables_returned[db][tbl] = Table(db, tbl)
-    return tables_returned[db][tbl]
 
 
 def set_mock(mock_table, mock_conn):

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -606,24 +606,24 @@ test_data = {
     },
     "13": {
         DESCR: "A VNET route is missing in STATE DB and another inactive route is missing in ASIC DB",
-         ARGS: "vnet_route_check",
-         PRE: {
-             APPL_DB: {
-                 VXLAN_TUNNEL_TABLE: {
+        ARGS: "vnet_route_check",
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
                     "tunnel_v4": {"src_ip": "10.1.0.32"}
-                 },
-                 VNET_TABLE: {
+                },
+                VNET_TABLE: {
                     "Vnet1": {"vxlan_tunnel": "tunnel_v4", "vni": "10001"}
-                 },
-                 INTF_TABLE: {
+                },
+                INTF_TABLE: {
                     "Vlan3001": {"vnet_name": "Vnet1"},
                     "Vlan3001:30.1.10.1/24": {}
-                 },
+                },
                 VNET_ROUTE_TABLE: {
                     "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
                     "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
                 }
-             },
+            },
             ASIC_DB: {
                 ASIC_STATE: {
                     RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Note: This PR is created from PR #3763 for the master branch.
Added the options `-a` and `--all` to `scripts/vnet_route_check.py`. Both options are equivalent. If none of them is provided, then when finding the VNET routes that are in APP DB but not in ASIC DB, we will ignore routes in APP DB that are not active.
Mock tests in `tests/test_vnet_route_check.py` are added to test this behavior.

#### How I did it
If `-a` and `--all` are not provided, we first filter routes in APP DB to find active routes and then check which active routes are not in ASIC DB. The status of each route is retrieved from STATE DB. If a route is not found in STATE DB, then it is considered to be active.

#### How to verify it
You can verify the behavior by running mock tests in `tests/test_vnet_route_check.py`, or by manually running the `vnet_route_check.py` script on a DUT.

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A

