### PR TITLE
[sfputil debug] Fix issue: do not check output status when CMIS version is lower than 5.0

### DIFF
--- a/sfputil/debug.py
+++ b/sfputil/debug.py
@@ -93,6 +93,20 @@ def set_output(port_name, enable, direction):
 
     subport = get_subport(port_name)
 
+    if hasattr(api, 'get_cmis_rev'):
+        cmis_rev = api.get_cmis_rev()
+        if cmis_rev is None:
+            click.echo(f"{port_name}: CMIS revision not available for subport {subport}")
+            sys.exit(EXIT_FAIL)
+
+        # OutputStatusRx and OutputStatusTx are supported from CMIS 5.0
+        if float(cmis_rev) < 5.0:
+            click.echo(
+                f"{port_name}: This functionality is not supported"
+                f" with CMIS version {cmis_rev}, requires CMIS 5.0 and above"
+            )
+            sys.exit(EXIT_FAIL)
+
     try:
         if direction == "tx":
             lane_count = get_media_lane_count(port_name)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

OutputStatusTx and OutputStatusRx are only supported since CMIS 5.0. `sfputil debug tx-output` and `sfputil debug rx-output` should check them only if CMIS rev is higher or equal to 5.0.

#### How I did it

1. Use `get_tx_disable` and `get_rx_disable` to check if the corresponding bits have been set by `sfputil debug` command
2. Check the CMIS rev, ignore checking of OutputStatusTx and OutputStatusRx if CMIS rev is below 5.0.

#### How to verify it

1. Manual test
2. unit test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

