### PR TITLE
Fix incorrect output format for pre-fec ber in sfpshow pm

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -580,6 +580,9 @@ class SFPShow(object):
             return pm_prefix.replace('_', '')
 
     def beautify_pm_field(self, prefix, field):
+        if type(field) == bool:
+            return str(field)
+
         if field is None:
             return 'N/A'
         elif prefix in {'prefec_ber'}:

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -192,12 +192,12 @@ Ethernet72: SFP EEPROM detected
         Supported Max TX Power: N/A
         Supported Min Laser Frequency: N/A
         Supported Min TX Power: N/A
-        Vendor Date Code(YYYY-MM-DD Lot): 2022-05-28   
-        Vendor Name: vendor1          
+        Vendor Date Code(YYYY-MM-DD Lot): 2022-05-28
+        Vendor Name: vendor1
         Vendor OUI: some-oui
-        Vendor PN: some-model    
+        Vendor PN: some-model
         Vendor Rev: A3
-        Vendor SN: serial1   
+        Vendor SN: serial1
         dom_capability: N/A
         is_replaceable: True
         ChannelMonitorValues:
@@ -328,7 +328,7 @@ Ethernet44:
     DGD              ps      5.37      5.56      5.81      7.0          7.0          False         0.0          0.0          False
     SOPMD            ps^2    0.0       0.0       0.0       655.35       655.35       False         0.0          0.0          False
     SOP ROC          krad/s  1.0       1.0       2.0       N/A          N/A          N/A           N/A          N/A          N/A
-    Pre-FEC BER      N/A     4.58E-04  4.66E-04  5.76E-04  1.25E-02     1.10E-02     0.0           0.0          0.0          0.0
+    Pre-FEC BER      N/A     4.58E-04  4.66E-04  5.76E-04  1.25E-02     1.10E-02     False         0.0          0.0          False
     Post-FEC BER     N/A     0.0       0.0       0.0       1000.0       1.0          False         0.0          0.0          False
     EVM              %       100.0     100.0     100.0     N/A          N/A          N/A           N/A          N/A          N/A
 """
@@ -984,7 +984,7 @@ Ethernet36  Present
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ["Ethernet8", "-d"])
         assert result.exit_code == 0
         assert result.output == test_qsfp_dd_eeprom_with_dom_output
-        
+
     def test_osfp_eeprom_with_dom(self):
         runner = CliRunner()
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["eeprom"], ["Ethernet72", "-d"])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

The original implementation incorrectly output floating point values when printing tcaHigh and tcaLow for pre-fec ber. I changed it to output true and false.

#### How I did it

Modify beautifypmfield function

#### How to verify it

Run UT

#### Previous command output (if the output of a command-line utility has changed)
```
Ethernet44:
    Parameter        Unit    Min       Avg       Max       Threshold    Threshold    Threshold     Threshold    Threshold    Threshold
                                                           High         High         Crossing      Low          Low          Crossing
                                                           Alarm        Warning      Alert-High    Alarm        Warning      Alert-Low
    ---------------  ------  --------  --------  --------  -----------  -----------  ------------  -----------  -----------  -----------
    Tx Power         dBm     -8.22     -8.23     -8.24     -5.0         -6.0         False         -16.99       -16.003      False
    Rx Total Power   dBm     -10.61    -10.62    -10.62    2.0          0.0          False         -21.0        -18.0        False
    Rx Signal Power  dBm     -40.0     0.0       40.0      13.0         10.0         True          -18.0        -15.0        True
    CD-short link    ps/nm   0.0       0.0       0.0       1000.0       500.0        False         -1000.0      -500.0       False
    PDL              dB      0.5       0.6       0.6       4.0          4.0          False         0.0          0.0          False
    OSNR             dB      36.5      36.5      36.5      99.0         99.0         False         0.0          0.0          False
    eSNR             dB      30.5      30.5      30.5      99.0         99.0         False         0.0          0.0          False
    CFO              MHz     54.0      70.0      121.0     3800.0       3800.0       False         -3800.0      -3800.0      False
    DGD              ps      5.37      5.56      5.81      7.0          7.0          False         0.0          0.0          False
    SOPMD            ps^2    0.0       0.0       0.0       655.35       655.35       False         0.0          0.0          False
    SOP ROC          krad/s  1.0       1.0       2.0       N/A          N/A          N/A           N/A          N/A          N/A
    Pre-FEC BER      N/A     4.58E-04  4.66E-04  5.76E-04  1.25E-02     1.10E-02     0.0           0.0          0.0          0.0
    Post-FEC BER     N/A     0.0       0.0       0.0       1000.0       1.0          False         0.0          0.0          False
    EVM              %       100.0     100.0     100.0     N/A          N/A          N/A           N/A          N/A          N/A
```
#### New command output (if the output of a command-line utility has changed)
```
Ethernet44:
    Parameter        Unit    Min       Avg       Max       Threshold    Threshold    Threshold     Threshold    Threshold    Threshold
                                                           High         High         Crossing      Low          Low          Crossing
                                                           Alarm        Warning      Alert-High    Alarm        Warning      Alert-Low
    ---------------  ------  --------  --------  --------  -----------  -----------  ------------  -----------  -----------  -----------
    Tx Power         dBm     -8.22     -8.23     -8.24     -5.0         -6.0         False         -16.99       -16.003      False
    Rx Total Power   dBm     -10.61    -10.62    -10.62    2.0          0.0          False         -21.0        -18.0        False
    Rx Signal Power  dBm     -40.0     0.0       40.0      13.0         10.0         True          -18.0        -15.0        True
    CD-short link    ps/nm   0.0       0.0       0.0       1000.0       500.0        False         -1000.0      -500.0       False
    PDL              dB      0.5       0.6       0.6       4.0          4.0          False         0.0          0.0          False
    OSNR             dB      36.5      36.5      36.5      99.0         99.0         False         0.0          0.0          False
    eSNR             dB      30.5      30.5      30.5      99.0         99.0         False         0.0          0.0          False
    CFO              MHz     54.0      70.0      121.0     3800.0       3800.0       False         -3800.0      -3800.0      False
    DGD              ps      5.37      5.56      5.81      7.0          7.0          False         0.0          0.0          False
    SOPMD            ps^2    0.0       0.0       0.0       655.35       655.35       False         0.0          0.0          False
    SOP ROC          krad/s  1.0       1.0       2.0       N/A          N/A          N/A           N/A          N/A          N/A
    Pre-FEC BER      N/A     4.58E-04  4.66E-04  5.76E-04  1.25E-02     1.10E-02     False         0.0          0.0          False
    Post-FEC BER     N/A     0.0       0.0       0.0       1000.0       1.0          False         0.0          0.0          False
    EVM              %       100.0     100.0     100.0     N/A          N/A          N/A           N/A          N/A          N/A
```

