### PR TITLE
Support reboot cause: Kernel Panic - Out of memory

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -19,6 +19,10 @@ VMCORE_FILE=/proc/vmcore
 if [ -e $VMCORE_FILE -a -s $VMCORE_FILE ]; then
         echo "We have a /proc/vmcore, then we just kdump'ed"
         echo "Kernel Panic [Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+        makedumpfile --dump-dmesg /proc/vmcore /tmp/dmesg
+        if  grep -q "Kernel panic - not syncing: Out of memory" /tmp/dmesg; then
+            echo "Kernel Panic - Out of memory [Time: ${REBOOT_TIME}]" > ${REBOOT_CAUSE_FILE}
+        fi
         sync
         PLATFORM=$(grep -oP 'sonic_platform=\K\S+' /proc/cmdline)
         if [ ! -z "${PLATFORM}" -a -x ${DEVPATH}/${PLATFORM}/${PLAT_REBOOT} ]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add new reboot-cause: Kernel Panic - Out of memory

#### How I did it
Existing code already supports "Kernel Panic" as reboot cause. By checking dmesg for kernel panic, overwrite the reboot cause as "Kernel Panic - Out of memory" when possible.

#### How to verify it
- Enable kdump: config kdump enable; config save; reboot
- Trigger OOM: python3 -c "blocks=[]; [blocks.append(bytearray(500*1024*1024)) for _ in iter(int, 1)]"
- Check reboot cause: "show reboot-cause" outputs "Kernel Panic - Out of memory [Time: Tue Jun 10 05:33:16 PM UTC 2025]"  

#### Previous command output (if the output of a command-line utility has changed)
show reboot-cause
Kernel Panic [Time: Tue Jun 10 03:40:28 PM UTC 2025]

#### New command output (if the output of a command-line utility has changed)
show reboot-cause
Kernel Panic - Out of memory [Time: Tue Jun 10 05:33:16 PM UTC 2025]

