### PR TITLE
Fix for 22138: Chassisd does not wait for the execution to complete for previous admin state change requests - Replaces PR: #3845

### DIFF
--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -75,6 +75,7 @@ def set_state_transition_in_progress(db, chassis_module_name, value):
         entry['transition_start_time'] = datetime.utcnow().isoformat()
     else:
         entry.pop('transition_start_time', None)
+        state_db.delete_field('CHASSIS_MODULE_TABLE', chassis_module_name, 'transition_start_time')
     state_db.set_entry('CHASSIS_MODULE_TABLE', chassis_module_name, entry)
 
 

--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -176,7 +176,6 @@ def shutdown_chassis_module(db, chassis_module_name):
 
     if not chassis_module_name.startswith(("SUPERVISOR", "LINE-CARD", "FABRIC-CARD", "DPU")):
         ctx.fail("'module_name' has to begin with 'SUPERVISOR', 'LINE-CARD', 'FABRIC-CARD', or 'DPU'")
-        return
 
     if get_config_module_state(db, chassis_module_name) == 'down':
         click.echo(f"Module {chassis_module_name} is already in down state")

--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -6,9 +6,26 @@ import re
 import subprocess
 import utilities_common.cli as clicommon
 from utilities_common.chassis import is_smartswitch, get_all_dpus
+from datetime import datetime, timedelta
 
 TIMEOUT_SECS = 10
+TRANSITION_TIMEOUT = timedelta(seconds=240)  # 4 minutes
 
+
+class StateDBHelper:
+    def __init__(self, sonic_db):
+        self.db = sonic_db
+
+    def get_entry(self, table, key):
+        """Fetch all fields from table|key."""
+        redis_key = f"{table}|{key}"
+        return self.db.get_all("STATE_DB", redis_key) or {}
+
+    def set_entry(self, table, key, entry):
+        """Set multiple fields to table|key."""
+        redis_key = f"{table}|{key}"
+        for field, value in entry.items():
+            self.db.set("STATE_DB", redis_key, field, value)
 
 #
 # 'chassis_modules' group ('config chassis_modules ...')
@@ -24,6 +41,12 @@ def modules():
     pass
 
 
+def ensure_statedb_connected(db):
+    if not hasattr(db, 'statedb'):
+        chassisdb = db.db
+        chassisdb.connect("STATE_DB")
+        db.statedb = StateDBHelper(chassisdb)
+
 def get_config_module_state(db, chassis_module_name):
     config_db = db.cfgdb
     fvs = config_db.get_entry('CHASSIS_MODULE', chassis_module_name)
@@ -35,6 +58,40 @@ def get_config_module_state(db, chassis_module_name):
     else:
         return fvs['admin_status']
 
+
+def get_state_transition_in_progress(db, chassis_module_name):
+    ensure_statedb_connected(db)
+    fvs = db.statedb.get_entry('CHASSIS_MODULE_TABLE', chassis_module_name)
+    value = fvs.get('state_transition_in_progress', 'False') if fvs else 'False'
+    return value
+
+
+def set_state_transition_in_progress(db, chassis_module_name, value):
+    ensure_statedb_connected(db)
+    state_db = db.statedb
+    entry = state_db.get_entry('CHASSIS_MODULE_TABLE', chassis_module_name) or {}
+    entry['state_transition_in_progress'] = value
+    if value == 'True':
+        entry['transition_start_time'] = datetime.utcnow().isoformat()
+    else:
+        entry.pop('transition_start_time', None)
+    state_db.set_entry('CHASSIS_MODULE_TABLE', chassis_module_name, entry)
+
+
+def is_transition_timed_out(db, chassis_module_name):
+    ensure_statedb_connected(db)
+    state_db = db.statedb
+    fvs = state_db.get_entry('CHASSIS_MODULE_TABLE', chassis_module_name)
+    if not fvs:
+        return False
+    start_time_str = fvs.get('transition_start_time')
+    if not start_time_str:
+        return False
+    try:
+        start_time = datetime.fromisoformat(start_time_str)
+    except ValueError:
+        return False
+    return datetime.utcnow() - start_time > TRANSITION_TIMEOUT
 
 #
 # Name: check_config_module_state_with_timeout
@@ -116,20 +173,34 @@ def shutdown_chassis_module(db, chassis_module_name):
     config_db = db.cfgdb
     ctx = click.get_current_context()
 
-    if not chassis_module_name.startswith("SUPERVISOR") and \
-       not chassis_module_name.startswith("LINE-CARD") and \
-       not chassis_module_name.startswith("FABRIC-CARD") and \
-       not chassis_module_name.startswith("DPU"):
-        ctx.fail("'module_name' has to begin with 'SUPERVISOR', 'LINE-CARD', 'FABRIC-CARD', 'DPU'")
-
-    # To avoid duplicate operation
-    if get_config_module_state(db, chassis_module_name) == 'down':
-        click.echo("Module {} is already in down state".format(chassis_module_name))
+    if not chassis_module_name.startswith(("SUPERVISOR", "LINE-CARD", "FABRIC-CARD", "DPU")):
+        ctx.fail("'module_name' has to begin with 'SUPERVISOR', 'LINE-CARD', 'FABRIC-CARD', or 'DPU'")
         return
 
