### PR TITLE
[nvidia-bluefield] Add CLI for packet-drop and config-record

### DIFF
--- a/config/plugins/nvidia_bluefield.py
+++ b/config/plugins/nvidia_bluefield.py
@@ -81,8 +81,7 @@ def run_nasa_cli(cmd, docker_client):
     # First create a temp file in the container
 
     lines = [cmd + '\n', 'quit\n']
-    content = ''.join(lines).replace("'", "'\"'\"'")  # Escape single quotes
-    command = f"sh -c 'echo -n \"{content}\" > {NASA_CLI_CMD_F}'"
+    command = f"sh -c 'echo -n \"{''.join(lines)}\" > {NASA_CLI_CMD_F}'"
     rc, stdout = run_in_syncd(command, docker_client)
 
     if rc != 0:
@@ -92,7 +91,7 @@ def run_nasa_cli(cmd, docker_client):
     return run_in_syncd(cmd, docker_client)
 
 
-def rotate_dump_files(path, count):
+def rotate_dump_files(path, max_count):
     """Rotate dump files in the given directory
 
     If the number of dump files in the directory is greater than the or equal to the count,
@@ -100,7 +99,7 @@ def rotate_dump_files(path, count):
 
     Args:
         path (str): Directory to rotate dump files. Should be accessible from the host
-        count (int): Number of dump files to keep
+        max_count (int): Max number of dump files to keep
         docker_client (docker.client.DockerClient): Docker client
 
     Returns:
@@ -110,7 +109,7 @@ def rotate_dump_files(path, count):
     syslog.syslog(syslog.LOG_INFO, f"Logrotate: Current size of the directory {path} : {pretty_size(num_bytes)}")
 
     # If number of files exceeds count, delete the oldest ones
-    num_delete = len(fs_stats) - count
+    num_delete = len(fs_stats) - max_count
     while num_delete >= 0:
         stat = fs_stats.pop()
         os.remove(stat[2])

--- a/config/plugins/nvidia_bluefield.py
+++ b/config/plugins/nvidia_bluefield.py
@@ -46,6 +46,7 @@ SAI_KEY_DUMP_STORE_COUNT = 'SAI_DUMP_STORE_AMOUNT'
 CFG_REC_DIR = "config-record"
 PKT_REC_DIR = "packet-drop"
 
+
 def run_in_syncd(cmd, docker_client):
     """Run a command in the syncd container using Docker Python SDK.
 
@@ -152,6 +153,7 @@ def cleanup_dump_files(path_root, count, dir_name):
     Path(path).mkdir(parents=True, exist_ok=True)
     rotate_dump_files(path, count)
 
+
 def parse_nasa_output(output, mode_type):
     """Parse NASA CLI output to determine status and filename"""
     if not output:
@@ -166,7 +168,6 @@ def parse_nasa_output(output, mode_type):
         # Look for filename line (format: "filename: /path/to/file.bin")
         if line.startswith("filename:"):
             filename = line.split(":", 1)[1].strip()
-            enabled = True
             break
 
     return "enabled" if filename else "disabled", filename
@@ -248,7 +249,7 @@ def packet_drop(state):
         click.echo(f"Packet drop recording is already enabled on {filename}")
         sys.exit(0)
     elif status == 'disabled' and state == 'disabled':
-        click.echo(f"Packet drop recording is already disabled")
+        click.echo("Packet drop recording is already disabled")
         sys.exit(0)
 
     if state == 'disabled':
@@ -260,7 +261,7 @@ def packet_drop(state):
     path_root, count = get_location_details(docker_client)
 
     if path_root is None or count is None:
-        click.echo(f"Could not enable packet drop recording, dump directory not configured", err=True)
+        click.echo("Could not enable packet drop recording, dump directory not configured", err=True)
         sys.exit(-1)
 
     cleanup_dump_files(path_root, count, PKT_REC_DIR)
@@ -294,7 +295,7 @@ def config_record(state):
         click.echo(f"Packet drop recording is already enabled on {filename}")
         sys.exit(0)
     elif status == 'disabled' and state == 'disabled':
-        click.echo(f"Packet drop recording is already disabled")
+        click.echo("Packet drop recording is already disabled")
         sys.exit(0)
 
     if state == 'disabled':
