### PR TITLE
Fix show interface errors CLI

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -537,22 +537,22 @@ def errors(ctx, interfacename):
 
     port_operr_table = get_all_port_errors(interfacename)
 
-    # Define a list of all potential errors
+    # Define a list of all potential errors's DB entries
     ALL_PORT_ERRORS = [
-        "oper_error_status",
-        "mac_local_fault",
-        "mac_remote_fault",
-        "fec_sync_loss",
-        "fec_alignment_loss",
-        "high_ser_error",
-        "high_ber_error",
-        "data_unit_crc_error",
-        "data_unit_misalignment_error",
-        "signal_local_error",
-        "crc_rate",
-        "data_unit_size",
-        "code_group_error",
-        "no_rx_reachability"
+        ("oper_error_status", "oper_error_status_time"),
+        ("mac_local_fault_count", "mac_local_fault_time"),
+        ("mac_remote_fault_count", "mac_remote_fault_time"),
+        ("fec_sync_loss_count", "fec_sync_loss_time"),
+        ("fec_alignment_loss_count", "fec_alignment_loss_time"),
+        ("high_ser_error_count", "high_ser_error_time"),
+        ("high_ber_error_count", "high_ber_error_time"),
+        ("data_unit_crc_error_count", "data_unit_crc_error_time"),
+        ("data_unit_misalignment_error_count", "data_unit_misalignment_error_time"),
+        ("signal_local_error_count", "signal_local_error_time"),
+        ("crc_rate_count", "crc_rate_time"),
+        ("data_unit_size_count", "data_unit_size_time"),
+        ("code_group_error_count", "code_group_error_time"),
+        ("no_rx_reachability_count", "no_rx_reachability_time")
     ]
 
     # Prepare the table headers and body
@@ -560,10 +560,7 @@ def errors(ctx, interfacename):
     body = []
 
     # Populate the table body with all errors, defaulting missing ones to 0 and Never
-    for error in ALL_PORT_ERRORS:
-        count_key = f"{error}_count"
-        time_key = f"{error}_time"
-
+    for count_key, time_key in ALL_PORT_ERRORS:
         if port_operr_table is not None:
             count = port_operr_table.get(count_key, "0")  # Default count to '0'
             timestamp = port_operr_table.get(time_key, "Never")  # Default timestamp to 'Never'
@@ -572,7 +569,7 @@ def errors(ctx, interfacename):
             timestamp = "Never"
 
         # Add to table
-        body.append([error.replace('_', ' '), count, timestamp])
+        body.append([count_key.replace('_', ' ').replace('count', ''), count, timestamp])
 
     # Sort the body for consistent display
     body.sort(key=lambda x: x[0])


### PR DESCRIPTION
#### Why I did it
The show interface errors command always displays '0' even if the oper_error_status is not:
```
Port Errors                     Count  Last timestamp(UTC)
----------------------------  -------  ---------------------
code group error                    0  Never
crc rate                            0  Never
data unit crc error                 0  Never
data unit misalignment error        0  Never
data unit size                      0  Never
fec alignment loss                  0  Never
fec sync loss                       0  Never
high ber error                      0  Never
high ser error                      0  Never
mac local fault                     7  2025-06-27 23:36:28
mac remote fault                    5  2025-06-27 23:36:28
no rx reachability                  0  Never
oper error status                   0  Never
signal local error                  0  Never
```

For example, if local fault and remote fault were set, We expect oper_status to be '3' and not '0'
```
typedef enum _sai_port_error_status_t
{
    /** No errors */
    SAI_PORT_ERROR_STATUS_CLEAR = 0,

    /** MAC Local fault asserted */
    SAI_PORT_ERROR_STATUS_MAC_LOCAL_FAULT = 1 << 0,  // 1

    /** MAC Remote fault asserted */
    SAI_PORT_ERROR_STATUS_MAC_REMOTE_FAULT = 1 << 1,  // 2
```

This correct value is in the PORT_OPERR_TABLE but the CLI does not use it:
```
(Pdb++) port_operr_table
{'mac_local_fault_count': '6', 'mac_local_fault_time': '2025-06-27 23:26:31', 'mac_remote_fault_count': '4', 'mac_remote_fault_time': '2025-06-27 23:19:36', 'oper_error_status': '3'}

```

#### How I did it
Changed `ALL_PORT_ERRORS` to be a list of tuples where we define the correct lookup key and time key. `oper_error_status` is not a count and `oper_error_status_count` does not exist, I changed this to the correct DB entry.

#### How to verify it
Run the show interface errors command and see the correct value being reflected:
```
Port Errors                     Count  Last timestamp(UTC)
----------------------------  -------  ---------------------
code group error                    0  Never
crc rate                            0  Never
data unit crc error                 0  Never
data unit misalignment error        0  Never
data unit size                      0  Never
fec alignment loss                  0  Never
fec sync loss                       0  Never
high ber error                      0  Never
high ser error                      0  Never
mac local fault                     7  2025-06-27 23:36:28
mac remote fault                    5  2025-06-27 23:36:28
no rx reachability                  0  Never
oper error status                   3  Never
signal local error                  0  Never
```

*Note* I will need to update sonic-swss so that the last time oper_error_status was updated is pushed to STATE_DB so that we display the correct time rather than never.
