### PR TITLE
[sonic-package-manager] Save tag that was used to install the application

### DIFF
--- a/sonic_package_manager/database.py
+++ b/sonic_package_manager/database.py
@@ -31,6 +31,7 @@ class PackageEntry:
         built_in: Boolean flag whether the package is built in.
         image_id: Image ID for this package or None if package
                   is not installed.
+        tag: Tag for this package or None if package is not installed.
     """
 
     name: str
@@ -41,6 +42,7 @@ class PackageEntry:
     installed: bool = False
     built_in: bool = False
     image_id: Optional[str] = None
+    tag: Optional[str] = None
 
 
 def package_from_dict(name: str, package_info: Dict) -> PackageEntry:
@@ -55,10 +57,10 @@ def package_from_dict(name: str, package_info: Dict) -> PackageEntry:
     installed = package_info.get('installed', False)
     built_in = package_info.get('built-in', False)
     image_id = package_info.get('image-id')
-
+    tag = package_info.get('tag')
     return PackageEntry(name, repository, description,
                         default_reference, version, installed,
-                        built_in, image_id)
+                        built_in, image_id, tag)
 
 
 def package_to_dict(package: PackageEntry) -> Dict:
@@ -72,6 +74,7 @@ def package_to_dict(package: PackageEntry) -> Dict:
         'installed': package.installed,
         'built-in': package.built_in,
         'image-id': package.image_id,
+        'tag': package.tag,
     }
 
 

--- a/sonic_package_manager/package.py
+++ b/sonic_package_manager/package.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from dataclasses import dataclass
+from typing import Optional
 
 from sonic_package_manager.database import PackageEntry
 from sonic_package_manager.metadata import Metadata
@@ -21,11 +22,13 @@ class Package:
                   It is set to None if package is not installed.
         installed: Boolean flag whether package is installed or not.
         build_in: Boolean flag whether package is built in or not.
+        tag: The actual tag being used for this package
 
     """
 
     entry: PackageEntry
     metadata: Metadata
+    tag: Optional[str] = None
 
     @property
     def name(self): return self.entry.name

--- a/sonic_package_manager/package.py
+++ b/sonic_package_manager/package.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from dataclasses import dataclass
-from typing import Optional
 
 from sonic_package_manager.database import PackageEntry
 from sonic_package_manager.metadata import Metadata
@@ -22,13 +21,11 @@ class Package:
                   It is set to None if package is not installed.
         installed: Boolean flag whether package is installed or not.
         build_in: Boolean flag whether package is built in or not.
