### PR TITLE
Skip checking offload flags for static routes/sids in route check and add check_sids

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -1010,11 +1010,15 @@ def main():
         signal.alarm(0)
         if ret1 < 0 or ret2 < 0:
             ret = -1
+        else:
+            ret = 0
+
+        if res1 is not None or res2 is not None:
             res = dict()
-            if res1 is not None:
-                res.update(res1)
-            if res2 is not None:
-                res.update(res2)
+            res.update(res1 if res1 else {})
+            res.update(res2 if res2 else {})
+        else:
+            res = None
 
         if interval:
             time.sleep(interval)

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -1003,11 +1003,18 @@ def main():
 
     while True:
         signal.alarm(TIMEOUT_SECONDS)
-        ret, res= check_routes(namespace)
-        print_message(syslog.LOG_DEBUG, "check_routes: ret={}, res={}".format(ret, res))
-        ret, res = check_sids(namespace)
-        print_message(syslog.LOG_DEBUG, "check_sids: ret={}, res={}".format(ret, res))
+        ret1, res1= check_routes(namespace)
+        print_message(syslog.LOG_DEBUG, "check_routes: ret={}, res={}".format(ret1, res1))
+        ret2, res2 = check_sids(namespace)
+        print_message(syslog.LOG_DEBUG, "check_sids: ret={}, res={}".format(ret2, res2))
         signal.alarm(0)
+        if ret1 < 0 or ret2 < 0:
+            ret = -1
+            res = dict()
+            if res1 is not None:
+                res.update(res1)
+            if res2 is not None:
+                res.update(res2)
 
         if interval:
             time.sleep(interval)

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -329,6 +329,59 @@ def get_asicdb_routes(namespace):
     return (selector, subs, sorted(rt))
 
 
+def get_appdb_sids(namespace):
+    """
+    helper to read SIDs table from APPL-DB.
+    :return list of sorted SIDs with prefix ensured
+    """
+    db = swsscommon.DBConnector(APPL_DB_NAME, REDIS_TIMEOUT_MSECS, True, namespace)
+    print_message(syslog.LOG_DEBUG, "APPL DB connected for sids")
+    tbl = swsscommon.Table(db, 'SRV6_MY_SID_TABLE')
+    keys = tbl.getKeys()
+
+    sids = []
+    for k in keys:
+        content = k.split(":", 1)
+
+        sid_entry = content[1]
+        sids.append(sid_entry)
+
+    sids = sorted(sids)
+    print_message(syslog.LOG_DEBUG, json.dumps({"APPL_MY_SID_TABLE": sids}, indent=4))
+    return sids
+
+
+def get_asicdb_sids(namespace):
+    """
+    helper to read SIDs table from APPL-DB.
+    :return list of sorted SIDs with prefix ensured
+    """
+    db = swsscommon.DBConnector(ASIC_DB_NAME, REDIS_TIMEOUT_MSECS, True, namespace)
+    print_message(syslog.LOG_DEBUG, "ASIC DB connected for sids")
+    tbl = swsscommon.Table(db, ASIC_TABLE_NAME)
+    keys = tbl.getKeys()
+
+    sids = []
+    for k in keys:
+        content = k.split(":", 1)
+        if content[0] != 'SAI_OBJECT_TYPE_MY_SID_ENTRY':
+            continue
+        sid_info = json.loads(content[1])
+        sid_entry = ":".join([
+            sid_info.get("locator_block_len", "0"),
+            sid_info.get("locator_node_len", "0"),
+            sid_info.get("function_len", "0"),
+            sid_info.get("args_len", "0"),
+            sid_info.get("sid")
+        ])
+
+        sids.append(sid_entry)
+
+    sids = sorted(sids)
+    print_message(syslog.LOG_DEBUG, json.dumps({"ASIC_MY_SID_TABLE": sids}, indent=4))
+    return sids
+
+
 def is_suppress_fib_pending_enabled(namespace):
     """
     Returns True if FIB suppression is enabled, False otherwise
@@ -839,6 +892,72 @@ def check_routes(namespace):
         print_message(syslog.LOG_INFO, "All good!")
         return 0, None
 
+
+def check_sids_for_namespace(namespace):
+    """
+    Process a Single Namespace for SIDs consistency check:
+    Read APPL-DB & ASIC-DB, the relevant tables for SID checking.
+    Checkout SIDs in ASIC-DB to match APPL-DB. Compared to check_routes,
+    this function does not wait for subscriber updates, as SIDs are not
+    expected to change frequently.
+
+    :return (0, None) on sucess, else (-1, results) where results holds
+    the unjustifiable entries.
+    """
+
+    results = {}
+    sid_appl_miss = []
+    sid_asic_miss = []
+
+    sids_asic = get_asicdb_sids(namespace)
+
+    sids_appl = get_appdb_sids(namespace)
+
+    # Diff APPL-DB SIDs & ASIC-DB SIDs
+    sid_appl_miss, sid_asic_miss = diff_sorted_lists(sids_appl, sids_asic)
+
+    if sid_appl_miss:
+        results["missed_APPL_MY_SID_TABLE_entries"] = sid_appl_miss
+
+    if sid_asic_miss:
+        results["missed_ASIC_MY_SID_TABLE_entries"] = sid_asic_miss
+
+
+def check_sids(namespace):
+    """
+    Main function to parallelize SID checks across all namespaces.
+    """
+    namespace_list = []
+    if namespace is not multi_asic.DEFAULT_NAMESPACE and namespace in multi_asic.get_namespace_list():
+        namespace_list.append(namespace)
+    else:
+        namespace_list = multi_asic.get_namespace_list()
+        print_message(syslog.LOG_INFO, "Checking SIDs for namespaces: ", namespace_list)
+
+    results = {}
+
+    # Use ThreadPoolExecutor to parallelize the check for each namespace
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = {executor.submit(check_sids_for_namespace, ns): ns for ns in namespace_list}
+
+        for future in concurrent.futures.as_completed(futures):
+            ns = futures[future]
+            try:
+                result = future.result()
+                if result:
+                    results[ns] = result
+            except Exception as e:
+                print_message(syslog.LOG_ERR, "Error processing namespace {}: {}".format(ns, e))
+                return -1, results
+
+    if results:
+        print_message(syslog.LOG_WARNING, "SIDs Check Failure results: {",  json.dumps(results, indent=4), "}")
+        return -1, results
+    else:
+        print_message(syslog.LOG_INFO, "All good!")
+        return 0, None
+
+
 def main():
     """
     main entry point, which mainly parses the args and call check_routes
