### PR TITLE
Update loopback interface admin status on config interface startup/shutdown

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4624,6 +4624,11 @@ def startup(ctx, interface_name):
         if sp_name in intf_fs:
             config_db.mod_entry("VLAN_SUB_INTERFACE", sp_name, {"admin_status": "up"})
 
+    lo_list = config_db.get_table("LOOPBACK_INTERFACE")
+    for lo in lo_list:
+        if lo in intf_fs:
+            config_db.mod_entry("LOOPBACK_INTERFACE", lo, {"admin_status": "up"})
+
 #
 # 'shutdown' subcommand
 #
@@ -4663,6 +4668,11 @@ def shutdown(ctx, interface_name):
     for sp_name in subport_list:
         if sp_name in intf_fs:
             config_db.mod_entry("VLAN_SUB_INTERFACE", sp_name, {"admin_status": "down"})
+
+    lo_list = config_db.get_table("LOOPBACK_INTERFACE")
+    for lo in lo_list:
+        if lo in intf_fs:
+            config_db.mod_entry("LOOPBACK_INTERFACE", lo, {"admin_status": "down"})
 
 #
 # 'speed' subcommand

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -3675,6 +3675,23 @@ class TestConfigInterface(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_with(['portconfig', '-p', str(interface_name), '-f', str(interface_fec), '-n', 'ns', '-vv'], display_cmd=True)
 
+    def test_startup_shutdown_loopback(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands['interface'].commands['ip'].commands['add'], ['Loopback0', '10.0.1.0/32'], obj=obj)
+        assert result.exit_code == 0
+        assert 'Loopback0' in db.cfgdb.get_table('LOOPBACK_INTERFACE')
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'], ['Loopback0'], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table('LOOPBACK_INTERFACE')['Loopback0']['admin_status'] == 'down'
+
+        result = runner.invoke(config.config.commands['interface'].commands['startup'], ['Loopback0'], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table('LOOPBACK_INTERFACE')['Loopback0']['admin_status'] == 'up'
+
     def teardown(self):
         print("TEARDOWN")
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -3680,7 +3680,8 @@ class TestConfigInterface(object):
         runner = CliRunner()
         obj = {'config_db': db.cfgdb}
 
-        result = runner.invoke(config.config.commands['interface'].commands['ip'].commands['add'], ['Loopback0', '10.0.1.0/32'], obj=obj)
+        result = runner.invoke(config.config.commands['interface'].commands['ip'].commands['add'],
+                               ['Loopback0', '10.0.1.0/32'], obj=obj)
         assert result.exit_code == 0
         assert 'Loopback0' in db.cfgdb.get_table('LOOPBACK_INTERFACE')
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Set admin_status to 'up' for loopback interfaces on interface startup.
Set admin_status to 'down' for loopback interfaces on interface shutdown.

Related PRs: [https://github.com/sonic-net/sonic-swss/pull/3565](https://github.com/sonic-net/sonic-swss/pull/3565)

#### How I did it

Updated config/main.py

#### How to verify it

pytest config_test.py::TestConfigInterface::test_startup_shutdown_loopback tests loopback interface startup/shutdown modifies admin_status as expected.
<img width="853" alt="image" src="https://github.com/user-attachments/assets/fcf6fee7-f6eb-4dae-9c5f-40007df019f4" />

#### Previous command output (if the output of a command-line utility has changed)

n/a

#### New command output (if the output of a command-line utility has changed)

n/a

