### PR TITLE
Add unsorted option.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1327,7 +1327,10 @@ def apply_patch_wrapper(args):
 
 
 # Function to apply patch for a single ASIC.
-def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_path):
+def apply_patch_for_scope(
+    scope_changes, results, config_format, verbose, dry_run,
+    ignore_non_yang_tables, ignore_path, unsorted
+):
     scope, changes = scope_changes
     # Replace localhost to DEFAULT_NAMESPACE which is db definition of Host
     if scope.lower() == HOST_NAMESPACE or scope == "":
@@ -1344,7 +1347,8 @@ def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_ru
                                                 verbose,
                                                 dry_run,
                                                 ignore_non_yang_tables,
-                                                ignore_path)
+                                                ignore_path,
+                                                unsorted=unsorted)
         results[scope_for_log] = {"success": True, "message": "Success"}
         log.log_notice(f"'apply-patch' executed successfully for {scope_for_log} by {changes} in thread:{thread_id}")
     except Exception as e:
@@ -1713,11 +1717,12 @@ def print_dry_run_message(dry_run):
                show_default=True)
 @click.option('-d', '--dry-run', is_flag=True, default=False, help='test out the command without affecting config state')
 @click.option('-p', '--parallel', is_flag=True, default=False, help='applying the change to all ASICs parallelly')
+@click.option('-u', '--unsorted', is_flag=True, default=False, help='do not sort the changes before applying')
 @click.option('-n', '--ignore-non-yang-tables', is_flag=True, default=False, help='ignore validation for tables without YANG models', hidden=True)
 @click.option('-i', '--ignore-path', multiple=True, help='ignore validation for config specified by given path which is a JsonPointer', hidden=True)
 @click.option('-v', '--verbose', is_flag=True, default=False, help='print additional details of what the operation is doing')
 @click.pass_context
