### PR TITLE
sfputil and sfpshow eeprom and DOM CLI enhancement to display data for all CMIS transceivers

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -356,7 +356,7 @@ class SFPShow(object):
         return output
 
     # Convert DOM sensor info in DB to CLI output string
-    def convert_dom_to_output_string(self, sfp_type, dom_info_dict):
+    def convert_dom_to_output_string(self, sfp_type, is_sfp_cmis, dom_info_dict):
         indent = ' ' * 8
         output_dom = ''
         channel_threshold_align = 18
@@ -364,7 +364,7 @@ class SFPShow(object):
 
         if sfp_type.startswith('QSFP') or sfp_type.startswith('OSFP'):
             # Channel Monitor
-            if sfp_type.startswith('QSFP-DD') or sfp_type.startswith('OSFP'):
+            if is_sfp_cmis:
                 output_dom += (indent + 'ChannelMonitorValues:\n')
                 sorted_key_table = natsorted(QSFP_DD_DOM_CHANNEL_MONITOR_MAP)
                 output_channel = self.format_dict_value_to_string(
@@ -382,7 +382,7 @@ class SFPShow(object):
                 output_dom += output_channel
 
             # Channel Threshold
-            if sfp_type.startswith('QSFP-DD') or sfp_type.startswith('OSFP'):
+            if is_sfp_cmis:
                 dom_map = SFP_DOM_CHANNEL_THRESHOLD_MAP
             else:
                 dom_map = QSFP_DOM_CHANNEL_THRESHOLD_MAP
@@ -477,7 +477,7 @@ class SFPShow(object):
                     sfp_type = sfp_info_dict['type']
                     dom_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_SENSOR|{}'.format(first_subport)) or {}
                     dom_info_dict.update(state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_THRESHOLD|{}'.format(first_subport)) or {})
-                    dom_output = self.convert_dom_to_output_string(sfp_type, dom_info_dict)
+                    dom_output = self.convert_dom_to_output_string(sfp_type, 'cmis_rev' in sfp_info_dict, dom_info_dict)
                     output += dom_output
         else:
             if is_rj45_port(interface_name):

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -29,6 +29,7 @@ from utilities_common.sfp_helper import (
         CCMIS_VDM_TO_LEGACY_STATUS_MAP,
         CCMIS_VDM_THRESHOLD_TO_LEGACY_DOM_THRESHOLD_MAP
 )
+from utilities_common.sfp_helper import is_transceiver_cmis
 from tabulate import tabulate
 
 # Mock the redis DB for unit test purposes
@@ -313,7 +314,7 @@ class SFPShow(object):
     def convert_sfp_info_to_output_string(self, sfp_info_dict, sfp_firmware_info_dict):
         indent = ' ' * 8
         output = ''
-        is_sfp_cmis = 'cmis_rev' in sfp_info_dict
+        is_sfp_cmis = is_transceiver_cmis(sfp_info_dict)
         is_sfp_c_cmis = 'supported_max_tx_power' in sfp_info_dict
 
         if is_sfp_c_cmis:
@@ -477,7 +478,7 @@ class SFPShow(object):
                     sfp_type = sfp_info_dict['type']
                     dom_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_SENSOR|{}'.format(first_subport)) or {}
                     dom_info_dict.update(state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_THRESHOLD|{}'.format(first_subport)) or {})
-                    dom_output = self.convert_dom_to_output_string(sfp_type, 'cmis_rev' in sfp_info_dict, dom_info_dict)
+                    dom_output = self.convert_dom_to_output_string(sfp_type, is_transceiver_cmis(sfp_info_dict), dom_info_dict)
                     output += dom_output
         else:
             if is_rj45_port(interface_name):

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -110,7 +110,7 @@ QSFP_DOM_CHANNEL_MONITOR_MAP = {
     'tx4power': 'TX4Power'
 }
 
-QSFP_DD_DOM_CHANNEL_MONITOR_MAP = {
+CMIS_DOM_CHANNEL_MONITOR_MAP = {
     'rx1power': 'RX1Power',
     'rx2power': 'RX2Power',
     'rx3power': 'RX3Power',
@@ -367,10 +367,10 @@ class SFPShow(object):
             # Channel Monitor
             if is_sfp_cmis:
                 output_dom += (indent + 'ChannelMonitorValues:\n')
-                sorted_key_table = natsorted(QSFP_DD_DOM_CHANNEL_MONITOR_MAP)
+                sorted_key_table = natsorted(CMIS_DOM_CHANNEL_MONITOR_MAP)
                 output_channel = self.format_dict_value_to_string(
                     sorted_key_table, dom_info_dict,
-                    QSFP_DD_DOM_CHANNEL_MONITOR_MAP,
+                    CMIS_DOM_CHANNEL_MONITOR_MAP,
                     QSFP_DD_DOM_VALUE_UNIT_MAP)
                 output_dom += output_channel
             else:
@@ -467,6 +467,7 @@ class SFPShow(object):
         sfp_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_INFO|{}'.format(interface_name))
         sfp_firmware_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_FIRMWARE_INFO|{}'.format(first_subport))
         if sfp_info_dict:
+            is_sfp_cmis = is_transceiver_cmis(sfp_info_dict)
             if sfp_info_dict['type'] == RJ45_PORT_TYPE:
                 output = 'SFP EEPROM is not applicable for RJ45 port\n'
             else:
@@ -478,7 +479,7 @@ class SFPShow(object):
                     sfp_type = sfp_info_dict['type']
                     dom_info_dict = state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_SENSOR|{}'.format(first_subport)) or {}
                     dom_info_dict.update(state_db.get_all(state_db.STATE_DB, 'TRANSCEIVER_DOM_THRESHOLD|{}'.format(first_subport)) or {})
-                    dom_output = self.convert_dom_to_output_string(sfp_type, is_transceiver_cmis(sfp_info_dict), dom_info_dict)
+                    dom_output = self.convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict)
                     output += dom_output
         else:
             if is_rj45_port(interface_name):

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -710,7 +710,8 @@ def eeprom(port, dump_dom, namespace):
                         click.echo("Sfp.get_transceiver_threshold_info() is currently not implemented for this platform")
                         sys.exit(ERROR_NOT_IMPLEMENTED)
 
-                    output += convert_dom_to_output_string(xcvr_info['type'], is_transceiver_cmis(xcvr_info), xcvr_dom_info)
+                    output += convert_dom_to_output_string(xcvr_info['type'],
+                                                           is_transceiver_cmis(xcvr_info), xcvr_dom_info)
 
             output += '\n'
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -28,6 +28,7 @@ from utilities_common.platform_sfputil_helper import (
 )
 from utilities_common.sfp_helper import covert_application_advertisement_to_output_string
 from utilities_common.sfp_helper import QSFP_DATA_MAP
+from utilities_common.sfp_helper import is_transceiver_cmis
 from tabulate import tabulate
 from utilities_common.general import load_db_config
 
@@ -335,7 +336,7 @@ def format_dict_value_to_string(sorted_key_table,
 def convert_sfp_info_to_output_string(sfp_info_dict):
     indent = ' ' * 8
     output = ''
-    is_sfp_cmis = 'cmis_rev' in sfp_info_dict
+    is_sfp_cmis = is_transceiver_cmis(sfp_info_dict)
     if is_sfp_cmis:
         sorted_qsfp_data_map_keys = sorted(QSFP_DD_DATA_MAP, key=QSFP_DD_DATA_MAP.get)
         for key in sorted_qsfp_data_map_keys:
@@ -709,7 +710,7 @@ def eeprom(port, dump_dom, namespace):
                         click.echo("Sfp.get_transceiver_threshold_info() is currently not implemented for this platform")
                         sys.exit(ERROR_NOT_IMPLEMENTED)
 
-                    output += convert_dom_to_output_string(xcvr_info['type'], 'cmis_rev' in xcvr_info, xcvr_dom_info)
+                    output += convert_dom_to_output_string(xcvr_info['type'], is_transceiver_cmis(xcvr_info), xcvr_dom_info)
 
             output += '\n'
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -172,7 +172,7 @@ QSFP_DOM_CHANNEL_MONITOR_MAP = {
     'tx4power': 'TX4Power'
 }
 
-QSFP_DD_DOM_CHANNEL_MONITOR_MAP = {
+CMIS_DOM_CHANNEL_MONITOR_MAP = {
     'rx1power': 'RX1Power',
     'rx2power': 'RX2Power',
     'rx3power': 'RX3Power',
@@ -395,10 +395,10 @@ def convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict):
         # Channel Monitor
         if is_sfp_cmis:
             output_dom += (indent + 'ChannelMonitorValues:\n')
-            sorted_key_table = natsorted(QSFP_DD_DOM_CHANNEL_MONITOR_MAP)
+            sorted_key_table = natsorted(CMIS_DOM_CHANNEL_MONITOR_MAP)
             output_channel = format_dict_value_to_string(
                 sorted_key_table, dom_info_dict,
-                QSFP_DD_DOM_CHANNEL_MONITOR_MAP,
+                CMIS_DOM_CHANNEL_MONITOR_MAP,
                 QSFP_DD_DOM_VALUE_UNIT_MAP)
             output_dom += output_channel
         else:
@@ -678,6 +678,7 @@ def eeprom(port, dump_dom, namespace):
 
                 try:
                     xcvr_info = platform_chassis.get_sfp(physical_port).get_transceiver_info()
+                    is_sfp_cmis = is_transceiver_cmis(xcvr_info)
                 except NotImplementedError:
                     click.echo("Sfp.get_transceiver_info() is currently not implemented for this platform")
                     sys.exit(ERROR_NOT_IMPLEMENTED)
@@ -711,7 +712,7 @@ def eeprom(port, dump_dom, namespace):
                         sys.exit(ERROR_NOT_IMPLEMENTED)
 
                     output += convert_dom_to_output_string(xcvr_info['type'],
-                                                           is_transceiver_cmis(xcvr_info), xcvr_dom_info)
+                                                           is_sfp_cmis, xcvr_dom_info)
 
             output += '\n'
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -335,9 +335,8 @@ def format_dict_value_to_string(sorted_key_table,
 def convert_sfp_info_to_output_string(sfp_info_dict):
     indent = ' ' * 8
     output = ''
-    sfp_type = sfp_info_dict['type']
-    # CMIS supported module types include QSFP-DD and OSFP
-    if sfp_type.startswith('QSFP-DD') or sfp_type.startswith('OSFP'):
+    is_sfp_cmis = 'cmis_rev' in sfp_info_dict
+    if is_sfp_cmis:
         sorted_qsfp_data_map_keys = sorted(QSFP_DD_DATA_MAP, key=QSFP_DD_DATA_MAP.get)
         for key in sorted_qsfp_data_map_keys:
             if key == 'cable_type':
@@ -385,7 +384,7 @@ def convert_sfp_info_to_output_string(sfp_info_dict):
 
 
 # Convert DOM sensor info in DB to CLI output string
-def convert_dom_to_output_string(sfp_type, dom_info_dict):
+def convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict):
     indent = ' ' * 8
     output_dom = ''
     channel_threshold_align = 18
@@ -393,7 +392,7 @@ def convert_dom_to_output_string(sfp_type, dom_info_dict):
 
     if sfp_type.startswith('QSFP') or sfp_type.startswith('OSFP'):
         # Channel Monitor
-        if sfp_type.startswith('QSFP-DD') or sfp_type.startswith('OSFP'):
+        if is_sfp_cmis:
             output_dom += (indent + 'ChannelMonitorValues:\n')
             sorted_key_table = natsorted(QSFP_DD_DOM_CHANNEL_MONITOR_MAP)
             output_channel = format_dict_value_to_string(
@@ -411,7 +410,7 @@ def convert_dom_to_output_string(sfp_type, dom_info_dict):
             output_dom += output_channel
 
         # Channel Threshold
-        if sfp_type.startswith('QSFP-DD') or sfp_type.startswith('OSFP'):
+        if is_sfp_cmis:
             dom_map = SFP_DOM_CHANNEL_THRESHOLD_MAP
         else:
             dom_map = QSFP_DOM_CHANNEL_THRESHOLD_MAP
@@ -710,7 +709,7 @@ def eeprom(port, dump_dom, namespace):
                         click.echo("Sfp.get_transceiver_threshold_info() is currently not implemented for this platform")
                         sys.exit(ERROR_NOT_IMPLEMENTED)
 
-                    output += convert_dom_to_output_string(xcvr_info['type'], xcvr_dom_info)
+                    output += convert_dom_to_output_string(xcvr_info['type'], 'cmis_rev' in xcvr_info, xcvr_dom_info)
 
             output += '\n'
 

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -71,6 +71,7 @@
     },
     "TRANSCEIVER_INFO|Ethernet8": {
         "type": "QSFP-DD Double Density 8X Pluggable Transceiver",
+        "cmis_rev": "5.0",
         "vendor_rev": "2A",
         "serial": "INKAO2900002A",
         "manufacturer": "INNOLIGHT",
@@ -85,7 +86,23 @@
         "cable_length": "10",
         "specification_compliance": "Not supported for CMIS cables",
         "nominal_bit_rate": "Not supported for CMIS cables",
-        "application_advertisement": "400GAUI-8 C2M (Annex 120E) - Active Cable assembly with BER < 2.6x10^-4\n\t\t\t\t   IB EDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 5x10^-5\n\t\t\t\t   IB QDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 10^-12"
+        "application_advertisement" : "{1: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1, 'media_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': '400GAUI-8 C2M (Annex 120E)', 'module_media_interface_id': '400ZR, Single Wavelength, Unamplified', 'media_lane_count': 1, 'host_lane_count': 8, 'host_lane_assignment_options': 1, 'media_lane_assignment_options': 1}, 3: {'host_electrical_interface_id': '100GAUI-2 C2M (Annex 135G)', 'module_media_interface_id': '400ZR, DWDM, amplified', 'media_lane_count': 1, 'host_lane_count': 2, 'host_lane_assignment_options': 85, 'media_lane_assignment_options': 1}}",
+        "host_lane_count" : "8",
+        "media_lane_count" : "1",
+        "active_apsel_hostlane1" : "1",
+        "active_apsel_hostlane2" : "1",
+        "active_apsel_hostlane3" : "1",
+        "active_apsel_hostlane4" : "1",
+        "active_apsel_hostlane5" : "1",
+        "active_apsel_hostlane6" : "1",
+        "active_apsel_hostlane7" : "1",
+        "active_apsel_hostlane8" : "1",
+        "hardware_rev" : "X.X",
+        "media_interface_technology" : "1550 nm DFB"
+    },
+    "TRANSCEIVER_FIRMWARE_INFO|Ethernet8": {
+        "active_firmware": "2.1.1",
+        "inactive_firmware": "1.2.3"
     },
     "TRANSCEIVER_DOM_SENSOR|Ethernet8": {
         "temperature": "44.9883",

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -83,7 +83,8 @@ Ethernet8: SFP EEPROM detected
         Active application selected code assigned to host lane 6: 1
         Active application selected code assigned to host lane 7: 1
         Active application selected code assigned to host lane 8: 1
-        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
+        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - \
+Media Assign (0x1)
                                    400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, \
 Unamplified - Media Assign (0x1)
                                    100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - \
@@ -260,7 +261,8 @@ Ethernet8: SFP EEPROM detected
         Active application selected code assigned to host lane 6: 1
         Active application selected code assigned to host lane 7: 1
         Active application selected code assigned to host lane 8: 1
-        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
+        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - \
+Media Assign (0x1)
                                    400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, \
 Unamplified - Media Assign (0x1)
                                    100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - \

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -84,8 +84,10 @@ Ethernet8: SFP EEPROM detected
         Active application selected code assigned to host lane 7: 1
         Active application selected code assigned to host lane 8: 1
         Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
-                                   400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, Unamplified - Media Assign (0x1)
-                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
+                                   400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, \
+Unamplified - Media Assign (0x1)
+                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - \
+Media Assign (0x1)
         CMIS Rev: 5.0
         Connector: No separable connector
         Encoding: Not supported for CMIS cables
@@ -259,8 +261,10 @@ Ethernet8: SFP EEPROM detected
         Active application selected code assigned to host lane 7: 1
         Active application selected code assigned to host lane 8: 1
         Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
-                                   400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, Unamplified - Media Assign (0x1)
-                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
+                                   400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, \
+Unamplified - Media Assign (0x1)
+                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - \
+Media Assign (0x1)
         CMIS Rev: 5.0
         Connector: No separable connector
         Encoding: Not supported for CMIS cables

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -74,15 +74,30 @@ Ethernet0: SFP EEPROM detected
 
 test_qsfp_dd_eeprom_with_dom_output = """\
 Ethernet8: SFP EEPROM detected
-        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Active Cable assembly with BER < 2.6x10^-4
-				   IB EDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 5x10^-5
-				   IB QDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 10^-12
+        Active Firmware: 2.1.1
+        Active application selected code assigned to host lane 1: 1
+        Active application selected code assigned to host lane 2: 1
+        Active application selected code assigned to host lane 3: 1
+        Active application selected code assigned to host lane 4: 1
+        Active application selected code assigned to host lane 5: 1
+        Active application selected code assigned to host lane 6: 1
+        Active application selected code assigned to host lane 7: 1
+        Active application selected code assigned to host lane 8: 1
+        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
+                                   400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, Unamplified - Media Assign (0x1)
+                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
+        CMIS Rev: 5.0
         Connector: No separable connector
         Encoding: Not supported for CMIS cables
         Extended Identifier: Power Class 1(10.0W Max)
         Extended RateSelect Compliance: Not supported for CMIS cables
+        Host Lane Count: 8
         Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
+        Inactive Firmware: 1.2.3
         Length Cable Assembly(m): 10
+        Media Interface Technology: 1550 nm DFB
+        Media Lane Count: 1
+        Module Hardware Rev: X.X
         Nominal Bit Rate(100Mbs): Not supported for CMIS cables
         Specification compliance: Not supported for CMIS cables
         Vendor Date Code(YYYY-MM-DD Lot): 2020-05-22
@@ -234,15 +249,30 @@ Ethernet0: SFP EEPROM detected
 
 test_qsfp_dd_eeprom_output = """\
 Ethernet8: SFP EEPROM detected
-        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Active Cable assembly with BER < 2.6x10^-4
-				   IB EDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 5x10^-5
-				   IB QDR (Arch.Spec.Vol.2) - Active Cable assembly with BER < 10^-12
+        Active Firmware: 2.1.1
+        Active application selected code assigned to host lane 1: 1
+        Active application selected code assigned to host lane 2: 1
+        Active application selected code assigned to host lane 3: 1
+        Active application selected code assigned to host lane 4: 1
+        Active application selected code assigned to host lane 5: 1
+        Active application selected code assigned to host lane 6: 1
+        Active application selected code assigned to host lane 7: 1
+        Active application selected code assigned to host lane 8: 1
+        Application Advertisement: 400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, DWDM, amplified - Media Assign (0x1)
+                                   400GAUI-8 C2M (Annex 120E) - Host Assign (0x1) - 400ZR, Single Wavelength, Unamplified - Media Assign (0x1)
+                                   100GAUI-2 C2M (Annex 135G) - Host Assign (0x55) - 400ZR, DWDM, amplified - Media Assign (0x1)
+        CMIS Rev: 5.0
         Connector: No separable connector
         Encoding: Not supported for CMIS cables
         Extended Identifier: Power Class 1(10.0W Max)
         Extended RateSelect Compliance: Not supported for CMIS cables
+        Host Lane Count: 8
         Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
+        Inactive Firmware: 1.2.3
         Length Cable Assembly(m): 10
+        Media Interface Technology: 1550 nm DFB
+        Media Lane Count: 1
+        Module Hardware Rev: X.X
         Nominal Bit Rate(100Mbs): Not supported for CMIS cables
         Specification compliance: Not supported for CMIS cables
         Vendor Date Code(YYYY-MM-DD Lot): 2020-05-22

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -265,9 +265,10 @@ class TestSfputil(object):
         output = sfputil.convert_sfp_info_to_output_string(sfp_info_dict)
         assert output == expected_output
 
-    @pytest.mark.parametrize("sfp_type, dom_info_dict, expected_output", [
+    @pytest.mark.parametrize("sfp_type, is_sfp_cmis, dom_info_dict, expected_output", [
         (
             'QSFP28 or later',
+            False,
             {
                 'temperature': '41.7539C',
                 'voltage': '3.2577Volts',
@@ -303,6 +304,7 @@ class TestSfputil(object):
         ), 
         (
             'QSFP-DD Double Density 8X Pluggable Transceiver',
+            True,
             {
                 'temperature': '41.7539C',
                 'voltage': '3.2577Volts',
@@ -358,6 +360,7 @@ class TestSfputil(object):
         ),
         (
             'OSFP 8X Pluggable Transceiver',
+            True,
             {
                 'temperature': '41.7539C',
                 'voltage': '3.2577Volts',
@@ -411,8 +414,8 @@ class TestSfputil(object):
         ModuleThresholdValues:
 '''
         )])
-    def test_convert_dom_to_output_string(self, sfp_type, dom_info_dict, expected_output):
-        output = sfputil.convert_dom_to_output_string(sfp_type, dom_info_dict)
+    def test_convert_dom_to_output_string(self, sfp_type, is_sfp_cmis, dom_info_dict, expected_output):
+        output = sfputil.convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict)
         assert output == expected_output
 
     def test_get_physical_port_name(self):

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -426,6 +426,7 @@ def covert_application_advertisement_to_output_string(indent, sfp_info_dict):
         output += '{}\n'.format(app_adv_str)
     return output
 
+
 def is_transceiver_cmis(sfp_info_dict):
     """
     Check if the transceiver is CMIS compliant.

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -430,5 +430,10 @@ def covert_application_advertisement_to_output_string(indent, sfp_info_dict):
 def is_transceiver_cmis(sfp_info_dict):
     """
     Check if the transceiver is CMIS compliant.
+    If the sfp_info_dict is None, return False.
+    If 'cmis_rev' is present in the dictionary, return True.
+    Otherwise, return False.
     """
+    if sfp_info_dict is None:
+        return False
     return 'cmis_rev' in sfp_info_dict

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -425,3 +425,9 @@ def covert_application_advertisement_to_output_string(indent, sfp_info_dict):
     except Exception:
         output += '{}\n'.format(app_adv_str)
     return output
+
+def is_transceiver_cmis(sfp_info_dict):
+    """
+    Check if the transceiver is CMIS compliant.
+    """
+    return 'cmis_rev' in sfp_info_dict


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR enhances the sfputil and sfpshow CLI tools to properly display EEPROM and DOM data for all CMIS-compliant transceivers, not just QSFP-DD and OSFP modules. The enhancement replaces hardcoded transceiver type checks with a more generic detection method based on the presence of the cmis_rev field in transceiver information.
https://github.com/sonic-net/sonic-utilities/blob/252a643567dda88ddf93a72508e0331cdd7cb677/sfputil/main.py#L340
https://github.com/sonic-net/sonic-utilities/blob/252a643567dda88ddf93a72508e0331cdd7cb677/sfputil/main.py#L396
https://github.com/sonic-net/sonic-utilities/blob/252a643567dda88ddf93a72508e0331cdd7cb677/sfputil/main.py#L414

Currently, the transceivers which have identifier register value as 0x1e (`QSFP+ or later with CMIS`) show EEPROM and DOM output for non-CMIS transceivers.

Also, fixes the below crash seen on Backplane cartridge
```
root@str5-7060x6-moby-512-4:/home/admin# sfputil show eeprom -p Ethernet128
Traceback (most recent call last):
  File "/usr/local/bin/sfputil", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sfputil/main.py", line 685, in eeprom
    output += convert_sfp_info_to_output_string(xcvr_info)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sfputil/main.py", line 382, in convert_sfp_info_to_output_string
    output += '{}{}: {}\n'.format(indent, QSFP_DATA_MAP[key], sfp_info_dict[key])
                                                              ~~~~~~~~~~~~~^^^^^
KeyError: 'connector'
```
#### How I did it
- Introduced a new helper function is_transceiver_cmis() to identify CMIS-compliant transceivers
- Modified DOM and EEPROM display logic to use CMIS detection instead of specific type checking
- Updated test data and expected outputs to reflect enhanced CMIS field display

sfputil Backplane Cartridge crash fix details
- The current crash was seen due to the sfputil CLI handler looking for `connector` field and this field was absent from the sfp_info_dict.
- Also, the backplane cartridge was treaterd as non CMIS optic. With the current fix, backplane catridge is now treated as a CMIS optic (due to the presence of `cmis_rev` field) and the crash due to the absence of connector field is not seen any more due to the already existing graceful handling of KeyError for CMIS optics (https://github.com/sonic-net/sonic-utilities/blob/c0838d7f6cabdc42079aea638706eed76567d75b/sfputil/main.py#L360-L361) unlike non-CMIS optics handling (https://github.com/sonic-net/sonic-utilities/blob/c0838d7f6cabdc42079aea638706eed76567d75b/sfputil/main.py#L382)

#### How to verify it
Ensured the CLI output shows all CMIS relevant fields for the transceiver with 0x1e in the identifier value.

sfpshow output change
- The DOM EEPROM dump CLI will show DOM data for lanes 5 through 8 too now (irrespective of it being used or not)
- Threshold data will be shown for TxPower thresholds

sfputil output change
- The EEPROM CLI will display data inline to other QSFP-DD and OSFP CMIS modules (example - Active application lane, CMIS revision etc)
- The DOM EEPROM dump CLI will show DOM data for lanes 5 through 8 too now (irrespective of it being used or not)
- Threshold data will be shown for TxPower thresholds

#### Previous command output (if the output of a command-line utility has changed)
```
sfputil show eeprom -d -p Ethernet96
Ethernet96: SFP EEPROM detected
        Application Advertisement: {1: {'host_electrical_interface_id': '200GAUI-4 C2M (Annex 120E)', 'module_media_interface_id': 'Active Cable assembly with BER < 2.6x10^-4', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 1, 'media_lane_assignment_options': 1}, 2: {'host_electrical_interface_id': 'CAUI-4 C2M (Annex 83E) without FEC', 'module_media_interface_id': 'Active Cable assembly with BER < 5x10^-5', 'media_lane_count': 4, 'host_lane_count': 4, 'host_lane_assignment_options': 1, 'media_lane_assignment_options': 1}}
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 3 (3.75W Max)
        Extended RateSelect Compliance: N/A
        Identifier: QSFP+ or later with CMIS
        Length Cable Assembly(m): 14.0
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance:
                N/A
        Vendor Date Code(YYYY-MM-DD Lot): 2025-01-24 
        Vendor Name: VENDOR_NAME_ABC
        Vendor OUI: 00-90-65
        Vendor PN: VENDOR_PN_A123456
        Vendor Rev: A0
        Vendor SN: SN12345
        ChannelMonitorValues:
                RX1Power: -0.818dBm
                RX2Power: -0.738dBm
                RX3Power: -0.46dBm
                RX4Power: -0.402dBm
                TX1Bias: 7.504mA
                TX1Power: -4.559dBm
                TX2Bias: 7.504mA
                TX2Power: -4.559dBm
                TX3Bias: 7.504mA
                TX3Power: -4.559dBm
                TX4Bias: 7.504mA
                TX4Power: -4.559dBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 5.0dBm
                RxPowerHighWarning: 4.0dBm
                RxPowerLowAlarm   : -14.001dBm
                RxPowerLowWarning : -11.002dBm
                TxBiasHighAlarm   : 13.0mA
                TxBiasHighWarning : 11.0mA
                TxBiasLowAlarm    : 3.0mA
                TxBiasLowWarning  : 5.0mA
        ModuleMonitorValues:
                Temperature: 27.457C
                Vcc: 3.283Volts
        ModuleThresholdValues:
                TempHighAlarm  : 75.0C
                TempHighWarning: 70.0C
                TempLowAlarm   : -5.0C
                TempLowWarning : 0.0C
                VccHighAlarm   : 3.465Volts
                VccHighWarning : 3.45Volts
                VccLowAlarm    : 3.135Volts
                VccLowWarning  : 3.15Volts
```
#### New command output (if the output of a command-line utility has changed)
```
sfputil show eeprom -d -p Ethernet96
Ethernet96: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 0
        Active App Selection Host Lane 6: 0
        Active App Selection Host Lane 7: 0
        Active App Selection Host Lane 8: 0
        Application Advertisement: 200GAUI-4 C2M (Annex 120E) - Host Assign (0x1) - Active Cable assembly with BER < 2.6x10^-4 - Media Assign (0x1)
                                   CAUI-4 C2M (Annex 83E) without FEC - Host Assign (0x1) - Active Cable assembly with BER < 5x10^-5 - Media Assign (0x1)
        CMIS Revision: 5.1
        Connector: No separable connector
        Encoding: N/A
        Extended Identifier: Power Class 3 (3.75W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 1.0
        Host Electrical Interface: 200GAUI-4 C2M (Annex 120E)
        Host Lane Assignment Options: 1
        Host Lane Count: 4
        Identifier: QSFP+ or later with CMIS
        Length Cable Assembly(m): 14.0
        Media Interface Code: Active Cable assembly with BER < 2.6x10^-4
        Media Interface Technology: 850 nm VCSEL
        Media Lane Assignment Options: 1
        Media Lane Count: 4
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: active_cable_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2025-01-24 
        Vendor Name: VENDOR_NAME_ABC
        Vendor OUI: 00-90-65
        Vendor PN: VENDOR_PN_A123456
        Vendor Rev: A0
        Vendor SN: SN12345
        ChannelMonitorValues:
                RX1Power: -0.799dBm
                RX2Power: -0.738dBm
                RX3Power: -0.46dBm
                RX4Power: -0.402dBm
                RX5Power: -infdBm
                RX6Power: -infdBm
                RX7Power: -infdBm
                RX8Power: -infdBm
                TX1Bias: 7.504mA
                TX1Power: -4.559dBm
                TX2Bias: 7.504mA
                TX2Power: -4.559dBm
                TX3Bias: 7.504mA
                TX3Power: -4.559dBm
                TX4Bias: 7.504mA
                TX4Power: -4.559dBm
                TX5Bias: 0.0mA
                TX5Power: -infdBm
                TX6Bias: 0.0mA
                TX6Power: -infdBm
                TX7Bias: 0.0mA
                TX7Power: -infdBm
                TX8Bias: 0.0mA
                TX8Power: -infdBm
        ChannelThresholdValues:
                RxPowerHighAlarm  : 5.0dBm
                RxPowerHighWarning: 4.0dBm
                RxPowerLowAlarm   : -14.001dBm
                RxPowerLowWarning : -11.002dBm
                TxBiasHighAlarm   : 13.0mA
                TxBiasHighWarning : 11.0mA
                TxBiasLowAlarm    : 3.0mA
                TxBiasLowWarning  : 5.0mA
                TxPowerHighAlarm  : 5.0dBm
                TxPowerHighWarning: 3.0dBm
                TxPowerLowAlarm   : -10.0dBm
                TxPowerLowWarning : -8.0dBm
        ModuleMonitorValues:
                Temperature: 27.977C
                Vcc: 3.282Volts
        ModuleThresholdValues:
                TempHighAlarm  : 75.0C
                TempHighWarning: 70.0C
                TempLowAlarm   : -5.0C
                TempLowWarning : 0.0C
                VccHighAlarm   : 3.465Volts
                VccHighWarning : 3.45Volts
                VccLowAlarm    : 3.135Volts
                VccLowWarning  : 3.15Volts
```

ADO - 34032819
