### PR TITLE
[DO NOT MERGE] Fix kdump remote option

### DIFF
--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -826,6 +826,9 @@ def main():
     parser.add_argument('--num_dumps', nargs='?', type=int, action='store', default=False,
         help='Maximum number of kernel dump files stored')
 
+    parser.add_argument('--remote', action='store_true',
+        help='Remote kdump via ssh')
+
     parser.add_argument('--ssh_string', nargs='?', type=str, action='store', default=False,
             help='ssh_string for remote kdump')
 


### PR DESCRIPTION
 * https://github.com/sonic-net/sonic-utilities/pull/3400 started using remote option without adding the option leading to errors seen like the following:

E               2025 Apr  1 04:56:08.321576 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--disable'] - failed: return code - 1, output:#012None
E               2025 Apr  1 04:56:09.638838 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M'] - failed: return code - 1, output:#012None
E               2025 Apr  1 04:56:11.199498 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--num_dumps', '3'] - failed: return code - 1, output:#012None
E               2025 Apr  1 04:56:13.969595 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--remote', 'false'] - failed: return code - 2, output:#012None
E               2025 Apr  1 04:56:16.373762 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--ssh_string', 'user@localhost'] - failed: return code - 1, output:#012None
E               2025 Apr  1 04:56:17.579657 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--ssh_path', '/a/b/c'] - failed: return code - 1, output:#012None

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

