### PR TITLE
[doc][TOC] Update entry for PINS

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -156,7 +156,7 @@
 * [Platform Specific Commands](#platform-specific-commands)
   * [Mellanox Platform Specific Commands](#mellanox-platform-specific-commands)
   * [Barefoot Platform Specific Commands](#barefoot-platform-specific-commands)
-* [PINS](#pins-show commands)
+* [PINS](#pins-show-commands)
 * [PortChannels](#portchannels)
   * [PortChannel Show commands](#portchannel-show-commands)
   * [PortChannel Config commands](#portchannel-config-commands)


### PR DESCRIPTION
Commit 63223891 ("[show] Add 'show p4-table' command (#2773)") added a table of contents entry for the "PINS Show commands" but the link target didn't match the generated anchor so the TOC entry didn't render correctly. Update it to use the correct link target so the TOC entry works as intended.


