### PR TITLE
[smartswitch] Update get_gnmi_port() based on smartswitch config updates

### DIFF
--- a/scripts/reboot_smartswitch_helper
+++ b/scripts/reboot_smartswitch_helper
@@ -40,8 +40,10 @@ function get_dpu_ip()
 # Function to retrieve GNMI port from CONFIG_DB
 function get_gnmi_port()
 {
-    local DPU_NAME=$1
-    sonic-db-cli CONFIG_DB HGET "DPU_PORT|$DPU_NAME" "gnmi_port"
+    local DPU_NAME=${1:-dpu0}
+    for k in $(sonic-db-cli CONFIG_DB keys "DPU|*$DPU_NAME"); do
+        sonic-db-cli CONFIG_DB hget "$k" 'gnmi_port'
+    done
 }
 
 # Function to get reboot status from DPU


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update the reboot script to fetch gnmi_port from CONFIG_DB in alignment with the latest YANG changes.

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#dpu-configuration

#### How I did it
Modify the get_gnmi_port() to fetch the gnmi_port.

#### How to verify it
Run the reboot command with latest configuration changes.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

