### PR TITLE
`vnet_route_check.py` should not report VNET routes in APP DB but not in STATE DB and ASIC DB as mismatches

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -50,7 +50,7 @@ RC_OK = 0
 RC_ERR = -1
 default_vrf_oid = ""
 
-report_level = syslog.LOG_ERR
+report_level = syslog.LOG_WARNING
 write_to_syslog = True
 
 
@@ -374,7 +374,7 @@ def filter_active_vnet_routes(vnet_routes: dict):
             exists, fvs = vnet_route_tunnel_table.get(key)
             if not exists:
                 print_message(syslog.LOG_WARNING, f"VNET_ROUTE_TUNNEL_TABLE|{key} does not exist in STATE DB.")
-                active_routes.append(prefix)  # Treating "prefix" as an active route
+                # Treating "prefix" as an inactive route
                 continue
             fvs_dict = dict(fvs)
             if fvs_dict.get("state") == "active":

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -567,7 +567,6 @@ test_data = {
     "12": {
         DESCR: "An IPv6 VNET route that is missing in STATE DB and ASIC DB",
         ARGS: "vnet_route_check",
-        RET: -1,
         PRE: {
             APPL_DB: {
                 VXLAN_TUNNEL_TABLE: {
@@ -592,17 +591,6 @@ test_data = {
                 }
             }
         },
-        RESULT: {
-            "results": {
-                "missed_in_asic_db_routes": {
-                    "Vnet_v6": {
-                        "routes": [
-                            "fd01:fc00::1/128"
-                        ]
-                    }
-                }
-            }
-        }
     },
     "13": {
         DESCR: "A VNET route is missing in STATE DB and another inactive route is missing in ASIC DB",
@@ -641,6 +629,34 @@ test_data = {
                 }
             }
         }
+    },
+    "14": {
+        DESCR: "An IPv4 VNET route that is missing in STATE DB and ASIC DB",
+        ARGS: "vnet_route_check",
+        PRE: {
+            APPL_DB: {
+                VXLAN_TUNNEL_TABLE: {
+                    "tunnel_v4": {"src_ip": "10.1.0.32"}
+                },
+                VNET_TABLE: {
+                    "Vnet_v4": [("vxlan_tunnel", "tunnel_v4"), ("scope", "default"), ("vni", "10002"),
+                                ("peer_list", "")]
+                },
+                VNET_ROUTE_TABLE: {
+                    "Vnet_v4_in_v4-0:150.62.191.1/32": {"endpoint": "100.251.7.1,100.251.7.2"}
+                }
+            },
+            ASIC_DB: {
+                ASIC_STATE: {
+                    "SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x6000000000d76": {
+                        "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": "oid:0x3000000000d4b"
+                    },
+                    "SAI_OBJECT_TYPE_VIRTUAL_ROUTER": {
+                         "oid:0x3000000000d4b": {"": ""}
+                    },
+                }
+            }
+        },
     }
 }
 

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -639,8 +639,8 @@ test_data = {
                     "tunnel_v4": {"src_ip": "10.1.0.32"}
                 },
                 VNET_TABLE: {
-                    "Vnet_v4": [("vxlan_tunnel", "tunnel_v4"), ("scope", "default"), ("vni", "10002"),
-                                ("peer_list", "")]
+                    "Vnet_v4_in_v4-0": [("vxlan_tunnel", "tunnel_v4"), ("scope", "default"), ("vni", "10002"),
+                                        ("peer_list", "")]
                 },
                 VNET_ROUTE_TABLE: {
                     "Vnet_v4_in_v4-0:150.62.191.1/32": {"endpoint": "100.251.7.1,100.251.7.2"}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Changed `vnet_route_check.py` so that when a VNET route is missing in STATE DB, then it is treated as an inactive route. This means that when the script is called without `-a` and `--all` options, if a route in APP DB is missing in both STATE DB and ASIC DB, it will not be reported as a mismatch.

#### How I did it
1. Changed the logic in `vnet_route_check.py`.
2. Added a new test and modified an existing test in `vnet_route_check_test.py` to verify the desired behavior.

#### How to verify it
Run the tests in `vnet_route_check_test.py`.

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A

