### PR TITLE
Optimize decode-syseeprom startup performance with lazy imports

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -16,24 +16,71 @@ import re
 import sys
 import errno
 
-import sonic_platform
-from sonic_platform_base.sonic_eeprom.eeprom_tlvinfo import TlvInfoDecoder
-from sonic_py_common import device_info, logger
-from swsscommon.swsscommon import SonicV2Connector
-from tabulate import tabulate
-
+from sonic_py_common import device_info
 
 EEPROM_INFO_TABLE = 'EEPROM_INFO'
 SYSLOG_IDENTIFIER = 'decode-syseeprom'
 
-log = logger.Logger(SYSLOG_IDENTIFIER)
+# Lazy-loaded modules
+_sonic_platform = None
+_TlvInfoDecoder = None
+_SonicV2Connector = None
+_tabulate = None
+_logger = None
+
+
+def _get_logger():
+    """Lazy load logger module"""
+    global _logger
+    if _logger is None:
+        from sonic_py_common import logger
+        _logger = logger.Logger(SYSLOG_IDENTIFIER)
+    return _logger
+
+
+def _get_sonic_platform():
+    """Lazy load sonic_platform module"""
+    global _sonic_platform
+    if _sonic_platform is None:
+        import sonic_platform
+        _sonic_platform = sonic_platform
+    return _sonic_platform
+
+
+def _get_TlvInfoDecoder():
+    """Lazy load TlvInfoDecoder class"""
+    global _TlvInfoDecoder
+    if _TlvInfoDecoder is None:
+        from sonic_platform_base.sonic_eeprom.eeprom_tlvinfo import TlvInfoDecoder
+        _TlvInfoDecoder = TlvInfoDecoder
+    return _TlvInfoDecoder
+
+
+def _get_SonicV2Connector():
+    """Lazy load SonicV2Connector class"""
+    global _SonicV2Connector
+    if _SonicV2Connector is None:
+        from swsscommon.swsscommon import SonicV2Connector
+        _SonicV2Connector = SonicV2Connector
+    return _SonicV2Connector
+
+
+def _get_tabulate():
+    """Lazy load tabulate function"""
+    global _tabulate
+    if _tabulate is None:
+        from tabulate import tabulate
+        _tabulate = tabulate
+    return _tabulate
 
 def instantiate_eeprom_object():
     eeprom = None
 
     try:
+        sonic_platform = _get_sonic_platform()
         eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
     except Exception as e:
+        log = _get_logger()
         log.log_error('Failed to obtain EEPROM object due to {}'.format(repr(e)))
         eeprom = None
 
@@ -67,6 +114,7 @@ def print_eeprom_dict(tlv_dict):
     for tlv in tlv_dict['tlv_list']:
         tlv_table_body.append([tlv['name'], tlv['code'], tlv['length'], tlv['value']])
 
+    tabulate = _get_tabulate()
     print(tabulate(tlv_table_body, tlv_table_header, tablefmt='simple'))
 
     print('')
@@ -80,6 +128,7 @@ def print_eeprom_dict(tlv_dict):
 def read_eeprom_from_db():
     tlv_dict = {}
 
+    SonicV2Connector = _get_SonicV2Connector()
     db = SonicV2Connector(host="127.0.0.1")
     db.connect(db.STATE_DB)
 
@@ -94,6 +143,7 @@ def read_eeprom_from_db():
     tlv_dict['header']['length'] = tlv_header.get('Total Length', 'N/A')
 
     tlv_dict['tlv_list'] = []
+    TlvInfoDecoder = _get_TlvInfoDecoder()
     concerned_tlvs = []
     concerned_tlvs.extend(range(TlvInfoDecoder._TLV_CODE_PRODUCT_NAME, TlvInfoDecoder._TLV_CODE_SERVICE_TAG + 1))
     concerned_tlvs.append(TlvInfoDecoder._TLV_CODE_VENDOR_EXT)
@@ -129,6 +179,7 @@ def read_eeprom_from_db():
 
 
 def get_tlv_value_from_db(tlv_code):
+    SonicV2Connector = _get_SonicV2Connector()
     db = SonicV2Connector(host="127.0.0.1")
     db.connect(db.STATE_DB)
 
@@ -145,6 +196,7 @@ def get_tlv_value_from_db(tlv_code):
 def print_mgmt_mac(use_db=False):
     base_mac_addr = None
     if use_db:
+        TlvInfoDecoder = _get_TlvInfoDecoder()
         base_mac_addr = get_tlv_value_from_db(TlvInfoDecoder._TLV_CODE_MAC_BASE)
     else:
         eeprom = instantiate_eeprom_object()
@@ -167,6 +219,7 @@ def print_mgmt_mac(use_db=False):
 def print_serial(use_db=False):
     serial = None
     if use_db:
+        TlvInfoDecoder = _get_TlvInfoDecoder()
         serial = get_tlv_value_from_db(TlvInfoDecoder._TLV_CODE_SERIAL_NUMBER)
     else:
         eeprom = instantiate_eeprom_object()
@@ -188,6 +241,7 @@ def print_serial(use_db=False):
 def print_model(use_db=False):
     model = None
     if use_db:
+        TlvInfoDecoder = _get_TlvInfoDecoder()
         model = get_tlv_value_from_db(TlvInfoDecoder._TLV_CODE_PRODUCT_NAME)
     else:
         eeprom = instantiate_eeprom_object()


### PR DESCRIPTION
The background is decode-syseeprom script had slow startup time due to expensive imports at the top level.

#### What I did
1. Removed top-level imports for sonic_platform, TlvInfoDecoder, device_info, logger, SonicV2Connector, and tabulate.
2. Added lazy import getter functions with caching.

