### PR TITLE
Extra delay between running firmware and checking firmware switch done

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1646,7 +1646,9 @@ def commit(port_name):
 @firmware.command()
 @click.argument('port_name', required=True, default=None)
 @click.argument('filepath', required=True, default=None)
-def upgrade(port_name, filepath):
+@click.option('--delay', metavar='<delay>', type=click.IntRange(0, 10), default=5,
+              help="Delay time before checking firmware switch done")
+def upgrade(port_name, filepath, delay):
     """Upgrade firmware on the transceiver"""
 
     physical_port = logical_port_to_physical_port_index(port_name)
@@ -1675,6 +1677,11 @@ def upgrade(port_name, filepath):
         sys.exit(EXIT_FAIL)
 
     click.echo("Firmware run in mode {} successful".format(default_mode))
+
+    # The cable firmware can be still under initialization immediately after run_firmware
+    # We put a delay here to avoid potential error message in accessing the cable EEPROM
+    if delay:
+        time.sleep(delay)
 
     if is_fw_switch_done(port_name) != 1:
         click.echo('Failed to switch firmware images!')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Introduce a delay in "sfputil firmware upgrade" between running firmware and checking fw switch done(accessing the cable EEPROM).

Same as PR #3610

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

