### PR TITLE
[202505] Added MAX pre-fec_ber for FEC counter (#4027)

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5261,11 +5261,11 @@ The "fec-stats" subcommand is used to disply the interface fec related statistic
 - Example:
   ```
   admin@ctd615:~$ show interfaces counters fec-stats
-        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FLR(O)    FLR(P) (Accuracy)
-  -----------  -------  ----------  ------------  ----------------  -------------  --------------    --------  -------------------
-   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00    4.31e-10       7.81e-10 (89%)
-   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           0       4.81e-10 (84%)
-  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00    1.24e-10       6.03e-09 (79%)
+      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
+-----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------  --------  -------------------
+ Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16  4.31e-10       7.81e-10 (89%)
+ Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14         0       4.81e-10 (84%)
+Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13  1.24e-10       6.03e-09 (79%)
   ```
 
 For debugging link related issues where you need to clear the FEC histogram and monitor the link again, use the following command

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -43,11 +43,11 @@ Ethernet8      N/A        6  1350.00 KB/s    9000.00/s        N/A       100     
 """  # noqa: E501
 
 intf_fec_counters = """\
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FLR(O)    FLR(P) (Accuracy)
----------  -------  ----------  ------------  ----------------  -------------  --------------  --------  -------------------
-Ethernet0        D     130,402             3                 4            N/A             N/A         0                    0
-Ethernet4      N/A     110,412             1                 0            N/A             N/A  4.21e-10       7.81e-10 (89%)
-Ethernet8      N/A     100,317             0                 0            N/A             N/A       N/A                  N/A
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
+---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------
+Ethernet0        D     130,402             3                 4            N/A             N/A                N/A         0                    0
+Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)
+Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A       N/A                  N/A
 """  # noqa: E501
 
 intf_fec_counters_fec_hist = """\

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -38,16 +38,16 @@ header_std = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP'
               'TX_OK', 'TX_BPS', 'TX_UTIL', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_errors_only = ['IFACE', 'STATE', 'RX_ERR', 'RX_DRP', 'RX_OVR', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_fec_only = ['IFACE', 'STATE', 'FEC_CORR', 'FEC_UNCORR', 'FEC_SYMBOL_ERR', 'FEC_PRE_BER',
-                   'FEC_POST_BER', 'FLR(O)', 'FLR(P) (Accuracy)']
+                   'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FLR(O)', 'FLR(P) (Accuracy)']
 header_fec_hist_only = ['IFACE', 'BIN0', 'BIN1', 'BIN2', 'BIN3', 'BIN4', 'BIN5', 'BIN6', 'BIN7',
                         'BIN8', 'BIN9', 'BIN10', 'BIN11', 'BIN12', 'BIN13', 'BIN14', 'BIN15']
 header_rates_only = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_OK', 'TX_BPS', 'TX_PPS', 'TX_UTIL']
 header_trim_only = ['IFACE', 'STATE', 'TRIM_PKTS']
 
 rates_key_list = ['RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_BPS', 'TX_PPS', 'TX_UTIL', 'FEC_PRE_BER',
-                  'FEC_POST_BER', 'FEC_FLR', 'FEC_FLR_PREDICTED', 'FEC_FLR_R_SQUARED']
+                  'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FEC_FLR', 'FEC_FLR_PREDICTED', 'FEC_FLR_R_SQUARED']
 ratestat_fields = ("rx_bps",  "rx_pps", "rx_util", "tx_bps", "tx_pps", "tx_util", "fec_pre_ber",
-                   "fec_post_ber", "fec_flr", "fec_flr_predicted", "fec_flr_r_squared")
+                   "fec_post_ber", "fec_pre_ber_max", "fec_flr", "fec_flr_predicted", "fec_flr_r_squared")
 RateStats = namedtuple("RateStats", ratestat_fields)
 
 """
@@ -241,6 +241,7 @@ class Portstat(object):
             tx_ovr = self.db.get(self.db.CHASSIS_STATE_DB, key, "tx_ovr")
             fec_pre_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_pre_ber")
             fec_post_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_post_ber")
+            fec_pre_ber_max = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_pre_ber_max")
             fec_flr = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr")
             fec_flr_predicted = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr_predicted")
             fec_flr_r_squared = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr_r_squared")
@@ -249,7 +250,7 @@ class Portstat(object):
                                                    [STATUS_NA] * (len(NStats._fields) - 8))._asdict()
             ratestat_dict[port_alias] = RateStats._make([rx_bps, rx_pps, rx_util, tx_bps,
                                                         tx_pps, tx_util, fec_pre_ber, fec_post_ber,
-                                                        fec_flr, fec_flr_predicted, fec_flr_r_squared])
+                                                        fec_pre_ber_max, fec_flr, fec_flr_predicted, fec_flr_r_squared])
         self.cnstat_dict.update(cnstat_dict)
         self.ratestat_dict.update(ratestat_dict)
 
@@ -335,7 +336,7 @@ class Portstat(object):
             """
                 Get the rates from specific table.
             """
-            fields = ["0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"]
+            fields = ["0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"]
             for pos, name in enumerate(rates_key_list):
                 full_table_id = RATES_TABLE_PREFIX + table_id
                 counter_data = self.db.get(self.db.COUNTERS_DB, full_table_id, name)
@@ -467,6 +468,7 @@ class Portstat(object):
                               format_number_with_comma(data['fec_symbol_err']),
                               format_fec_ber(rates.fec_pre_ber),
                               format_fec_ber(rates.fec_post_ber),
+                              format_fec_ber(rates.fec_pre_ber_max),
                               format_fec_flr(rates.fec_flr),
                               format_fec_flr_predicted(rates.fec_flr_predicted, rates.fec_flr_r_squared)))
             elif fec_hist_only:


### PR DESCRIPTION
202505 cherry-pick for https://github.com/sonic-net/sonic-utilities/pull/4027

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added new column FEC_PRE_BER_MAX in portstat -f

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show interfaces counters fec-stats 
      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FLR(O)    FLR(P) (Accuracy)
-----------  -------  ----------  ------------  ----------------  -------------  --------------  --------  -------------------
  Ethernet0        U         916             4               980       5.65e-11        0.00e+00       N/A                  N/A
  Ethernet1        U         220             4               284       1.88e-11        0.00e+00       N/A                  N/A
  Ethernet2        U          50             0                50       9.41e-12        0.00e+00       N/A                  N/A
  Ethernet3        U          88             4               152       0.00e+00        0.00e+00       N/A                  N/A
  Ethernet4        U          32             4                96       0.00e+00        0.00e+00       N/A                  N/A
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show interfaces counters fec-stats 
      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
-----------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------
  Ethernet0        U       4,048             0             4,048       1.41e-10        0.00e+00           3.01e-10       N/A                  N/A
  Ethernet1        U         768             0               768       0.00e+00        0.00e+00           9.41e-11       N/A                  N/A
  Ethernet2        U         310             0               310       9.41e-12        0.00e+00           3.76e-11       N/A                  N/A
  Ethernet3        U         277             0               277       9.41e-12        0.00e+00           4.71e-11       N/A                  N/A
  Ethernet4        U         102             0               102       9.41e-12        0.00e+00           1.88e-11       N/A                  N/A
```
