### PR TITLE
Fixing state_db not having delete_field attribute causing a crash when DPUs in bad state

### DIFF
--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -75,7 +75,6 @@ def set_state_transition_in_progress(db, chassis_module_name, value):
         entry['transition_start_time'] = datetime.utcnow().isoformat()
     else:
         entry.pop('transition_start_time', None)
-        state_db.delete_field('CHASSIS_MODULE_TABLE', chassis_module_name, 'transition_start_time')
     state_db.set_entry('CHASSIS_MODULE_TABLE', chassis_module_name, entry)
 
 


### PR DESCRIPTION
#### What I did
Fixing state_db not having delete_field attribute causing a crash when DPUs in bad state. Removed the line of code in set_state_transition_in_progress, which was deleting the field "transition_start_time".  This information is redundant.  Leaving the  'transition_start_time' in the CHASSIS_MODULE_TABLE is no harm.  This part of the code is  refactored and that PR is almost ready to be merged.  This is just an interim fix mainly for 202505/06 branches.

#### How I did it
Removed the line of code in set_state_transition_in_progress, which was deleting the field "transition_start_time'.  This information is redundant. 

#### How to verify it
Make the DPU midplane unreachable for one of the DPUs.  Toggle the DPU ON/OFF state a couple of times using "config chassis  modules startup/shutdown DPUx"

Which release branch to backport (provide reason below if selected)
[x] 202505
[x] 202506


