### PR TITLE
Add counterpoll port-attr CLI support

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -7,7 +7,7 @@ from sonic_py_common import device_info
 
 BUFFER_POOL_WATERMARK = "BUFFER_POOL_WATERMARK"
 PORT_BUFFER_DROP = "PORT_BUFFER_DROP"
-PORT_SERDES_ATTR = "PORT_SERDES_ATTR"
+PORT_ATTR = "PORT_ATTR"
 PG_DROP = "PG_DROP"
 ACL = "ACL"
 ENI = "ENI"
@@ -139,38 +139,38 @@ def disable():
     port_info['FLEX_COUNTER_STATUS'] = DISABLE
     configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_BUFFER_DROP, port_info)
 
-# Port SERDES attributes counter commands
+# PHY counter commands
 @cli.group()
-def port_serdes_attr():
-    """ Port SERDES attributes counter commands """
+def phy():
+    """ PHY counter commands """
 
-@port_serdes_attr.command()
+@phy.command()
 @click.argument('poll_interval', type=click.IntRange(100, 30000))
 def interval(poll_interval):
-    """ Set port SERDES attributes counter query interval """
+    """ Set PHY counter query interval """
     configdb = ConfigDBConnector()
     configdb.connect()
     port_info = {}
     port_info['POLL_INTERVAL'] = poll_interval
-    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_SERDES_ATTR, port_info)
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_ATTR, port_info)
 
-@port_serdes_attr.command()
+@phy.command()
 def enable():
-    """ Enable port SERDES attributes counter query """
+    """ Enable PHY counter query """
     configdb = ConfigDBConnector()
     configdb.connect()
     port_info = {}
     port_info['FLEX_COUNTER_STATUS'] = ENABLE
-    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_SERDES_ATTR, port_info)
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_ATTR, port_info)
 
-@port_serdes_attr.command()
+@phy.command()
 def disable():
-    """ Disable port SERDES attributes counter query """
+    """ Disable PHY counter query """
     configdb = ConfigDBConnector()
     configdb.connect()
     port_info = {}
     port_info['FLEX_COUNTER_STATUS'] = DISABLE
-    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_SERDES_ATTR, port_info)
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_ATTR, port_info)
 
 # Ingress PG drop packet stat
 @cli.group()
@@ -581,7 +581,7 @@ def show():
     queue_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE')
     port_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PORT')
     port_drop_info = configdb.get_entry('FLEX_COUNTER_TABLE', PORT_BUFFER_DROP)
-    port_serdes_attr_info = configdb.get_entry('FLEX_COUNTER_TABLE', PORT_SERDES_ATTR)
+    port_attr_info = configdb.get_entry('FLEX_COUNTER_TABLE', PORT_ATTR)
     rif_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'RIF')
     queue_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE_WATERMARK')
     pg_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PG_WATERMARK')
@@ -604,8 +604,8 @@ def show():
         data.append(["PORT_STAT", port_info.get("POLL_INTERVAL", DEFLT_1_SEC), port_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_drop_info:
         data.append([PORT_BUFFER_DROP, port_drop_info.get("POLL_INTERVAL", DEFLT_60_SEC), port_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
-    if port_serdes_attr_info:
-        data.append([PORT_SERDES_ATTR, port_serdes_attr_info.get("POLL_INTERVAL", DEFLT_10_SEC), port_serdes_attr_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+    if port_attr_info:
+        data.append(["PHY", port_attr_info.get("POLL_INTERVAL", DEFLT_10_SEC), port_attr_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if rif_info:
         data.append(["RIF_STAT", rif_info.get("POLL_INTERVAL", DEFLT_1_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if queue_wm_info:


### PR DESCRIPTION
  #### What I did
  Added `counterpoll port-attr` CLI commands to enable/disable/configure PORT_ATTR flex counter monitoring.

  #### How I did it
  - Added `port_attr` command group in counterpoll/main.py
  - Implemented three subcommands:
    - `enable`: Sets FLEX_COUNTER_STATUS=enable in CONFIG_DB
    - `disable`: Sets FLEX_COUNTER_STATUS=disable in CONFIG_DB
    - `interval <100-30000>`: Sets POLL_INTERVAL in milliseconds (validated range)
  - Integrated PORT_ATTR status into `counterpoll show` output

  #### How to verify it
  ```bash
  # Enable PORT_ATTR monitoring
  counterpoll port-attr enable

  # Set polling interval to 5 seconds
  counterpoll port-attr interval 5000

  # Verify configuration
  counterpoll show

  # Disable monitoring
  counterpoll port-attr disable

  Previous command output (if the output of a command-line utility has changed)

  Type                        Interval (in ms)    Status
  --------------------------  ------------------  --------
  QUEUE_STAT                  10000               enable
  PORT_STAT                   1000                enable
  PORT_BUFFER_DROP            60000               enable
  RIF_STAT                    1000                enable
  QUEUE_WATERMARK_STAT        10000               enable
  PG_WATERMARK_STAT           10000               enable

  New command output (if the output of a command-line utility has changed)

  Type                        Interval (in ms)    Status
  --------------------------  ------------------  --------
  QUEUE_STAT                  10000               enable
  PORT_STAT                   1000                enable
  PORT_BUFFER_DROP            60000               enable
  PORT_ATTR            10000               enable
  RIF_STAT                    1000                enable
  QUEUE_WATERMARK_STAT        10000               enable
  PG_WATERMARK_STAT           10000               enable
