### PR TITLE
FIX ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY key unavailable in database

### DIFF
--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -81,10 +81,18 @@ class NbrBase(object):
             if not fdb:
                 continue
 
-            ent = self.db.get_all('ASIC_DB', s, blocking=True)
+            try:
+                ent = self.db.get_all('ASIC_DB', s, blocking=False)
+            except:
+                continue
+
+            if "SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID" not in ent:
+                continue
+
             br_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][oid_pfx:]
             if br_port_id not in self.if_br_oid_map:
                 continue
+
             port_id = self.if_br_oid_map[br_port_id]
             if port_id in self.if_oid_map:
                 if_name = self.if_oid_map[port_id]


### PR DESCRIPTION
When excessive MAC addresses are learned and MAC ageout occurs, pre-fetched keys may become out of sync with the actual state.

### **What I did**

1. disable blocking , do not repeatedly try to get the value from the database
2. Implemented try-except to prevent nbrshow termination on database access failure.
3. Added checks for required keys in the dictionary to avoid access failures.

### **How to verify it**
1. Use scapy sending 30k of diffent ARP request packets from another device to the DUT
2. wait the mac start ageout out and execute `nbrshow -4` on the DUT
   - OR execute `nbrshow -4 `on the DUT and delete some **ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY** key from the **ASIC_DB** same time

### **Results:**
**Before:**
```
Key '{ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x26000000000bd0","mac":"4E:5A:72:F3:09:04","switch_id":"oid:0x21000000000000"}}' unavailable in database '{ASIC_DB}'
```

### **After:**
```
...
128.255.251.97   24:93:aa:8b:86:b1  -        100
192.168.0.254    78:18:ec:0d:83:eb  eth0     -
192.168.3.46     ac:1f:6b:37:51:a2  eth0     -
Total number of entries 28572
```

