### PR TITLE
BGP chassis tests needed fixes after single asic VOQ fixed system support

### DIFF
--- a/tests/bgp_commands_test.py
+++ b/tests/bgp_commands_test.py
@@ -559,9 +559,9 @@ class TestBgpCommandsSingleAsic(object):
         indirect=['setup_single_bgp_instance_chassis']
     )
     @patch.object(multi_asic.MultiAsic, 'get_display_option', display_external)
-    @patch.object(device_info, 'is_chassis', mock.MagicMock(return_value=True))
+    @patch.object(device_info, 'is_voq_chassis', mock.MagicMock(return_value=True))
     def test_bgp_summary_v4_chassis(
-        self, mock_is_chassis, setup_bgp_commands,
+        self, setup_bgp_commands,
         setup_single_bgp_instance_chassis
     ):
         show = setup_bgp_commands
@@ -577,9 +577,9 @@ class TestBgpCommandsSingleAsic(object):
         indirect=['setup_single_bgp_instance_chassis']
     )
     @patch.object(multi_asic.MultiAsic, 'get_display_option', display_external)
-    @patch.object(device_info, 'is_chassis', mock.MagicMock(return_value=True))
+    @patch.object(device_info, 'is_voq_chassis', mock.MagicMock(return_value=True))
     def test_bgp_vrf_summary_v4_chassis(
-        self, mock_is_chassis, setup_bgp_commands,
+        self, setup_bgp_commands,
         setup_single_bgp_instance_chassis
     ):
         show = setup_bgp_commands
@@ -595,9 +595,9 @@ class TestBgpCommandsSingleAsic(object):
         indirect=['setup_single_bgp_instance_chassis']
     )
     @patch.object(multi_asic.MultiAsic, 'get_display_option', display_external)
-    @patch.object(device_info, 'is_chassis', mock.MagicMock(return_value=True))
+    @patch.object(device_info, 'is_voq_chassis', mock.MagicMock(return_value=True))
     def test_bgp_summary_v6_chassis(
-        self, mock_is_chassis, setup_bgp_commands,
+        self, setup_bgp_commands,
         setup_single_bgp_instance_chassis
     ):
         show = setup_bgp_commands
@@ -613,9 +613,9 @@ class TestBgpCommandsSingleAsic(object):
         indirect=['setup_single_bgp_instance_chassis']
     )
     @patch.object(multi_asic.MultiAsic, 'get_display_option', display_external)
-    @patch.object(device_info, 'is_chassis', mock.MagicMock(return_value=True))
+    @patch.object(device_info, 'is_voq_chassis', mock.MagicMock(return_value=True))
     def test_bgp_vrf_summary_v6_chassis(
-        self, mock_is_chassis, setup_bgp_commands,
+        self, setup_bgp_commands,
         setup_single_bgp_instance_chassis
     ):
         show = setup_bgp_commands


### PR DESCRIPTION
#### What I did
Currently bgp v4 and v6 chassis tests rely on switch type to be voq. But with recent single asic voq fixed system feature, this assumption has been changed.
So updated these tests to use is_voq_chassis() function instead of switch_type

Please see below PR for context:
https://github.com/sonic-net/sonic-buildimage/pull/24163

#### How I did it
Mocked is_voq_chassis() function

#### How to verify it
Run UT

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
