### PR TITLE
Enforce create-only vnet_name for interface

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1166,19 +1166,26 @@ class RemoveCreateOnlyDependencyMoveGenerator:
 
 class VNETAssociationChangeValidator:
     """
-    A class to validate that VNET associations cannot be modified after they're set.
-    This validation ensures that any attempt to modify a VNET association, whether
-    through a replace operation or a delete-then-recreate approach, is flagged as invalid.
-    
-    How differences in `vnet_name` are detected:
-    - The `validate` method iterates through predefined tables (e.g., "VLAN_SUB_INTERFACE").
-    - For each table, it checks if the `vnet_name` field in the current configuration
-      differs from the target configuration.
-    - If a difference is detected, the interface is added to the `failed_interfaces` list.
-    
-    What the error message communicates:
-    - The error message indicates which interfaces have invalid VNET association changes.
-    - This helps users identify and correct configuration issues.
+    A class to validate that VNET associations of interfaces cannot be modified after they're set.
+    What is allowed:
+        - Creating new interfaces with VNET associations
+        - Adding non-VNET properties to interfaces with existing VNET associations
+        - Modifying non-VNET properties of interfaces with existing VNET associations
+        - Completely deleting interfaces with VNET associations
+        - Completely removing a VNET association from an interface without adding a new one
+        - Adding a VNET association to an interface that didn't have one before
+        - Adding a previously deleted interface with the same VNET name it had before
+
+    What is NOT allowed:
+    - Changing an existing VNET association to a different VNET association
+    - Attempting to modify a VNET association in a single operation
+    - Any operation that results in the same interface having a different VNET name
+      in the target configuration compared to the current configuration
+
+    Two-step process for changing VNETs:
+    Users can effectively "change" a VNET association by performing two separate operations:
+        1. First operation: Delete the entire interface with its old VNET association
+        2. Later operation: Create a new interface with a different VNET association
     """
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1163,6 +1163,45 @@ class RemoveCreateOnlyDependencyMoveGenerator:
                                member_name, create_only_field):
         return config[table_to_check][member_name].get(create_only_field, None)
 
+class VNETAssociationChangeValidator:
+    """
+    A class to validate that VNET associations cannot be modified after they're set.
+    Whether through replace or delete-then-recreate approach.
+    """
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+        self.tables = ["VLAN_SUB_INTERFACE", "VLAN_INTERFACE", "INTERFACE"]
+        self.failed_interface = None
+
+    def validate(self, move, diff):
+        current_config = diff.current_config
+        target_config = diff.target_config
+        
+        for table in self.tables:
+            if table not in current_config:
+                continue
+                
+            for interface, config in current_config[table].items():
+                if "|" in interface: # Skip IP prefix entries
+                    continue
+                    
+                if "vnet_name" not in config:
+                    continue
+                    
+                if table in target_config and interface in target_config[table]:
+                    if ("vnet_name" in target_config[table][interface] and 
+                        target_config[table][interface]["vnet_name"] != config["vnet_name"]):
+                        simulated_config = move.apply(current_config)
+                        
+                        # If the move changes the vnet or deletes the table/interface that has a vnet
+                        if (table not in simulated_config or 
+                            interface not in simulated_config[table] or
+                            "vnet_name" not in simulated_config[table][interface] or
+                            simulated_config[table][interface]["vnet_name"] != config["vnet_name"]):
+                            self.failed_interface = interface
+                            return False
+        
+        return True
 
 class SingleRunLowLevelMoveGenerator:
     """
@@ -1648,6 +1687,7 @@ class SortAlgorithmFactory:
                           DeleteInsteadOfReplaceMoveExtender(),
                           DeleteRefsMoveExtender(self.path_addressing)]
         move_validators = [DeleteWholeConfigMoveValidator(),
+                           VNETAssociationChangeValidator(self.path_addressing),
                            FullConfigMoveValidator(self.config_wrapper),
                            NoDependencyMoveValidator(self.path_addressing, self.config_wrapper),
                            CreateOnlyMoveValidator(self.path_addressing),
@@ -1936,6 +1976,9 @@ class PatchSorter:
         moves = sort_algorithm.sort(diff)
 
         if moves is None:
+            for validator in sort_algorithm.move_wrapper.move_validators:
+                if isinstance(validator, VNETAssociationChangeValidator) and validator.failed_interface:
+                    raise GenericConfigUpdaterError(f"Vnet is already associated with interface {validator.failed_interface} and cannot be modified")
             raise GenericConfigUpdaterError("There is no possible sorting")
 
         changes = [JsonChange(move.patch) for move in moves]

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -571,6 +571,9 @@ class CreateOnlyFilter:
             ["BGP_MONITORS", "*", "nhopself"],
             ["BGP_MONITORS", "*", "rrclient"],
             ["MIRROR_SESSION", "*", "*"],
+            ["VLAN_SUB_INTERFACE", "*", "vnet_name"],
+            ["VLAN_INTERFACE", "*", "vnet_name"],
+            ["INTERFACE", "*", "vnet_name"],
         ]
 
     def get_filter(self):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1163,6 +1163,7 @@ class RemoveCreateOnlyDependencyMoveGenerator:
                                member_name, create_only_field):
         return config[table_to_check][member_name].get(create_only_field, None)
 
+
 class VNETAssociationChangeValidator:
     """
     A class to validate that VNET associations cannot be modified after they're set.
