### PR TITLE
Enable config reload yang validation for multiasic

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1865,11 +1865,7 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             return
 
     if filename is not None and filename != "/dev/stdin":
-        if multi_asic.is_multi_asic():
-            # Multiasic has not 100% fully validated. Thus pass here.
-            pass
-        else:
-            config_file_yang_validation(filename)
+        config_file_yang_validation(filename)
 
     #Stop services before config push
     if not no_service_restart:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -196,9 +196,12 @@ Released lock on {0}
 RELOAD_MASIC_CONFIG_DB_OUTPUT = """\
 Acquired lock on {0}
 Stopping SONiC target ...
+Running command: /usr/local/bin/sonic-cfggen -H -k  --write-to-db
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json -n asic0 --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json -n asic1 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -H -k  -n asic0 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /tmp/config0.json -n asic0 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -H -k  -n asic1 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /tmp/config1.json -n asic1 --write-to-db
 Restarting SONiC target ...
 Reloading Monit configuration ...
 Released lock on {0}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1487,7 +1487,7 @@ class TestReloadConfig(object):
             return {}
 
         with mock.patch("utilities_common.cli.run_command",
-                        mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command,\
+                        mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
                        mock.MagicMock(side_effect=read_json_file_side_effect)),\
             mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -838,11 +838,7 @@ class TestConfigReloadMasic(object):
         with mock.patch("utilities_common.cli.run_command",
                         mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                       mock.MagicMock(side_effect=read_json_file_side_effect)),\
-            mock.patch('config.main.sonic_yang.SonicYang.loadData',
-                       return_value=True),\
-            mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',
-                       return_value=True):
+                       mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -917,11 +913,7 @@ class TestConfigReloadMasic(object):
         with mock.patch("utilities_common.cli.run_command",
                         mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                       mock.MagicMock(side_effect=read_json_file_side_effect)),\
-            mock.patch('config.main.sonic_yang.SonicYang.loadData',
-                       return_value=True),\
-            mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',
-                       return_value=True):
+                       mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -1347,26 +1339,6 @@ class TestReloadConfig(object):
                 }
             }
             f.write(json.dumps(device_metadata))
-        with open(self.dummy_cfg_file_asic0, 'w') as f:
-            device_metadata = {
-                "DEVICE_METADATA": {
-                    "localhost": {
-                        "platform": "some_platform",
-                        "mac": "02:42:f0:7f:01:05"
-                    }
-                }
-            }
-            f.write(json.dumps(device_metadata))
-        with open(self.dummy_cfg_file_asic1, 'w') as f:
-            device_metadata = {
-                "DEVICE_METADATA": {
-                    "localhost": {
-                        "platform": "some_platform",
-                        "mac": "02:42:f0:7f:01:05"
-                    }
-                }
-            }
-            f.write(json.dumps(device_metadata))
 
     def test_reload_config_invalid_input(self, get_cmd_module, setup_single_broadcom_asic):
         open(self.dummy_cfg_file, 'w').close()
@@ -1513,10 +1485,7 @@ class TestReloadConfig(object):
         with mock.patch("utilities_common.cli.run_command",
                         mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                       mock.MagicMock(side_effect=read_json_file_side_effect)),\
-            mock.patch('config.main.sonic_yang.SonicYang.loadData', return_value=True),\
-            mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',
-                       return_value=True):
+                       mock.MagicMock(side_effect=read_json_file_side_effect)):
             (config, show) = get_cmd_module
             runner = CliRunner()
             # 3 config files: 1 for host and 2 for asic

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -199,9 +199,9 @@ Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -k  --write-to-db
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
 Running command: /usr/local/bin/sonic-cfggen -H -k  -n asic0 --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /tmp/config0.json -n asic0 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json -n asic0 --write-to-db
 Running command: /usr/local/bin/sonic-cfggen -H -k  -n asic1 --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /tmp/config1.json -n asic1 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json -n asic1 --write-to-db
 Restarting SONiC target ...
 Reloading Monit configuration ...
 Released lock on {0}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1504,12 +1504,14 @@ class TestReloadConfig(object):
                 reload_config_with_disabled_service_output.format(config.SYSTEM_RELOAD_LOCK)
 
     def test_reload_config_masic(self, get_cmd_module, setup_multi_broadcom_masic):
-        self.add_sysinfo_to_cfg_file()
+        def read_json_file_side_effect(filename):
+            return {}
 
         with mock.patch("utilities_common.cli.run_command",
                         mock.MagicMock(side_effect=mock_run_command_side_effect)),\
-            mock.patch('config.main.sonic_yang.SonicYang.loadData',
-                       return_value=True),\
+            mock.patch('config.main.read_json_file',
+                       mock.MagicMock(side_effect=read_json_file_side_effect)),\
+            mock.patch('config.main.sonic_yang.SonicYang.loadData', return_value=True),\
             mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',
                        return_value=True):
             (config, show) = get_cmd_module

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -836,6 +836,8 @@ class TestConfigReloadMasic(object):
                         mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
                        mock.MagicMock(side_effect=read_json_file_side_effect)),\
+            mock.patch('config.main.sonic_yang.SonicYang.loadData',
+                       return_value=True),\
             mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',
                        return_value=True):
 
@@ -913,6 +915,8 @@ class TestConfigReloadMasic(object):
                         mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
                        mock.MagicMock(side_effect=read_json_file_side_effect)),\
+            mock.patch('config.main.sonic_yang.SonicYang.loadData',
+                       return_value=True),\
             mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',
                        return_value=True):
 
@@ -1490,6 +1494,8 @@ class TestReloadConfig(object):
                         mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
                        mock.MagicMock(side_effect=read_json_file_side_effect)),\
+            mock.patch('config.main.sonic_yang.SonicYang.loadData',
+                       return_value=True),\
             mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree',
                        return_value=True):
             (config, show) = get_cmd_module

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1488,6 +1488,8 @@ class TestReloadConfig(object):
         self.add_sysinfo_to_cfg_file()
 
         def read_json_file_side_effect(filename):
+            with open(filename, "w") as f:
+                f.write('{}')
             return {}
 
         with mock.patch("utilities_common.cli.run_command",
@@ -1516,6 +1518,12 @@ class TestReloadConfig(object):
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) \
                 == RELOAD_MASIC_CONFIG_DB_OUTPUT.format(config.SYSTEM_RELOAD_LOCK)
+
+            for f in [self.dummy_cfg_file_localhost,
+                      self.dummy_cfg_file_asic0,
+                      self.dummy_cfg_file_asic1]:
+                if os.path.exists(f):
+                    os.remove(f)
 
     def test_reload_yang_config(self, get_cmd_module,
                                         setup_single_broadcom_asic):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -196,12 +196,9 @@ Released lock on {0}
 RELOAD_MASIC_CONFIG_DB_OUTPUT = """\
 Acquired lock on {0}
 Stopping SONiC target ...
