### PR TITLE
Adding support to consolidate the show system-health output of all modules under the host smartswitch:phase_two

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -11486,7 +11486,67 @@ If any of the elements under each of these two sections is 'Not OK' a proper mes
   Hardware:
     Status: OK
   ```
+**show system-health summary \<module/all\>**
+  ```
+  admin@sonic:~$ show system-health summary DPU0
+  System status summary
 
+  System status LED  red
+  Services:
+    Status: Not OK
+    Not Running: 'syncd'
+  Hardware:
+    Status: OK
+  ```
+  ```
+  admin@sonic:~$ show system-health summary all
+  SWITCH
+  System status summary
+
+    System status LED  green
+    Services:
+      Status: OK
+    Hardware:
+      Status: OK
+
+  Module: dpu5
+  Module: 169.254.200.6 down
+
+  Module: dpu6
+  Module: 169.254.200.7 down
+
+  Module: dpu7
+  Module: 169.254.200.8 down
+
+  Module: dpu3
+  Module: 169.254.200.4 down
+
+  Module: dpu4
+  Module: 169.254.200.5 down
+
+  Module: dpu2
+  Module: 169.254.200.3 down
+
+  Module: dpu0
+
+  System status summary
+
+    System status LED  green
+    Services:
+      Status: OK
+    Hardware:
+      Status: OK
+
+  Module: dpu1
+
+  System status summary
+
+    System status LED  green
+    Services:
+      Status: OK
+    Hardware:
+      Status: OK
+  ```
 **show system-health monitor-list**
 
 This command displays a list of all current 'Services' and 'Hardware' being monitored, their status and type.
@@ -11549,6 +11609,269 @@ This command displays a list of all current 'Services' and 'Hardware' being moni
   fan6            OK        Fan
   fan9            OK        Fan
   fan8            OK        Fan
+  ```
+
+**show system-health monitor-list \<module/all\>**
+
+This command displays a list of all current 'Services' and 'Hardware' being monitored, their status and type of specified module(s).
+
+- Usage:
+  ```
+  show system-health monitor-list DPU0
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show system-health monitor-list DPU0
+
+  Module: dpu0
+
+
+  System services and devices monitor list
+
+  Name                      Status    Type
+  ------------------------  --------  ----------
+  sonic                     OK        System
+  rsyslog                   OK        Process
+  root-overlay              OK        Filesystem
+  var-log                   OK        Filesystem
+  routeCheck                OK        Program
+  dualtorNeighborCheck      OK        Program
+  diskCheck                 OK        Program
+  container_checker         OK        Program
+  vnetRouteCheck            OK        Program
+  memory_check              OK        Program
+  arp_update_checker        OK        Program
+  controlPlaneDropCheck     OK        Program
+  mgmtOperStatus            OK        Program
+  container_memory_snmp     OK        Program
+  container_memory_gnmi     OK        Program
+  container_memory_bmp      OK        Program
+  dpu-db-util               OK        Program
+  database:redis            OK        Process
+  bgp:zebra                 OK        Process
+  bgp:staticd               OK        Process
+  bgp:bgpd                  OK        Process
+  bgp:fpmsyncd              OK        Process
+  bgp:bgpcfgd               OK        Process
+  syncd:syncd               OK        Process
+  swss:orchagent            OK        Process
+  swss:portsyncd            OK        Process
+  swss:neighsyncd           OK        Process
+  swss:fdbsyncd             OK        Process
+  swss:intfmgrd             OK        Process
+  swss:portmgrd             OK        Process
+  swss:fabricmgrd           OK        Process
+  swss:buffermgrd           OK        Process
+  swss:vrfmgrd              OK        Process
+  swss:nbrmgrd              OK        Process
+  swss:coppmgrd             OK        Process
+  swss:tunnelmgrd           OK        Process
+  snmp:snmpd                OK        Process
+  snmp:snmp-subagent        OK        Process
+  lldp:lldpd                OK        Process
+  lldp:lldp-syncd           OK        Process
+  lldp:lldpmgrd             OK        Process
+  gnmi:gnmi-native          OK        Process
+  dpu-pdsagent              OK        UserDefine
+  dpu-pciemgrd              OK        UserDefine
+  dpu-eth_Uplink1/1_status  OK        UserDefine
+  dpu-pcie_link             OK        UserDefine
+  ```
+- Usage:
+  ```
+  show system-health monitor-list all
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show system-health monitor-list all
+
+  SWITCH
+  System services and devices monitor list
+
+  Name                   Status    Type
+  ---------------------  --------  ----------
+  MtFuji                 OK        System
+  rsyslog                OK        Process
+  root-overlay           OK        Filesystem
+  var-log                OK        Filesystem
+  routeCheck             OK        Program
+  dualtorNeighborCheck   OK        Program
+  diskCheck              OK        Program
+  container_checker      OK        Program
+  vnetRouteCheck         OK        Program
+  memory_check           OK        Program
+  arp_update_checker     OK        Program
+  controlPlaneDropCheck  OK        Program
+  mgmtOperStatus         OK        Program
+  container_memory_snmp  OK        Program
+  container_memory_gnmi  OK        Program
+  container_eventd       OK        Program
+  container_memory_bmp   OK        Program
+  swss:orchagent         OK        Process
+  swss:portsyncd         OK        Process
+  swss:neighsyncd        OK        Process
+  swss:fdbsyncd          OK        Process
+  swss:vlanmgrd          OK        Process
+  swss:intfmgrd          OK        Process
+  swss:portmgrd          OK        Process
+  swss:fabricmgrd        OK        Process
+  swss:buffermgrd        OK        Process
+  swss:vrfmgrd           OK        Process
+  swss:nbrmgrd           OK        Process
+  swss:vxlanmgrd         OK        Process
+  swss:coppmgrd          OK        Process
+  swss:tunnelmgrd        OK        Process
+  teamd:teammgrd         OK        Process
+  teamd:teamsyncd        OK        Process
+  teamd:tlm_teamd        OK        Process
+  syncd:syncd            OK        Process
+  database:redis         OK        Process
+  database:redis_bmp     OK        Process
+  lldp:lldpd             OK        Process
+  lldp:lldp-syncd        OK        Process
+  lldp:lldpmgrd          OK        Process
+  gnmi:gnmi-native       OK        Process
+  eventd:eventd          OK        Process
+  bgp:zebra              OK        Process
+  bgp:staticd            OK        Process
+  bgp:bgpd               OK        Process
+  bgp:fpmsyncd           OK        Process
+  bgp:bgpcfgd            OK        Process
+  snmp:snmpd             OK        Process
+  snmp:snmp-subagent     OK        Process
+  PSU0.fan0              OK        Fan
+  PSU1.fan0              OK        Fan
+  fantray0.fan0          OK        Fan
+  fantray1.fan0          OK        Fan
+  fantray2.fan0          OK        Fan
+  fantray3.fan0          OK        Fan
+  PSU 1                  OK        PSU
+  PSU 2                  OK        PSU
+
+  Module: dpu5
+  Module: 169.254.200.6 down
+
+  Module: dpu2
+  Module: 169.254.200.3 down
+
+  Module: dpu6
+  Module: 169.254.200.7 down
+
+  Module: dpu7
+  Module: 169.254.200.8 down
+
+  Module: dpu3
+  Module: 169.254.200.4 down
+
+  Module: dpu4
+  Module: 169.254.200.5 down
+
+  Module: dpu0
+
+
+  System services and devices monitor list
+
+  Name                      Status    Type
+  ------------------------  --------  ----------
+  sonic                     OK        System
+  rsyslog                   OK        Process
+  root-overlay              OK        Filesystem
+  var-log                   OK        Filesystem
+  routeCheck                OK        Program
+  dualtorNeighborCheck      OK        Program
+  diskCheck                 OK        Program
+  container_checker         OK        Program
+  vnetRouteCheck            OK        Program
+  memory_check              OK        Program
+  arp_update_checker        OK        Program
+  controlPlaneDropCheck     OK        Program
+  mgmtOperStatus            OK        Program
+  container_memory_snmp     OK        Program
+  container_memory_gnmi     OK        Program
+  container_memory_bmp      OK        Program
+  dpu-db-util               OK        Program
+  database:redis            OK        Process
+  bgp:zebra                 OK        Process
+  bgp:staticd               OK        Process
+  bgp:bgpd                  OK        Process
+  bgp:fpmsyncd              OK        Process
+  bgp:bgpcfgd               OK        Process
+  syncd:syncd               OK        Process
+  swss:orchagent            OK        Process
+  swss:portsyncd            OK        Process
+  swss:neighsyncd           OK        Process
+  swss:fdbsyncd             OK        Process
+  swss:intfmgrd             OK        Process
+  swss:portmgrd             OK        Process
+  swss:fabricmgrd           OK        Process
+  swss:buffermgrd           OK        Process
+  swss:vrfmgrd              OK        Process
+  swss:nbrmgrd              OK        Process
+  swss:coppmgrd             OK        Process
+  swss:tunnelmgrd           OK        Process
+  snmp:snmpd                OK        Process
+  snmp:snmp-subagent        OK        Process
+  lldp:lldpd                OK        Process
+  lldp:lldp-syncd           OK        Process
+  lldp:lldpmgrd             OK        Process
+  gnmi:gnmi-native          OK        Process
+  dpu-pdsagent              OK        UserDefine
+  dpu-pciemgrd              OK        UserDefine
+  dpu-eth_Uplink1/1_status  OK        UserDefine
+  dpu-pcie_link             OK        UserDefine
+
+  Module: dpu1
+
+
+  System services and devices monitor list
+
+  Name                      Status    Type
+  ------------------------  --------  ----------
+  sonic                     OK        System
+  rsyslog                   OK        Process
+  root-overlay              OK        Filesystem
+  var-log                   OK        Filesystem
+  routeCheck                OK        Program
+  dualtorNeighborCheck      OK        Program
+  diskCheck                 OK        Program
+  container_checker         OK        Program
+  vnetRouteCheck            OK        Program
+  memory_check              OK        Program
+  arp_update_checker        OK        Program
+  controlPlaneDropCheck     OK        Program
+  mgmtOperStatus            OK        Program
+  container_memory_snmp     OK        Program
+  container_memory_gnmi     OK        Program
+  container_memory_bmp      OK        Program
+  dpu-db-util               OK        Program
+  database:redis            OK        Process
+  syncd:syncd               OK        Process
+  bgp:zebra                 OK        Process
+  bgp:staticd               OK        Process
+  bgp:bgpd                  OK        Process
+  bgp:fpmsyncd              OK        Process
+  bgp:bgpcfgd               OK        Process
+  swss:orchagent            OK        Process
+  swss:portsyncd            OK        Process
+  swss:neighsyncd           OK        Process
+  swss:fdbsyncd             OK        Process
+  swss:vlanmgrd             OK        Process
+  swss:intfmgrd             OK        Process
+  swss:portmgrd             OK        Process
+  swss:fabricmgrd           OK        Process
+  swss:buffermgrd           OK        Process
+  swss:vrfmgrd              OK        Process
+  swss:nbrmgrd              OK        Process
+  swss:vxlanmgrd            OK        Process
+  swss:coppmgrd             OK        Process
+  swss:tunnelmgrd           OK        Process
+  gnmi:gnmi-native          OK        Process
+  dpu-pdsagent              OK        UserDefine
+  dpu-pciemgrd              OK        UserDefine
+  dpu-eth_Uplink1/1_status  OK        UserDefine
+  dpu-pcie_link             OK        UserDefine
   ```
 
 **show system-health detail**