@@ -1176,31 +1177,25 @@ class VNETAssociationChangeValidator:
     def validate(self, move, diff):
         current_config = diff.current_config
         target_config = diff.target_config
-        
         for table in self.tables:
             if table not in current_config:
                 continue
-                
             for interface, config in current_config[table].items():
-                if "|" in interface: # Skip IP prefix entries
+                if "|" in interface:  # Skip IP prefix entries
                     continue
-                    
                 if "vnet_name" not in config:
                     continue
-                    
                 if table in target_config and interface in target_config[table]:
                     if ("vnet_name" in target_config[table][interface] and 
-                        target_config[table][interface]["vnet_name"] != config["vnet_name"]):
+                            target_config[table][interface]["vnet_name"] != config["vnet_name"]):
                         simulated_config = move.apply(current_config)
-                        
                         # If the move changes the vnet or deletes the table/interface that has a vnet
                         if (table not in simulated_config or 
-                            interface not in simulated_config[table] or
-                            "vnet_name" not in simulated_config[table][interface] or
-                            simulated_config[table][interface]["vnet_name"] != config["vnet_name"]):
+                                interface not in simulated_config[table] or
+                                "vnet_name" not in simulated_config[table][interface] or
+                                simulated_config[table][interface]["vnet_name"] != config["vnet_name"]):
                             self.failed_interface = interface
                             return False
-        
         return True
 
 class SingleRunLowLevelMoveGenerator:
@@ -1978,7 +1973,10 @@ class PatchSorter:
         if moves is None:
             for validator in sort_algorithm.move_wrapper.move_validators:
                 if isinstance(validator, VNETAssociationChangeValidator) and validator.failed_interface:
-                    raise GenericConfigUpdaterError(f"Vnet is already associated with interface {validator.failed_interface} and cannot be modified")
+                    raise GenericConfigUpdaterError(
+                        f"Vnet is already associated with interface {validator.failed_interface} "
+                        "and cannot be modified"
+                    )
             raise GenericConfigUpdaterError("There is no possible sorting")
 
         changes = [JsonChange(move.patch) for move in moves]

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1186,11 +1186,11 @@ class VNETAssociationChangeValidator:
                 if "vnet_name" not in config:
                     continue
                 if table in target_config and interface in target_config[table]:
