### PR TITLE
Improve chassis info retrieval with enhanced error handling and fallback logic

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -37,7 +37,7 @@ def get_chassis_info():
         click.echo("Error retrieving chassis info from STATE_DB: {}".format(str(e)), err=True)
         chassis_info = {k: 'N/A' for k in keys}
 
-    if all(v is [None, 'N/A'] for v in chassis_info.values()):
+    if all(v is None or v == 'N/A' for v in chassis_info.values()):
         platform_cache = {"chassis": None}
         chassis_info = {k: try_get(platform_cache, k) for k in keys}
 

--- a/show/platform.py
+++ b/show/platform.py
@@ -58,7 +58,17 @@ def platform():
 @click.option('--json', is_flag=True, help="Output in JSON format")
 def summary(json):
     """Show hardware platform information"""
-    platform_info = device_info.get_platform_info()
+    try:
+        platform_info = device_info.get_platform_info()
+    except Exception as e:
+        click.echo("Error retrieving platform info: {}".format(str(e)), err=True)
+        platform_info = {
+            'platform': 'N/A',
+            'hwsku': 'N/A',
+            'asic_type': 'N/A',
+            'asic_count': 'N/A'
+        }
+
     chassis_info = get_chassis_info()
 
     if json:

--- a/show/platform.py
+++ b/show/platform.py
@@ -19,7 +19,7 @@ def get_chassis_info():
 
     keys = ["serial", "model", "revision"]
 
-    def try_get(platform, attr):
+    def try_get(platform, attr, fallback):
         try:
             if platform["chassis"] is None:
                 import sonic_platform
@@ -39,7 +39,7 @@ def get_chassis_info():
 
     if all(v is None or v == 'N/A' for v in chassis_info.values()):
         platform_cache = {"chassis": None}
-        chassis_info = {k: try_get(platform_cache, k) for k in keys}
+        chassis_info = {k:try_get(platform_cache, k, "N/A") for k in keys}
 
     return chassis_info
 

--- a/show/platform.py
+++ b/show/platform.py
@@ -61,7 +61,7 @@ def summary(json):
     try:
         platform_info = device_info.get_platform_info()
     except Exception as e:
-        click.echo("Error retrieving platform info: {}".format(str(e)), err=True)
+        click.echo("{}".format(str(e)), err=True)
         platform_info = {
             'platform': 'N/A',
             'hwsku': 'N/A',

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -44,8 +44,9 @@ class TestGetChassisInfo(object):
         with mock.patch("sonic_py_common.device_info.get_chassis_info",
                         side_effect=Exception("Error retrieving chassis info")):
             with mock.patch("click.echo") as mock_echo:
-                result = show.platform.get_chassis_info()
-                mock_echo.assert_any_call("Error retrieving chassis info from STATE_DB: Error retrieving chassis info", err=True)
+                show.platform.get_chassis_info()
+                mock_echo.assert_any_call("Error retrieving chassis info from STATE_DB: Error retrieving chassis info",
+                                          err=True)
 
 
 @pytest.mark.usefixtures('config_env')

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -36,9 +36,16 @@ class TestGetChassisInfo(object):
 
     def test_get_chassis_info_failure(self):
         result = show.platform.get_chassis_info()
-        assert result["serial"] == None
-        assert result["model"] == None
-        assert result["revision"] == None
+        assert result["serial"] is None
+        assert result["model"] is None
+        assert result["revision"] is None
+
+    def test_get_chassis_info_with_exception(self):
+        with mock.patch("sonic_py_common.device_info.get_chassis_info",
+                        side_effect=Exception("Error retrieving chassis info")):
+            with mock.patch("click.echo") as mock_echo:
+                result = show.platform.get_chassis_info()
+                mock_echo.assert_any_call("Error retrieving chassis info from STATE_DB: Error retrieving chassis info", err=True)
 
 
 @pytest.mark.usefixtures('config_env')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
If `CHASSIS_INFO `in `STATE_DB `does not contain serial, model or revision information, 

```
$ redis-cli -n 6 hgetall "CHASSIS_INFO|chassis 1"
1) "psu_num"
2) "2"
```

"show ver" command is not displaying available information.

In such cases, return 'N/A' if chassis_info is not available.

#### How I did it
If `device_info.get_chassis_info` returns an exception, set the key values to `N/A`.
Additionally set key values to 'N/A', if device_info.get_platform_info() throws an ex

#### .How to verify it
Verify "show ver" command output after deleting entries in STATE_DB

```
$ show ver

SONiC Software Version: SONiC.20231110.31
SONiC OS Version: 11
Distribution: Debian 11.11
Kernel: 5.10.0-30-2-amd64
Build commit: 75b45e9e8f
Build date: Thu Feb  6 08:38:57 UTC 2025
Built by: azureuser@0d43ba0cc000000

Platform: x86_64-mlnx_msn2700a1-r0
HwSKU: Mellanox-SN2700-A1
ASIC: mellanox
ASIC Count: 1
Serial Number: None
Model Number: None
Hardware Revision: None
Uptime: 19:30:44 up 11:40,  2 users,  load average: 0.45, 0.59, 0.84
Date: Mon 17 Mar 2025 19:30:44
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

