### PR TITLE
skip pfcwd if disabled in golden_config

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2135,15 +2135,15 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
     # get the device type
     device_type = _get_device_type()
     if device_type != 'MgmtToRRouter' and device_type != 'MgmtTsToR' and device_type != 'BmcMgmtToRRouter' and device_type != 'EPMS':
-        start_pfcwd = True
+        # default behavior to call pfcwd start_default for all platforms
+        default_pfcwd_status = 'enable'
         if override_config and config_to_check:
             # If pfcwd is disabled in the golden config, skip starting pfcwd
             # This is needed for platform which doesn't support lossless traffic.
-            device_metadata = config_to_check.get('DEVICE_METADATA', {})
-            default_pfcwd_status = device_metadata.get('localhost', {}).get('default_pfcwd_status')
-            if default_pfcwd_status == 'disable':
-                start_pfcwd = False
-        if start_pfcwd:
+            override_metadata = config_to_check.get('DEVICE_METADATA', {}).get('localhost', {})
+            if 'default_pfcwd_status' in override_metadata:
+                default_pfcwd_status = override_metadata['default_pfcwd_status'].lower()
+        if default_pfcwd_status == 'enable':
             clicommon.run_command(['pfcwd', 'start_default'], display_cmd=True)
 
     # Write latest db version string into db

--- a/config/main.py
+++ b/config/main.py
@@ -2135,7 +2135,16 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
     # get the device type
     device_type = _get_device_type()
     if device_type != 'MgmtToRRouter' and device_type != 'MgmtTsToR' and device_type != 'BmcMgmtToRRouter' and device_type != 'EPMS':
-        clicommon.run_command(['pfcwd', 'start_default'], display_cmd=True)
+        start_pfcwd = True
+        if override_config and config_to_check:
+            # If pfcwd is disabled in the golden config, skip starting pfcwd
+            # This is needed for platform which doesn't support lossless traffic.
+            device_metadata = config_to_check.get('DEVICE_METADATA', {})
+            default_pfcwd_status = device_metadata.get('localhost', {}).get('default_pfcwd_status')
+            if default_pfcwd_status == 'disable':
+                start_pfcwd = False
+        if start_pfcwd:
+            clicommon.run_command(['pfcwd', 'start_default'], display_cmd=True)
 
     # Write latest db version string into db
     db_migrator = '/usr/local/bin/db_migrator.py'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

## Skip pfcwd config if it's disabled in golden config

In `sudo config load_minigraph --override_config -y`,  it will call `pfcwd start_default` by default.
```
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
......
Running command: pfcwd start_default
Running command: config override-config-table /etc/sonic/golden_config_db.json
```

When golden_config_db.json has `"default_pfcwd_status": disable`, pfcwd should not be generated in the config.
However, in current code, when `pfcwd start_default` is called, the `default_pfcwd_status` is still using the value in `init_cfg.json` which is `enable`.  So, pfcwd configuration is still generated even though it's not needed.

#### What I did
Disable default_pfcwd_status for all lossy platform.

#### How I did it
Check `default_pfcwd_status` in `golden_config_db.json` and skip `pfcwd start_default` if it's disabled.

#### How to verify it

Run deploy-mg on all lossy platform

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

