### PR TITLE
Add secondary poll factor to flex counter infra

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -118,6 +118,17 @@ def port_interval(ctx, poll_interval):
     ctx.obj.mod_entry("FLEX_COUNTER_TABLE", "PORT", port_info)
 
 
+@port.command('flr-interval-factor')
+@click.argument('factor', type=click.IntRange(min=1))
+def flr_interval_factor(factor):
+    """ Set port counter FLR interval factor """
+    configdb = ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    if factor is not None:
+        port_info['SECONDARY_POLL_FACTOR'] = factor
+    configdb.mod_entry("FLEX_COUNTER_TABLE", "PORT", port_info)
+
 @port.command(name='enable')
 @click.pass_context
 def port_enable(ctx):
@@ -846,7 +857,11 @@ def show(namespace):
     if queue_info:
         data.append(["QUEUE_STAT", queue_info.get("POLL_INTERVAL", DEFLT_10_SEC), queue_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_info:
-        data.append(["PORT_STAT", port_info.get("POLL_INTERVAL", DEFLT_1_SEC), port_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+        interval_display = port_info.get("POLL_INTERVAL", DEFLT_1_SEC)
+        flr_factor = port_info.get("SECONDARY_POLL_FACTOR", "")
+        if flr_factor:
+            interval_display = f"{interval_display} (FLR: {flr_factor})"
+        data.append(["PORT_STAT", interval_display, port_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_drop_info:
         data.append([PORT_BUFFER_DROP, port_drop_info.get("POLL_INTERVAL", DEFLT_60_SEC), port_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_phy_attr_info:


### PR DESCRIPTION
HLD Link : [fec-flr-hld](https://github.com/sonic-net/SONiC/blob/master/doc/port_fec_flr/port_fec_flr.md)


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added a secondary poll factor (FLR interval factor) feature to the flex counter infrastructure for port counters. This introduces a new `flr-interval-factor` command to the counterpoll utility.

#### How I did it

- Added a new CLI command `flr-interval-factor` under the port counter configuration that accepts an integer factor (minimum value of 1)
- Implemented a `flr_interval_factor()` function in `counterpoll/main.py` that sets the `SECONDARY_POLL_FACTOR` in the ConfigDB's FLEX_COUNTER_TABLE for PORT entries
- Modified the `show()` function to display the secondary poll factor when it's configured

#### How to verify it

1. Configure the FLR interval factor using the command:
   ```bash
   counterpoll port flr-interval-factor <factor>