### PR TITLE
Issue 23798: (trixie) Wrap getpass.getpass in a signal handler to avoid SIGTTOU

### DIFF
--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -12,6 +12,7 @@ import select
 import socket
 import termios
 import getpass
+import signal
 
 MULTI_LC_REXEC_OUTPUT = '''======== LINE-CARD0|sonic-lc1 output: ========
 hello world
@@ -83,7 +84,18 @@ def mock_getpass(prompt="Password:", stream=None):
 
 
 class TestRemoteExec(object):
-    __getpass = getpass.getpass
+    # Store the original function at class definition time to avoid recursion
+    _original_getpass = getpass.getpass
+
+    @staticmethod
+    def __getpass(prompt="Password:", stream=None):
+        """SIGTTOU-safe wrapper for getpass.getpass() for Python 3.13 compatibility"""
+        original_sigttou_handler = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        try:
+            # Call the original function, in case getpass.getpass has been overridden
+            return TestRemoteExec._original_getpass(prompt, stream)
+        finally:
+            signal.signal(signal.SIGTTOU, original_sigttou_handler)
 
     @classmethod
     def setup_class(cls):
@@ -225,9 +237,10 @@ class TestRemoteExec(object):
         runner = CliRunner()
         getpass.getpass = TestRemoteExec.__getpass
         LINECARD_NAME = "all"
-        result = runner.invoke(
-            rexec.cli, [LINECARD_NAME, "-c", "show version"])
+
+        result = runner.invoke(rexec.cli, [LINECARD_NAME, "-c", "show version"])
         getpass.getpass = mock_getpass
+
         print(result.output)
         assert result.exit_code == 1, result.output
         assert "Aborted" in result.output


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Python 3.13 will raise a SIGTTOU signal when getpass.getpass is called in a background process, like when running under pytest. Add a signal handler to `tests/remote_cli_test.py` to handle SIGTTOU whenever `getpass.getpass()` is called, since this will raise SIGTTOU when running `trixie`.

This closes [#23798](https://github.com/sonic-net/sonic-buildimage/issues/23798)

#### How I did it

Wrap the call in a signal handler to ignore the signal. This avoids a hang when running `trixie`.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

