### PR TITLE
Issue #22420: Modify 'config route add' command not to include empty …

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1248,7 +1248,7 @@ def cli_sroute_to_config(ctx, command_str, strict_nh = True):
     else:
         key = ip_prefix
 
-    return key, config_entry
+    return key, config_entry, vrf_name
 
 def update_sonic_environment():
     """Prepare sonic environment variable using SONiC environment template file.
@@ -7282,7 +7282,7 @@ def route(ctx):
 def add_route(ctx, command_str):
     """Add route command"""
     config_db = ctx.obj['config_db']
-    key, route = cli_sroute_to_config(ctx, command_str)
+    key, route, vrf = cli_sroute_to_config(ctx, command_str)
 
     entry_counter = 1
     if 'nexthop' in route:
@@ -7298,7 +7298,7 @@ def add_route(ctx, command_str):
                 vrf = route['nexthop-vrf'].split(',')[0]
                 route['nexthop-vrf'] += ',' + vrf
         else:
-            route['nexthop-vrf'] = ''
+            route['nexthop-vrf'] = vrf
 
         # Set nexthop to empty string if not defined
         if 'nexthop' in route:
@@ -7361,7 +7361,7 @@ def add_route(ctx, command_str):
 def del_route(ctx, command_str):
     """Del route command"""
     config_db = ctx.obj['config_db']
-    key, route = cli_sroute_to_config(ctx, command_str, strict_nh=False)
+    key, route, vrf = cli_sroute_to_config(ctx, command_str, strict_nh=False)
     keys = config_db.get_keys('STATIC_ROUTE')
 
     if not tuple(key.split("|")) in keys:
@@ -7404,6 +7404,8 @@ def del_route(ctx, command_str):
                 if ',' in route[item]:
                     ctx.fail('Only one nexthop can be deleted at a time')
                 cli_tuple += (route[item],)
+            elif item == 'nexthop-vrf':
+                cli_tuple += (vrf,)
             else:
                 cli_tuple += ('',)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

The config route commands accept a `nexthop-vrf` as an argument. When that argument is not specified, the commands use the empty string as the default. This violates the yang model, which only accepts vrf names of the form (`default`, `mgmt`, or `Vrf*`). In the case where a `nexthop-vrf` is not defined, we should fall back to using the same vrf given for the prefix we are adding. If that is not specified, then both prefix and nexthop will use the default vrf.

Fixes: [#22420](https://github.com/sonic-net/sonic-buildimage/issues/22420)

#### How I did it

Modify the` add_route()` and `del_route()` codepaths from sonic-utilites/config/main.py to set nexthop-vrf to whatever the vrf is for the associated prefix whenever it is not explicitly specified.

#### How to verify it

All unit tests pass (including all tests in `static_route_test.py`).

I don't think the output of any show commands changes because of this, but it's possible there are combinations of different VRFs which would show up differently. Before this merges I'll set up some routes and nexthops with different VRFs and make sure any changes there may be are shown here.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