@@ -306,7 +307,7 @@ def config_record(state):
     path_root, count = get_location_details(docker_client)
 
     if path_root is None or count is None:
-        click.echo(f"Could not enable config recording, dump directory/count not configured", err=True)
+        click.echo("Could not enable config recording, dump directory/count not configured", err=True)
         sys.exit(-1)
 
     cleanup_dump_files(path_root, count, CFG_REC_DIR)

--- a/config/plugins/nvidia_bluefield.py
+++ b/config/plugins/nvidia_bluefield.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# main.py
+#
+# Specific command-line utility for Nvidia-bluefield platform
+#
+
+try:
+    import click
+    import os
+    import sys
+    import glob
+    from pathlib import Path
+    import datetime
+    import syslog
+    from sonic_py_common import device_info
+    from utilities_common.auto_techsupport_helper import get_stats, pretty_size
+except ImportError as e:
+    raise ImportError("%s - required module not found" % str(e))
+
+SYNCD_CONTAINER_NAME = 'syncd'
+NASA_CLI = '/usr/sbin/cli/nasa_cli.py -u --exit_on_failure'
+NASA_CLI_CMD_F = '/tmp/nasa_cli_cmd.txt'
+CFG_REC_CMD_PREFIX = 'set_sai_debug_mode'
+PKT_REC_CMD_PREFIX = 'set_packet_debug_mode'
+
+SAI_PROFILE_FILE = '/tmp/sai.profile'
+SAI_KEY_DUMP_STORE_PATH = 'SAI_DUMP_STORE_PATH'
+SAI_KEY_DUMP_STORE_COUNT = 'SAI_DUMP_STORE_AMOUNT'
+CFG_REC_DIR = "config-record"
+PKT_REC_DIR = "packet-drop"
+
+def get_sai_profile_value(key, docker_client):
+    """Get value for a given key from /tmp/sai.profile file in syncd container.
+
+    Args:
+        key (str): Key to look up in the profile file
+        docker_client (docker.client.DockerClient): Docker client
+
+    Returns:
+        str: Value for the given key, or None if not found
+    """
+    cmd = f"cat {SAI_PROFILE_FILE}"
+    rc, out = run_in_syncd(cmd, docker_client)
+
+    if rc == 0 and out:
+        for line in out.splitlines():
+            if line.startswith(f"{key}="):
+                return line.split('=', 1)[1]
+    return ""
+
+
+def run_in_syncd(cmd, docker_client):
+    """Run a command in the syncd container using Docker Python SDK.
+
+    Args:
+        cmd (str): Command to run in the container
+        docker_client (docker.client.DockerClient): Docker client
+
+    Returns:
+        tuple: (return_code, stdout)
+    """
+    try:
+        container = docker_client.containers.get(SYNCD_CONTAINER_NAME)
+        exit_code, output = container.exec_run(cmd)
+        return exit_code, output.decode('utf-8')
+    except Exception as e:
+        click.echo(f"Error executing command in syncd container: {str(e)}", err=True)
+        return 1, str(e)
+
+
+def run_nasa_cli(cmd, docker_client):
+    """Run a command in the syncd container using NASA CLI
+
+    Args:
+        cmd (str): Command to run in the container
+            Eg: set_packet_debug_mode on filepath /tmp/nasa_pkt_record.bin
+            Eg: set_sai_debug_mode on filepath /tmp/nasa_cfg_record.bin
+        docker_client (docker.client.DockerClient): Docker client
+
+    Returns:
+        tuple: (return_code, stdout)
+    """
+    # First create a temp file in the container
+
+    lines = [cmd + '\n', 'quit\n']
+    content = ''.join(lines).replace("'", "'\"'\"'")  # Escape single quotes
+    command = f"sh -c 'echo -n \"{content}\" > {NASA_CLI_CMD_F}'"
+    rc, stdout = run_in_syncd(command, docker_client)
+
+    if rc != 0:
+        return rc, stdout
+
+    cmd = f"{NASA_CLI} -l {NASA_CLI_CMD_F}"
+    return run_in_syncd(cmd, docker_client)
+
+
+def rotate_dump_files(path, count, docker_client):
+    """Rotate dump files in the given directory
+
+    If the number of dump files in the directory is greater than the or equal to the count,
+    the oldest file is deleted.
+
+    Args:
+        path (str): Directory to rotate dump files. Should be accessible from the host
+        count (int): Number of dump files to keep
+        docker_client (docker.client.DockerClient): Docker client
+
+    Returns:
+        None
+    """
+    fs_stats, num_bytes = get_stats(os.path.join(path, "*"))
+    syslog.syslog(syslog.LOG_INFO, f"Logrotate: Current size of the directory {path} : {pretty_size(num_bytes)}")
+
+    # If number of files exceeds count, delete the oldest ones
+    num_delete = len(fs_stats) - count
+    while num_delete >= 0:
+        stat = fs_stats.pop()
+        os.remove(stat[2])
+        num_delete -= 1
+        syslog.syslog(syslog.LOG_INFO, f"Logrotate: Deleted {stat[2]}, size: {pretty_size(stat[1])}")
+
+    return
+
+
+def get_location_details(docker_client):
+    """Get the dump details from the sai.profile file
+
+    Args:
+        docker_client (docker.client.DockerClient): Docker client
+
+    Returns:
+        tuple: (path, count)
+    """
+    path_root = get_sai_profile_value(SAI_KEY_DUMP_STORE_PATH, docker_client)
+    count = get_sai_profile_value(SAI_KEY_DUMP_STORE_COUNT, docker_client)
+
+    if not Path(path_root).exists():
+        click.echo(f"Directory {path_root} does not exist", err=True)
+        return (None, None)
+
+    try:
+        count = int(count)
+    except ValueError as e:
+        click.echo(f"Invalid count value: {count}, error: {e}", err=True)
+        return (None, None)
+
+    return path_root, count
+
+def cleanup_dump_files(docker_client, path_root, count, dir_name):
+    """Cleanup dump files in the given directory"""
+    if path_root is None or count is None:
+        return
+    path = os.path.join(path_root, dir_name)
+    Path(path).mkdir(parents=True, exist_ok=True)
+    rotate_dump_files(path, count, docker_client)
+
+@click.group()
+def nvidia_bluefield():
+    """NVIDIA BlueField platform configuration tasks"""
+    pass
+
+
+@nvidia_bluefield.group('sdk')
+def sdk():
+    """SDK related configuration"""
+    pass
+
+
+@sdk.command('packet-drop')
+@click.argument('state', type=click.Choice(['enabled', 'disabled']))
+def packet_drop(state):
+    """Enable or disable packet drop recording"""
+    import docker
+    docker_client = docker.from_env()
+    if state == 'disabled':
+        rc, _ = run_nasa_cli(PKT_REC_CMD_PREFIX, docker_client)
+        if rc == 0:
+            click.echo(f"Packet drop recording {state}.")
+        return rc
+
+    path_root, count = get_location_details(docker_client)
+    cleanup_dump_files(docker_client, path_root, count, PKT_REC_DIR)
+    path = os.path.join(path_root, PKT_REC_DIR)
+
+    # create the bin file under the path path with timestamp
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    bin_path = os.path.join(path, f"pkt_dump_record_{timestamp}.bin")
+    os.mknod(bin_path)
+
+    cmd = f"{PKT_REC_CMD_PREFIX} on filepath {bin_path}"
+    rc, stdout = run_nasa_cli(cmd, docker_client)
+    if rc != 0:
+        click.echo(f"Could not enable packet drop recording: {stdout}", err=True)
+    else:
+        syslog.syslog(syslog.LOG_NOTICE, f"Packet drop recording enabled on {bin_path}")
+        click.echo(f"Packet drop recording {state}.")
+
+    sys.exit(rc)
+
+
+@sdk.command('config-record')
+@click.argument('state', type=click.Choice(['enabled', 'disabled']))
+def config_record(state):
+    """Enable or disable configuration recording"""
+    import docker
+    docker_client = docker.from_env()
+    if state == 'disabled':
+        rc, _ = run_nasa_cli(CFG_REC_CMD_PREFIX, docker_client)
+        if rc == 0:
+            click.echo(f"Config recording {state}.")
+        return rc
+
+    path_root, count = get_location_details(docker_client)
+    cleanup_dump_files(docker_client, path_root, count, CFG_REC_DIR)
+    path = os.path.join(path_root, CFG_REC_DIR)
+
+    # create the bin file under the path path with timestamp
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    bin_path = os.path.join(path, f"cfg_record_{timestamp}.bin")
+    os.mknod(bin_path)
+
+    cmd = f"{CFG_REC_CMD_PREFIX} on filepath {bin_path}"
+    rc, stdout = run_nasa_cli(cmd, docker_client)
+    if rc != 0:
+        click.echo(f"Could not enable config recording: {stdout}", err=True)
+    else:
+        syslog.syslog(syslog.LOG_NOTICE, f"Config recording enabled on {bin_path}")
+        click.echo(f"Config recording {state}.")
+    
+    sys.exit(rc)
+
+
+def register(cli):
+    version_info = device_info.get_sonic_version_info()
+    if (version_info and version_info.get('asic_type') == 'nvidia-bluefield'):
+        cli.commands['platform'].add_command(nvidia_bluefield)