-                    if ("vnet_name" in target_config[table][interface] and 
+                    if ("vnet_name" in target_config[table][interface] and
                             target_config[table][interface]["vnet_name"] != config["vnet_name"]):
                         simulated_config = move.apply(current_config)
                         # If the move changes the vnet or deletes the table/interface that has a vnet
-                        if (table not in simulated_config or 
+                        if (table not in simulated_config or
                                 interface not in simulated_config[table] or
                                 "vnet_name" not in simulated_config[table][interface] or
                                 simulated_config[table][interface]["vnet_name"] != config["vnet_name"]):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1190,7 +1190,7 @@ class VNETAssociationChangeValidator:
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
         self.tables = ["VLAN_SUB_INTERFACE", "VLAN_INTERFACE", "INTERFACE"]
-        self.failed_interfaces = []
+        self.failed_interfaces = set()
 
     def validate(self, move, diff):
         current_config = diff.current_config
@@ -1213,7 +1213,7 @@ class VNETAssociationChangeValidator:
                                 "vnet_name" not in simulated_config[table][interface] or
                                 simulated_config[table][interface]["vnet_name"] != config["vnet_name"]):
                             failed_interface = f"{table}/{interface}"
-                            self.failed_interfaces.append(failed_interface)
+                            self.failed_interfaces.add(failed_interface)
         return len(self.failed_interfaces) == 0
 
 class SingleRunLowLevelMoveGenerator:
@@ -1991,7 +1991,7 @@ class PatchSorter:
         if moves is None:
             for validator in sort_algorithm.move_wrapper.move_validators:
                 if isinstance(validator, VNETAssociationChangeValidator) and validator.failed_interfaces:
-                    failed_interfaces_str = ", ".join(validator.failed_interfaces)
+                    failed_interfaces_str = ", ".join(sorted(validator.failed_interfaces))
                     raise GenericConfigUpdaterError(
                         f"Vnet associations cannot be modified for interfaces: {failed_interfaces_str}"
                     )

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1167,7 +1167,18 @@ class RemoveCreateOnlyDependencyMoveGenerator:
 class VNETAssociationChangeValidator:
     """
     A class to validate that VNET associations cannot be modified after they're set.
-    Whether through replace or delete-then-recreate approach.
+    This validation ensures that any attempt to modify a VNET association, whether
+    through a replace operation or a delete-then-recreate approach, is flagged as invalid.
+    
+    How differences in `vnet_name` are detected:
+    - The `validate` method iterates through predefined tables (e.g., "VLAN_SUB_INTERFACE").
+    - For each table, it checks if the `vnet_name` field in the current configuration
+      differs from the target configuration.
+    - If a difference is detected, the interface is added to the `failed_interfaces` list.
+    
+    What the error message communicates:
+    - The error message indicates which interfaces have invalid VNET association changes.
+    - This helps users identify and correct configuration issues.
     """
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing

--- a/tests/generic_config_updater/files/change_applier_test.data.json
+++ b/tests/generic_config_updater/files/change_applier_test.data.json
@@ -136,6 +136,11 @@
                 "type": "LeafRouter"
             }
         },
