### PR TITLE
[db_migrator] Fix parse_xml fails when minigraph has SonicQosProfile

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -64,6 +64,8 @@ class DBMigrator():
         self.TABLE_KEY       = 'DATABASE'
         self.TABLE_FIELD     = 'VERSION'
 
+        self.platform = device_info.get_platform_info().get('platform')
+
         # Generate config_src_data from minigraph and golden config
         self.generate_config_src(namespace)
 
@@ -135,7 +137,7 @@ class DBMigrator():
         minigraph_data = None
         try:
             if os.path.isfile(MINIGRAPH_FILE):
-                minigraph_data = parse_xml(MINIGRAPH_FILE)
+                minigraph_data = parse_xml(MINIGRAPH_FILE, platform=self.platform)
         except Exception as e:
             log.log_error('Caught exception while trying to parse minigraph: ' + str(e))
             pass


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This change is to fix https://github.com/sonic-net/sonic-buildimage/issues/22120 "Bug: [db_migrator] parse_xml fails when minigraph has SonicQosProfile".

If there is `SonicQosProfile` in minigraph.xml, parse_xml fails with below error:
```
2025 Jul 14 06:49:23.590302 vlab-01 ERR db_migrator: Caught exception while trying to parse minigraph: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
```
It's because select_mmu_profiles needs platform.
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-config-engine/minigraph.py#L1925

#### How I did it
This change added code in db_migrator.py to get platform info. While calling `parse_xml`, pass in the `platform` argument.

#### How to verify it
Add SonicQosProfile to minigraph:
```
    <a:DeviceProperty>
        <a:Name>SonicQosProfile</a:Name>
        <a:Reference i:nil="true"/>
        <a:Value>Balanced</a:Value>
    </a:DeviceProperty>
```

Run `db_migrator.py -o migrate`. Check syslog, migration passed without exception.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

