### PR TITLE
Revert "[config]Restrict YANG validation to Golden Config (#3656)"

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1868,7 +1868,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
         if multi_asic.is_multi_asic():
             # Multiasic has not 100% fully validated. Thus pass here.
             pass
-        elif "golden" in filename.lower():
+        else:
             config_file_yang_validation(filename)
 
     #Stop services before config push

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1315,7 +1315,6 @@ class TestLoadMinigraph(object):
 
 class TestReloadConfig(object):
     dummy_cfg_file = os.path.join(os.sep, "tmp", "config.json")
-    dummy_golden_cfg_file = os.path.join(os.sep, "tmp", "golden_config.json")
 
     @classmethod
     def setup_class(cls):
@@ -1518,7 +1517,7 @@ class TestReloadConfig(object):
                 == RELOAD_YANG_CFG_OUTPUT.format(config.SYSTEM_RELOAD_LOCK)
 
     def test_reload_config_fails_yang_validation(self, get_cmd_module, setup_single_broadcom_asic):
-        with open(self.dummy_golden_cfg_file, 'w') as f:
+        with open(self.dummy_cfg_file, 'w') as f:
             device_metadata = {
                 "DEVICE_METADATA": {
                     "localhost": {
@@ -1537,7 +1536,7 @@ class TestReloadConfig(object):
 
             result = runner.invoke(
                 config.config.commands["reload"],
-                [self.dummy_golden_cfg_file, '-y', '-f'])
+                [self.dummy_cfg_file, '-y', '-f'])
 
             print(result.exit_code)
             print(result.output)
@@ -1549,7 +1548,6 @@ class TestReloadConfig(object):
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
         os.remove(cls.dummy_cfg_file)
-        os.remove(cls.dummy_golden_cfg_file)
         print("TEARDOWN")
 
 


### PR DESCRIPTION
This reverts commit 032a0e03ab0330053a42c899dc049baa337386b9.
Since issue has been resolved: https://github.com/sonic-net/sonic-buildimage/issues/20730?reload=1
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

