### PR TITLE
When json flag is set do not print  other than json

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -149,7 +149,7 @@ Examples:
         if os.path.isfile(cnstat_fqn_file):
             try:
                 cnstat_cached_dict = json.load(open(cnstat_fqn_file, 'r'))
-                if not detail:
+                if not use_json and not detail:
                     print("Last cached time was " + str(cnstat_cached_dict.get('time')))
                 portstat.cnstat_diff_print(cnstat_dict, cnstat_cached_dict, ratestat_dict,
                                            intf_list, use_json, print_all, errors_only,
@@ -169,7 +169,8 @@ Examples:
     else:
         #wait for the specified time and then gather the new stats and output the difference.
         time.sleep(wait_time_in_seconds)
-        print("The rates are calculated within %s seconds period" % wait_time_in_seconds)
+        if not use_json:
+            print("The rates are calculated within %s seconds period" % wait_time_in_seconds)
         cnstat_new_dict, ratestat_new_dict = portstat.get_cnstat_dict()
         portstat.cnstat_diff_print(cnstat_new_dict, cnstat_dict, ratestat_new_dict,
                                    intf_list, use_json, print_all, errors_only,


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it
```
admin@str-7060x6-64pe-stress-01:~$ portstat -i Ethernet0 -j -p 3
{
    "Ethernet0": {
        "RX_BPS": "0.00 B/s",
        "RX_DRP": "0",
        "RX_ERR": "0",
        "RX_OK": "0",
        "RX_OVR": "0",
        "RX_UTIL": "0.00%",
        "STATE": "U",
        "TX_BPS": "17.12 B/s",
        "TX_DRP": "0",
        "TX_ERR": "0",
        "TX_OK": "0",
        "TX_OVR": "0",
        "TX_UTIL": "0.00%"
    }
}
admin@str-7060x6-64pe-stress-01:~$ portstat -i Ethernet0 -p 3
The rates are calculated within 3 seconds period       <----------------------------
    IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK     TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
---------  -------  -------  --------  ---------  --------  --------  --------  -------  ---------  ---------  --------  --------  --------
Ethernet0        U        0  0.00 B/s      0.00%         0         0         0        6  12.92 B/s      0.00%         0         0         0

```

#### Previous command output (if the output of a command-line utility has changed)
```
admin@str-7060x6-64pe-stress-01:~$ portstat -i Ethernet0 -p 3 -j
The rates are calculated within 3 seconds period
{
    "Ethernet0": {
        "RX_BPS": "0.00 B/s",
        "RX_DRP": "0",
        "RX_ERR": "0",
        "RX_OK": "0",
        "RX_OVR": "0",
        "RX_UTIL": "0.00%",
        "STATE": "U",
        "TX_BPS": "1.69 B/s",
        "TX_DRP": "0",
        "TX_ERR": "0",
        "TX_OK": "0",
        "TX_OVR": "0",
        "TX_UTIL": "0.00%"
    }
}
```
#### New command output (if the output of a command-line utility has changed)
```
admin@str-7060x6-64pe-stress-01:~$ portstat -i Ethernet0 -p 3 -j
{
    "Ethernet0": {
        "RX_BPS": "0.00 B/s",
        "RX_DRP": "0",
        "RX_ERR": "0",
        "RX_OK": "0",
        "RX_OVR": "0",
        "RX_UTIL": "0.00%",
        "STATE": "U",
        "TX_BPS": "4.79 B/s",
        "TX_DRP": "0",
        "TX_ERR": "0",
        "TX_OK": "0",
        "TX_OVR": "0",
        "TX_UTIL": "0.00%"
    }
}
```
