### PR TITLE
generate_dump: add interface FEC stats

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2085,6 +2085,7 @@ save_counter_snapshot() {
 
     save_cmd "echo $counter_t" "date.counter_$idx"
     save_cmd "show interface counters" "interface.counters_$idx"
+    save_cmd "show interface counters fec-stats" "interface.counters.fec-stats_$idx"
     if ! $IS_SUPERVISOR; then
        save_cmd "show queue counters" "queue.counters_$idx"
     fi


### PR DESCRIPTION
Add FEC stats to the tech support tarball produced by "show tech". The stats can be found in files named "interface.counters.fec-stats_$idx".