@@ -885,7 +1004,9 @@ def main():
     while True:
         signal.alarm(TIMEOUT_SECONDS)
         ret, res= check_routes(namespace)
-        print_message(syslog.LOG_DEBUG, "ret={}, res={}".format(ret, res))
+        print_message(syslog.LOG_DEBUG, "check_routes: ret={}, res={}".format(ret, res))
+        ret, res = check_sids(namespace)
+        print_message(syslog.LOG_DEBUG, "check_sids: ret={}, res={}".format(ret, res))
         signal.alarm(0)
 
         if interval:

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -922,6 +922,8 @@ def check_sids_for_namespace(namespace):
     if sid_asic_miss:
         results["missed_ASIC_MY_SID_TABLE_entries"] = sid_asic_miss
 
+    return results
+
 
 def check_sids(namespace):
     """

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -1003,7 +1003,7 @@ def main():
 
     while True:
         signal.alarm(TIMEOUT_SECONDS)
-        ret1, res1= check_routes(namespace)
+        ret1, res1 = check_routes(namespace)
         print_message(syslog.LOG_DEBUG, "check_routes: ret={}, res={}".format(ret1, res1))
         ret2, res2 = check_sids(namespace)
         print_message(syslog.LOG_DEBUG, "check_sids: ret={}, res={}".format(ret2, res2))

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -339,14 +339,7 @@ def get_appdb_sids(namespace):
     tbl = swsscommon.Table(db, 'SRV6_MY_SID_TABLE')
     keys = tbl.getKeys()
 
-    sids = []
-    for k in keys:
-        content = k.split(":", 1)
-
-        sid_entry = content[1]
-        sids.append(sid_entry)
-
-    sids = sorted(sids)
+    sids = sorted(keys)
     print_message(syslog.LOG_DEBUG, json.dumps({"APPL_MY_SID_TABLE": sids}, indent=4))
     return sids
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -575,7 +575,7 @@ def check_frr_pending_routes(namespace):
 
         for _, entries in frr_routes.items():
             for entry in entries:
-                if entry['protocol'] in ('connected', 'kernel'):
+                if entry['protocol'] in ('connected', 'kernel', 'static'):
                     continue
 
                 # TODO: Also handle VRF routes. Currently this script does not check for VRF routes so it would be incorrect for us

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -20,6 +20,7 @@ OP_DEL = "DEL"
 
 NEIGH_TABLE = 'NEIGH_TABLE'
 ROUTE_TABLE = 'ROUTE_TABLE'
+MY_SID_TABLE = 'SRV6_MY_SID_TABLE'
 VNET_ROUTE_TABLE = 'VNET_ROUTE_TABLE'
 INTF_TABLE = 'INTF_TABLE'
 RT_ENTRY_TABLE = 'ASIC_STATE'
@@ -30,8 +31,10 @@ MUX_CABLE = "MUX_CABLE"
 
 LOCALHOST = "localhost"
 
-RT_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest":\"'
-RT_ENTRY_KEY_SUFFIX = '\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000023\"}'
+ASIC_RT_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest":\"'
+ASIC_RT_ENTRY_KEY_SUFFIX = '\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000023\"}'
+ASIC_SID_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"0","locator_block_len":"32","locator_node_len":"16","sid":"'
+ASIC_SID_ENTRY_KEY_SUFFIX = '","switch_id":"oid:0x21000000000000","vr_id":"oid:0x3000000000023"}'
 
 DEFAULT_CONFIG_DB = {
     DEVICE_METADATA: {
@@ -68,11 +71,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -99,11 +102,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -113,10 +116,10 @@ TEST_DATA = {
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
                         OP_SET: {
-                            RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                            ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
                         },
                         OP_DEL: {
-                            RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + RT_ENTRY_KEY_SUFFIX: {}
+                            ASIC_RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                         }
                     }
                 }
@@ -146,11 +149,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "20.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "20.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "20.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "3603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "20.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "20.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "20.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "3603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -196,11 +199,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -235,14 +238,14 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.197.1/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df5::1/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "101.0.0.0/24" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.197.1/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df5::1/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "101.0.0.0/24" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -271,11 +274,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -317,15 +320,15 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "30.1.10.1/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "50.1.1.0/24" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "50.2.2.0/24" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "30.1.10.1/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "30.1.10.0/24" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "50.1.1.0/24" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "50.2.2.0/24" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -355,7 +358,7 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "fc02:1000::99/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "fc02:1000::99/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
                     }
                 }
             }
@@ -382,11 +385,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -427,10 +430,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "192.168.0.2/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "fc02:1000::2/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "192.168.0.3/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "fc02:1000::3/128" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "192.168.0.2/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "fc02:1000::2/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "192.168.0.3/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "fc02:1000::3/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -456,10 +459,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 },
             },
@@ -513,10 +516,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 },
             },
@@ -586,10 +589,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 },
             },
@@ -637,7 +640,7 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "2000:31::1/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2000:31::1/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
                     }
                 }
             }
@@ -681,11 +684,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "20.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "20.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "20.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "192.168.0.101/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "192.168.0.102/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "20.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "20.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "20.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "192.168.0.101/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "192.168.0.102/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
                     }
                 }
             }
@@ -730,11 +733,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -762,11 +765,11 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             },
@@ -786,11 +789,11 @@ TEST_DATA = {
                },
                ASIC_DB: {
                    RT_ENTRY_TABLE: {
-                       RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                       ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                    }
                }
            },
@@ -818,10 +821,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             }
@@ -857,10 +860,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 }
             },
@@ -879,11 +882,11 @@ TEST_DATA = {
                },
                ASIC_DB: {
                    RT_ENTRY_TABLE: {
-                       RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                       RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                       ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                       ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                    }
                }
            },
@@ -936,10 +939,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 },
             },
@@ -1011,10 +1014,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 },
             },
@@ -1075,10 +1078,10 @@ TEST_DATA = {
                 },
                 ASIC_DB: {
                     RT_ENTRY_TABLE: {
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
-                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
                     }
                 },
             },
@@ -1107,5 +1110,258 @@ TEST_DATA = {
                 ],
             },
         },
+    },
+    "24": {
+        DESCR: "Good one with static routes",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            CONFIG_DB: {
+                DEVICE_METADATA: {
+                    LOCALHOST: {
+                    }
+                }
+            },
+            APPL_DB: {
+                ROUTE_TABLE: {
+                    "0.0.0.0/0" : { "ifname": "portchannel0" },
+                    "10.10.196.12/31" : { "ifname": "portchannel0" },
+                },
+                INTF_TABLE: {
+                    "PortChannel1013:10.10.196.24/31": {},
+                    "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                    "PortChannel1024": {}
+                },
+                MY_SID_TABLE: {
+                    "32:16:0:0:fcbb:bbbb:1::": {}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_SID_ENTRY_KEY_PREFIX + "fcbb:bbbb:1::" + ASIC_SID_ENTRY_KEY_SUFFIX: {}
+                }
+            },
+        },
+        FRR_ROUTES: {
+            "0.0.0.0/0": [
+                {
+                    "prefix": "0.0.0.0/0",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "offloaded": "true",
+                },
+            ],
+            "10.10.196.12/31": [
+                {
+                    "prefix": "10.10.196.12/31",
+                    "vrfName": "default",
+                    "protocol": "static"
+                },
+            ],
+            "10.10.196.24/31": [
+                {
+                    "protocol": "connected",
+                },
+            ],
+        },
+    },
+    "25": {
+        DESCR: "Good one with SIDs",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            CONFIG_DB: {
+                DEVICE_METADATA: {
+                    LOCALHOST: {
+                    }
+                }
+            },
+            APPL_DB: {
+                ROUTE_TABLE: {
+                    "0.0.0.0/0" : { "ifname": "portchannel0" },
+                    "10.10.196.12/31" : { "ifname": "portchannel0" },
+                },
+                INTF_TABLE: {
+                    "PortChannel1013:10.10.196.24/31": {},
+                    "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                    "PortChannel1024": {}
+                },
+                MY_SID_TABLE: {
+                    "32:16:0:0:fcbb:bbbb:1::": {}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                    ASIC_SID_ENTRY_KEY_PREFIX + "fcbb:bbbb:1::" + ASIC_SID_ENTRY_KEY_SUFFIX: {}
+                }
+            },
+        },
+        FRR_ROUTES: {
+            "0.0.0.0/0": [
+                {
+                    "prefix": "0.0.0.0/0",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "offloaded": "true",
+                },
+            ],
+            "10.10.196.12/31": [
+                {
+                    "prefix": "10.10.196.12/31",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "offloaded": "true",
+                },
+            ],
+            "10.10.196.24/31": [
+                {
+                    "protocol": "connected",
+                },
+            ],
+        },
+    },
+    "26": {
+        DESCR: "Bad one with SID missing in ASIC_DB",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                CONFIG_DB: {
+                    DEVICE_METADATA: {
+                        LOCALHOST: {
+                        }
+                    }
+                },
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    },
+                    MY_SID_TABLE: {
+                        "32:16:0:0:fcbb:bbbb:1::": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_ROUTES: {
+            "0.0.0.0/0": [
+                {
+                    "prefix": "0.0.0.0/0",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "offloaded": "true",
+                },
+            ],
+            "10.10.196.12/31": [
+                {
+                    "prefix": "10.10.196.12/31",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "offloaded": "true",
+                },
+            ],
+            "10.10.196.24/31": [
+                {
+                    "protocol": "connected",
+                },
+            ],
+        },
+        RESULT: {
+            DEFAULTNS: {
+                "missed_APPL_MY_SID_TABLE_entries": [
+                    "32:16:0:0:fcbb:bbbb:1::"
+                ],
+            }
+        }
+    },
+    "27": {
+        DESCR: "Bad one with SID missing in APPL_DB",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                CONFIG_DB: {
+                    DEVICE_METADATA: {
+                        LOCALHOST: {
+                        }
+                    }
+                },
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_SID_ENTRY_KEY_PREFIX + "fcbb:bbbb:1::" + ASIC_SID_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_ROUTES: {
+            "0.0.0.0/0": [
+                {
+                    "prefix": "0.0.0.0/0",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "offloaded": "true",
+                },
+            ],
+            "10.10.196.12/31": [
+                {
+                    "prefix": "10.10.196.12/31",
+                    "vrfName": "default",
+                    "protocol": "bgp",
+                    "offloaded": "true",
+                },
+            ],
+            "10.10.196.24/31": [
+                {
+                    "protocol": "connected",
+                },
+            ],
+        },
+        RESULT: {
+            DEFAULTNS: {
+                "missed_APPL_MY_SID_TABLE_entries": [
+                    "32:16:0:0:fcbb:bbbb:1::"
+                ],
+            }
+        }
     },
 }

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -61,8 +61,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -93,8 +93,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -139,8 +139,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:90.10.196.24/31": {},
@@ -189,8 +189,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -221,8 +221,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" },
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" },
                         "10.10.197.1" : { "ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
                         "2603:10b0:503:df5::1" : { "ifname": "Ethernet-IB0", "nexthop": "::"},
                         "100.0.0.2/32" : { "ifname": "Ethernet-IB0", "nexthop": "0.0.0.0" },
@@ -264,8 +264,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo", "nexthop": "100.0.0.2" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo", "nexthop": "100.0.0.2" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -303,8 +303,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     VNET_ROUTE_TABLE: {
                         "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
@@ -374,9 +374,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "Vrf1:0.0.0.0/0" : {"ifname": "portchannel0"},
-                        "Vrf1:10.10.196.12/31" : {"ifname": "portchannel0"},
-                        "Vrf1:10.10.196.20/31" : {"ifname": "portchannel0"}
+                        "Vrf1:0.0.0.0/0": {"ifname": "portchannel0"},
+                        "Vrf1:10.10.196.12/31": {"ifname": "portchannel0"},
+                        "Vrf1:10.10.196.20/31": {"ifname": "portchannel0"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -668,7 +668,7 @@ TEST_DATA = {
                 APPL_DB: {
                     ROUTE_TABLE: {
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
                         "192.168.0.101/32": { "ifname": "tun0" },
                         "192.168.0.103/32": { "ifname": "tun0" },
                     },
@@ -723,8 +723,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -755,8 +755,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -779,8 +779,8 @@ TEST_DATA = {
                    ROUTE_TABLE: {
                        "0.0.0.0/0": {"ifname": "portchannel0"},
                        "10.10.196.12/31": {"ifname": "portchannel0"},
-                       "10.10.196.20/31" : {"ifname": "portchannel0"},
-                       "10.10.196.30/31" : { "ifname": "lo" }
+                       "10.10.196.20/31": {"ifname": "portchannel0"},
+                       "10.10.196.30/31": { "ifname": "lo" }
                    },
                    INTF_TABLE: {
                        "PortChannel1013:10.10.196.24/31": {},
@@ -811,8 +811,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -850,8 +850,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
-                        "10.10.196.20/31" : {"ifname": "portchannel0"},
-                        "10.10.196.30/31" : { "ifname": "lo" }
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": { "ifname": "lo" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -872,8 +872,8 @@ TEST_DATA = {
                APPL_DB: {
                    ROUTE_TABLE: {
                        "0.0.0.0/0": {"ifname": "portchannel0"},
-                       "10.10.196.20/31" : {"ifname": "portchannel0"},
-                       "10.10.196.30/31" : { "ifname": "lo" }
+                       "10.10.196.20/31": {"ifname": "portchannel0"},
+                       "10.10.196.30/31": { "ifname": "lo" }
                    },
                    INTF_TABLE: {
                        "PortChannel1013:10.10.196.24/31": {},

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -563,8 +563,7 @@ TEST_DATA = {
         RESULT: {
             DEFAULTNS: {
                 "missed_FRR_routes": [
-                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp", "selected": True},
-                    {"prefix": "1.1.1.0/24", "vrfName": "default", "protocol": "static", "selected": True},
+                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp", "selected": True}
                 ],
             },
         },
@@ -1113,65 +1112,6 @@ TEST_DATA = {
         },
     },
     "24": {
-        DESCR: "Good one with static routes",
-        MULTI_ASIC: False,
-        NAMESPACE: [''],
-        ARGS: "route_check -m INFO -i 1000",
-        PRE: {
-            CONFIG_DB: {
-                DEVICE_METADATA: {
-                    LOCALHOST: {
-                    }
-                }
-            },
-            APPL_DB: {
-                ROUTE_TABLE: {
-                    "0.0.0.0/0": {"ifname": "portchannel0"},
-                    "10.10.196.12/31": {"ifname": "portchannel0"},
-                },
-                INTF_TABLE: {
-                    "PortChannel1013:10.10.196.24/31": {},
-                    "PortChannel1023:2603:10b0:503:df4::5d/126": {},
-                    "PortChannel1024": {}
-                },
-                MY_SID_TABLE: {
-                    "32:16:0:0:fcbb:bbbb:1::": {}
-                }
-            },
-            ASIC_DB: {
-                RT_ENTRY_TABLE: {
-                    ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
-                    ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
-                    ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
-                    ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
-                    ASIC_SID_ENTRY_KEY_PREFIX + "fcbb:bbbb:1::" + ASIC_SID_ENTRY_KEY_SUFFIX: {}
-                }
-            },
-        },
-        FRR_ROUTES: {
-            "0.0.0.0/0": [
-                {
-                    "prefix": "0.0.0.0/0",
-                    "vrfName": "default",
-                    "protocol": "bgp",
-                    "offloaded": "true",
-                },
-            ],
-            "10.10.196.12/31": [
-                {
-                    "prefix": "10.10.196.12/31",
-                    "vrfName": "default",
-                    "protocol": "static"
-                },
-            ],
-            "10.10.196.24/31": [
-                {
-                    "protocol": "connected",
-                },
-            ],
-        },
-    },
-    "25": {
         DESCR: "Good one with SIDs",
         MULTI_ASIC: False,
         NAMESPACE: [''],
@@ -1231,19 +1171,13 @@ TEST_DATA = {
             ],
         },
     },
-    "26": {
+    "25": {
         DESCR: "Bad one with SID missing in ASIC_DB",
         MULTI_ASIC: False,
         NAMESPACE: [''],
         ARGS: "route_check -m INFO -i 1000",
         PRE: {
             DEFAULTNS: {
-                CONFIG_DB: {
-                    DEVICE_METADATA: {
-                        LOCALHOST: {
-                        }
-                    }
-                },
                 APPL_DB: {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
@@ -1297,7 +1231,8 @@ TEST_DATA = {
                     "32:16:0:0:fcbb:bbbb:1::"
                 ],
             }
-        }
+        },
+        RET: -1,
     },
     "27": {
         DESCR: "Bad one with SID missing in APPL_DB",
@@ -1306,12 +1241,6 @@ TEST_DATA = {
         ARGS: "route_check -m INFO -i 1000",
         PRE: {
             DEFAULTNS: {
-                CONFIG_DB: {
-                    DEVICE_METADATA: {
-                        LOCALHOST: {
-                        }
-                    }
-                },
                 APPL_DB: {
                     ROUTE_TABLE: {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
@@ -1359,10 +1288,11 @@ TEST_DATA = {
         },
         RESULT: {
             DEFAULTNS: {
-                "missed_APPL_MY_SID_TABLE_entries": [
+                "missed_ASIC_MY_SID_TABLE_entries": [
                     "32:16:0:0:fcbb:bbbb:1::"
                 ],
             }
-        }
+        },
+        RET: -1,
     },
 }

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -223,11 +223,11 @@ TEST_DATA = {
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
                         "10.10.196.30/31": {"ifname": "lo"},
-                        "10.10.197.1" : {"ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
-                        "2603:10b0:503:df5::1" : {"ifname": "Ethernet-IB0", "nexthop": "::"},
-                        "100.0.0.2/32" : {"ifname": "Ethernet-IB0", "nexthop": "0.0.0.0" },
-                        "2064:100::2/128" : {"ifname": "Ethernet-IB0", "nexthop": "::" },
-                        "101.0.0.0/24" : {"ifname": "Ethernet-IB0", "nexthop": "100.0.0.2"}
+                        "10.10.197.1": {"ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
+                        "2603:10b0:503:df5::1": {"ifname": "Ethernet-IB0", "nexthop": "::"},
+                        "100.0.0.2/32": {"ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
+                        "2064:100::2/128": {"ifname": "Ethernet-IB0", "nexthop": "::"},
+                        "101.0.0.0/24": {"ifname": "Ethernet-IB0", "nexthop": "100.0.0.2"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -307,9 +307,9 @@ TEST_DATA = {
                         "10.10.196.30/31": {"ifname": "lo"}
                     },
                     VNET_ROUTE_TABLE: {
-                        "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001" },
-                        "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001" },
-                        "Vnet1:50.2.2.0/24": {"ifname": "Vlan3001" }
+                        "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001"},
+                        "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001"},
+                        "Vnet1:50.2.2.0/24": {"ifname": "Vlan3001"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -669,8 +669,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "192.168.0.101/32": {"ifname": "tun0" },
-                        "192.168.0.103/32": {"ifname": "tun0" },
+                        "192.168.0.101/32": {"ifname": "tun0"},
+                        "192.168.0.103/32": {"ifname": "tun0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:90.10.196.24/31": {},

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -33,7 +33,8 @@ LOCALHOST = "localhost"
 
 ASIC_RT_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest":\"'
 ASIC_RT_ENTRY_KEY_SUFFIX = '\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000023\"}'
-ASIC_SID_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"0","locator_block_len":"32","locator_node_len":"16","sid":"'
+ASIC_SID_ENTRY_KEY_PREFIX = 'SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"0","locator_block_len":"32",\
+"locator_node_len":"16","sid":"'
 ASIC_SID_ENTRY_KEY_SUFFIX = '","switch_id":"oid:0x21000000000000","vr_id":"oid:0x3000000000023"}'
 
 DEFAULT_CONFIG_DB = {
@@ -58,9 +59,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -90,9 +91,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -136,9 +137,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -186,9 +187,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -218,9 +219,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" },
                         "10.10.197.1" : { "ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
                         "2603:10b0:503:df5::1" : { "ifname": "Ethernet-IB0", "nexthop": "::"},
@@ -261,9 +262,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo", "nexthop": "100.0.0.2" }
                     },
                     INTF_TABLE: {
@@ -300,9 +301,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     VNET_ROUTE_TABLE: {
@@ -373,9 +374,9 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "Vrf1:0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "Vrf1:10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "Vrf1:10.10.196.20/31" : { "ifname": "portchannel0" }
+                        "Vrf1:0.0.0.0/0" : {"ifname": "portchannel0"},
+                        "Vrf1:10.10.196.12/31" : {"ifname": "portchannel0"},
+                        "Vrf1:10.10.196.20/31" : {"ifname": "portchannel0"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -448,8 +449,8 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -505,8 +506,8 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -578,8 +579,8 @@ TEST_DATA = {
             DEFAULTNS: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -666,8 +667,8 @@ TEST_DATA = {
                 },
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "192.168.0.101/32": { "ifname": "tun0" },
                         "192.168.0.103/32": { "ifname": "tun0" },
                     },
@@ -720,9 +721,9 @@ TEST_DATA = {
             ASIC0: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -752,9 +753,9 @@ TEST_DATA = {
             ASIC0: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -776,9 +777,9 @@ TEST_DATA = {
             ASIC1: {
                APPL_DB: {
                    ROUTE_TABLE: {
-                       "0.0.0.0/0" : { "ifname": "portchannel0" },
-                       "10.10.196.12/31" : { "ifname": "portchannel0" },
-                       "10.10.196.20/31" : { "ifname": "portchannel0" },
+                       "0.0.0.0/0": {"ifname": "portchannel0"},
+                       "10.10.196.12/31": {"ifname": "portchannel0"},
+                       "10.10.196.20/31" : {"ifname": "portchannel0"},
                        "10.10.196.30/31" : { "ifname": "lo" }
                    },
                    INTF_TABLE: {
@@ -808,9 +809,9 @@ TEST_DATA = {
             ASIC0: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -847,9 +848,9 @@ TEST_DATA = {
             ASIC0: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
-                        "10.10.196.20/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31" : {"ifname": "portchannel0"},
                         "10.10.196.30/31" : { "ifname": "lo" }
                     },
                     INTF_TABLE: {
@@ -870,8 +871,8 @@ TEST_DATA = {
             ASIC1: {
                APPL_DB: {
                    ROUTE_TABLE: {
-                       "0.0.0.0/0" : { "ifname": "portchannel0" },
-                       "10.10.196.20/31" : { "ifname": "portchannel0" },
+                       "0.0.0.0/0": {"ifname": "portchannel0"},
+                       "10.10.196.20/31" : {"ifname": "portchannel0"},
                        "10.10.196.30/31" : { "ifname": "lo" }
                    },
                    INTF_TABLE: {
@@ -928,8 +929,8 @@ TEST_DATA = {
             ASIC1: {
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -1003,8 +1004,8 @@ TEST_DATA = {
                 },
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -1067,8 +1068,8 @@ TEST_DATA = {
                 },
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -1125,8 +1126,8 @@ TEST_DATA = {
             },
             APPL_DB: {
                 ROUTE_TABLE: {
-                    "0.0.0.0/0" : { "ifname": "portchannel0" },
-                    "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    "0.0.0.0/0": {"ifname": "portchannel0"},
+                    "10.10.196.12/31": {"ifname": "portchannel0"},
                 },
                 INTF_TABLE: {
                     "PortChannel1013:10.10.196.24/31": {},
@@ -1184,8 +1185,8 @@ TEST_DATA = {
             },
             APPL_DB: {
                 ROUTE_TABLE: {
-                    "0.0.0.0/0" : { "ifname": "portchannel0" },
-                    "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    "0.0.0.0/0": {"ifname": "portchannel0"},
+                    "10.10.196.12/31": {"ifname": "portchannel0"},
                 },
                 INTF_TABLE: {
                     "PortChannel1013:10.10.196.24/31": {},
@@ -1245,8 +1246,8 @@ TEST_DATA = {
                 },
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -1313,8 +1314,8 @@ TEST_DATA = {
                 },
                 APPL_DB: {
                     ROUTE_TABLE: {
-                        "0.0.0.0/0" : { "ifname": "portchannel0" },
-                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -62,7 +62,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -94,7 +94,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -140,7 +140,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:90.10.196.24/31": {},
@@ -190,7 +190,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -222,12 +222,12 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" },
-                        "10.10.197.1" : { "ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
-                        "2603:10b0:503:df5::1" : { "ifname": "Ethernet-IB0", "nexthop": "::"},
-                        "100.0.0.2/32" : { "ifname": "Ethernet-IB0", "nexthop": "0.0.0.0" },
-                        "2064:100::2/128" : { "ifname": "Ethernet-IB0", "nexthop": "::" },
-                        "101.0.0.0/24" : { "ifname": "Ethernet-IB0", "nexthop": "100.0.0.2"}
+                        "10.10.196.30/31": {"ifname": "lo"},
+                        "10.10.197.1" : {"ifname": "Ethernet-IB0", "nexthop": "0.0.0.0"},
+                        "2603:10b0:503:df5::1" : {"ifname": "Ethernet-IB0", "nexthop": "::"},
+                        "100.0.0.2/32" : {"ifname": "Ethernet-IB0", "nexthop": "0.0.0.0" },
+                        "2064:100::2/128" : {"ifname": "Ethernet-IB0", "nexthop": "::" },
+                        "101.0.0.0/24" : {"ifname": "Ethernet-IB0", "nexthop": "100.0.0.2"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -265,7 +265,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo", "nexthop": "100.0.0.2" }
+                        "10.10.196.30/31": {"ifname": "lo", "nexthop": "100.0.0.2"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -304,12 +304,12 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     VNET_ROUTE_TABLE: {
-                        "Vnet1:30.1.10.0/24": { "ifname": "Vlan3001" },
-                        "Vnet1:50.1.1.0/24": { "ifname": "Vlan3001" },
-                        "Vnet1:50.2.2.0/24": { "ifname": "Vlan3001" }
+                        "Vnet1:30.1.10.0/24": {"ifname": "Vlan3001" },
+                        "Vnet1:50.1.1.0/24": {"ifname": "Vlan3001" },
+                        "Vnet1:50.2.2.0/24": {"ifname": "Vlan3001" }
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -669,8 +669,8 @@ TEST_DATA = {
                     ROUTE_TABLE: {
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "192.168.0.101/32": { "ifname": "tun0" },
-                        "192.168.0.103/32": { "ifname": "tun0" },
+                        "192.168.0.101/32": {"ifname": "tun0" },
+                        "192.168.0.103/32": {"ifname": "tun0" },
                     },
                     INTF_TABLE: {
                         "PortChannel1013:90.10.196.24/31": {},
@@ -724,7 +724,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -756,7 +756,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -780,7 +780,7 @@ TEST_DATA = {
                        "0.0.0.0/0": {"ifname": "portchannel0"},
                        "10.10.196.12/31": {"ifname": "portchannel0"},
                        "10.10.196.20/31": {"ifname": "portchannel0"},
-                       "10.10.196.30/31": { "ifname": "lo" }
+                       "10.10.196.30/31": {"ifname": "lo"}
                    },
                    INTF_TABLE: {
                        "PortChannel1013:10.10.196.24/31": {},
@@ -812,7 +812,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -851,7 +851,7 @@ TEST_DATA = {
                         "0.0.0.0/0": {"ifname": "portchannel0"},
                         "10.10.196.12/31": {"ifname": "portchannel0"},
                         "10.10.196.20/31": {"ifname": "portchannel0"},
-                        "10.10.196.30/31": { "ifname": "lo" }
+                        "10.10.196.30/31": {"ifname": "lo"}
                     },
                     INTF_TABLE: {
                         "PortChannel1013:10.10.196.24/31": {},
@@ -873,7 +873,7 @@ TEST_DATA = {
                    ROUTE_TABLE: {
                        "0.0.0.0/0": {"ifname": "portchannel0"},
                        "10.10.196.20/31": {"ifname": "portchannel0"},
-                       "10.10.196.30/31": { "ifname": "lo" }
+                       "10.10.196.30/31": {"ifname": "lo"}
                    },
                    INTF_TABLE: {
                        "PortChannel1013:10.10.196.24/31": {},


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

1. Skip checking offload flags for static routes and static SIDs in FRR in check_frr_pending_routes.
2. Add check_sids to check consistency between MY_SID tables of ASIC_DB and APPL_DB

#### How I did it

#### How to verify it

Run on a device supporting SRv6

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

