### PR TITLE
fix misaligned code block in command reference

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -11791,10 +11791,9 @@ This command is to add or delete a member port into multiple already created vla
   admin@sonic:~$ sudo config vlan member add -e 100 Ethernet12
   Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet12 as member of vlan 101, vlan 102, vlan 103, vlan 104, vlan 105
   ```
-   ```
+  ```
   admin@sonic:~$ sudo config vlan member add all Ethernet20
-  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet20 as member of vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 1
-05
+  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet20 as member of vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105
   ```
 
 **config proxy_arp enabled/disabled**


### PR DESCRIPTION
#### What I did
Updated the command reference guide to fix a misaligned code block

#### How I did it
With my own two hands

#### How to verify it
Open the modified file in a browser and verify that all the code blocks following the one I modified are no longer inverted