--- a/tests/config_nvidia_bluefield_test.py
+++ b/tests/config_nvidia_bluefield_test.py
@@ -172,20 +172,20 @@ class TestNvidiaBluefieldCliSdk(TestCase):
     @mock.patch('config.plugins.nvidia_bluefield.get_location_details', return_value=("/var/log/bluefield/", 5))
     @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value=ASIC_TYPE_NVDA_BF)
     def test_packet_drop_cli(
-            self, 
-            m_device_info, 
-            m_get_location_details, 
-            m_cleanup_dump_files, 
-            m_run_in_syncd, 
-            m_current, 
-            m_mknod, 
-            m_docker
-        ):
+        self,
+        m_device_info,
+        m_get_location_details,
+        m_cleanup_dump_files,
+        m_run_in_syncd,
+        m_current,
+        m_mknod,
+        m_docker
+    ):
         helper = util_base.UtilHelper()
         helper.load_and_register_plugins(plugins, config.config)
         runner = CliRunner()
         result = runner.invoke(
-            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
+            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"],
             ["packet-drop", "enabled"]
         )
         f_name = m_mknod.call_args.args[0]
@@ -203,7 +203,7 @@ class TestNvidiaBluefieldCliSdk(TestCase):
 
         runner = CliRunner()
         result = runner.invoke(
-            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
+            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"],
             ["packet-drop", "disabled"]
         )
         assert m_run_in_syncd.call_count == 2