-        tag: The actual tag being used for this package
 
     """
 
     entry: PackageEntry
     metadata: Metadata
-    tag: Optional[str] = None
 
     @property
     def name(self): return self.entry.name

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -283,7 +283,7 @@ class ServiceCreator:
             'docker_container_name': name,
             'docker_image_id': image_id,
             'docker_image_name': package.entry.repository,
-            'docker_image_tag': package.tag,
+            'docker_image_tag': package.entry.tag,
             'docker_image_run_opt': run_opt,
             'sonic_asic_platform': sonic_asic_platform
         }

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -283,6 +283,7 @@ class ServiceCreator:
             'docker_container_name': name,
             'docker_image_id': image_id,
             'docker_image_name': package.entry.repository,
+            'docker_image_tag': package.tag,
             'docker_image_run_opt': run_opt,
             'sonic_asic_platform': sonic_asic_platform
         }

--- a/sonic_package_manager/source.py
+++ b/sonic_package_manager/source.py
@@ -51,7 +51,10 @@ class PackageSource(object):
 
         image = self.install_image(package)
         package.entry.image_id = image.id
-        package.tag = image.tags[0]
+        if image.tags:
+            package.tag = image.tags[0]
+        else:
+            package.tag = image.id
 
         # if no repository is defined for this package
         # get repository from image

--- a/sonic_package_manager/source.py
+++ b/sonic_package_manager/source.py
@@ -51,6 +51,8 @@ class PackageSource(object):
 
         image = self.install_image(package)
         package.entry.image_id = image.id
+        package.tag = image.tags[0]
+
         # if no repository is defined for this package
         # get repository from image
         if not package.repository:

--- a/sonic_package_manager/source.py
+++ b/sonic_package_manager/source.py
@@ -52,9 +52,9 @@ class PackageSource(object):
         image = self.install_image(package)
         package.entry.image_id = image.id
         if image.tags:
-            package.tag = image.tags[0]
+            package.entry.tag = image.tags[0]
         else:
-            package.tag = image.id
+            package.entry.tag = image.id
 
         # if no repository is defined for this package
         # get repository from image

--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -26,13 +26,14 @@ def mock_docker_api():
     @dataclass
     class Image:
         id: str
-
+        tags: list[str]
+        
         @property
         def attrs(self):
             return {'RepoTags': [self.id]}
 
     def pull(repo, ref):
-        return Image(f'{repo}:{ref}')
+        return Image(f'{repo}:{ref}', [ref])
 
     def load(filename):
         return Image(filename)

--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -36,7 +36,7 @@ def mock_docker_api():
         return Image(f'{repo}:{ref}', [ref])
 
     def load(filename):
-        return Image(filename)
+        return Image(filename, ["latest"])
 
     docker.pull = MagicMock(side_effect=pull)
     docker.load = MagicMock(side_effect=load)

--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -27,7 +27,7 @@ def mock_docker_api():
     class Image:
         id: str
         tags: list[str]
-        
+
         @property
         def attrs(self):
             return {'RepoTags': [self.id]}

--- a/tests/sonic_package_manager/test_database.py
+++ b/tests/sonic_package_manager/test_database.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from sonic_package_manager.database import PackageEntry
+from sonic_package_manager.database import PackageEntry, package_from_dict
 from sonic_package_manager.errors import (
     PackageNotFoundError,
     PackageAlreadyExistsError,
@@ -87,3 +87,48 @@ def test_database_remove_package_built_in(fake_db):
                        match='Package swss is built-in, '
                              'cannot remove it'):
         fake_db.remove_package('swss')
+
+
+def test_package_from_dict():
+    """Test converting dictionary to PackageEntry object."""
+    package_info = {
+        'repository': 'test-repo',
+        'description': 'Test package description',
+        'default-reference': '1.0.0',
+        'installed-version': '1.0.0',
+        'installed': True,
+        'built-in': False,
+        'image-id': 'abc123',
+        'tag': 'latest'
+    }
+
+    package = package_from_dict('test-package', package_info)
+
+    assert package.name == 'test-package'
+    assert package.repository == 'test-repo'
+    assert package.description == 'Test package description'
+    assert package.default_reference == '1.0.0'
+    assert package.version == Version.parse('1.0.0')
+    assert package.installed is True
+    assert package.built_in is False
+    assert package.image_id == 'abc123'
+    assert package.tag == 'latest'
+
+
+def test_package_from_dict_minimal():
+    """Test converting minimal dictionary to PackageEntry object."""
+    package_info = {
+        'repository': 'test-repo'
+    }
+
+    package = package_from_dict('test-package', package_info)
+
+    assert package.name == 'test-package'
+    assert package.repository == 'test-repo'
+    assert package.description is None
+    assert package.default_reference is None
+    assert package.version is None
+    assert package.installed is False
+    assert package.built_in is False
+    assert package.image_id is None
+    assert package.tag is None


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
- Added functionality to save and track the Docker image tag used during package installation
- Modified the service creator to include the tag information in container configuration
- This change will improve visibility in `docker ps` output by showing the actual tag used for each container

#### How I did it
- Added a new `tag` field to the `Package` class to store the image tag
- Modified the `PackageSource` class to save the tag from the installed image
- Updated the `ServiceCreator` to include the tag information in the container configuration
- The tag is extracted from the first tag in the image's tags list during installation

#### How to verify it

1. Install a package using sonic-package-manager
2. Run `docker ps` to verify that the container is running with the correct tag
3. Check the container configuration to ensure the tag is properly saved

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

