### PR TITLE
Fix for MIGSMSFT-1038 "Config on device gets wiped out when upgrading from Cisco factory image to Microsoft golden image on Smartswitch"

### DIFF
--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -6,7 +6,6 @@ import os
 import re
 import subprocess
 import shutil
-import datetime
 
 import click
 
@@ -67,7 +66,6 @@ class GrubBootloader(OnieInstallerBootloader):
         old_config_dir = "/etc/sonic"
         backup_dir = "/host/old_config"
         os.makedirs(backup_dir, exist_ok=True)
-        timestamp = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
 
         for cfg_file in ["config_db.json"]:
             src = os.path.join(old_config_dir, cfg_file)

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -5,6 +5,8 @@ Bootloader implementation for grub based platforms
 import os
 import re
 import subprocess
+import shutil
+import datetime
 
 import click
 
@@ -62,6 +64,18 @@ class GrubBootloader(OnieInstallerBootloader):
         return True
 
     def install_image(self, image_path):
+        old_config_dir = "/etc/sonic"
+        backup_dir = "/host/old_config"
+        os.makedirs(backup_dir, exist_ok=True)
+        timestamp = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+        for cfg_file in ["config_db.json"]:
+            src = os.path.join(old_config_dir, cfg_file)
+            dst = os.path.join(backup_dir, cfg_file)
+            if os.path.isfile(src):
+                shutil.copy2(src, dst)
+                click.echo(f"[installer] Backed up {src} -> {dst}")
+
         run_command(["bash", image_path])
         run_command(['grub-set-default', '--boot-directory=' + HOST_PATH, '0'])
 

--- a/tests/installer_bootloader_grub_test.py
+++ b/tests/installer_bootloader_grub_test.py
@@ -36,7 +36,12 @@ def test_install_image():
         call(["bash", image_path]),
         call(['grub-set-default', '--boot-directory=' + grub.HOST_PATH, '0'])
     ]
-    with patch('sonic_installer.bootloader.grub.run_command') as mock_cmd:
+
+    with patch('sonic_installer.bootloader.grub.run_command') as mock_cmd, \
+         patch('os.makedirs') as mock_makedirs, \
+         patch('builtins.open', new_callable=Mock), \
+         patch('shutil.copy') as mock_copy:
+
         bootloader = grub.GrubBootloader()
         bootloader.install_image(image_path)
         mock_cmd.assert_has_calls(expected_calls)

--- a/tests/installer_bootloader_grub_test.py
+++ b/tests/installer_bootloader_grub_test.py
@@ -45,6 +45,8 @@ def test_install_image():
         bootloader = grub.GrubBootloader()
         bootloader.install_image(image_path)
         mock_cmd.assert_has_calls(expected_calls)
+        mock_makedirs.assert_called_with('/host/old_config', exist_ok=True)
+        mock_copy.assert_any_call('/etc/sonic/config_db.json', '/host/old_config/config_db.json')
 
 @patch("sonic_installer.bootloader.grub.subprocess.call", Mock())
 @patch("sonic_installer.bootloader.grub.open")

--- a/tests/installer_bootloader_grub_test.py
+++ b/tests/installer_bootloader_grub_test.py
@@ -31,25 +31,20 @@ def test_set_next_image():
         mock_cmd.assert_has_calls(expected_call)
 
 
-@patch('os.makedirs')
-@patch('shutil.copy')
-@patch('os.path.exists', return_value=True)
+@patch('sonic_installer.bootloader.grub.os.path.isfile', return_value=True)
+@patch('sonic_installer.bootloader.grub.shutil.copy2')
+@patch('sonic_installer.bootloader.grub.os.makedirs')
 @patch('sonic_installer.bootloader.grub.run_command')
-def test_install_image(mock_run_cmd, mock_exists, mock_copy, mock_makedirs):
+def test_install_image(mock_run_cmd, mock_makedirs, mock_copy2, mock_isfile):
     image_path = 'sonic'
     bootloader = grub.GrubBootloader()
     bootloader.install_image(image_path)
 
-    # Check backup logic
+    # Verify directory creation
     mock_makedirs.assert_called_once_with('/host/old_config', exist_ok=True)
-    mock_copy.assert_any_call('/etc/sonic/config_db.json', '/host/old_config/config_db.json')
 
-    # Check image install logic
-    expected_calls = [
-        call(["bash", image_path]),
-        call(['grub-set-default', '--boot-directory=' + grub.HOST_PATH, '0'])
-    ]
-    mock_run_cmd.assert_has_calls(expected_calls)
+    # Verify backup copy occurred
+    mock_copy2.assert_any_call('/etc/sonic/config_db.json', '/host/old_config/config_db.json')
 
 @patch("sonic_installer.bootloader.grub.subprocess.call", Mock())
 @patch("sonic_installer.bootloader.grub.open")

--- a/tests/installer_bootloader_grub_test.py
+++ b/tests/installer_bootloader_grub_test.py
@@ -30,6 +30,7 @@ def test_set_next_image():
         bootloader.set_next_image(image)
         mock_cmd.assert_has_calls(expected_call)
 
+
 @patch('os.makedirs')
 @patch('shutil.copy')
 @patch('os.path.exists', return_value=True)


### PR DESCRIPTION
Fix for config wipeout issue during pilot. There is a corresponding PR in sonic-buildimage  #https://github.com/sonic-net/sonic-buildimage/pull/23228 . Saves the config from /etc/sonic to /host/old_config

Fixes: #[MIGSMSFT-1038](https://migsonic.atlassian.net/browse/MIGSMSFT-1038)

Why I did it
Config on device gets wiped out when upgrading from Cisco factory image to Microsoft golden image on Smartswitch.

Work item tracking
Microsoft ADO (number only):
How I did it
Reproduced the problem by issuing the "sonic-installer install" CLI more than once on the same installed image. Then identified the root cause to be that the second installation takes a different code path and doesn't store and restore the the config file. Moreover the during the second instance of the CLI on the same image the file system clean up happens wiping out all config files in "/etc/sonic"

How to verify it
Patch the PRs on the following two files and issue "sonic-installer install " two or more times on the same image.
Before issuing the second instance of the CLI change the hostname and see the change is persisted.

Which release branch to backport (provide reason below if selected)
 202205
 202211
 202305
 202311
[ x] 202405
[ x] 202411
[ x] 202505
Tested branch (Please provide the tested image version)
[ x] 202505
Description for the changelog
There is a corresponding fix in rc.role in sonic-buildimage