@@ -11630,6 +11953,333 @@ In addition, displays a list of all current 'Services' and 'Hardware' being moni
   Name         Status    Type
   -----------  --------  ------
   psu.voltage  Ignored   Device
+  ```
+
+**show system-health detail \<module/all\>**
+
+This command displays the current status of 'Services' and 'Hardware' under monitoring.
+If any of the elements under each of these two sections is 'Not OK' a proper message will appear under the relevant section.
+In addition, displays a list of all current 'Services' and 'Hardware' being monitored and a list of ignored elements.
+
+Depening on the input "DPUx or all" the corresponing output will be disaplyed.
+
+- Usage:
+  ```
+  show system-health detail DPU0
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show system-health detail DPU0
+
+  Module: dpu0
+
+  System status summary
+
+    System status LED  green
+    Services:
+      Status: OK
+    Hardware:
+      Status: OK
+
+  System services and devices monitor list
+
+  Name                      Status    Type
+  ------------------------  --------  ----------
+  sonic                     OK        System
+  rsyslog                   OK        Process
+  root-overlay              OK        Filesystem
+  var-log                   OK        Filesystem
+  routeCheck                OK        Program
+  dualtorNeighborCheck      OK        Program
+  diskCheck                 OK        Program
+  container_checker         OK        Program
+  vnetRouteCheck            OK        Program
+  memory_check              OK        Program
+  arp_update_checker        OK        Program
+  controlPlaneDropCheck     OK        Program
+  mgmtOperStatus            OK        Program
+  container_memory_snmp     OK        Program
+  container_memory_gnmi     OK        Program
+  container_memory_bmp      OK        Program
+  dpu-db-util               OK        Program
+  database:redis            OK        Process
+  bgp:zebra                 OK        Process
+  bgp:staticd               OK        Process
+  bgp:bgpd                  OK        Process
+  bgp:fpmsyncd              OK        Process
+  bgp:bgpcfgd               OK        Process
+  syncd:syncd               OK        Process
+  swss:orchagent            OK        Process
+  swss:portsyncd            OK        Process
+  swss:neighsyncd           OK        Process
+  swss:fdbsyncd             OK        Process
+  swss:intfmgrd             OK        Process
+  swss:portmgrd             OK        Process
+  swss:fabricmgrd           OK        Process
+  swss:buffermgrd           OK        Process
+  swss:vrfmgrd              OK        Process
+  swss:nbrmgrd              OK        Process
+  swss:coppmgrd             OK        Process
+  swss:tunnelmgrd           OK        Process
+  snmp:snmpd                OK        Process
+  snmp:snmp-subagent        OK        Process
+  lldp:lldpd                OK        Process
+  lldp:lldp-syncd           OK        Process
+  lldp:lldpmgrd             OK        Process
+  gnmi:gnmi-native          OK        Process
+  dpu-pdsagent              OK        UserDefine
+  dpu-pciemgrd              OK        UserDefine
+  dpu-eth_Uplink1/1_status  OK        UserDefine
+  dpu-pcie_link             OK        UserDefine
+
+  System services and devices ignore list
+
+  Name       Status    Type
+  ---------  --------  -------
+  vxlanmgrd  Ignored   Service
+  vlanmgrd   Ignored   Service
+  psu        Ignored   Device
+  fan        Ignored   Device
+  ```
+
+- Usage:
+  ```
+  show system-health detail all
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show system-health detail all
+
+  SWITCH
+  System status summary
+
+    System status LED  green
+    Services:
+      Status: OK
+    Hardware:
+      Status: OK
+
+  System services and devices monitor list
+
+  Name                   Status    Type
+  ---------------------  --------  ----------
+  MtFuji                 OK        System
+  rsyslog                OK        Process
+  root-overlay           OK        Filesystem
+  var-log                OK        Filesystem
+  routeCheck             OK        Program
+  dualtorNeighborCheck   OK        Program
+  diskCheck              OK        Program
+  container_checker      OK        Program
+  vnetRouteCheck         OK        Program
+  memory_check           OK        Program
+  arp_update_checker     OK        Program
+  controlPlaneDropCheck  OK        Program
+  mgmtOperStatus         OK        Program
+  container_memory_snmp  OK        Program
+  container_memory_gnmi  OK        Program
+  container_eventd       OK        Program
+  container_memory_bmp   OK        Program
+  swss:orchagent         OK        Process
+  swss:portsyncd         OK        Process
+  swss:neighsyncd        OK        Process
+  swss:fdbsyncd          OK        Process
+  swss:vlanmgrd          OK        Process
+  swss:intfmgrd          OK        Process
+  swss:portmgrd          OK        Process
+  swss:fabricmgrd        OK        Process
+  swss:buffermgrd        OK        Process
+  swss:vrfmgrd           OK        Process
+  swss:nbrmgrd           OK        Process
+  swss:vxlanmgrd         OK        Process
+  swss:coppmgrd          OK        Process
+  swss:tunnelmgrd        OK        Process
+  teamd:teammgrd         OK        Process
+  teamd:teamsyncd        OK        Process
+  teamd:tlm_teamd        OK        Process
+  syncd:syncd            OK        Process
+  database:redis         OK        Process
+  database:redis_bmp     OK        Process
+  lldp:lldpd             OK        Process
+  lldp:lldp-syncd        OK        Process
+  lldp:lldpmgrd          OK        Process
+  gnmi:gnmi-native       OK        Process
+  eventd:eventd          OK        Process
+  bgp:zebra              OK        Process
+  bgp:staticd            OK        Process
+  bgp:bgpd               OK        Process
+  bgp:fpmsyncd           OK        Process
+  bgp:bgpcfgd            OK        Process
+  snmp:snmpd             OK        Process
+  snmp:snmp-subagent     OK        Process
+  PSU0.fan0              OK        Fan
+  PSU1.fan0              OK        Fan
+  fantray0.fan0          OK        Fan
+  fantray1.fan0          OK        Fan
+  fantray2.fan0          OK        Fan
+  fantray3.fan0          OK        Fan
+  PSU 1                  OK        PSU
+  PSU 2                  OK        PSU
+
+  System services and devices ignore list
+
+  Name    Status    Type
+  ------  --------  ------
+
+  Module: dpu5
+  Module: 169.254.200.6 down
+
+  Module: dpu6
+  Module: 169.254.200.7 down
+
+  Module: dpu7
+  Module: 169.254.200.8 down
+
+  Module: dpu2
+  Module: 169.254.200.3 down
+
+  Module: dpu4
+  Module: 169.254.200.5 down
+
+  Module: dpu3
+  Module: 169.254.200.4 down
+
+  Module: dpu0
+
+  System status summary
+
+    System status LED  green
+    Services:
+      Status: OK
+    Hardware:
+      Status: OK
+
+  System services and devices monitor list
+
+  Name                      Status    Type
+  ------------------------  --------  ----------
+  sonic                     OK        System
+  rsyslog                   OK        Process
+  root-overlay              OK        Filesystem
+  var-log                   OK        Filesystem
+  routeCheck                OK        Program
+  dualtorNeighborCheck      OK        Program
+  diskCheck                 OK        Program
+  container_checker         OK        Program
+  vnetRouteCheck            OK        Program
+  memory_check              OK        Program
+  arp_update_checker        OK        Program
+  controlPlaneDropCheck     OK        Program
+  mgmtOperStatus            OK        Program
+  container_memory_snmp     OK        Program
+  container_memory_gnmi     OK        Program
+  container_memory_bmp      OK        Program
+  dpu-db-util               OK        Program
+  database:redis            OK        Process
+  bgp:zebra                 OK        Process
+  bgp:staticd               OK        Process
+  bgp:bgpd                  OK        Process
+  bgp:fpmsyncd              OK        Process
+  bgp:bgpcfgd               OK        Process
+  syncd:syncd               OK        Process
+  swss:orchagent            OK        Process
+  swss:portsyncd            OK        Process
+  swss:neighsyncd           OK        Process
+  swss:fdbsyncd             OK        Process
+  swss:intfmgrd             OK        Process
+  swss:portmgrd             OK        Process
+  swss:fabricmgrd           OK        Process
+  swss:buffermgrd           OK        Process
+  swss:vrfmgrd              OK        Process
+  swss:nbrmgrd              OK        Process
+  swss:coppmgrd             OK        Process
+  swss:tunnelmgrd           OK        Process
+  snmp:snmpd                OK        Process
+  snmp:snmp-subagent        OK        Process
+  lldp:lldpd                OK        Process
+  lldp:lldp-syncd           OK        Process
+  lldp:lldpmgrd             OK        Process
+  gnmi:gnmi-native          OK        Process
+  dpu-pdsagent              OK        UserDefine
+  dpu-pciemgrd              OK        UserDefine
+  dpu-eth_Uplink1/1_status  OK        UserDefine
+  dpu-pcie_link             OK        UserDefine
+
+  System services and devices ignore list
+
+  Name       Status    Type
+  ---------  --------  -------
+  vxlanmgrd  Ignored   Service
+  vlanmgrd   Ignored   Service
+  fan        Ignored   Device
+  psu        Ignored   Device
+
+  Module: dpu1
+
+  System status summary
+
+    System status LED  green
+    Services:
+      Status: OK
+    Hardware:
+      Status: OK
+
+  System services and devices monitor list
+
+  Name                      Status    Type
+  ------------------------  --------  ----------
+  sonic                     OK        System
+  rsyslog                   OK        Process
+  root-overlay              OK        Filesystem
+  var-log                   OK        Filesystem
+  routeCheck                OK        Program
+  dualtorNeighborCheck      OK        Program
+  diskCheck                 OK        Program
+  container_checker         OK        Program
+  vnetRouteCheck            OK        Program
+  memory_check              OK        Program
+  arp_update_checker        OK        Program
+  controlPlaneDropCheck     OK        Program
+  mgmtOperStatus            OK        Program
+  container_memory_snmp     OK        Program
+  container_memory_gnmi     OK        Program
+  container_memory_bmp      OK        Program
+  dpu-db-util               OK        Program
+  database:redis            OK        Process
+  syncd:syncd               OK        Process
+  bgp:zebra                 OK        Process
+  bgp:staticd               OK        Process
+  bgp:bgpd                  OK        Process
+  bgp:fpmsyncd              OK        Process
+  bgp:bgpcfgd               OK        Process
+  swss:orchagent            OK        Process
+  swss:portsyncd            OK        Process
+  swss:neighsyncd           OK        Process
+  swss:fdbsyncd             OK        Process
+  swss:vlanmgrd             OK        Process
+  swss:intfmgrd             OK        Process
+  swss:portmgrd             OK        Process
+  swss:fabricmgrd           OK        Process
+  swss:buffermgrd           OK        Process
+  swss:vrfmgrd              OK        Process
+  swss:nbrmgrd              OK        Process
+  swss:vxlanmgrd            OK        Process
+  swss:coppmgrd             OK        Process
+  swss:tunnelmgrd           OK        Process
+  gnmi:gnmi-native          OK        Process
+  dpu-pdsagent              OK        UserDefine
+  dpu-pciemgrd              OK        UserDefine
+  dpu-eth_Uplink1/1_status  OK        UserDefine
+  dpu-pcie_link             OK        UserDefine
+
+  System services and devices ignore list
+
+  Name    Status    Type
+  ------  --------  ------
+  psu     Ignored   Device
+  fan     Ignored   Device
   ```
 
 **show system-health dpu <option>**

--- a/show/system_health.py
+++ b/show/system_health.py
@@ -1,18 +1,28 @@
 import os
 import sys
-
+import re
 import click
 from tabulate import tabulate
 import utilities_common.cli as clicommon
 from swsscommon.swsscommon import SonicV2Connector
 from natsort import natsorted
-from utilities_common.chassis import is_smartswitch, get_all_dpu_options
+from utilities_common.chassis import is_smartswitch, get_all_dpus, get_all_dpu_options, is_midplane_reachable, get_dpu_ip_list
+import subprocess
+import paramiko
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 DPU_STATE = 'DPU_STATE'
 CHASSIS_SERVER = 'redis_chassis.server'
 CHASSIS_SERVER_PORT = 6380
 CHASSIS_STATE_DB = 13
 
+# Global toggle to allow or disable auto SSH key setup
+AUTO_SSH_KEY_SETUP_ENABLED = True
+# Default SSH public key path
+DEFAULT_KEY_PATH = os.path.expanduser("~/.ssh/id_rsa")
+DEFAULT_PUBLIC_KEY_PATH = f"{DEFAULT_KEY_PATH}.pub"
+# Internal cache to avoid repeat setup attempts
+_ssh_key_cache = set()
 
 def get_system_health_status():
     if os.environ.get("UTILITIES_UNIT_TESTING") == "1":
@@ -107,6 +117,128 @@ def display_ignore_list(manager):
             table.append(entry)
     click.echo(tabulate(table, header))
 
+def ensure_ssh_key_exists():
+    if not os.path.exists(DEFAULT_PUBLIC_KEY_PATH):
+        click.echo("SSH key not found. Generating...")
+        subprocess.run(["ssh-keygen", "-t", "rsa", "-b", "4096", "-N", "", "-f", key_path],
+                       check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+# define the function to set up SSH key for remote module
+def setup_ssh_key_for_remote(module_host, username, password, public_key_path):
+    """Automatically copies the public SSH key to the remote module"""
+    # Read the public key
+    with open(public_key_path, 'r') as f:
+        public_key = f.read().strip()
+
+    # Create the SSH client
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # Automatically accept unknown keys
+
+    # Connect to the DPU using the password
+    ssh.connect(module_host, username=username, password=password)
+
+    # Create the .ssh directory if it doesn't exist
+    stdin, stdout, stderr = ssh.exec_command('mkdir -p ~/.ssh')
+    stdin.channel.recv_exit_status()  # Wait for the command to finish
+
+    # Add the public key to authorized_keys
+    stdin, stdout, stderr = ssh.exec_command(f'echo "{public_key}" >> ~/.ssh/authorized_keys')
+    stdin.channel.recv_exit_status()
+
+    # Set proper permissions for the authorized_keys file
+    stdin, stdout, stderr = ssh.exec_command('chmod 600 ~/.ssh/authorized_keys')
+    stdin.channel.recv_exit_status()
+
+    # Close the SSH connection
+    ssh.close()
+
+def ensure_ssh_key_setup(ip, username="admin"):
+    if not AUTO_SSH_KEY_SETUP_ENABLED or ip in _ssh_key_cache:
+        return
+
+    if not is_midplane_reachable(ip):
+        return
+
+    ensure_ssh_key_exists()
+
+    try:
+        ssh_test = subprocess.run([
+            "ssh", "-i", DEFAULT_KEY_PATH,
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=5",
+            f"{username}@{ip}", "echo OK"
+        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        if ssh_test.returncode != 0:
+            click.echo(f"SSH key not set for {ip}. Attempting setup...")
+            click.echo(f"Reason: {ssh_test.stderr.decode().strip()}")
+            password = click.prompt(f"Password for {username}@{ip}", hide_input=True)
+            setup_ssh_key_for_remote(ip, username, password, DEFAULT_PUBLIC_KEY_PATH)
+    except Exception as e:
+        click.echo(f"Auto SSH key setup failed for {ip}: {e}")
+
+    _ssh_key_cache.add(ip)
+
+
+def get_module_health(ip, command_type, timeout=60):
+    module_host = f"admin@{ip}"
+    remote_cmd = f"sudo -n bash -c 'show system-health {command_type}'"
+    ssh_command = [
+        "ssh",
+        "-i", DEFAULT_KEY_PATH,
+        "-T",
+        "-o", "ConnectTimeout=10",
+        "-o", "StrictHostKeyChecking=no",
+        module_host,
+        remote_cmd
+    ]
+    try:
+        output = subprocess.check_output(
+            ssh_command, stderr=subprocess.STDOUT, text=True, timeout=timeout
+        )
+        lines = output.strip().splitlines()
+        lines = [line for line in lines if not re.match(r'(Debian|GNU/Linux|Welcome)', line)]
+        return ip, "\n".join(lines)
+    except subprocess.TimeoutExpired:
+        return ip, f"Module: {ip} down (timeout)"
+    except subprocess.CalledProcessError as e:
+        err = e.output.strip()
+        if "No route to host" in err:
+            return ip, f"Module: {ip} down"
+        if "Permission denied" in err or "Too many authentication failures" in err:
+            return ip, f"Module: {ip} authentication failed"
+        return ip, f"Module: {ip} error: {err}"
+
+def display_module_health_summary(module_name, command_type, reachable_only=False):
+    dpulist = []
+    if module_name == "all":
+        dpulist = "all"
+    else:
+        dpulist = [module_name.lower()]
+    modules = get_dpu_ip_list(dpulist)
+    if reachable_only:
+        modules = [(name, ip) for name, ip in modules if is_midplane_reachable(ip)]
+    if not modules:
+        click.echo("No reachable DPU modules found.")
+        return
+
+    for _, ip in modules:
+        ensure_ssh_key_setup(ip)
+
+    with ThreadPoolExecutor(max_workers=len(modules)) as executor:
+        future_to_module = {
+            executor.submit(get_module_health, ip, command_type): name for name, ip in modules
+        }
+        for future in as_completed(future_to_module):
+            module = future_to_module[future]
+            try:
+                _, health_status = future.result()
+                click.echo(f"\nModule: {module}")
+                click.echo(health_status)
+            except Exception as e:
+                click.echo(f"\nModule: {module}")
+                click.echo(f"Module: {module} error: {e}")
+
 #
 # 'system-health' command ("show system-health")
 #
@@ -116,27 +248,66 @@ def system_health():
     return
 
 @system_health.command()
-def summary():
-    """Show system-health summary information"""
+@click.argument('module_name', required=False)
+@click.option('--reachable-only', is_flag=True, help="Only include modules reachable via midplane.")
+def summary(module_name, reachable_only):
+    if not module_name or module_name == "all":
+        if module_name == "all":
+            print("SWITCH")
+        _, chassis, stat = get_system_health_status()
+        display_system_health_summary(stat, chassis.get_status_led())
+    if module_name and module_name.startswith("DPU") or module_name == "all":
+        display_module_health_summary(module_name, "summary", reachable_only)
+
+
+@system_health.command()
+@click.argument('module_name', required=False)
+@click.option('--reachable-only', is_flag=True, help="Only include modules reachable via midplane.")
+def detail(module_name, reachable_only):
     _, chassis, stat = get_system_health_status()
     display_system_health_summary(stat, chassis.get_status_led())
-
-
-@system_health.command()
-def detail():
-    """Show system-health detail information"""
-    manager, chassis, stat = get_system_health_status()
-    display_system_health_summary(stat, chassis.get_status_led())
     display_monitor_list(stat)
-    display_ignore_list(manager)
-
+    display_ignore_list(_)
+    if module_name and module_name.startswith("DPU") or module_name == "all":
+        display_module_health_summary(module_name, "detail", reachable_only)
 
 @system_health.command()
-def monitor_list():
-    """Show system-health monitored services and devices name list"""
+@click.argument('module_name', required=False)
+@click.option('--reachable-only', is_flag=True, help="Only include modules reachable via midplane.")
+def monitor_list(module_name, reachable_only):
     _, _, stat = get_system_health_status()
     display_monitor_list(stat)
+    if module_name and module_name.startswith("DPU") or module_name == "all":
+        display_module_health_summary(module_name, "monitor-list", reachable_only)
 
+@system_health.command()
+@click.argument('module_host')
+@click.argument('username')
+@click.argument('password')
+@click.argument('public_key_path', required=False)
+def setup_ssh_key(module_host, username, password, public_key_path):
+    """Manually set up SSH key authentication for the remote module"""
+    click.echo(f"Setting up SSH key for module: {module_host}")
+    if not public_key_path:
+        public_key_path = DEFAULT_PUBLIC_KEY_PATH
+    public_key_path = os.path.expanduser(public_key_path)
+
+    if not os.path.exists(public_key_path):
+        click.echo(f"Public key not found at {public_key_path}. Please generate it first.")
+        return
+
+    try:
+        setup_ssh_key_for_remote(module_host, username, password, public_key_path)
+        click.echo(f"SSH key setup completed for {module_host}")
+    except Exception as e:
+        click.echo(f"Failed to set up SSH key for {module_host}: {str(e)}")
+
+@system_health.command()
+def disable_auto_ssh_key():
+    """Disable automatic SSH key setup for modules"""
+    global AUTO_SSH_KEY_SETUP_ENABLED
+    AUTO_SSH_KEY_SETUP_ENABLED = False
+    click.echo("Auto SSH key setup has been disabled.")
 
 @system_health.group('sysready-status',invoke_without_command=True)
 @click.pass_context

--- a/show/system_health.py
+++ b/show/system_health.py
@@ -259,15 +259,16 @@ def summary(module_name, reachable_only):
     if module_name and module_name.startswith("DPU") or module_name == "all":
         display_module_health_summary(module_name, "summary", reachable_only)
 
-
 @system_health.command()
 @click.argument('module_name', required=False)
 @click.option('--reachable-only', is_flag=True, help="Only include modules reachable via midplane.")
 def detail(module_name, reachable_only):
-    _, chassis, stat = get_system_health_status()
-    display_system_health_summary(stat, chassis.get_status_led())
-    display_monitor_list(stat)
-    display_ignore_list(_)
+    if not module_name or module_name == "all":
+        print("SWITCH")
+        _, chassis, stat = get_system_health_status()
+        display_system_health_summary(stat, chassis.get_status_led())
+        display_monitor_list(stat)
+        display_ignore_list(_)
     if module_name and module_name.startswith("DPU") or module_name == "all":
         display_module_health_summary(module_name, "detail", reachable_only)
 
@@ -275,8 +276,10 @@ def detail(module_name, reachable_only):
 @click.argument('module_name', required=False)
 @click.option('--reachable-only', is_flag=True, help="Only include modules reachable via midplane.")
 def monitor_list(module_name, reachable_only):
-    _, _, stat = get_system_health_status()
-    display_monitor_list(stat)
+    if not module_name or module_name == "all":
+        print("SWITCH")
+        _, _, stat = get_system_health_status()
+        display_monitor_list(stat)
     if module_name and module_name.startswith("DPU") or module_name == "all":
         display_module_health_summary(module_name, "monitor-list", reachable_only)
 


### PR DESCRIPTION
Adding support to consolidate the show system-health output of the modules under the host as part of smartswitch phase_two implementation as previously planned.

#### What I did
Extending the "show system-health summary",  "show system-health detail", "show system-health monitor-list" to include the modules especially for smartswitch as shown below.

New Extensions:
"show system-health summary  DPUx"  where DPUx is the module name. Example: "show system-health summary DPU0"
The second extension is ""show system-health summary  all" where all represents all the modules.

Similarly we have the following:
"show system-health detail  DPUx"  and "show system-health detail all" 
"show system-health monitor-list  DPUx"  and "show system-health monitor-list all" 

In order to access the the module system-health the SWITCH/NPU (host) has to ssh to the modules (DPU) to fetch the data.
However, SSH requires authentication and that is supported via two more CLIs.  One CLI is provided to enable passwordless SSH and one CLI to disable passwordless SSH in case the user wants to disable it.

root@MtFuji:/home/cisco# show system-health ?
Usage: show system-health [OPTIONS] COMMAND [ARGS]...

  Show system-health information

Options:
  -h, -?, --help  Show this message and exit.

Commands:
  detail
  **disable-auto-ssh-key  Disable automatic SSH key setup for modules**
  dpu                   Show system-health dpu information
  monitor-list
  **setup-ssh-key         Manually set up SSH key authentication for the...**
  summary
  sysready-status       Show system-health system ready status

To enable passwordless SSH:
Example: show system-health setup-ssh-key USERNAME admin PASSWORD *********

To disable passwordless SSH:
Example: show system-health disable-auto-ssh-key

#### How I did it
Created  a CLI / function to copy the key from host to module
Once the key is copied, the host can ssh into the module without a password and fetch the system-health CLI output
Display the output on the host

#### How to verify it
Issued the new CLI extensions and verified it against the expected output as specified in the "Command-Reference.md" document

#### Previous command output (if the output of a command-line utility has changed)
Previous command output and new output remains the same

#### New command output (if the output of a command-line utility has changed)
Previous command output and new output remains the same
