### PR TITLE
[mellanox] [db_migrator] add a migration for tunnel ecn mode

### DIFF
--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1054,3 +1054,36 @@ class TestIPinIPTunnelMigrator(object):
             expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
             diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
             assert not diff
+
+
+class TestIPinIPTunnelEcnModeMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['APPL_DB'] = None
+
+    def test_ipinip_tunnel_ecn_mode_migrator(self):
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_input')
+
+        device_info.get_sonic_version_info = get_sonic_version_info_mlnx
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate_ipinip_tunnel_ecn_mode_mellanox()
+
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_expected')
+        expected_appl_db = SonicV2Connector(host='127.0.0.1')
+        expected_appl_db.connect(expected_appl_db.APPL_DB)
+
+        expected_keys = sorted(expected_appl_db.keys(expected_appl_db.APPL_DB, "*"))
+        resulting_keys = sorted(dbmgtr.appDB.keys(dbmgtr.appDB.APPL_DB, "*"))
+
+        assert expected_keys == resulting_keys
+        for key in expected_keys:
+            resulting_keys = dbmgtr.appDB.get_all(dbmgtr.appDB.APPL_DB, key)
+            expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
+            diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
+            assert not diff


### PR DESCRIPTION
#### What I did
In the 202505, the tunnel ecn mode for Mellanox platforms has changed from standard to copy_from_outer.
This commit adds a migration that aligns APPL_DB to this change.

#### How I did it
Added a new migration for the Mellanox platform.

#### How to verify it
New unit test, manual tests.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

