### PR TITLE
Add -x to smartctl in log_ssd_health

### DIFF
--- a/scripts/log_ssd_health
+++ b/scripts/log_ssd_health
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-timeout --foreground 30 smartctl -a /dev/sda > /tmp/smartctl
+timeout --foreground 30 smartctl -xa /dev/sda > /tmp/smartctl
 if [ -f /tmp/smartctl ];then
     logger -f /tmp/smartctl
 fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add -x to smartctl in log_ssd_health, which provides more debug info.

Depending on the storage model, this device may display additional information such as error logs, device statistics, and SATA PHY event counters.

#### How I did it
Add -x to smartctl parameters

#### How to verify it
Verified that additional information is added on some storage device models

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
Addition information show on Arista 7260 devices are
> AAM feature is:   Disabled
> APM feature is:   Unavailable
> Rd look-ahead is: Enabled
> Write cache is:   Enabled
> DSN feature is:   Unavailable
> ATA Security is:  Disabled, NOT FROZEN [SEC1]
> Wt Cache Reorder: Unknown

> General Purpose Log Directory Version 1
> SMART           Log Directory Version 1 [multi-sector log support]
> Address    Access  R/W   Size  Description
> 0x00       GPL,SL  R/O      1  Log Directory
> 0x01       GPL,SL  R/O      1  Summary SMART error log
> 0x02       GPL,SL  R/O      1  Comprehensive SMART error log
> 0x03       GPL,SL  R/O      1  Ext. Comprehensive SMART error log
> 0x04       GPL,SL  R/O      8  Device Statistics log
> 0x06       GPL,SL  R/O      1  SMART self-test log
> 0x07       GPL,SL  R/O      1  Extended self-test log
> 0x09       GPL,SL  R/W      1  Selective self-test log
> 0x10       GPL,SL  R/O      1  NCQ Command Error log
> 0x11       GPL,SL  R/O      1  SATA Phy Event Counters log
> 0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
> 0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
> 0xe0       GPL,SL  R/W      1  SCT Command/Status
> 0xe1       GPL,SL  R/W      1  SCT Data Transfer
> 
> SMART Extended Comprehensive Error Log Version: 1 (1 sectors)
> No Errors Logged

> SCT Status Version:                  3
> SCT Version (vendor specific):       0 (0x0000)
> Device State:                        Active (0)
> Current Temperature:                     0 Celsius
> Power Cycle Min/Max Temperature:     45/45 Celsius
> Lifetime    Min/Max Temperature:      0/63 Celsius
> Under/Over Temperature Limit Count:   0/0
> 
> SCT Temperature History Version:     2
> Temperature Sampling Period:         1 minute
> Temperature Logging Interval:        1 minute
> Min/Max recommended Temperature:      0/100 Celsius
> Min/Max Temperature Limit:            0/100 Celsius
> Temperature History Size (Index):    128 (94)
> 
> Index    Estimated Time   Temperature Celsius
>   95    2026-05-29 15:04     ?  -
>  ...    ..(115 skipped).    ..  -
>   83    2026-05-29 17:00     ?  -
>   84    2026-05-29 17:01    45  **************************
>  ...    ..(  8 skipped).    ..  **************************
>   93    2026-05-29 17:10    45  **************************
>   94    2026-05-29 17:11     ?  -
> 
> SCT Error Recovery Control:
>            Read: Disabled
>           Write: Disabled
> 
> Device Statistics (GP Log 0x04)
> Page  Offset Size        Value Flags Description
> 0x01  =====  =               =  ===  == General Statistics (rev 2) ==
> 0x01  0x008  4           35516  ---  Lifetime Power-On Resets
> 0x01  0x010  4           29037  ---  Power-on Hours
> 0x01  0x018  6    131673095952  ---  Logical Sectors Written
> 0x01  0x020  6       208432551  ---  Number of Write Commands
> 0x01  0x028  6    152062372316  ---  Logical Sectors Read
> 0x01  0x030  6       790809873  ---  Number of Read Commands
> 0x02  =====  =               =  ===  == Free-Fall Statistics (empty) ==
> 0x03  =====  =               =  ===  == Rotating Media Statistics (empty) ==
> 0x04  =====  =               =  ===  == General Errors Statistics (rev 1) ==
> 0x04  0x008  4               0  ---  Number of Reported Uncorrectable Errors
> 0x04  0x010  4           27645  ---  Resets Between Cmd Acceptance and Completion
> 0x05  =====  =               =  ===  == Temperature Statistics (empty) ==
> 0x06  =====  =               =  ===  == Transport Statistics (rev 1) ==
> 0x06  0x008  4          161198  ---  Number of Hardware Resets
> 0x06  0x018  4              15  ---  Number of Interface CRC Errors
> 0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
> 0x07  0x008  1             133  ---  Percentage Used Endurance Indicator
>                                 |||_ C monitored condition met
>                                 ||__ D supports DSN
>                                 |___ N normalized value
> 
> Pending Defects log (GP Log 0x0c) not supported
> 
> SATA Phy Event Counters (GP Log 0x11)
> ID      Size     Value  Description
> 0x0001  2            0  Command failed due to ICRC error
> 0x0002  2            0  R_ERR response for data FIS
> 0x0003  2            0  R_ERR response for device-to-host data FIS
> 0x0004  2            0  R_ERR response for host-to-device data FIS
> 0x0005  2            0  R_ERR response for non-data FIS
> 0x0006  2            0  R_ERR response for device-to-host non-data FIS
> 0x0007  2            0  R_ERR response for host-to-device non-data FIS
> 0x0008  2            0  Device-to-host non-data FIS retries
> 0x0009  2            0  Transition from drive PhyRdy to drive PhyNRdy
> 0x000a  2            5  Device-to-host register FISes sent due to a COMRESET
> 0x000b  2            0  CRC errors within host-to-device FIS
> 0x000d  2            0  Non-CRC errors within host-to-device FIS
> 0x000f  2            0  R_ERR response for host-to-device data FIS, CRC
> 0x0010  2            0  R_ERR response for host-to-device data FIS, non-CRC
> 0x0012  2            0  R_ERR response for host-to-device non-data FIS, CRC
> 0x0013  2            0  R_ERR response for host-to-device non-data FIS, non-CRC