### PR TITLE
Adding missing xcvr debug CLIs to showtech dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2249,6 +2249,11 @@ main() {
     save_cmd "show interface status -d all" "interface.status" &
     save_cmd "show interface transceiver presence" "interface.xcvrs.presence" &
     save_cmd "show interface transceiver eeprom --dom" "interface.xcvrs.eeprom" &
+    save_cmd "show interface transceiver status" "interface.xcvrs.status" &
+    save_cmd "show interface transceiver info" "interface.xcvrs.info" &
+    save_cmd "show interface transceiver lpmode" "interface.xcvrs.lpmode" &
+    save_cmd "show interface transceiver pm" "interface.xcvrs.pm" &
+    save_cmd "show interface transceiver error-status" "interface.xcvrs.error-status" &
     save_cmd "show ip interface -d all" "ip.interface" &
     save_cmd "sfputil show eeprom-hexdump" "interface.xcvrs.eeprom.raw" &
     wait


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added few xcvr debug CLIs to the showtech dump
#### How I did it
Modified the generate_dump script to include the CLIs
#### How to verify it
Run "show techsupport" and check the generated dump:

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/var/dump/sonic_dump_sonic_20250625_025020/dump# ls -l interface.xcvrs.*
-rw-r--r-- 1 root root 61624 Jun 25 02:51 interface.xcvrs.eeprom
-rw-r--r-- 1 root root 95633 Jun 25 02:51 interface.xcvrs.eeprom.raw
-rw-r--r-- 1 root root   751 Jun 25 02:51 interface.xcvrs.presence
```
#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/var/dump/sonic_dump_sonic_20250625_025020/dump# ls -l interface.xcvrs.*
-rw-r--r-- 1 root root 61624 Jun 25 02:51 interface.xcvrs.eeprom
-rw-r--r-- 1 root root 95633 Jun 25 02:51 interface.xcvrs.eeprom.raw
-rw-r--r-- 1 root root   622 Jun 25 02:51 interface.xcvrs.error-status
-rw-r--r-- 1 root root 33814 Jun 25 02:51 interface.xcvrs.info
-rw-r--r-- 1 root root   600 Jun 25 02:51 interface.xcvrs.lpmode
-rw-r--r-- 1 root root  6668 Jun 25 02:51 interface.xcvrs.pm
-rw-r--r-- 1 root root   751 Jun 25 02:51 interface.xcvrs.presence
-rw-r--r-- 1 root root 61812 Jun 25 02:51 interface.xcvrs.status
```
Time taken by the new CLI dumps: 
[ save_cmd:show interface transceiver status ] : 3244 msec
[ save_cmd:show interface transceiver pm ] : 3270 msec
[ save_cmd:show interface transceiver info ] : 4691 msec
[ save_cmd:show interface transceiver error-status ] : 4884 msec
[ save_cmd:show interface transceiver lpmode ] : 12836 msec

Total added time on a 32 port chassis with 24 optics present: 28925 msec (28.925 seconds)
