### PR TITLE
Changes to make the docker_device_config_mode to unified

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -830,8 +830,6 @@ class DBMigrator():
         """
         log.log_notice('Migrate FRR Config mode configuration')
         metadata = self.configDB.get_entry('DEVICE_METADATA', 'localhost')
-        #device_metadata_data = self.config_src_data["DEVICE_METADATA"]["localhost"]
-        #metadata['docker_router_config_mode'] = "unified"
         if 'docker_routing_config_mode' not in metadata:
             metadata['docker_routing_config_mode'] = "unified"
             self.configDB.set_entry('DEVICE_METADATA', 'localhost', metadata)

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -824,6 +824,23 @@ class DBMigrator():
             self.configDB.set_entry('FLEX_COUNTER_TABLE', obj, flex_counter)
 
 
+    def migrate_frr_separate_config_mode (self):
+        """
+        Modify docker_routing_config_mode field.
+        """
+        log.log_notice('Migrate FRR Config mode configuration')
+        metadata = self.configDB.get_entry('DEVICE_METADATA', 'localhost')
+        #device_metadata_data = self.config_src_data["DEVICE_METADATA"]["localhost"]
+        #metadata['docker_router_config_mode'] = "unified"
+        if 'docker_routing_config_mode' not in metadata:
+            metadata['docker_routing_config_mode'] = "unified"
+            self.configDB.set_entry('DEVICE_METADATA', 'localhost', metadata)
+        else:
+            if metadata['docker_routing_config_mode'] == "separated" :
+                metadata['docker_routing_config_mode'] = "unified"
+                self.configDB.set_entry('DEVICE_METADATA', 'localhost', metadata)
+
+
     def migrate_sflow_table(self):
         """
         Migrate "SFLOW_TABLE" and "SFLOW_SESSION_TABLE" to update default sample_direction
@@ -1489,6 +1506,8 @@ class DBMigrator():
 
         self.migrate_tacplus()
         self.migrate_aaa()
+
+        self.migrate_frr_separate_config_mode()
 
     def migrate(self):
         version = self.get_version()


### PR DESCRIPTION
#### What I did
Added migrator changes to change the docker_device_config_mode to unified

#### How I did it

#### How to verify it
When the older version had docker_device_config_mode as separated, with this change, the newer version will always have the device_config_mode as unified

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

UT Logs
--------
[UT_Logs.txt](https://github.com/user-attachments/files/19689837/UT_Logs.txt)
