### PR TITLE
Improve set/get cmdline to support uefi

### DIFF
--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -93,7 +93,10 @@ class GrubBootloader(OnieInstallerBootloader):
         config.close()
         for line in menuentry.split('\n'):
             line = line.strip()
-            if line.startswith('linux '):
+            if line.startswith('linuxefi '):
+                cmdline = line[9:].strip()
+                break
+            elif line.startswith('linux '):
                 cmdline = line[6:].strip()
                 break
         return cmdline
@@ -106,7 +109,10 @@ class GrubBootloader(OnieInstallerBootloader):
         new_menuentry = old_menuentry
         for line in old_menuentry.split('\n'):
             line = line.strip()
-            if line.startswith('linux '):
+            if line.startswith('linuxefi '):
+                new_menuentry = old_menuentry.replace(line, "linuxefi " + cmdline)
+                break
+            elif line.startswith('linux '):
                 new_menuentry = old_menuentry.replace(line, "linux " + cmdline)
                 break
         config = open(HOST_PATH + '/grub/grub.cfg', 'w')


### PR DESCRIPTION
Improve set/get cmdline to support uefi

#### What I did
Fix https://github.com/sonic-net/sonic-buildimage/issues/23820
sonic-installer get-fips/set-fips not working on systems in UEFI mode

#### How I did it
Improve get_linux_cmdline and set_linux_cmdline to support linuxefi

#### How to verify it
Manually verify.
Pass all test case

##### Work item tracking
- Microsoft ADO: 34847974

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

