### PR TITLE
Integrated Security Cipher for TACPLUS passkey encryption

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -6,11 +6,31 @@ from .validated_config_db_connector import ValidatedConfigDBConnector
 from jsonpatch import JsonPatchConflict
 from jsonpointer import JsonPointerException
 import utilities_common.cli as clicommon
+from sonic_py_common.security_cipher import master_key_mgr
+import getpass
 
 ADHOC_VALIDATION = True
 RADIUS_MAXSERVERS = 8
 RADIUS_PASSKEY_MAX_LEN = 65
 VALID_CHARS_MSG = "Valid chars are ASCII printable except SPACE, '#', and ','"
+TACACS_PASSKEY_MAX_LEN = 65
+
+def rotate_tacplus_key(table_info):
+    #Extract table and nested_key names
+    table = table_info.split('|')[0]
+    nested_key = table_info.split('|')[1]
+
+    # Re-encrypt with updated password
+    value = secure_cipher.encrypt_passkey("TACPLUS", secret)
+    add_table_kv(table, nested_key, 'passkey', value)
+
+# Security cipher Callback dir
+# Note: Required for Security Cipher - password rotation feature
+security_cipher_clbk_lookup = {
+        #TACPLUS
+        "rotate_tacplus_key": rotate_tacplus_key
+}
+secure_cipher = master_key_mgr(security_cipher_clbk_lookup)
 
 def is_secret(secret):
     return bool(re.match('^' + '[^ #,]*' + '$', secret))
@@ -122,7 +142,7 @@ authentication.add_command(trace)
 @clicommon.pass_db
 def login(db, auth_protocol):
     """Switch login authentication [ {ldap, radius, tacacs+, local} | default ]"""
-    if len(auth_protocol) is 0:
+    if len(auth_protocol) == 0:
         click.echo('Argument "auth_protocol" is required')
         return
     elif len(auth_protocol) > 2:
@@ -243,16 +263,64 @@ default.add_command(authtype)
 
 @click.command()
 @click.argument('secret', metavar='<secret_string>', required=False)
+@click.option('-e', '--encrypt', help='Enable secret encryption', is_flag=True)
+@click.option('-r', '--rotate', help='Rotate encryption secret', is_flag=True)
 @click.pass_context
 @clicommon.pass_db
-def passkey(db, ctx, secret):
+def passkey(db, ctx, secret, encrypt, rotate):
     """Specify TACACS+ server global passkey <STRING>"""
     if ctx.obj == 'default':
         del_table_key(db, 'TACPLUS', 'global', 'passkey')
     elif secret:
-        add_table_kv(db, 'TACPLUS', 'global', 'passkey', secret)
+        if len(secret) > TACACS_PASSKEY_MAX_LEN:
+            click.echo('Maximum of %d chars can be configured' % TACACS_PASSKEY_MAX_LEN)
+            return
+        elif not is_secret(secret):
+            click.echo(VALID_CHARS_MSG)
+            return
+
+    if encrypt:
+        try:
+            # Set new passwd if not set already
+            if secure_cipher.is_key_encrypt_enabled("TACPLUS", "global") is False:
+                #Register feature with Security Cipher module for the 1st time
+                secure_cipher.register("TACPLUS", rotate_tacplus_key)
+                passwd = getpass.getpass()
+                #Set new password for encryption
+                secure_cipher.set_feature_password("TACPLUS", passwd)
+            else:
+                #Check if password rotation is enabled
+                if rotate:
+                    passwd = getpass.getpass()
+                    #Rotate password for TACPLUS feature and re-encrypt the secret
+                    secure_cipher.rotate_feature_passwd("TACPLUS", "TACPLUS|global", secret, passwd)
+                    return
+            b64_encoded = secure_cipher.encrypt_passkey("TACPLUS", secret)
+            if b64_encoded is not None:
+                # Update key_encrypt flag
+                add_table_kv('TACPLUS', 'global', 'key_encrypt', True)
+                add_table_kv('TACPLUS', 'global', 'passkey', b64_encoded)
+            else:
+                #Deregister feature with Security Cipher module
+                secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
+                click.echo('Passkey encryption failed: %s' % errs)
+                return
+        except (EOFError, KeyboardInterrupt):
+            #Deregister feature with Security Cipher module
+            secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
+            add_table_kv('TACPLUS', 'global', 'key_encrypt', False)
+            click.echo('Input cancelled')
+            return
+        except Exception as e:
+            #Deregister feature with Security Cipher module
+            secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
+            add_table_kv('TACPLUS', 'global', 'key_encrypt', False)
+            click.echo('Unexpected error: %s' %e)
+            return
     else:
