### PR TITLE
Issue #22407: ConfigReload fails when RADIUS options are enabled

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -498,9 +498,9 @@ def statistics(db, option):
         del_table_key(db, 'RADIUS', 'global', 'statistics')
     else:
         if option == 'enable':
-            add_table_kv('RADIUS', 'global', 'statistics', True)
+            add_table_kv(db, 'RADIUS', 'global', 'statistics', 'true')
         elif option == 'disable':
-            add_table_kv('RADIUS', 'global', 'statistics', False)
+            add_table_kv(db, 'RADIUS', 'global', 'statistics', 'false')
 radius.add_command(statistics)
 
 

--- a/tests/radius_test.py
+++ b/tests/radius_test.py
@@ -269,8 +269,55 @@ class TestRadius(object):
         assert result.exit_code == 0
         assert result.output == show_radius_default_output
 
+    def test_config_radius_statistics(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.delete_table("RADIUS")
+
+        result = runner.invoke(config.config.commands["radius"],
+                               ["statistics", "enable"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == config_radius_empty_output
+
+        result = runner.invoke(show.cli.commands["radius"], [], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "RADIUS global statistics true" in result.output
+
+        result = runner.invoke(config.config.commands["radius"],
+                               ["statistics", "disable"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == config_radius_empty_output
+
+        result = runner.invoke(show.cli.commands["radius"], [], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "RADIUS global statistics false" in result.output
+
+        result = runner.invoke(config.config.commands["radius"],
+                               ["statistics", "default"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == config_radius_empty_output
+
+        result = runner.invoke(show.cli.commands["radius"], [], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "RADIUS global statistics true" not in result.output
+        assert "RADIUS global statistics false" not in result.output
+
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
-    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry",
+           mock.Mock(side_effect=ValueError))
     def test_config_radius_server_invalidkey_yang_validation(self):
         aaa.ADHOC_VALIDATION = False
         runner = CliRunner()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Enabling RADIUS `statistics` adds config entries which are not valid in YANG.  The option adds the True/False boolean values instead of the 'true'/'false' booleans that are defined in the YANG model, which causes failures when trying to reload/replace the config.

Fixes: [#22407](https://github.com/sonic-net/sonic-buildimage/issues/22407)

#### How I did it

Modified relevant config command to use the correct values.

#### How to verify it

Manually verified.

I added a test case for `config radius statistics` command. Note that this test follows the pattern in this file, which is not actually exercising the correct codepath (see https://github.com/sonic-net/sonic-utilities/issues/3754 for details).

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

