### PR TITLE
restart USB to Ethernet management interface if not RUNNING

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1019,6 +1019,157 @@ def wait_service_restart_finish(service, last_timestamp, timeout=30):
     log.log_warning("Service: {} does not restart in {} seconds, stop waiting".format(service, timeout))
 
 
+def _iface_vrf(iface: str) -> str | None:
+    try:
+        out = subprocess.check_output(["ip", "-o", "link", "show", "dev", iface], text=True)
+        m = re.search(r"master\s+(\S+)", out)
+        return m.group(1) if m else None
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _capture_default_routes(iface: str):
+    vrf = _iface_vrf(iface)
+    scope = ["vrf", vrf] if vrf else []
+    routes = []
+    for fam in (["-4"], ["-6"]):
+        try:
+            out = subprocess.check_output(["ip", *fam, "route", "show", *scope, "default", "dev", iface], text=True)
+        except subprocess.CalledProcessError:
+            continue
+        for line in out.splitlines():
+            # Example: "default via 192.0.2.1 dev eth0 metric 102"
+            m = re.search(r"^default(?:\s+via\s+(\S+))?.*?dev\s+\S+(?:.*?\smetric\s+(\d+))?", line)
+            if m:
+                routes.append({"fam": fam[0], "vrf": vrf, "gw": m.group(1), "metric": m.group(2)})
+    return routes
+
+
+def _restore_default_routes(iface: str, routes):
+    for r in routes:
+        fam = r["fam"]
+        vrf = r["vrf"]
+        cmd = ["ip", fam, "route", "replace"]
+        if vrf:
+            cmd += ["vrf", vrf]
+        cmd += ["default"]
+        if r["gw"]:
+            cmd += ["via", r["gw"]]
+        cmd += ["dev", iface]
+        if r["metric"]:
+            cmd += ["metric", r["metric"]]
+        subprocess.run([str(x) for x in cmd if x], check=False)
+
+
+def get_mgmt_interface():
+    """
+    Parse /etc/sonic/config_db.json to find the management interface name (e.g., eth0).
+    """
+    try:
+        with open('/etc/sonic/config_db.json') as f:
+            config = json.load(f)
+        mgmt_entries = config.get("MGMT_INTERFACE", {})
+        if not mgmt_entries:
+            return None
+        # Example key: "eth0|10.3.141.10/24"
+        return list(mgmt_entries.keys())[0].split('|')[0]
+    except Exception:
+        # Valid - no mgmt interface in config_db.json
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        return None
+
+
+def reset_mgmt_interface_if_usb_not_running():
+    """
+    If the management interface is a USB device and not RUNNING,
+    bring it down and up with delay to trigger renegotiation.
+    """
+    iface = get_mgmt_interface()
+    if not iface:
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        time.sleep(0.001)
+        return
+    if 'usb' not in os.path.realpath(f"/sys/class/net/{iface}/device"):
+        return
+    try:
+        with open(f"/sys/class/net/{iface}/operstate") as f:
+            operstate = f.read().strip()
+        if operstate == "up":
+            return  # Already RUNNING
+    except Exception:
+        pass  # Continue to attempt reset
+
+    click.echo("Reset USB-based mgmt interface for re-negotiation")
+    # Flap admin state but preserve default routes
+    saved = _capture_default_routes(iface)
+
+    subprocess.run(["ip", "link", "set", iface, "down"], check=True)
+    time.sleep(1.0)
+    subprocess.run(["ip", "link", "set", iface, "up"], check=True)
+    # Continue anyway
+    # Give carrier a moment, then restore default routes if needed
+    time.sleep(1)
+    _restore_default_routes(iface, saved)
+
+
 def _restart_services():
     last_interface_config_timestamp = get_service_finish_timestamp('interfaces-config')
     last_networking_timestamp = get_service_finish_timestamp('networking')
@@ -1042,6 +1193,8 @@ def _restart_services():
     # Reload Monit configuration to pick up new hostname in case it changed
     click.echo("Reloading Monit configuration ...")
     clicommon.run_command(['sudo', 'monit', 'reload'])
+
+    reset_mgmt_interface_if_usb_not_running()
 
 def _per_namespace_swss_ready(service_name):
     out, _ = clicommon.run_command(['systemctl', 'show', str(service_name), '--property', 'ActiveState', '--value'], return_cmd=True)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -11,6 +11,8 @@ import sys
 import unittest
 import ipaddress
 
+import config.main as cfg
+
 from datetime import timezone
 from unittest import mock
 from jsonpatch import JsonPatchConflict
@@ -388,6 +390,25 @@ def mock_run_command_side_effect_disabled_timer(*args, **kwargs):
             return '0', 0
         else:
             return '', 0
+
+
+def test__VRF():
+    cfg._iface_vrf("eth0")
+    cfg._iface_vrf("lo")
+    cfg._iface_vrf("bla")
+
+
+def test__capture_restore_default_routes():
+    routes1 = cfg._capture_default_routes("bla")
+    routes1.append({"fam": [-4], "vrf": 0, "gw": "255.255.255.255", "metric": 1})
+    cfg._restore_default_routes("bla", routes1)
+    routes2 = cfg._capture_default_routes("lo")
+    routes2.append({"fam": [-4], "vrf": 0, "gw": "255.255.255.255", "metric": 1})
+    cfg._restore_default_routes("lo", routes2)
+    routes3 = cfg._capture_default_routes("eth0")
+    routes3.append({"fam": [-4], "vrf": 0, "gw": "255.255.255.255", "metric": 1})
+    cfg._restore_default_routes("eth0", routes3)
+
 
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')


### PR DESCRIPTION
PROBLEM:
Sometimes after "config reload" command the management interface (eth0) connected over ETH-USB device is
  UP/RUNNING on a remote peer side, but
  stays UP/not-running on the local side.
Well-known negotiation problem of ETH-over-USB devices (ASIX).

SOLUTION:
If the management interface is a USB device and is not RUNNING (/sys/class/net/${if}/operstate is not "up") at the end of the "config reload" command
bring it down and up with delay to trigger renegotiation.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
restart USB to Ethernet management interface if not at RUNNING state

#### How I did it
If the management interface is a USB device and is not at RUNNING state at the end of the config reload command, bring it down and up with delay

#### How to verify it
Manual test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

