### PR TITLE
Remove direct dependency on libyang

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: semgrep ci
         env:
-           SEMGREP_RULES: "p/default r/python.lang.security.audit.dangerous-system-call-audit.dangerous-system-call-audit"
+           SEMGREP_RULES: "p/default r/python.lang.security.audit.dangerous-system-call-audit.dangerous-system-call-audit .semgrep/"

--- a/.semgrep/no-direct-libyang.yml
+++ b/.semgrep/no-direct-libyang.yml
@@ -1,0 +1,21 @@
+rules:
+  - id: no-direct-libyang-import
+    patterns:
+      - pattern-either:
+          - pattern: import yang
+          - pattern: import yang as $X
+          - pattern: from yang import $X
+          - pattern: from yang import $X as $Y
+          - pattern: import libyang
+          - pattern: import libyang as $X
+          - pattern: from libyang import $X
+          - pattern: from libyang import $X as $Y
+    message: >-
+      Do not import libyang directly. sonic-utilities must go through
+      sonic_yang / sonic_yang_ext so that libyang API/ABI changes (libyang1
+      vs libyang2 vs libyang3) are isolated to sonic-yang-mgmt.
+    languages: [python]
+    severity: ERROR
+    paths:
+      exclude:
+        - tests/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Currently, this list of dependencies is as follows:
 - libyang_1.0.73_amd64.deb
 - libyang-cpp_1.0.73_amd64.deb
 - python3-yang_1.0.73_amd64.deb
+- libyang3_3.*_amd64.deb
+- python3-libyang_3.*_amd64.deb
 - redis_dump_load-1.1-py3-none-any.whl
 - sonic_py_common-1.0-py3-none-any.whl
 - sonic_config_engine-1.0-py3-none-any.whl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,8 @@ stages:
         sudo dpkg -i libyang_1.0.73_amd64.deb
         sudo dpkg -i libyang-cpp_1.0.73_amd64.deb
         sudo dpkg -i python3-yang_1.0.73_amd64.deb
+        sudo dpkg -i libyang3_3.*_amd64.deb
+        sudo dpkg -i python3-libyang_3.*_amd64.deb
       workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
       displayName: 'Install Debian dependencies'
 

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -8,7 +8,6 @@ import re
 import shutil
 import syslog
 import tempfile
-import yang as ly
 from json import load
 from sys import flags
 from time import sleep as tsleep
@@ -35,8 +34,7 @@ class ConfigMgmt():
     to verify config for the commands which are capable of change in config DB.
     '''
 
-    def __init__(self, source="configDB", debug=False, allowTablesWithoutYang=True,
-                 sonicYangOptions=0, configdb=None):
+    def __init__(self, source="configDB", debug=False, allowTablesWithoutYang=True, configdb=None):
         '''
         Initialise the class, --read the config, --load in data tree.
 
@@ -55,7 +53,6 @@ class ConfigMgmt():
             self.configdbJsonOut = None
             self.source = source
             self.allowTablesWithoutYang = allowTablesWithoutYang
-            self.sonicYangOptions = sonicYangOptions
             self.configdb = configdb
 
             # logging vars
@@ -71,7 +68,7 @@ class ConfigMgmt():
         return
 
     def __init_sonic_yang(self):
-        self.sy = sonic_yang.SonicYang(YANG_DIR, debug=self.DEBUG, sonic_yang_options=self.sonicYangOptions)
+        self.sy = sonic_yang.SonicYang(YANG_DIR, debug=self.DEBUG)
         # load yang models
         self.sy.loadYangModel()
         # load jIn from config DB or from config DB json file.
@@ -291,8 +288,7 @@ class ConfigMgmt():
 
         # Instantiate new context since parse_module_mem() loads the module into context.
         sy = sonic_yang.SonicYang(YANG_DIR)
-        module = sy.ctx.parse_module_mem(yang_module_str, ly.LYS_IN_YANG)
-        return module.name()
+        return sy.load_module_str_name(yang_module_str)
 
 
 # End of Class ConfigMgmt

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -5,7 +5,6 @@ from jsonpointer import JsonPointer
 import sonic_yang
 import sonic_yang_ext
 import subprocess
-import yang as ly
 import copy
 import re
 import os
@@ -546,10 +545,8 @@ class PathAddressing:
         # Iterate across all paths fetching references
         for path in paths:
             xpath = self.convert_path_to_xpath(path, config, sy)
-
-            leaf_xpaths = self._get_inner_leaf_xpaths(xpath, sy)
-            for xpath in leaf_xpaths:
-                ref_xpaths.extend(sy.find_data_dependencies(xpath))
+            # NOTE: This will recursively find dependencies for all decendents
+            ref_xpaths.extend(sy.find_data_dependencies(xpath))
 
         # For each xpath, convert to configdb path
         for ref_xpath in ref_xpaths:
@@ -560,22 +557,6 @@ class PathAddressing:
 
         ref_paths.sort()
         return ref_paths
-
-    def _get_inner_leaf_xpaths(self, xpath, sy):
-        if xpath == "/": # Point to Root element which contains all xpaths
-            nodes = sy.root.tree_for()
-        else: # Otherwise get all nodes that match xpath
-            nodes = sy.root.find_path(xpath).data()
-
-        for node in nodes:
-            for inner_node in node.tree_dfs():
-                # TODO: leaflist also can be used as the 'path' argument in 'leafref' so add support to leaflist
-                if self._is_leaf_node(inner_node):
-                    yield inner_node.path()
-
-    def _is_leaf_node(self, node):
-        schema = node.schema()
-        return ly.LYS_LEAF == schema.nodetype()
 
     def convert_path_to_xpath(self, path, config=None, sy=None):
         """

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -6,7 +6,6 @@ import os
 import pkgutil
 import subprocess
 import tempfile
-import yang as ly
 from inspect import signature
 from typing import Any, Iterable, List, Callable, Dict, Optional
 
@@ -1344,7 +1343,7 @@ class PackageManager:
         docker_api = DockerApi(docker.from_env(), ProgressManager())
         registry_resolver = RegistryResolver()
         metadata_resolver = MetadataResolver(docker_api, registry_resolver)
-        cfg_mgmt = config_mgmt.ConfigMgmt(source=INIT_CFG_JSON, sonicYangOptions=ly.LY_CTX_DISABLE_SEARCHDIR_CWD)
+        cfg_mgmt = config_mgmt.ConfigMgmt(source=INIT_CFG_JSON)
         cli_generator = CliGenerator(log)
         feature_registry = FeatureRegistry(SonicDB)
         service_creator = ServiceCreator(feature_registry,


### PR DESCRIPTION
#### What I did

sonic-utilities should never call directly into libyang.  All functionality it needs should be provided in sonic-yang-mgmt.  This resolves issues when libyang changes API/ABI such as happened between libyang1 and libyang2, and again between libyang2 and libyang3.

Depends on https://github.com/sonic-net/sonic-buildimage/pull/24414 and https://github.com/sonic-net/sonic-buildimage/pull/26563
Fixes https://github.com/sonic-net/sonic-buildimage/pull/22385

#### How I did it

Removed calls to libyang and instead uses new functionality introduced in sonic-yang-mgmt.

Also installs both libyang1 and libyang3 for tests to maintain compatibility with both during the migration.

#### How to verify it

After https://github.com/sonic-net/sonic-buildimage/pull/24414 merges observe test cases still pass.

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A

