### PR TITLE
Improved GCU's field validation logic for the WRED_PROFILE table

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -67,7 +67,24 @@ def get_asic_name():
     return asic
 
 
-def rdma_config_update_validator(scope, patch_element):
+def fields_match_exact(cleaned_patch_field, gcu_field):
+    return cleaned_patch_field == gcu_field
+
+
+def fields_match_endswith(cleaned_patch_field, gcu_field):
+    """
+    Checks if cleaned_patch_field ends with gcu_field
+    """
+    field = cleaned_patch_field.split('/')[-1]
+    return field == gcu_field
+
+
+# If exact_field_match is True, then each field in GCU_TABLE_MOD_CONF_FILE must match exactly with
+# the corresponding cleaned field from the patch.
+# If exact_field_match is False, then each field in GCU_TABLE_MOD_CONF_FILE must appear at the end of
+# the corresponding cleaned fields from the patch.
+# remove_port controls the behavior of the _get_fields_in_patch function.
+def rdma_config_update_validator_common(scope, patch_element, exact_field_match=False, remove_port=False):
     asic = get_asic_name()
     if asic == "unknown":
         return False
@@ -75,23 +92,27 @@ def rdma_config_update_validator(scope, patch_element):
     build_version = version_info.get('build_version')
     version_substrings = build_version.split('.')
     branch_version = None
-    
+
     for substring in version_substrings:
         if substring.isdigit() and re.match(r'^\d{8}$', substring):
             branch_version = substring
-    
+
     path = patch_element["path"]
     table = jsonpointer.JsonPointer(path).parts[0]
-    
+
     # Helper function to return relevant cleaned paths, considers case where the jsonpatch value is a dict
-    # For paths like /PFC_WD/Ethernet112/action, remove Ethernet112 from the path so that we can clearly determine the relevant field (i.e. action, not Ethernet112)
+    # If remove_port is True, then for paths like /PFC_WD/Ethernet112/action, remove Ethernet112 from
+    # the path so that we can clearly determine the relevant field (i.e. action, not Ethernet112)
     def _get_fields_in_patch():
         cleaned_fields = []
 
         field_elements = jsonpointer.JsonPointer(path).parts[1:]
-        cleaned_field_elements = [elem for elem in field_elements if not any(char.isdigit() for char in elem)]
+        if remove_port:
+            cleaned_field_elements = [elem for elem in field_elements if not any(char.isdigit() for char in elem)]
+        else:
+            cleaned_field_elements = field_elements
         cleaned_field = '/'.join(cleaned_field_elements).lower()
-        
+
 
         if 'value' in patch_element.keys() and isinstance(patch_element['value'], dict):
             for key in patch_element['value']:
@@ -103,7 +124,7 @@ def rdma_config_update_validator(scope, patch_element):
             cleaned_fields.append(cleaned_field)
 
         return cleaned_fields
-    
+
     if os.path.exists(GCU_TABLE_MOD_CONF_FILE):
         with open(GCU_TABLE_MOD_CONF_FILE, "r") as s:
             gcu_field_operation_conf = json.load(s)
@@ -112,24 +133,27 @@ def rdma_config_update_validator(scope, patch_element):
 
     tables = gcu_field_operation_conf["tables"]
     scenarios = tables[table]["validator_data"]["rdma_config_update_validator"]
-    
-    cleaned_fields = _get_fields_in_patch()
-    for cleaned_field in cleaned_fields:
+    cleaned_patch_fields = _get_fields_in_patch()
+    fields_match = fields_match_exact if exact_field_match else fields_match_endswith
+    for cleaned_patch_field in cleaned_patch_fields:
         scenario = None
         for key in scenarios.keys():
-            if cleaned_field in scenarios[key]["fields"]:
-                scenario = scenarios[key]
+            for gcu_field in scenarios[key]["fields"]:
+                if fields_match(cleaned_patch_field, gcu_field):
+                    scenario = scenarios[key]
+                    break
+            if scenario:
                 break
-    
+
         if scenario is None:
             return False
-        
+
         if scenario["platforms"][asic] == "":
             return False
 
         if patch_element['op'] not in scenario["operations"]:
             return False
-    
+
         if branch_version is not None:
             if asic in scenario["platforms"]:
                 if branch_version < scenario["platforms"][asic]:
@@ -138,6 +162,14 @@ def rdma_config_update_validator(scope, patch_element):
                 return False
 
     return True
+
+
+def rdma_config_update_validator(scope, patch_element):
+    return rdma_config_update_validator_common(scope, patch_element, exact_field_match=True, remove_port=True)
+
+
+def wred_profile_config_update_validator(scope, patch_element):
+    return rdma_config_update_validator_common(scope, patch_element)
 
 
 def read_statedb_entry(scope, table, key, field):