#### How I did it
Implemented lazy import pattern for all heavy dependencies:
1. Created getter functions (_get_sonic_platform, _get_TlvInfoDecoder, etc.) that import modules only when first accessed.
2. Moved all slow imports from module level to function level
3. Updated all call sites to use the lazy import getters

#### How to verify it
Before lazy import update:
```bash
root@sonic:/home/admin# time python3 decode-syseeprom_ori -d
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 496
TLV Name          Code      Len  Value
----------------  ------  -----  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Product Name      0x21        7  MSN2700
Part Number       0x22       20  MSN2700-CS2FO
Serial Number     0x23       24  MT2020T04244
Base MAC Address  0x24        6  1C:34:DA:A1:96:80
Manufacture Date  0x25       19  05/18/2020 11:05:43
Device Version    0x26        1  17
Platform Name     0x28       22  x86_64-mlnx_msn2700-r0
ONIE Version      0x29       21  2023.11-5.3.0011-9600
MAC Addresses     0x2A        2  128
Manufacturer      0x2B        8  Mellanox
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x16 0x01 0x01 0x00 0x56 0x00 0x00 0x4D 0x4C 0x4E 0x58 0x02 0x01 0x0C 0x05 0x0E 0x02 0x10 0x06 0x12 0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD      164  0x00 0x00 0x81 0x19 0x00 0x92 0x00 0x03 0x01 0xE3 0x00 0x00 0x4D 0x54 0x32 0x30 0x32 0x30 0x54 0x30 0x34 0x32 0x34 0x34 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x4D 0x53 0x4E 0x32 0x37 0x30 0x30 0x2D 0x43 0x53 0x32 0x46 0x4F 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x42 0x41 0x00 0x00 0x00 0x31 0xA6 0xC3 0x50 0x61 0x6E 0x74 0x68 0x65 0x72 0x20 0x45 0x74 0x68 0x20 0x31 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x50 0x11 0x00 0x00 0x0A 0x8C 0x4D 0x53 0x4E 0x32 0x37 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x10 0x00 0x03 0x05 0xE8 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x1E 0x00 0x11 0x02 0x7D 0x00 0x00 0x0D 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x1C 0x34 0xDA 0xA1 0x96 0x80 0x00 0x80 0x1C 0x34 0xDA 0x03 0x00 0xA1 0x96 0x80
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x12 0x00 0x01 0x06 0x85 0x00 0x00 0x00 0x46 0x00 0x00 0x08 0x00 0x05 0x05 0x05 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       20  0x00 0x00 0x81 0x19 0x00 0x0E 0x00 0x02 0x07 0x99 0x00 0x00 0x30 0x00 0x20 0x00 0x00 0x00 0x00 0x00
CRC-32            0xFE        4  0x878FA694

(checksum valid)

real    0m1.690s
user    0m0.782s
sys     0m0.136s
```
After lazy import update:
```bash
admin@sonic:/home/admin# time sudo python3 decode-syseeprom -d
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 496
TLV Name          Code      Len  Value
----------------  ------  -----  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Product Name      0x21        7  MSN2700
Part Number       0x22       20  MSN2700-CS2FO
Serial Number     0x23       24  MT2020T04244
Base MAC Address  0x24        6  1C:34:DA:A1:96:80
Manufacture Date  0x25       19  05/18/2020 11:05:43
Device Version    0x26        1  17
Platform Name     0x28       22  x86_64-mlnx_msn2700-r0
ONIE Version      0x29       21  2023.11-5.3.0011-9600
MAC Addresses     0x2A        2  128
Manufacturer      0x2B        8  Mellanox
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x16 0x01 0x01 0x00 0x56 0x00 0x00 0x4D 0x4C 0x4E 0x58 0x02 0x01 0x0C 0x05 0x0E 0x02 0x10 0x06 0x12 0x07 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD      164  0x00 0x00 0x81 0x19 0x00 0x92 0x00 0x03 0x01 0xE3 0x00 0x00 0x4D 0x54 0x32 0x30 0x32 0x30 0x54 0x30 0x34 0x32 0x34 0x34 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x4D 0x53 0x4E 0x32 0x37 0x30 0x30 0x2D 0x43 0x53 0x32 0x46 0x4F 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x42 0x41 0x00 0x00 0x00 0x31 0xA6 0xC3 0x50 0x61 0x6E 0x74 0x68 0x65 0x72 0x20 0x45 0x74 0x68 0x20 0x31 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x50 0x11 0x00 0x00 0x0A 0x8C 0x4D 0x53 0x4E 0x32 0x37 0x30 0x30 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x10 0x00 0x03 0x05 0xE8 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x1E 0x00 0x11 0x02 0x7D 0x00 0x00 0x0D 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x1C 0x34 0xDA 0xA1 0x96 0x80 0x00 0x80 0x1C 0x34 0xDA 0x03 0x00 0xA1 0x96 0x80
Vendor Extension  0xFD       36  0x00 0x00 0x81 0x19 0x00 0x12 0x00 0x01 0x06 0x85 0x00 0x00 0x00 0x46 0x00 0x00 0x08 0x00 0x05 0x05 0x05 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Vendor Extension  0xFD       20  0x00 0x00 0x81 0x19 0x00 0x0E 0x00 0x02 0x07 0x99 0x00 0x00 0x30 0x00 0x20 0x00 0x00 0x00 0x00 0x00
CRC-32            0xFE        4  0x878FA694

(checksum valid)

real    0m0.835s
user    0m0.655s
sys     0m0.171s
```