### PR TITLE
sonic-cli-gen: modified help string to be formatted with multi-line comments

### DIFF
--- a/sonic-utilities-data/templates/sonic-cli-gen/config.py.j2
+++ b/sonic-utilities-data/templates/sonic-cli-gen/config.py.j2
@@ -255,7 +255,7 @@ Result:
 {%- for attr in attrs %}
 @click.option(
     "--{{ cli_name(attr.name) }}",
-    help="{{ attr.description }}{% if attr['is-mandatory'] %}[mandatory]{% endif %}",
+    help="""{{ attr.description }}{% if attr['is-mandatory'] %}[mandatory]{% endif %}""",
 )
 {%- endfor %}
 {%- endmacro %}


### PR DESCRIPTION
* switched from single-line comments to multi-line comments

Signed-off-by: Megh Dedhia m11dedhia@gmail.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modified macro-gen_click_options inside `sonic-utilities-data/templates/sonic-cli-gen/config.py.j2` to render all strings as  multi-line comment for help option under click.option
#### How I did it

#### How to verify it
```
sonic-cli-gen generate config sonic-buffer-pool
config buffer-pool
```
#### Previous command output (if the output of a command-line utility has changed)
```
failed to import plugin config.plugins.auto.sonic-buffer-pool_yang: unterminated string literal (detected at line 287) (sonic-buffer-pool_yang.py, line 287)
```
#### New command output (if the output of a command-line utility has changed)
```
Usage: config buffer-pool [OPTIONS] COMMAND [ARGS]...

Options:
  -h, -?, --help   Show this message and exit

Commands:
  add          Add object in BUFFER_POOL.
  delete      Delete object in BUFFER_POOL.
  update    Add object in BUFFER_POOL.
```

Fixes sonic-net/sonic-buildimage#24006