### PR TITLE
feat: Add user management CLI commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -61,6 +61,7 @@ from . import kdump
 from . import kube
 from . import muxcable
 from . import nat
+from . import user
 from . import vlan
 from . import vxlan
 from . import plugins
@@ -1787,6 +1788,7 @@ config.add_command(kdump.kdump)
 config.add_command(kube.kubernetes)
 config.add_command(muxcable.muxcable)
 config.add_command(nat.nat)
+config.add_command(user.user)
 config.add_command(vlan.vlan)
 config.add_command(vxlan.vxlan)
 

--- a/config/user.py
+++ b/config/user.py
@@ -1,0 +1,697 @@
+import click
+import getpass
+import re
+import time
+import grp
+import subprocess
+from .validated_config_db_connector import ValidatedConfigDBConnector
+from jsonpatch import JsonPatchConflict
+import utilities_common.cli as clicommon
+
+# Constants
+LOCAL_USER_TABLE = "LOCAL_USER"
+LOCAL_ROLE_SECURITY_POLICY_TABLE = "LOCAL_ROLE_SECURITY_POLICY"
+DEVICE_METADATA_TABLE = "DEVICE_METADATA"
+DEVICE_METADATA_LOCALHOST_KEY = "localhost"
+LOCAL_USER_MANAGEMENT_FIELD = "local_user_management"
+
+# System users to exclude from import
+SYSTEM_USERS = {'root', 'daemon', 'bin', 'sys', 'sync', 'games', 'man', 'lp', 'mail',
+                'news', 'uucp', 'proxy', 'www-data', 'backup', 'list', 'irc', 'gnats',
+                'nobody', '_apt', 'systemd-network', 'systemd-resolve', 'messagebus',
+                'systemd-timesync', 'sshd', 'redis', 'ntp', 'frr', 'snmp'}
+
+# Administrator groups
+ADMIN_GROUPS = {'sudo', 'docker', 'redis', 'admin'}
+
+
+def validate_username(username):
+    """Validate username according to YANG model constraints"""
+    if not re.match(r'^[a-z_][a-z0-9_-]*[$]?$', username):
+        return False, ("Invalid username. Must start with a lowercase letter or underscore, "
+                       "followed by lowercase letters, numbers, underscores, or hyphens.")
+
+    if len(username) < 1 or len(username) > 32:
+        return False, "Username must be between 1 and 32 characters."
+
+    if username == 'root':
+        return False, "Username cannot be 'root'."
+
+    return True, ""
+
+
+def validate_password_hash(password_hash):
+    """Validate password hash"""
+    if password_hash.startswith('!'):
+        return False, "Password hash cannot start with '!'. Use the 'enabled' attribute to disable user accounts."
+
+    return True, ""
+
+
+def get_config_db(db):
+    """Get a connected ValidatedConfigDBConnector instance"""
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
+    config_db.connect()
+    return config_db
+
+
+def handle_password_input(username, password_hash, password_prompt, db, is_new_user=True):
+    """Handle password input and validation for user operations
+
+    Args:
+        username: Username for the operation
+        password_hash: Pre-hashed password (if provided)
+        password_prompt: Whether to prompt for password
+        db: Database connection
+        is_new_user: Whether this is for a new user (affects prompt text)
+
+    Returns:
+        tuple: (password_hash, success) where success is True if operation should continue
+    """
+    # Handle password conflicts
+    if password_prompt and password_hash:
+        click.echo("Error: Cannot specify both --password-hash and --password-prompt")
+        return None, False
+
+    if password_prompt:
+        prompt_text = (f"Enter password for user {username}: " if is_new_user
+                       else f"Enter new password for user {username}: ")
+        password = getpass.getpass(prompt_text)
+        confirm_password = getpass.getpass("Confirm password: ")
+
+        try:
+            if password != confirm_password:
+                click.echo("Error: Passwords do not match")
+                return None, False
+
+            # Check for empty password
+            if not password or password.strip() == "":
+                click.echo("Error: Password cannot be empty")
+                time.sleep(3)  # Security delay to prevent rapid brute-force attempts
+                return None, False
+
+            # Validate password against hardening policies
+            policies = get_password_hardening_policies(db)
+            valid, error_msg = validate_password_against_policies(password, username, policies)
+            if not valid:
+                click.echo(f"Error: {error_msg}")
+                time.sleep(3)  # Security delay to prevent rapid brute-force attempts
+                return None, False
+
+            password_hash = hash_password(password)
+            if not password_hash:
+                click.echo("Error: Failed to generate password hash")
+                return None, False
+        finally:
+            # Always clear passwords from memory
+            password = None
+            confirm_password = None
+
+    # Validate password hash if provided
+    if password_hash and password_hash != '!':
+        valid, error_msg = validate_password_hash(password_hash)
+        if not valid:
+            click.echo(f"Error: {error_msg}")
+            time.sleep(3)  # Security delay to prevent rapid brute-force attempts
+            return None, False
+
+    return password_hash, True
+
+
+def handle_ssh_key_modifications(user_data, add_ssh_key, remove_ssh_key, replace_ssh_keys):
+    """Handle SSH key modifications for user data
+
+    Args:
+        user_data: Current user data dict
+        add_ssh_key: SSH keys to add
+        remove_ssh_key: SSH keys to remove
+        replace_ssh_keys: SSH keys to replace all existing keys with
+
+    Returns:
+        list: Updated SSH keys list
+    """
+    if replace_ssh_keys:
+        # Replace all SSH keys
+        return list(replace_ssh_keys)
+    else:
+        # Get existing SSH keys
+        existing_keys = set(user_data.get('ssh_keys', []))
+
+        # Add new keys
+        if add_ssh_key:
+            existing_keys.update(add_ssh_key)
+
+        # Remove specified keys
+        if remove_ssh_key:
+            existing_keys.difference_update(remove_ssh_key)
+
+        # Return modified key list
+        return list(existing_keys)
+
+
+def update_user_in_db(config_db, username, user_data, operation="modified"):
+    """Update user in CONFIG_DB with error handling
+
+    Args:
+        config_db: Database connection
+        username: Username to update
+        user_data: User data to set
+        operation: Operation description for error message (e.g., "added", "modified")
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        config_db.set_entry(LOCAL_USER_TABLE, username, user_data)
+        return True
+    except (ValueError, JsonPatchConflict) as e:
+        click.echo(f"Error: Failed to {operation.rstrip('d')} user. {e}")
+        return False
+
+
+def get_password_hardening_policies(db):
+    """Get password hardening policies from CONFIG_DB"""
+    config_db = get_config_db(db)
+
+    policies = config_db.get_entry("PASSW_HARDENING", "POLICIES")
+    if not policies:
+        return None
+
+    # Convert string boolean values to actual booleans
+    bool_fields = ['reject_user_passw_match', 'lower_class', 'upper_class', 'digits_class', 'special_class']
+    for field in bool_fields:
+        if field in policies:
+            if isinstance(policies[field], str):
+                policies[field] = policies[field].lower() in ('true', '1', 'yes', 'on')
+
+    # Convert numeric fields
+    numeric_fields = ['len_min', 'history_cnt', 'expiration', 'expiration_warning']
+    for field in numeric_fields:
+        if field in policies:
+            try:
+                policies[field] = int(policies[field])
+            except (ValueError, TypeError):
+                pass
+
+    return policies
+
+
+def validate_password_against_policies(password, username, policies):
+    """Validate password against password hardening policies"""
+    if not policies or policies.get('state') != 'enabled':
+        return True, ""
+
+    errors = []
+
+    # Check minimum length
+    if 'len_min' in policies:
+        min_len = policies['len_min']
+        if len(password) < min_len:
+            errors.append(f"Password must be at least {min_len} characters long")
+
+    # Check character class requirements
+    if policies.get('lower_class', False):
+        if not any(c.islower() for c in password):
+            errors.append("Password must contain at least one lowercase letter")
+
+    if policies.get('upper_class', False):
+        if not any(c.isupper() for c in password):
+            errors.append("Password must contain at least one uppercase letter")
+
+    if policies.get('digits_class', False):
+        if not any(c.isdigit() for c in password):
+            errors.append("Password must contain at least one digit")
+
+    if policies.get('special_class', False):
+        # Define special characters (common set used by pam_pwquality)
+        special_chars = "!@#$%^&*()_+-=[]{}|;:,.<>?"
+        if not any(c in special_chars for c in password):
+            errors.append("Password must contain at least one special character")
+
+    # Check username matching
+    if policies.get('reject_user_passw_match', False):
+        if username.lower() in password.lower():
+            errors.append("Password cannot contain the username")
+
+    if errors:
+        return False, "; ".join(errors)
+
+    return True, ""
+
+
+def hash_password(password):
+    """Hash a password using mkpasswd (from whois package)"""
+    try:
+        result = subprocess.run(['mkpasswd', '--stdin'],
+                                input=password, text=True,
+                                capture_output=True, check=True)
+        return result.stdout.strip()
+    except FileNotFoundError:
+        click.echo("Error: mkpasswd command not found. Please ensure the 'whois' package is installed.")
+        return None
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Error: mkpasswd failed: {e}")
+        return None
+
+
+def check_admin_constraint(db, username, enabled):
+    """Check that at least one administrator remains enabled"""
+    config_db = get_config_db(db)
+
+    users = config_db.get_table(LOCAL_USER_TABLE)
+    admin_count = 0
+
+    for user, data in users.items():
+        if data.get('role') == 'administrator':
+            user_enabled = data.get('enabled', True)
+            if user == username:
+                user_enabled = enabled
+            if user_enabled:
+                admin_count += 1
+
+    return admin_count >= 1
+
+
+def is_feature_enabled(db):
+    """Check if local user management is enabled in DEVICE_METADATA"""
+    config_db = get_config_db(db)
+
+    device_metadata = config_db.get_table(DEVICE_METADATA_TABLE)
+    localhost_data = device_metadata.get(DEVICE_METADATA_LOCALHOST_KEY, {})
+    return localhost_data.get(LOCAL_USER_MANAGEMENT_FIELD) == 'enabled'
+
+
+def get_existing_linux_users(uid_min=1000, uid_max=60000):
+    """Get existing Linux users in specified UID range"""
+    users = {}
+
+    # Read /etc/passwd
+    try:
+        with open('/etc/passwd', 'r') as f:
+            passwd_lines = f.readlines()
+    except (IOError, OSError) as e:
+        click.echo(f"Error reading /etc/passwd: {e}")
+        return users
+
+    # Read /etc/shadow once for all users
+    shadow_passwords = {}
+    try:
+        with open('/etc/shadow', 'r') as f:
+            for line in f:
+                parts = line.strip().split(':')
+                if len(parts) >= 2:
+                    shadow_passwords[parts[0]] = parts[1]
+    except (IOError, OSError):
+        # Shadow file may not be readable, continue with default password hash
+        pass
+
+    # Process each user
+    for line in passwd_lines:
+        parts = line.strip().split(':')
+        if len(parts) < 7:
+            continue
+
+        username = parts[0]
+        try:
+            uid = int(parts[2])
+            gid = int(parts[3])
+        except ValueError:
+            continue
+
+        home = parts[5]
+        shell = parts[6]
+
+        # Skip system users and users outside UID range
+        if username in SYSTEM_USERS or not (uid_min <= uid <= uid_max):
+            continue
+
+        # Get user groups (with error handling for individual users)
+        user_groups = set()
+        try:
+            # Get all groups the user is a member of
+            for group in grp.getgrall():
+                if username in group.gr_mem:
+                    user_groups.add(group.gr_name)
+
+            # Add primary group
+            primary_group = grp.getgrgid(gid)
+            user_groups.add(primary_group.gr_name)
+        except (KeyError, OSError):
+            # If we can't get group info, default to operator role
+            pass
+
+        # Determine role
+        role = 'administrator' if user_groups & ADMIN_GROUPS else 'operator'
+
+        # Get password hash from shadow file
+        password_hash = shadow_passwords.get(username, '!')
+
+        # Get SSH keys
+        ssh_keys = []
+        auth_keys_file = f"{home}/.ssh/authorized_keys"
+        try:
+            with open(auth_keys_file, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        ssh_keys.append(line)
+        except (IOError, OSError):
+            # SSH keys file may not exist or be readable
+            pass
+
+        users[username] = {
+            'role': role,
+            'password_hash': password_hash,
+            'enabled': shell != '/usr/sbin/nologin',
+            'ssh_keys': ssh_keys,
+            'uid': uid,
+            'gid': gid,
+            'home': home,
+            'shell': shell
+        }
+
+    return users
+
+
+@click.group()
+def user():
+    """User management commands"""
+    pass
+
+
+@click.command()
+@click.argument('state', type=click.Choice(['enabled', 'disabled']))
+@clicommon.pass_db
+def feature(db, state):
+    """Enable or disable local user management"""
+    config_db = get_config_db(db)
+
+    # Get current DEVICE_METADATA localhost entry
+    device_metadata = config_db.get_table(DEVICE_METADATA_TABLE)
+    localhost_data = device_metadata.get(DEVICE_METADATA_LOCALHOST_KEY, {})
+
+    # Update the local_user_management field
+    localhost_data[LOCAL_USER_MANAGEMENT_FIELD] = state
+
+    try:
+        config_db.set_entry(DEVICE_METADATA_TABLE, DEVICE_METADATA_LOCALHOST_KEY, localhost_data)
+        click.echo(f"Local user management {state}")
+    except (ValueError, JsonPatchConflict):
+        click.echo(f"Error: Failed to {state[:-1]} local user management")
+
+
+@click.command()
+@click.option('--dry-run', is_flag=True, help='Show what would be imported without making changes')
+@click.option('--uid-range', help='UID range to import (e.g., 1000-60000)', default='1000-60000')
+@clicommon.pass_db
+def import_existing(db, dry_run, uid_range):
+    """Import existing Linux users into CONFIG_DB LOCAL_USER table
+
+    Note: This command should be run BEFORE enabling the local user management feature
+    to ensure a clean transition from system users to managed users.
+    """
+
+    if is_feature_enabled(db):
+        click.echo("Error: Local user management is already enabled")
+        click.echo("Import existing users before enabling the feature for safer operation")
+        return
+
+    # Parse UID range
+    try:
+        uid_min, uid_max = map(int, uid_range.split('-'))
+    except ValueError:
+        click.echo("Error: Invalid UID range format. Use format: min-max (e.g., 1000-60000)")
+        return
+
+    # Get existing Linux users
+    linux_users = get_existing_linux_users(uid_min, uid_max)
+
+    # Get existing CONFIG_DB users
+    config_db = get_config_db(db)
+    config_users = set(config_db.get_table(LOCAL_USER_TABLE).keys())
+
+    # Find users to import (not already in CONFIG_DB)
+    users_to_import = {k: v for k, v in linux_users.items() if k not in config_users}
+
+    if not users_to_import:
+        click.echo("No users found to import")
+        return
+
+    if dry_run:
+        click.echo("Users that would be imported:")
+        for username, user_data in users_to_import.items():
+            ssh_key_count = len(user_data['ssh_keys'])
+            click.echo(f"  {username}: role={user_data['role']}, "
+                       f"enabled={user_data['enabled']}, ssh_keys={ssh_key_count}")
+        return
+
+    # Import users
+    imported_count = 0
+    for username, user_data in users_to_import.items():
+        try:
+            import_data = {
+                'role': user_data['role'],
+                'password_hash': user_data['password_hash'],
+                'enabled': user_data['enabled']
+            }
+
+            if user_data['ssh_keys']:
+                import_data['ssh_keys'] = user_data['ssh_keys']
+
+            config_db.set_entry(LOCAL_USER_TABLE, username, import_data)
+            imported_count += 1
+            click.echo(f"Imported user: {username}")
+
+        except Exception as e:
+            click.echo(f"Failed to import user {username}: {e}")
+
+
+@click.command()
+@click.argument('username')
+@click.option('--role', type=click.Choice(['administrator', 'operator']), required=True,
+              help='User role (administrator or operator)')
+@click.option('--password-hash', help='Pre-hashed password')
+@click.option('--password-prompt', is_flag=True, help='Prompt for password interactively')
+@click.option('--ssh-key', multiple=True, help='SSH public key (can be specified multiple times)')
+@click.option('--disabled', is_flag=True, help='Create user in disabled state')
+@clicommon.pass_db
+def add(db, username, role, password_hash, password_prompt, ssh_key, disabled):
+    """Add a new user"""
+
+    if not is_feature_enabled(db):
+        click.echo("Error: Local user management is not enabled")
+        return
+
+    # Validate username
+    valid, error_msg = validate_username(username)
+    if not valid:
+        click.echo(f"Error: {error_msg}")
+        return
+
+    # Check if user already exists
+    config_db = get_config_db(db)
+
+    existing_user = config_db.get_entry(LOCAL_USER_TABLE, username)
+    if existing_user:
+        click.echo(f"Error: User '{username}' already exists in CONFIG_DB")
+        click.echo(f"To modify an existing user, use: config user modify {username} [options]")
+        return
+
+    # Handle password input and validation
+    password_hash, success = handle_password_input(username, password_hash,
+                                                   password_prompt, db, is_new_user=True)
+    if not success:
+        return
+
+    if not password_hash:
+        click.echo("Error: Failed to generate password hash")
+        return
+
+    # Prepare user data
+    user_data = {
+        'role': role,
+        'password_hash': password_hash,
+        'enabled': not disabled
+    }
+
+    if ssh_key:
+        user_data['ssh_keys'] = list(ssh_key)
+
+    # Add user to CONFIG_DB
+    update_user_in_db(config_db, username, user_data, "added")
+
+
+@click.command()
+@click.argument('username')
+@clicommon.pass_db
+def delete(db, username):
+    """Delete a user"""
+
+    if not is_feature_enabled(db):
+        click.echo("Error: Local user management is not enabled")
+        return
+
+    config_db = get_config_db(db)
+
+    # Check if user exists
+    user_data = config_db.get_entry(LOCAL_USER_TABLE, username)
+    if not user_data:
+        click.echo(f"Error: User '{username}' does not exist")
+        return
+
+    # Check admin constraint
+    if user_data.get('role') == 'administrator':
+        if not check_admin_constraint(db, username, False):
+            click.echo("Error: Cannot delete the last administrator user")
+            return
+
+    # Delete user
+    update_user_in_db(config_db, username, None, "deleted")
+
+
+@click.command()
+@click.argument('username')
+@click.option('--password-hash', help='New pre-hashed password')
+@click.option('--password-prompt', is_flag=True, help='Prompt for new password interactively')
+@click.option('--add-ssh-key', multiple=True, help='Add SSH public key (can be specified multiple times)')
+@click.option('--remove-ssh-key', multiple=True, help='Remove SSH public key (can be specified multiple times)')
+@click.option('--replace-ssh-keys', multiple=True, help='Replace all SSH keys with specified keys')
+@click.option('--enabled', 'enabled_flag', is_flag=True, help='Enable the user account')
+@click.option('--disabled', 'disabled_flag', is_flag=True, help='Disable the user account')
+@clicommon.pass_db
+def modify(db, username, password_hash, password_prompt, add_ssh_key, remove_ssh_key,
+           replace_ssh_keys, enabled_flag, disabled_flag):
+    """Modify an existing user"""
+
+    if not is_feature_enabled(db):
+        click.echo("Error: Local user management is not enabled")
+        return
+
+    config_db = get_config_db(db)
+
+    # Check if user exists
+    user_data = config_db.get_entry(LOCAL_USER_TABLE, username)
+    if not user_data:
+        click.echo(f"Error: User '{username}' does not exist")
+        return
+
+    # Validate that both --enabled and --disabled are not specified together
+    if enabled_flag and disabled_flag:
+        click.echo("Error: Cannot specify both --enabled and --disabled together")
+        return
+
+    # Validate SSH key options - only one type should be specified
+    ssh_options_count = sum([bool(add_ssh_key), bool(remove_ssh_key), bool(replace_ssh_keys)])
+    if ssh_options_count > 1:
+        click.echo("Error: Cannot specify multiple SSH key options "
+                   "(--add-ssh-key, --remove-ssh-key, --replace-ssh-keys) together")
+        return
+
+    # Handle password input and validation (only if password options are provided)
+    if password_prompt or password_hash:
+        password_hash, success = handle_password_input(username, password_hash,
+                                                       password_prompt, db, is_new_user=False)
+        if not success:
+            return
+
+    # Check admin constraint if modifying enabled status of an administrator
+    if (enabled_flag or disabled_flag) and user_data.get('role') == 'administrator':
+        # Calculate the final enabled state after modification
+        final_enabled_state = True if enabled_flag else False if disabled_flag else user_data.get('enabled', True)
+
+        if not check_admin_constraint(db, username, final_enabled_state):
+            click.echo("Error: Cannot disable the last administrator user")
+            return
+
+    # Update user data - start with existing data and only modify specified fields
+    updated_data = user_data.copy()
+
+    # Update password if specified
+    if password_hash:
+        updated_data['password_hash'] = password_hash
+
+    # Handle SSH key modifications (only if SSH key changes were requested)
+    if add_ssh_key or remove_ssh_key or replace_ssh_keys:
+        ssh_keys_result = handle_ssh_key_modifications(user_data, add_ssh_key,
+                                                       remove_ssh_key, replace_ssh_keys)
+        if ssh_keys_result:
+            # Only set ssh_keys field if there are actual keys
+            updated_data['ssh_keys'] = ssh_keys_result
+        elif 'ssh_keys' in updated_data:
+            # Remove ssh_keys field if result is empty (all keys were removed)
+            del updated_data['ssh_keys']
+
+    # Update enabled status if specified
+    if enabled_flag:
+        updated_data['enabled'] = True
+    elif disabled_flag:
+        updated_data['enabled'] = False
+
+    # Update user in CONFIG_DB
+    update_user_in_db(config_db, username, updated_data, "modified")
+
+
+@click.group()
+def security_policy():
+    """User security policy commands"""
+    pass
+
+
+@click.command()
+@click.argument('role', type=click.Choice(['administrator', 'operator']))
+@click.option('--max-login-attempts', type=click.IntRange(1, 1000), required=True,
+              help='Maximum number of failed login attempts before account lockout')
+@clicommon.pass_db
+def set_policy(db, role, max_login_attempts):
+    """Set security policy for a role"""
+
+    if not is_feature_enabled(db):
+        click.echo("Error: Local user management is not enabled")
+        return
+
+    config_db = get_config_db(db)
+
+    policy_data = {
+        'max_login_attempts': max_login_attempts
+    }
+
+    try:
+        config_db.set_entry(LOCAL_ROLE_SECURITY_POLICY_TABLE, role, policy_data)
+    except (ValueError, JsonPatchConflict) as e:
+        click.echo(f"Error: Failed to set security policy. {e}")
+
+
+@click.command()
+@click.argument('role', type=click.Choice(['administrator', 'operator']))
+@clicommon.pass_db
+def clear_policy(db, role):
+    """Clear security policy for a role"""
+
+    if not is_feature_enabled(db):
+        click.echo("Error: Local user management is not enabled")
+        return
+
+    config_db = get_config_db(db)
+
+    # Check if policy exists
+    existing_policy = config_db.get_entry(LOCAL_ROLE_SECURITY_POLICY_TABLE, role)
+    if not existing_policy or existing_policy == {}:
+        return
+
+    try:
+        config_db.set_entry(LOCAL_ROLE_SECURITY_POLICY_TABLE, role, None)
+    except (ValueError, JsonPatchConflict) as e:
+        click.echo(f"Error: Failed to clear security policy. {e}")
+
+
+# Add security policy commands
+security_policy.add_command(set_policy)
+security_policy.add_command(clear_policy)
+
+# Add commands to the user group
+user.add_command(feature)
+user.add_command(import_existing, name='import-existing')
+user.add_command(add)
+user.add_command(delete)
+user.add_command(modify)
+user.add_command(security_policy, name='security-policy')

--- a/config/user.py
+++ b/config/user.py
@@ -1,12 +1,12 @@
 import click
 import getpass
 import re
-import time
 import grp
 import subprocess
 from .validated_config_db_connector import ValidatedConfigDBConnector
 from jsonpatch import JsonPatchConflict
 import utilities_common.cli as clicommon
+from utilities_common.general import is_true, is_user_feature_enabled
 
 # Constants
 LOCAL_USER_TABLE = "LOCAL_USER"
@@ -16,6 +16,10 @@ DEVICE_METADATA_LOCALHOST_KEY = "localhost"
 LOCAL_USER_MANAGEMENT_FIELD = "local_user_management"
 
 # System users to exclude from import
+# These users are managed by the system and should not be imported to SONiC user management:
+# - Standard Linux system users (root, daemon, bin, sys, etc.)
+# - System service accounts (systemd-*, messagebus, sshd, _apt)
+# - SONiC-specific service accounts (redis, ntp, frr, snmp) that are managed by their respective containers
 SYSTEM_USERS = {'root', 'daemon', 'bin', 'sys', 'sync', 'games', 'man', 'lp', 'mail',
                 'news', 'uucp', 'proxy', 'www-data', 'backup', 'list', 'irc', 'gnats',
                 'nobody', '_apt', 'systemd-network', 'systemd-resolve', 'messagebus',
@@ -87,7 +91,6 @@ def handle_password_input(username, password_hash, password_prompt, db, is_new_u
             # Check for empty password
             if not password or password.strip() == "":
                 click.echo("Error: Password cannot be empty")
-                time.sleep(3)  # Security delay to prevent rapid brute-force attempts
                 return None, False
 
             # Validate password against hardening policies
@@ -95,7 +98,6 @@ def handle_password_input(username, password_hash, password_prompt, db, is_new_u
             valid, error_msg = validate_password_against_policies(password, username, policies)
             if not valid:
                 click.echo(f"Error: {error_msg}")
-                time.sleep(3)  # Security delay to prevent rapid brute-force attempts
                 return None, False
 
             password_hash = hash_password(password)
@@ -103,7 +105,7 @@ def handle_password_input(username, password_hash, password_prompt, db, is_new_u
                 click.echo("Error: Failed to generate password hash")
                 return None, False
         finally:
-            # Always clear passwords from memory
+            # Clear passwords from memory for security
             password = None
             confirm_password = None
 
@@ -112,7 +114,6 @@ def handle_password_input(username, password_hash, password_prompt, db, is_new_u
         valid, error_msg = validate_password_hash(password_hash)
         if not valid:
             click.echo(f"Error: {error_msg}")
-            time.sleep(3)  # Security delay to prevent rapid brute-force attempts
             return None, False
 
     return password_hash, True
@@ -191,7 +192,10 @@ def get_password_hardening_policies(db):
             try:
                 policies[field] = int(policies[field])
             except (ValueError, TypeError):
-                pass
+                click.echo(
+                    f"Warning: Invalid value for password policy '{field}': {policies[field]!r}. "
+                    f"Ignoring this policy.", err=True)
+                del policies[field]
 
     return policies
 
@@ -206,7 +210,7 @@ def validate_password_against_policies(password, username, policies):
     # Check minimum length
     if 'len_min' in policies:
         min_len = policies['len_min']
-        if len(password) < min_len:
+        if isinstance(min_len, int) and len(password) < min_len:
             errors.append(f"Password must be at least {min_len} characters long")
 
     # Check character class requirements
@@ -263,22 +267,13 @@ def check_admin_constraint(db, username, enabled):
 
     for user, data in users.items():
         if data.get('role') == 'administrator':
-            user_enabled = data.get('enabled', True)
+            user_enabled = is_true(data.get('enabled'), default=True)
             if user == username:
                 user_enabled = enabled
             if user_enabled:
                 admin_count += 1
 
     return admin_count >= 1
-
-
-def is_feature_enabled(db):
-    """Check if local user management is enabled in DEVICE_METADATA"""
-    config_db = get_config_db(db)
-
-    device_metadata = config_db.get_table(DEVICE_METADATA_TABLE)
-    localhost_data = device_metadata.get(DEVICE_METADATA_LOCALHOST_KEY, {})
-    return localhost_data.get(LOCAL_USER_MANAGEMENT_FIELD) == 'enabled'
 
 
 def get_existing_linux_users(uid_min=1000, uid_max=60000):
@@ -302,8 +297,8 @@ def get_existing_linux_users(uid_min=1000, uid_max=60000):
                 if len(parts) >= 2:
                     shadow_passwords[parts[0]] = parts[1]
     except (IOError, OSError):
-        # Shadow file may not be readable, continue with default password hash
-        pass
+        click.echo("Warning: Unable to read /etc/shadow. Imported users will have locked accounts ('!' password hash).")
+        click.echo("Run as root to import password hashes.")
 
     # Process each user
     for line in passwd_lines:
@@ -351,10 +346,10 @@ def get_existing_linux_users(uid_min=1000, uid_max=60000):
         auth_keys_file = f"{home}/.ssh/authorized_keys"
         try:
             with open(auth_keys_file, 'r') as f:
-                for line in f:
-                    line = line.strip()
-                    if line and not line.startswith('#'):
-                        ssh_keys.append(line)
+                for ssh_line in f:
+                    ssh_line = ssh_line.strip()
+                    if ssh_line and not ssh_line.startswith('#'):
+                        ssh_keys.append(ssh_line)
         except (IOError, OSError):
             # SSH keys file may not exist or be readable
             pass
@@ -362,7 +357,7 @@ def get_existing_linux_users(uid_min=1000, uid_max=60000):
         users[username] = {
             'role': role,
             'password_hash': password_hash,
-            'enabled': shell != '/usr/sbin/nologin',
+            'enabled': 'true' if shell != '/usr/sbin/nologin' else 'false',
             'ssh_keys': ssh_keys,
             'uid': uid,
             'gid': gid,
@@ -411,7 +406,7 @@ def import_existing(db, dry_run, uid_range):
     to ensure a clean transition from system users to managed users.
     """
 
