### PR TITLE
[Chassis][ShowTechSupport] Add show chassis modules info to techSupport

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1221,6 +1221,24 @@ save_platform_info() {
 }
 
 ###############################################################################
+# Save chassis modules related info
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+save_chassis_modules_info() {
+    trap 'handle_error $? $LINENO' ERR
+    if ! $IS_SUPERVISOR; then
+        return
+    fi
+    save_cmd "show chassis modules status" "chassis_modules.status"
+    save_cmd "show chassis modules midplane-status" "chassis_modules.midplane_status"
+}
+
+###############################################################################
 # Runs a comamnd and saves its output to the incrementally built tar.
 # Globals:
 #  LOGDIR
@@ -2291,6 +2309,9 @@ main() {
     save_cmd "systemd-analyze plot" "systemd.analyze.plot.svg" &
     wait
 
+    save_chassis_modules_info &
+    wait
+    
     save_platform_info &
     save_cmd "show vlan brief" "vlan.summary" &
     save_cmd "show version" "version" &


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add save_chassis_modules_info() to the generate_dump to include the chassis module info to the Supervisor TechSupport.

#### How I did it
Add save_chassis_modules_info"() to generate_dump.  This function only applicable to the Supervisor card.  Annd following functions will be called:
show chassis module status
show chassis modules midplane-status

#### How to verify it
1) Generate the techSupport file on Supervisor by using CLI cmd: "show techsupport"
2) Download the TechSupport file and un-tar the file to verify the following two files with the correct output
```
~/sonic_dump_ixre-cpm-chassis7_20251105_183350/dump$ cat chassis_modules.midplane_status
      Name    IP-Address    Reachability
----------  ------------  --------------
LINE-CARD0    10.6.1.100            True
LINE-CARD1    10.6.2.100            True
LINE-CARD2    10.6.3.100           False
LINE-CARD3    10.6.4.100           False
LINE-CARD4    10.6.5.100           False
LINE-CARD5    10.6.6.100           False
LINE-CARD6    10.6.7.100           False
LINE-CARD7    10.6.8.100           False 
~/duts/cpm7/sonic_dump_ixre-cpm-chassis7_20251105_183350/dump$ cat chassis_modules.status 
        Name             Description    Physical-Slot    Oper-Status    Admin-Status       Serial
------------  ----------------------  ---------------  -------------  --------------  -----------
FABRIC-CARD0             Unavailable                1          Empty              up          N/A
FABRIC-CARD1             Unavailable                2          Empty              up          N/A
FABRIC-CARD2             Unavailable                3          Empty              up          N/A
FABRIC-CARD3             Unavailable                4          Empty              up          N/A
FABRIC-CARD4             Unavailable                5          Empty              up          N/A
FABRIC-CARD5             Unavailable                6          Empty              up          N/A
FABRIC-CARD6                    SFM7                7         Online              up  NS215110068
FABRIC-CARD7             Unavailable                8          Empty              up          N/A
  LINE-CARD0  Nokia-IXR7250E-36x100G                1         Online              up  EAG2-02-040
  LINE-CARD1  Nokia-IXR7250E-36x100G                2         Online              up  EAG2-02-142
  LINE-CARD2             Unavailable                3          Empty              up          N/A
  LINE-CARD3             Unavailable                4          Empty              up          N/A
  LINE-CARD4             Unavailable                5          Empty              up          N/A
  LINE-CARD5             Unavailable                6          Empty              up          N/A
  LINE-CARD6             Unavailable                7          Empty              up          N/A
  LINE-CARD7             Unavailable                8          Empty              up          N/A
 SUPERVISOR0   Nokia-IXR7250E-SUP-10                A         Online              up  NS243362676
mlok@mlok2:~/duts/cpm7/sonic_dump_ixre-cpm-chassis7_20251105_183350/dump$ 

```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [ ] 202505

#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A
