### PR TITLE
[show][interface] Add changes for show interface flap command (#3724)

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -419,6 +419,70 @@ def mpls(ctx, interfacename, namespace, display):
 interfaces.add_command(portchannel.portchannel)
 
 
+@interfaces.command()
+@click.argument('interfacename', required=False)
+@click.pass_context
+def flap(ctx, interfacename):
+    """Show Interface Flap Information <interfacename>"""
+
+    namespace = ''  # Default namespace
+    port_dict = multi_asic.get_port_table(namespace=namespace)
+
+    # If interfacename is given, validate it
+    if interfacename:
+        interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
+        if interfacename not in port_dict:
+            ctx.fail("Invalid interface name {}".format(interfacename))
+
+    db = SonicV2Connector(host=REDIS_HOSTIP)
+    db.connect(db.APPL_DB)
+
+    # Prepare the table headers and body
+    header = [
+        'Interface',
+        'Flap Count',
+        'Admin',
+        'Oper',
+        'Link Down TimeStamp(UTC)',
+        'Link Up TimeStamp(UTC)'
+    ]
+    body = []
+
+    # Loop through all ports or the specified port
+    ports = [interfacename] if interfacename else natsorted(list(port_dict.keys()))
+
+    for port in ports:
+        port_data = db.get_all(db.APPL_DB, f'PORT_TABLE:{port}') or {}
+
+        flap_count = port_data.get('flap_count', 'Never')
+        admin_status = port_data.get('admin_status', 'Unknown').capitalize()
+        oper_status = port_data.get('oper_status', 'Unknown').capitalize()
+
+        # Get timestamps and convert them to UTC format if possible
+        last_up_time = port_data.get('last_up_time', 'Never')
+        last_down_time = port_data.get('last_down_time', 'Never')
+
+        # Format output row
+        row = [
+            port,
+            flap_count,
+            admin_status,
+            oper_status,
+            f"{last_down_time}" if last_down_time != 'Never' else 'Never',
+            f"{last_up_time}" if last_up_time != 'Never' else 'Never'
+        ]
+
+        body.append(row)
+
+    # Sort the body by interface name for consistent display
+    body = natsorted(body, key=lambda x: x[0])
+
+    # Display the formatted table
+    click.echo(tabulate(body, header))
+
+    db.close(db.APPL_DB)
+
+
 def get_all_port_errors(interfacename):
 
     port_operr_table = {}

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -263,6 +263,55 @@ PortChannel0004  routed
 PortChannel1001  trunk               4000
 """
 
+intf_flap_expected_output_with_data = """\
+Interface      Flap Count  Admin    Oper    Link Down TimeStamp(UTC)    Link Up TimeStamp(UTC)
+-----------  ------------  -------  ------  --------------------------  ------------------------
+Ethernet0               3  Up       Down    Sat Jan 17 00:04:42 2025    Sat Jan 18 00:08:42 2025
+"""
+
+intf_flap_expected_output_with_data_concise = """\
+Interface    Flap Count    Admin    Oper     Link Down TimeStamp(UTC)    Link Up TimeStamp(UTC)
+-----------  ------------  -------  -------  --------------------------  ------------------------
+Ethernet4    Never         Unknown  Unknown  Never                       Never
+"""
+
+intf_flap_expected_output_all_data = """\
+Interface    Flap Count    Admin    Oper     Link Down TimeStamp(UTC)    Link Up TimeStamp(UTC)
+-----------  ------------  -------  -------  --------------------------  ------------------------
+Ethernet0    3             Up       Down     Sat Jan 17 00:04:42 2025    Sat Jan 18 00:08:42 2025
+Ethernet4    Never         Unknown  Unknown  Never                       Never
+Ethernet8    Never         Unknown  Unknown  Never                       Never
+Ethernet12   Never         Unknown  Unknown  Never                       Never
+Ethernet16   7             Up       Up       Sat Jan 19 00:04:42 2025    Sat Jan 20 00:04:42 2025
+Ethernet20   Never         Unknown  Unknown  Never                       Never
+Ethernet24   Never         Up       Up       Never                       Never
+Ethernet28   Never         Up       Up       Never                       Never
+Ethernet32   Never         Up       Up       Never                       Never
+Ethernet36   7             Up       Up       Never                       Sat Jan 20 00:04:42 2025
+Ethernet40   Never         Unknown  Unknown  Never                       Never
+Ethernet44   Never         Unknown  Unknown  Never                       Never
+Ethernet48   Never         Unknown  Unknown  Never                       Never
+Ethernet52   Never         Unknown  Unknown  Never                       Never
+Ethernet56   Never         Unknown  Unknown  Never                       Never
+Ethernet60   Never         Unknown  Unknown  Never                       Never
+Ethernet64   Never         Unknown  Unknown  Never                       Never
+Ethernet68   Never         Unknown  Unknown  Never                       Never
+Ethernet72   Never         Unknown  Unknown  Never                       Never
+Ethernet76   Never         Unknown  Unknown  Never                       Never
+Ethernet80   Never         Unknown  Unknown  Never                       Never
+Ethernet84   Never         Unknown  Unknown  Never                       Never
+Ethernet88   Never         Unknown  Unknown  Never                       Never
+Ethernet92   Never         Unknown  Unknown  Never                       Never
+Ethernet96   Never         Unknown  Unknown  Never                       Never
+Ethernet100  Never         Unknown  Unknown  Never                       Never
+Ethernet104  Never         Unknown  Unknown  Never                       Never
+Ethernet108  Never         Unknown  Unknown  Never                       Never
+Ethernet112  Never         Up       Up       Never                       Never
+Ethernet116  Never         Up       Up       Never                       Never
+Ethernet120  Never         Up       Up       Never                       Never
+Ethernet124  Never         Up       Up       Never                       Never
+"""
+
 intf_errors_Ethernet64 = """\
 Port Errors                     Count  Last timestamp(UTC)
 ----------------------------  -------  ---------------------
@@ -281,6 +330,7 @@ no rx reachability                  0  Never
 oper error status                   0  Never
 signal local error                  0  Never
 """
+
 intf_errors_Ethernet16 = """\
 Port Errors                     Count  Last timestamp(UTC)
 ----------------------------  -------  ---------------------
@@ -571,6 +621,45 @@ class TestInterfaces(object):
 
         assert result.exit_code == 0
         assert result.output == show_interfaces_switchport_config_in_alias_mode_output
+
+    def test_show_intf_flap_no_data(self):
+        """Test case for an interface with no flap data."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["flap"], ["Ethernet5"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 2
+
+    def test_show_intf_flap_with_data(self):
+        """Test case for an interface with valid flap data."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["flap"], ["Ethernet0"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == intf_flap_expected_output_with_data
+
+    def test_show_intf_flap_with_data_concise(self):
+        """Test case for an interface with valid flap data."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["flap"], ["Ethernet4"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == intf_flap_expected_output_with_data_concise
+
+    def test_show_intf_flap_with_all_ports_data(self):
+        """Test case for an interface with valid flap data."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["flap"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == intf_flap_expected_output_all_data
 
     def test_show_intf_errors_filled_data(self):
         """Test case for an interface with filled error data."""

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -44,6 +44,9 @@
         "interface_type": "CR4",
         "adv_interface_types": "CR4,CR2",
         "autoneg": "on",
+        "flap_count": "3",
+        "last_up_time": "Sat Jan 18 00:08:42 2025",
+        "last_down_time": "Sat Jan 17 00:04:42 2025",
         "link_training": "on"
     },
     "PORT_TABLE:Ethernet16": {
@@ -55,6 +58,9 @@
         "oper_status": "up",
         "pfc_asym": "off",
         "mtu": "9100",
+        "flap_count": "7",
+        "last_up_time": "Sat Jan 20 00:04:42 2025",
+        "last_down_time": "Sat Jan 19 00:04:42 2025",
         "admin_status": "up"
     },
     "PORT_TABLE:Ethernet36": {
@@ -67,6 +73,8 @@
         "pfc_asym": "off",
         "mtu": "9100",
         "tpid": "0x8100",
+        "flap_count": "7",
+        "last_up_time": "Sat Jan 20 00:04:42 2025",
         "admin_status": "up"
     },
     "PORT_TABLE:Ethernet24": {


### PR DESCRIPTION
cherry-pick #3724 
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

####
MSFT ADO 
30169187

#### What I did
This PR introduces a new CLI command, show interfaces flap, to display interface flap information. The command fetches details about flap counts, admin and operational status, and timestamps of link down/up events for specified or all interfaces.

#### How I did it
- Fetches data from the PORT_TABLE in the APPL_DB.
- Ensures consistent display by sorting the output by interface names.
- Handles single and multiple interface scenarios gracefully, with validation for invalid interface names.
#### How to verify it
UT and deploy on testbed

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

