### PR TITLE
[chassis][show_tech]Fix show queue counters to only run on host

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2074,7 +2074,7 @@ save_counter_snapshot() {
     save_cmd "echo $counter_t" "date.counter_$idx"
     save_cmd "show interface counters" "interface.counters_$idx"
     if ! $IS_SUPERVISOR; then
-       save_cmd_all_ns "show queue counters" "queue.counters_$idx"
+       save_cmd "show queue counters" "queue.counters_$idx"
     fi
     save_redis "COUNTERS_DB" "COUNTERS_DB_$idx"
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`show queue counters` is supported and runs on host instance, even for mult-asic platforms.
We don't have to run `show queue counters` for each asic namespace.

This fixes https://github.com/sonic-net/sonic-buildimage/issues/22394

#### How I did it
Modifiy generate_dump to call `save_cmd` instead of `save_cmd_all_ns` for `show queue counters`

#### How to verify it
Run `show techsupport` on multi-asic platform.
Verfiy that  the `queue.counters` files show correct information.

#### Which release branch to backport (provide reason below if selected)
 
 - [ ] 202305
 - [x] 202405
 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

