### PR TITLE
Secureboot: Image signing verification enhancements

### DIFF
--- a/scripts/verify_image_sign_common.sh
+++ b/scripts/verify_image_sign_common.sh
@@ -15,35 +15,27 @@ verify_image_sign_common() {
         no_check_time="-noattr"
     fi
     
-    # This command verifies the signing as a complete certificate chain root of trust and requires the DB Key to
-    # be a self-signed root, but the image signed with an intermediate embedded into the certificate.
     EFI_CERTS_DIR=/tmp/efi_certs
     RESULT="CMS Verification Failure"
-    LOG=$(openssl cms -verify $no_check_time -noout -CAfile $EFI_CERTS_DIR/cert.pem -binary -in ${CMS_SIG_FILE} -content ${DATA_FILE} -inform pem 2>&1 > /dev/null )
-    VALIDATION_RES=$?
-    if [ $VALIDATION_RES -eq 0 ]; then
-        RESULT="CMS Verified OK"
-        if  [ -d "${TMP_DIR}" ]; then rm -rf ${TMP_DIR}; fi
-        echo "verification ok:$RESULT"
-        # No need to continue.
-        # Exit without error if any success signature verification.
-        return 0
-    fi
 
-    # This is a backup signature verification method which does NOT trust the certificate embedded into the pkcs7
-    # signature (via the -nointern flag) and assumes the DB key directly signed the image (via the -certfile flag).
-    # Since the DB key is trusted, it doesn't need to be a root CA so we turn off root CA verification with the
-    # -noverify flag.
-    LOG=$(openssl cms -verify $no_check_time -noout -certfile $EFI_CERTS_DIR/cert.pem -binary -nointern -noverify -in ${CMS_SIG_FILE} -content ${DATA_FILE} -inform pem 2>&1 > /dev/null )
-    VALIDATION_RES=$?
-    if [ $VALIDATION_RES -eq 0 ]; then
-        RESULT="CMS Verified OK"
-        if  [ -d "${TMP_DIR}" ]; then rm -rf ${TMP_DIR}; fi
-        echo "verification ok:$RESULT"
-        # No need to continue.
-        # Exit without error if any success signature verification.
-        return 0
-    fi
+    # Verify the signature in two ways:
+    # 1. As a complete certificate chain root of trust which requires the DB Key to be a self-signed root, but the image
+    #    signed with an intermediate embedded into the certificate.
+    # 2. Assuming the DB key directly signed the image without trusting the certificate embedded into the
+    #    pkcs7 signature (-nointern). Since the DB key is trusted, it doesn't need to be a root CA so we turn off root
+    #    CA verification with the -noverify flag.
+    for variant in "-CAfile" "-nointern -noverify -certfile"; do
+        LOG=$(openssl cms -verify $no_check_time -noout ${variant} $EFI_CERTS_DIR/cert.pem -binary -in ${CMS_SIG_FILE} -content ${DATA_FILE} -inform pem 2>&1 > /dev/null )
+        VALIDATION_RES=$?
+        if [ $VALIDATION_RES -eq 0 ]; then
+            RESULT="CMS Verified OK"
+            if  [ -d "${TMP_DIR}" ]; then rm -rf ${TMP_DIR}; fi
+            echo "verification ok:$RESULT"
+            # No need to continue.
+            # Exit without error if any success signature verification.
+            return 0
+        fi
+    done
 
     if  [ -d "${TMP_DIR}" ]; then rm -rf ${TMP_DIR}; fi
     return 1


### PR DESCRIPTION
#### What I did

The current signature verification of sonic images assumes the DB Keys are all Root CAs.  The secureboot standard says nothing about this, the DBKeys are explicitly trusted by signing them with the KEK, and that signing method does not follow the standard X.509 PKI architecture.  Therefore the DB Key is not guaranteed to be a CA Root (aka not self-signed).  It is possible the DB Key was created as an intermediate, but since it is explicitly trusted that is ok.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/23406

#### How I did it

This adds this explicit trust of the DB Key as a secondary signing verification if the original verification fails.  It disables looking inside the pkcs7 container for any keys at all and assumes the key specified is the exact key for the signature.

#### How to verify it

Build secureboot image signed with a DB Key that is not self-signed, then run through the sonic-installer install with that image and see the verification succeeds.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