@@ -214,7 +214,6 @@ class TestNvidiaBluefieldCliSdk(TestCase):
         assert result.exit_code == 0
         assert "Packet drop recording disabled" in result.output
 
-
     @mock.patch('docker.from_env')
     @mock.patch('os.mknod')
     @mock.patch('config.plugins.nvidia_bluefield.get_sai_debug_mode', return_value=('', ''))
@@ -223,15 +222,15 @@ class TestNvidiaBluefieldCliSdk(TestCase):
     @mock.patch('config.plugins.nvidia_bluefield.get_location_details', return_value=("/var/log/bluefield/", 5))
     @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value=ASIC_TYPE_NVDA_BF)
     def test_config_record_cli(
-            self, 
-            m_device_info, 
-            m_get_location_details, 
-            m_cleanup_dump_files, 
-            m_run_in_syncd, 
-            m_current, 
-            m_mknod, 
-            m_docker
-        ):
+        self, 
+        m_device_info,
+        m_get_location_details,
+        m_cleanup_dump_files,
+        m_run_in_syncd,
+        m_current,
+        m_mknod,
+        m_docker
+    ):
         helper = util_base.UtilHelper()
         helper.load_and_register_plugins(plugins, config.config)
         runner = CliRunner()

--- a/tests/config_nvidia_bluefield_test.py
+++ b/tests/config_nvidia_bluefield_test.py
@@ -222,7 +222,7 @@ class TestNvidiaBluefieldCliSdk(TestCase):
     @mock.patch('config.plugins.nvidia_bluefield.get_location_details', return_value=("/var/log/bluefield/", 5))
     @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value=ASIC_TYPE_NVDA_BF)
     def test_config_record_cli(
-        self, 
+        self,
         m_device_info,
         m_get_location_details,
         m_cleanup_dump_files,

--- a/tests/config_nvidia_bluefield_test.py
+++ b/tests/config_nvidia_bluefield_test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import pytest
+import mock
+from unittest import TestCase
+from click.testing import CliRunner
+import sonic_py_common
+from utilities_common import util_base
+import config.main as config
+import config.plugins as plugins
+from config.plugins.nvidia_bluefield import (
+    get_sai_profile_value,
+    rotate_dump_files,
+    get_location_details,
+    run_nasa_cli,
+    cleanup_dump_files
+)
+
+class TestNvidiaBluefieldSdk(TestCase):
+    def setUp(self):
+        self.docker_client = mock.MagicMock()
+        self.container = mock.MagicMock()
+        self.docker_client.containers.get.return_value = self.container
+        self.runner = CliRunner()
+
+    def test_get_sai_profile_value_success(self):
+        self.container.exec_run.return_value = (0, b"SAI_DUMP_STORE_PATH=/var/log/bluefield/sdk-dumps/\nSAI_DUMP_STORE_AMOUNT=5")
+        result = get_sai_profile_value("SAI_DUMP_STORE_PATH", self.docker_client)
+        self.assertEqual(result, "/var/log/bluefield/sdk-dumps/")
+        
+        # Test getting count
+        result = get_sai_profile_value("SAI_DUMP_STORE_AMOUNT", self.docker_client)
+        self.assertEqual(result, "5")
+
+    def test_get_sai_profile_value_not_found(self):
+        self.container.exec_run.return_value = (0, b"OTHER_KEY=value")
+        result = get_sai_profile_value("SAI_DUMP_STORE_PATH", self.docker_client)
+        self.assertEqual(result, "")
+
+    def test_get_sai_profile_value_error(self):
+        self.container.exec_run.return_value = (1, b"Error")
+        result = get_sai_profile_value("SAI_DUMP_STORE_PATH", self.docker_client)
+        self.assertEqual(result, "")
+
+    @mock.patch('os.path.join')
+    @mock.patch('os.remove')
+    @mock.patch('config.plugins.nvidia_bluefield.get_stats')
+    def test_rotate_dump_files(self, mock_get_stats, mock_remove, mock_join):
+        # Mock the filesystem stats
+        mock_get_stats.return_value = (
+            [(0, 100, '/var/log/file1'), (0, 200, '/var/log/file2')],
+            600
+        )
+        rotate_dump_files("/var/log", 2, self.docker_client)
+        mock_remove.assert_called_once_with('/var/log/file2')
+
+    @mock.patch('pathlib.Path.exists')
+    def test_get_location_details_success(self, mock_exists):
+        mock_exists.return_value = True
+        with mock.patch('config.plugins.nvidia_bluefield.get_sai_profile_value') as mock_get:
+            mock_get.side_effect = ["/var/log", "5"]
+            path, count = get_location_details(self.docker_client)
+            self.assertEqual(path, "/var/log")
+            self.assertEqual(count, 5)
+
+    @mock.patch('pathlib.Path.exists')
+    def test_get_location_details_invalid_path(self, mock_exists):
+        mock_exists.return_value = False
+        path, count = get_location_details(self.docker_client)
+        self.assertIsNone(path)
+        self.assertIsNone(count)
+
+    @mock.patch('pathlib.Path.exists')
+    def test_get_location_details_invalid_count(self, mock_exists):
+        mock_exists.return_value = True
+        with mock.patch('config.plugins.nvidia_bluefield.get_sai_profile_value') as mock_get:
+            mock_get.side_effect = ["/var/log", "invalid"]
+            
+            path, count = get_location_details(self.docker_client)
+            self.assertIsNone(path)
+            self.assertIsNone(count)
+
+    def test_nasa_cli(self):
+        self.container.exec_run = mock.MagicMock()
+        self.container.exec_run.return_value = (0, b"")
+        run_nasa_cli("get_packet_debug_mode", self.docker_client)
+        self.container.exec_run.assert_has_calls([
+            mock.call('sh -c \'echo -n "get_packet_debug_mode\nquit\n" > /tmp/nasa_cli_cmd.txt\''),
+            mock.call('/usr/sbin/cli/nasa_cli.py -u --exit_on_failure -l /tmp/nasa_cli_cmd.txt'),
+        ])
+
+    @mock.patch('pathlib.Path.mkdir')
+    @mock.patch('config.plugins.nvidia_bluefield.rotate_dump_files')
+    def test_cleanup_dump_files(self, m_rotate_dump_files, m_mkdir):
+        cleanup_dump_files(self.docker_client, "/var/log", 2, "test_dir")
+        m_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        m_rotate_dump_files.assert_called_once_with("/var/log/test_dir", 2, self.docker_client)
+
+class TestNvidiaBluefieldCliSdk(TestCase):
+
+    @mock.patch('docker.from_env')
+    @mock.patch('os.mknod')
+    @mock.patch('config.plugins.nvidia_bluefield.run_in_syncd', return_value=(0, b""))
+    @mock.patch('config.plugins.nvidia_bluefield.cleanup_dump_files')
+    @mock.patch('config.plugins.nvidia_bluefield.get_location_details', return_value=("/var/log/bluefield/sdk-dumps", 5))
+    @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value={"asic_type": "nvidia-bluefield"})
+    def test_packet_drop_cli(self, m_device_info, m_get_location_details, m_cleanup_dump_files, m_run_in_syncd, m_mknod, m_docker):
+        helper = util_base.UtilHelper()
+        helper.load_and_register_plugins(plugins, config.config)
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], ["packet-drop", "enabled"])
+        f_name = m_mknod.call_args.args[0]
+        assert f_name.startswith("/var/log/bluefield/sdk-dumps/packet-drop/pkt_dump_record_")
+        assert result.exit_code == 0
+        assert "Packet drop recording enabled." in result.output
+        assert m_run_in_syncd.call_count == 2
+        cmd_create = m_run_in_syncd.call_args_list[0].args[0]
+        cmd_run = m_run_in_syncd.call_args_list[1].args[0]
+        assert 'set_packet_debug_mode on filepath /var/log/bluefield/sdk-dumps/packet-drop/pkt_dump_record_' in cmd_create
+        assert '/usr/sbin/cli/nasa_cli.py -u --exit_on_failure -l /tmp/nasa_cli_cmd.txt' in cmd_run
+
+        m_run_in_syncd.reset_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], ["packet-drop", "disabled"])
+        assert m_run_in_syncd.call_count == 2
+        cmd_create = m_run_in_syncd.call_args_list[0].args[0]
+        cmd_run = m_run_in_syncd.call_args_list[1].args[0]
+        assert 'set_packet_debug_mode' in cmd_create
+        assert '/usr/sbin/cli/nasa_cli.py -u --exit_on_failure -l /tmp/nasa_cli_cmd.txt' in cmd_run
+        assert result.exit_code == 0
+        assert "Packet drop recording disabled." in result.output
+        
+
+    @mock.patch('docker.from_env')
+    @mock.patch('os.mknod')
+    @mock.patch('config.plugins.nvidia_bluefield.run_in_syncd', return_value=(0, b""))
+    @mock.patch('config.plugins.nvidia_bluefield.cleanup_dump_files')
+    @mock.patch('config.plugins.nvidia_bluefield.get_location_details', return_value=("/var/log/bluefield/sdk-dumps", 5))
+    @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value={"asic_type": "nvidia-bluefield"})
+    def test_config_record_cli(self, m_device_info, m_get_location_details, m_cleanup_dump_files, m_run_in_syncd, m_mknod, m_docker):
+        helper = util_base.UtilHelper()
+        helper.load_and_register_plugins(plugins, config.config)
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], ["config-record", "enabled"])
+        f_name = m_mknod.call_args.args[0]
+        assert f_name.startswith("/var/log/bluefield/sdk-dumps/config-record/cfg_record_")
+        assert result.exit_code == 0
+        assert "Config recording enabled." in result.output
+        assert m_run_in_syncd.call_count == 2
+        cmd_create = m_run_in_syncd.call_args_list[0].args[0]
+        cmd_run = m_run_in_syncd.call_args_list[1].args[0]
+        assert 'set_sai_debug_mode on filepath /var/log/bluefield/sdk-dumps/config-record/cfg_record_' in cmd_create
+        assert '/usr/sbin/cli/nasa_cli.py -u --exit_on_failure -l /tmp/nasa_cli_cmd.txt' in cmd_run
+
+        m_run_in_syncd.reset_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], ["config-record", "disabled"])
+        assert m_run_in_syncd.call_count == 2
+        cmd_create = m_run_in_syncd.call_args_list[0].args[0]
+        cmd_run = m_run_in_syncd.call_args_list[1].args[0]
+        assert 'set_sai_debug_mode' in cmd_create
+        assert '/usr/sbin/cli/nasa_cli.py -u --exit_on_failure -l /tmp/nasa_cli_cmd.txt' in cmd_run
+        assert result.exit_code == 0
+        assert "Config recording disabled." in result.output

