### PR TITLE
Fixed cli command for ECN config on voq switch

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -54,6 +54,7 @@ import os
 import sys
 
 from tabulate import tabulate
+from sonic_py_common import device_info
 
 # mock the redis for unit test purposes #
 try:
@@ -273,6 +274,16 @@ class EcnQ(object):
         self.ports_key.sort(
             key = lambda k: int(k[8:]) if "BP" not in k else int(k[11:]) + 1024
         )
+
+        switch_type  = device_info.get_localhost_info('switch_type', self.config_db)
+        if switch_type == 'voq':
+            ports_key_temp = []
+            host_name = device_info.get_localhost_info('hostname', self.config_db)
+            asic_name = device_info.get_localhost_info('asic_name', self.config_db)
+            for port_key in self.ports_key:
+                key = '|'.join([host_name, asic_name, port_key])
+                ports_key_temp.append(key)
+            self.ports_key = ports_key_temp
 
     def dump_table_info(self):
         """

--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -276,7 +276,7 @@ class EcnQ(object):
         )
 
         switch_type  = device_info.get_localhost_info('switch_type', self.config_db)
-        if switch_type == 'voq':
+        if switch_type == 'voq' or os.environ.get("UTILITIES_UNIT_TESTING_VOQ", "0") == "1":
             ports_key_temp = []
             host_name = device_info.get_localhost_info('hostname', self.config_db)
             asic_name = device_info.get_localhost_info('asic_name', self.config_db)

--- a/tests/ecn_input/ecn_test_vectors.py
+++ b/tests/ecn_input/ecn_test_vectors.py
@@ -369,5 +369,9 @@ testData = {
                                                                  'asic1,wred_profile,AZURE_LOSSLESS'],
                                                     'cmp_q_args': ['0'],
                                                     'other_q': ['1']
-                                                    }
+                                                    },
+             'ecn_cfg_q_voq': {'cmd': ['q_cmd'],
+                               'args': ['-q', '3', 'off'],
+                               'rc': 0,
+                               }
            }

--- a/tests/multi_asic_ecnconfig_test.py
+++ b/tests/multi_asic_ecnconfig_test.py
@@ -58,6 +58,11 @@ class TestEcnConfigMultiAsic(TestEcnConfigBase):
     def test_ecn_q_set_off_one_masic(self):
         self.executor(testData['ecn_cfg_q_one_ns_off_verbose_masic'])
 
+    def test_ecn_queue_set_q_on_voq(self):
+        os.environ['UTILITIES_UNIT_TESTING_VOQ'] = "1"
+        self.executor(testData['ecn_cfg_q_voq'])
+        os.environ['UTILITIES_UNIT_TESTING_VOQ'] = "0"
+
     @classmethod
     def teardown_class(cls):
         super().teardown_class()


### PR DESCRIPTION
https://github.com/sonic-net/sonic-buildimage/issues/22856

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
 Fixed the ECN cli command to use the system ports for ECN config for voq switch to address
 https://github.com/sonic-net/sonic-buildimage/issues/22856
#### How I did it
 Changed the ecnconfig to use the system ports for ECN config for voq switch
#### How to verify it
Verified with configuring ECN for certain queues on voq switch
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

