### PR TITLE
[DPB] Remove unnecessary prompts

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -240,9 +240,10 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
             # find relavent tables in extra tables, i.e. one which can have deleted
             # ports
             tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
-            click.secho("Below Config can not be verified, It may cause harm "\
-                "to the system\n {}".format(json.dumps(tables, indent=2)))
-            click.confirm('Do you wish to Continue?', abort=True)
+            if len(tables):
+                click.secho("Below Config can not be verified, It may cause harm "\
+                    "to the system\n {}".format(json.dumps(tables, indent=2)))
+                click.confirm('Do you wish to Continue?', abort=True)
     except Exception as e:
         raise Exception("Failed in breakout_warnUser_extraTables. Error: {}".format(str(e)))
     return

--- a/config/main.py
+++ b/config/main.py
@@ -241,8 +241,8 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
             # ports
             tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
             if len(tables):
-                click.secho("Below Config can not be verified, It may cause harm "\
-                    "to the system\n {}".format(json.dumps(tables, indent=2)))
+                click.secho("Below Config can not be verified, It may cause harm "
+                            "to the system\n {}".format(json.dumps(tables, indent=2)))
                 click.confirm('Do you wish to Continue?', abort=True)
     except Exception as e:
         raise Exception("Failed in breakout_warnUser_extraTables. Error: {}".format(str(e)))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
```
admin@SPINE-1-AS7326-56X-4-8U:~$ sudo config int breakout Ethernet76 "2x50G" -y

Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 2x50G

Ports to be deleted :
 {
    "Ethernet76": "100000"
}
Ports to be added :
 {
    "Ethernet76": "50000",
    "Ethernet78": "50000"
}
sonic_yang(6):Note: Below table(s) have no YANG models: REST_SERVER
Below Config can not be verified, It may cause harm to the system
 {}
Do you wish to Continue? [y/N]:
```

The unverified config is empty, it would not cause harm to the system.

#### How I did it
check the length of the unverified table

#### How to verify it
```
admin@SPINE-1-AS7326-56X-4-8U:~$ sudo config int breakout Ethernet76 "2x50G" -y

Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 2x50G

Ports to be deleted :
 {
    "Ethernet76": "100000"
}
Ports to be added :
 {
    "Ethernet76": "50000",
    "Ethernet78": "50000"
}
sonic_yang(6):Note: Below table(s) have no YANG models: REST_SERVER
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