-    if is_feature_enabled(db):
+    if is_user_feature_enabled(db.cfgdb):
         click.echo("Error: Local user management is already enabled")
         click.echo("Import existing users before enabling the feature for safer operation")
         return
@@ -478,9 +473,7 @@ def import_existing(db, dry_run, uid_range):
 def add(db, username, role, password_hash, password_prompt, ssh_key, disabled):
     """Add a new user"""
 
-    if not is_feature_enabled(db):
-        click.echo("Error: Local user management is not enabled")
-        return
+    feature_enabled = is_user_feature_enabled(db.cfgdb)
 
     # Validate username
     valid, error_msg = validate_username(username)
@@ -503,15 +496,22 @@ def add(db, username, role, password_hash, password_prompt, ssh_key, disabled):
     if not success:
         return
 
+    # If no password provided, use locked password hash '!' (SSH-key-only user)
+    # Note: password_hash can be None when neither --password-prompt nor --password-hash is provided
     if not password_hash:
-        click.echo("Error: Failed to generate password hash")
+        password_hash = '!'
+
+    # Validate that user has at least one authentication method
+    if password_hash == '!' and not ssh_key:
+        click.echo("Error: User must have at least one authentication method")
+        click.echo("Please provide either a password (--password-prompt or --password-hash) or an SSH key (--ssh-key)")
         return
 
     # Prepare user data
     user_data = {
         'role': role,
         'password_hash': password_hash,
-        'enabled': not disabled
+        'enabled': 'false' if disabled else 'true'
     }
 
     if ssh_key:
@@ -520,6 +520,10 @@ def add(db, username, role, password_hash, password_prompt, ssh_key, disabled):
     # Add user to CONFIG_DB
     update_user_in_db(config_db, username, user_data, "added")
 
+    # Show warning if feature is not enabled
+    if not feature_enabled:
+        click.echo("Warning: Local user management is not enabled.")
+
 
 @click.command()
 @click.argument('username')
@@ -527,9 +531,7 @@ def add(db, username, role, password_hash, password_prompt, ssh_key, disabled):
 def delete(db, username):
     """Delete a user"""
 
-    if not is_feature_enabled(db):
-        click.echo("Error: Local user management is not enabled")
-        return
+    feature_enabled = is_user_feature_enabled(db.cfgdb)
 
     config_db = get_config_db(db)
 
@@ -539,14 +541,19 @@ def delete(db, username):
         click.echo(f"Error: User '{username}' does not exist")
         return
 
-    # Check admin constraint
-    if user_data.get('role') == 'administrator':
+    # Check admin constraint only when feature is enabled
+    # (when disabled, allow deleting even the last admin since userd won't act on it)
+    if feature_enabled and user_data.get('role') == 'administrator':
         if not check_admin_constraint(db, username, False):
             click.echo("Error: Cannot delete the last administrator user")
             return
 
     # Delete user
     update_user_in_db(config_db, username, None, "deleted")
+
+    # Show warning if feature is not enabled
+    if not feature_enabled:
+        click.echo("Warning: Local user management is not enabled.")
 
 
 @click.command()
@@ -563,9 +570,7 @@ def modify(db, username, password_hash, password_prompt, add_ssh_key, remove_ssh
            replace_ssh_keys, enabled_flag, disabled_flag):
     """Modify an existing user"""
 
-    if not is_feature_enabled(db):
-        click.echo("Error: Local user management is not enabled")
-        return
+    feature_enabled = is_user_feature_enabled(db.cfgdb)
 
     config_db = get_config_db(db)
 
