### PR TITLE
Added counterpoll CLI support

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -142,38 +142,46 @@ def disable():
     port_info['FLEX_COUNTER_STATUS'] = DISABLE
     configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_BUFFER_DROP, port_info)
 
+
 # PHY counter commands
 @cli.group()
-def phy():
+@click.pass_context
+def phy(ctx):
     """ PHY counter commands """
+    ctx.obj = ConfigDBConnector()
+    ctx.obj.connect()
+
 
 @phy.command()
 @click.argument('poll_interval', type=click.IntRange(100, 30000))
-def interval(poll_interval):
+@click.pass_context
+def interval(ctx, poll_interval):  # noqa: F811
     """ Set PHY counter query interval """
-    configdb = ConfigDBConnector()
-    configdb.connect()
+    configdb = ctx.obj
     port_info = {}
     port_info['POLL_INTERVAL'] = poll_interval
     configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
 
+
 @phy.command()
-def enable():
+@click.pass_context
+def enable(ctx):  # noqa: F811
     """ Enable PHY counter query """
-    configdb = ConfigDBConnector()
-    configdb.connect()
+    configdb = ctx.obj
     port_info = {}
     port_info['FLEX_COUNTER_STATUS'] = ENABLE
     configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
 
+
 @phy.command()
-def disable():
+@click.pass_context
+def disable(ctx):  # noqa: F811
     """ Disable PHY counter query """
-    configdb = ConfigDBConnector()
-    configdb.connect()
+    configdb = ctx.obj
     port_info = {}
     port_info['FLEX_COUNTER_STATUS'] = DISABLE
     configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
+
 
 # Ingress PG drop packet stat
 @cli.group()
@@ -659,7 +667,8 @@ def show():
     if port_drop_info:
         data.append([PORT_BUFFER_DROP, port_drop_info.get("POLL_INTERVAL", DEFLT_60_SEC), port_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_phy_attr_info:
-        data.append(["PHY", port_phy_attr_info.get("POLL_INTERVAL", DEFLT_10_SEC), port_phy_attr_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+        data.append(["PHY", port_phy_attr_info.get("POLL_INTERVAL", DEFLT_10_SEC),
+                     port_phy_attr_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if rif_info:
         data.append(["RIF_STAT", rif_info.get("POLL_INTERVAL", DEFLT_1_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if queue_wm_info:

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -24,6 +24,7 @@ expected_counterpoll_show = """Type                  Interval (in ms)    Status
 QUEUE_STAT            10000               enable
 PORT_STAT             1000                enable
 PORT_BUFFER_DROP      60000               enable
+PHY                   10000               enable
 QUEUE_WATERMARK_STAT  default (60000)     enable
 PG_WATERMARK_STAT     default (60000)     enable
 PG_DROP_STAT          10000               enable
@@ -42,6 +43,7 @@ expected_counterpoll_show_dpu = """Type                  Interval (in ms)    Sta
 QUEUE_STAT            10000               enable
 PORT_STAT             1000                enable
 PORT_BUFFER_DROP      60000               enable
+PHY                   10000               enable
 QUEUE_WATERMARK_STAT  default (60000)     enable
 PG_WATERMARK_STAT     default (60000)     enable
 PG_DROP_STAT          10000               enable
@@ -386,6 +388,31 @@ class TestCounterpoll(object):
 
         table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
         assert test_interval == table["SWITCH"]["POLL_INTERVAL"]
+
+    @pytest.mark.parametrize("status", ["disable", "enable"])
+    def test_update_phy_status(self, status):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(counterpoll.cli.commands["phy"].commands[status], [], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
+        assert status == table["PORT_PHY_ATTR"]["FLEX_COUNTER_STATUS"]
+
+    def test_update_phy_interval(self):
+        runner = CliRunner()
+        db = Db()
+        test_interval = "20000"
+
+        result = runner.invoke(counterpoll.cli.commands["phy"].commands["interval"], [test_interval], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
+        assert test_interval == table["PORT_PHY_ATTR"]["POLL_INTERVAL"]
+
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1797,6 +1797,10 @@
         "POLL_INTERVAL": "60000",
         "FLEX_COUNTER_STATUS": "enable"
     },
+    "FLEX_COUNTER_TABLE|PORT_PHY_ATTR": {
+        "POLL_INTERVAL": "10000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
     "FLEX_COUNTER_TABLE|QUEUE_WATERMARK": {
         "FLEX_COUNTER_STATUS": "enable"
     },


### PR DESCRIPTION
#### What I did
Added counterpoll CLI support (enable/disable/interval/show)

#### How I did it
Extended the existing infrastructure to support a new attribute.

#### How to verify it
Manually configured via CLI and ensured CONFIG-DB is populated.

#### Previous command output (if the output of a command-line utility has changed)
counterpoll show
Type                        Interval (in ms)    Status
--------------------------  ------------------  --------
QUEUE_STAT                  default (10000)     enable
PORT_STAT                   default (1000)      enable
PORT_BUFFER_DROP            default (60000)     enable
RIF_STAT                    default (1000)      enable
QUEUE_WATERMARK_STAT        default (60000)     enable
PG_WATERMARK_STAT           default (60000)     enable
PG_DROP_STAT                default (10000)     enable
BUFFER_POOL_WATERMARK_STAT  default (60000)     enable
ACL                         10000               enable

#### New command output (if the output of a command-line utility has changed)
counterpoll phy ?
disable   enable    interval

counterpoll show
Type                        Interval (in ms)    Status
--------------------------  ------------------  --------
QUEUE_STAT                  default (10000)     enable
PORT_STAT                   default (1000)      enable
PORT_BUFFER_DROP            default (60000)     enable
**PHY                         10000               disable**
RIF_STAT                    default (1000)      enable
QUEUE_WATERMARK_STAT        default (60000)     enable
PG_WATERMARK_STAT           default (60000)     enable
PG_DROP_STAT                default (10000)     enable
BUFFER_POOL_WATERMARK_STAT  default (60000)     enable
ACL                         10000               enable