--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -165,19 +165,19 @@
             }
         },
         "WRED_PROFILE": {
-            "field_operation_validators": [ "generic_config_updater.field_operation_validators.rdma_config_update_validator" ],
+            "field_operation_validators": [ "generic_config_updater.field_operation_validators.wred_profile_config_update_validator" ],
             "validator_data": {
                 "rdma_config_update_validator": {
                     "ECN tuning": {
                         "fields": [
-                            "azure_lossless/green_min_threshold",
-                            "azure_lossless/green_max_threshold",
-                            "azure_lossless/green_drop_probability"
+                            "green_min_threshold",
+                            "green_max_threshold",
+                            "green_drop_probability"
                         ],
                         "operations": ["replace"],
                         "platforms": {
                             "spc1": "20181100",
-			    "spc2": "20191100",
+                            "spc2": "20191100",
                             "spc3": "20220500",
                             "spc4": "20221100",
                             "spc5": "20241200",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When using `config apply-patch` to update CONFIG_DB, GCU tries to validate the patch according to the rules in `gcu_field_operation_validators.conf.json`. As explained in [Issue 22295](https://github.com/sonic-net/sonic-buildimage/issues/22295), since fields for the `WRED_PROFILE` table in this file contain the profile name `azure_lossless`, patches that target other WRED profiles will be rejected with the following error:
```
Error: Failed to apply patch on the following scopes:
- localhost: Modification of WRED_PROFILE table is illegal- validating function generic_config_updater.field_operation_validators.rdma_config_update_validator returned False
```

#### How I did it
1. Modified `gcu_field_operation_validators.conf.json` to remove the profile name `azure_lossless` from `WRED_PROFILE` fields.
2. In order to minimize side effect for other tables, we created a new validation function specifically for the `WRED_PROFILE` table named `wred_profile_config_update_validator`. This function modifies the path in patch by removing the table name (i.e., `WRED_PROFILE`), and then converting the whole path to lowercase. Then it verifies that the last part of this path matches a field defined in `gcu_field_operation_validators.conf.json` for the `WRED_PROFILE` table. For example, a path like `/WRED_PROFILE/AZURE_LOSSY/green_min_threshold` will be converted to `azure_lossy/green_min_threshold`, which will match `green_min_threshold`.

#### How to verify it
Store a JSON patch that targets a WRED profile different from `azure_lossless` in a file, and then run `sudo config apply-patch {your_patch_name.json}`.

*Test 1: Wrong WRED profile name*
Patch: `[{"op": "replace", "path": "/WRED_PROFILE/DUMMY/green_min_threshold", "value": "1234"}]`
Result:
```
Failed to apply patch due to: Validate json patch: [{"op": "replace", "path": "/WRED_PROFILE/DUMMY/green_min_threshold", "value": "1234"}] failed due to:member 'DUMMY' not found
```

*Test 2: Existing field name that is not in `gcu_field_operation_validators.conf.json`*
Patch: `[{"op": "replace", "path": "/WRED_PROFILE/AZURE_LOSSY/red_min_threshold", "value": "1234"}]`
Result:
```
Error: Failed to apply patch on the following scopes:
- localhost: Modification of WRED_PROFILE table is illegal- validating function generic_config_updater.field_operation_validators.wred_profile_config_update_validator returned False
```

*Test 3: Correct patch for 1 field*
Patch: `[{"op": "replace", "path": "/WRED_PROFILE/AZURE_LOSSY/green_min_threshold", "value": "1234"}]`
Result:
```
Patch applied successfully.
$ ecnconfig -l
Profile: AZURE_LOSSY
-----------------------  -------
...
green_min_threshold      1234
...
-----------------------  -------
```

*Test 4: Non-existent field name*
Patch: `[{"op": "replace", "path": "/WRED_PROFILE/AZURE_LOSSY/min_threshold", "value": "2468"}]`
Result:
```
Error: Validate json patch: [{"op": "replace", "path": "/WRED_PROFILE/AZURE_LOSSY/min_threshold", "value": "2468"}] failed due to:can't replace a non-existent object 'min_threshold'
```

*Test 5: Correct patch for multiple fields*
Patch: `[{"op": "replace", "path": "/WRED_PROFILE/AZURE_LOSSY/green_min_threshold", "value": "2468"},{"op": "replace", "path": "/WRED_PROFILE/AZURE_LOSSY/green_max_threshold", "value": "9876"},{"op": "replace", "path": "/WRED_PROFILE/AZURE_LOSSY/green_drop_probability", "value": "10"}]`
Result:
```
Patch applied successfully.
$ ecnconfig -l
Profile: AZURE_LOSSY
-----------------------  -------
...
green_drop_probability   10
green_max_threshold      9876
green_min_threshold      2468
...
-----------------------  -------
```

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A

