### PR TITLE
Add a check for the condition where asic_id is not present on VS platform

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2257,7 +2257,7 @@ def generate_sysinfo(cur_config, config_input, ns=None):
 
     device_metadata['localhost']['mac'] = mac.rstrip('\n')
     device_metadata['localhost']['platform'] = platform.rstrip('\n')
-    if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+    if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE and asic_id is not None:
         device_metadata['localhost']['asic_id'] = asic_id.rstrip('\n')
 
     return


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add a check in generate_sysinfo function to prevent runtime error when the asic_id is none because it is not present on VS and Cisco platform.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

