### PR TITLE
Fixed #22430 SmartSwitch reboot-cause not stored to DB on system reboot 

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -300,6 +300,10 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_UPDATE_REBOOT_CAUSE} ]; then
     ${DEVPATH}/${PLATFORM}/${PLATFORM_UPDATE_REBOOT_CAUSE}
 fi
 
+if [ "$smartswitch" == "True" ]; then
+    /usr/local/bin/process-reboot-cause
+fi
+
 if [ -x ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK} ]; then
     debug "Executing the pre-reboot script"
     ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK}

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -301,7 +301,11 @@ if [ -x ${DEVPATH}/${PLATFORM}/${PLATFORM_UPDATE_REBOOT_CAUSE} ]; then
 fi
 
 if [ "$smartswitch" == "True" ]; then
-    /usr/local/bin/process-reboot-cause
+    if [ -x /usr/local/bin/process-reboot-cause ]; then
+        /usr/local/bin/process-reboot-cause
+    else
+        debug "WARNING: /usr/local/bin/process-reboot-cause is not executable or missing."
+    fi
 fi
 
 if [ -x ${DEVPATH}/${PLATFORM}/${PRE_REBOOT_HOOK} ]; then


### PR DESCRIPTION
Fixed #22430 SmartSwitch reboot-cause not stored to DB on system reboot 

https://github.com/sonic-net/sonic-buildimage/issues/22430

#### What I did
Invoked /usr/local/bin/process-reboot-cause in the reboot script after reboot-cause update

#### How I did it
Check if smartswitch and if it is True:  and invoked process-reboot-cause in the reboot script after reboot-cause update

#### How to verify it
check the "show reboot-cause history all" output and if the DPU recent reboot is shown we are good.

Last login: Tue May 27 18:30:36 2025
cisco@sonic:~$ sudo su
root@sonic:/home/cisco# 
root@sonic:/home/cisco# 
root@sonic:/home/cisco# show reboot-cause history all
Device    Name                 Cause                Time                             User    Comment
--------  -------------------  -------------------  -------------------------------  ------  ------------------------------------------------------------------------------------
NPU       2025_05_27_18_24_01  reboot               Tue May 27 06:13:55 PM UTC 2025  cisco   N/A
NPU       2025_05_27_18_01_09  reboot               Tue May 27 05:56:08 PM UTC 2025  cisco   N/A
NPU       2025_05_27_17_12_26  reboot               Tue May 27 05:07:27 PM UTC 2025  cisco   N/A
NPU       2025_05_27_16_41_47  reboot               Tue May 27 04:36:50 PM UTC 2025  cisco   N/A
NPU       2025_05_27_16_30_40  reboot               Tue May 27 04:20:34 PM UTC 2025  cisco   N/A
NPU       2025_05_27_16_10_14  reboot               Tue May 27 04:05:20 PM UTC 2025  cisco   N/A
NPU       2025_05_27_15_40_55  Power Loss           N/A                              N/A     Unknown (First boot of SONiC version azure_cisco_master.25481-dirty-20250526.063241)
DPU0      2025_05_27_18_18_55  Switch rebooted DPU  Tue May 27 06:18:55 PM UTC 2025          Non-Hardware
DPU0      2025_05_27_18_15_56  Switch rebooted DPU  Tue May 27 06:15:56 PM UTC 2025          Non-Hardware
DPU0      2025_05_27_18_03_35  Switch rebooted DPU  Tue May 27 06:03:35 PM UTC 2025          Non-Hardware
DPU0      2025_05_27_16_22_36  Switch rebooted DPU  Tue May 27 04:22:36 PM UTC 2025          Non-Hardware
DPU0      2025_05_27_16_16_32  Switch rebooted DPU  Tue May 27 04:16:32 PM UTC 2025          Non-Hardware
root@sonic:/home/cisco# uptime
 18:31:42 up 9 min,  2 users,  load average: 1.43, 1.22, 0.71
