### PR TITLE
Issue 24036: Add help for 'show ip route' subcommands

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -501,6 +501,11 @@ This command displays the full list of show commands available in the software; 
 
 The same syntax applies to all subgroups of `show` which themselves contain subcommands, and subcommands which accept options/arguments.
 
+Some `show` commands that wrap FRR's CLI (currently `show ip route` and
+`show ipv6 route`) provide enhanced help and TAB completion sourced live
+from FRR. Their `-h`/`--help` output lists the subcommands FRR actually
+supports, and shell TAB completion offers the same set as you type.
+
 - Example:
   ```
   admin@sonic:~$ show interfaces -?
@@ -6803,6 +6808,11 @@ This sub-section explains the various IP protocol specific show commands that ar
 
 This command displays either all the route entries from the routing table or a specific route.
 
+`show ip route --help` (or `show ip route -?`) lists the available
+subcommands sourced live from FRR (e.g. `bgp`, `connected`, `static`,
+`summary`, `vrf`, etc.). Shell TAB completion offers the same set as
+you type, including for nested subcommands like `show ip route vrf <TAB>`.
+
 - Usage:
   ```
   show ip route [<vrf-name>] [<ip_address>]
@@ -6932,6 +6942,11 @@ This sub-section explains the various IPv6 protocol specific show commands that 
 **show ipv6 route**
 
 This command displays either all the IPv6 route entries from the routing table or a specific IPv6 route.
