### PR TITLE
Switch to using chrony instead of ntpd : gcu - services_validator.py

### DIFF
--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -104,7 +104,7 @@ def caclmgrd_validator(old_config, upd_config, keys):
 
 
 def ntp_validator(old_config, upd_config, keys):
-    return _service_restart("ntp-config")
+    return _service_restart("chrony")
 
 def vlanintf_validator(old_config, upd_config, keys):
     old_vlan_intf = old_config.get("VLAN_INTERFACE", {})


### PR DESCRIPTION
#### What I did
https://github.com/sonic-net/sonic-utilities/pull/3574

With this PR ntp-config is changes to chrony, but ntp-config service was still getting used for gcu, so error was seen  for apply-patch operation

```
 sudo config apply-patch /tmp/ntp.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "add", "path": "/NTP_SERVER/10.11.0.2", "value": {"resolve_as": "10.11.0.2", "association_type": "server", "iburst": "on"}}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 2 changes:
Patch Applier: localhost: applying 2 changes in order:
Patch Applier:   * [{"op": "add", "path": "/NTP_SERVER/10.11.0.2/resolve_as", "value": "10.11.0.2"}]
Failed to restart ntp-config.service: Unit ntp-config.service not found.
Failed to restart ntp-config.service: Unit ntp-config.service not found.
```

#### How I did it
Updated gcu code to use chrony instead of ntp-config service

#### How to verify it
With this fix
```
sudo config apply-patch /tmp/ntp.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "add", "path": "/NTP_SERVER/10.11.0.3", "value": {"resolve_as": "10.11.0.3", "association_type": "server", "iburst": "on"}}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier: localhost: applying 1 change in order:
Patch Applier:   * [{"op": "add", "path": "/NTP_SERVER/10.11.0.3", "value": {"resolve_as": "10.11.0.3", "association_type": "server", "iburst": "on"}}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
root@mathilda-01:/usr# rm -rf local/lib/python3.11/dist-packages/generic_config_updater/__pycache__
root@mathilda-01:/usr# vim local/lib/python3.11/dist-packages/generic_config_updater/services_validator.py
```

Also tested sonic-mgmt/tests/gcu/test_ntp.py



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