+        "INTERFACE": {
+            "Ethernet2": {
+                "vnet_name": "Vnet3"
+            }
+        },
         "PORT": {
             "Ethernet0": {
                 "alias": "fortyGigE0/0",
@@ -232,7 +237,10 @@
         "VLAN_INTERFACE": {
             "Vlan1000": {},
             "Vlan1000|192.168.0.1/21": {},
-            "Vlan1000|2603:10b0:b13:c70::1/64": {}
+            "Vlan1000|2603:10b0:b13:c70::1/64": {},
+            "Vlan100": {
+                "vnet_name": "Vnet2"
+            }
         },
         "VLAN_MEMBER": {
             "Vlan1000|Ethernet12": {
@@ -242,6 +250,12 @@
                 "tagging_mode": "untagged"
             },
             "Vlan1000|Ethernet28": {
+            }
+        },
+        "VLAN_SUB_INTERFACE": {
+            "Ethernet0.10": {
+                "vlan": 10,
+                "vnet_name": "Vnet1"
             }
         },
         "WRED_PROFILE": {

--- a/tests/generic_config_updater/files/patch_sorter_test_failure.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_failure.json
@@ -105,5 +105,153 @@
         "expected_error_substrings": [
             "There is no possible sorting"
         ]
+    },
+    "VLAN_SUB_INTERFACE_CHANGE_VNET_ASSOCIATION__FAILURE": {
+        "desc": [
+            "Changing a VLAN subinterface VNET association fails.", 
+            "If a subinterface is already associated with a VNET, it cannot be associated with a new VNET.",
+            "e.g. Changing /VLAN_SUB_INTERFACE/Ethernet8.10/vnet_name from Vnet1 to Vnet2 fails."
+        ],
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                },
+                "Vnet2": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10012"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet8.10": {
+                    "vnet_name": "Vnet1",
+                    "vlan": 10
+                },
+                "Ethernet8.10|10.0.0.1/30": {
+                    "ip-prefix": "10.0.0.1/30"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/VLAN_SUB_INTERFACE/Ethernet8.10/vnet_name",
+                "value": "Vnet2"
+            }
+        ],
+        "expected_error_substrings": [
+            "Vnet is already associated with interface Ethernet8.10 and cannot be modified"
+        ]
+    },
+    "VLAN_INTERFACE_CHANGE_VNET_ASSOCIATION__FAILURE": {
+        "desc": [
+            "Changing a VLAN interface VNET association fails.",
+            "If an interface is already associated with a VNET, it cannot be associated with a new VNET.",
+            "e.g. Changing /VLAN_INTERFACE/Vlan1000/vnet_name from Vnet1 to Vnet2 fails."
+        ],
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                },
+                "Vnet2": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10012"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan1000": {
+                    "vnet_name": "Vnet1"
+                },
+                "Vlan1000|192.168.0.1/21": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/VLAN_INTERFACE/Vlan1000/vnet_name",
+                "value": "Vnet2"
+            }
+        ],
+        "expected_error_substrings": [
+            "Vnet is already associated with interface Vlan1000 and cannot be modified"
+        ]
+    },
+    "INTERFACE_CHANGE_VNET_ASSOCIATION__FAILURE": {
+        "desc": [
+            "Changing a regular interface VNET association fails.",
+            "If an interface is already associated with a VNET, it cannot be associated with a new VNET.",
+            "e.g. Changing /INTERFACE/Ethernet8/vnet_name from Vnet1 to Vnet2 fails."
+        ],
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                },
+                "Vnet2": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10012"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet8": {
+                    "vnet_name": "Vnet1"
+                },
+                "Ethernet8|10.0.0.1/30": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/INTERFACE/Ethernet8/vnet_name",
+                "value": "Vnet2"
+            }
+        ],
+        "expected_error_substrings": [
+            "Vnet is already associated with interface Ethernet8 and cannot be modified"
+        ]
     }
 }

--- a/tests/generic_config_updater/files/patch_sorter_test_failure.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_failure.json
@@ -156,7 +156,7 @@
             }
         ],
         "expected_error_substrings": [
-            "Vnet is already associated with interface Ethernet8.10 and cannot be modified"
+            "Vnet associations cannot be modified for interfaces: VLAN_SUB_INTERFACE/Ethernet8.10"
         ]
     },
     "VLAN_INTERFACE_CHANGE_VNET_ASSOCIATION__FAILURE": {
@@ -201,7 +201,7 @@
             }
         ],
         "expected_error_substrings": [
-            "Vnet is already associated with interface Vlan1000 and cannot be modified"
+            "Vnet associations cannot be modified for interfaces: VLAN_INTERFACE/Vlan1000"
         ]
     },
     "INTERFACE_CHANGE_VNET_ASSOCIATION__FAILURE": {
@@ -251,7 +251,88 @@
             }
         ],
         "expected_error_substrings": [
-            "Vnet is already associated with interface Ethernet8 and cannot be modified"
+            "Vnet associations cannot be modified for interfaces: INTERFACE/Ethernet8"
+        ]
+    },
+    "MULTIPLE_INTERFACES_CHANGE_VNET_ASSOCIATION__FAILURE": {
+        "desc": [
+            "Changing multiple interfaces VNET associations fails.",
+            "If interfaces are already associated with a VNET, they cannot be associated with a new VNET.",
+            "e.g. Changing VNET associations for Ethernet8, Vlan1000 and Ethernet8.10 fails."
+        ],
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                },
+                "Vnet2": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10012"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan1000": {
+                    "vnet_name": "Vnet1"
+                },
+                "Vlan1000|192.168.0.1/21": {}
+            },
+            "INTERFACE": {
+                "Ethernet8": {
+                    "vnet_name": "Vnet1"
+                },
+                "Ethernet8|10.0.0.1/30": {}
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet8.10": {
+                    "vnet_name": "Vnet1",
+                    "vlan": 10
+                },
+                "Ethernet8.10|10.0.0.1/30": {
+                    "ip-prefix": "10.0.0.1/30"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/VLAN_INTERFACE/Vlan1000/vnet_name",
+                "value": "Vnet2"
+            },
+            {
+                "op": "replace",
+                "path": "/INTERFACE/Ethernet8/vnet_name",
+                "value": "Vnet2"
+            },
+            {
+                "op": "replace",
+                "path": "/VLAN_SUB_INTERFACE/Ethernet8.10/vnet_name",
+                "value": "Vnet2"
+            }
+        ],
+        "expected_error_substrings": [
+            "Vnet associations cannot be modified for interfaces: ",
+            "INTERFACE/Ethernet8, VLAN_SUB_INTERFACE/Ethernet8.10, VLAN_INTERFACE/Vlan1000"
         ]
     }
 }

