### PR TITLE
[nvidia-bluefield] Generate component-versions file for the dpu in the generated dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1837,6 +1837,8 @@ collect_nvidia_bluefield() {
     else
       echo "Platform dump script $DUMP_FILE does not exist"
     fi
+
+    save_cmd "get_component_versions.py" "component_versions"
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Include component-versions file for sonic nvidia bluefield dpu

#### How I did it
I enabled the get_component_versions.py script for the bluefield dpu through the PR [here](https://github.com/sonic-net/sonic-buildimage/pull/22100)
Once that is merged this change helps enable component-versions file is included in the generated dump for the dpu
#### How to verify it
component-versions file included in the generated dump

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

**NOTE**: This PR must be merged only after [this PR](https://github.com/sonic-net/sonic-buildimage/pull/22100) is merged into the sonic-buildimage repository.