--- a/tests/config_nvidia_bluefield_test.py
+++ b/tests/config_nvidia_bluefield_test.py
@@ -52,6 +52,8 @@ nasa_cli> get_packet_debug_mode
 RC: SAI_STATUS_ITEM_NOT_FOUND (-0x7)
 """
 
+ASIC_TYPE_NVDA_BF = {"asic_type": "nvidia-bluefield"}
+
 
 class TestNvidiaBluefieldSdk(TestCase):
     def setUp(self):
@@ -168,14 +170,24 @@ class TestNvidiaBluefieldCliSdk(TestCase):
     @mock.patch('config.plugins.nvidia_bluefield.run_in_syncd', return_value=(0, b""))
     @mock.patch('config.plugins.nvidia_bluefield.cleanup_dump_files')
     @mock.patch('config.plugins.nvidia_bluefield.get_location_details', return_value=("/var/log/bluefield/", 5))
-    @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value={"asic_type":"nvidia-bluefield"})
-    def test_packet_drop_cli(self, m_device_info, m_get_location_details, m_cleanup_dump_files, 
-                            m_run_in_syncd, m_current, m_mknod, m_docker):
+    @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value=ASIC_TYPE_NVDA_BF)
+    def test_packet_drop_cli(
+            self, 
+            m_device_info, 
+            m_get_location_details, 
+            m_cleanup_dump_files, 
+            m_run_in_syncd, 
+            m_current, 
+            m_mknod, 
+            m_docker
+        ):
         helper = util_base.UtilHelper()
         helper.load_and_register_plugins(plugins, config.config)
         runner = CliRunner()
-        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
-                                ["packet-drop", "enabled"])
+        result = runner.invoke(
+            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
+            ["packet-drop", "enabled"]
+        )
         f_name = m_mknod.call_args.args[0]
         assert f_name.startswith("/var/log/bluefield/packet-drop/pkt_dump_record_")
         assert result.exit_code == 0
@@ -190,8 +202,10 @@ class TestNvidiaBluefieldCliSdk(TestCase):
         m_run_in_syncd.reset_mock()
 
         runner = CliRunner()
-        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
-                                ["packet-drop", "disabled"])
+        result = runner.invoke(
+            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
+            ["packet-drop", "disabled"]
+        )
         assert m_run_in_syncd.call_count == 2
         cmd_create = m_run_in_syncd.call_args_list[0].args[0]
         cmd_run = m_run_in_syncd.call_args_list[1].args[0]
@@ -207,14 +221,24 @@ class TestNvidiaBluefieldCliSdk(TestCase):
     @mock.patch('config.plugins.nvidia_bluefield.run_in_syncd', return_value=(0, b""))
     @mock.patch('config.plugins.nvidia_bluefield.cleanup_dump_files')
     @mock.patch('config.plugins.nvidia_bluefield.get_location_details', return_value=("/var/log/bluefield/", 5))
-    @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value={"asic_type":"nvidia-bluefield"})
-    def test_config_record_cli(self, m_device_info, m_get_location_details, m_cleanup_dump_files, 
-                                m_run_in_syncd, m_current, m_mknod, m_docker):
+    @mock.patch('sonic_py_common.device_info.get_sonic_version_info', return_value=ASIC_TYPE_NVDA_BF)
+    def test_config_record_cli(
+            self, 
+            m_device_info, 
+            m_get_location_details, 
+            m_cleanup_dump_files, 
+            m_run_in_syncd, 
+            m_current, 
+            m_mknod, 
+            m_docker
+        ):
         helper = util_base.UtilHelper()
         helper.load_and_register_plugins(plugins, config.config)
         runner = CliRunner()
-        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
-                                ["config-record", "enabled"])
+        result = runner.invoke(
+            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"],
+            ["config-record", "enabled"]
+        )
         f_name = m_mknod.call_args.args[0]
         assert f_name.startswith("/var/log/bluefield/config-record/cfg_record_")
         assert result.exit_code == 0
@@ -228,8 +252,10 @@ class TestNvidiaBluefieldCliSdk(TestCase):
         m_run_in_syncd.reset_mock()
 
         runner = CliRunner()
-        result = runner.invoke(config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"], 
-                                ["config-record", "disabled"])
+        result = runner.invoke(
+            config.config.commands["platform"].commands["nvidia-bluefield"].commands["sdk"],
+            ["config-record", "disabled"]
+        )
         assert m_run_in_syncd.call_count == 2
         cmd_create = m_run_in_syncd.call_args_list[0].args[0]
         cmd_run = m_run_in_syncd.call_args_list[1].args[0]

--- a/tests/config_nvidia_bluefield_test.py
+++ b/tests/config_nvidia_bluefield_test.py
@@ -143,7 +143,7 @@ class TestNvidiaBluefieldSdk(TestCase):
             mock.call('/usr/sbin/cli/nasa_cli.py -u --exit_on_failure -l /tmp/nasa_cli_cmd.txt'),
         ])
 
-    def test_debug_mode_disabed(self):
+    def test_debug_mode_disabled(self):
         self.container.exec_run = mock.MagicMock()
         self.container.exec_run.return_value = (0, GET_CMD_OUTPUT_DISABLED)
         status, filename = get_packet_debug_mode(self.docker_client)
@@ -154,7 +154,7 @@ class TestNvidiaBluefieldSdk(TestCase):
             mock.call('/usr/sbin/cli/nasa_cli.py -u --exit_on_failure -l /tmp/nasa_cli_cmd.txt'),
         ])
 
-    def test_debug_mode_disabed_error(self):
+    def test_debug_mode_disabled_error(self):
         self.container.exec_run = mock.MagicMock()
         self.container.exec_run.return_value = (1, b"Random error")
         status, filename = get_packet_debug_mode(self.docker_client)

--- a/tests/config_nvidia_bluefield_test.py
+++ b/tests/config_nvidia_bluefield_test.py
@@ -69,7 +69,7 @@ class TestNvidiaBluefieldSdk(TestCase):
             [(0, 100, '/var/log/file1'), (0, 200, '/var/log/file2')],
             600
         )
-        rotate_dump_files("/var/log", 2, self.docker_client)
+        rotate_dump_files("/var/log", 2)
         mock_remove.assert_called_once_with('/var/log/file2')
 
     @mock.patch('pathlib.Path.exists')
@@ -95,7 +95,6 @@ class TestNvidiaBluefieldSdk(TestCase):
             mock_get.side_effect = ["/var/log", "invalid"]
             
             path, count = get_location_details(self.docker_client)
-            self.assertIsNone(path)
             self.assertIsNone(count)
 
     def test_nasa_cli(self):
@@ -110,9 +109,9 @@ class TestNvidiaBluefieldSdk(TestCase):
     @mock.patch('pathlib.Path.mkdir')
     @mock.patch('config.plugins.nvidia_bluefield.rotate_dump_files')
     def test_cleanup_dump_files(self, m_rotate_dump_files, m_mkdir):
-        cleanup_dump_files(self.docker_client, "/var/log", 2, "test_dir")
+        cleanup_dump_files("/var/log", 2, "test_dir")
         m_mkdir.assert_called_once_with(parents=True, exist_ok=True)
-        m_rotate_dump_files.assert_called_once_with("/var/log/test_dir", 2, self.docker_client)
+        m_rotate_dump_files.assert_called_once_with("/var/log/test_dir", 2)
 
 class TestNvidiaBluefieldCliSdk(TestCase):
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added a New Config plugin implementing CLI commands for nvidia-bluefield sdk

packet-drop: Captures packet drops in the NASA pipeline.
config-cli: Captures config applied in a format applied to NASA team

These debug 'bin' files are captured during techsupport

Also, this config is not persistent and will not survive config-reload/reboot and is disabled by default

```
config platform nvidia-bluefield sdk config-record enabled
config platform nvidia-bluefield sdk config-record disabled
config platform nvidia-bluefield sdk packet-drop enabled
config platform nvidia-bluefield sdk packet-drop disabled
```

#### How I did it

#### How to verify it

UT:
verify on the device to make sure if the changes are applied


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

