### PR TITLE
Vnet_name added in create_only patterns

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -571,6 +571,9 @@ class CreateOnlyFilter:
             ["BGP_MONITORS", "*", "nhopself"],
             ["BGP_MONITORS", "*", "rrclient"],
             ["MIRROR_SESSION", "*", "*"],
+            ["VLAN_SUB_INTERFACE", "*", "vnet_name"],
+            ["VLAN_INTERFACE", "*", "vnet_name"],
+            ["INTERFACE", "*", "vnet_name"],
         ]
 
     def get_filter(self):

--- a/tests/generic_config_updater/files/change_applier_test.data.json
+++ b/tests/generic_config_updater/files/change_applier_test.data.json
@@ -136,6 +136,11 @@
                 "type": "LeafRouter"
             }
         },
+        "INTERFACE": {
+            "Ethernet2": {
+                "vnet_name": "Vnet3"
+            }
+        },
         "PORT": {
             "Ethernet0": {
                 "alias": "fortyGigE0/0",
@@ -232,7 +237,10 @@
         "VLAN_INTERFACE": {
             "Vlan1000": {},
             "Vlan1000|192.168.0.1/21": {},
-            "Vlan1000|2603:10b0:b13:c70::1/64": {}
+            "Vlan1000|2603:10b0:b13:c70::1/64": {},
+            "Vlan100": {
+                "vnet_name": "Vnet2"
+            }
         },
         "VLAN_MEMBER": {
             "Vlan1000|Ethernet12": {
@@ -242,6 +250,12 @@
                 "tagging_mode": "untagged"
             },
             "Vlan1000|Ethernet28": {
+            }
+        },
+        "VLAN_SUB_INTERFACE": {
+            "Ethernet0.10": {
+                "vlan": 10,
+                "vnet_name": "Vnet1"
             }
         },
         "WRED_PROFILE": {

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -5922,5 +5922,352 @@
                 }
             ]
         ]
+    },
+    "VLAN_SUB_INTERFACE_ADD_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Adding a VNET association to a VLAN subinterface that doesn't have one succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet8.10": {},
+                "Ethernet8.10|10.0.0.1/30": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/VLAN_SUB_INTERFACE/Ethernet8.10/vnet_name",
+                "value": "Vnet1"
+            }
+        ],
+        "expected_changes": [
+            [{"op": "remove", "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130"}],
+            [{"op": "remove", "path": "/VLAN_SUB_INTERFACE"}],
+            [{"op": "add", "path": "/VLAN_SUB_INTERFACE", "value": {"Ethernet8.10": {"vnet_name": "Vnet1"}}}],
+            [{"op": "add", "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130", "value": {}}]
+        ]
+    },
+    "VLAN_SUB_INTERFACE_REMOVE_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Removing a VNET association from a VLAN subinterface succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet8.10": {
+                    "vnet_name": "Vnet1"
+                },
+                "Ethernet8.10|10.0.0.1/30": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/VLAN_SUB_INTERFACE/Ethernet8.10/vnet_name"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_SUB_INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_SUB_INTERFACE",
+                    "value": {
+                        "Ethernet8.10": {}
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_SUB_INTERFACE/Ethernet8.10|10.0.0.1~130",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "VLAN_INTERFACE_ADD_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Adding a VNET association to a VLAN interface that doesn't have one succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan1000": {},
+                "Vlan1000|192.168.0.1/21": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/VLAN_INTERFACE/Vlan1000/vnet_name",
+                "value": "Vnet1"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_INTERFACE"
+                }
+            ],
+            [
+                {
+                  "op": "add",
+                  "path": "/VLAN_INTERFACE",
+                  "value": {"Vlan1000": {"vnet_name": "Vnet1"}}
+                }
+            ],
+            [
+                {
+                  "op": "add",
+                  "path": "/VLAN_INTERFACE/Vlan1000|192.168.0.1~121",
+                  "value": {}
+                }
+            ]
+        ]
+    },
+    "VLAN_INTERFACE_REMOVE_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Removing a VNET association from a VLAN interface succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "VLAN": {
+                "Vlan1000": {
+                    "vlanid": "1000"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan1000": {
+                    "vnet_name": "Vnet1"
+                },
+                "Vlan1000|192.168.0.1/21": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/VLAN_INTERFACE/Vlan1000/vnet_name"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE",
+                    "value": {
+                        "Vlan1000": {}
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/VLAN_INTERFACE/Vlan1000|192.168.0.1~121",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "INTERFACE_ADD_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Adding a VNET association to a regular interface that doesn't have one succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet8": {},
+                "Ethernet8|10.0.0.1/30": {}
+                }
+        },
+        "patch": [
+            {
+                "op": "add",
+                "path": "/INTERFACE/Ethernet8/vnet_name",
+                "value": "Vnet1"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE",
+                    "value": {
+                        "Ethernet8": {
+                            "vnet_name": "Vnet1"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130",
+                    "value": {}
+                }
+            ]
+        ]
+    },
+    "INTERFACE_REMOVE_VNET_ASSOCIATION__SUCCESS": {
+        "desc": "Removing a VNET association from a regular interface succeeds.",
+        "current_config": {
+            "VXLAN_TUNNEL": {
+                "vtep1": {
+                    "src_ip": "1.2.3.4"
+                }
+            },
+            "VNET": {
+                "Vnet1": {
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10011"
+                }
+            },
+            "PORT": {
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "Ethernet8/1",
+                    "description": "Ethernet8",
+                    "lanes": "45,46,47,48",
+                    "mtu": "9000",
+                    "speed": "100000"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet8": {
+                    "vnet_name": "Vnet1"
+                },
+                "Ethernet8|10.0.0.1/30": {}
+            }
+        },
+        "patch": [
+            {
+                "op": "remove",
+                "path": "/INTERFACE/Ethernet8/vnet_name"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/INTERFACE"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE",
+                    "value": {
+                        "Ethernet8": {}
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet8|10.0.0.1~130",
+                    "value": {}
+                }
+              ]
+        ]
     }
 }

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1134,6 +1134,22 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
                     "ttl": "32",
                     "type": "ERSPAN"
                 }
