### PR TITLE
Add Arista-7060X6-64PE-B-O128S2, Arista-7060X6-16PE-384C-B-O128S2 to GCU

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -31,7 +31,7 @@
                 "th3": [ "Nokia-IXR7220-H3" ],
                 "th4": [ "Nokia-IXR7220-H4-64D", "Nokia-IXR7220-H4-32D" ],
                 "th5": [ "Nokia-IXR7220-H5-64D", "Arista-7060X6-64DE", "Arista-7060X6-64PE", "Arista-7060X6-64PE-C224O8", "Arista-7060X6-64PE-C256S2", "Nokia-IXR7220-H5-64O", "Nokia-IXR7220-H5-32D",
-                         "Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-64PE-B-O128"],
+                         "Arista-7060X6-64PE-B-C512S2", "Arista-7060X6-64PE-B-C448O16", "Arista-7060X6-64PE-B-O128", "Arista-7060X6-64PE-B-O128S2", "Arista-7060X6-16PE-384C-B-O128S2"],
                 "td2": [ "Force10-S6000", "Force10-S6000-Q24S32", "Arista-7050-QX32", "Arista-7050-QX-32S", "Nexus-3164", "Arista-7050QX32S-Q32" ],
                 "td3": [ "Arista-7050CX3-32C-C32", "Arista-7050CX3-32S-C32", "Arista-7050CX3-32S-D48C8", "Arista-7050CX3-32S-C28S4" ],
                 "td4": [ "Nokia-IXR7220-D4-36D" ],


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add Arista-7060X6-64PE-B-O128S2, Arista-7060X6-16PE-384C-B-O128S2 to  generic_config_updater/gcu_field_operation_validators.conf.json.

This fixes the following failures:

```
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[all]
generic_config_updater/test_pfcwd_status.py::test_start_pfcwd[single]
generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[all]
generic_config_updater/test_pfcwd_status.py::test_stop_pfcwd[single]
```

#### How to verify it
Manually ran the generic_config_updater tests