### PR TITLE
Added protection for warm-upgrade when leftover VXLAN config is present

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -50,6 +50,7 @@ EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
 EXIT_PLATFORM_FW_AU_FAILURE=22
 EXIT_TEAMD_RETRY_COUNT_FAILURE=23
 EXIT_NO_MIRROR_SESSION_ACLS=24
+EXIT_LEFTOVER_CPA_TUNNEL=30
 
 function error()
 {
@@ -348,8 +349,43 @@ function check_mirror_session_acls()
     debug "Mirror session ACLs (arp, nd) programmed to ASIC successfully"
 }
 
+function abort_reboot_if_cpa_tunnel_is_leftover()
+{
+    # Devices containing any temporary CPA configuration at this point are indicative of cleanup issues
+    # from the previous warm-reboot. Warm-rebooting now is at risk of causing dataplane downtime.
+    # If any temporary CPA configuration is found, abort the warm-reboot.
+    # This preserves the current state of the system including the logs_before_reboot so that the leftover config
+    # can be debugged, cleaned up and the warm-reboot attempted again.
+
+    local has_leftover_tunnel=false
+    local has_leftover_tunnel_term_table_entry=false
+
+    local tunnel_list=$(redis-cli -n 1 KEYS "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:*")
+    for key in $tunnel_list; do
+        if [[ $(redis-cli -n 1 HGET "$key" "SAI_TUNNEL_ATTR_TYPE") == "SAI_TUNNEL_TYPE_VXLAN" ]]; then
+            debug "Found leftover SAI_OBJECT_TYPE_TUNNEL with SAI_TUNNEL_ATTR_TYPE: SAI_TUNNEL_TYPE_VXLAN. (key = $key)"
+            has_leftover_tunnel=true
+        fi
+    done
+
+    local tunnel_term_table_entry_list=$(redis-cli -n 1 KEYS "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY:*")
+    for key in $tunnel_term_table_entry_list; do
+        if [[ $(redis-cli -n 1 HGET "$key" "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE") == "SAI_TUNNEL_TYPE_VXLAN" ]]; then
+            debug "Found leftover SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY with SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE: SAI_TUNNEL_TYPE_VXLAN. (key = $key)"
+            has_leftover_tunnel_term_table_entry=true
+        fi
+    done
+
+    if [[ $has_leftover_tunnel == true || $has_leftover_tunnel_term_table_entry == true ]]; then
+        error "Device has leftover CPA tunnel configuration. Aborting warm-reboot."
+        exit "${EXIT_LEFTOVER_CPA_TUNNEL}"
+    fi
+}
+
 function setup_control_plane_assistant()
 {
+    abort_reboot_if_cpa_tunnel_is_leftover
+
     if [[ -n "${ASSISTANT_IP_LIST}" && -x ${ASSISTANT_SCRIPT} ]]; then
         # TH3 HW is not capable of VxLAN programming thus skipping TH3 platforms
         if [[ "${HWSKU}" != "DellEMC-Z9332f-M-O16C64" && "${HWSKU}" != "DellEMC-Z9332f-M-O16C64-lab" ]]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
MSFT ADO: 32296065

#### What I did
Added an additional safety check before proceeding to warm-reboot.

#### How I did it
Added a blocking check into the warm-reboot/fast-reboot script. If at the time of setting up the VXLAN tunnel, there is leftover/pre-existing VXLAN configuration, the script will exit with an error message.

#### How to verify it
Create leftover VXLAN config. This can be easily done by running the neighbor_advertiser setup script: `/usr/local/bin/neighbor_advertiser -s 10.64.247.9 -m set`

Then trigger a warm-reboot: `sudo warm-reboot -c 10.64.247.9 -v`

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
warm-reboot command output:
```
sudo warm-reboot -c 10.64.247.9 -v
...
2025 Apr 14 07:51:43.499136 str2-7260cx3-acs-9 NOTICE root: Found leftover SAI_OBJECT_TYPE_TUNNEL with SAI_TUNNEL_ATTR_TYPE: SAI_TUNNEL_TYPE_VXLAN. (key = ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a000000001783)
2025 Apr 14 07:51:44.388738 str2-7260cx3-acs-9 NOTICE root: Found leftover SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY with SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE: SAI_TUNNEL_TYPE_VXLAN. (key = ASIC_STATE:SAI
2025 Apr 14 07:51:44.630734 str2-7260cx3-acs-9 ERR root: Error seen during warm-reboot shutdown process: Device has leftover CPA tunnel configuration. Aborting warm-reboot.
2025 Apr 14 07:51:44.635435 str2-7260cx3-acs-9 NOTICE root: warm-reboot failure (30) cleanup ...
2025 Apr 14 07:51:44.645410 str2-7260cx3-acs-9 NOTICE root: Tearing down control plane assistant: 10.64.246.142 ...
```
