### PR TITLE
[muxcable] Add grpc CLI support for transceiver presence retrieval fr…

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2177,7 +2177,7 @@ def get_grpc_cached_version_mux_direction_per_port(db, port):
     mux_info_full_dict[asic_index] = state_db[asic_index].get_all(
         state_db[asic_index].STATE_DB, 'MUX_CABLE_INFO|{}'.format(port))
     trans_info_full_dict[asic_index] = state_db[asic_index].get_all(
-        state_db[asic_index].STATE_DB, 'TRANSCEIVER_STATUS|{}'.format(port))
+        state_db[asic_index].STATE_DB, 'TRANSCEIVER_INFO|{}'.format(port)) or {}
 
     res_dir = {}
     res_dir = mux_info_full_dict[asic_index]
@@ -2187,9 +2187,8 @@ def get_grpc_cached_version_mux_direction_per_port(db, port):
 
     trans_dir = {}
     trans_dir = trans_info_full_dict[asic_index]
-    
-    status = trans_dir.get("status", "0")
-    presence = "True" if status == "1" else "False"
+
+    presence = "True" if trans_dir else "False"
 
     mux_info_dict["presence"] = presence
 

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -793,6 +793,23 @@
         "status": "67",
         "error": "Blocking Error|High temperature"
     },
+    "TRANSCEIVER_INFO|Ethernet4": {
+        "type": "SFP28 25G Pluggable Transceiver",
+        "hardware_rev": "X.X",
+        "serial": "0123456789",
+        "manufacturer": "XXXX",
+        "model": "XXX",
+        "connector": "LC",
+        "encoding": "N/A",
+        "ext_identifier": "Power Class 1 (0.5W Max)",
+        "ext_rateselect_compliance": "N/A",
+        "cable_type": "Length Cable Assembly(m)",
+        "cable_length": "0.0",
+        "nominal_bit_rate": "0",
+        "specification_compliance": "sm_media_interface",
+        "vendor_date": "2021-11-19",
+        "vendor_oui": "XX-XX-XX"
+    },
     "TRANSCEIVER_STATUS|Ethernet4": {
         "status": "1",
         "error": "N/A",

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -390,7 +390,7 @@ Ethernet4  standby      True        active           READY
 show_muxcable_grpc_muxdirection_active_expected_all_output = """\
 Port       Direction    Presence    PeerDirection    ConnectivityState
 ---------  -----------  ----------  ---------------  -------------------
-Ethernet0  active       False       active           READY
+Ethernet0  active       True        active           READY
 """
 
 show_muxcable_grpc_muxdirection_active_expected_all_output_json = """\
@@ -398,7 +398,7 @@ show_muxcable_grpc_muxdirection_active_expected_all_output_json = """\
     "HWMODE": {
         "Ethernet0": {
             "Direction": "active",
-            "Presence": "False",
+            "Presence": "True",
             "PeerDirection": "active",
             "ConnectivityState": "READY"
         }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
xcvrd will now move the `status` field from the TRANSCEIVER_STATUS table to the TRANSCEIVER_STATUS_SW table. This is being done via the below PRs

[Update CMIS diagnostics monitoring HLD with TRANSCEIVER_STATUS_SW table by mihirpat1 · Pull Request #1964 · sonic-net/SONiC](https://github.com/sonic-net/SONiC/pull/1964)
[[xcvrd] Re-organize transceiver DOM and STATUS tables by mihirpat1 · Pull Request #604 · sonic-net/sonic-platform-daemons](https://github.com/sonic-net/sonic-platform-daemons/pull/604)

Therefore, the corresponding CLIs that rely on the TRANSCEIVER_STATUS table for retrieving transceiver presence need to be changed.

However, a more robust method to retrieve transceiver presence is by checking if the TRANSCEIVER_INFO table is present. Thus, the relevant code change will be made to address this.

#### How I did it
The CLI handler now looks at the TRANSCEIVER_INFO table to find transceiver presence

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