-        click.echo('Argument "secret" is required')
+        # Update key_encrypt flag to false
+        add_table_kv('TACPLUS', 'global', 'key_encrypt', False)
+        add_table_kv('TACPLUS', 'global', 'passkey', secret)
 tacacs.add_command(passkey)
 default.add_command(passkey)
 
@@ -261,13 +329,15 @@ default.add_command(passkey)
 @click.command()
 @click.argument('address', metavar='<ip_address>')
 @click.option('-t', '--timeout', help='Transmission timeout interval, default 5', type=int)
-@click.option('-k', '--key', help='Shared secret')
+@click.option('-k', '--key', help='Shared secret, stored in plaintext')
+@click.option('-K', '--encrypted_key', help='Shared secret, stored in encrypted format')
+@click.option('-r', '--rotate', help='Rotate encryption secret', is_flag=True)
 @click.option('-a', '--auth_type', help='Authentication type, default pap', type=click.Choice(["chap", "pap", "mschap", "login"]))
 @click.option('-o', '--port', help='TCP port range is 1 to 65535, default 49', type=click.IntRange(1, 65535), default=49)
 @click.option('-p', '--pri', help="Priority, default 1", type=click.IntRange(1, 64), default=1)
 @click.option('-m', '--use-mgmt-vrf', help="Management vrf, default is no vrf", is_flag=True)
 @clicommon.pass_db
