### PR TITLE
[doc] Fix formatting error in `Command-Reference.md`

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -12483,12 +12483,12 @@ This command is to add or delete a member port into multiple already created vla
   ```
   admin@sonic:~$ sudo config vlan member add -m 100-103 Ethernet0
   This command will add Ethernet0 as member of the vlan 100, vlan 101, vlan 102, vlan 103
-   ```
-   ```
+  ```
+  ```
   admin@sonic:~$ sudo config vlan member add -m 100,101,102 Ethernet4
   This command will add Ethernet4 as member of the vlan 100, vlan 101, vlan 102
-   ```
-   ```
+  ```
+  ```
   admin@sonic:~$ sudo config vlan member add -e -m 104,105 Ethernet8
   Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet8 as member of  vlan 100, vlan 101, vlan 102, vlan 103
   ```
@@ -12496,10 +12496,9 @@ This command is to add or delete a member port into multiple already created vla
   admin@sonic:~$ sudo config vlan member add -e 100 Ethernet12
   Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet12 as member of vlan 101, vlan 102, vlan 103, vlan 104, vlan 105
   ```
-   ```
+  ```
   admin@sonic:~$ sudo config vlan member add all Ethernet20
-  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet20 as member of vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 1
-05
+  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet20 as member of vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105
   ```
 
 **config proxy_arp enabled/disabled**


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix #4039 
Fix https://github.com/sonic-net/sonic-buildimage/issues/24696

Unindented line inside an indented code block breaks Markdown parsing and inverts code/non-code rendering from that point onward. The new line in the following code block is likely a typo and needs to be removed for Markdown to render properly.

https://github.com/sonic-net/sonic-utilities/blob/70926dd50c1c39d88e24ca8efaf0a99724569785/doc/Command-Reference.md?plain=1#L12499-L12503

#### How I did it

Correct the typo that caused markdown to display incorrectly. 

#### How to verify it

View the markdown file at `sonic-utilities/doc/Command-Reference.md`.

#### Previous command output (if the output of a command-line utility has changed)

No command line output change. 

#### New command output (if the output of a command-line utility has changed)

No command line output change.

<details open>
<summary>Doc file rendering screenshot, before and after</summary>
</br>

**Before Fix:**

<img width="1386" height="442" alt="after2" src="https://github.com/user-attachments/assets/9d81e93b-f746-4a17-a0e4-b427188320c1" />

</br></br>

**After Fix:**

<img width="1386" height="442" alt="before2" src="https://github.com/user-attachments/assets/c3e71fa0-c8fc-4f02-b2e6-2ae7d0b6ff02" />

</details>



