### PR TITLE
[warm/fast-reboot] fix lag_keepalive.py hang

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -746,7 +746,7 @@ init_warm_reboot_states
 # start sending LACPDUs to keep the LAGs refreshed
 # the process will die in 30s
 debug "Starting lag_keepalive to send LACPDUs ..."
-timeout 30 python3 ${LAG_KEEPALIVE_SCRIPT} --fork-into-background
+timeout --foreground 30 python3 ${LAG_KEEPALIVE_SCRIPT} --fork-into-background
 # give the lag_keepalive script a chance to send some LACPDUs
 sleep 5
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Issue introduced in https://github.com/sonic-net/sonic-utilities/pull/3170

lag_keepalive invokes teamdctl which is a wrapper around docker exec -i. This command is known to not work togather with timeout and similar issues have been fixed before - https://github.com/sonic-net/sonic-utilities/pull/1904

#### How I did it

Add ```--foreground``` option for timeout to receive TTY signals.

#### How to verify it

Run warm or fast reboot.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

