### PR TITLE
[mellanox] [db_migrator] add a migration for tunnel ecn mode

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -935,6 +935,36 @@ class DBMigrator():
             except Exception as e:
                 log.log_error(f"Failed to migrate DHCP servers for {vlan_key}: {str(e)}")
 
+    def migrate_ipinip_tunnel_ecn_mode_mellanox(self):
+        """
+        Migrate IPINIP_TUNNEL ecn mode to copy_from_outer.
+
+        Prior to 202511, on Mellanox platform, the ecn mode of IPINIP tunnel was set to standard.
+        """
+
+        table_name = 'TUNNEL_DECAP_TABLE'
+        keys_to_migrate = [
+            'IPINIP_SUBNET',
+            'IPINIP_TUNNEL',
+            'IPINIP_SUBNET_V6',
+            'IPINIP_V6_TUNNEL'
+        ]
+
+        for k, v in self.appDB.get_table(table_name).items():
+            if k in keys_to_migrate:
+                log.log_info(f"Migrating APPL_DB {k}, ecn mode: {v.get('ecn_mode')} -> copy_from_outer")
+                v['ecn_mode'] = 'copy_from_outer'
+                self.appDB.set_entry(table_name, k, v)
+
+        state_db_keys = self.stateDB.keys(self.stateDB.STATE_DB, f"{table_name}:*")
+        if not state_db_keys:
+            return
+        for key in keys_to_migrate:
+            state_db_key = f"{table_name}:{key}"
+            if state_db_key in state_db_keys:
+                ecn_mode = self.stateDB.get(self.stateDB.STATE_DB, state_db_key, 'ecn_mode')
+                log.log_info(f"Migrating STATE_DB {state_db_key}, ecn mode: {ecn_mode} -> copy_from_outer")
+                self.stateDB.set(self.stateDB.STATE_DB, state_db_key, 'ecn_mode', 'copy_from_outer')
 
     def version_unknown(self):
         """
@@ -1396,6 +1426,8 @@ class DBMigrator():
         Version 202511_01
         """
         log.log_info('Handling version_202511_01')
+        if self.asic_type == "mellanox":
+            self.migrate_ipinip_tunnel_ecn_mode_mellanox()
         self.set_version('version_202605_01')
         return 'version_202605_01'
 

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -956,11 +956,11 @@ class DBMigrator():
                 v['ecn_mode'] = 'copy_from_outer'
                 self.appDB.set_entry(table_name, k, v)
 
-        state_db_keys = self.stateDB.keys(self.stateDB.STATE_DB, f"{table_name}:*")
+        state_db_keys = self.stateDB.keys(self.stateDB.STATE_DB, f"{table_name}|*")
         if not state_db_keys:
             return
         for key in keys_to_migrate:
-            state_db_key = f"{table_name}:{key}"
+            state_db_key = f"{table_name}|{key}"
             if state_db_key in state_db_keys:
                 ecn_mode = self.stateDB.get(self.stateDB.STATE_DB, state_db_key, 'ecn_mode')
                 log.log_info(f"Migrating STATE_DB {state_db_key}, ecn mode: {ecn_mode} -> copy_from_outer")

--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_expected.json
+++ b/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_expected.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE|IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_input.json
+++ b/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_input.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE|IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1243,18 +1243,18 @@ class TestIPinIPTunnelEcnModeMigrator(object):
         dbconnector.dedicated_dbs['STATE_DB'] = None
 
     def compare_keys(self, expected_db, resulting_db, db_name):
-        expected_keys = sorted(expected_db.keys(db_name, "*"))
-        resulting_keys = sorted(resulting_db.keys(db_name, "*"))
-        assert expected_keys == resulting_keys
-        for key in expected_keys:
-            expected_keys = expected_db.get_all(db_name, key)
-            resulting_keys = resulting_db.get_all(db_name, key)
-            diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
+        expected_values = sorted(expected_db.keys(db_name, "*"))
+        resulting_values = sorted(resulting_db.keys(db_name, "*"))
+        assert expected_values == resulting_values
+        for key in expected_values:
+            expected_values = expected_db.get_all(db_name, key)
+            resulting_values = resulting_db.get_all(db_name, key)
+            diff = DeepDiff(resulting_values, expected_values, ignore_order=True)
             assert not diff
 
     def test_ipinip_tunnel_ecn_mode_migrator(self):
         dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_input')
-        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_input')
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'tunnel_table_ecn_mode_input')
 
         device_info.get_sonic_version_info = get_sonic_version_info_mlnx
         import db_migrator
@@ -1262,7 +1262,7 @@ class TestIPinIPTunnelEcnModeMigrator(object):
         dbmgtr.migrate_ipinip_tunnel_ecn_mode_mellanox()
 
         dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_expected')
-        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_expected')
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'tunnel_table_ecn_mode_expected')
 
         expected_appl_db = SonicV2Connector(host='127.0.0.1')
         expected_appl_db.connect(expected_appl_db.APPL_DB)

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1229,3 +1229,45 @@ class TestDhcpv4RelayMigrator(object):
         # Verify migration was executed
         relay_entry = dbmgtr.configDB.get_entry("DHCPV4_RELAY", vlan_name)
         assert relay_entry.get("dhcpv4_servers") == [dhcp_server]
+
+
+class TestIPinIPTunnelEcnModeMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['APPL_DB'] = None
+        dbconnector.dedicated_dbs['STATE_DB'] = None
+
+    def compare_keys(self, expected_db, resulting_db, db_name):
+        expected_keys = sorted(expected_db.keys(db_name, "*"))
+        resulting_keys = sorted(resulting_db.keys(db_name, "*"))
+        assert expected_keys == resulting_keys
+        for key in expected_keys:
+            expected_keys = expected_db.get_all(db_name, key)
+            resulting_keys = resulting_db.get_all(db_name, key)
+            diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
+            assert not diff
+
+    def test_ipinip_tunnel_ecn_mode_migrator(self):
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_input')
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_input')
+
+        device_info.get_sonic_version_info = get_sonic_version_info_mlnx
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate_ipinip_tunnel_ecn_mode_mellanox()
+
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_expected')
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_expected')
+
+        expected_appl_db = SonicV2Connector(host='127.0.0.1')
+        expected_appl_db.connect(expected_appl_db.APPL_DB)
+        self.compare_keys(expected_appl_db, dbmgtr.appDB, 'APPL_DB')
+
+        expected_state_db = SonicV2Connector(host='127.0.0.1')
+        expected_state_db.connect(expected_state_db.STATE_DB)
+        self.compare_keys(expected_state_db, dbmgtr.stateDB, 'STATE_DB')


### PR DESCRIPTION
#### What I did
In the 202511, the tunnel ECN mode for Mellanox platforms has changed from standard to copy_from_outer.
This commit adds a migration that aligns APPL_DB to this change.

#### How I did it
Added a new migration for the Mellanox platform.

#### How to verify it
New unit test, manual tests.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

