### PR TITLE
Feature/nosi 141 create a neighbor command group

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4668,14 +4668,14 @@ def neighbor(ipaddr_or_hostname, verbose):
 # 'remove' subgroup ('config bgp remove ...')
 #
 
-@bgp.group(cls=clicommon.AbbreviationGroup)
-def neighbor():
+@bgp.group(cls=clicommon.AbbreviationGroup, name='neighbor')
+def bgp_neighbor():
     "Remove BGP neighbor configuration from the device"
     pass
 
-@neighbor.command('remove')
+@bgp_neighbor.command('remove')
 @click.argument('neighbor_ip_or_hostname', metavar='<neighbor_ip_or_hostname>', required=True)
-def remove_neighbor(neighbor_ip_or_hostname):
+def bgp_neighbor_remove(neighbor_ip_or_hostname):
     """Deletes BGP neighbor configuration of given hostname or ip from devices
        User can specify either internal or external BGP neighbor to remove
     """


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Changed bgp remove group to be a command and neighbor to be a group. So now the way of using the CLI would be>

`sudo config bgp neighbor remove`

#### How I did it

Changed the function names, avoiding the only use of names _remove_ and _neighbor_ to avoid function names collisions. 

#### How to verify it

Generate the .whl file, install it on SONiC running on QEMU and verify the above command.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

