### PR TITLE
[Mellanox] Update generate_dump to include SDK sysfs files

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -913,6 +913,65 @@ save_sys() {
     chmod ugo+rw -R $DUMPDIR/$BASE/sys
 }
 
+save_sysfs() {
+    trap 'handle_error $? $LINENO' ERR
+    local src="$1"
+    local dest="$2"
+    shift 2
+    # sys files we do not want to include in dump
+    local excludes=("$@")
+
+    $MKDIR $V -p "$dest"
+
+    should_skip() {
+        local base="$1"
+        for ex in "${excludes[@]}"; do
+            [[ "$base" == "$ex" ]] && return 0
+        done
+        return 1
+    }
+
+    # Copy files directly under src
+    for f in "$src"/*; do
+        if [ -f "$f" ]; then
+            local base="$(basename "$f")"
+            should_skip "$base" && continue
+            local target="$dest/$base"
+
+            if $NOOP; then
+                echo "cat $f > $target 2>/dev/null"
+            else
+                cat "$f" > "$target" 2>/dev/null
+            fi
+        fi
+    done
+
+    # Copy sub folders
+    for d in "$src"/*; do
+        if [ -d "$d" ]; then
+            local subdir_dest="$dest/$(basename "$d")"
+            $MKDIR $V -p "$subdir_dest"
+
+            # copy only files inside sub folder, not sub-sub folders
+            for f in "$d"/*; do
+                if [ -f "$f" ]; then
+                    local base="$(basename "$f")"
+                    should_skip "$base" && continue
+                    local target="$subdir_dest/$base"
+
+                    if $NOOP; then
+                        echo "cat $f > $target 2>/dev/null"
+                    else
+                        cat "$f" > "$target" 2>/dev/null
+                    fi
+                fi
+            done
+        fi
+    done
+
+    chmod ugo+rw -R "$dest"
+}
+
 ###############################################################################
 # Given list of pstore directories or files, saves subdirectories and files to tar.
 # Globals:
@@ -1409,6 +1468,12 @@ collect_mellanox() {
         save_cmd "dpuctl dpu-status" "dpu_status"
     fi
 
+    local sdk_sysfs_src_path="/sys/module/sx_core/asic0"
+    local sdk_sysfs_dest_path="$TARDIR/sdk_sysfs/sx_core/asic0"
+    local excludes_sysfs_files=(rx_los tx_disable module_info module_latched_flag_info power_mode power_mode_policy reinsert reset)
+
+    save_sysfs "$sdk_sysfs_src_path" "$sdk_sysfs_dest_path" "${excludes_sysfs_files[@]}" &
+
     # Save CMIS-host-management related files
     local cmis_host_mgmt_path="cmis-host-mgmt"
 
@@ -1423,6 +1488,8 @@ collect_mellanox() {
     fi
 
     save_cmd "show interfaces autoneg status" "autoneg.status"
+
+    wait
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update generate_dump script to include SDK sysfs for Mellanox vendor.

#### How I did it
* Add save_sys_depth1 function
* Call function with relevant parameters inside collect_mellanox() function.

#### How to verify it
Generate dump in Mellanox/Nvidia SONiC switch (using show techsupport command), and make sure 'sdk_sysfs' folder is created, with SDK sysfs files. 

#### Previous command output (if the output of a command-line utility has changed)
Dump didn't contain sdk_sysfs folder.
#### New command output (if the output of a command-line utility has changed)
Dump contains sdk_sysfs folder. 
