### PR TITLE
Mux cable show config command Added prober_type and fixed one format

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -550,7 +550,7 @@ def create_table_dump_per_port_status(db, print_data, muxcable_info_dict, muxcab
     print_data.append(print_port_data)
 
 
-def create_table_dump_per_port_config(db ,print_data, per_npu_configdb, asic_id, port, is_dualtor_active_active):
+def create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port):
 
     port_list = []
     port_name = platform_sfputil_helper.get_interface_alias(port, db)
@@ -564,17 +564,25 @@ def create_table_dump_per_port_config(db ,print_data, per_npu_configdb, asic_id,
     cable_type = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "cable_type", "MUX_CABLE")
     if cable_type is not None:
         port_list.append(cable_type)
+    else:
+        port_list.append("")
     soc_ipv4_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv4", "MUX_CABLE")
     if soc_ipv4_value is not None:
         port_list.append(soc_ipv4_value)
-        is_dualtor_active_active[0] = True
+    else:
+        port_list.append("")
     soc_ipv6_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv6", "MUX_CABLE")
     if soc_ipv6_value is not None:
-        if cable_type is None:
-            port_list.append("")
-        if soc_ipv4_value is None:
-            port_list.append("")
         port_list.append(soc_ipv6_value)
+    else:
+        port_list.append("")
+    prober_type_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id],
+                                                                 port, "prober_type", "MUX_CABLE")
+    if prober_type_value is not None:
+        port_list.append(prober_type_value)
+    else:
+        port_list.append("software")
+
     print_data.append(port_list)
 
 
@@ -597,6 +605,11 @@ def create_json_dump_per_port_config(db, port_status_dict, per_npu_configdb, asi
     soc_ipv6_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id], port, "soc_ipv6", "MUX_CABLE")
     if soc_ipv6_value is not None:
         port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["soc_ipv6"] = soc_ipv6_value
+    prober_type_value = get_optional_value_for_key_in_config_tbl(per_npu_configdb[asic_id],
+                                                                 port, "prober_type", "MUX_CABLE")
+    if prober_type_value is not None:
+        port_status_dict["MUX_CABLE"]["PORTS"][port_name]["SERVER"]["prober_type"] = prober_type_value
+
 
 def get_tunnel_route_per_port(db, port_tunnel_route, per_npu_configdb, per_npu_appl_db, per_npu_asic_db, asic_id, port):
 
@@ -861,10 +874,8 @@ def config(db, port, json_output):
                 else:
                     print_data = []
                     print_peer_tor = []
-                    is_dualtor_active_active = [False]
 
-
-                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port, is_dualtor_active_active)
+                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port)
 
                     headers = ['SWITCH_NAME', 'PEER_TOR']
                     peer_tor_data = []
@@ -872,10 +883,7 @@ def config(db, port, json_output):
                     peer_tor_data.append(peer_switch_value)
                     print_peer_tor.append(peer_tor_data)
                     click.echo(tabulate(print_peer_tor, headers=headers))
-                    if is_dualtor_active_active[0]:
-                        headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6']
-                    else:
-                        headers = ['port', 'state', 'ipv4', 'ipv6']
+                    headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6', 'prober_type']
                     click.echo(tabulate(print_data, headers=headers))
 
                     sys.exit(CONFIG_SUCCESSFUL)
@@ -911,12 +919,11 @@ def config(db, port, json_output):
         else:
             print_data = []
             print_peer_tor = []
-            is_dualtor_active_active = [False]
 
             for namespace in namespaces:
                 asic_id = multi_asic.get_asic_index_from_namespace(namespace)
                 for port in natsorted(port_mux_tbl_keys[asic_id]):
-                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port, is_dualtor_active_active)
+                    create_table_dump_per_port_config(db, print_data, per_npu_configdb, asic_id, port)
 
             headers = ['SWITCH_NAME', 'PEER_TOR']
             peer_tor_data = []
@@ -924,10 +931,7 @@ def config(db, port, json_output):
             peer_tor_data.append(peer_switch_value)
             print_peer_tor.append(peer_tor_data)
             click.echo(tabulate(print_peer_tor, headers=headers))
-            if is_dualtor_active_active[0]:
-                headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6']
-            else:
-                headers = ['port', 'state', 'ipv4', 'ipv6']
+            headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6', 'prober_type']
             click.echo(tabulate(print_data, headers=headers))
 
         sys.exit(CONFIG_SUCCESSFUL)

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1942,12 +1942,14 @@
     },
     "MUX_CABLE|Ethernet4": {
         "state": "auto",
+	"prober_type": "software",
         "server_ipv4": "10.3.1.1",
         "server_ipv6": "e801::46",
         "soc_ipv6": "e801::47"
     },
     "MUX_CABLE|Ethernet8": {
         "state": "active",
+	"prober_type": "hardware",
 	"server_ipv4": "10.4.1.1",
 	"server_ipv6": "e802::46"
     },


### PR DESCRIPTION
Orignal PR was reverted because of pre-test failure as part of following issue 
https://github.com/sonic-net/sonic-utilities/issues/3978

orignal PR https://github.com/sonic-net/sonic-utilities/pull/3884

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it
Fixed show mux config to one format no matter if soc_ipv4 is given or not 

#### How to verify it
Ran the test_pretest as part of sonic_mgmt

#### Previous command output (if the output of a command-line utility has changed)
port         state    ipv4             ipv6               cable_type     soc_ipv4         soc_ipv6    
-----------  -------  ---------------  -----------------  -------------  --------------- 
Ethernet8    auto     192.168.0.2/32   fc02:1000::2/128   active-active  192.168.0.3/32 
Ethernet16   auto     192.168.0.4/32   fc02:1000::4/128   active-active  192.168.0.5/32

#### New command output (if the output of a command-line utility has changed)
port         state    ipv4             ipv6               cable_type     soc_ipv4         soc_ipv6    prober_type
-----------  -------  ---------------  -----------------  -------------  ---------------  ----------  -------------
Ethernet8    auto     192.168.0.2/32   fc02:1000::2/128   active-active  192.168.0.3/32               software
Ethernet16   auto     192.168.0.4/32   fc02:1000::4/128   active-active  192.168.0.5/32               software