-def add(db, address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
+def add(address, timeout, key, encrypted_key, rotate, auth_type, port, pri, use_mgmt_vrf, encrypt):
     """Specify a TACACS+ server"""
     if ADHOC_VALIDATION:
         if not clicommon.is_ipaddress(address):
@@ -288,8 +358,54 @@ def add(db, address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
             data['auth_type'] = auth_type
         if timeout is not None:
             data['timeout'] = str(timeout)
-        if key is not None:
-            data['passkey'] = key
+
+        if key and secret_key:
+          raise click.UsageError("You must provide either --key or --secret_key")
+
+        if encrypted_key is not None:
+            try:
+                # Set new passwd if not set already
+                if secure_cipher.is_key_encrypt_enabled("TACPLUS_SERVER", address) is False:
+                    #Register feature with Security Cipher module for the 1st time
+                    secure_cipher.register("TACPLUS", rotate_tacplus_key)
+                    passwd = getpass.getpass()
+                    #Set new password for encryption
+                    secure_cipher.set_feature_password("TACPLUS", passwd)
+                else:
+                    #Check if password rotation is enabled
+                    if rotate:
+                        passwd = getpass.getpass()
+                        #Rotate password for TACPLUS feature and re-encrypt the secret
+                        secure_cipher.rotate_feature_passwd("TACPLUS", ("TACPLUS_SERVER|" + address), secret, passwd)
+                        return
+                b64_encoded = secure_cipher.encrypt_passkey("TACPLUS", secret)
+                if b64_encoded is not None:
+                    # Update key_encrypt flag
+                    add_table_kv('TACPLUS_SERVER', address, 'key_encrypt', True)
+                    add_table_kv('TACPLUS_SERVER', address, 'passkey', b64_encoded)
+                else:
+                    #Deregister feature with Security Cipher module
+                    secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
+                    click.echo('Passkey encryption failed: %s' % errs)
+                    return
+            except (EOFError, KeyboardInterrupt):
+                #Deregister feature with Security Cipher module
+                secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
+                add_table_kv('TACPLUS_SERVER', address, 'key_encrypt', False)
+                click.echo('Input cancelled')
+                return
+            except Exception as e:
+                #Deregister feature with Security Cipher module
+                secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
+                add_table_kv('TACPLUS_SERVER', address, 'key_encrypt', False)
+                click.echo('Unexpected error: %s' %e)
+                return
+        else:
+            if key is not None:
+                # Update key_encrypt flag to false
+                add_table_kv('TACPLUS_SERVER', address, 'key_encrypt', False)
+                data['passkey'] = key
+
         if use_mgmt_vrf :
             data['vrf'] = "mgmt"
         try:

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -362,7 +362,7 @@ def add(address, timeout, key, encrypted_key, rotate, auth_type, port, pri, use_
             data['timeout'] = str(timeout)
 
         if key and encrypted_key:
-            aise click.UsageError("You must provide either --key or --encrypted_key")
+            raise click.UsageError("You must provide either --key or --encrypted_key")
 
         if encrypted_key is not None:
             try:

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -15,23 +15,6 @@ RADIUS_PASSKEY_MAX_LEN = 65
 VALID_CHARS_MSG = "Valid chars are ASCII printable except SPACE, '#', and ','"
 TACACS_PASSKEY_MAX_LEN = 65
 
-
-def rotate_tacplus_key(table_info, secret):
-    # Extract table and nested_key names
-    table = table_info.split('|')[0]
-    nested_key = table_info.split('|')[1]
-
-    # Re-encrypt with updated password
-    value = secure_cipher.encrypt_passkey("TACPLUS", secret)
-    add_table_kv(table, nested_key, 'passkey', value)
-
-
-# Security cipher Callback dir
-# Note: Required for Security Cipher - password rotation feature
-security_cipher_clbk_lookup = {
-        # TACPLUS
-        "rotate_tacplus_key": rotate_tacplus_key
-}
 secure_cipher = master_key_mgr(security_cipher_clbk_lookup)
 
 

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -15,7 +15,7 @@ RADIUS_PASSKEY_MAX_LEN = 65
 VALID_CHARS_MSG = "Valid chars are ASCII printable except SPACE, '#', and ','"
 TACACS_PASSKEY_MAX_LEN = 65
 
-def rotate_tacplus_key(table_info):
+def rotate_tacplus_key(table_info, secret):
     #Extract table and nested_key names
     table = table_info.split('|')[0]
     nested_key = table_info.split('|')[1]

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -28,8 +28,8 @@ def rotate_tacplus_key(table_info, secret):
 
 # Security cipher Callback dir
 # Note: Required for Security Cipher - password rotation feature
-security_cipher_clbk_lookup = {        
-        "rotate_tacplus_key": rotate_tacplus_key       #TACPLUS
+security_cipher_clbk_lookup = {
+        "rotate_tacplus_key": rotate_tacplus_key # TACPLUS
 }
 secure_cipher = master_key_mgr(security_cipher_clbk_lookup)
 
@@ -317,7 +317,7 @@ def passkey(db, ctx, secret, encrypt, rotate):
             # Deregister feature with Security Cipher module
             secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
             add_table_kv('TACPLUS', 'global', 'key_encrypt', False)
-            click.echo('Unexpected error: %s' %e)
+            click.echo('Unexpected error: %s' % e)
             return
     else:
         # Update key_encrypt flag to false
@@ -378,7 +378,12 @@ def add(address, timeout, key, encrypted_key, rotate, auth_type, port, pri, use_
                     if rotate:
                         passwd = getpass.getpass()
                         # Rotate password for TACPLUS feature and re-encrypt the secret
-                        secure_cipher.rotate_feature_passwd("TACPLUS", ("TACPLUS_SERVER|" + address), encrypted_key, passwd)
+                        secure_cipher.rotate_feature_passwd(
+                            "TACPLUS",
+                            f"TACPLUS_SERVER|{address}",
+                            encrypted_key,
+                            passwd
+                        )
                         return
                 b64_encoded = secure_cipher.encrypt_passkey("TACPLUS", encrypted_key)
                 if b64_encoded is not None:
@@ -400,7 +405,7 @@ def add(address, timeout, key, encrypted_key, rotate, auth_type, port, pri, use_
                 # Deregister feature with Security Cipher module
                 secure_cipher.deregister("TACPLUS", rotate_tacplus_key)
                 add_table_kv('TACPLUS_SERVER', address, 'key_encrypt', False)
-                click.echo('Unexpected error: %s' %e)
+                click.echo('Unexpected error: %s' % e)
                 return
         else:
             if key is not None:

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -29,7 +29,8 @@ def rotate_tacplus_key(table_info, secret):
 # Security cipher Callback dir
 # Note: Required for Security Cipher - password rotation feature
 security_cipher_clbk_lookup = {
-        "rotate_tacplus_key": rotate_tacplus_key # TACPLUS
+        # TACPLUS
+        "rotate_tacplus_key": rotate_tacplus_key
 }
 secure_cipher = master_key_mgr(security_cipher_clbk_lookup)
 


### PR DESCRIPTION
- What I did
Made use of Security Cipher module to encrypt the TACPLUS passkey.

- How I did it
Implemented the feature by following [HLD](https://github.com/sonic-net/SONiC/pull/1471)

- How to verify it
Unit test logs:
```
1. Encrypt passkey:
sonic# config tacacs passkey nikhil --encrypt
sonic# show run al | jq .TACPLUS
{
  "global": {
    "auth_type": "login",
    "key_encrypt": "True",
    "passkey": "U2FsdGVkX19YTUcG+0r3+d78A5E0zTXEukS3ZNrfyFk=",
    "src_intf": "Loopback0"
  }
}
sonic# cat /etc/pam.d/common-auth-sonic
#THIS IS AN AUTO-GENERATED FILE
#
# /etc/pam.d/common-auth- authentication settings common to all services
# This file is included from other service-specific PAM config files,
# and should contain a list of the authentication modules that define
# the central authentication scheme for use on the system
# (e.g., /etc/shadow, LDAP, Kerberos, etc.). The default is to use the
# traditional Unix authentication mechanisms.
#
# here are the per-package modules (the "Primary" block)

auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=<> secret=nikhil login=login timeout=5   try_first_pass
auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=<> secret=nikhil login=login timeout=5   try_first_pass
auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass

#
# here's the fallback if no module succeeds
auth    requisite                       pam_deny.so
# prime the stack with a positive return value if there isn't one already;
# this avoids us returning an error just because nothing sets a success code
# since the modules above will each just jump around
auth    required                        pam_permit.so
# and here are more per-package modules (the "Additional" block)
sonic# cat /etc/cipher_pass.json
{
  "TACPLUS": {
    "table_info": [
      "TACPLUS|global"
    ],
    "password": "TEST1"
  }

2. Encrypt passkey and update existing password
sonic# config tacacs passkey nikhil --encrypt --rotate
Password:
sonic# cat /etc/cipher_pass.json
{
  "TACPLUS": {
    "table_info": [
      "TACPLUS|global"
    ],
    "password": "TEST3"
  }
sonic# cat /etc/pam.d/common-auth-sonic
#THIS IS AN AUTO-GENERATED FILE
#
# /etc/pam.d/common-auth- authentication settings common to all services
# This file is included from other service-specific PAM config files,
# and should contain a list of the authentication modules that define
# the central authentication scheme for use on the system
# (e.g., /etc/shadow, LDAP, Kerberos, etc.). The default is to use the
# traditional Unix authentication mechanisms.
#
# here are the per-package modules (the "Primary" block)

auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=<> secret=nikhil login=login timeout=5   try_first_pass
auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=<> secret=nikhil login=login timeout=5   try_first_pass
auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass

#
# here's the fallback if no module succeeds
auth    requisite                       pam_deny.so
# prime the stack with a positive return value if there isn't one already;
# this avoids us returning an error just because nothing sets a success code
# since the modules above will each just jump around
auth    required                        pam_permit.so
# and here are more per-package modules (the "Additional" block)
sonic# show run al | jq .TACPLUS
{
  "global": {
    "auth_type": "login",
    "key_encrypt": "True",
    "passkey": "U2FsdGVkX18/8nFrAiCe01pOqgPoUUZFaTpmtawdi8I=",
    "src_intf": "Loopback0"
  }
}

3. Revert back to plaintext passkey
sonic# config tacacs passkey ravi
sonic# cat /etc/pam.d/common-auth-sonic
#THIS IS AN AUTO-GENERATED FILE
#
# /etc/pam.d/common-auth- authentication settings common to all services
# This file is included from other service-specific PAM config files,
# and should contain a list of the authentication modules that define
# the central authentication scheme for use on the system
# (e.g., /etc/shadow, LDAP, Kerberos, etc.). The default is to use the
# traditional Unix authentication mechanisms.
#
# here are the per-package modules (the "Primary" block)

auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=<> secret=ravi login=login timeout=5   try_first_pass
auth	[success=done new_authtok_reqd=done default=ignore auth_err=die]	pam_tacplus.so server=<> secret=ravi login=login timeout=5   try_first_pass
auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass

#
# here's the fallback if no module succeeds
auth    requisite                       pam_deny.so
# prime the stack with a positive return value if there isn't one already;
# this avoids us returning an error just because nothing sets a success code
# since the modules above will each just jump around
auth    required                        pam_permit.so
# and here are more per-package modules (the "Additional" block)
sonic# show run al | jq .TACPLUS
{
  "global": {
    "auth_type": "login",
    "key_encrypt": "False",
    "passkey": "ravi",
    "src_intf": "Loopback0"
  }
}
sonic# cat /etc/cipher_pass.json
{
  "TACPLUS": {
    "table_info": [],
    "password": null
  }
```

- Related PR(s)
- [PR#17201](https://github.com/sonic-net/sonic-buildimage/pull/17201)
- [PR#22711](https://github.com/sonic-net/sonic-buildimage/pull/22711)
- [PR#81](https://github.com/sonic-net/sonic-host-services/pull/81)

Note: This PR is created by closing the old [PR](https://github.com/sonic-net/sonic-utilities/pull/3027) due to several merge conflicts.