### PR TITLE
Fix syntax and semantic errors in kdump remote feature

### DIFF
--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -447,13 +447,11 @@ def write_kdump_remote():
 
     if remote:
         # Uncomment SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/#SSH/SSH/' %s" % kdump_cfg, use_shell=False)
-        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' %s" % kdump_cfg, use_shell=False)
+        run_command("/bin/sed -i 's/^#SSH/SSH/' %s" % kdump_cfg, use_shell=False)
         print("SSH and SSH_KEY uncommented for remote configuration.")
     else:
         # Comment out SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/SSH/#SSH/' %s" % kdump_cfg, use_shell=False)
-        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' %s" % kdump_cfg, use_shell=False)
+        run_command("/bin/sed -i 's/^SSH/#SSH/' %s" % kdump_cfg, use_shell=False)
         print("SSH and SSH_KEY commented out for local configuration.")
 
 def read_ssh_string():
@@ -513,7 +511,7 @@ def read_ssh_path():
         sys.exit(1)
 
 def write_ssh_path(ssh_path):
-    cmd = "/bin/sed -i -e 's/#*SSH_KEY=.*/SSH_KEY=\"%s\"/' %s" % (ssh_path, kdump_cfg)
+    cmd = "/bin/sed -i -e 's|#*SSH_KEY=.*|SSH_KEY=\"%s\"|' %s" % (ssh_path, kdump_cfg)
 
     (rc, lines, err_str) = run_command(cmd, use_shell=False)  # Make sure to set use_shell=True
     if rc == 0 and type(lines) == list and len(lines) == 0:
@@ -772,14 +770,12 @@ def cmd_kdump_remote(verbose):
 
     if remote:
         # Uncomment SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/#SSH/SSH/' /etc/default/kdump-tools", use_shell=False)
-        run_command("/bin/sed -i 's/#SSH_KEY/SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
+        run_command("/bin/sed -i 's/^#SSH/SSH/' /etc/default/kdump-tools", use_shell=False)
         if verbose:
             print("SSH and SSH_KEY uncommented for remote configuration.")
     else:
         # Comment out SSH and SSH_KEY in the /etc/default/kdump-tools file
-        run_command("/bin/sed -i 's/SSH/#SSH/' /etc/default/kdump-tools", use_shell=False)
-        run_command("/bin/sed -i 's/SSH_KEY/#SSH_KEY/' /etc/default/kdump-tools", use_shell=False)
+        run_command("/bin/sed -i 's/^SSH/#SSH/' /etc/default/kdump-tools", use_shell=False)
         if verbose:
             print("SSH and SSH_KEY commented out for local configuration.")
 
@@ -798,10 +794,8 @@ def cmd_kdump_ssh_path(verbose, ssh_path):
         (rc, lines, err_str) = run_command("show kdump ssh_path", use_shell=False)
         print('\n'.join(lines))
     else:
-        current_ssh_path = read_ssh_path()
-        if current_ssh_path != ssh_path:
-            write_ssh_path(ssh_path)
-            print("SSH path updated. Changes will take effect after reboot.")
+        write_ssh_path(ssh_path)
+        print("SSH path updated. Changes will take effect after reboot.")
 
 def main():
 
@@ -846,7 +840,7 @@ def main():
         help='Maximum number of kernel dump files stored')
 
     parser.add_argument('--remote', action='store_true', default=False,
-                help='Enable remote kdump via SSH')
+                help='Update remote kdump via SSH based on CONFIG_DB')
     
     parser.add_argument('--ssh_string', nargs='?', type=str, action='store', default=False,
             help='ssh_string for remote kdump')
@@ -892,7 +886,7 @@ def main():
         elif options.ssh_string:
             cmd_kdump_ssh_string(options.verbose, options.ssh_string)
         elif options.ssh_path:
-            cmd_kdump_ssh_path(options.verbos, options.ssh_path)
+            cmd_kdump_ssh_path(options.verbose, options.ssh_path)
         elif options.num_dumps != False:
             cmd_kdump_num_dumps(options.verbose, options.num_dumps)
         elif options.dump_db:


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-utilities/issues/4115

#### What I did

Fixed bugs in the upstream kdump remote SSH feature:
1. Fixed regex patterns in `sed` commands to prevent unintended replacements
2. Removed redundant SSH_KEY operations
3. Fixed typo: `options.verbos` → `options.verbose`
4. Simplified SSH path update logic by removing unnecessary comparison check
5. Updated help text for `--remote` flag to better reflect its functionality
6. Changed delimiter in `write_ssh_path()` sed command from `/` to `|` to handle paths correctly

#### How I did it

**1. Fixed sed regex patterns:**
- Added `^` anchor to sed patterns (`s/#SSH/SSH/` → `s/^#SSH/SSH/`) to ensure only lines starting with `#SSH` are matched, preventing false matches in comments or other parts of the configuration file

**2. Removed redundant SSH_KEY operations:**
- The SSH_KEY line doesn't need separate toggling since it's controlled by the same sed command. Removed duplicate `sed` commands for SSH_KEY in both `write_kdump_remote()` and `cmd_kdump_remote()` functions

**3. Fixed typo:**
- Corrected `options.verbos` to `options.verbose` in the main argument parsing section

**4. Simplified SSH path update:**
- Removed unnecessary check comparing current SSH path with new path in `cmd_kdump_ssh_path()`. The function now always writes the path when provided, simplifying the logic

**5. Updated sed delimiter:**
- Changed delimiter in `write_ssh_path()` from `/` to `|` (`s/#*SSH_KEY=.*/` → `s|#*SSH_KEY=.*|`) to properly handle SSH key paths that may contain forward slashes

**6. Updated tests:**
- Modified unit tests to reflect the simplified implementation
- Removed obsolete test case `test_cmd_kdump_ssh_path_no_update` that tested the removed comparison logic

#### How to verify it
```
Initial state:
Manually uncommented SSH and SSH_KEY config in /etc/default/kdump-tools
After reboot we expect the hostcfgd service to start and uncomment it because KDUMP|config|remote is false

After reboot:
#SSH="user@localhost"
#SSH_KEY="/a/b/c"

>>> root@device:~# sonic-kdump-config --ssh_string "trial@localhost"
SSH string updated. Changes will take effect after the next reboot.
>>> root@device:~# sonic-kdump-config --ssh_path "/var/"
SSH path updated. Changes will take effect after reboot.

State of /etc/default/kdump-tools:
SSH="trial@localhost"
SSH_KEY="/var/"

>>> root@device:~# sonic-db-cli CONFIG_DB HGETALL "KDUMP|config"
{'enabled': 'true', 'memory': '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M', 'num_dumps': '3', 'remote': 'false', 'ssh_string': 'user@localhost', 'ssh_path': '/a/b/c'}
>>> root@device:~# sonic-kdump-config --remote 

State of /etc/default/kdump-tools:
#SSH="trial@localhost"
#SSH_KEY="/var/"

After another reboot:

State of /etc/default/kdump-tools:
#SSH="trial@localhost"
#SSH_KEY="/var/"
```