+
+`show ipv6 route --help` (or `show ipv6 route -?`) lists the available
+subcommands sourced live from FRR. Shell TAB completion offers the same
+set as you type, including for nested subcommands like
+`show ipv6 route vrf <TAB>`.
 
 - Usage:
   ```

--- a/show/main.py
+++ b/show/main.py
@@ -40,6 +40,7 @@ except KeyError:
 
 from . import acl
 from . import bgp_common
+from .vtysh_helper import vtysh_command
 from . import chassis_modules
 from . import dropcounters
 from . import fabric
@@ -1411,8 +1412,9 @@ def loopback_action():
 # 'route' subcommand ("show ip route")
 #
 
-@ip.command()
-@click.argument('args', metavar='[IPADDRESS] [vrf <vrf_name>] [...]', nargs=-1, required=False)
+
+@ip.command(cls=vtysh_command("show ip route"))
+@click.argument('args', nargs=-1, required=False)
 @click.option('--display', '-d', 'display', default=None, show_default=False, type=str, help='all|frontend')
 @click.option('--namespace', '-n', 'namespace', default=None, type=str, show_default=False, help='Namespace name or all')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
@@ -1508,16 +1510,15 @@ def interfaces(namespace, display):
 # 'route' subcommand ("show ipv6 route")
 #
 
-@ipv6.command()
-@click.argument('args', metavar='[IPADDRESS] [vrf <vrf_name>] [...]', nargs=-1, required=False)
+@ipv6.command(cls=vtysh_command("show ipv6 route"))
+@click.argument('args', nargs=-1, required=False)
 @click.option('--display', '-d', 'display', default=None, show_default=False, type=str, help='all|frontend')
 @click.option('--namespace', '-n', 'namespace', default=None, type=str, show_default=False, help='Namespace name or all')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def route(args, namespace, display, verbose):
     """Show IPv6 routing table"""
-    # Call common handler to handle the show ipv6 route cmd
+    # Call common handler to handle the show ip route cmd
     bgp_common.show_routes(args, namespace, display, verbose, "ipv6")
-
 
 # 'protocol' command
 @ipv6.command()

--- a/show/main.py
+++ b/show/main.py
@@ -1517,7 +1517,7 @@ def interfaces(namespace, display):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def route(args, namespace, display, verbose):
     """Show IPv6 routing table"""
-    # Call common handler to handle the show ip route cmd
+    # Call common handler to handle the show ipv6 route cmd
     bgp_common.show_routes(args, namespace, display, verbose, "ipv6")
 
 # 'protocol' command

--- a/show/vtysh_helper.py
+++ b/show/vtysh_helper.py
@@ -1,0 +1,262 @@
+import click
+import functools
+import subprocess
+
+from click.shell_completion import CompletionItem
+
+
+class VtyshParamType(click.types.StringParamType):
+    """Custom type for vtysh command arguments that provides shell completion."""
+
+    def shell_complete(self, ctx, param, incomplete):
+        cmd = ctx.command
+        if not isinstance(cmd, VtyshCommand):
+            return []
+
+        args = ctx.params.get(param.name or "args", ())
+        if args:
+            cmd_prefix = f"{cmd.vtysh_command_prefix} {' '.join(args)}"
+        else:
+            cmd_prefix = cmd.vtysh_command_prefix
+
+        completions = cmd.get_vtysh_completions(cmd_prefix, completion=False)
+
+        if incomplete:
+            completions = [c for c in completions if c.startswith(incomplete)]
+
+        return [CompletionItem(c) for c in completions]
+
+
+class VtyshCommand(click.Command):
+    """
+    Custom Click command class that integrates vtysh help functionality.
+    This provides enhanced help by showing both Click help and vtysh subcommands.
+    """
+
+    # List of vtysh commands that support completion
+    vtysh_completion_commands = []
+
+    def __init__(self, name, vtysh_command_prefix, **kwargs):
+        """
+        Initialize the VtyshCommand.
+
+        Args:
+            name: Command name
+            vtysh_command_prefix: The vtysh command prefix (e.g., "show ip route")
+            **kwargs: Other Click command arguments
+        """
+        self.vtysh_command_prefix = vtysh_command_prefix
+        super().__init__(name, **kwargs)
+
+        # Patch variadic arguments to use VtyshParamType for shell completion
+        for param in self.params:
+            if isinstance(param, click.Argument) and param.nargs == -1:
+                param.type = VtyshParamType()
+
+    def parse_args(self, ctx, args):
+        """Track vtysh command args for later use"""
+        help_options = ['-h', '--help', '-?', '?']
+        self.raw_args = []
+        for arg in args:
+            if arg in help_options:
+                break
+            self.raw_args.append(arg)
+        # SONiC CLI accepts '?' as a hidden help option, handle it explicitly here
+        if '?' in args:
+            click.echo(ctx.get_help())
+            ctx.exit()
+        return super().parse_args(ctx, args)
+
+    def get_help(self, ctx):
+        """Override Click's get_help to provide enhanced vtysh help."""
+        formatter = click.HelpFormatter()
+
+        # Try the full command first
+        is_valid = False
+        last_valid_command = self.vtysh_command_prefix
+        if len(self.raw_args) == 0:
+            is_valid = True
+        else:
+            arg_prefix = ' '.join(self.raw_args[:-1])
+            full_command_prefix = f"{self.vtysh_command_prefix}"
+            if arg_prefix != "":
+                full_command_prefix += f" {arg_prefix}"
+            full_command = f"{self.vtysh_command_prefix} {' '.join(self.raw_args)}"
+            # Handle partial commands (ie, "show ip route sum")
+            completions = self.get_vtysh_completions(full_command)
+            if len(completions) == 1:
+                last_valid_command = f"{full_command_prefix} {completions[0]}"
+                is_valid = True
+
+        if not is_valid:
+            # If the full command failed, work backwards to find last valid command prefix
+            last_valid_command = self.vtysh_command_prefix
+            for arg in self.raw_args:
+                test_command = f"{last_valid_command} {arg}"
+
+                # Handle partial commands (ie, "show ip route sum")
+                completions = self.get_vtysh_completions(test_command)
+                if len(completions) == 1:
+                    test_command = f"{last_valid_command} {completions[0]}"
+                elif len(completions) > 1:
+                    usage_args = self.get_usage_args(last_valid_command)
+                    formatter.write_usage(last_valid_command, usage_args)
+                    formatter.write(f'Try "{last_valid_command} -h" for help.')
+                    formatter.write_paragraph()
+                    formatter.write_paragraph()
+                    formatter.write_text(f'Error: Too many matches: {", ".join(sorted(completions))}')
+                    return formatter.getvalue().rstrip()
+
+                vtysh_help_text = self.get_vtysh_help(test_command)
+                if vtysh_help_text and "% There is no matched command." in vtysh_help_text:
+                    usage_args = self.get_usage_args(last_valid_command)
+                    formatter.write_usage(last_valid_command, usage_args)
+                    formatter.write(f'Try "{last_valid_command} -h" for help.')
+                    formatter.write_paragraph()
+                    formatter.write_paragraph()
+                    formatter.write_text(f'Error: No such command "{arg}".')
+                    return formatter.getvalue().rstrip()
+
+                last_valid_command = test_command
+
+        # Add Usage section
+        usage_args = self.get_usage_args(last_valid_command)
+        formatter.write_usage(last_valid_command, usage_args)
+
+        # Add description
+        description = None
+        if self.raw_args:
+            description = self.get_vtysh_command_description(last_valid_command)
+        elif self.callback and self.callback.__doc__:
+            description = self.callback.__doc__.strip().split('\n')[0]
+        if description:
+            formatter.write_paragraph()
+            formatter.write_text(description)
+
+        # Add Options section
+        opts = []
+        for param in self.get_params(ctx):
+            rv = param.get_help_record(ctx)
+            if rv is not None:
+                opts.append(rv)
+        if opts:
+            with formatter.section("Options"):
+                formatter.write_dl(opts)
+
+        # Add Commands section (from vtysh)
+        vtysh_subcommands = self.get_vtysh_subcommands(last_valid_command)
+        if len(vtysh_subcommands) > 0:
+            with formatter.section("Commands"):
+                formatter.write_dl(vtysh_subcommands)
+
+        return formatter.getvalue().rstrip()
+
+    def get_usage_args(self, command):
+        """Set usage args appropriately for nested vs. leaf commands."""
+        vtysh_subcommands = self.get_vtysh_subcommands(command)
+        if vtysh_subcommands:
+            return "[OPTIONS] COMMAND [ARGS]..."
+        return "[OPTIONS]"
+
+    def get_vtysh_command_description(self, command):
+        """Get description for the current command from vtysh help."""
+        # remove last arg
+        curr_command = command.split()[-1]
+        prev_command = command.split()[:-1]
+        vtysh_subcommands = self.get_vtysh_subcommands(" ".join(prev_command))
+        for c, d in vtysh_subcommands:
+            if c == curr_command:
+                return d
+        return ""
+
+    def get_vtysh_completions(self, cmd_prefix, completion=True):
+        """
+        Get completion options from vtysh for the given command.
+
+        Args:
+            cmd_prefix: The command prefix to query
+            completion: If True, use "?" (no space) to complete partial words.
+                       If False, use " ?" (with space) to show all next commands.
+        """
+        subcommands = self.get_vtysh_subcommands(cmd_prefix, completion=completion)
+        completions = []
+        for cmpl, _ in subcommands:
+            if any(c.isupper() for c in cmpl) or (cmpl.startswith("(") and cmpl.endswith(")")):
+                # skip user-defined arguments like VRF_NAME or A.B.C.D, or ranges like (1-100)
+                continue
+            completions.append(cmpl)
+        return completions
+
+    def get_vtysh_subcommands(self, command, completion=False):
+        """Get subcommands from vtysh for the given command."""
+        vtysh_help_content = self.get_vtysh_help(command, completion)
+        if (not vtysh_help_content
+                or "Error response from daemon:" in vtysh_help_content
+                or "failed to connect to any daemons" in vtysh_help_content):
+            return []
+
+        subcommands = []
+        lines = vtysh_help_content.strip().split('\n')
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Vtysh help format is typically: "subcommand    description"
+            parts = line.split(None, 1)  # Split on whitespace, max 2 parts
+            if len(parts) >= 1:
+                subcommand = parts[0].strip()
+                description = parts[1].strip() if len(parts) > 1 else ""
+
+                # Only filter out obvious non-subcommands
+                if (subcommand and subcommand != "<cr>"
+                        and not subcommand.startswith("%")
+                        and not subcommand.startswith("Error:")):
+                    subcommands.append((subcommand, description))
+        return subcommands
+
+    @functools.lru_cache()
+    def get_vtysh_help(self, cmd_prefix, completion=False):
+        """
+        Get help for a vtysh command.
+        """
+        try:
+            help_command = f"{cmd_prefix}"
+            help_command += "?" if completion else " ?"
+            result = subprocess.run(
+                ["vtysh", "-c", help_command],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            # Check if command succeeded
+            if result.returncode == 0:
+                help_content = result.stdout.strip()
+            else:
+                # If there's an error, it might be in stderr
+                help_content = result.stderr.strip() if result.stderr else None
+            return help_content
+
+        except Exception:
+            return None
+
+
+def vtysh_command(vtysh_command_prefix):
+    """
+    Factory function to create a VtyshCommand class with the given command prefix.
+
+    Args:
+        vtysh_command_prefix (str): The vtysh command prefix (e.g., "show ip route")
+
+    Returns:
+        A partial VtyshCommand class that can be used with @click.command(cls=...)
+    """
+    VtyshCommand.vtysh_completion_commands.append(vtysh_command_prefix)
+
+    class _VtyshCommand(VtyshCommand):
+        def __init__(self, name, **kwargs):
+            super().__init__(name, vtysh_command_prefix, **kwargs)
+
+    return _VtyshCommand

--- a/show/vtysh_helper.py
+++ b/show/vtysh_helper.py
@@ -3,6 +3,8 @@ import functools
 import subprocess
 
 from click.shell_completion import CompletionItem
+from sonic_py_common import multi_asic
+from utilities_common import constants
 
 
 class VtyshParamType(click.types.StringParamType):
@@ -19,7 +21,8 @@ class VtyshParamType(click.types.StringParamType):
         else:
             cmd_prefix = cmd.vtysh_command_prefix
 
-        completions = cmd.get_vtysh_completions(cmd_prefix, completion=False)
+        namespace = ctx.params.get('namespace')
+        completions = cmd.get_vtysh_completions(cmd_prefix, completion=False, namespace=namespace)
 
         if incomplete:
             completions = [c for c in completions if c.startswith(incomplete)]
@@ -54,13 +57,26 @@ class VtyshCommand(click.Command):
                 param.type = VtyshParamType()
 
     def parse_args(self, ctx, args):
-        """Track vtysh command args for later use"""
+        """Track vtysh command args + namespace for later use.
+
+        We extract --namespace here rather than reading ctx.params later because
+        Click's eager --help callback can fire before non-eager options have
+        been populated into ctx.params.
+        """
         help_options = ['-h', '--help', '-?', '?']
         self.raw_args = []
-        for arg in args:
+        self.namespace = None
+        i = 0
+        while i < len(args):
+            arg = args[i]
             if arg in help_options:
                 break
+            if arg in ('-n', '--namespace') and i + 1 < len(args):
+                self.namespace = args[i + 1]
+                i += 2
+                continue
             self.raw_args.append(arg)
+            i += 1
         # SONiC CLI accepts '?' as a hidden help option, handle it explicitly here
         if '?' in args:
             click.echo(ctx.get_help())
@@ -70,6 +86,7 @@ class VtyshCommand(click.Command):
     def get_help(self, ctx):
         """Override Click's get_help to provide enhanced vtysh help."""
         formatter = click.HelpFormatter()
+        namespace = self.namespace
 
         # Try the full command first
         is_valid = False
@@ -83,7 +100,7 @@ class VtyshCommand(click.Command):
                 full_command_prefix += f" {arg_prefix}"
             full_command = f"{self.vtysh_command_prefix} {' '.join(self.raw_args)}"
             # Handle partial commands (ie, "show ip route sum")
-            completions = self.get_vtysh_completions(full_command)
+            completions = self.get_vtysh_completions(full_command, namespace=namespace)
             if len(completions) == 1:
                 last_valid_command = f"{full_command_prefix} {completions[0]}"
                 is_valid = True
@@ -95,11 +112,11 @@ class VtyshCommand(click.Command):
                 test_command = f"{last_valid_command} {arg}"
 
                 # Handle partial commands (ie, "show ip route sum")
-                completions = self.get_vtysh_completions(test_command)
+                completions = self.get_vtysh_completions(test_command, namespace=namespace)
                 if len(completions) == 1:
                     test_command = f"{last_valid_command} {completions[0]}"
                 elif len(completions) > 1:
-                    usage_args = self.get_usage_args(last_valid_command)
+                    usage_args = self.get_usage_args(last_valid_command, namespace=namespace)
                     formatter.write_usage(last_valid_command, usage_args)
                     formatter.write(f'Try "{last_valid_command} -h" for help.')
                     formatter.write_paragraph()
@@ -107,9 +124,9 @@ class VtyshCommand(click.Command):
                     formatter.write_text(f'Error: Too many matches: {", ".join(sorted(completions))}')
                     return formatter.getvalue().rstrip()
 
-                vtysh_help_text = self.get_vtysh_help(test_command)
+                vtysh_help_text = self.get_vtysh_help(test_command, namespace=namespace)
                 if vtysh_help_text and "% There is no matched command." in vtysh_help_text:
-                    usage_args = self.get_usage_args(last_valid_command)
+                    usage_args = self.get_usage_args(last_valid_command, namespace=namespace)
                     formatter.write_usage(last_valid_command, usage_args)
                     formatter.write(f'Try "{last_valid_command} -h" for help.')
                     formatter.write_paragraph()
@@ -120,13 +137,13 @@ class VtyshCommand(click.Command):
                 last_valid_command = test_command
 
         # Add Usage section
-        usage_args = self.get_usage_args(last_valid_command)
+        usage_args = self.get_usage_args(last_valid_command, namespace=namespace)
         formatter.write_usage(last_valid_command, usage_args)
 
         # Add description
         description = None
         if self.raw_args:
-            description = self.get_vtysh_command_description(last_valid_command)
+            description = self.get_vtysh_command_description(last_valid_command, namespace=namespace)
         elif self.callback and self.callback.__doc__:
             description = self.callback.__doc__.strip().split('\n')[0]
         if description:
@@ -144,32 +161,32 @@ class VtyshCommand(click.Command):
                 formatter.write_dl(opts)
 
         # Add Commands section (from vtysh)
-        vtysh_subcommands = self.get_vtysh_subcommands(last_valid_command)
+        vtysh_subcommands = self.get_vtysh_subcommands(last_valid_command, namespace=namespace)
         if len(vtysh_subcommands) > 0:
             with formatter.section("Commands"):
                 formatter.write_dl(vtysh_subcommands)
 
         return formatter.getvalue().rstrip()
 
-    def get_usage_args(self, command):
+    def get_usage_args(self, command, namespace=None):
         """Set usage args appropriately for nested vs. leaf commands."""
-        vtysh_subcommands = self.get_vtysh_subcommands(command)
+        vtysh_subcommands = self.get_vtysh_subcommands(command, namespace=namespace)
         if vtysh_subcommands:
             return "[OPTIONS] COMMAND [ARGS]..."
         return "[OPTIONS]"
 
-    def get_vtysh_command_description(self, command):
+    def get_vtysh_command_description(self, command, namespace=None):
         """Get description for the current command from vtysh help."""
         # remove last arg
         curr_command = command.split()[-1]
         prev_command = command.split()[:-1]
-        vtysh_subcommands = self.get_vtysh_subcommands(" ".join(prev_command))
+        vtysh_subcommands = self.get_vtysh_subcommands(" ".join(prev_command), namespace=namespace)
         for c, d in vtysh_subcommands:
             if c == curr_command:
                 return d
         return ""
 
-    def get_vtysh_completions(self, cmd_prefix, completion=True):
+    def get_vtysh_completions(self, cmd_prefix, completion=True, namespace=None):
         """
         Get completion options from vtysh for the given command.
 
@@ -177,8 +194,9 @@ class VtyshCommand(click.Command):
             cmd_prefix: The command prefix to query
             completion: If True, use "?" (no space) to complete partial words.
                        If False, use " ?" (with space) to show all next commands.
+            namespace: SONiC namespace name (e.g. "asic0") for multi-ASIC targeting.
         """
-        subcommands = self.get_vtysh_subcommands(cmd_prefix, completion=completion)
+        subcommands = self.get_vtysh_subcommands(cmd_prefix, completion=completion, namespace=namespace)
         completions = []
         for cmpl, _ in subcommands:
             if any(c.isupper() for c in cmpl) or (cmpl.startswith("(") and cmpl.endswith(")")):
@@ -187,9 +205,9 @@ class VtyshCommand(click.Command):
             completions.append(cmpl)
         return completions
 
-    def get_vtysh_subcommands(self, command, completion=False):
+    def get_vtysh_subcommands(self, command, completion=False, namespace=None):
         """Get subcommands from vtysh for the given command."""
-        vtysh_help_content = self.get_vtysh_help(command, completion)
+        vtysh_help_content = self.get_vtysh_help(command, completion, namespace)
         if (not vtysh_help_content
                 or "Error response from daemon:" in vtysh_help_content
                 or "failed to connect to any daemons" in vtysh_help_content):
@@ -217,15 +235,38 @@ class VtyshCommand(click.Command):
         return subcommands
 
     @functools.lru_cache()
-    def get_vtysh_help(self, cmd_prefix, completion=False):
+    def get_vtysh_help(self, cmd_prefix, completion=False, namespace=None):
         """
         Get help for a vtysh command.
+
+        Uses rvtysh so that on multi-ASIC platforms the query lands in the
+        right FRR instance. When `namespace` is set, passes `-n <asic_id>`.
+        When unset, rvtysh's default-namespace behavior is used — fine for
+        help/completion because the FRR command tree is identical per ASIC.
         """
         try:
             help_command = f"{cmd_prefix}"
             help_command += "?" if completion else " ?"
+            # rvtysh (read-only vtysh wrapper) — no sudo. Read-only help
+            # queries shouldn't require elevation.
+            cmd = [constants.RVTYSH_COMMAND]
+            # The SONiC vtysh wrapper only consumes `-n N` on multi-ASIC
+            # platforms; on single-ASIC it falls through into the docker
+            # container's vtysh, which then looks for nonexistent
+            # /var/run/frr/N/ and silently returns empty. So gate `-n`
+            # on is_multi_asic() — on single-ASIC, ignore the namespace
+            # (the regular `show ip route` handler already rejects
+            # --namespace on single-ASIC, so this is a misuse edge case).
+            if namespace and multi_asic.is_multi_asic():
+                try:
+                    asic_id = multi_asic.get_asic_id_from_name(namespace)
+                    cmd += ["-n", str(asic_id)]
+                except Exception:
+                    # Namespace name not recognized; fall back to default.
+                    pass
+            cmd += ["-c", help_command]
             result = subprocess.run(
-                ["vtysh", "-c", help_command],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=10

--- a/tests/vtysh_help_test.py
+++ b/tests/vtysh_help_test.py
@@ -1,0 +1,531 @@
+import os
+import sys
+from click.testing import CliRunner
+from unittest import mock
+
+import show.main as show
+
+from show.vtysh_helper import VtyshCommand
+
+# Add test path
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+
+class TestVtyshHelpCommands:
+    """Test VtyshCommand help functionality for vtysh-integrated commands.
+
+       The test uses 'show ip route' as an example command, but all output is mocked
+       and we're just testing internals. The coverage should apply to any command
+       that uses the VtyshCommand class.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
+    def teardown_method(self, method):
+        VtyshCommand.get_vtysh_help.cache_clear()
+
+    def test_vtysh_help_basic_functionality(self):
+        """Test basic help output structure for VtyshCommand."""
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route" in result.output
+        assert "Show IP (IPv4) routing table" in result.output
+        assert "Options:" in result.output
+        assert "--help" in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_vtysh_help_with_subcommands(self, mock_subprocess):
+        """Test help output when vtysh subcommands exist."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+  A.B.C.D         Network in the IP routing table to display
+"""
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route [OPTIONS] COMMAND [ARGS]..." in result.output
+        assert "Commands:" in result.output
+        assert "summary" in result.output
+        assert "Summary of all routes" in result.output
+        assert "vrf" in result.output
+        assert "Specify the VRF" in result.output
+        assert "A.B.C.D" in result.output
+        assert "Network in the IP routing table to display" in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_vtysh_help_without_subcommands(self, mock_subprocess):
+        """Test help output when no vtysh subcommands exist."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""  # No subcommands available
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["summary", "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route summary [OPTIONS]" in result.output
+        assert "COMMAND [ARGS]" not in result.output
+        assert "Commands:" not in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_nested_command_help(self, mock_subprocess):
+        """Test help for nested commands shows correct usage and description."""
+        # Mock vtysh response - need to handle multiple calls
+        def subprocess_side_effect(*args, **kwargs):
+            command = args[0]
+            mock_result = mock.Mock()
+            mock_result.returncode = 0
+
+            if 'show ip route ?' in ' '.join(command):
+                # Parent command help
+                mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+"""
+            elif 'show ip route vrf ?' in ' '.join(command):
+                # Nested command help
+                mock_result.stdout = """
+  NAME            VRF name
+  all             All VRFs
+"""
+            else:
+                mock_result.stdout = ""
+
+            return mock_result
+
+        mock_subprocess.side_effect = subprocess_side_effect
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["vrf", "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route vrf" in result.output
+        assert "Commands:" in result.output
+        assert "NAME" in result.output
+        assert "all" in result.output
+        assert "Specify the VRF" in result.output  # Description from parent command
+        assert "summary" not in result.output  # Not a subcommand of 'vrf'
+        assert "Summary of all routes" not in result.output  # Not a subcommand of 'vrf'
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_basic_invalid_command_error_handling(self, mock_subprocess):
+        """Test error handling for invalid commands."""
+        def subprocess_side_effect(*args, **kwargs):
+            command = args[0]
+            mock_result = mock.Mock()
+            mock_result.returncode = 0
+
+            if 'invalid' in ' '.join(command):
+                mock_result.stdout = "% There is no matched command."
+            else:
+                mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+"""
+            return mock_result
+
+        mock_subprocess.side_effect = subprocess_side_effect
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["invalid", "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route [OPTIONS] COMMAND [ARGS]..." in result.output
+        assert "Error:" in result.output
+        assert 'No such command "invalid"' in result.output
+        assert 'Try "show ip route -h" for help' in result.output
+        assert "Commands:" not in result.output
+        assert "summary" not in result.output
+        assert "vrf" not in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_nested_invalid_command_error_handling(self, mock_subprocess):
+        """Test that error usage line shows the last valid command, not the failing one."""
+        def subprocess_side_effect(*args, **kwargs):
+            command = args[0]
+            command_str = ' '.join(command)
+            mock_result = mock.Mock()
+            mock_result.returncode = 0
+
+            if 'show ip route ?' in command_str:
+                mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+"""
+            elif 'show ip route vrf ?' in command_str:
+                mock_result.stdout = """
+  NAME            VRF name
+  all             All VRFs
+"""
+            elif 'invalid' in command_str:
+                mock_result.stdout = "% There is no matched command."
+            else:
+                mock_result.stdout = ""
+
+            return mock_result
+
+        mock_subprocess.side_effect = subprocess_side_effect
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["vrf", "invalid", "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route vrf [OPTIONS] COMMAND [ARGS]..." in result.output
+        assert 'No such command "invalid"' in result.output
+        assert 'Try "show ip route vrf -h" for help' in result.output
+        assert "Commands:" not in result.output
+        assert "summary" not in result.output
+        assert "all" not in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_vtysh_caching_functionality(self, mock_subprocess):
+        """Test that vtysh calls are cached to avoid repeated calls."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+"""
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        # First call
+        result1 = runner.invoke(show.cli.commands["ip"].commands["route"], ["--help"])
+        # Second call (should use cache)
+        result2 = runner.invoke(show.cli.commands["ip"].commands["route"], ["--help"])
+
+        assert result1.exit_code == 0
+        assert result2.exit_code == 0
+        # Should have been called only once due to caching
+        assert mock_subprocess.call_count == 1
+
+
+class TestVtyshCompletionCommands:
+    """Test VtyshCommand completion functionality for vtysh-integrated commands."""
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
+    def teardown_method(self, method):
+        VtyshCommand.get_vtysh_help.cache_clear()
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_basic_completion_functionality(self, mock_subprocess):
+        """Test basic completion returns available subcommands."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+  A.B.C.D         Network in the IP routing table to display
+  json            JavaScript Object Notation
+  (1-100)         Number of entries to display
+"""
+        mock_subprocess.return_value = mock_result
+
+        route_cmd = show.cli.commands["ip"].commands["route"]
+        completions = route_cmd.get_vtysh_completions("show ip route")
+
+        assert "summary" in completions
+        assert "vrf" in completions
+        assert "json" in completions
+        assert "A.B.C.D" not in completions
+        assert "(1-100)" not in completions
+        assert len(completions) == 3
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_nested_completion_functionality(self, mock_subprocess):
+        """Test completion for nested commands."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+  NAME            VRF name
+  all             All VRFs
+  default         Default VRF
+"""
+        mock_subprocess.return_value = mock_result
+
+        route_cmd = show.cli.commands["ip"].commands["route"]
+        completions = route_cmd.get_vtysh_completions("show ip route vrf")
+
+        assert "NAME" not in completions
+        assert "all" in completions
+        assert "default" in completions
+        assert len(completions) == 2
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_completion_with_no_results(self, mock_subprocess):
+        """Test completion when no subcommands are available."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_subprocess.return_value = mock_result
+
+        route_cmd = show.cli.commands["ip"].commands["route"]
+        completions = route_cmd.get_vtysh_completions("show ip route summary")
+
+        assert completions == []
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_completion_with_vtysh_error(self, mock_subprocess):
+        """Test completion when vtysh returns an error."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = "% There is no matched command."
+        mock_result.stderr = "Error: command not found"
+        mock_subprocess.return_value = mock_result
+
+        route_cmd = show.cli.commands["ip"].commands["route"]
+        completions = route_cmd.get_vtysh_completions("show ip route invalid")
+
+        assert completions == []
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_completion_with_whitespace_handling(self, mock_subprocess):
+        """Test completion parsing handles whitespace correctly."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+
+  summary         Summary of all routes
+
+  vrf             Specify the VRF
+  json            JavaScript Object Notation
+
+"""
+        mock_subprocess.return_value = mock_result
+
+        route_cmd = show.cli.commands["ip"].commands["route"]
+        completions = route_cmd.get_vtysh_completions("show ip route")
+
+        assert "summary" in completions
+        assert "vrf" in completions
+        assert "json" in completions
+        assert len(completions) == 3
+        # Should not include empty strings
+        assert "" not in completions
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_completion_false_uses_space_before_question_mark(self, mock_subprocess):
+        """
+        Test that completion=False sends " ?" (space before ?) to vtysh.
+
+        when providing shell completions, we need to query vtysh with " ?" (space before ?)
+        to get all possible next commands, not "?" (no space) which would try to complete
+        a partial word.
+
+        The difference:
+        - "show ip route?" (completion=True) - tries to complete "route"
+        - "show ip route ?" (completion=False) - shows all commands after "route"
+
+        We want completion=False in shell_complete() because Click already handles
+        the partial matching via the 'incomplete' parameter.
+        """
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+  json            JavaScript Object Notation
+"""
+        mock_subprocess.return_value = mock_result
+
+        route_cmd = show.cli.commands["ip"].commands["route"]
+
+        # Call get_vtysh_completions with completion=False
+        completions = route_cmd.get_vtysh_completions("show ip route", completion=False)
+
+        # Verify vtysh was called with " ?" (space before ?)
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[0][0]
+        assert call_args == ['vtysh', '-c', 'show ip route ?']  # Note the space before ?
+
+        # Verify we got all completions
+        assert "summary" in completions
+        assert "vrf" in completions
+        assert "json" in completions
+        assert len(completions) == 3
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_completion_true_uses_no_space_before_question_mark(self, mock_subprocess):
+        """
+        Test that completion=True sends "?" (no space) to vtysh.
+
+        This is used for completing partial words, not listing all commands.
+        For example, if the user types "summ" and we want vtysh to complete it to "summary".
+        """
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "summary"  # vtysh completes "summ" to "summary"
+        mock_subprocess.return_value = mock_result
+
+        route_cmd = show.cli.commands["ip"].commands["route"]
+
+        # Call get_vtysh_completions with completion=True
+        route_cmd.get_vtysh_help.cache_clear()
+        route_cmd.get_vtysh_help("show ip route summ", completion=True)
+
+        # Verify vtysh was called with "?" (no space before ?)
+        call_args = mock_subprocess.call_args[0][0]
+        assert call_args == ['vtysh', '-c', 'show ip route summ?']  # No space before ?
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_shell_complete_end_to_end(self, mock_subprocess):
+        """
+        Test completion end-to-end by simulating what bash does: invoking the
+        CLI with _SHOW_COMPLETE=bash_complete and COMP_WORDS/COMP_CWORD env vars.
+
+        This tests the full Click completion framework, not just individual methods.
+        """
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+  summary         Summary of all routes
+  static          Statically configured routes
+  vrf             Specify the VRF
+  json            JavaScript Object Notation
+"""
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli, prog_name='show', args=[], env={
+            '_SHOW_COMPLETE': 'bash_complete',
+            'COMP_WORDS': 'show ip route s',
+            'COMP_CWORD': '3',
+        })
+
+        assert result.exit_code == 0
+        # Click 8 bash_complete format returns "type,value" lines
+        assert 'plain,summary' in result.output
+        assert 'plain,static' in result.output
+        assert 'plain,vrf' not in result.output
+        assert 'plain,json' not in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_shell_complete_end_to_end_no_filter(self, mock_subprocess):
+        """
+        Test completion with no partial input returns all vtysh subcommands.
+        """
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = """
+  summary         Summary of all routes
+  vrf             Specify the VRF
+  json            JavaScript Object Notation
+"""
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli, prog_name='show', args=[], env={
+            '_SHOW_COMPLETE': 'bash_complete',
+            'COMP_WORDS': 'show ip route ',
+            'COMP_CWORD': '3',
+        })
+
+        assert result.exit_code == 0
+        assert 'plain,summary' in result.output
+        assert 'plain,vrf' in result.output
+        assert 'plain,json' in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_nested_command_help_with_completion(self, mock_subprocess):
+        """Test help for nested commands shows correct usage and description, with completion."""
+        # Mock vtysh response - need to handle multiple calls
+        def subprocess_side_effect(*args, **kwargs):
+            command = args[0]
+            mock_result = mock.Mock()
+            mock_result.returncode = 0
+
+            if 'show ip route summ?' in ' '.join(command) or 'show ip route ?' in ' '.join(command):
+                # Completion command help
+                mock_result.stdout = """
+  summary         Summary of all routes
+"""
+            elif 'show ip route summary ?' in ' '.join(command):
+                # Parent command help
+                mock_result.stdout = """
+  vrf             Specify the VRF
+"""
+            else:
+                mock_result.stdout = ""
+
+            return mock_result
+
+        mock_subprocess.side_effect = subprocess_side_effect
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["summ", "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route summary" in result.output
+        assert "Summary of all routes" in result.output
+        assert "Commands:" in result.output
+        assert "vrf" in result.output
+        assert "Specify the VRF" in result.output
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_nested_command_help_with_inline_completion(self, mock_subprocess):
+        """Test help for nested commands shows correct usage and description, with inline completion."""
+        # Mock vtysh response - need to handle multiple calls
+        def subprocess_side_effect(*args, **kwargs):
+            command = args[0]
+            mock_result = mock.Mock()
+            mock_result.returncode = 0
+
+            if 'show ip route summ?' in ' '.join(command) or 'show ip route ?' in ' '.join(command):
+                # Completion command help
+                mock_result.stdout = """
+  summary         Summary of all routes
+"""
+            elif 'show ip route summary ?' in ' '.join(command):
+                # Parent command help
+                mock_result.stdout = """
+  vrf             Specify the VRF
+"""
+            elif 'show ip route summary vrf ?' in ' '.join(command):
+                # Nested command help
+                mock_result.stdout = """
+  NAME            VRF name
+  all             All VRFs
+"""
+            else:
+                mock_result.stdout = ""
+
+            return mock_result
+
+        mock_subprocess.side_effect = subprocess_side_effect
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["summ", "vrf", "--help"])
+
+        assert result.exit_code == 0
+        assert "Usage: show ip route summary vrf" in result.output
+        assert "Commands:" in result.output
+        assert "NAME" in result.output
+        assert "Specify the VRF" in result.output
+        assert "all" in result.output
+        assert "All VRFs" in result.output
+        assert "Summary of all routes" not in result.output

--- a/tests/vtysh_help_test.py
+++ b/tests/vtysh_help_test.py
@@ -217,6 +217,101 @@ class TestVtyshHelpCommands:
         # Should have been called only once due to caching
         assert mock_subprocess.call_count == 1
 
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_help_with_vtysh_unavailable(self, mock_subprocess):
+        """When rvtysh fails (e.g. chassis supervisor with no local FRR), help
+        renders without crashing and without a Commands section."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "failed to connect to any daemons"
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["--help"])
+
+        assert result.exit_code == 0
+        # Usage + description + options still render.
+        assert "Usage: show ip route" in result.output
+        assert "Show IP (IPv4) routing table" in result.output
+        assert "Options:" in result.output
+        # No Commands section since rvtysh returned no usable subcommand list.
+        assert "Commands:" not in result.output
+
+    @mock.patch('show.vtysh_helper.multi_asic.is_multi_asic')
+    @mock.patch('show.vtysh_helper.multi_asic.get_asic_id_from_name')
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_namespace_passed_through_to_rvtysh(self, mock_subprocess, mock_get_asic_id, mock_is_multi):
+        """On multi-ASIC, --namespace propagates to rvtysh as `-n <asic_id>`."""
+        mock_is_multi.return_value = True
+        mock_get_asic_id.return_value = 0
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "  summary  Summary of all routes\n"
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"],
+            ["--namespace", "asic0", "--help"],
+        )
+
+        assert result.exit_code == 0
+        assert mock_subprocess.called
+        # Every rvtysh call for this invocation should target asic0.
+        for call in mock_subprocess.call_args_list:
+            cmd = call.args[0]
+            assert "rvtysh" in cmd
+            assert "-n" in cmd
+            asic_arg = cmd[cmd.index("-n") + 1]
+            assert asic_arg == "0"
+        mock_get_asic_id.assert_called_with("asic0")
+
+    @mock.patch('show.vtysh_helper.multi_asic.is_multi_asic')
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_namespace_ignored_on_single_asic(self, mock_subprocess, mock_is_multi):
+        """On single-ASIC, --namespace is silently ignored for help rendering
+        (the actual route command already rejects --namespace on single-ASIC).
+        SONiC's vtysh wrapper does not consume -n on single-ASIC, so passing
+        it would yield empty help output."""
+        mock_is_multi.return_value = False
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "  summary  Summary of all routes\n"
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"],
+            ["--namespace", "asic0", "--help"],
+        )
+
+        assert result.exit_code == 0
+        assert mock_subprocess.called
+        # rvtysh is invoked, but without -n.
+        for call in mock_subprocess.call_args_list:
+            cmd = call.args[0]
+            assert "rvtysh" in cmd
+            assert "-n" not in cmd
+
+    @mock.patch('show.vtysh_helper.subprocess.run')
+    def test_no_namespace_omits_n_flag(self, mock_subprocess):
+        """Without --namespace, rvtysh is invoked without -n (default namespace)."""
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_result.stdout = "  summary  Summary of all routes\n"
+        mock_subprocess.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["route"], ["--help"])
+
+        assert result.exit_code == 0
+        assert mock_subprocess.called
+        for call in mock_subprocess.call_args_list:
+            cmd = call.args[0]
+            assert "rvtysh" in cmd
+            assert "-n" not in cmd
+
 
 class TestVtyshCompletionCommands:
     """Test VtyshCommand completion functionality for vtysh-integrated commands."""

--- a/tests/vtysh_help_test.py
+++ b/tests/vtysh_help_test.py
@@ -456,7 +456,7 @@ class TestVtyshCompletionCommands:
         # Verify vtysh was called with " ?" (space before ?)
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args[0][0]
-        assert call_args == ['vtysh', '-c', 'show ip route ?']  # Note the space before ?
+        assert call_args == ['rvtysh', '-c', 'show ip route ?']  # Note the space before ?
 
         # Verify we got all completions
         assert "summary" in completions
@@ -485,7 +485,7 @@ class TestVtyshCompletionCommands:
 
         # Verify vtysh was called with "?" (no space before ?)
         call_args = mock_subprocess.call_args[0][0]
-        assert call_args == ['vtysh', '-c', 'show ip route summ?']  # No space before ?
+        assert call_args == ['rvtysh', '-c', 'show ip route summ?']  # No space before ?
 
     @mock.patch('show.vtysh_helper.subprocess.run')
     def test_shell_complete_end_to_end(self, mock_subprocess):


### PR DESCRIPTION
#### What I did

Add a new `VtyshCommand` class that extends click CLI commands with vtysh help text and shell completions. The class calls into vtysh to get subcommand information and generates help text following the existing SONiC CLI format.

Closes: [#24036](https://github.com/sonic-net/sonic-buildimage/issues/24036)

#### How I did it

Call into vtysh to extract subcommands and descriptions, and use that information to populate help text and completions. A `VtyshCommand` wrapper class handles everything so other commands can easily be extended.

**Update from original submission:** Replaced the old `click._bashcomplete` monkey-patch (removed in Click 8) with Click 8's native shell completion API — a `VtyshParamType` class that implements `shell_complete()` using `CompletionItem`. This is cleaner and forward-compatible.

An important consideration is whether it's acceptable to call into vtysh to retrieve this information. The underlying issue is that the `show ip route` command tree is implemented in FRR, not SONiC. The current CLI is a thin shim. This approach is a general solution that works for any show command passing through to vtysh, and automatically supports new vtysh commands.

Note: This PR does not handle description strings for user-defined arguments (IPADDRESS, vrf NAME, etc). That can be added in a follow-up.

#### How to verify it

Manually verify that subcommand help works, existing help works, tab completions work, and existing commands still function.

Unit tests:

```
tests/vtysh_help_test.py::TestVtyshHelpCommands::test_vtysh_help_basic_functionality PASSED
tests/vtysh_help_test.py::TestVtyshHelpCommands::test_vtysh_help_with_subcommands PASSED
tests/vtysh_help_test.py::TestVtyshHelpCommands::test_vtysh_help_without_subcommands PASSED
tests/vtysh_help_test.py::TestVtyshHelpCommands::test_nested_command_help PASSED
tests/vtysh_help_test.py::TestVtyshHelpCommands::test_basic_invalid_command_error_handling PASSED
tests/vtysh_help_test.py::TestVtyshHelpCommands::test_nested_invalid_command_error_handling PASSED
tests/vtysh_help_test.py::TestVtyshHelpCommands::test_vtysh_caching_functionality PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_basic_completion_functionality PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_nested_completion_functionality PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_completion_with_no_results PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_completion_with_vtysh_error PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_completion_with_whitespace_handling PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_nested_command_help_with_completion PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_nested_command_help_with_inline_completion PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_completion_false_uses_space_before_question_mark PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_completion_true_uses_no_space_before_question_mark PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_shell_complete_end_to_end PASSED
tests/vtysh_help_test.py::TestVtyshCompletionCommands::test_shell_complete_end_to_end_no_filter PASSED
```

#### New command output

```
admin@vlab-01:~$ show ip route -h
Usage: show ip route [OPTIONS] COMMAND [ARGS]...

Show IP (IPv4) routing table

Options:
  -d, --display TEXT    all|frontend
  -n, --namespace TEXT  Namespace name or all
  --verbose             Enable verbose output
  -?, -h, --help        Show this message and exit.

Commands:
  A.B.C.D         Network in the IP routing table to display
  A.B.C.D/M       IP prefix <network>/<length>, e.g., 35.0.0.0/8
  babel           Babel routing protocol (Babel)
  bgp             Border Gateway Protocol (BGP)
  connected       Connected routes (directly attached subnet or host)
  ...
  vrf             Specify the VRF
```