### PR TITLE
Teamd serviceability - CLI command for dumping detailed portchannel info and clearing portchannel statistics

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -13,6 +13,8 @@ from show.plugins.pbh import read_pbh_counters
 from config.plugins.pbh import serialize_pbh_counters
 from . import plugins
 from . import stp
+from . import portchannel
+
 # This is from the aliases example:
 # https://github.com/pallets/click/blob/57c6f09611fc47ca80db0bd010f05998b3c0aa95/examples/aliases/aliases.py
 class Config(object):
@@ -148,6 +150,10 @@ def ipv6():
 # 'STP'
 #
 cli.add_command(stp.spanning_tree)
+
+# 'portchannel'
+#
+cli.add_command(portchannel.portchannel)
 
 #
 # Inserting BGP functionality into cli's clear parse-chain.

--- a/clear/portchannel.py
+++ b/clear/portchannel.py
@@ -1,0 +1,70 @@
+import click
+import utilities_common.cli as clicommon
+from natsort import natsorted
+from swsscommon.swsscommon import SonicV2Connector
+
+
+def check_portchannel_name_member_port_exists(portchannel_name, port_name):
+    db = SonicV2Connector(host='127.0.0.1')
+    db.connect(db.STATE_DB)
+    KEY = 'LAG_TABLE|' + portchannel_name
+    if not db.exists(db.STATE_DB, KEY):
+        return False
+    if port_name:
+        MKEY = 'LAG_MEMBER_TABLE|' + portchannel_name + '|' + port_name
+        if not db.exists(db.STATE_DB, MKEY):
+            return False
+    return True
+
+
+@click.group()
+def portchannel():
+    """Clear portchannel lacp stats counters"""
+    pass
+
+
+@click.command('statistics')
+@click.argument('portchannel_name', metavar='<portchannel_name>', required=False)
+@click.argument('port_name', metavar='<port_name>', required=False)
+def statistics(portchannel_name, port_name):
+    """clearing statistics"""
+    if portchannel_name and port_name is None:
+        valid = check_portchannel_name_member_port_exists(portchannel_name, None)
+        if not valid:
+            click.echo("No such portchannel interface : {}". format(portchannel_name))
+            return
+        command = 'sudo teamdctl ' + portchannel_name + ' clear statistics'
+        try:
+            clicommon.run_command(command, shell=True)
+            click.echo("Cleared stats counter for LAG : {}". format(portchannel_name))
+        except Exception as e:
+            click.echo("Warning: Could not clear stats for {} {}". format(portchannel_name, str(e)))
+    elif portchannel_name and port_name:
+        valid = check_portchannel_name_member_port_exists(portchannel_name, port_name)
+        if not valid:
+            click.echo(f"No such portchannel or portchannel member interface : {portchannel_name} {port_name}")
+            return
+        command = 'sudo teamdctl ' + portchannel_name + ' clear statistics port ' + port_name
+        try:
+            clicommon.run_command(command, shell=True)
+            click.echo("Cleared stats counter for LAG : {} LAG_MEMBER : {}". format(portchannel_name, port_name))
+        except Exception as e:
+            click.echo("Warning: Could not clear stats for {} {} {}". format(portchannel_name, port_name, str(e)))
+    elif portchannel_name is None and port_name is None:
+        db = SonicV2Connector(host='127.0.0.1')
+        db.connect(db.STATE_DB)
+        lag_keys = db.keys(db.STATE_DB, 'LAG_TABLE|*')
+        cleared = True
+        for lag_key in natsorted(lag_keys):
+            lag_name = lag_key.split('|')[-1]
+            command = 'sudo teamdctl ' + lag_name + ' clear statistics'
+            try:
+                clicommon.run_command(command, shell=True)
+            except Exception as e:
+                cleared = False
+                click.echo("Warning: Could not clear stats for {} {}". format(lag_name, str(e)))
+        if cleared:
+            click.echo("Cleared stats counter for all LAGs")
+
+
+portchannel.add_command(statistics)

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2274,6 +2274,8 @@ main() {
     save_cmd "show spanning-tree bpdu_guard" "stp.bg"
     save_cmd "show spanning-tree root_guard" "stp.rg"
 
+    save_cmd "show interfaces portchannel info" "portchannel.log"
+
     save_cmd "ps aux" "ps.aux" &
     save_cmd "top -b -n 1" "top" &
     save_cmd "free" "free" &

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1105,7 +1105,16 @@
         "runner.aggregator.selected": "false",
         "runner.aggregator.id": "0",
         "link.up": "false",
-        "ifinfo.ifindex": "98"
+        "ifinfo.ifindex": "98",
+        "runner.statistics.lacpdu_illegal_pkts": "0",
+        "runner.statistics.lacpdu_rx_stats": "0",
+        "runner.actor_lacpdu_info.key": "11",
+        "runner.statistics.lacpdu_tx_stats": "1103",
+        "runner.actor_lacpdu_info.state": "69",
+        "runner.partner_lacpdu_info.key": "0",
+        "runner.partner_lacpdu_info.state": "2",
+        "runner.statistics.last_lacpdu_tx_time": "2025-06-26T07:54:23.926776098Z",
+        "runner.statistics.last_lacpdu_rx_time": "N/A"
     },
     "LAG_MEMBER_TABLE|PortChannel0002|Ethernet116": {
         "runner.actor_lacpdu_info.state": "61",
@@ -1121,7 +1130,16 @@
         "runner.aggregator.selected": "true",
         "runner.aggregator.id": "97",
         "link.up": "true",
-        "ifinfo.ifindex": "97"
+        "ifinfo.ifindex": "97",
+        "runner.statistics.lacpdu_illegal_pkts": "0",
+        "runner.statistics.lacpdu_rx_stats": "1003",
+        "runner.actor_lacpdu_info.key": "12",
+        "runner.statistics.lacpdu_tx_stats": "1103",
+        "runner.actor_lacpdu_info.state": "61",
+        "runner.partner_lacpdu_info.key": "13",
+        "runner.partner_lacpdu_info.state": "61",
+        "runner.statistics.last_lacpdu_tx_time": "2025-06-26T07:54:23.926776098Z",
+        "runner.statistics.last_lacpdu_rx_time": "2025-06-26T07:54:23.926776098Z"
     },
     "LAG_MEMBER_TABLE|PortChannel0003|Ethernet120": {
         "runner.actor_lacpdu_info.state": "61",
@@ -1137,7 +1155,16 @@
         "runner.aggregator.selected": "true",
         "runner.aggregator.id": "100",
         "link.up": "true",
-        "ifinfo.ifindex": "100"
+        "ifinfo.ifindex": "100",
+        "runner.statistics.lacpdu_illegal_pkts": "0",
+        "runner.statistics.lacpdu_rx_stats": "1003",
+        "runner.actor_lacpdu_info.key": "13",
+        "runner.statistics.lacpdu_tx_stats": "1103",
+        "runner.actor_lacpdu_info.state": "61",
+        "runner.partner_lacpdu_info.key": "12",
+        "runner.partner_lacpdu_info.state": "61",
+        "runner.statistics.last_lacpdu_tx_time": "2025-06-26T07:54:23.926776098Z",
+        "runner.statistics.last_lacpdu_rx_time": "2025-06-26T07:54:23.926776098Z"
     },
     "LAG_TABLE|PortChannel0001": {
         "runner.fallback": "false",
@@ -1147,7 +1174,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "LAG_TABLE|PortChannel0002": {
         "runner.fallback": "false",
@@ -1157,7 +1189,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "LAG_TABLE|PortChannel0003": {
         "runner.fallback": "false",
@@ -1167,7 +1204,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "LAG_TABLE|PortChannel0004": {
         "runner.fallback": "false",
@@ -1177,7 +1219,12 @@
         "state": "ok",
         "runner.fast_rate": "false",
         "setup.kernel_team_mode_name": "loadbalance",
-        "runner.active": "true"
+        "runner.active": "true",
+        "runner.retry_count": "3",
+        "runner.min_ports": "1",
+        "runner.enable_retry_count_feature": "true",
+        "mtu": "9100",
+        "runner.sys_prio": "65535"
     },
     "FAN_INFO|fan1": {
         "drawer_name": "drawer1",

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -1,4 +1,5 @@
 import os
+import re
 import pytest
 import subprocess
 import traceback
@@ -10,8 +11,74 @@ from jsonpatch import JsonPatchConflict
 import config.main as config
 import config.validated_config_db_connector as validated_config_db_connector
 import show.main as show
+import clear.main as clear
 from utilities_common.db import Db
 from mock import patch
+
+EXPECTED_SHOW_LACP_INFO_PORTCHANNEL_WITH_NO_MEMBERS_OUTPUT = """\
+--------------------------------------------------------------------------
+LAG: PortChannel0004 is up, mode LACP
+Minimum number of links to bring PortChannel up is 1
+address is 52:54:00:f2:e1:23
+Fallback: Disabled
+Fast_rate: Disabled
+Retry_count_feature: Enabled
+Retry_count: 3
+MTU: 9100
+LACP: mode ACTIVE, priority 65535, address 52:54:00:f2:e1:23
+LAG MEMBER: None
+--------------------------------------------------------------------------
+"""
+
+EXPECTED_SHOW_LACP_INFO_PORTCHANNEL_WITH_DESELECTED_MEMBER_OUTPUT = """\
+--------------------------------------------------------------------------
+LAG: PortChannel0001 is down, mode LACP
+Minimum number of links to bring PortChannel up is 1
+address is 52:54:00:f2:e1:23
+Fallback: Disabled
+Fast_rate: Disabled
+Retry_count_feature: Enabled
+Retry_count: 3
+MTU: 9100
+LACP: mode ACTIVE, priority 65535, address 52:54:00:f2:e1:23
+LAG MEMBER: Ethernet112(deselected)
+    LACP Actor: port 113, address 52:54:00:f2:e1:23, key 11
+    LACP Actor State: (Act, Agg, Def)
+    LACP Partner: port 0, address 00:00:00:00:00:00, key 0
+    LACP Partner State: (Tmo)
+    Statistics:
+        lacpdu_illegal_pkts: 0
+        lacpdu_rx_stats: 0
+        lacpdu_tx_stats: 1103
+        last rx lacpdu at: N/A
+        last tx lacpdu at: 2025-06-26T07:54:23.926776098Z
+--------------------------------------------------------------------------
+"""
+
+EXPECTED_SHOW_LACP_INFO_PORTCHANNEL_WITH_SELECTED_MEMBER_OUTPUT = """\
+--------------------------------------------------------------------------
+LAG: PortChannel0002 is up, mode LACP
+Minimum number of links to bring PortChannel up is 1
+address is 52:54:00:f2:e1:23
+Fallback: Disabled
+Fast_rate: Disabled
+Retry_count_feature: Enabled
+Retry_count: 3
+MTU: 9100
+LACP: mode ACTIVE, priority 65535, address 52:54:00:f2:e1:23
+LAG MEMBER: Ethernet116(selected)
+    LACP Actor: port 117, address 52:54:00:f2:e1:23, key 12
+    LACP Actor State: (Act, Agg, Sync, Coll, Dist)
+    LACP Partner: port 1, address 1e:af:77:fc:79:ee, key 13
+    LACP Partner State: (Act, Agg, Sync, Coll, Dist)
+    Statistics:
+        lacpdu_illegal_pkts: 0
+        lacpdu_rx_stats: 1003
+        lacpdu_tx_stats: 1103
+        last rx lacpdu at: 2025-06-26T07:54:23.926776098Z
+        last tx lacpdu at: 2025-06-26T07:54:23.926776098Z
+--------------------------------------------------------------------------
+"""
 
 class TestPortChannel(object):
 
@@ -450,6 +517,102 @@ class TestPortChannel(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == ""
+
+    def test_show_interfaces_portchannel_info_portchannel_with_no_members(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(show.cli.commands["interfaces"].commands["portchannel"].commands["info"],
+                               ["PortChannel0004"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert (re.sub(r'\s+', ' ', result.output.strip())) == (re.sub(
+                r'\s+', ' ', EXPECTED_SHOW_LACP_INFO_PORTCHANNEL_WITH_NO_MEMBERS_OUTPUT.strip()))
+
+    def test_show_interfaces_portchannel_info_portchannel_with_deselected_member(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(show.cli.commands["interfaces"].commands["portchannel"].commands["info"],
+                               ["PortChannel0001"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert (re.sub(r'\s+', ' ', result.output.strip())) == (re.sub(
+                r'\s+', ' ', EXPECTED_SHOW_LACP_INFO_PORTCHANNEL_WITH_DESELECTED_MEMBER_OUTPUT.strip()))
+
+    def test_show_interfaces_portchannel_info_portchannel_with_selected_member(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(show.cli.commands["interfaces"].commands["portchannel"].commands["info"],
+                               ["PortChannel0002"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert (re.sub(r'\s+', ' ', result.output.strip())) == (re.sub(
+                r'\s+', ' ', EXPECTED_SHOW_LACP_INFO_PORTCHANNEL_WITH_SELECTED_MEMBER_OUTPUT.strip()))
+
+    def test_show_interfaces_portchannel_info_portchannel_non_exists(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(show.cli.commands["interfaces"].commands["portchannel"].commands["info"],
+                               ["PortChannel107"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "No such PortChannel interface" in result.output
+
+    def test_show_interfaces_portchannel_info(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(show.cli.commands["interfaces"].commands["portchannel"].commands["info"],
+                               [], obj=db, catch_exceptions=False)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+    @patch('clear.portchannel.clicommon.run_command')
+    def test_clear_portchannel_statistics(self, run_command):
+        runner = CliRunner()
+        db = Db()
+        # Clearing stats for all LAGs
+        result = runner.invoke(clear.cli.commands['portchannel'].commands['statistics'], obj=db, catch_exceptions=False)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        # Clearing stats for specific PortChannel - Exists
+        result = runner.invoke(clear.cli.commands['portchannel'].commands['statistics'], ['PortChannel0001'], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        run_command.assert_called_with('sudo teamdctl PortChannel0001 clear statistics', shell=True)
+        run_command.reset_mock()
+
+        # Clearing stats for specific PortChannel member - Exists
+        result = runner.invoke(clear.cli.commands['portchannel'].commands['statistics'],
+                               ['PortChannel0001', 'Ethernet112'], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        run_command.assert_called_with('sudo teamdctl PortChannel0001 clear statistics port Ethernet112', shell=True)
+        run_command.reset_mock()
+
+        # Clearing stats for specific PortChannel - Not Exists
+        result = runner.invoke(clear.cli.commands['portchannel'].commands['statistics'], ['PortChannel107'], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        if "No such portchannel interface" in result.output:
+            assert not run_command.called, "run_command should not be called when PortChannel is missing"
+
+        # Clearing stats for specific PortChannel member - Not Exists
+        result = runner.invoke(clear.cli.commands['portchannel'].commands['statistics'],
+                               ['PortChannel0001', 'Ethernet4'], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        if "No such portchannel or portchannel member interface" in result.output:
+            assert not run_command.called, "run_command should not be called when PortChannel is missing"
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
Teamd Serviceability -

CLI commands:

show interfaces portchannel info <portchannel_name>

sonic-clear portchannel statistics <portchannel_name> <port_name>

Logs:
[clear_portchannel_statistics_logs.txt](https://github.com/user-attachments/files/21145933/clear_portchannel_statistics_logs.txt)
[show_interfaces_portchannel_info_logs.txt](https://github.com/user-attachments/files/21145934/show_interfaces_portchannel_info_logs.txt)

cli_plugin_tests:
[cli_plugin_tests_logs.txt](https://github.com/user-attachments/files/21145939/cli_plugin_tests_logs.txt)

pre-commit:
sonic-utilities$ pre-commit run flake8 --all-files
flake8...................................................................Passed

tech-support logs:

root@sonic:/home/admin# show techsupport
Lock succesfully accquired and installed signal handlers
mkdir: created directory '/var/dump/sonic_dump_sonic_20250709_145215'
cat
}; show spanning-tree bpdu_guard | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20250709_145215/dump/stp.bg'"
timeout --foreground 5m bash -c "dummy_cleanup_method ()
{
cat
}; show spanning-tree root_guard | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20250709_145215/dump/stp.rg'"
timeout --foreground 5m bash -c "dummy_cleanup_method ()
{
cat
}; show interfaces portchannel info | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20250709_145215/dump/portchannel.log'"
timeout --foreground 5m bash -c "dummy_cleanup_method ()
{
cat
}; free | dummy_cleanup_method &> '/var/dump/sonic_dump_sonic_20250709_145215/dump/free'"
timeout --foreground 5m bash -c "dummy_cleanup_method ()
/var/dump/sonic_dump_sonic_20250709_145215.tar.gz
root@sonic:/home/admin#

root@sonic:/home/admin# tar -xzvf sonic_dump_sonic_20250709_145215.tar.gz sonic_dump_sonic_20250709_145215/dump/portchannel.log
sonic_dump_sonic_20250709_145215/dump/portchannel.log
root@sonic:/home/admin# ls
lacp.py port.pcap sonic_dump_sonic_20250709_145215 stpctl stpmgrd
packet.py pvst.pcap sonic_dump_sonic_20250709_145215.tar.gz stpd 
root@sonic:/home/admin# cd sonic_dump_sonic_20250709_145215/dump/
root@sonic:/home/admin/sonic_dump_sonic_20250709_145215/dump# ls
portchannel.log
root@sonic:/home/admin/sonic_dump_sonic_20250709_145215/dump#
root@sonic:/home/admin/sonic_dump_sonic_20250709_145215/dump# vim [portchannel.log](https://github.com/user-attachments/files/21145967/portchannel.log)

portchannel.log

Test_coverage_log:

admin@sonic:/serviceability/without_unified/sonic-utilities$ diff-cover coverage.xml --compare-branch HEAD~1

............................................
Diff Coverage
Diff: HEAD~1...HEAD, staged and unstaged changes
.............................................
clear/main.py (100%)
clear/portchannel.py (86.7%): Missing lines 23,40-41,51-52,63-65
show/interfaces/portchannel.py (93.1%): Missing lines 167-170
............................................
Total: 120 lines
Missing: 12 lines
Coverage: 90%
............................................