### PR TITLE
[fast/warm-reboot] Fix timers query

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -851,7 +851,7 @@ if [ -x ${LOG_SSD_HEALTH} ]; then
 fi
 
 # Stop any timers to prevent any containers starting in the middle of the process.
-TIMERS=$(systemctl list-dependencies --plain sonic-delayed.target | sed 1d)
+TIMERS=$(systemctl list-dependencies --plain sonic.target | sed 1d | grep '.timer$')
 for timer in ${TIMERS}; do
     debug "Stopping ${timer} ..."
     systemctl stop ${timer}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed an issue that timers weren't stopped upon warm or fast-reboot. This is because sonic-delayed.target was removed but this script was not updated.

#### How I did it

Fetch timers associated with sonic.target

#### How to verify it

fast-reboot:

```
...
Thu Aug 7 05:41:03 PM IDT 2025 Stopping aaastatsd.timer ...
Thu Aug 7 05:41:03 PM IDT 2025 Stopped aaastatsd.timer ...
Thu Aug 7 05:41:03 PM IDT 2025 Stopping featured.timer ...
Thu Aug 7 05:41:03 PM IDT 2025 Stopped featured.timer ...
Thu Aug 7 05:41:03 PM IDT 2025 Stopping hostcfgd.timer ...
Thu Aug 7 05:41:03 PM IDT 2025 Stopped hostcfgd.timer ...
Thu Aug 7 05:41:03 PM IDT 2025 Stopping tacacs-config.timer ...
Thu Aug 7 05:41:03 PM IDT 2025 Stopped tacacs-config.timer ...
...
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

