### PR TITLE
[Port-breakout] Fixing breakout configuration resulting in cable_length None

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -230,6 +230,27 @@ class ConfigMgmt():
         self.sysLog(msg="Write in DB: {}".format(data))
         configdb.mod_config(sonic_cfggen.FormatConverter.output_to_db(data))
 
+        # Handle deletion of column key when it's value is 'None' using set_entry
+        # data: config data in a dictionary form
+        # {
+        #     'TABLE_NAME': { 'row_key': {'column_key': None, ...}, ...}
+        # }
+        for table_name, table_data in sonic_cfggen.FormatConverter.output_to_db(data).items():
+            if table_data is None:
+                continue;
+            for row_key, row_val in table_data.items():
+                if row_val is None:
+                    continue;
+                elif isinstance(row_val, dict):
+                    entry = configdb.get_entry(table_name, row_key)
+                    if entry and isinstance(entry, dict):
+                        need_modification = 0
+                        for col_key, col_val in row_val.items():
+                            if col_key in entry and col_val is None:
+                                need_modification = 1
+                                del entry[col_key]
+                        if need_modification == 1:
+                            configdb.set_entry(table_name, row_key, entry)
         return
 
     def add_module(self, yang_module_str):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When port breakout is performed, configMgmt creates the list of configs to be deleted and mark the value with None for the value to be deleted like below.

{'BUFFER_PG': {'Ethernet0|0': None, 'Ethernet0|1-2': None,
'Ethernet0|3-4': None, 'Ethernet0|5-7': None}, 'BUFFER_QUEUE':
{'Ethernet0|0-2': None, 'Ethernet0|3-4': None, 'Ethernet0|5-7': None},
'CABLE_LENGTH': {'AZURE': {'Ethernet0': None}},
'INTERFACE': {'Ethernet0': None, 'Ethernet0|10.0.0.0/31': None},
'PORT': {'Ethernet0': None}, 'QUEUE': {}}

and perform writeConfigDB operation hoping to delete all configs. But for the configs which are part of dictionary and not the key like CABLE_LENGTH. the entry get modified to None instead of getting deleted.

and if further break-out/break-in is triggered then it result in to configure failure like below as yang schema does not accept None value.

libyang[0]: Value "None" does not satisfy the constraint "[0-9]+m" (range, length, or pattern). (path: /son ic-cable-length:sonic-cable-length/CABLE_LENGTH/CABLE_LENGTH_LIST[name='AZURE']/CABLE_LENGTH[port='Ethernet 448']/length)
libyang[0]: Invalid cable length. (path: /sonic-cable-length:sonic-cable-length/CABLE_LENGTH/CABLE_LENGTH_L IST[name='AZURE']/CABLE_LENGTH[port='Ethernet448']/length) sonic_yang(3):Data Loading Failed:Invalid cable length. Data Loading Failed
Invalid cable length.

ConfigMgmt Class creation failed
Failed to break out Port. Error: Failed to load the config. Error: ConfigMgmtDPB Class creation failed


This fix takes care of deleting the cable length 'None' entry from the config DB.

#### How I did it

Handling deletion of column key when it's value is 'None' using set_entry

data: config data in a dictionary form
{
     'TABLE_NAME': { 'row_key': {'column_key': None, ...}, ...}
}

#### How to verify it

By performing port-breakout/break-in CLI, it should not result-in cable length None issue. also config db should not have breakout interface in dictionary value of CABLE_LENGTH|AZURE

Port breakout from 1x800G to 4x200G => sudo config interface breakout Ethernet0 "4x200G[100G,50G]" -y -f
Port break-in back to 1x800G from 4x200G => sudo config interface breakout Ethernet0 "1x800G[400G,200G]" -y -f

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

