### PR TITLE
[config show]BGP Suppress fib pending config and display for multi-asic

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2567,8 +2567,8 @@ def synchronous_mode(sync_mode):
 #
 @config.command('suppress-fib-pending')
 @click.argument('state', metavar='<enabled|disabled>', required=True, type=click.Choice(['enabled', 'disabled']))
-@click.option('-n', '--namespace', help='Namespace name',
-             required=True if multi_asic.is_multi_asic() else False, type=click.Choice(multi_asic.get_namespace_list()))
+@click.option('-n', '--namespace', help='Namespace name', required=True if multi_asic.is_multi_asic() else False,
+              type=click.Choice(multi_asic.get_namespace_list()))
 @clicommon.pass_db
 def suppress_pending_fib(db, namespace, state):
     ''' Enable or disable pending FIB suppression. Once enabled,

--- a/config/main.py
+++ b/config/main.py
@@ -2567,13 +2567,19 @@ def synchronous_mode(sync_mode):
 #
 @config.command('suppress-fib-pending')
 @click.argument('state', metavar='<enabled|disabled>', required=True, type=click.Choice(['enabled', 'disabled']))
+@click.option('-n', '--namespace', help='Namespace name',
+             required=True if multi_asic.is_multi_asic() else False, type=click.Choice(multi_asic.get_namespace_list()))
 @clicommon.pass_db
-def suppress_pending_fib(db, state):
+def suppress_pending_fib(db, namespace, state):
     ''' Enable or disable pending FIB suppression. Once enabled,
         BGP will not advertise routes that are not yet installed in the hardware '''
 
-    config_db = db.cfgdb
-    config_db.mod_entry('DEVICE_METADATA', 'localhost', {"suppress-fib-pending": state})
+    # Set namespace to default_namespace if it is None.
+    if namespace is None:
+        namespace = DEFAULT_NAMESPACE
+
+    config_db = db.cfgdb_clients[namespace]
+    config_db.mod_entry('DEVICE_METADATA', 'localhost', {"suppress_fib_pending": state})
 
 #
 # 'yang_config_validation' command ('config yang_config_validation ...')

--- a/config/main.py
+++ b/config/main.py
@@ -2579,7 +2579,7 @@ def suppress_pending_fib(db, namespace, state):
         namespace = DEFAULT_NAMESPACE
 
     config_db = db.cfgdb_clients[namespace]
-    config_db.mod_entry('DEVICE_METADATA', 'localhost', {"suppress_fib_pending": state})
+    config_db.mod_entry('DEVICE_METADATA', 'localhost', {"suppress-fib-pending": state})
 
 #
 # 'yang_config_validation' command ('config yang_config_validation ...')

--- a/show/main.py
+++ b/show/main.py
@@ -2676,7 +2676,7 @@ def suppress_pending_fib(db, namespace):
 
         config_db = db.cfgdb_clients[ns]
         field_values = config_db.get_entry('DEVICE_METADATA', 'localhost')
-        state = field_values.get('suppress_fib_pending', 'enabled').title()
+        state = field_values.get('suppress-fib-pending', 'enabled').title()
 
         if masic:
             click.echo("{}: {}".format(ns, state))

--- a/show/main.py
+++ b/show/main.py
@@ -2657,10 +2657,8 @@ def peer(db, peer_ip, namespace):
 
 # 'suppress-fib-pending' subcommand ("show suppress-fib-pending")
 @cli.command('suppress-fib-pending')
-@click.option('--namespace', '-n', 'namespace', default=None, show_default=True,
-              type=click.Choice(multi_asic_util.multi_asic_ns_choices()), help='Namespace name or all')
 @clicommon.pass_db
-def suppress_pending_fib(db, namespace):
+def suppress_pending_fib(db):
     """ Show the status of suppress pending FIB feature """
 
     if multi_asic.get_num_asics() > 1:
@@ -2671,9 +2669,6 @@ def suppress_pending_fib(db, namespace):
         masic = False
 
     for ns in namespace_list:
-        if namespace and namespace != ns:
-            continue
-
         config_db = db.cfgdb_clients[ns]
         field_values = config_db.get_entry('DEVICE_METADATA', 'localhost')
         state = field_values.get('suppress-fib-pending', 'enabled').title()

--- a/tests/suppress_pending_fib_test.py
+++ b/tests/suppress_pending_fib_test.py
@@ -35,6 +35,7 @@ class TestSuppressFibPending:
         print(result.output)
         assert result.exit_code != 0
 
+
 class TestSuppressFibPendingMultiAsic(object):
     @classmethod
     def setup_class(cls):
@@ -70,19 +71,19 @@ class TestSuppressFibPendingMultiAsic(object):
         cfgdb0 = db.cfgdb_clients['asic0']
         cfgdb1 = db.cfgdb_clients['asic1']
 
-        #Test config and db check for asic0
+        # Test config and db check for asic0
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic0', 'disabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
         assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'disabled'
 
-        #Test config and db check for asic1
+        # Test config and db check for asic1
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic1', 'enabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
         assert cfgdb1.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'enabled'
 
-        #Show for all asics
+        # Show for all asics
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
         assert result.exit_code == 0
         assert result.output == 'asic0: Disabled\nasic1: Enabled\n'

--- a/tests/suppress_pending_fib_test.py
+++ b/tests/suppress_pending_fib_test.py
@@ -51,42 +51,35 @@ class TestSuppressFibPendingMultiAsic(object):
         importlib.reload(mock_multi_asic)
         dbconnector.load_namespace_config()
 
-    def test_config_suppress_fib_pending_specific_asic(self):
-        runner = CliRunner()
-        db = Db()
-        cfgdb0 = db.cfgdb_clients['asic0']
-
-        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic0', 'enabled'], obj=db)
-        print(result.output)
-        assert result.exit_code == 0
-        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
-
-        result = runner.invoke(show.cli.commands['suppress-fib-pending'], ['-n', 'asic0'], obj=db)
-        assert result.exit_code == 0
-        assert result.output == 'asic0: Enabled\n'
-
     def test_config_suppress_fib_pending_all_asics(self):
         runner = CliRunner()
         db = Db()
         cfgdb0 = db.cfgdb_clients['asic0']
         cfgdb1 = db.cfgdb_clients['asic1']
 
-        # Test config and db check for asic0
-        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic0', 'disabled'], obj=db)
+        # Test config = disable and db check for all asics (asic0 and asic1)
+        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['disabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
         assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'disabled'
+        assert cfgdb1.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'disabled'
 
-        # Test config and db check for asic1
-        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic1', 'enabled'], obj=db)
-        print(result.output)
-        assert result.exit_code == 0
-        assert cfgdb1.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
-
-        # Show for all asics
+        # Show disable for all asics
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
         assert result.exit_code == 0
-        assert result.output == 'asic0: Disabled\nasic1: Enabled\n'
+        assert result.output == 'asic0: Disabled\nasic1: Disabled\n'
+
+        # Test config = enable and db check for all asics (asic0 and asic1)
+        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['enabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
+        assert cfgdb1.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
+
+        # Show enable for all asics
+        result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
+        assert result.exit_code == 0
+        assert result.output == 'asic0: Enabled\nasic1: Enabled\n'
 
     @classmethod
     def teardown_class(cls):

--- a/tests/suppress_pending_fib_test.py
+++ b/tests/suppress_pending_fib_test.py
@@ -1,3 +1,5 @@
+import os
+import importlib
 from click.testing import CliRunner
 
 import config.main as config
@@ -14,7 +16,7 @@ class TestSuppressFibPending:
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['enabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
-        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'enabled'
 
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
         assert result.exit_code == 0
@@ -23,7 +25,7 @@ class TestSuppressFibPending:
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['disabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
-        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'disabled'
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'disabled'
 
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
         assert result.exit_code == 0
@@ -32,3 +34,65 @@ class TestSuppressFibPending:
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['invalid-input'], obj=db)
         print(result.output)
         assert result.exit_code != 0
+
+class TestSuppressFibPendingMultiAsic(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "2"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        import show.main
+        importlib.reload(show.main)
+        import config.main
+        importlib.reload(config.main)
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+
+    def test_config_suppress_fib_pending_specific_asic(self):
+        runner = CliRunner()
+        db = Db()
+        cfgdb0 = db.cfgdb_clients['asic0']
+
+        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic0', 'enabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'enabled'
+
+        result = runner.invoke(show.cli.commands['suppress-fib-pending'], ['-n', 'asic0'], obj=db)
+        assert result.exit_code == 0
+        assert result.output == 'asic0: Enabled\n'
+
+    def test_config_suppress_fib_pending_all_asics(self):
+        runner = CliRunner()
+        db = Db()
+        cfgdb0 = db.cfgdb_clients['asic0']
+        cfgdb1 = db.cfgdb_clients['asic1']
+
+        #Test config and db check for asic0
+        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic0', 'disabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'disabled'
+
+        #Test config and db check for asic1
+        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic1', 'enabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert cfgdb1.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'enabled'
+
+        #Show for all asics
+        result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
+        assert result.exit_code == 0
+        assert result.output == 'asic0: Disabled\nasic1: Enabled\n'
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_single_asic
+        importlib.reload(mock_single_asic)
+        dbconnector.load_namespace_config()

--- a/tests/suppress_pending_fib_test.py
+++ b/tests/suppress_pending_fib_test.py
@@ -16,7 +16,7 @@ class TestSuppressFibPending:
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['enabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
-        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'enabled'
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
 
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
         assert result.exit_code == 0
@@ -25,7 +25,7 @@ class TestSuppressFibPending:
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['disabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
-        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'disabled'
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'disabled'
 
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
         assert result.exit_code == 0
@@ -59,7 +59,7 @@ class TestSuppressFibPendingMultiAsic(object):
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic0', 'enabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
-        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'enabled'
+        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
 
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], ['-n', 'asic0'], obj=db)
         assert result.exit_code == 0
@@ -75,13 +75,13 @@ class TestSuppressFibPendingMultiAsic(object):
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic0', 'disabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
-        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'disabled'
+        assert cfgdb0.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'disabled'
 
         # Test config and db check for asic1
         result = runner.invoke(config.config.commands['suppress-fib-pending'], ['-n', 'asic1', 'enabled'], obj=db)
         print(result.output)
         assert result.exit_code == 0
-        assert cfgdb1.get_entry('DEVICE_METADATA', 'localhost')['suppress_fib_pending'] == 'enabled'
+        assert cfgdb1.get_entry('DEVICE_METADATA', 'localhost')['suppress-fib-pending'] == 'enabled'
 
         # Show for all asics
         result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
CLI commands part of the fix for issue (https://github.com/sonic-net/sonic-buildimage/issues/19022)

#### How I did it
- To send the suppress-fib-pending configuration to all asics in multi-asic system
- Show command to diplay current suppress-fib-pending configuration for all available asics
- Unit tests to test the multi-asic support of suppress-fib-pending configuration

#### How to verify it
- In a multi-asic device configure suppress-fib-pending using command "sudo config suppress-fib-pending enabled"
- Check the config db of all asics to verify whether the "suppress-fib-pending": "enabled" fv pair is avialable in the config db DEVICE_METADATA
- Run the same test for "disabled" 

#### Previous command output (if the output of a command-line utility has changed)
    admin@sonic:~$ show suppress-fib-pending 
    Enabled

#### New command output (if the output of a command-line utility has changed)

    admin@sonic:~$ show suppress-fib-pending 
    asic0: Enabled
    asic1: Enabled
    admin@sonic:~$ 
    
 