@@ -606,29 +611,26 @@ def modify(db, username, password_hash, password_prompt, add_ssh_key, remove_ssh
     # Update user data - start with existing data and only modify specified fields
     updated_data = user_data.copy()
 
-    # Update password if specified
     if password_hash:
         updated_data['password_hash'] = password_hash
 
-    # Handle SSH key modifications (only if SSH key changes were requested)
     if add_ssh_key or remove_ssh_key or replace_ssh_keys:
         ssh_keys_result = handle_ssh_key_modifications(user_data, add_ssh_key,
                                                        remove_ssh_key, replace_ssh_keys)
-        if ssh_keys_result:
-            # Only set ssh_keys field if there are actual keys
-            updated_data['ssh_keys'] = ssh_keys_result
-        elif 'ssh_keys' in updated_data:
-            # Remove ssh_keys field if result is empty (all keys were removed)
-            del updated_data['ssh_keys']
+        updated_data['ssh_keys'] = ssh_keys_result
 
     # Update enabled status if specified
     if enabled_flag:
-        updated_data['enabled'] = True
+        updated_data['enabled'] = 'true'
     elif disabled_flag:
-        updated_data['enabled'] = False
+        updated_data['enabled'] = 'false'
 
     # Update user in CONFIG_DB
     update_user_in_db(config_db, username, updated_data, "modified")
+
+    # Show warning if feature is not enabled
+    if not feature_enabled:
+        click.echo("Warning: Local user management is not enabled.")
 
 
 @click.group()
@@ -645,14 +647,14 @@ def security_policy():
 def set_policy(db, role, max_login_attempts):
     """Set security policy for a role"""
 
-    if not is_feature_enabled(db):
+    if not is_user_feature_enabled(db.cfgdb):
         click.echo("Error: Local user management is not enabled")
         return
 
     config_db = get_config_db(db)
 
     policy_data = {
-        'max_login_attempts': max_login_attempts
+        'max_login_attempts': str(max_login_attempts)
     }
 
     try:
@@ -667,7 +669,7 @@ def set_policy(db, role, max_login_attempts):
 def clear_policy(db, role):
     """Clear security policy for a role"""
 
-    if not is_feature_enabled(db):
+    if not is_user_feature_enabled(db.cfgdb):
         click.echo("Error: Local user management is not enabled")
         return
 

--- a/show/main.py
+++ b/show/main.py
@@ -59,6 +59,7 @@ from . import p4_table
 from . import processes
 from . import reboot_cause
 from . import sflow
+from . import user
 from . import vlan
 from . import vnet
 from . import vxlan
@@ -323,6 +324,7 @@ cli.add_command(p4_table.p4_table)
 cli.add_command(processes.processes)
 cli.add_command(reboot_cause.reboot_cause)
 cli.add_command(sflow.sflow)
+cli.add_command(user.user)
 cli.add_command(vlan.vlan)
 cli.add_command(vnet.vnet)
 cli.add_command(vxlan.vxlan)

--- a/show/user.py
+++ b/show/user.py
@@ -1,0 +1,239 @@
+import click
+import os
+import getpass
+from swsscommon.swsscommon import ConfigDBConnector
+import utilities_common.cli as clicommon
+
+# Constants
+LOCAL_USER_TABLE = "LOCAL_USER"
+LOCAL_ROLE_SECURITY_POLICY_TABLE = "LOCAL_ROLE_SECURITY_POLICY"
+
+
+def get_user_database(config_db=None):
+    """Get connected ConfigDBConnector and user table data"""
+    if config_db is None:
+        config_db = ConfigDBConnector()
+        config_db.connect()
+    users = config_db.get_table(LOCAL_USER_TABLE)
+    return users
+
+
+def get_security_policies(config_db=None):
+    """Get security policies from CONFIG_DB"""
+    if config_db is None:
+        config_db = ConfigDBConnector()
+        config_db.connect()
+    return config_db.get_table(LOCAL_ROLE_SECURITY_POLICY_TABLE)
+
+
+def can_view_passwords():
+    """Check if current user can view password hashes"""
+    # Root user can always view passwords
+    if os.geteuid() == 0:
+        return True
+
+    # Check if current user has administrator role in SONiC user management
+    current_username = getpass.getuser()
+    users = get_user_database()
+
+    user_data = users.get(current_username)
+    return user_data and user_data.get('role') == 'administrator'
+
+
+def format_ssh_keys_count(ssh_keys):
+    """Format SSH keys for count display"""
+    if not ssh_keys:
+        return "None"
+
+    # Handle both array format (real system) and string format (test system)
+    if isinstance(ssh_keys, list):
+        ssh_key_count = len(ssh_keys)
+    elif isinstance(ssh_keys, str):
+        # Check if it's a string representation of an array (from mock Redis)
+        if ssh_keys.startswith('[') and ssh_keys.endswith(']'):
+            if ssh_keys == '[]':
+                ssh_key_count = 0
+            else:
+                # Count items in array string representation
+                inner = ssh_keys[1:-1].strip()
+                if not inner:
+                    ssh_key_count = 0
+                else:
+                    # Count items by splitting on comma (handles quoted strings)
+                    ssh_key_count = len([item.strip() for item in inner.split(',') if item.strip()])
+        else:
+            # Split by comma and filter out empty strings (regular string format)
+            ssh_key_count = len([key.strip() for key in ssh_keys.split(',') if key.strip()])
+    else:
+        ssh_key_count = 0
+
+    return f"({ssh_key_count})" if ssh_key_count > 0 else "None"
+
+
+def format_ssh_keys_detailed(ssh_keys):
+    """Format SSH keys for detailed display with previews"""
+    if not ssh_keys:
+        return "  SSH Keys: None"
+
+    # Handle both array format (real system) and string format (test system)
+    if isinstance(ssh_keys, list):
+        key_list = ssh_keys
+    elif isinstance(ssh_keys, str):
+        # Check if it's a string representation of an array (from mock Redis)
+        if ssh_keys.startswith('[') and ssh_keys.endswith(']'):
+            if ssh_keys == '[]':
+                key_list = []
+            else:
+                # Parse array string representation (simplified approach)
+                inner = ssh_keys[1:-1].strip()
+                if not inner:
+                    key_list = []
+                else:
+                    # Split on comma and clean up quotes
+                    items = [item.strip() for item in inner.split(',') if item.strip()]
+                    key_list = []
+                    for item in items:
+                        # Remove surrounding quotes if present
+                        item = item.strip()
+                        if ((item.startswith("'") and item.endswith("'")) or
+                                (item.startswith('"') and item.endswith('"'))):
+                            item = item[1:-1]
+                        key_list.append(item)
+        else:
+            # Split by comma and filter out empty strings (regular string format)
+            key_list = [key.strip() for key in ssh_keys.split(',') if key.strip()]
+    else:
+        return "  SSH Keys: None"
+
+    if not key_list:
+        return "  SSH Keys: None"
+
+    result = [f"  SSH Keys ({len(key_list)}):"]
+
+    for i, key in enumerate(key_list, 1):
+        result.append(f"    {i}. {key.strip()}")
+
+    return "\n".join(result)
+
+
+def display_user_details(username, user_data):
+    """Display detailed information for a single user"""
+    click.echo(f"User: {username}")
+    click.echo(f"  Role: {user_data.get('role', 'N/A')}")
+    click.echo(f"  Enabled: {'Yes' if user_data.get('enabled', True) else 'No'}")
+
+    # Show password hash only if user has administrator privileges
+    if can_view_passwords():
+        password_hash = user_data.get('password_hash', '!')
+        click.echo(f"  Password Hash: {password_hash}")
+
+    # Display SSH keys
+    ssh_keys = user_data.get('ssh_keys', [])
+    click.echo(format_ssh_keys_detailed(ssh_keys))
+
+
+@click.group()
+def user():
+    """Show user information"""
+    pass
+
+
+@click.command(name='list')
+@clicommon.pass_db
+def show_users(db):
+    """Show all configured users"""
+
+    users = get_user_database(db.cfgdb)
+
+    if not users:
+        click.echo("No users configured")
+        return
+
+    # Show password hashes only if user has administrator privileges
+    show_passwords = can_view_passwords()
+
+    click.echo("Users:")
+    for username, user_data in users.items():
+        role = user_data.get('role', 'N/A')
+        enabled = user_data.get('enabled', True)
+        ssh_keys = user_data.get('ssh_keys', [])
+
+        click.echo(f"  Username: {username}")
+        click.echo(f"    Role: {role}")
+        click.echo(f"    Enabled: {'Yes' if enabled else 'No'}")
+
+        if show_passwords:
+            password_hash = user_data.get('password_hash', '!')
+            click.echo(f"    Password Hash: {password_hash}")
+
+        # Display SSH key count for summary view
+        ssh_key_count = format_ssh_keys_count(ssh_keys)
+        if ssh_key_count == "None":
+            click.echo(f"    SSH Keys: {ssh_key_count}")
+        else:
+            click.echo(f"    SSH Keys {ssh_key_count}")
+        click.echo()  # Empty line between users
+
+
+@click.command(name='details')
+@click.argument('username', required=False)
+@clicommon.pass_db
+def show_user_details(db, username):
+    """Show detailed information for a specific user or all users"""
+
+    users = get_user_database(db.cfgdb)
+
+    if not users:
+        click.echo("No users configured")
+        return
+
+    if username:
+        # Show specific user
+        if username not in users:
+            click.echo(f"User '{username}' not found")
+            return
+
+        user_data = users[username]
+        display_user_details(username, user_data)
+    else:
+        # Show all users with details
+        for username, user_data in users.items():
+            display_user_details(username, user_data)
+            click.echo()
+
+
+@click.command(name='security-policy')
+@click.argument('role', type=click.Choice(['administrator', 'operator']), required=False)
+@clicommon.pass_db
+def show_security_policy(db, role):
+    """Show security policies for roles"""
+
+    policies = get_security_policies(db.cfgdb)
+    if not policies:
+        click.echo("No security policies configured")
+        return
+
+    if role:
+        # Show specific role policy
+        if role not in policies:
+            click.echo(f"No security policy configured for role '{role}'")
+            return
+
+        policy_data = policies[role]
+        click.echo(f"Security policy for role '{role}':")
+        for key, value in policy_data.items():
+            click.echo(f"  {key}: {value}")
+    else:
+        # Show all policies
+        click.echo("Security policies:")
+        for role_name, policy_data in policies.items():
+            click.echo(f"  Role: {role_name}")
+            for key, value in policy_data.items():
+                click.echo(f"    {key}: {value}")
+            click.echo()
+
+
+# Add commands to the user group
+user.add_command(show_users)
+user.add_command(show_user_details)
+user.add_command(show_security_policy)

--- a/show/user.py
+++ b/show/user.py
@@ -3,6 +3,7 @@ import os
 import getpass
 from swsscommon.swsscommon import ConfigDBConnector
 import utilities_common.cli as clicommon
+from utilities_common.general import is_true, is_user_feature_enabled
 
 # Constants
 LOCAL_USER_TABLE = "LOCAL_USER"
@@ -33,7 +34,12 @@ def can_view_passwords():
         return True
 
     # Check if current user has administrator role in SONiC user management
-    current_username = getpass.getuser()
+    try:
+        current_username = getpass.getuser()
+    except Exception:
+        # Cannot determine username (e.g., in containers without proper user mapping)
+        return False
+
     users = get_user_database()
 
     user_data = users.get(current_username)
@@ -120,7 +126,13 @@ def display_user_details(username, user_data):
     """Display detailed information for a single user"""
     click.echo(f"User: {username}")
     click.echo(f"  Role: {user_data.get('role', 'N/A')}")
-    click.echo(f"  Enabled: {'Yes' if user_data.get('enabled', True) else 'No'}")
+
+    # Show N/A if enabled field is missing to avoid misleading defaults
+    if 'enabled' in user_data:
+        enabled = is_true(user_data.get('enabled'), default=True)
+        click.echo(f"  Enabled: {'Yes' if enabled else 'No'}")
+    else:
+        click.echo("  Enabled: N/A")
 
     # Show password hash only if user has administrator privileges
     if can_view_passwords():
@@ -143,6 +155,11 @@ def user():
 def show_users(db):
     """Show all configured users"""
 
+    # Show feature status
+    feature_enabled = is_user_feature_enabled(db.cfgdb)
+    click.echo(f"Local User Management: {'Enabled' if feature_enabled else 'Disabled'}")
+    click.echo()
+
     users = get_user_database(db.cfgdb)
 
     if not users:
@@ -154,8 +171,10 @@ def show_users(db):
 
     click.echo("Users:")
     for username, user_data in users.items():
+        if not isinstance(user_data, dict):
+            continue
         role = user_data.get('role', 'N/A')
-        enabled = user_data.get('enabled', True)
+        enabled = is_true(user_data.get('enabled'), default=True)
         ssh_keys = user_data.get('ssh_keys', [])
 
         click.echo(f"  Username: {username}")
@@ -180,6 +199,11 @@ def show_users(db):
 @clicommon.pass_db
 def show_user_details(db, username):
     """Show detailed information for a specific user or all users"""
+
+    # Show feature status
+    feature_enabled = is_user_feature_enabled(db.cfgdb)
+    click.echo(f"Local User Management: {'Enabled' if feature_enabled else 'Disabled'}")
+    click.echo()
 
     users = get_user_database(db.cfgdb)
 

--- a/tests/config_user_test.py
+++ b/tests/config_user_test.py
@@ -1,0 +1,1687 @@
+#!/usr/bin/env python3
+
+import subprocess
+import unittest
+import unittest.mock as mock
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+import config.user as user_module
+
+
+class TestUserCLI(unittest.TestCase):
+    """Test cases for user CLI commands"""
+
+    def setUp(self):
+        """Set up test environment with real database"""
+        self.runner = CliRunner()
+        self.db = Db()
+        self.clear_existing_data()
+        # Set up initial test data in CONFIG_DB
+        self.setup_test_data()
+
+    def clear_existing_data(self):
+        """Clear existing data from shared database"""
+        self.db.cfgdb.delete_table("LOCAL_USER")
+        self.db.cfgdb.delete_table("LOCAL_ROLE_SECURITY_POLICY")
+        # Reset device metadata
+        self.db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {})
+
+    def setup_test_data(self):
+        """Set up initial test data in CONFIG_DB"""
+        # Enable local user management feature
+        self.db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {
+            "local_user_management": "enabled"
+        })
+
+        # Add some test users
+        self.db.cfgdb.set_entry("LOCAL_USER", "admin", {
+            "role": "administrator",
+            "password_hash": "$y$j9T$salt$adminhash",
+            "enabled": True,
+            "ssh_keys": ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA admin@host"]
+        })
+
+        self.db.cfgdb.set_entry("LOCAL_USER", "operator1", {
+            "role": "operator",
+            "password_hash": "$y$j9T$salt$ophash",
+            "enabled": True,
+            "ssh_keys": []
+        })
+
+        self.db.cfgdb.set_entry("LOCAL_USER", "disabled_user", {
+            "role": "operator",
+            "password_hash": "$y$j9T$salt$disabledhash",
+            "enabled": False,
+            "ssh_keys": []
+        })
+
+        # Add security policies
+        self.db.cfgdb.set_entry("LOCAL_ROLE_SECURITY_POLICY", "administrator", {
+            "max_login_attempts": "5"
+        })
+
+    def tearDown(self):
+        """Clean up test environment"""
+        self.clear_existing_data()
+
+    def test_cli_feature_enable_disable(self):
+        """Test enabling and disabling the local user management feature via CLI"""
+        # Test disable
+        result = self.runner.invoke(user_module.user, [
+            "feature", "disabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("disabled", result.output)
+
+        # Verify in database
+        metadata = self.db.cfgdb.get_entry("DEVICE_METADATA", "localhost")
+        self.assertEqual(metadata.get("local_user_management"), "disabled")
+
+        # Test enable
+        result = self.runner.invoke(user_module.user, [
+            "feature", "enabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("enabled", result.output)
+
+        # Verify in database
+        metadata = self.db.cfgdb.get_entry("DEVICE_METADATA", "localhost")
+        self.assertEqual(metadata.get("local_user_management"), "enabled")
+
+    def test_cli_add_user_success(self):
+        """Test successful user addition via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "newuser",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$newhash"
+        ], obj=self.db)
+
+        # Verify command succeeded
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify user was added to database
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "newuser")
+        self.assertIsNotNone(user_data)
+        self.assertEqual(user_data["role"], "operator")
+        self.assertEqual(user_data["password_hash"], "$y$j9T$salt$newhash")
+        # CONFIG_DB stores boolean values as strings
+        self.assertIn(user_data["enabled"], [True, "True"])  # Default enabled
+
+    def test_cli_add_user_disabled(self):
+        """Test adding user in disabled state via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "disableduser",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$disabledhash",
+            "--disabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify user is disabled
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disableduser")
+        # CONFIG_DB stores boolean values as strings
+        self.assertIn(user_data["enabled"], [False, "False"])
+
+    def test_cli_add_user_already_exists(self):
+        """Test adding user that already exists via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "admin",  # Already exists in test data
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$hash"
+        ], obj=self.db)
+
+        # Should succeed with exit code 0 but show error message
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("already exists", result.output)
+
+    def test_cli_add_user_feature_disabled(self):
+        """Test adding user when feature is disabled via CLI"""
+        # Disable the feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        result = self.runner.invoke(user_module.user, [
+            "add", "newuser",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$hash"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+        # Verify user was NOT added (CONFIG_DB returns empty dict for non-existent entries)
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "newuser")
+        self.assertIn(user_data, [None, {}])  # Accept both None and empty dict
+
+    def test_cli_delete_user_success(self):
+        """Test successful user deletion via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "delete", "operator1"  # Exists in test data
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify user was removed from database
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "operator1")
+        # CONFIG_DB returns empty dict for non-existent entries
+        self.assertIn(user_data, [None, {}])
+
+    def test_cli_delete_user_not_exists(self):
+        """Test deleting user that doesn't exist via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "delete", "nonexistent"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("does not exist", result.output)
+
+    def test_cli_modify_user_success(self):
+        """Test successful user modification via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "modify", "disabled_user",
+            "--password-hash", "$y$j9T$salt$newhash",
+            "--enabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify changes in database
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disabled_user")
+        self.assertEqual(user_data["password_hash"], "$y$j9T$salt$newhash")
+        # CONFIG_DB stores boolean values as strings
+        self.assertIn(user_data["enabled"], [True, "True"])
+
+    def test_cli_security_policy_set(self):
+        """Test setting security policy via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "10"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify in database
+        policy = self.db.cfgdb.get_entry("LOCAL_ROLE_SECURITY_POLICY", "operator")
+        self.assertEqual(policy["max_login_attempts"], "10")
+
+    @mock.patch('config.user.get_existing_linux_users')
+    def test_cli_import_existing_success(self, mock_get_users):
+        """Test successful import of existing Linux users via CLI"""
+        # Disable feature first (import only works when disabled)
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        # Mock existing Linux users (matching get_existing_linux_users structure)
+        mock_get_users.return_value = {
+            'linuxuser1': {
+                'role': 'operator',  # Determined from group membership
+                'password_hash': '$y$j9T$salt$linuxhash1',
+                'enabled': True,  # Based on shell (not /usr/sbin/nologin)
+                'ssh_keys': [],  # From ~/.ssh/authorized_keys
+                'uid': 1001,
+                'gid': 1001,
+                'home': '/home/linuxuser1',
+                'shell': '/bin/bash'
+            },
+            'linuxuser2': {
+                'role': 'operator',  # Determined from group membership
+                'password_hash': '$y$j9T$salt$linuxhash2',
+                'enabled': True,  # Based on shell (not /usr/sbin/nologin)
+                'ssh_keys': [],  # From ~/.ssh/authorized_keys
+                'uid': 1002,
+                'gid': 1002,
+                'home': '/home/linuxuser2',
+                'shell': '/bin/bash'
+            }
+        }
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify users were imported to database
+        user1_data = self.db.cfgdb.get_entry("LOCAL_USER", "linuxuser1")
+        user2_data = self.db.cfgdb.get_entry("LOCAL_USER", "linuxuser2")
+
+        self.assertIsNotNone(user1_data)
+        self.assertIsNotNone(user2_data)
+        self.assertEqual(user1_data["role"], "operator")  # Default role
+        self.assertEqual(user1_data["password_hash"], "$y$j9T$salt$linuxhash1")
+        # CONFIG_DB stores boolean values as strings
+        self.assertIn(user1_data["enabled"], [True, "True"])
+
+    def test_cli_import_existing_feature_enabled(self):
+        """Test import-existing when feature is enabled (should fail) via CLI"""
+        # Feature is enabled by default in test setup
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)  # SONiC commands return 0 even for user errors
+        self.assertIn("already enabled", result.output)
+
+    @mock.patch('config.user.get_existing_linux_users')
+    def test_cli_import_existing_dry_run(self, mock_get_users):
+        """Test dry-run import of existing Linux users via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        # Mock existing Linux users (matching get_existing_linux_users structure)
+        mock_get_users.return_value = {
+            'dryrunuser': {
+                'role': 'operator',  # Determined from group membership
+                'password_hash': '$y$j9T$salt$dryrunhash',
+                'enabled': True,  # Based on shell (not /usr/sbin/nologin)
+                'ssh_keys': [],  # From ~/.ssh/authorized_keys
+                'uid': 1003,
+                'gid': 1003,
+                'home': '/home/dryrunuser',
+                'shell': '/bin/bash'
+            }
+        }
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing", "--dry-run"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Users that would be imported", result.output)
+
+        # Verify user was NOT actually imported
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "dryrunuser")
+        # CONFIG_DB returns empty dict for non-existent entries
+        self.assertIn(user_data, [None, {}])
+
+    def test_cli_add_user_invalid_username(self):
+        """Test adding user with invalid username via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "Invalid-User!",  # Invalid characters
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$hash"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)  # SONiC commands return 0 for user errors
+        self.assertIn("Invalid username", result.output)
+
+        # Verify user was NOT added
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "Invalid-User!")
+        # CONFIG_DB returns empty dict for non-existent entries
+        self.assertIn(user_data, [None, {}])
+
+    def test_cli_add_user_invalid_role(self):
+        """Test adding user with invalid role via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "testuser",
+            "--role", "invalid_role",  # Invalid role
+            "--password-hash", "$y$j9T$salt$hash"
+        ], obj=self.db)
+
+        # Should fail with Click validation error
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn('Invalid value for "--role"', result.output)
+
+    def test_cli_add_user_no_password(self):
+        """Test adding user without password via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "newuser",
+            "--role", "operator"
+            # No password provided
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("password", result.output.lower())  # Should mention password requirement
+
+    def test_cli_delete_user_feature_disabled(self):
+        """Test deleting user when feature is disabled via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        result = self.runner.invoke(user_module.user, [
+            "delete", "operator1"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+        # Verify user was NOT deleted
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "operator1")
+        self.assertIsNotNone(user_data)
+
+    def test_cli_delete_last_admin(self):
+        """Test deleting the last administrator user via CLI"""
+        # Delete all admins except one
+        self.db.cfgdb.delete_table("LOCAL_USER")  # Clear all users
+        self.db.cfgdb.set_entry("LOCAL_USER", "lastadmin", {
+            "role": "administrator",
+            "password_hash": "$y$j9T$salt$lastadminhash",
+            "enabled": True,
+            "ssh_keys": []
+        })
+
+        result = self.runner.invoke(user_module.user, [
+            "delete", "lastadmin"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("last administrator", result.output)
+
+        # Verify user was NOT deleted
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "lastadmin")
+        self.assertIsNotNone(user_data)
+
+    def test_cli_delete_user_case_sensitivity(self):
+        """Test deleting user with different case via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "delete", "ADMIN"  # Different case
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("does not exist", result.output)  # Should be case sensitive
+
+    def test_cli_modify_user_not_exists(self):
+        """Test modifying user that doesn't exist via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "modify", "nonexistent",
+            "--password-hash", "$y$j9T$salt$newhash"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("does not exist", result.output)
+
+    def test_cli_modify_user_feature_disabled(self):
+        """Test modifying user when feature is disabled via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        result = self.runner.invoke(user_module.user, [
+            "modify", "operator1",
+            "--password-hash", "$y$j9T$salt$newhash"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+    def test_cli_modify_user_password_only(self):
+        """Test modifying only user password via CLI"""
+        original_data = self.db.cfgdb.get_entry("LOCAL_USER", "operator1")
+
+        result = self.runner.invoke(user_module.user, [
+            "modify", "operator1",
+            "--password-hash", "$y$j9T$salt$newpasshash"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify only password changed
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "operator1")
+        self.assertEqual(user_data["password_hash"], "$y$j9T$salt$newpasshash")
+        self.assertEqual(user_data["role"], original_data["role"])  # Unchanged
+        self.assertEqual(user_data["enabled"], original_data["enabled"])  # Unchanged
+
+    def test_cli_modify_user_enable_disable(self):
+        """Test enabling and disabling user via CLI"""
+        # Test enable disabled user
+        result = self.runner.invoke(user_module.user, [
+            "modify", "disabled_user",
+            "--enabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disabled_user")
+        # CONFIG_DB stores boolean values as strings
+        self.assertIn(user_data["enabled"], [True, "True"])
+
+        # Test disable enabled user
+        result = self.runner.invoke(user_module.user, [
+            "modify", "disabled_user",
+            "--disabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disabled_user")
+        # CONFIG_DB stores boolean values as strings
+        self.assertIn(user_data["enabled"], [False, "False"])
+
+    def test_cli_modify_user_conflicting_flags(self):
+        """Test modifying user with conflicting enabled/disabled flags via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "modify", "operator1",
+            "--enabled",
+            "--disabled"  # Conflicting flags
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Cannot specify both", result.output)
+
+    def test_cli_modify_last_admin_disable(self):
+        """Test disabling the last administrator user via CLI"""
+        # Make admin the only administrator
+        self.db.cfgdb.delete_table("LOCAL_USER")  # Clear all users
+        self.db.cfgdb.set_entry("LOCAL_USER", "admin", {
+            "role": "administrator",
+            "password_hash": "$y$j9T$salt$adminhash",
+            "enabled": True,
+            "ssh_keys": []
+        })
+
+        result = self.runner.invoke(user_module.user, [
+            "modify", "admin",
+            "--disabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("last administrator", result.output)
+
+        # Verify admin was NOT disabled
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "admin")
+        # CONFIG_DB stores boolean values as strings
+        self.assertIn(user_data["enabled"], [True, "True"])
+
+    def test_cli_security_policy_set_all_options(self):
+        """Test setting security policy with available options via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "administrator",
+            "--max-login-attempts", "8"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify policy setting
+        policy = self.db.cfgdb.get_entry("LOCAL_ROLE_SECURITY_POLICY", "administrator")
+        self.assertEqual(policy["max_login_attempts"], "8")
+
+    def test_cli_security_policy_set_invalid_role(self):
+        """Test setting security policy for invalid role via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "invalid_role",
+            "--max-login-attempts", "5"
+        ], obj=self.db)
+
+        # Should fail with Click validation error
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.output)
+
+    def test_cli_security_policy_set_invalid_values(self):
+        """Test setting security policy with invalid values via CLI"""
+        # Test invalid max-login-attempts (Click validation error)
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "0"  # Invalid: must be positive
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 2)  # Click validation error
+        self.assertIn("not in the valid range", result.output)
+
+        # Test invalid max-login-attempts too high (Click validation error)
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "1001"  # Invalid: exceeds maximum
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 2)  # Click validation error
+        self.assertIn("not in the valid range", result.output)
+
+    def test_cli_security_policy_clear(self):
+        """Test clearing security policy via CLI"""
+        # First set a policy
+        self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "3"
+        ], obj=self.db)
+
+        # Verify policy exists
+        policy = self.db.cfgdb.get_entry("LOCAL_ROLE_SECURITY_POLICY", "operator")
+        self.assertIsNotNone(policy)
+
+        # Clear the policy
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "clear-policy", "operator"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Silent on success - no output expected
+
+        # Verify policy was removed
+        policy = self.db.cfgdb.get_entry("LOCAL_ROLE_SECURITY_POLICY", "operator")
+        # CONFIG_DB returns empty dict for non-existent entries
+        self.assertIn(policy, [None, {}])
+
+    def test_cli_security_policy_clear_nonexistent(self):
+        """Test clearing non-existent security policy via CLI"""
+        # Ensure no operator policy exists by clearing the entire table and only adding administrator
+        self.db.cfgdb.delete_table("LOCAL_ROLE_SECURITY_POLICY")
+        self.db.cfgdb.set_entry("LOCAL_ROLE_SECURITY_POLICY", "administrator", {
+            "max_login_attempts": "5"
+        })
+
+        # Verify no operator policy exists
+        policy = self.db.cfgdb.get_entry("LOCAL_ROLE_SECURITY_POLICY", "operator")
+        self.assertIn(policy, [None, {}])  # Should be empty
+
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "clear-policy", "operator"  # No policy set
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("", result.output)
+
+    def test_cli_security_policy_feature_disabled(self):
+        """Test security policy commands when feature is disabled via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "5"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+    def test_cli_invalid_command(self):
+        """Test invalid user command via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "invalid-command"
+        ], obj=self.db)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No such command", result.output)
+
+    def test_cli_missing_required_args(self):
+        """Test commands with missing required arguments via CLI"""
+        # Test add without username
+        result = self.runner.invoke(user_module.user, [
+            "add"
+        ], obj=self.db)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Missing argument", result.output)
+
+        # Test delete without username
+        result = self.runner.invoke(user_module.user, [
+            "delete"
+        ], obj=self.db)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Missing argument", result.output)
+
+    def test_cli_help_commands(self):
+        """Test help output for user commands via CLI"""
+        # Test main help
+        result = self.runner.invoke(user_module.user, ["--help"], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("User management commands", result.output)
+
+        # Test add help
+        result = self.runner.invoke(user_module.user, ["add", "--help"], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Add a new user", result.output)
+
+        # Test security-policy help
+        result = self.runner.invoke(user_module.user, ["security-policy", "--help"], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("User security policy commands", result.output)
+
+    def test_cli_username_validation(self):
+        """Test username validation with various username scenarios"""
+        # Test scenarios: (username, should_succeed, expected_error_keywords)
+        username_scenarios = [
+            # Valid usernames - should succeed
+            ("validuser", True, []),
+            ("user_123", True, []),
+            ("_underscore", True, []),
+            ("user-dash", True, []),
+            ("user$", True, []),
+            ("a", True, []),  # Minimum length
+            ("a" * 32, True, []),  # Maximum length
+
+            # Invalid usernames - should fail
+            ("123invalid", False, ["Invalid username"]),  # Starts with number
+            ("User", False, ["Invalid username"]),  # Uppercase
+            ("user@invalid", False, ["Invalid username"]),  # Invalid character
+            ("user space", False, ["Invalid username"]),  # Space
+            ("user#hash", False, ["Invalid username"]),  # Hash symbol
+            ("", False, ["Invalid username"]),  # Empty
+            ("a" * 33, False, ["Username must be between 1 and 32 characters"]),  # Too long
+            ("root", False, ["cannot be 'root'"]),  # Reserved name
+        ]
+
+        for username, should_succeed, expected_errors in username_scenarios:
+            with self.subTest(username=username):
+                result = self.runner.invoke(user_module.user, [
+                    "add", username,
+                    "--role", "operator",
+                    "--password-hash", "$y$j9T$salt$hash"
+                ], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+
+                if should_succeed:
+                    # Should succeed silently (no error output)
+                    self.assertNotIn("Error:", result.output)
+                    # Verify user was created
+                    user_data = self.db.cfgdb.get_entry("LOCAL_USER", username)
+                    self.assertIsNotNone(user_data)
+
+                    self.db.cfgdb.set_entry("LOCAL_USER", username, None)
+                else:
+                    # Should fail with expected error messages
+                    for error_keyword in expected_errors:
+                        self.assertIn(error_keyword, result.output)
+                    # Verify user was NOT created
+                    user_data = self.db.cfgdb.get_entry("LOCAL_USER", username)
+                    self.assertIn(user_data, [None, {}])
+
+    def test_cli_password_hash_validation(self):
+        """Test password hash validation"""
+        # Test scenarios: (password_hash, should_succeed, expected_error_keywords)
+        password_hash_scenarios = [
+            # Valid password hashes - should succeed
+            ("$y$j9T$salt$hash", True, []),
+            ("$6$salt$hash", True, []),
+            ("$5$salt$hash", True, []),
+            ("$1$salt$hash", True, []),
+
+            # Invalid password hash - should fail
+            ("!locked", False, ["cannot start with '!'"]),
+            ("!!invalid", False, ["cannot start with '!'"]),
+        ]
+
+        for password_hash, should_succeed, expected_errors in password_hash_scenarios:
+            with self.subTest(password_hash=password_hash):
+                result = self.runner.invoke(user_module.user, [
+                    "add", "hashuser",
+                    "--role", "operator",
+                    "--password-hash", password_hash
+                ], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+
+                if should_succeed:
+                    # Should succeed silently (no error output)
+                    self.assertNotIn("Error:", result.output)
+                    # Verify user was created
+                    user_data = self.db.cfgdb.get_entry("LOCAL_USER", "hashuser")
+                    self.assertIsNotNone(user_data)
+                    self.assertEqual(user_data["password_hash"], password_hash)
+
+                    self.db.cfgdb.set_entry("LOCAL_USER", "hashuser", None)
+                else:
+                    # Should fail with expected error messages
+                    for error_keyword in expected_errors:
+                        self.assertIn(error_keyword, result.output)
+                    # Verify user was NOT created
+                    user_data = self.db.cfgdb.get_entry("LOCAL_USER", "hashuser")
+                    self.assertIn(user_data, [None, {}])
+
+    @mock.patch('subprocess.run')
+    def test_cli_password_hashing_scenarios(self, mock_subprocess):
+        """Test password hashing scenarios"""
+        # Test successful hashing
+        mock_result = mock.MagicMock()
+        mock_result.stdout = "$y$j9T$salt$hashedpassword\n"
+        mock_subprocess.return_value = mock_result
+
+        with mock.patch('config.user.getpass.getpass', side_effect=["testpass", "testpass"]):
+            result = self.runner.invoke(user_module.user, [
+                "add", "hashtest",
+                "--role", "operator",
+                "--password-prompt"
+            ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Should succeed and create user
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "hashtest")
+        self.assertIsNotNone(user_data)
+        self.assertEqual(user_data["password_hash"], "$y$j9T$salt$hashedpassword")
+
+        self.db.cfgdb.set_entry("LOCAL_USER", "hashtest", None)
+
+        # Test mkpasswd not found
+        mock_subprocess.side_effect = FileNotFoundError()
+
+        with mock.patch('config.user.getpass.getpass', side_effect=["testpass", "testpass"]):
+            result = self.runner.invoke(user_module.user, [
+                "add", "hashfail1",
+                "--role", "operator",
+                "--password-prompt"
+            ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("mkpasswd command not found", result.output)
+
+        # Test mkpasswd failure
+        mock_subprocess.side_effect = subprocess.CalledProcessError(1, 'mkpasswd')
+
+        with mock.patch('config.user.getpass.getpass', side_effect=["testpass", "testpass"]):
+            result = self.runner.invoke(user_module.user, [
+                "add", "hashfail2",
+                "--role", "operator",
+                "--password-prompt"
+            ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("mkpasswd failed", result.output)
+
+    @mock.patch('subprocess.run')
+    @mock.patch('config.user.getpass.getpass')
+    def test_cli_password_hardening_policies_integration(self, mock_getpass, mock_subprocess):
+        """Test password hardening policies with various password scenarios"""
+        # Mock successful password hashing
+        mock_result = mock.MagicMock()
+        mock_result.stdout = "$y$j9T$salt$hashedpassword\n"
+        mock_subprocess.return_value = mock_result
+
+        # Set up comprehensive password hardening policies
+        self.db.cfgdb.set_entry("PASSW_HARDENING", "POLICIES", {
+            "state": "enabled",
+            "len_min": "8",
+            "reject_user_passw_match": "true",
+            "lower_class": "true",
+            "upper_class": "true",
+            "digits_class": "true",
+            "special_class": "true"
+        })
+
+        # Test scenarios: (password, confirm_password, should_succeed, expected_error_keywords)
+        password_scenarios = [
+            # Valid password - should succeed
+            ("StrongP@ss1", "StrongP@ss1", True, []),
+
+            # Password too short - should fail
+            ("Short1!", "Short1!", False, ["at least 8 characters"]),
+
+            # Missing lowercase - should fail
+            ("UPPERCASE1!", "UPPERCASE1!", False, ["lowercase letter"]),
+
+            # Missing uppercase - should fail
+            ("lowercase1!", "lowercase1!", False, ["uppercase letter"]),
+
+            # Missing digits - should fail
+            ("NoDigits!", "NoDigits!", False, ["digit"]),
+
+            # Missing special characters - should fail
+            ("NoSpecial1", "NoSpecial1", False, ["special character"]),
+
+            # Contains username - should fail
+            ("newuser123!", "newuser123!", False, ["cannot contain the username"]),
+
+            # Multiple violations - should fail with multiple errors
+            ("weak", "weak", False, ["at least 8 characters", "uppercase letter", "digit", "special character"]),
+
+            # Password mismatch - should fail
+            ("StrongP@ss1", "DifferentP@ss1", False, ["do not match"]),
+        ]
+
+        for password, confirm_password, should_succeed, expected_errors in password_scenarios:
+            with self.subTest(password=password):
+                mock_getpass.side_effect = [password, confirm_password]
+
+                result = self.runner.invoke(user_module.user, [
+                    "add", "newuser",
+                    "--role", "operator",
+                    "--password-prompt"
+                ], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+
+                if should_succeed:
+                    # Should succeed silently (no error output)
+                    self.assertNotIn("Error:", result.output)
+                    # Verify user was created
+                    user_data = self.db.cfgdb.get_entry("LOCAL_USER", "newuser")
+                    self.assertIsNotNone(user_data)
+
+                    self.db.cfgdb.set_entry("LOCAL_USER", "newuser", None)
+
+    @mock.patch('subprocess.run')
+    @mock.patch('config.user.getpass.getpass')
+    def test_cli_password_policy_edge_cases(self, mock_getpass, mock_subprocess):
+        """Test password policy edge cases and data type handling"""
+        # Mock successful password hashing
+        mock_result = mock.MagicMock()
+        mock_result.stdout = "$y$j9T$salt$hashedpassword\n"
+        mock_subprocess.return_value = mock_result
+
+        # Test with string boolean values and invalid numeric values
+        self.db.cfgdb.set_entry("PASSW_HARDENING", "POLICIES", {
+            "state": "enabled",
+            "len_min": "invalid_number",  # Invalid numeric value
+            "reject_user_passw_match": "TRUE",  # String boolean
+            "lower_class": "1",  # Numeric boolean
+            "upper_class": "yes",  # String boolean
+            "digits_class": "on",  # String boolean
+            "special_class": "false"  # String boolean false
+        })
+
+        mock_getpass.side_effect = ["ValidP@ss1", "ValidP@ss1"]
+
+        result = self.runner.invoke(user_module.user, [
+            "add", "edgeuser",
+            "--role", "operator",
+            "--password-prompt"
+        ], obj=self.db)
+
+        # System should fail when password policies have invalid values
+        # Invalid numeric values like "invalid_number" should cause validation to fail
+        self.assertNotEqual(result.exit_code, 0,
+                            "Command should fail when password policies contain invalid values")
+
+        # Verify user was NOT created due to policy validation failure
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "edgeuser")
+        self.assertIn(user_data, [None, {}],
+                      "User should not be created when policy validation fails")
+
+    def test_cli_password_hardening_policies_disabled(self):
+        """Test that weak passwords are accepted when policies are disabled"""
+        # Ensure no password policies are configured (disabled by default)
+        self.db.cfgdb.set_entry("PASSW_HARDENING", "POLICIES", None)
+
+        # Test with a weak password that would fail if policies were enabled
+        result = self.runner.invoke(user_module.user, [
+            "add", "weakpassuser",
+            "--role", "operator",
+            "--password-hash", "weak"  # Very weak password
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Should succeed silently when policies are disabled
+        self.assertNotIn("Error:", result.output)
+
+        # Verify user was created
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "weakpassuser")
+        self.assertIsNotNone(user_data)
+        self.assertEqual(user_data["password_hash"], "weak")
+
+    def test_cli_password_input_conflicting_options(self):
+        """Test CLI with conflicting password options"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "conflictuser",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$hash",
+            "--password-prompt"  # Conflicting with password-hash
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Cannot specify both", result.output)
+
+        # Verify user was NOT created
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "conflictuser")
+        self.assertIn(user_data, [None, {}])
+
+    @mock.patch('config.user.getpass.getpass')
+    def test_cli_password_prompt_hash_failure(self, mock_getpass):
+        """Test CLI password prompt when password hashing fails"""
+        mock_getpass.side_effect = ["testpass123", "testpass123"]
+
+        # Mock hash_password to return None (failure)
+        with mock.patch('config.user.hash_password', return_value=None):
+            result = self.runner.invoke(user_module.user, [
+                "add", "hashfailuser",
+                "--role", "operator",
+                "--password-prompt"
+            ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Failed to generate password hash", result.output)
+
+        # Verify user was NOT created
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "hashfailuser")
+        self.assertIn(user_data, [None, {}])
+
+    def test_cli_ssh_key_operations_comprehensive(self):
+        """Test comprehensive SSH key operations through CLI commands"""
+        # Test 1: Add user with multiple SSH keys
+        result = self.runner.invoke(user_module.user, [
+            "add", "sshtest",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$sshhash",
+            "--ssh-key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA key1@host",
+            "--ssh-key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQw8hdMNBWG key2@host"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "sshtest")
+        self.assertEqual(len(user_data["ssh_keys"]), 2)
+        self.assertIn("key1@host", str(user_data["ssh_keys"]))
+        self.assertIn("key2@host", str(user_data["ssh_keys"]))
+
+        # Test 2: Add more SSH keys to existing user
+        result = self.runner.invoke(user_module.user, [
+            "modify", "sshtest",
+            "--add-ssh-key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDnewkey key3@host",
+            "--add-ssh-key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDanother key4@host"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "sshtest")
+        self.assertEqual(len(user_data["ssh_keys"]), 4)
+        self.assertIn("key3@host", str(user_data["ssh_keys"]))
+        self.assertIn("key4@host", str(user_data["ssh_keys"]))
+
+        # Test 3: Remove specific SSH key
+        result = self.runner.invoke(user_module.user, [
+            "modify", "sshtest",
+            "--remove-ssh-key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA key1@host"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "sshtest")
+        self.assertEqual(len(user_data["ssh_keys"]), 3)
+        self.assertNotIn("key1@host", str(user_data["ssh_keys"]))
+
+        # Test 4: Replace all SSH keys
+        result = self.runner.invoke(user_module.user, [
+            "modify", "sshtest",
+            "--replace-ssh-keys", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCreplacement replacement@host"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "sshtest")
+        self.assertEqual(len(user_data["ssh_keys"]), 1)
+        self.assertIn("replacement@host", str(user_data["ssh_keys"]))
+
+        # Test 5: Edge cases - remove non-existent key (should succeed silently)
+        result = self.runner.invoke(user_module.user, [
+            "modify", "sshtest",
+            "--remove-ssh-key", "nonexistent_key"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Should succeed silently
+
+        # Test 6: Add duplicate key (should handle gracefully)
+        current_keys = self.db.cfgdb.get_entry("LOCAL_USER", "sshtest")["ssh_keys"]
+        original_key_count = len(current_keys)
+        duplicate_key = current_keys[0]
+
+        result = self.runner.invoke(user_module.user, [
+            "modify", "sshtest",
+            "--add-ssh-key", duplicate_key  # Add existing key
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Verify no duplicate was added and keys remain the same
+        updated_user_data = self.db.cfgdb.get_entry("LOCAL_USER", "sshtest")
+        self.assertEqual(len(updated_user_data["ssh_keys"]), original_key_count)
+        self.assertIn(duplicate_key, updated_user_data["ssh_keys"])
+
+        # Test 7: Conflicting SSH key options
+        result = self.runner.invoke(user_module.user, [
+            "modify", "sshtest",
+            "--add-ssh-key", "key1",
+            "--remove-ssh-key", "key2",
+            "--replace-ssh-keys", "key3"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Cannot specify multiple SSH key options", result.output)
+
+    def test_cli_admin_constraint_scenarios(self):
+        """Test admin constraint scenarios through CLI operations"""
+        # Scenario 1: Multiple admins - should allow disabling one
+        self.db.cfgdb.set_entry("LOCAL_USER", "admin1", {
+            "role": "administrator",
+            "enabled": True,
+            "password_hash": "$y$j9T$salt$hash1",
+            "ssh_keys": []
+        })
+        self.db.cfgdb.set_entry("LOCAL_USER", "admin2", {
+            "role": "administrator",
+            "enabled": True,
+            "password_hash": "$y$j9T$salt$hash2",
+            "ssh_keys": []
+        })
+
+        # Should allow disabling one admin when another exists
+        result = self.runner.invoke(user_module.user, [
+            "modify", "admin1", "--disabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Verify admin1 was disabled
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "admin1")
+        self.assertIn(user_data["enabled"], [False, "False"])
+
+        # Scenario 2: Last admin - should NOT allow disabling
+        # Clear all users and add only one admin
+        self.db.cfgdb.delete_table("LOCAL_USER")
+        self.db.cfgdb.set_entry("LOCAL_USER", "lastadmin", {
+            "role": "administrator",
+            "enabled": True,
+            "password_hash": "$y$j9T$salt$lasthash",
+            "ssh_keys": []
+        })
+
+        # Should not allow disabling the last admin
+        result = self.runner.invoke(user_module.user, [
+            "modify", "lastadmin", "--disabled"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Cannot disable the last administrator user", result.output)
+
+        # Verify admin was NOT disabled
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "lastadmin")
+        self.assertIn(user_data["enabled"], [True, "True"])
+
+        # Scenario 3: Should not allow deleting the last admin
+        result = self.runner.invoke(user_module.user, [
+            "delete", "lastadmin"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Cannot delete the last administrator user", result.output)
+
+        # Verify admin was NOT deleted
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "lastadmin")
+        self.assertIsNotNone(user_data)
+
+    def test_cli_import_existing_invalid_uid_range(self):
+        """Test import-existing with invalid UID range via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing", "--uid-range", "invalid-range"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Invalid UID range format", result.output)
+
+    @mock.patch('config.user.get_existing_linux_users')
+    def test_cli_import_existing_no_users_found(self, mock_get_users):
+        """Test import-existing when no users are found via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        # Mock no existing Linux users
+        mock_get_users.return_value = {}
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No users found to import", result.output)
+
+    @mock.patch('config.user.get_existing_linux_users')
+    def test_cli_import_existing_users_already_in_config(self, mock_get_users):
+        """Test import-existing when users already exist in CONFIG_DB via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        # Mock existing Linux users that match CONFIG_DB users
+        mock_get_users.return_value = {
+            'admin': {  # This user already exists in test data
+                'role': 'administrator',
+                'password_hash': '$y$j9T$salt$linuxhash',
+                'enabled': True,
+                'ssh_keys': [],
+                'uid': 1001,
+                'gid': 1001,
+                'home': '/home/admin',
+                'shell': '/bin/bash'
+            }
+        }
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No users found to import", result.output)
+
+    @mock.patch('config.user.get_existing_linux_users')
+    def test_cli_import_existing_with_custom_uid_range(self, mock_get_users):
+        """Test import-existing with custom UID range via CLI"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        # Mock existing Linux users
+        mock_get_users.return_value = {
+            'customuser': {
+                'role': 'operator',
+                'password_hash': '$y$j9T$salt$customhash',
+                'enabled': True,
+                'ssh_keys': [],
+                'uid': 2001,
+                'gid': 2001,
+                'home': '/home/customuser',
+                'shell': '/bin/bash'
+            }
+        }
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing", "--uid-range", "2000-3000"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Should call get_existing_linux_users with custom range
+        mock_get_users.assert_called_once_with(2000, 3000)
+
+    def test_cli_database_error_handling(self):
+        """Test CLI behavior when database operations fail"""
+        # Enable the feature first so we can test database operations
+        self.db.cfgdb.set_entry("DEVICE_METADATA", "localhost", {"local_user_management": "enabled"})
+
+        # Test JsonPatchConflict error during user addition
+        with mock.patch('config.user.ValidatedConfigDBConnector') as mock_connector_class:
+            mock_config_db = mock.MagicMock()
+            mock_config_db.set_entry.side_effect = user_module.JsonPatchConflict("Conflict")
+            mock_connector_class.return_value = mock_config_db
+
+            result = self.runner.invoke(user_module.user, [
+                "add", "conflictuser",
+                "--role", "operator",
+                "--password-hash", "$y$j9T$salt$hash"
+            ], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            # Should show some error message (could be feature disabled or database error)
+            self.assertTrue(
+                "Error:" in result.output or
+                "Local user management is not enabled" in result.output or
+                "Failed to modify user" in result.output
+            )
+
+        # Test ValueError in database operations
+        with mock.patch('config.user.ValidatedConfigDBConnector') as mock_connector_class:
+            mock_config_db = mock.MagicMock()
+            mock_config_db.set_entry.side_effect = ValueError("Invalid data")
+            mock_connector_class.return_value = mock_config_db
+
+            result = self.runner.invoke(user_module.user, [
+                "add", "erroruser",
+                "--role", "operator",
+                "--password-hash", "$y$j9T$salt$hash"
+            ], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Error:", result.output)
+
+        # Test ValueError during user modification
+        with mock.patch('config.user.ValidatedConfigDBConnector') as mock_connector_class:
+            mock_config_db = mock.MagicMock()
+            mock_config_db.set_entry.side_effect = ValueError("Invalid value")
+            mock_connector_class.return_value = mock_config_db
+
+            result = self.runner.invoke(user_module.user, [
+                "modify", "admin",
+                "--password-hash", "$y$j9T$salt$newhash"
+            ], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertTrue(
+                "Failed to modify user" in result.output or
+                "Local user management is not enabled" in result.output or
+                "Error:" in result.output
+            )
+
+        # Test successful database operations through normal CLI flow
+        result = self.runner.invoke(user_module.user, [
+            "add", "dbtest",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$hash"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Verify user was added successfully
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "dbtest")
+        self.assertIsNotNone(user_data)
+        self.assertEqual(user_data["role"], "operator")
+
+        # Test successful deletion
+        result = self.runner.invoke(user_module.user, [
+            "delete", "dbtest"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Verify user was deleted
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "dbtest")
+        self.assertIn(user_data, [None, {}])
+
+    def test_integration_user_lifecycle(self):
+        """Test complete user lifecycle: add, modify, show, delete"""
+        # Add a new user
+        result = self.runner.invoke(user_module.user, [
+            "add", "lifecycle_user",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$initialhash"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify user exists in database
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "lifecycle_user")
+        self.assertIsNotNone(user_data)
+        self.assertEqual(user_data["role"], "operator")
+
+        # Modify the user
+        result = self.runner.invoke(user_module.user, [
+            "modify", "lifecycle_user",
+            "--password-hash", "$y$j9T$salt$newhash",
+            "--add-ssh-key", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA lifecycle@host"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify modifications
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "lifecycle_user")
+        self.assertEqual(user_data["password_hash"], "$y$j9T$salt$newhash")
+        self.assertIn("lifecycle@host", str(user_data["ssh_keys"]))
+
+        # Delete the user
+        result = self.runner.invoke(user_module.user, [
+            "delete", "lifecycle_user"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify user is deleted
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "lifecycle_user")
+        self.assertIn(user_data, [None, {}])
+
+    def test_integration_security_policy_lifecycle(self):
+        """Test complete security policy lifecycle: set, show, clear"""
+        # Set a security policy
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "7"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify policy exists in database
+        policy_data = self.db.cfgdb.get_entry("LOCAL_ROLE_SECURITY_POLICY", "operator")
+        self.assertIsNotNone(policy_data)
+        self.assertEqual(policy_data["max_login_attempts"], "7")
+
+        # Clear the policy
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "clear-policy", "operator"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify policy is cleared
+        policy_data = self.db.cfgdb.get_entry("LOCAL_ROLE_SECURITY_POLICY", "operator")
+        self.assertIn(policy_data, [None, {}])
+
+    def test_integration_feature_toggle_affects_operations(self):
+        """Test that feature enable/disable affects all user operations"""
+        # Start with feature enabled (default in test setup)
+
+        # Add a user (should work)
+        result = self.runner.invoke(user_module.user, [
+            "add", "toggle_test_user",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$hash"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Disable the feature
+        result = self.runner.invoke(user_module.user, [
+            "feature", "disabled"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Try to add another user (should fail)
+        result = self.runner.invoke(user_module.user, [
+            "add", "should_fail_user",
+            "--role", "operator",
+            "--password-hash", "$y$j9T$salt$hash"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+        # Try to modify existing user (should fail)
+        result = self.runner.invoke(user_module.user, [
+            "modify", "toggle_test_user",
+            "--password-hash", "$y$j9T$salt$newhash"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+        # Try to delete user (should fail)
+        result = self.runner.invoke(user_module.user, [
+            "delete", "toggle_test_user"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+        # Try to set security policy (should fail)
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "5"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("not enabled", result.output)
+
+        # Re-enable the feature
+        result = self.runner.invoke(user_module.user, [
+            "feature", "enabled"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Now operations should work again
+        result = self.runner.invoke(user_module.user, [
+            "modify", "toggle_test_user",
+            "--password-hash", "$y$j9T$salt$newhash"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        # Should succeed silently
+
+    def test_integration_admin_constraint_enforcement(self):
+        """Test that admin constraint is enforced across operations"""
+        # Clear existing users and create scenario with one admin
+        self.db.cfgdb.delete_table("LOCAL_USER")
+        self.db.cfgdb.set_entry("LOCAL_USER", "only_admin", {
+            "role": "administrator",
+            "password_hash": "$y$j9T$salt$adminhash",
+            "enabled": True
+        })
+
+        # Try to delete the only admin (should fail)
+        result = self.runner.invoke(user_module.user, [
+            "delete", "only_admin"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("last administrator", result.output)
+
+        # Verify admin still exists
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "only_admin")
+        self.assertIsNotNone(user_data)
+
+        # Try to disable the only admin (should fail)
+        result = self.runner.invoke(user_module.user, [
+            "modify", "only_admin",
+            "--disabled"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("last administrator", result.output)
+
+        # Verify admin is still enabled
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "only_admin")
+        self.assertIn(user_data["enabled"], [True, "True"])
+
+        # Add another admin
+        result = self.runner.invoke(user_module.user, [
+            "add", "second_admin",
+            "--role", "administrator",
+            "--password-hash", "$y$j9T$salt$secondhash"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Now should be able to disable the first admin
+        result = self.runner.invoke(user_module.user, [
+            "modify", "only_admin",
+            "--disabled"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify first admin is now disabled
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "only_admin")
+        self.assertIn(user_data["enabled"], [False, "False"])
+
+        # Verify second admin is still enabled
+        second_admin_data = self.db.cfgdb.get_entry("LOCAL_USER", "second_admin")
+        self.assertIn(second_admin_data["enabled"], [True, "True"])
+
+    @mock.patch('config.user.get_existing_linux_users')
+    def test_integration_import_and_feature_enable(self, mock_get_users):
+        """Test importing users and then enabling the feature"""
+        # Start with feature disabled
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        # Mock existing Linux users
+        mock_get_users.return_value = {
+            'imported_user1': {
+                'role': 'administrator',
+                'password_hash': '$y$j9T$salt$importhash1',
+                'enabled': True,
+                'ssh_keys': ['ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA imported1@host'],
+                'uid': 1001,
+                'gid': 1001,
+                'home': '/home/imported_user1',
+                'shell': '/bin/bash'
+            },
+            'imported_user2': {
+                'role': 'operator',
+                'password_hash': '$y$j9T$salt$importhash2',
+                'enabled': False,
+                'ssh_keys': [],
+                'uid': 1002,
+                'gid': 1002,
+                'home': '/home/imported_user2',
+                'shell': '/usr/sbin/nologin'
+            }
+        }
+
+        # Import existing users
+        result = self.runner.invoke(user_module.user, [
+            "import-existing"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify users were imported
+        user1_data = self.db.cfgdb.get_entry("LOCAL_USER", "imported_user1")
+        user2_data = self.db.cfgdb.get_entry("LOCAL_USER", "imported_user2")
+        self.assertIsNotNone(user1_data)
+        self.assertIsNotNone(user2_data)
+        self.assertEqual(user1_data["role"], "administrator")
+        self.assertEqual(user2_data["role"], "operator")
+
+        # Enable the feature
+        result = self.runner.invoke(user_module.user, [
+            "feature", "enabled"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Now should be able to manage the imported users
+        result = self.runner.invoke(user_module.user, [
+            "modify", "imported_user2",
+            "--enabled"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify modification worked
+        user2_data = self.db.cfgdb.get_entry("LOCAL_USER", "imported_user2")
+        self.assertIn(user2_data["enabled"], [True, "True"])
+
+    def test_negative_security_policy_extreme_values(self):
+        """Test security policy with extreme values"""
+        # Test maximum boundary + 1
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "1001"  # Exceeds maximum of 1000
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 2)  # Click validation error
+        self.assertIn("not in the valid range", result.output)
+
+        # Test minimum boundary - 1
+        result = self.runner.invoke(user_module.user, [
+            "security-policy", "set-policy", "operator",
+            "--max-login-attempts", "0"  # Below minimum of 1
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 2)  # Click validation error
+        self.assertIn("not in the valid range", result.output)
+
+    def test_negative_security_policy_non_numeric_values(self):
+        """Test security policy with non-numeric values"""
+        invalid_values = ["abc", "1.5", "-5", "1e10", "infinity", "null", ""]
+
+        for value in invalid_values:
+            with self.subTest(value=value):
+                result = self.runner.invoke(user_module.user, [
+                    "security-policy", "set-policy", "operator",
+                    "--max-login-attempts", value
+                ], obj=self.db)
+
+                self.assertNotEqual(result.exit_code, 0)  # Should fail validation
+
+    @mock.patch('config.user.getpass.getpass')
+    def test_negative_password_prompt_empty_password(self, mock_getpass):
+        """Test password prompt with empty password"""
+        mock_getpass.side_effect = ["", ""]  # Empty passwords
+
+        result = self.runner.invoke(user_module.user, [
+            "add", "emptypassuser",
+            "--role", "operator",
+            "--password-prompt"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Password cannot be empty", result.output)
+
+        # Verify user was NOT created
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "emptypassuser")
+        self.assertIn(user_data, [None, {}])
+
+    @mock.patch('config.user.getpass.getpass')
+    def test_negative_password_prompt_whitespace_password(self, mock_getpass):
+        """Test password prompt with whitespace-only password"""
+        mock_getpass.side_effect = ["   ", "   "]  # Whitespace-only passwords
+
+        result = self.runner.invoke(user_module.user, [
+            "add", "whitespaceuser",
+            "--role", "operator",
+            "--password-prompt"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Password cannot be empty", result.output)
+
+        # Verify user was NOT created
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "whitespaceuser")
+        self.assertIn(user_data, [None, {}])
+
+    @mock.patch('config.user.getpass.getpass')
+    def test_negative_password_prompt_very_long_password(self, mock_getpass):
+        """Test password prompt with extremely long password"""
+        very_long_password = "a" * 10000  # Extremely long password
+        mock_getpass.side_effect = [very_long_password, very_long_password]
+
+        with mock.patch('config.user.get_password_hardening_policies', return_value=None):
+            with mock.patch('config.user.hash_password', return_value="$y$j9T$salt$hash"):
+                result = self.runner.invoke(user_module.user, [
+                    "add", "longpassuser",
+                    "--role", "operator",
+                    "--password-prompt"
+                ], obj=self.db)
+
+        # Should handle very long passwords
+        self.assertEqual(result.exit_code, 0)
+
+    def test_negative_modify_user_all_conflicting_options(self):
+        """Test modify user with all possible conflicting options"""
+        result = self.runner.invoke(user_module.user, [
+            "modify", "admin",
+            "--enabled",
+            "--disabled",  # Conflicting enable/disable
+            "--add-ssh-key", "key1",
+            "--remove-ssh-key", "key2",
+            "--replace-ssh-keys", "key3"  # Conflicting SSH key options
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        # Should detect and report conflicts
+        self.assertTrue(
+            "Cannot specify both" in result.output or
+            "Cannot specify multiple" in result.output
+        )
+
+    def test_negative_import_existing_malformed_uid_ranges(self):
+        """Test import-existing with various malformed UID ranges"""
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        malformed_ranges = [
+            "abc-def",  # Non-numeric
+            "1000",     # Missing range end
+            "",         # Empty string
+        ]
+
+        for uid_range in malformed_ranges:
+            with self.subTest(uid_range=uid_range):
+                result = self.runner.invoke(user_module.user, [
+                    "import-existing", "--uid-range", uid_range
+                ], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+                self.assertIn("Invalid UID range format", result.output)
+
+        # Test reversed range separately (parses but returns no users)
+        result = self.runner.invoke(user_module.user, [
+            "import-existing", "--uid-range", "2000-1000"
+        ], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No users found to import", result.output)
+
+    @mock.patch('config.user.get_existing_linux_users')
+    def test_negative_import_existing_permission_error(self, mock_get_users):
+        """Test import-existing with permission error reading system files"""
+        # Mock get_existing_linux_users to raise an exception (simulating permission error)
+        mock_get_users.side_effect = Exception("Permission denied reading /etc/passwd")
+
+        # Disable feature first
+        self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
+
+        result = self.runner.invoke(user_module.user, [
+            "import-existing"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 1)  # Should fail with exit code 1
+        # Exception propagates up, so output may be empty (exception not caught by CLI)
+        # The important thing is that the command fails with exit code 1
+
+    def test_negative_delete_nonexistent_user_variations(self):
+        """Test deleting users with various nonexistent username patterns"""
+        nonexistent_users = [
+            "nonexistent_user",  # Typical nonexistent username
+            "ADMIN",            # Wrong case (case sensitivity)
+            "",                 # Empty string
+        ]
+
+        for username in nonexistent_users:
+            with self.subTest(username=repr(username)):
+                result = self.runner.invoke(user_module.user, [
+                    "delete", username
+                ], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+                if username.strip():  # Non-empty usernames
+                    self.assertIn("does not exist", result.output)
+
+    def test_negative_modify_nonexistent_user_variations(self):
+        """Test modifying users with various nonexistent username patterns"""
+        nonexistent_users = ["nonexistent_user", "ADMIN", ""]
+
+        for username in nonexistent_users:
+            with self.subTest(username=repr(username)):
+                result = self.runner.invoke(user_module.user, [
+                    "modify", username,
+                    "--password-hash", "$y$j9T$salt$newhash"
+                ], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+                if username.strip():  # Non-empty usernames
+                    self.assertIn("does not exist", result.output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/config_user_test.py
+++ b/tests/config_user_test.py
@@ -35,24 +35,25 @@ class TestUserCLI(unittest.TestCase):
         })
 
         # Add some test users
+        # Note: CONFIG_DB stores boolean values as strings 'true'/'false'
         self.db.cfgdb.set_entry("LOCAL_USER", "admin", {
             "role": "administrator",
             "password_hash": "$y$j9T$salt$adminhash",
-            "enabled": True,
+            "enabled": "true",
             "ssh_keys": ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA admin@host"]
         })
 
         self.db.cfgdb.set_entry("LOCAL_USER", "operator1", {
             "role": "operator",
             "password_hash": "$y$j9T$salt$ophash",
-            "enabled": True,
+            "enabled": "true",
             "ssh_keys": []
         })
 
         self.db.cfgdb.set_entry("LOCAL_USER", "disabled_user", {
             "role": "operator",
             "password_hash": "$y$j9T$salt$disabledhash",
-            "enabled": False,
+            "enabled": "false",
             "ssh_keys": []
         })
 
@@ -101,7 +102,8 @@ class TestUserCLI(unittest.TestCase):
 
         # Verify command succeeded
         self.assertEqual(result.exit_code, 0)
-        # Silent on success - no output expected
+        # Silent on success - verify no output is produced
+        self.assertEqual(result.output.strip(), "")
 
         # Verify user was added to database
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "newuser")
@@ -109,7 +111,7 @@ class TestUserCLI(unittest.TestCase):
         self.assertEqual(user_data["role"], "operator")
         self.assertEqual(user_data["password_hash"], "$y$j9T$salt$newhash")
         # CONFIG_DB stores boolean values as strings
-        self.assertIn(user_data["enabled"], [True, "True"])  # Default enabled
+        self.assertEqual(user_data["enabled"], "true")  # Default enabled
 
     def test_cli_add_user_disabled(self):
         """Test adding user in disabled state via CLI"""
@@ -126,7 +128,7 @@ class TestUserCLI(unittest.TestCase):
         # Verify user is disabled
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disableduser")
         # CONFIG_DB stores boolean values as strings
-        self.assertIn(user_data["enabled"], [False, "False"])
+        self.assertEqual(user_data["enabled"], "false")
 
     def test_cli_add_user_already_exists(self):
         """Test adding user that already exists via CLI"""
@@ -141,7 +143,7 @@ class TestUserCLI(unittest.TestCase):
         self.assertIn("already exists", result.output)
 
     def test_cli_add_user_feature_disabled(self):
-        """Test adding user when feature is disabled via CLI"""
+        """Test adding user when feature is disabled via CLI - should succeed with warning"""
         # Disable the feature first
         self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
 
@@ -154,9 +156,9 @@ class TestUserCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("not enabled", result.output)
 
-        # Verify user was NOT added (CONFIG_DB returns empty dict for non-existent entries)
+        # Verify user WAS added (allowed even when feature is disabled, with warning)
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "newuser")
-        self.assertIn(user_data, [None, {}])  # Accept both None and empty dict
+        self.assertEqual(user_data.get('role'), 'operator')
 
     def test_cli_delete_user_success(self):
         """Test successful user deletion via CLI"""
@@ -196,7 +198,7 @@ class TestUserCLI(unittest.TestCase):
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disabled_user")
         self.assertEqual(user_data["password_hash"], "$y$j9T$salt$newhash")
         # CONFIG_DB stores boolean values as strings
-        self.assertIn(user_data["enabled"], [True, "True"])
+        self.assertEqual(user_data["enabled"], "true")
 
     def test_cli_security_policy_set(self):
         """Test setting security policy via CLI"""
@@ -223,7 +225,7 @@ class TestUserCLI(unittest.TestCase):
             'linuxuser1': {
                 'role': 'operator',  # Determined from group membership
                 'password_hash': '$y$j9T$salt$linuxhash1',
-                'enabled': True,  # Based on shell (not /usr/sbin/nologin)
+                'enabled': 'true',  # Based on shell (not /usr/sbin/nologin)
                 'ssh_keys': [],  # From ~/.ssh/authorized_keys
                 'uid': 1001,
                 'gid': 1001,
@@ -233,7 +235,7 @@ class TestUserCLI(unittest.TestCase):
             'linuxuser2': {
                 'role': 'operator',  # Determined from group membership
                 'password_hash': '$y$j9T$salt$linuxhash2',
-                'enabled': True,  # Based on shell (not /usr/sbin/nologin)
+                'enabled': 'true',  # Based on shell (not /usr/sbin/nologin)
                 'ssh_keys': [],  # From ~/.ssh/authorized_keys
                 'uid': 1002,
                 'gid': 1002,
@@ -258,7 +260,7 @@ class TestUserCLI(unittest.TestCase):
         self.assertEqual(user1_data["role"], "operator")  # Default role
         self.assertEqual(user1_data["password_hash"], "$y$j9T$salt$linuxhash1")
         # CONFIG_DB stores boolean values as strings
-        self.assertIn(user1_data["enabled"], [True, "True"])
+        self.assertEqual(user1_data["enabled"], "true")
 
     def test_cli_import_existing_feature_enabled(self):
         """Test import-existing when feature is enabled (should fail) via CLI"""
@@ -282,7 +284,7 @@ class TestUserCLI(unittest.TestCase):
             'dryrunuser': {
                 'role': 'operator',  # Determined from group membership
                 'password_hash': '$y$j9T$salt$dryrunhash',
-                'enabled': True,  # Based on shell (not /usr/sbin/nologin)
+                'enabled': 'true',  # Based on shell (not /usr/sbin/nologin)
                 'ssh_keys': [],  # From ~/.ssh/authorized_keys
                 'uid': 1003,
                 'gid': 1003,
@@ -329,21 +331,43 @@ class TestUserCLI(unittest.TestCase):
 
         # Should fail with Click validation error
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn('Invalid value for "--role"', result.output)
+        self.assertIn("Invalid value for '--role'", result.output)
 
-    def test_cli_add_user_no_password(self):
-        """Test adding user without password via CLI"""
+    def test_cli_add_user_no_password_no_ssh_key(self):
+        """Test adding user without password or SSH key via CLI - should fail"""
         result = self.runner.invoke(user_module.user, [
             "add", "newuser",
             "--role", "operator"
-            # No password provided
+            # No password or SSH key provided
         ], obj=self.db)
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("password", result.output.lower())  # Should mention password requirement
+        self.assertIn("at least one authentication method", result.output)
+
+        # Verify user was NOT added
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "newuser")
+        self.assertIn(user_data, [None, {}])
+
+    def test_cli_add_user_ssh_key_only(self):
+        """Test adding user with SSH key only (no password) via CLI"""
+        result = self.runner.invoke(user_module.user, [
+            "add", "sshonlyuser",
+            "--role", "operator",
+            "--ssh-key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHYAev8HgrcPTf5lOGAmtDDQkQx3xV1EUhGQ96+4LJOI test@host"
+        ], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+
+        # Verify user was added with locked password
+        user_data = self.db.cfgdb.get_entry("LOCAL_USER", "sshonlyuser")
+        self.assertEqual(user_data["role"], "operator")
+        self.assertEqual(user_data["password_hash"], "!")  # Locked password
+        self.assertEqual(user_data["enabled"], "true")
+        self.assertEqual(len(user_data["ssh_keys"]), 1)
+        self.assertIn("test@host", str(user_data["ssh_keys"]))
 
     def test_cli_delete_user_feature_disabled(self):
-        """Test deleting user when feature is disabled via CLI"""
+        """Test deleting user when feature is disabled via CLI - should succeed with warning"""
         # Disable feature first
         self.runner.invoke(user_module.user, ["feature", "disabled"], obj=self.db)
 
@@ -354,9 +378,9 @@ class TestUserCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("not enabled", result.output)
 
-        # Verify user was NOT deleted
+        # Verify user WAS deleted (allowed even when feature is disabled, with warning)
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "operator1")
-        self.assertIsNotNone(user_data)
+        self.assertIn(user_data, [None, {}])  # Accept both None and empty dict
 
     def test_cli_delete_last_admin(self):
         """Test deleting the last administrator user via CLI"""
@@ -365,7 +389,7 @@ class TestUserCLI(unittest.TestCase):
         self.db.cfgdb.set_entry("LOCAL_USER", "lastadmin", {
             "role": "administrator",
             "password_hash": "$y$j9T$salt$lastadminhash",
-            "enabled": True,
+            "enabled": "true",
             "ssh_keys": []
         })
 
@@ -443,7 +467,7 @@ class TestUserCLI(unittest.TestCase):
 
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disabled_user")
         # CONFIG_DB stores boolean values as strings
-        self.assertIn(user_data["enabled"], [True, "True"])
+        self.assertEqual(user_data["enabled"], "true")
 
         # Test disable enabled user
         result = self.runner.invoke(user_module.user, [
@@ -456,7 +480,7 @@ class TestUserCLI(unittest.TestCase):
 
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "disabled_user")
         # CONFIG_DB stores boolean values as strings
-        self.assertIn(user_data["enabled"], [False, "False"])
+        self.assertEqual(user_data["enabled"], "false")
 
     def test_cli_modify_user_conflicting_flags(self):
         """Test modifying user with conflicting enabled/disabled flags via CLI"""
@@ -476,7 +500,7 @@ class TestUserCLI(unittest.TestCase):
         self.db.cfgdb.set_entry("LOCAL_USER", "admin", {
             "role": "administrator",
             "password_hash": "$y$j9T$salt$adminhash",
-            "enabled": True,
+            "enabled": "true",
             "ssh_keys": []
         })
 
@@ -491,7 +515,7 @@ class TestUserCLI(unittest.TestCase):
         # Verify admin was NOT disabled
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "admin")
         # CONFIG_DB stores boolean values as strings
-        self.assertIn(user_data["enabled"], [True, "True"])
+        self.assertEqual(user_data["enabled"], "true")
 
     def test_cli_security_policy_set_all_options(self):
         """Test setting security policy with available options via CLI"""
@@ -527,7 +551,7 @@ class TestUserCLI(unittest.TestCase):
         ], obj=self.db)
 
         self.assertEqual(result.exit_code, 2)  # Click validation error
-        self.assertIn("not in the valid range", result.output)
+        self.assertIn("not in the range", result.output)
 
         # Test invalid max-login-attempts too high (Click validation error)
         result = self.runner.invoke(user_module.user, [
@@ -536,7 +560,7 @@ class TestUserCLI(unittest.TestCase):
         ], obj=self.db)
 
         self.assertEqual(result.exit_code, 2)  # Click validation error
-        self.assertIn("not in the valid range", result.output)
+        self.assertIn("not in the range", result.output)
 
     def test_cli_security_policy_clear(self):
         """Test clearing security policy via CLI"""
@@ -879,15 +903,20 @@ class TestUserCLI(unittest.TestCase):
             "--password-prompt"
         ], obj=self.db)
 
-        # System should fail when password policies have invalid values
-        # Invalid numeric values like "invalid_number" should cause validation to fail
-        self.assertNotEqual(result.exit_code, 0,
-                            "Command should fail when password policies contain invalid values")
+        # System should succeed but warn about invalid numeric values
+        # Invalid fields are now removed with a warning, allowing the command to proceed
+        self.assertEqual(result.exit_code, 0,
+                         "Command should succeed after ignoring invalid policy values")
 
-        # Verify user was NOT created due to policy validation failure
+        # Verify warning was shown about invalid value
+        self.assertIn("Warning", result.output,
+                      "Should show warning about invalid policy values")
+
+        # Verify user was created successfully
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "edgeuser")
-        self.assertIn(user_data, [None, {}],
-                      "User should not be created when policy validation fails")
+        self.assertIsNotNone(user_data,
+                             "User should be created when invalid policies are ignored")
+        self.assertEqual(user_data.get('role'), 'operator')
 
     def test_cli_password_hardening_policies_disabled(self):
         """Test that weak passwords are accepted when policies are disabled"""
@@ -1035,17 +1064,21 @@ class TestUserCLI(unittest.TestCase):
         self.assertIn("Cannot specify multiple SSH key options", result.output)
 
     def test_cli_admin_constraint_scenarios(self):
-        """Test admin constraint scenarios through CLI operations"""
+        """Test admin constraint scenarios through CLI operations.
+
+        Note: CONFIG_DB stores boolean values as strings 'true'/'false',
+        so we use string values here to match real behavior.
+        """
         # Scenario 1: Multiple admins - should allow disabling one
         self.db.cfgdb.set_entry("LOCAL_USER", "admin1", {
             "role": "administrator",
-            "enabled": True,
+            "enabled": "true",
             "password_hash": "$y$j9T$salt$hash1",
             "ssh_keys": []
         })
         self.db.cfgdb.set_entry("LOCAL_USER", "admin2", {
             "role": "administrator",
-            "enabled": True,
+            "enabled": "true",
             "password_hash": "$y$j9T$salt$hash2",
             "ssh_keys": []
         })
@@ -1058,14 +1091,14 @@ class TestUserCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         # Verify admin1 was disabled
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "admin1")
-        self.assertIn(user_data["enabled"], [False, "False"])
+        self.assertEqual(user_data["enabled"], "false")
 
         # Scenario 2: Last admin - should NOT allow disabling
         # Clear all users and add only one admin
         self.db.cfgdb.delete_table("LOCAL_USER")
         self.db.cfgdb.set_entry("LOCAL_USER", "lastadmin", {
             "role": "administrator",
-            "enabled": True,
+            "enabled": "true",
             "password_hash": "$y$j9T$salt$lasthash",
             "ssh_keys": []
         })
@@ -1080,7 +1113,7 @@ class TestUserCLI(unittest.TestCase):
 
         # Verify admin was NOT disabled
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "lastadmin")
-        self.assertIn(user_data["enabled"], [True, "True"])
+        self.assertEqual(user_data["enabled"], "true")
 
         # Scenario 3: Should not allow deleting the last admin
         result = self.runner.invoke(user_module.user, [
@@ -1133,7 +1166,7 @@ class TestUserCLI(unittest.TestCase):
             'admin': {  # This user already exists in test data
                 'role': 'administrator',
                 'password_hash': '$y$j9T$salt$linuxhash',
-                'enabled': True,
+                'enabled': 'true',
                 'ssh_keys': [],
                 'uid': 1001,
                 'gid': 1001,
@@ -1160,7 +1193,7 @@ class TestUserCLI(unittest.TestCase):
             'customuser': {
                 'role': 'operator',
                 'password_hash': '$y$j9T$salt$customhash',
-                'enabled': True,
+                'enabled': 'true',
                 'ssh_keys': [],
                 'uid': 2001,
                 'gid': 2001,
@@ -1391,7 +1424,7 @@ class TestUserCLI(unittest.TestCase):
         self.db.cfgdb.set_entry("LOCAL_USER", "only_admin", {
             "role": "administrator",
             "password_hash": "$y$j9T$salt$adminhash",
-            "enabled": True
+            "enabled": "true"
         })
 
         # Try to delete the only admin (should fail)
@@ -1415,7 +1448,7 @@ class TestUserCLI(unittest.TestCase):
 
         # Verify admin is still enabled
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "only_admin")
-        self.assertIn(user_data["enabled"], [True, "True"])
+        self.assertEqual(user_data["enabled"], "true")
 
         # Add another admin
         result = self.runner.invoke(user_module.user, [
@@ -1434,11 +1467,11 @@ class TestUserCLI(unittest.TestCase):
 
         # Verify first admin is now disabled
         user_data = self.db.cfgdb.get_entry("LOCAL_USER", "only_admin")
-        self.assertIn(user_data["enabled"], [False, "False"])
+        self.assertEqual(user_data["enabled"], "false")
 
         # Verify second admin is still enabled
         second_admin_data = self.db.cfgdb.get_entry("LOCAL_USER", "second_admin")
-        self.assertIn(second_admin_data["enabled"], [True, "True"])
+        self.assertEqual(second_admin_data["enabled"], "true")
 
     @mock.patch('config.user.get_existing_linux_users')
     def test_integration_import_and_feature_enable(self, mock_get_users):
@@ -1451,7 +1484,7 @@ class TestUserCLI(unittest.TestCase):
             'imported_user1': {
                 'role': 'administrator',
                 'password_hash': '$y$j9T$salt$importhash1',
-                'enabled': True,
+                'enabled': 'true',
                 'ssh_keys': ['ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA imported1@host'],
                 'uid': 1001,
                 'gid': 1001,
@@ -1499,7 +1532,7 @@ class TestUserCLI(unittest.TestCase):
 
         # Verify modification worked
         user2_data = self.db.cfgdb.get_entry("LOCAL_USER", "imported_user2")
-        self.assertIn(user2_data["enabled"], [True, "True"])
+        self.assertEqual(user2_data["enabled"], "true")
 
     def test_negative_security_policy_extreme_values(self):
         """Test security policy with extreme values"""
@@ -1510,7 +1543,7 @@ class TestUserCLI(unittest.TestCase):
         ], obj=self.db)
 
         self.assertEqual(result.exit_code, 2)  # Click validation error
-        self.assertIn("not in the valid range", result.output)
+        self.assertIn("not in the range", result.output)
 
         # Test minimum boundary - 1
         result = self.runner.invoke(user_module.user, [
@@ -1519,7 +1552,7 @@ class TestUserCLI(unittest.TestCase):
         ], obj=self.db)
 
         self.assertEqual(result.exit_code, 2)  # Click validation error
-        self.assertIn("not in the valid range", result.output)
+        self.assertIn("not in the range", result.output)
 
     def test_negative_security_policy_non_numeric_values(self):
         """Test security policy with non-numeric values"""

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -3368,6 +3368,41 @@
         "ip_range@": "fc00::80/126",
         "name": "BGPSLBPassiveV6",
         "src_address": "fc00::1"
-     }
+     },
+     "LOCAL_USER|admin": {
+        "role": "administrator",
+        "enabled": "true",
+        "password_hash": "$y$j9T$salt$adminhash",
+        "ssh_keys": [
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7vbqnKMi0K9ZKdRTlIHwjlAzck+SQtDufzQg4mf0b1q2nKMi0K9ZKdRTlIHwjlAzck+SQtDufzQg4mf0b1q2 admin@sonic"
+        ]
+    },
+    "LOCAL_USER|operator1": {
+        "role": "operator",
+        "enabled": "false",
+        "password_hash": "$y$j9T$salt$operatorhash",
+        "ssh_keys": []
+    },
+    "LOCAL_USER|testuser": {
+        "role": "operator",
+        "enabled": "true",
+        "password_hash": "$y$j9T$salt$testuserhash",
+        "ssh_keys": [
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7vbqnKMi0K9ZKdRTlIHwjlAzck+SQtDufzQg4mf0b1q2nKMi0K9ZKdRTlIHwjlAzck+SQtDufzQg4mf0b1q2 testuser@sonic",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGNqKKYlELY2IdwjlAzck+SQtDufzQg4mf0b1q2nKMi0K9ZK testuser@laptop"
+        ]
+    },
+    "LOCAL_ROLE_SECURITY_POLICY|administrator": {
+        "max_login_attempts": "5",
+        "lockout_duration": "300",
+        "password_min_length": "8",
+        "password_complexity": "enabled"
+    },
+    "LOCAL_ROLE_SECURITY_POLICY|operator": {
+        "max_login_attempts": "3",
+        "lockout_duration": "600",
+        "password_min_length": "6",
+        "password_complexity": "disabled"
+    }
 
 }

--- a/tests/show_user_test.py
+++ b/tests/show_user_test.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+from click.testing import CliRunner
+from utilities_common.db import Db
+
+# Add the parent directory to the path to access show module
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+# Set up environment for testing
+os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+# Import the show user module
+import show.user as show_user  # noqa: E402
+
+
+class TestShowUserCLI(unittest.TestCase):
+    """Test cases for show user CLI commands"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up class fixtures"""
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up class fixtures"""
+        print("TEARDOWN")
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.runner = CliRunner()
+        self.db = Db()
+
+    def test_show_user_all(self):
+        """Test showing all users"""
+
+        from .mock_tables import dbconnector
+
+        try:
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('admin', result.output)
+            self.assertIn('administrator', result.output)
+            self.assertIn('operator1', result.output)
+            self.assertIn('operator', result.output)
+            self.assertIn('testuser', result.output)
+            # Check SSH key display - operator1 has empty array [] in config_db.json
+            self.assertIn('SSH Keys (1)', result.output)  # admin has 1 SSH key
+            self.assertIn('SSH Keys: None', result.output)  # operator1 has no SSH keys
+            self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 SSH keys
+        finally:
+            pass
+
+    @mock.patch('show.user.can_view_passwords', return_value=True)
+    def test_show_user_all_admin_view(self, mock_can_view_passwords):
+        """Test show users command with admin privileges (can see passwords)"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            # Admin should see password hashes from config_db.json
+            self.assertIn('$y$j9T$salt$adminhash', result.output)
+            self.assertIn('$y$j9T$salt$operatorhash', result.output)
+            self.assertIn('$y$j9T$salt$testuserhash', result.output)
+        finally:
+            pass
+
+    @mock.patch('show.user.can_view_passwords', return_value=False)
+    def test_show_user_all_operator_view(self, mock_can_view):
+        """Test show users command with operator privileges (cannot see passwords)"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            # Operator should NOT see password hashes from config_db.json
+            self.assertNotIn('$y$j9T$salt$adminhash', result.output)
+            self.assertNotIn('$y$j9T$salt$operatorhash', result.output)
+            # But should still see other user info
+            self.assertIn('admin', result.output)
+            self.assertIn('administrator', result.output)
+            self.assertIn('operator1', result.output)
+        finally:
+
+            pass
+
+    def test_show_user_specific(self):
+        """Test showing specific user"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_user_details, ['admin'], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('admin', result.output)
+            self.assertIn('administrator', result.output)
+            self.assertIn('Yes', result.output)  # enabled should show as "Yes"
+        finally:
+
+            pass
+
+    def test_show_user_not_found(self):
+        """Test showing non-existent user"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_user_details, ['nonexistent'], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)  # Command succeeds but shows error message
+            self.assertIn("User 'nonexistent' not found", result.output)
+        finally:
+
+            pass
+
+    def test_show_user_with_sudo(self):
+        """Test showing users with sudo (should show password hashes)"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            # Mock os.geteuid to simulate running with sudo
+            with mock.patch('show.user.os.geteuid', return_value=0):
+                result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('admin', result.output)
+            # Should show password hash from config_db.json when running with sudo
+            self.assertIn('$y$j9T$salt$adminhash', result.output)
+        finally:
+
+            pass
+
+    @mock.patch('show.user.get_security_policies')
+    def test_show_user_security_policy_all(self, mock_get_policies):
+        """Test showing all security policies"""
+        # Mock security policy data
+        mock_policies = {
+            'administrator': {
+                'max_login_attempts': '5'
+            },
+            'operator': {
+                'max_login_attempts': '3'
+            }
+        }
+        mock_get_policies.return_value = mock_policies
+
+        result = self.runner.invoke(show_user.show_security_policy, [], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('administrator', result.output)
+        self.assertIn('operator', result.output)
+        self.assertIn('max_login_attempts', result.output)
+        self.assertIn('5', result.output)
+        self.assertIn('3', result.output)
+
+    @mock.patch('show.user.get_security_policies')
+    def test_show_user_security_policy_specific(self, mock_get_policies):
+        """Test showing specific role security policy"""
+        # Mock security policy data
+        mock_policies = {
+            'administrator': {
+                'max_login_attempts': '5'
+            },
+            'operator': {
+                'max_login_attempts': '3'
+            }
+        }
+        mock_get_policies.return_value = mock_policies
+
+        result = self.runner.invoke(show_user.show_security_policy, ['administrator'], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('administrator', result.output)
+        self.assertIn('max_login_attempts', result.output)
+        self.assertIn('5', result.output)
+        # Should not show operator policy
+        self.assertNotIn('3', result.output)
+
+    @mock.patch('show.user.get_security_policies')
+    def test_show_user_security_policy_not_found(self, mock_get_policies):
+        """Test showing security policy for role that has no policy configured"""
+        # Mock policies that don't include the operator role
+        mock_policies = {
+            'administrator': {
+                'max_login_attempts': '5'
+            }
+            # operator role is missing - no policy configured
+        }
+        mock_get_policies.return_value = mock_policies
+
+        result = self.runner.invoke(show_user.show_security_policy, ['operator'], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No security policy configured for role 'operator'", result.output)
+
+    @mock.patch('show.user.get_user_database')
+    def test_show_user_empty_table(self, mock_get_user_database):
+        """Test showing users when no users are configured"""
+        # Mock empty user database
+        mock_get_user_database.return_value = {}
+
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('No users configured', result.output)
+
+    def test_show_user_with_ssh_keys(self):
+        """Test showing user with SSH keys"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_user_details, ['testuser'], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('testuser', result.output)
+            self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 SSH keys in config_db.json
+        finally:
+
+            pass
+
+    def test_show_user_disabled(self):
+        """Test showing disabled user"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_user_details, ['operator1'], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('operator1', result.output)
+            self.assertIn('No', result.output)  # operator1 is disabled in config_db.json
+        finally:
+
+            pass
+
+    def test_cli_ssh_key_formatting_through_show_commands(self):
+        """Test SSH key formatting through actual show commands"""
+
+        # config_db.json has: admin (1 key), operator1 (0 keys), testuser (2 keys)
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            # Test show users command (shows SSH key counts)
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+
+            # Verify SSH key count formatting using data from config_db.json
+            self.assertIn('SSH Keys: None', result.output)  # operator1 has no keys
+            self.assertIn('SSH Keys (1)', result.output)    # admin has 1 key
+            self.assertIn('SSH Keys (2)', result.output)    # testuser has 2 keys
+
+            # Test show user details command (shows detailed SSH keys)
+            result = self.runner.invoke(show_user.show_user_details, ['testuser'], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+
+            # Verify detailed SSH key formatting for testuser (2 keys)
+            self.assertIn("SSH Keys (2):", result.output)
+            self.assertIn("1. ssh-rsa", result.output)
+            self.assertIn("2. ssh-ed25519", result.output)
+
+            # Test single key detailed view
+            result = self.runner.invoke(show_user.show_user_details, ['admin'], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("SSH Keys (1):", result.output)
+            self.assertIn("1. ssh-rsa", result.output)
+
+            # Test no keys detailed view
+            result = self.runner.invoke(show_user.show_user_details, ['operator1'], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("SSH Keys: None", result.output)
+        finally:
+
+            pass
+
+    @mock.patch('show.user.getpass.getuser')
+    @mock.patch('show.user.os.geteuid')
+    def test_cli_password_visibility_based_on_user_permissions(self, mock_geteuid, mock_getuser):
+        """Test password visibility in show commands based on user permissions"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            # Test 1: Root user should see password hashes
+            mock_geteuid.return_value = 0  # Root user
+            mock_getuser.return_value = "root"
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('$y$j9T$salt$adminhash', result.output)
+            self.assertIn('$y$j9T$salt$operatorhash', result.output)
+
+            # Test 2: Admin user should see password hashes
+            mock_geteuid.return_value = 1000  # Non-root user
+            mock_getuser.return_value = "admin"
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('$y$j9T$salt$adminhash', result.output)
+            self.assertIn('$y$j9T$salt$operatorhash', result.output)
+
+            # Test 3: Operator user should NOT see password hashes
+            mock_getuser.return_value = "operator1"
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+            self.assertNotIn('$y$j9T$salt$adminhash', result.output)
+            self.assertNotIn('$y$j9T$salt$operatorhash', result.output)
+            # Should still show other user info
+            self.assertIn('admin', result.output)
+            self.assertIn('operator1', result.output)
+            self.assertIn('administrator', result.output)
+        finally:
+
+            pass
+
+        # Test 4: Unknown user should NOT see password hashes
+        mock_getuser.return_value = "unknown"
+
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn('$y$j9T$salt$adminhash', result.output)
+        self.assertNotIn('$y$j9T$salt$operatorhash', result.output)
+
+    def test_show_user_details_all_users(self):
+        """Test showing details for all users when no username specified"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_user_details, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('admin', result.output)
+            self.assertIn('operator1', result.output)
+            self.assertIn('testuser', result.output)
+            self.assertIn('administrator', result.output)
+            self.assertIn('SSH Keys (1)', result.output)  # admin has 1 key
+            self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 keys
+        finally:
+
+            pass
+
+    @mock.patch('show.user.get_user_database')
+    def test_show_user_details_empty_database(self, mock_get_users):
+        """Test showing user details when database is empty"""
+        mock_get_users.return_value = {}
+
+        result = self.runner.invoke(show_user.show_user_details, ['anyuser'], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('No users configured', result.output)
+
+    @mock.patch('show.user.get_security_policies')
+    def test_show_security_policy_empty_database(self, mock_get_security_policies):
+        """Test showing security policies when none are configured"""
+        # Mock empty security policies
+        mock_get_security_policies.return_value = {}
+
+        result = self.runner.invoke(show_user.show_security_policy, [], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('No security policies configured', result.output)
+
+    @mock.patch('show.user.get_security_policies')
+    def test_show_security_policy_multiple_policies(self, mock_get_policies):
+        """Test showing multiple security policies"""
+        mock_policies = {
+            'administrator': {
+                'max_login_attempts': '5',
+                'lockout_duration': '300'
+            },
+            'operator': {
+                'max_login_attempts': '3',
+                'lockout_duration': '600'
+            }
+        }
+        mock_get_policies.return_value = mock_policies
+
+        result = self.runner.invoke(show_user.show_security_policy, [], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('administrator', result.output)
+        self.assertIn('operator', result.output)
+        self.assertIn('max_login_attempts', result.output)
+        self.assertIn('lockout_duration', result.output)
+        self.assertIn('5', result.output)
+        self.assertIn('3', result.output)
+        self.assertIn('300', result.output)
+        self.assertIn('600', result.output)
+
+    @mock.patch('show.user.can_view_passwords', return_value=False)
+    def test_show_users_mixed_enabled_disabled(self, mock_can_view):
+        """Test showing users with mixed enabled/disabled states"""
+
+        # config_db.json has: admin (enabled), operator1 (disabled), testuser (enabled)
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('admin', result.output)      # enabled admin
+            self.assertIn('operator1', result.output)  # disabled operator
+            self.assertIn('testuser', result.output)   # enabled operator
+            # Should show enabled/disabled status
+            self.assertIn('Yes', result.output)  # For enabled users (admin, testuser)
+            self.assertIn('No', result.output)   # For disabled users (operator1)
+            # Should not show password hashes (operator view)
+            self.assertNotIn('$y$j9T$salt$adminhash', result.output)
+        finally:
+
+            pass
+
+    def test_show_user_with_missing_fields(self):
+        """Test showing user with complete fields (using shared database)"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_user_details, ['operator1'], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('operator1', result.output)
+            self.assertIn('operator', result.output)
+            self.assertIn('No', result.output)  # operator1 is disabled in config_db.json
+            self.assertIn('SSH Keys: None', result.output)  # operator1 has no SSH keys
+        finally:
+
+            pass
+
+    @mock.patch('show.user.get_user_database')
+    def test_show_user_with_malformed_data(self, mock_get_users):
+        """Test showing user with malformed data"""
+        mock_users = {
+            'malformed_user': {
+                'role': 'operator',
+                'enabled': 'invalid_boolean',  # Invalid boolean value
+                'ssh_keys': 'not_a_list'  # Invalid SSH keys format
+            }
+        }
+        mock_get_users.return_value = mock_users
+
+        result = self.runner.invoke(show_user.show_user_details, ['malformed_user'], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('malformed_user', result.output)
+        # Should handle malformed data gracefully
+
+    def test_show_users_with_long_ssh_keys(self):
+        """Test showing users with SSH keys (using shared database)"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('admin', result.output)
+            self.assertIn('testuser', result.output)
+            self.assertIn('SSH Keys (1)', result.output)  # admin has 1 SSH key
+            self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 SSH keys
+        finally:
+
+            pass
+
+    @mock.patch('show.user.get_user_database')
+    def test_show_users_with_many_ssh_keys(self, mock_get_users):
+        """Test showing users with many SSH keys"""
+        many_keys = [f'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDhA key{i}@host'
+                     for i in range(10)]
+        mock_users = {
+            'user_with_many_keys': {
+                'role': 'administrator',
+                'enabled': True,
+                'ssh_keys': many_keys
+            }
+        }
+        mock_get_users.return_value = mock_users
+
+        result = self.runner.invoke(show_user.show_user_details, ['user_with_many_keys'], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('user_with_many_keys', result.output)
+        self.assertIn('SSH Keys (10)', result.output)
+        # Should show all keys numbered
+        self.assertIn('1. ssh-rsa', result.output)
+        self.assertIn('10. ssh-rsa', result.output)
+
+    @mock.patch('show.user.get_security_policies')
+    def test_show_security_policy_with_various_data_types(self, mock_get_policies):
+        """Test showing security policies with various data types"""
+        mock_policies = {
+            'test_role': {
+                'max_login_attempts': 5,  # Integer
+                'lockout_duration': '300',  # String
+                'enabled': True,  # Boolean
+                'custom_setting': 'custom_value'  # Custom string
+            }
+        }
+        mock_get_policies.return_value = mock_policies
+
+        # Use valid role name instead of 'test_role'
+        result = self.runner.invoke(show_user.show_security_policy, ['administrator'], obj=self.db)
+
+        # Should fail with exit code 2 because 'test_role' is not a valid choice
+        # But let's test with a valid role name and mock data
+        mock_policies = {
+            'administrator': {
+                'max_login_attempts': 5,  # Integer
+                'lockout_duration': '300',  # String
+                'enabled': True,  # Boolean
+                'custom_setting': 'custom_value'  # Custom string
+            }
+        }
+        mock_get_policies.return_value = mock_policies
+
+        result = self.runner.invoke(show_user.show_security_policy, ['administrator'], obj=self.db)
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('administrator', result.output)
+        self.assertIn('max_login_attempts: 5', result.output)
+        self.assertIn('lockout_duration: 300', result.output)
+        self.assertIn('enabled: True', result.output)
+        self.assertIn('custom_setting: custom_value', result.output)
+
+    @mock.patch('show.user.get_user_database')
+    def test_cli_database_connection_error_handling(self, mock_get_users):
+        """Test CLI behavior when database connection fails"""
+        # Test database connection error during show users
+        mock_get_users.side_effect = Exception("Database connection failed")
+
+        # Should handle database exceptions gracefully
+        try:
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+            # If no exception propagates, command should handle it gracefully
+            self.assertEqual(result.exit_code, 0)
+        except Exception:
+            # If exception propagates, it should be handled appropriately
+            pass
+
+        # Test with security policies
+        with mock.patch('show.user.get_security_policies') as mock_get_policies:
+            mock_get_policies.side_effect = Exception("Database connection failed")
+
+            try:
+                result = self.runner.invoke(show_user.show_security_policy, [], obj=self.db)
+                # Should handle gracefully
+                self.assertEqual(result.exit_code, 0)
+            except Exception:
+                pass
+
+    def test_show_users_case_sensitivity(self):
+        """Test that usernames are case-sensitive in display"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+            self.assertEqual(result.exit_code, 0)
+            # Test that exact usernames are displayed (case-sensitive)
+            self.assertIn('admin', result.output)      # lowercase admin
+            self.assertIn('operator1', result.output)  # lowercase operator1
+            self.assertIn('testuser', result.output)   # lowercase testuser
+            # Verify case sensitivity by ensuring wrong case doesn't match
+            self.assertNotIn('ADMIN', result.output)
+            self.assertNotIn('Admin', result.output)
+        finally:
+
+            pass
+
+    def test_show_user_details_case_sensitive_lookup(self):
+        """Test that user lookup is case-sensitive"""
+
+        from .mock_tables import dbconnector
+
+        try:
+
+            dbconnector.load_database_config()
+
+            # Test exact case match
+            result = self.runner.invoke(show_user.show_user_details, ['admin'], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('admin', result.output)
+
+            # Test different case - should not find user
+            result = self.runner.invoke(show_user.show_user_details, ['ADMIN'], obj=self.db)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("User 'ADMIN' not found", result.output)
+        finally:
+
+            pass
+
+    @mock.patch('show.user.get_user_database')
+    def test_negative_show_user_database_exception(self, mock_get_users):
+        """Test show users when database access raises exception"""
+        mock_get_users.side_effect = Exception("Database connection failed")
+
+        # Should handle database exceptions gracefully
+        try:
+            self.runner.invoke(show_user.show_users, [], obj=self.db)
+            # If no exception propagates, command should handle it gracefully
+        except Exception:
+            # If exception propagates, it should be handled appropriately
+            pass
+
+    @mock.patch('show.user.get_security_policies')
+    def test_negative_show_security_policy_database_exception(self, mock_get_policies):
+        """Test show security policies when database access raises exception"""
+        mock_get_policies.side_effect = Exception("Database connection failed")
+
+        # Should handle database exceptions gracefully
+        try:
+            self.runner.invoke(show_user.show_security_policy, [], obj=self.db)
+            # If no exception propagates, command should handle it gracefully
+        except Exception:
+            # If exception propagates, it should be handled appropriately
+            pass
+
+    @mock.patch('show.user.get_user_database')
+    def test_negative_show_user_with_none_data(self, mock_get_users):
+        """Test show users when database returns None"""
+        mock_get_users.return_value = None
+
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+        # Should handle None gracefully (treat as empty)
+        self.assertEqual(result.exit_code, 0)
+
+    @mock.patch('show.user.get_user_database')
+    def test_negative_show_user_with_corrupted_data(self, mock_get_users):
+        """Test show users with corrupted/invalid data structures"""
+        # Test with non-dict user data
+        mock_get_users.return_value = {
+            'corrupted_user': "not_a_dict",
+            'another_corrupted': 12345,
+            'null_user': None
+        }
+
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+        # Should handle corrupted data gracefully (may fail with exit code 1)
+        self.assertIn(result.exit_code, [0, 1])
+
+    @mock.patch('show.user.get_user_database')
+    def test_cli_special_username_handling(self, mock_get_users):
+        """Test show user details with special/problematic usernames"""
+        special_usernames = [
+            "nonexistent_user",  # Normal nonexistent user
+            "ADMIN",            # Case sensitivity
+        ]
+
+        mock_get_users.return_value = {}  # Empty database
+
+        for username in special_usernames:
+            with self.subTest(username=repr(username)):
+                result = self.runner.invoke(show_user.show_user_details, [username], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+                # When no users are configured, should show "No users configured"
+                self.assertIn("No users configured", result.output)
+
+    @mock.patch('show.user.get_security_policies')
+    def test_cli_security_policy_invalid_roles(self, mock_get_policies):
+        """Test show security policy with invalid role names"""
+        mock_get_policies.return_value = {}  # Empty policies
+
+        # Test CLI validation - invalid role names should get exit code 2
+        invalid_roles = [
+            "invalid_role",     # Nonexistent role
+            "ADMINISTRATOR",    # Wrong case
+        ]
+
+        for role in invalid_roles:
+            with self.subTest(role=repr(role)):
+                result = self.runner.invoke(show_user.show_security_policy, [role], obj=self.db)
+
+                # CLI validation should reject invalid role names with exit code 2
+                self.assertEqual(result.exit_code, 2)
+                self.assertIn("Invalid value", result.output)
+
+        # Test with valid role names that don't exist in policies
+        valid_roles = ["administrator", "operator"]
+
+        for role in valid_roles:
+            with self.subTest(role=repr(role)):
+                result = self.runner.invoke(show_user.show_security_policy, [role], obj=self.db)
+
+                self.assertEqual(result.exit_code, 0)
+                # Should show appropriate message for valid but nonexistent role
+                self.assertTrue(
+                    "no security policy" in result.output.lower() or
+                    "configured" in result.output.lower()
+                )
+
+    @mock.patch('show.user.get_user_database')
+    def test_negative_show_user_with_missing_required_fields(self, mock_get_users):
+        """Test show users with missing required fields"""
+        mock_users = {
+            'incomplete_user1': {},  # Completely empty
+            'incomplete_user2': {'role': 'operator'},  # Missing other fields
+            'incomplete_user3': {'enabled': True},  # Missing role
+            'incomplete_user4': {'ssh_keys': ['key1']},  # Missing role and enabled
+        }
+        mock_get_users.return_value = mock_users
+
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+        # Should handle missing fields gracefully with defaults
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('incomplete_user1', result.output)
+        self.assertIn('incomplete_user2', result.output)
+
+    @mock.patch('show.user.get_user_database')
+    def test_negative_show_user_with_invalid_field_types(self, mock_get_users):
+        """Test show users with invalid field types"""
+        mock_users = {
+            'invalid_types_user': {
+                'role': 123,  # Should be string
+                'enabled': 'not_a_boolean',  # Should be boolean
+                'ssh_keys': 'not_a_list',  # Should be list
+                'password_hash': ['not', 'a', 'string']  # Should be string
+            }
+        }
+        mock_get_users.return_value = mock_users
+
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+
+        # Should handle invalid types gracefully
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('invalid_types_user', result.output)
+
+    @mock.patch('show.user.get_security_policies')
+    def test_negative_show_security_policy_with_invalid_data_types(self, mock_get_policies):
+        """Test show security policies with invalid data types"""
+        mock_policies = {
+            'administrator': {  # Use valid role name
+                'max_login_attempts': ['not', 'a', 'number'],  # Should be number
+                'invalid_field': {'nested': 'dict'},  # Nested structure
+                'null_field': None,  # Null value
+                'empty_string': '',  # Empty string
+                'boolean_field': True,  # Boolean value
+                'list_field': [1, 2, 3]  # List value
+            }
+        }
+        mock_get_policies.return_value = mock_policies
+
+        result = self.runner.invoke(show_user.show_security_policy, ['administrator'], obj=self.db)
+
+        # Should handle invalid data types gracefully
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('administrator', result.output)
+
+    @mock.patch('show.user.get_user_database')
+    def test_cli_error_handling_comprehensive(self, mock_get_users):
+        """Test CLI error handling with various error scenarios"""
+        # Test 1: Invalid SSH key data handling through CLI
+        mock_users = {
+            'user_invalid_ssh': {
+                'role': 'operator',
+                'enabled': True,
+                'ssh_keys': "not_a_list"  # Invalid SSH key data type
+            }
+        }
+        mock_get_users.return_value = mock_users
+
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+        self.assertEqual(result.exit_code, 0)
+        # Should handle invalid SSH key data gracefully
+        self.assertIn('user_invalid_ssh', result.output)
+
+        # Test 2: Permission error handling through CLI
+        with mock.patch('show.user.getpass.getuser') as mock_getuser:
+            with mock.patch('show.user.os.geteuid') as mock_geteuid:
+                mock_geteuid.return_value = 1000  # Non-root user
+                mock_getuser.side_effect = Exception("Cannot get username")
+
+                # Should handle getuser errors gracefully (may fail with exit code 1)
+                result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+                # Accept either success (graceful handling) or failure (exception propagation)
+                self.assertIn(result.exit_code, [0, 1])
+                if result.exit_code == 0:
+                    # Should not show password hashes when permission check fails
+                    self.assertNotIn('$y$j9T$salt$', result.output)
+
+        # Test 3: UID error handling through CLI
+        with mock.patch('show.user.os.geteuid') as mock_geteuid:
+            mock_geteuid.side_effect = Exception("Cannot get UID")
+
+            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+            # Accept either success (graceful handling) or failure (exception propagation)
+            self.assertIn(result.exit_code, [0, 1])
+            if result.exit_code == 0:
+                # Should handle UID errors gracefully
+                self.assertIn('user_invalid_ssh', result.output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/show_user_test.py
+++ b/tests/show_user_test.py
@@ -62,6 +62,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('SSH Keys: None', result.output)  # operator1 has no SSH keys
             self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 SSH keys
         finally:
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.can_view_passwords', return_value=True)
@@ -82,6 +83,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('$y$j9T$salt$operatorhash', result.output)
             self.assertIn('$y$j9T$salt$testuserhash', result.output)
         finally:
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.can_view_passwords', return_value=False)
@@ -105,7 +107,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('administrator', result.output)
             self.assertIn('operator1', result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     def test_show_user_specific(self):
@@ -124,7 +126,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('administrator', result.output)
             self.assertIn('Yes', result.output)  # enabled should show as "Yes"
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     def test_show_user_not_found(self):
@@ -141,7 +143,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)  # Command succeeds but shows error message
             self.assertIn("User 'nonexistent' not found", result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     def test_show_user_with_sudo(self):
@@ -162,7 +164,7 @@ class TestShowUserCLI(unittest.TestCase):
             # Should show password hash from config_db.json when running with sudo
             self.assertIn('$y$j9T$salt$adminhash', result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.get_security_policies')
@@ -254,11 +256,15 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('testuser', result.output)
             self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 SSH keys in config_db.json
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     def test_show_user_disabled(self):
-        """Test showing disabled user"""
+        """Test showing disabled user.
+
+        Note: operator1 has "enabled": "false" (string) in config_db.json,
+        which should display as 'Enabled: No'.
+        """
 
         from .mock_tables import dbconnector
 
@@ -270,9 +276,10 @@ class TestShowUserCLI(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 0)
             self.assertIn('operator1', result.output)
-            self.assertIn('No', result.output)  # operator1 is disabled in config_db.json
+            # Use specific assertion to verify disabled status (not just 'No' which could match other output)
+            self.assertIn('Enabled: No', result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     def test_cli_ssh_key_formatting_through_show_commands(self):
@@ -314,7 +321,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertIn("SSH Keys: None", result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.getpass.getuser')
@@ -358,7 +365,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('operator1', result.output)
             self.assertIn('administrator', result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
         # Test 4: Unknown user should NOT see password hashes
@@ -388,7 +395,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('SSH Keys (1)', result.output)  # admin has 1 key
             self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 keys
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.get_user_database')
@@ -462,7 +469,7 @@ class TestShowUserCLI(unittest.TestCase):
             # Should not show password hashes (operator view)
             self.assertNotIn('$y$j9T$salt$adminhash', result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     def test_show_user_with_missing_fields(self):
@@ -482,7 +489,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('No', result.output)  # operator1 is disabled in config_db.json
             self.assertIn('SSH Keys: None', result.output)  # operator1 has no SSH keys
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.get_user_database')
@@ -520,7 +527,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertIn('SSH Keys (1)', result.output)  # admin has 1 SSH key
             self.assertIn('SSH Keys (2)', result.output)  # testuser has 2 SSH keys
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.get_user_database')
@@ -559,11 +566,7 @@ class TestShowUserCLI(unittest.TestCase):
         }
         mock_get_policies.return_value = mock_policies
 
-        # Use valid role name instead of 'test_role'
-        result = self.runner.invoke(show_user.show_security_policy, ['administrator'], obj=self.db)
-
-        # Should fail with exit code 2 because 'test_role' is not a valid choice
-        # But let's test with a valid role name and mock data
+        # Use valid role name and set appropriate mock data
         mock_policies = {
             'administrator': {
                 'max_login_attempts': 5,  # Integer
@@ -589,25 +592,14 @@ class TestShowUserCLI(unittest.TestCase):
         # Test database connection error during show users
         mock_get_users.side_effect = Exception("Database connection failed")
 
-        # Should handle database exceptions gracefully
-        try:
-            result = self.runner.invoke(show_user.show_users, [], obj=self.db)
-            # If no exception propagates, command should handle it gracefully
-            self.assertEqual(result.exit_code, 0)
-        except Exception:
-            # If exception propagates, it should be handled appropriately
-            pass
+        result = self.runner.invoke(show_user.show_users, [], obj=self.db)
+        # Command may fail gracefully (exit code 1) or suppress error (exit code 0)
+        self.assertIn(result.exit_code, [0, 1])
 
-        # Test with security policies
         with mock.patch('show.user.get_security_policies') as mock_get_policies:
             mock_get_policies.side_effect = Exception("Database connection failed")
-
-            try:
-                result = self.runner.invoke(show_user.show_security_policy, [], obj=self.db)
-                # Should handle gracefully
-                self.assertEqual(result.exit_code, 0)
-            except Exception:
-                pass
+            result = self.runner.invoke(show_user.show_security_policy, [], obj=self.db)
+            self.assertIn(result.exit_code, [0, 1])
 
     def test_show_users_case_sensitivity(self):
         """Test that usernames are case-sensitive in display"""
@@ -629,7 +621,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertNotIn('ADMIN', result.output)
             self.assertNotIn('Admin', result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     def test_show_user_details_case_sensitive_lookup(self):
@@ -651,7 +643,7 @@ class TestShowUserCLI(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertIn("User 'ADMIN' not found", result.output)
         finally:
-
+            # Cleanup handled by mock_tables reset
             pass
 
     @mock.patch('show.user.get_user_database')
@@ -702,8 +694,9 @@ class TestShowUserCLI(unittest.TestCase):
 
         result = self.runner.invoke(show_user.show_users, [], obj=self.db)
 
-        # Should handle corrupted data gracefully (may fail with exit code 1)
-        self.assertIn(result.exit_code, [0, 1])
+        # Should handle corrupted data gracefully by skipping invalid users
+        # Prefer graceful handling (exit code 0) over failing
+        self.assertEqual(result.exit_code, 0)
 
     @mock.patch('show.user.get_user_database')
     def test_cli_special_username_handling(self, mock_get_users):
@@ -718,9 +711,7 @@ class TestShowUserCLI(unittest.TestCase):
         for username in special_usernames:
             with self.subTest(username=repr(username)):
                 result = self.runner.invoke(show_user.show_user_details, [username], obj=self.db)
-
                 self.assertEqual(result.exit_code, 0)
-                # When no users are configured, should show "No users configured"
                 self.assertIn("No users configured", result.output)
 
     @mock.patch('show.user.get_security_policies')

--- a/utilities_common/general.py
+++ b/utilities_common/general.py
@@ -45,6 +45,40 @@ def get_optional_value_for_key_in_config_tbl(config_db, port, key, table):
     return value
 
 
+def is_true(value, default=False):
+    """Convert CONFIG_DB boolean value to Python boolean.
+
+    CONFIG_DB stores boolean values as strings 'true'/'false'.
+    This function handles both string and native boolean inputs.
+
+    Args:
+        value: The value to convert (string 'true'/'false', bool, or other)
+        default: Default value to return if value is None
+
+    Returns:
+        bool: True if value represents true, False otherwise
+    """
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.lower() == 'true'
+    return bool(value)
+
+
+def is_user_feature_enabled(config_db):
+    """Check if local user management feature is enabled in DEVICE_METADATA.
+
+    Args:
+        config_db: ConfigDBConnector instance
+
+    Returns:
+        bool: True if local_user_management is 'enabled', False otherwise
+    """
+    device_metadata = config_db.get_table('DEVICE_METADATA')
+    localhost_data = device_metadata.get('localhost', {})
+    return localhost_data.get('local_user_management') == 'enabled'
+
+
 def get_feature_state_data(config_db, feature):
     '''
     Get feature state from FEATURE table from CONFIG_DB.


### PR DESCRIPTION
#### What I did
This implementation addresses the User Management HLD requirements for user administration in SONiC. https://github.com/sonic-net/SONiC/pull/2018

Add CLI interface for SONiC local user management:

- config user add/modify/delete - User lifecycle management
- config user add-ssh-key/remove-ssh-key - SSH key management
- config user import-existing - Import system users to SONiC
- show user [username] - Display user information and status
- show user roles - Display available roles and permissions


#### How I did it
Features:
- Role-based access control (administrator/operator)
- Secure password handling with confirmation prompts
- SSH key format validation and management
- CONFIG_DB integration for persistent configuration
- Comprehensive input validation and error handling
- Complete test suite with unit and integration tests

Commands integrate with userd daemon for system-level user operations.

#### How to verify it
Validated the CLI and its functionality.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