--- a/tests/generic_config_updater/files/patch_sorter_test_failure.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_failure.json
@@ -332,7 +332,7 @@
         ],
         "expected_error_substrings": [
             "Vnet associations cannot be modified for interfaces: ",
-            "INTERFACE/Ethernet8, VLAN_SUB_INTERFACE/Ethernet8.10, VLAN_INTERFACE/Vlan1000"
+            "INTERFACE/Ethernet8, VLAN_INTERFACE/Vlan1000, VLAN_SUB_INTERFACE/Ethernet8.10"
         ]
     }
 }

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -5922,5 +5922,352 @@
                 }
             ]
         ]
+    },
+    "VLAN_SUB_INTERFACE_ADD_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Adding a VNET association to a VLAN subinterface that doesn't have one succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet8.10": {},
+                "Ethernet8.10|10.0.0.1/30": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/VLAN_SUB_INTERFACE/Ethernet8.10/vnet_name",
+                "value": "Vnet1"
+            }
+        ],
+        "expected_changes": [
+            [{"op": "remove", "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130"}],
+            [{"op": "remove", "path": "/VLAN_SUB_INTERFACE"}],
+            [{"op": "add", "path": "/VLAN_SUB_INTERFACE", "value": {"Ethernet8.10": {"vnet_name": "Vnet1"}}}],
+            [{"op": "add", "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130", "value": {}}]
+        ]
+    },
+    "VLAN_SUB_INTERFACE_REMOVE_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Removing a VNET association from a VLAN subinterface succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet8.10": {
+                    "vnet_name": "Vnet1"
+                },
+                "Ethernet8.10|10.0.0.1/30": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/VLAN_SUB_INTERFACE/Ethernet8.10/vnet_name"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_SUB_INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_SUB_INTERFACE",
+                    "value": {
+                        "Ethernet8.10": {}
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "VLAN_INTERFACE_ADD_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Adding a VNET association to a VLAN interface that doesn't have one succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan1000": {},
+                "Vlan1000|192.168.0.1/21": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/VLAN_INTERFACE/Vlan1000/vnet_name",
+                "value": "Vnet1"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_INTERFACE"
+                }
+            ],
+            [
+                {
+                  "op": "add",
+                  "path": "/VLAN_INTERFACE",
+                  "value": {"Vlan1000": {"vnet_name": "Vnet1"}}
+                }
+            ],
+            [
+                {
+                  "op": "add",
+                  "path": "/VLAN_INTERFACE/Vlan1000|192.168.0.1~121",
+                  "value": {}
+                }
+            ]
+        ]
+    },
+    "VLAN_INTERFACE_REMOVE_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Removing a VNET association from a VLAN interface succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan1000": {
+                    "vnet_name": "Vnet1"
+                },
+                "Vlan1000|192.168.0.1/21": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/VLAN_INTERFACE/Vlan1000/vnet_name"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE",
+                    "value": {
+                        "Vlan1000": {}
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE/Vlan1000|192.168.0.1~121",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "INTERFACE_ADD_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Adding a VNET association to a regular interface that doesn't have one succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet8": {},
+                "Ethernet8|10.0.0.1/30": {}
+                }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/INTERFACE/Ethernet8/vnet_name",
+                "value": "Vnet1"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE",
+                    "value": {
+                        "Ethernet8": {
+                            "vnet_name": "Vnet1"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "INTERFACE_REMOVE_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Removing a VNET association from a regular interface succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet8": {
+                    "vnet_name": "Vnet1"
+                },
+                "Ethernet8|10.0.0.1/30": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/INTERFACE/Ethernet8/vnet_name"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE",
+                    "value": {
+                        "Ethernet8": {}
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130",
+                    "value": {}
+                }
+              ]
+        ]
     }
 }

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -3291,7 +3291,8 @@ class TestSortAlgorithmFactory(unittest.TestCase):
                               ps.CreateOnlyMoveValidator,
                               ps.RequiredValueMoveValidator,
                               ps.RemoveCreateOnlyDependencyMoveValidator,
