### PR TITLE
Improve show environment to have json formatted output option

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1712,9 +1712,12 @@ def version(verbose):
 
 @cli.command()
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def environment(verbose):
+@click.option('--json', '-j', is_flag=True, help="Output in json format")
+def environment(verbose, json):
     """Show environmentals (voltages, fans, temps)"""
     cmd = ['sudo', 'sensors']
+    if json:
+        cmd.append('-j')
     run_command(cmd, display_cmd=verbose)
 
 

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -1067,6 +1067,13 @@ class TestShow(object):
         mock_run_command.assert_called_with(['sudo', 'sensors'], display_cmd=True)
 
     @patch('show.main.run_command')
+    def test_show_environment_json(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands['environment'], ['--json'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'sensors', '-j'], display_cmd=False)
+
+    @patch('show.main.run_command')
     def test_show_users(self, mock_run_command):
         runner = CliRunner()
         result = runner.invoke(show.cli.commands['users'], ['--verbose'])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added ability to have output of `show environment` to be in json format for easier output parsing.

#### How I did it

`show environment` is just a wrapper to `sensors`. The `sensors` utility has an option `-j` such that the ouput is printed in json format. So added a `-j, —json` option on wrapper function.

#### How to verify it

```
admin@gold111:~$ show env -j | head
{
   "tmp451-i2c-96-4c":{
      "Adapter": "i2c-22-mux (chan_id 1)",
      "temp1":{
         "temp1_input": 26.687,
         "temp1_max": 85.000,
         "temp1_min": 0.000,
         "temp1_crit": 85.000,
         "temp1_crit_hyst": 75.000,
         "temp1_max_alarm": 0.000,
admin@gold111:~$
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

