### PR TITLE
[smartswitch] Fix incorrect reboot status check and improve debug logging in reboot scripts

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -77,7 +77,7 @@ function stop_pmon_service()
      fi
      systemctl stop pmon || debug "Ignore stopping pmon error $?"
      docker kill pmon &> /dev/null || CONTAINER_STOP_RC=$?
-     if [[ CONTAINER_STOP_RC -ne 0 ]]; then
+     if [[ $CONTAINER_STOP_RC -ne 0 ]]; then
         debug "Failed killing container pmon RC $CONTAINER_STOP_RC ."
      fi
 }
@@ -315,7 +315,7 @@ if [ -x ${WATCHDOG_UTIL} ]; then
 fi
 
 if [[ "${PRE_SHUTDOWN}" == "yes" ]]; then
-    echo "${DPU_MODULE_NAME} pre-shutdown steps are completed"
+    debug "${DPU_MODULE_NAME} pre-shutdown steps are completed"
     exit ${EXIT_SUCCESS}
 fi
 

--- a/scripts/reboot_smartswitch_helper
+++ b/scripts/reboot_smartswitch_helper
@@ -49,13 +49,13 @@ function get_reboot_status()
 {
     local dpu_ip=$1
     local port=$2
-    $(docker exec gnmi gnoi_client -target "${dpu_ip}:${port}" -logtostderr -notls -module System -rpc RebootStatus &>/dev/null)
+    $(docker exec gnmi gnoi_client -target "${dpu_ip}:${port}" -logtostderr -notls -module System -rpc RebootStatus | tee reboot_status.txt &>/dev/null)
     if [ $? -ne 0 ]; then
         return ${EXIT_ERROR}
     fi
     local is_reboot_active
-    is_reboot_active=$(echo "$reboot_status" | grep "active" | awk '{print $2}')
-    if [ "$is_reboot_active" == "false" ]; then
+    is_reboot_active=$(cat "reboot_status.txt" | awk '/^{.*}$/' | jq -r '.active')
+    if [ "$is_reboot_active" != "true" ]; then
         return ${EXIT_SUCCESS}
     fi
     return ${EXIT_ERROR}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/22157

#### What I did
- Fixed the logic for evaluating is_reboot_active from the gNOI RebootStatus response in reboot_smartswitch_helper.
- Redirected the gNOI reboot status output to a file for reliable parsing.
- Updated condition to correctly check container stop return code in reboot script.
- Replaced a plain echo statement with debug logging for consistency.

#### How I did it
- Used jq to parse the active field in the JSON response returned by gNOI RebootStatus call.
- Ensured reboot_status.txt captures the output of gnoi_client.
- Checked $CONTAINER_STOP_RC with correct syntax.

#### How to verify it
- Run reboot and reboot_smartswitch_helper scripts on a system with a connected DPU.

#### Previous command output (if the output of a command-line utility has changed)
-$ sudo reboot -d dpu0
True
2025-05-20 02:04:52 - INFO: DPU dpu0 is in 'Online' state before reboot.
2025-05-20 02:04:52 - INFO: Rebooting dpu0, ip:169.254.200.1 gnmi_port:8080
2025-05-20 02:05:53 - ERROR: Timeout waiting for dpu0 to finish halting the services
2025-05-20 02:08:01 - INFO: Rebooting dpu0 with reboot_type:DPU...
#### New command output (if the output of a command-line utility has changed)
- $ sudo reboot -d dpu0
True
2025-05-20 00:09:53 - INFO: DPU dpu0 is in 'Online' state before reboot.
2025-05-20 00:09:53 - INFO: Rebooting dpu0, ip:169.254.200.1 gnmi_port:8080
2025-05-20 00:10:19 - INFO: dpu0 halted the services successfully
2025-05-20 00:12:27 - INFO: Rebooting dpu0 with reboot_type:DPU...