-                              ps.NoEmptyTableMoveValidator]
+                              ps.NoEmptyTableMoveValidator,
+                              ps.VNETAssociationChangeValidator]
 
         # Act
         sorter = factory.create(algo)

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1134,6 +1134,22 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
                     "ttl": "32",
                     "type": "ERSPAN"
                 }
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet0.10": {
+                    "vlan": 10,
+                    "vnet_name": "Vnet1"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan100": {
+                    "vnet_name": "Vnet2"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet2": {
+                    "vnet_name": "Vnet3"
+                }
             }
         }
         expected = [
@@ -1170,6 +1186,9 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
             "/MIRROR_SESSION/mirror_session_dscp/src_ip",
             "/MIRROR_SESSION/mirror_session_dscp/ttl",
             "/MIRROR_SESSION/mirror_session_dscp/type",
+            "/VLAN_SUB_INTERFACE/Ethernet0.10/vnet_name",
+            "/VLAN_INTERFACE/Vlan100/vnet_name",
+            "/INTERFACE/Ethernet2/vnet_name",
         ]
 
         actual = self.validator._get_create_only_paths(config)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support to mark the `vnet_name` field as a create-only field in `VLAN_INTERFACE`, `VLAN_SUB_INTERFACE`, and `INTERFACE` tables.

#### How I did it
1. Updated `patch_sorter.py` to include the following patterns as create-only fields:

```python3
["VLAN_SUB_INTERFACE", "*", "vnet_name"],
["VLAN_INTERFACE", "*", "vnet_name"],
["INTERFACE", "*", "vnet_name"]
```

2. Added test data in `patch_sorter_test.py` to verify these fields are identified as `create-only`.
3. Updated `change_applier_test.data.json` with example entries containing `vnet_name` fields.
4. Added unit tests in `patch_sorter_test_success.json` for `test_patch_sorter_success` in `patch_sorter_test.py` 

#### How to verify it
```
make configure PLATFORM=generic
make -f Makefile.work BLDENV=bookworm KEEP_SLAVE_ON=yes target/python-wheels/bookworm/sonic_utilities-1.2-py3-none-any.whl
cd src/sonic-utilities/
python3 setup.py bdist_wheel
```

```
pytest tests/generic_config_updater/patch_sorter_test.py::TestCreateOnlyMoveValidator::test_hard_coded_create_only_paths
pytest tests/generic_config_updater/change_applier_test.py::TestChangeApplier::test_change_apply
```
![image](https://github.com/user-attachments/assets/8930278c-49c7-4ab7-9814-5f6a94aee005)

![image](https://github.com/user-attachments/assets/87678ed7-a584-4e3a-a44d-f0feb325ce4f)

![image](https://github.com/user-attachments/assets/fcd33a79-b33a-4f4f-8002-e26959be575d)



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

