### PR TITLE
[fast-reboot] Remove teamsyncd timer override by fast-boot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -692,7 +692,6 @@ case "$REBOOT_TYPE" in
         BOOT_TYPE_ARG=$REBOOT_TYPE
         trap clear_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
         sonic-db-cli STATE_DB HSET "FAST_RESTART_ENABLE_TABLE|system" "enable" "true" &>/dev/null
-        config warm_restart teamsyncd_timer 1
         config warm_restart enable system
         ;;
     "warm-reboot")


### PR DESCRIPTION
Timer override to 1 sec was used to speed up kernel IP configuration on PortChannel as a W/A.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Remove teamsyncd 1 sec timer override. It was used to speed up kernel IP configuration on PortChannel as a W/A.
Original issue is solved by https://github.com/sonic-net/sonic-swss/pull/3782.

#### How I did it

Remove teamsyncd 1 sec timer override.

#### How to verify it

Ran fast-boot and warm-boot tests.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