-Running command: /usr/local/bin/sonic-cfggen -H -k  --write-to-db
 Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -H -k  -n asic0 --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /tmp/config0.json -n asic0 --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -H -k  -n asic1 --write-to-db
-Running command: /usr/local/bin/sonic-cfggen -j /tmp/config1.json -n asic1 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json -n asic0 --write-to-db
+Running command: /usr/local/bin/sonic-cfggen -j /tmp/config.json -n asic1 --write-to-db
 Restarting SONiC target ...
 Reloading Monit configuration ...
 Released lock on {0}
@@ -800,7 +797,7 @@ class TestConfigReloadMasic(object):
                             "cloudtype": "None",
                             "default_bgp_status": "down",
                             "default_pfcwd_status": "enable",
-                            "deployment_id": "None",
+                            "deployment_id": "1",
                             "docker_routing_config_mode": "separated",
                             "hostname": "sonic",
                             "hwsku": "multi_asic",
@@ -821,7 +818,7 @@ class TestConfigReloadMasic(object):
                             "cloudtype": "None",
                             "default_bgp_status": "down",
                             "default_pfcwd_status": "enable",
-                            "deployment_id": "None",
+                            "deployment_id": "1",
                             "docker_routing_config_mode": "separated",
                             "hostname": "sonic",
                             "hwsku": "multi_asic",
@@ -879,7 +876,7 @@ class TestConfigReloadMasic(object):
                             "cloudtype": "None",
                             "default_bgp_status": "down",
                             "default_pfcwd_status": "enable",
-                            "deployment_id": "None",
+                            "deployment_id": "1",
                             "docker_routing_config_mode": "separated",
                             "hostname": "sonic",
                             "hwsku": "multi_asic",
@@ -898,7 +895,7 @@ class TestConfigReloadMasic(object):
                             "cloudtype": "None",
                             "default_bgp_status": "down",
                             "default_pfcwd_status": "enable",
-                            "deployment_id": "None",
+                            "deployment_id": "1",
                             "docker_routing_config_mode": "separated",
                             "hostname": "sonic",
                             "hwsku": "multi_asic",
@@ -1491,8 +1488,8 @@ class TestReloadConfig(object):
             # 3 config files: 1 for host and 2 for asic
             cfg_files = "{},{},{}".format(
                             self.dummy_cfg_file,
-                            self.dummy_cfg_file_asic0,
-                            self.dummy_cfg_file_asic1)
+                            self.dummy_cfg_file,
+                            self.dummy_cfg_file)
 
             result = runner.invoke(
                 config.config.commands["reload"],


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Remove multi asic check for reload operation since multi asis golden config has finished qualification.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

