### PR TITLE
fix issue #22476 fix show cmd for bgp

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -89,7 +89,7 @@ COMMAND_TIMEOUT = 300
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = None
-    command = "sudo docker ps | grep bgp | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"
+    command = "sudo docker ps | grep bgp | grep -E 'quagga|frr' | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"
 
     try:
         stdout = subprocess.check_output(command, shell=True, text=True, timeout=COMMAND_TIMEOUT)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add an additional check in the cmd of the get_routing_stack function to detect the "frr" or "quagga"

#### How I did it
Modify the CMD, add "grep -E 'quagga|frr'" in CMD

#### How to verify it
quagga
```
admin@bjw-can-7050qx-1:~$ sudo docker ps | grep bgp | grep -E 'quagga|frr' | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1
quagga
admin@bjw-can-7050qx-1:~$ 
```

frr
```
admin@str3-7060-acs-2:/usr/local/lib/python3.11/dist-packages/show$ docker ps
CONTAINER ID   IMAGE                             COMMAND                  CREATED             STATUS             PORTS     NAMES
8a9e151d08bb   docker-sonic-restapi              "/usr/local/bin/supe…"   About an hour ago   Up About an hour             docker-sonic-restapi_but_bgp
21b846f8d085   docker-fpm-frr:latest             "/usr/bin/docker_ini…"   6 hours ago         Up 6 hours                   bgp
...
admin@str3-7060-acs-2:/usr/local/lib/python3.11/dist-packages/show$ 
admin@str3-7060-acs-2:/usr/local/lib/python3.11/dist-packages/show$ sudo docker ps | grep bgp | grep -E 'quagga|frr' | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1
frr
admin@str3-7060-acs-2:/usr/local/lib/python3.11/dist-packages/show$ 
admin@str3-7060-acs-2:/usr/local/lib/python3.11/dist-packages/show$ show ip bgp summary
IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6409
RIB entries 12807, using 2868768 bytes of memory
Peers 4, using 2967904 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       3609       3548         0      0       0  05:42:55             6400  ARISTA01T1
10.0.0.59      4  64600       3609       3550         0      0       0  05:42:53             6400  ARISTA02T1
10.0.0.61      4  64600       3606       3548         0      0       0  05:42:55             6400  ARISTA03T1
10.0.0.63      4  64600       3607       3548         0      0       0  05:42:55             6400  ARISTA04T1

Total number of neighbors 4
admin@str3-7060-acs-2:/usr/local/lib/python3.11/dist-packages/show$ 
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