-    click.echo("Shutting down chassis module {}".format(chassis_module_name))
-    fvs = {'admin_status': 'down'}
-    config_db.set_entry('CHASSIS_MODULE', chassis_module_name, fvs)
+    if get_config_module_state(db, chassis_module_name) == 'down':
+        click.echo(f"Module {chassis_module_name} is already in down state")
+        return
+
+    if is_smartswitch():
+        if get_state_transition_in_progress(db, chassis_module_name) == 'True':
+            if is_transition_timed_out(db, chassis_module_name):
+                set_state_transition_in_progress(db, chassis_module_name, 'False')
+                click.echo(f"Previous transition for module {chassis_module_name} timed out. Proceeding with shutdown.")
+            else:
+                click.echo(f"Module {chassis_module_name} state transition is already in progress")
+                return
+        else:
+            set_state_transition_in_progress(db, chassis_module_name, 'True')
+
+        click.echo(f"Shutting down chassis module {chassis_module_name}")
+        fvs = {
+            'admin_status': 'down',
+        }
+        config_db.set_entry('CHASSIS_MODULE', chassis_module_name, fvs)
+    else:
+        click.echo(f"Shutting down chassis module {chassis_module_name}")
+        config_db.set_entry('CHASSIS_MODULE', chassis_module_name, {'admin_status': 'down'})
+
     if chassis_module_name.startswith("FABRIC-CARD"):
         if not check_config_module_state_with_timeout(ctx, db, chassis_module_name, 'down'):
             fabric_module_set_admin_status(db, chassis_module_name, 'down')
@@ -149,16 +220,32 @@ def startup_chassis_module(db, chassis_module_name):
     config_db = db.cfgdb
     ctx = click.get_current_context()
 
-    # To avoid duplicate operation
-    if get_config_module_state(db, chassis_module_name) == 'up':
-        click.echo("Module {} is already set to up state".format(chassis_module_name))
+    if not chassis_module_name.startswith(("SUPERVISOR", "LINE-CARD", "FABRIC-CARD", "DPU")):
+        ctx.fail("'module_name' has to begin with 'SUPERVISOR', 'LINE-CARD', 'FABRIC-CARD', or 'DPU'")
         return
 
-    click.echo("Starting up chassis module {}".format(chassis_module_name))
+    if get_config_module_state(db, chassis_module_name) == 'up':
+        click.echo(f"Module {chassis_module_name} is already set to up state")
+        return
+
     if is_smartswitch():
-        fvs = {'admin_status': 'up'}
+        if get_state_transition_in_progress(db, chassis_module_name) == 'True':
+            if is_transition_timed_out(db, chassis_module_name):
+                set_state_transition_in_progress(db, chassis_module_name, 'False')
+                click.echo(f"Previous transition for module {chassis_module_name} timed out. Proceeding with startup.")
+            else:
+                click.echo(f"Module {chassis_module_name} state transition is already in progress")
+                return
+        else:
+            set_state_transition_in_progress(db, chassis_module_name, 'True')
+
+        click.echo(f"Starting up chassis module {chassis_module_name}")
+        fvs = {
+            'admin_status': 'up',
+        }
         config_db.set_entry('CHASSIS_MODULE', chassis_module_name, fvs)
     else:
+        click.echo(f"Starting up chassis module {chassis_module_name}")
         config_db.set_entry('CHASSIS_MODULE', chassis_module_name, None)
 
     if chassis_module_name.startswith("FABRIC-CARD"):


### PR DESCRIPTION
Fixed issue #22138
Replaces PR: #3845 which was closed accidentally
The corresponding sonic-platform-daemon PR is : https://github.com/sonic-net/sonic-platform-daemons/pull/607

What I did
Fixed issue #22138
Chassisd does not wait for the execution to complete for previous admin state change requests. Added support to solve this.

How I did it
Added a state to indicate the progress of an admin_state transition period (window) of every module in config_db.
When in progress do not allow another admin_state change for that module.
Mark the beginning of state transition in the CLI itself. Added a timeout also for error cases.
Mark the end of state transition in chassisd.

How to verify it
Issue "config chassis module startup DPU0". This takes around 3 mins. Check the config_db and verify the new variable is set to True.
Issue another "config chassis module startup DPU0" and also ""config chassis module shutdown DPU0".
See both are blocked.
Once the DPU operational state is the admin_sate check if a new config is accepted.

Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)

#### Request for 202505
- [x] 202505
