### PR TITLE
[202411] Stop the hwclock service and timer files before updating CMOS time

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -902,6 +902,7 @@ sleep 1
 sync
 
 # sync the current system time to CMOS
+systemctl stop hwclock.service hwclock.timer
 if [ -x /sbin/hwclock ]; then
     /sbin/hwclock -w || /bin/true
 fi

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -255,6 +255,7 @@ sync
 sleep 3
 
 # sync the current system time to CMOS
+systemctl stop hwclock.service hwclock.timer
 if [ -x /sbin/hwclock ]; then
     /sbin/hwclock -w || /bin/true
 fi


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When rebooting or doing a warm/fast reboot, stop the hwclock service and timer files before running `hwclock -w`. This removes the chance of a race condition where both of them run at the same time, causing one of them to fail.

Fixes sonic-net/sonic-buildimage#22230

#### How I did it

#### How to verify it

This is a race condition, and as such, may require a couple hundred reboot attempts to occur. With the fix, it's expected that this race condition will not occur at all.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

