### PR TITLE
Add support for multi-asic fixed boxes in get_routing_stack

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -82,7 +82,7 @@ def get_routing_stack():
     result = 'frr'
 
     cmd0 = ["sudo", "docker", "ps", "--format", "{{.Image}}\t{{.Names}}"]
-    cmd1 = ["awk", '$2 == "bgp"']
+    cmd1 = ["awk", '$2 ~ /^bgp[01]?$/']
     cmd2 = ["cut", "-d-", "-f3"]
     cmd3 = ["cut", "-d:", "-f1"]
     cmd4 = ["head", "-n", "1"]

--- a/show/main.py
+++ b/show/main.py
@@ -89,7 +89,7 @@ COMMAND_TIMEOUT = 300
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'
-    command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 == \"bgp\"' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"  # noqa: E501
+    command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 ~ /^bgp[01]?$/' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"  # noqa: E501
 
     try:
         stdout = subprocess.check_output(command, shell=True, text=True, timeout=COMMAND_TIMEOUT)


### PR DESCRIPTION
Fixes #3976 

#### What I did
Addressed a bug where the `show ip bgp summary` command was missing from the CLI, particularly in multi-ASIC SONiC deployments. The fix ensures the `get_routing_stack()` function correctly identifies BGP containers, enabling proper CLI chain updates.

#### How I did it
Modified the `get_routing_stack()` function in `clear/main.py` and `show/main.py`. The `awk` command used to identify the BGP container image name was updated from an exact string match (`$2 == "bgp"`) to a regular expression match (`$2 ~ /^bgp[01]?$/`). This new regex correctly matches BGP container names across single-ASIC (`bgp`) and multi-ASIC (`bgp0`, `bgp1`).

#### How to verify it
1.  **Reproduce original issue:**
    * Deploy a SONiC image on a multi-ASIC platform (e.g., disaggregated T2 topology).
    * Verify that `show ip bgp summary` command is not found.
    * Verify that `show ip -?` does not list `bgp` as a subcommand.
2.  **Apply this fix.**
3.  **Verify the fix:**
    * Reboot the device or reload relevant services.
    * Execute `show ip bgp summary` and confirm the command is now available and displays BGP summary information.
    * Execute `show ip -?` and confirm `bgp` is now listed as a subcommand.