### PR TITLE
Add PORT_SERDES_ATTR flex counter support

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -10,6 +10,7 @@ from swsscommon.swsscommon import CFG_FLEX_COUNTER_TABLE_NAME as CFG_FLEX_COUNTE
 
 BUFFER_POOL_WATERMARK = "BUFFER_POOL_WATERMARK"
 PORT_BUFFER_DROP = "PORT_BUFFER_DROP"
+PORT_SERDES_ATTR = "PORT_SERDES_ATTR"
 PG_DROP = "PG_DROP"
 ACL = "ACL"
 ENI = "ENI"
@@ -141,6 +142,38 @@ def disable():
     port_info['FLEX_COUNTER_STATUS'] = DISABLE
     configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_BUFFER_DROP, port_info)
 
+# Port SERDES attributes counter commands
+@cli.group()
+def port_serdes_attr():
+    """ Port SERDES attributes counter commands """
+
+@port_serdes_attr.command()
+@click.argument('poll_interval', type=click.IntRange(100, 30000))
+def interval(poll_interval):
+    """ Set port SERDES attributes counter query interval """
+    configdb = ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['POLL_INTERVAL'] = poll_interval
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_SERDES_ATTR, port_info)
+
+@port_serdes_attr.command()
+def enable():
+    """ Enable port SERDES attributes counter query """
+    configdb = ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['FLEX_COUNTER_STATUS'] = ENABLE
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_SERDES_ATTR, port_info)
+
+@port_serdes_attr.command()
+def disable():
+    """ Disable port SERDES attributes counter query """
+    configdb = ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['FLEX_COUNTER_STATUS'] = DISABLE
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_SERDES_ATTR, port_info)
 
 # Ingress PG drop packet stat
 @cli.group()
@@ -601,6 +634,7 @@ def show():
     queue_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE')
     port_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PORT')
     port_drop_info = configdb.get_entry('FLEX_COUNTER_TABLE', PORT_BUFFER_DROP)
+    port_serdes_attr_info = configdb.get_entry('FLEX_COUNTER_TABLE', PORT_SERDES_ATTR)
     rif_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'RIF')
     queue_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE_WATERMARK')
     pg_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PG_WATERMARK')
@@ -624,6 +658,8 @@ def show():
         data.append(["PORT_STAT", port_info.get("POLL_INTERVAL", DEFLT_1_SEC), port_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_drop_info:
         data.append([PORT_BUFFER_DROP, port_drop_info.get("POLL_INTERVAL", DEFLT_60_SEC), port_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+    if port_serdes_attr_info:
+        data.append([PORT_SERDES_ATTR, port_serdes_attr_info.get("POLL_INTERVAL", DEFLT_10_SEC), port_serdes_attr_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if rif_info:
         data.append(["RIF_STAT", rif_info.get("POLL_INTERVAL", DEFLT_1_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if queue_wm_info:


### PR DESCRIPTION
This change adds command-line interface support for managing PORT_SERDES_ATTR flex counter collection, enabling operators to control SERDES physical link attribute monitoring through the counterpoll utility.

Changes:
  - Implement port_serdes_attr CLI command group with three subcommands:
    * interval: Set poll interval (100-30000ms range) for SERDES attribute queries
    * enable: Enable SERDES attribute counter collection
    * disable: Disable SERDES attribute counter collection
  - Extend counterpoll show command to display PORT_SERDES_ATTR status,
    poll interval, and enabled/disabled state