-def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang_tables, ignore_path, verbose):
+def apply_patch(ctx, patch_file_path, format, dry_run, parallel, unsorted, ignore_non_yang_tables, ignore_path, verbose):
     """Apply given patch of updates to Config. A patch is a JsonPatch which follows rfc6902.
        This command can be used do partial updates to the config with minimum disruption to running processes.
        It allows addition as well as deletion of configs. The patch file represents a diff of ConfigDb(ABNF)
@@ -1767,7 +1772,7 @@ def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 # Prepare the argument tuples
                 arguments = [(scope_changes, results, config_format,
-                              verbose, dry_run, ignore_non_yang_tables, ignore_path)
+                              verbose, dry_run, ignore_non_yang_tables, ignore_path, unsorted)
                              for scope_changes in changes_by_scope.items()]
 
                 # Submit all tasks and wait for them to complete
@@ -1782,7 +1787,8 @@ def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang
                                       config_format,
                                       verbose, dry_run,
                                       ignore_non_yang_tables,
-                                      ignore_path)
+                                      ignore_path,
+                                      unsorted)
 
         # Check if any updates failed
         failures = [scope for scope, result in results.items() if not result['success']]

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4159,6 +4159,115 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
                     # Ensure ConfigDBConnector was never instantiated or called
                     mock_config_db_connector.assert_not_called()
 
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
+    def test_apply_patch_dryrun_unsorted_multiasic(self):
+        # Mock open to simulate file reading
+        with patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as mocked_open:
+            # Mock GenericUpdater to avoid actual patch application
+            with patch('config.main.GenericUpdater') as mock_generic_updater:
+                mock_generic_updater.return_value.apply_patch = MagicMock()
+
+                # Mock ConfigDBConnector to ensure it's not called during dry-run
+                with patch('config.main.ConfigDBConnector') as mock_config_db_connector:
+
+                    print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                    # Invocation of the command with the CliRunner
+                    result = self.runner.invoke(config.config.commands["apply-patch"],
+                                                [self.patch_file_path,
+                                                 "--format", ConfigFormat.SONICYANG.name,
+                                                 "--dry-run",
+                                                 "--unsorted",
+                                                 "--ignore-non-yang-tables",
+                                                 "--ignore-path", "/ANY_TABLE",
+                                                 "--ignore-path", "/ANY_OTHER_TABLE/ANY_FIELD",
+                                                 "--ignore-path", "",
+                                                 "--verbose"],
+                                                catch_exceptions=False)
+
+                    print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                    # Assertions and verifications
+                    self.assertEqual(result.exit_code, 0, "Command should succeed")
+                    self.assertIn("Patch applied successfully.", result.output)
+
+                    # Verify mocked_open was called as expected
+                    mocked_open.assert_called_with(self.patch_file_path, 'r')
+
+                    # Ensure ConfigDBConnector was never instantiated or called
+                    mock_config_db_connector.assert_not_called()
+
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
+    @patch('config.main.concurrent.futures.wait', autospec=True)
+    def test_apply_patch_dryrun_unsorted_parallel_multiasic(self, MockThreadPoolWait):
+        # Mock open to simulate file reading
+        with patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as mocked_open:
+            # Mock GenericUpdater to avoid actual patch application
+            with patch('config.main.GenericUpdater') as mock_generic_updater:
+                mock_generic_updater.return_value.apply_patch = MagicMock()
+
+                # Mock ConfigDBConnector to ensure it's not called during dry-run
+                with patch('config.main.ConfigDBConnector') as mock_config_db_connector:
+
+                    print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                    # Invocation of the command with the CliRunner
+                    result = self.runner.invoke(config.config.commands["apply-patch"],
+                                                [self.patch_file_path,
+                                                 "--format", ConfigFormat.SONICYANG.name,
+                                                 "--dry-run",
+                                                 "--unsorted",
+                                                 "--parallel",
+                                                 "--ignore-non-yang-tables",
+                                                 "--ignore-path", "/ANY_TABLE",
+                                                 "--ignore-path", "/ANY_OTHER_TABLE/ANY_FIELD",
+                                                 "--ignore-path", "",
+                                                 "--verbose"],
+                                                catch_exceptions=False)
+
+                    print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                    # Assertions and verifications
+                    self.assertEqual(result.exit_code, 0, "Command should succeed")
+                    self.assertIn("Patch applied successfully.", result.output)
+
+                    # Assertions to check if ThreadPoolExecutor was used correctly
+                    MockThreadPoolWait.assert_called_once()
+
+                    # Verify mocked_open was called as expected
+                    mocked_open.assert_called_with(self.patch_file_path, 'r')
+
+                    # Ensure ConfigDBConnector was never instantiated or called
+                    mock_config_db_connector.assert_not_called()
+
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
+    def test_apply_patch_unsorted_parallel_with_error_multiasic(self):
+        # Mock open to simulate file reading
+        with patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as mocked_open:
+            # Mock GenericUpdater to avoid actual patch application
+            with patch('config.main.GenericUpdater') as mock_generic_updater:
+                # Simulate an error during apply_patch
+                mock_generic_updater.return_value.apply_patch.side_effect = Exception("Simulated error")
+
+                print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                # Invocation of the command with the CliRunner
+                result = self.runner.invoke(config.config.commands["apply-patch"],
+                                            [self.patch_file_path,
+                                             "--format", ConfigFormat.SONICYANG.name,
+                                             "--dry-run",
+                                             "--unsorted",
+                                             "--parallel",
+                                             "--ignore-non-yang-tables",
+                                             "--ignore-path", "/ANY_TABLE",
+                                             "--ignore-path", "/ANY_OTHER_TABLE/ANY_FIELD",
+                                             "--ignore-path", "",
+                                             "--verbose"],
+                                            catch_exceptions=True)
+
+                print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                # Assertions and verifications
+                self.assertNotEqual(result.exit_code, 0, "Command should fail due to simulated error")
+                self.assertIn("Simulated error", result.output)
+
+                # Verify mocked_open was called as expected
+                mocked_open.assert_called_with(self.patch_file_path, 'r')
+
     @patch('config.main.subprocess.Popen')
     @patch('config.main.SonicYangCfgDbGenerator.validate_config_db_json', mock.Mock(return_value=True))
     def test_apply_patch_validate_patch_multiasic(self, mock_subprocess_popen):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

admin@str2-7060cx-32s-29:~/gcu$ sudo config apply-patch --help
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH

  Apply given patch of updates to Config. A patch is a JsonPatch which
  follows rfc6902. This command can be used do partial updates to the config
  with minimum disruption to running processes. It allows addition as well
  as deletion of configs. The patch file represents a diff of ConfigDb(ABNF)
  format or SonicYang format.

  <patch-file-path>: Path to the patch file on the file-system.

Options:
  -f, --format [CONFIGDB|SONICYANG]
                                  format of config of the patch is either
                                  ConfigDb(ABNF) or SonicYang  [default:
                                  CONFIGDB]
  -d, --dry-run                   test out the command without affecting
                                  config state
  -p, --parallel                  applying the change to all ASICs parallelly
  **-u, --unsorted                  do not sort the changes before applying**
  -v, --verbose                   print additional details of what the
                                  operation is doing
  -?, -h, --help                  Show this message and exit.


admin@str2-7060cx-32s-29:~/gcu$ vim p.json 
[
  {
    "op": "add",
    "path": "/AUTO_TECHSUPPORT/GLOBAL/max_core_limit",
    "value": "6.0"
  },
  {
    "op": "add",
    "path": "/AUTO_TECHSUPPORT/GLOBAL/available_mem_threshold",
    "value": "11.0"
  }
]

admin@str2-7060cx-32s-29:~/gcu$ sudo config apply-patch --unsorted p.json 
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/max_core_limit", "value": "6.0"}, {"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/available_mem_threshold", "value": "11.0"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/generic_updater.py(133)apply()
-> if unsorted:
(Pdb) unsorted
True
(Pdb) n
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/generic_updater.py(134)apply()
-> self.logger.log_notice(f"{scope}: converting patch to JsonChange.")
(Pdb) n
Patch Applier: localhost: converting patch to JsonChange.
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/generic_updater.py(135)apply()
-> changes = [JsonChange(jsonpatch.JsonPatch([element])) for element in patch]
(Pdb) patch
<jsonpatch.JsonPatch object at 0x7f43942dd950>
(Pdb) print(patch)
[{"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/max_core_limit", "value": "6.0"}, {"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/available_mem_threshold", "value": "11.0"}]
(Pdb) c
Patch Applier: The localhost patch was converted into 2 changes:
Patch Applier: localhost: applying 2 changes in order:
Patch Applier:   * [{"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/max_core_limit", "value": "6.0"}]
Patch Applier:   * [{"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/available_mem_threshold", "value": "11.0"}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.


admin@str2-7060cx-32s-29:~/gcu$ sudo config apply-patch p.json 
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/max_core_limit", "value": "6.0"}, {"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/available_mem_threshold", "value": "11.0"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/generic_updater.py(133)apply()
-> if unsorted:
(Pdb) unsorted
False
(Pdb) n
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/generic_updater.py(137)apply()
-> self.logger.log_notice(f"{scope}: sorting patch updates.")
(Pdb) n
Patch Applier: localhost: sorting patch updates.
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/generic_updater.py(138)apply()
-> changes = self.patchsorter.sort(patch)
(Pdb) print(patch)
[{"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/max_core_limit", "value": "6.0"}, {"op": "add", "path": "/AUTO_TECHSUPPORT/GLOBAL/available_mem_threshold", "value": "11.0"}]
(Pdb) c
Patch Applier: The localhost patch was converted into 2 changes:
Patch Applier: localhost: applying 2 changes in order:
Patch Applier:   * [{"op": "replace", "path": "/AUTO_TECHSUPPORT/GLOBAL/available_mem_threshold", "value": "11.0"}]
Patch Applier:   * [{"op": "replace", "path": "/AUTO_TECHSUPPORT/GLOBAL/max_core_limit", "value": "6.0"}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