+            },
+            "VLAN_SUB_INTERFACE": {
+                "Ethernet0.10": {
+                    "vlan": 10,
+                    "vnet_name": "Vnet1"
+                }
+            },
+            "VLAN_INTERFACE": {
+                "Vlan100": {
+                    "vnet_name": "Vnet2"
+                }
+            },
+            "INTERFACE": {
+                "Ethernet2": {
+                    "vnet_name": "Vnet3"
+                }
             }
         }
         expected = [
@@ -1170,6 +1186,9 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
             "/MIRROR_SESSION/mirror_session_dscp/src_ip",
             "/MIRROR_SESSION/mirror_session_dscp/ttl",
             "/MIRROR_SESSION/mirror_session_dscp/type",
+            "/VLAN_SUB_INTERFACE/Ethernet0.10/vnet_name",
+            "/VLAN_INTERFACE/Vlan100/vnet_name",
+            "/INTERFACE/Ethernet2/vnet_name",
         ]
 
         actual = self.validator._get_create_only_paths(config)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support to mark the `vnet_name` field as a create-only field in `VLAN_INTERFACE`, `VLAN_SUB_INTERFACE`, and `INTERFACE` tables.

#### How I did it
1. Updated `patch_sorter.py` to include the following patterns as create-only fields:

```python3
["VLAN_SUB_INTERFACE", "*", "vnet_name"],
["VLAN_INTERFACE", "*", "vnet_name"],
["INTERFACE", "*", "vnet_name"]
```
2. Added test data in `patch_sorter_test.py` to verify these fields are identified as `create-only`.
3. Updated `change_applier_test.data.json` with example entries containing `vnet_name` fields.
4. Added unit tests in `patch_sorter_test_success.json` for `test_patch_sorter_success` in `patch_sorter_test.py` 

#### How to verify it
![image](https://github.com/user-attachments/assets/0fca17c3-112c-4f2e-b2cd-98da6838d229)

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

