### PR TITLE
Fixed show vxlan remotemac ambiguity

### DIFF
--- a/tests/installer_dependency_test.py
+++ b/tests/installer_dependency_test.py
@@ -1,4 +1,5 @@
 import pytest
+import click
 import sonic_installer.main as sonic_installer
 import utilities_common.cli as clicommon
 
@@ -35,3 +36,38 @@ def test_sonic_installer_not_depends_on_database_container():
         exception_happen = True
 
     assert exception_happen == True
+
+
+# --- AliasedGroup bash completion context tests ---
+
+@click.group(cls=clicommon.AliasedGroup)
+def sample_cli():
+    """Sample CLI for testing AliasedGroup completion"""
+    pass
+
+
+@sample_cli.command()
+def remotemac():
+    """show vxlan remotemac"""
+    click.echo("remotemac")
+
+
+@sample_cli.command()
+def remotevni():
+    """show vxlan remotevni"""
+    click.echo("remotevni")
+
+
+def test_ambiguous_command_returns_none_with_resilient_parsing():
+    """In completion mode (resilient_parsing=True), ambiguous commands return None"""
+    ctx = click.Context(sample_cli, resilient_parsing=True)
+    # 'remote' matches both 'remotemac' and 'remotevni'
+    result = sample_cli.get_command(ctx, 'remote')
+    assert result is None
+
+
+def test_ambiguous_command_raises_usageerror_without_resilient_parsing():
+    """Without completion context, ambiguous commands should raise UsageError"""
+    ctx = click.Context(sample_cli, resilient_parsing=False)
+    with pytest.raises(click.UsageError):
+        sample_cli.get_command(ctx, 'remote')

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -116,6 +116,13 @@ class AliasedGroup(click.Group):
             return None
         elif len(matches) == 1:
             return click.Group.get_command(self, ctx, matches[0])
+
+        # In completion context, Click sets ctx.resilient_parsing = True.
+        # Return None instead of raising an error to avoid showing traceback during tab completion.
+        if ctx.resilient_parsing:
+            return None
+
+        # For normal command execution, use ctx.fail() to show usage error properly
         ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 


### PR DESCRIPTION
Summary:
When users type ambiguous commands like show vxlan remote, they see a Python traceback instead of a clean error message because the CLI finds multiple matching commands and throws an backtrace and an exception.

Root Cause
The AliasedGroup.get_command() method calls ctx.fail() which raises a UsageError exception that propagates through Click's bash completion system, causing the traceback.

Approach:
Implement context-aware error handling in the [AliasedGroup.get_command() method to differentiate between: Bash completion context: Where tracebacks should be suppressed Normal command execution context: Where clean error messages should be displayed

How did you do it?
Added environment variable detection to handle bash completion context differently Command execution results in a clear error message without any tracebacks No changes to the existing CLI functionality

#### How to verify it
sonic-utility UT - Ran UT cases and results are intact 

#### Previous command output (if the output of a command-line utility has changed)
root@W65-TL7-DUT-1:/home/admin# show vxlan remote 
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 712, in main
    _bashcomplete(self, prog_name, complete_var)
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 57, in _bashcomplete
    if bashcomplete(cmd, prog_name, complete_var, complete_instr):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/_bashcomplete.py", line 292, in bashcomplete
    return do_complete(cli, prog_name, complete_instr == 'complete_zsh')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/_bashcomplete.py", line 277, in do_complete
    for item in get_choices(cli, prog_name, args, incomplete):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/_bashcomplete.py", line 232, in get_choices
    ctx = resolve_ctx(cli, prog_name, args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/_bashcomplete.py", line 98, in resolve_ctx
    cmd_name, cmd, args = ctx.command.resolve_command(ctx, args)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1171, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/cli.py", line 119, in get_command
    ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 496, in fail
    raise UsageError(message, self)
click.exceptions.UsageError: Too many matches: remotemac, remotevni, remotevtepUsage: show vxlan [OPTIONS] COMMAND [ARGS]...
Try "show vxlan -h" for help.Error: Too many matches: remotemac, remotevni, remotevtep

#### New command output (if the output of a command-line utility has changed)
root@W65-TL7-DUT-1:/home/admin# show vxlan remote
remotemac   remotevni   remotevtep

root@W65-TL7-DUT-1:/home/admin# show vxlan remote mac
Usage: show vxlan [OPTIONS] COMMAND [ARGS]...
Try "show vxlan -h" for help.

Error: Too many matches: remotemac, remotevni, remotevtep

