### PR TITLE
To Fix Bug in the 

### DIFF
--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -850,7 +850,10 @@
     "KDUMP|config": {
         "enabled": "false",
         "memory": "256MB",
-        "num_dumps": "3"
+        "num_dumps": "3",
+        "remote": "false",
+        "ssh_string": "root@127.0.0.1",
+        "ssh_path": "/root/.ssh/id_rsa"
     },
     "FEATURE|bgp": {
         "state": "enabled",


### PR DESCRIPTION
Link to all PRs of the KDUMP = [KDUMP SONiC HLD PRs](https://github.com/sonic-net/SONiC/pull/1714)

Related sonic-utilities: [Fixing remote feature build failure](https://github.com/sonic-net/sonic-utilities/pull/3835)

Issue: There was a build failure for the remote variable in [kdump-sonic-utilities PR](https://github.com/sonic-net/sonic-utilities/pull/3835)

**Following were to be addressed, which are ADDRESSED in this PR**
    
    ```
        E 2025 Apr 1 04:56:08.321576 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--disable'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:09.638838 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:11.199498 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--num_dumps', '3'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:13.969595 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--remote', 'false'] - failed: return code - 2, output:#012None
        E 2025 Apr 1 04:56:16.373762 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--ssh_string', 'user@localhost'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:17.579657 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--ssh_path', '/a/b/c'] - failed: return code - 1, output:#012None
```

