### PR TITLE
[202411] fix show bgp cli on multiple asic device

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -82,7 +82,7 @@ def get_routing_stack():
     result = 'frr'
 
     cmd0 = ["sudo", "docker", "ps", "--format", "{{.Image}}\t{{.Names}}"]
-    cmd1 = ["awk", '$2 == "bgp"']
+    cmd1 = ["awk", '$2 ~ /^bgp([0-9]+)?$/']
     cmd2 = ["cut", "-d-", "-f3"]
     cmd3 = ["cut", "-d:", "-f1"]
     cmd4 = ["head", "-n", "1"]

--- a/show/main.py
+++ b/show/main.py
@@ -86,7 +86,7 @@ COMMAND_TIMEOUT = 300
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'
-    command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 ~ /^bgp([0-9]+)?$/' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1" # noqa: E501
+    command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 ~ /^bgp([0-9]+)?$/' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"  # noqa: E501
 
     try:
         stdout = subprocess.check_output(command, shell=True, text=True, timeout=COMMAND_TIMEOUT)

--- a/show/main.py
+++ b/show/main.py
@@ -86,7 +86,7 @@ COMMAND_TIMEOUT = 300
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'
-    command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 == \"bgp\"' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"  # noqa: E501
+    command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 ~ /^bgp([0-9]+)?$/' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1" # noqa: E501
 
     try:
         stdout = subprocess.check_output(command, shell=True, text=True, timeout=COMMAND_TIMEOUT)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The PR https://github.com/sonic-net/sonic-utilities/pull/3960 check the docker container's name.
Check the docker's name whether is exactly same with "bgp"
However, on multiple asic devices, there are several bgp containers, and named bgp0, bgp1 ....

#### How I did it
Modified the cmd to handle the multiple asic with several bgp containers.

#### How to verify it
Verified on multiple devices:
```
admin@strtk5-8800-lc1-1:~$ docker ps -a | grep bgp
8ff934f85dfb   docker-fpm-frr:latest             "/usr/bin/docker_iniâ€¦"   40 hours ago   Up 19 hours             bgp1
5702ae6e60c2   docker-fpm-frr:latest             "/usr/bin/docker_iniâ€¦"   40 hours ago   Up 19 hours             bgp0
e059d9688b25   docker-fpm-frr:latest             "/usr/bin/docker_iniâ€¦"   40 hours ago   Up 19 hours             bgp2
admin@strtk5-8800-lc1-1:~$ 
admin@strtk5-8800-lc1-1:~$ python
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> COMMAND_TIMEOUT = 300
>>> command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 ~ /^bgp([0-9]+)?$/' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"
>>> stdout = subprocess.check_output(command, shell=True, text=True, timeout=COMMAND_TIMEOUT)
>>> result = stdout.rstrip('\n')
>>> print(resutl)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'resutl' is not defined. Did you mean: 'result'?
>>> print(result)
frr
>>> 
admin@strtk5-8800-lc1-1:~$ 
admin@strtk5-8800-lc1-1:~$ python
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sonic_py_common.general import getstatusoutput_noshell_pipe
>>> cmd0 = ["sudo", "docker", "ps", "--format", "{{.Image}}\t{{.Names}}"]
>>> cmd1 = ["awk", '$2 ~ /^bgp([0-9]+)?$/']
>>> cmd2 = ["cut", "-d-", "-f3"]
>>> cmd3 = ["cut", "-d:", "-f1"]
>>> cmd4 = ["head", "-n", "1"]
>>> _, result = getstatusoutput_noshell_pipe(cmd0, cmd1, cmd2, cmd3, cmd4)
>>> print(result)
frr
>>> 
```

None multiple asic device
```
admin@bjw-can-2700-4:~$ docker ps -a | grep bgp
68cb4c153e7d   docker-fpm-frr:latest             "/usr/bin/docker_ini…"   18 hours ago   Up 2 hours              bgp
admin@bjw-can-2700-4:~$ 
admin@bjw-can-2700-4:~$ python
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> COMMAND_TIMEOUT = 300
>>> command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 ~ /^bgp([0-9]+)?$/' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"
>>> stdout = subprocess.check_output(command, shell=True, text=True, timeout=COMMAND_TIMEOUT)
>>> result = stdout.rstrip('\n')
>>> print(result)
frr
>>> 
>>> from sonic_py_common.general import getstatusoutput_noshell_pipe
>>> cmd0 = ["sudo", "docker", "ps", "--format", "{{.Image}}\t{{.Names}}"]
>>> cmd1 = ["awk", '$2 ~ /^bgp([0-9]+)?$/']
>>> cmd2 = ["cut", "-d-", "-f3"]
>>> cmd3 = ["cut", "-d:", "-f1"]
>>> cmd4 = ["head", "-n", "1"]
>>> _, result = getstatusoutput_noshell_pipe(cmd0, cmd1, cmd2, cmd3, cmd4)
>>> print(result)
frr
>>> 
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

