### PR TITLE
add cli to show liquid cooling leakage status

### DIFF
--- a/scripts/leakageshow
+++ b/scripts/leakageshow
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+"""
+    Script to show leakage status.
+"""
+
+import os
+import sys
+from tabulate import tabulate
+from natsort import natsorted
+
+# mock the redis for unit test purposes #
+try:
+    if os.environ["UTILITIES_UNIT_TESTING"] == "1":
+        modules_path = os.path.join(os.path.dirname(__file__), "..")
+        test_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, test_path)
+        import mock_tables.dbconnector
+except KeyError:
+    pass
+
+from swsscommon.swsscommon import SonicV2Connector
+
+header = ['Name', 'Leak']
+
+LIQUID_COOLING_TABLE_NAME = 'LIQUID_COOLING_INFO'
+STATUS_FIELD_NAME = 'leak_status'
+
+class LeakageShow(object):
+    def __init__(self):
+        self.db = SonicV2Connector(host="127.0.0.1")
+        self.db.connect(self.db.STATE_DB)
+
+    def show(self):
+        keys = self.db.keys(self.db.STATE_DB, LIQUID_COOLING_TABLE_NAME + '*')
+        if not keys:
+            print('Leakage sensor Not detected\n')
+            return
+
+        table = []
+        for key in natsorted(keys):
+            key_list = key.split('|')
+            if len(key_list) != 2: # error data in DB, log it and ignore
+                print('Warn: Invalid key in table LIQUID_COOLING_INFO: {}'.format(key))
+                continue
+
+            name = key_list[1]
+            data_dict = self.db.get_all(self.db.STATE_DB, key)
+            status = data_dict[STATUS_FIELD_NAME]
+            
+            table.append((name, status))
+
+        if table:
+            print(tabulate(table, header, tablefmt='simple', stralign='right'))
+        else:
+            print('No leakage status data available\n')
+
+
+if __name__ == "__main__":
+    leakageShow = LeakageShow()
+    leakageShow.show()

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ setup(
         'scripts/intfstat',
         'scripts/ipintutil',
         'scripts/lag_keepalive.py',
+        'scripts/leakageshow',
         'scripts/lldpshow',
         'scripts/log_ssd_health',
         'scripts/mellanox_buffer_migrator.py',

--- a/show/platform.py
+++ b/show/platform.py
@@ -198,3 +198,16 @@ def firmware(args):
         subprocess.check_call(cmd)
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
+
+# 'leakage' subcommand ("show platform leakage status")
+@platform.group()
+def leakage():
+    """Show platform leakage information"""
+    pass
+
+@leakage.command()
+def status():
+    """Show platform leakage status"""
+    cmd = ["leakageshow"]
+    clicommon.run_command(cmd)
+

--- a/tests/leakage_status_test.py
+++ b/tests/leakage_status_test.py
@@ -1,0 +1,38 @@
+import sys
+import os
+from click.testing import CliRunner
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, modules_path)
+
+import show.main as show
+
+class TestFan(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def test_show_platform_leakage_status(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["platform"].commands["leakage"].commands["status"])
+        print(result.output)
+        expected = """\
+    Name    Leak
+--------  ------
+leakage1      No
+leakage2      No
+leakage3     Yes
+"""
+
+        assert result.output == expected
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1249,6 +1249,15 @@
         "14": "200:200:200:200::5@Vlan1000",
         "15": "200:200:200:200::5@Vlan1000"
     },
+    "LIQUID_COOLING_INFO|leakage1": {
+        "leak_status": "No"
+    },
+    "LIQUID_COOLING_INFO|leakage2": {
+        "leak_status": "No"
+    },
+    "LIQUID_COOLING_INFO|leakage3": {
+        "leak_status": "Yes"
+    },
     "FG_ROUTE_TABLE|100.50.25.12/32": {
         "0": "200.200.200.4@Vlan1000",
         "1": "200.200.200.4@Vlan1000",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Following this HLD for liquid cooling https://github.com/sonic-net/SONiC/pull/2032, I created this pr to add relevant CLI for checking liquid cooling status
#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

