### PR TITLE
Display only external ports on single-asic systems by default

### DIFF
--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -45,11 +45,9 @@ class MultiAsic(object):
         '''
         The function determines if the passed cli_object has to be displayed or not.
         returns true if the display_option is external and  the cli object is internal.
-        returns false, if the cli option is all or if it the platform is single ASIC.
+        returns false, if the cli option is all.
 
         '''
-        if not self.is_multi_asic and not device_info.is_chassis():
-            return False
         if self.get_display_option() == constants.DISPLAY_ALL:
             return False
         return self.is_object_internal(object_type, cli_object)
@@ -87,10 +85,7 @@ def multi_asic_display_choices():
 
 
 def multi_asic_display_default_option():
-    if not multi_asic.is_multi_asic() and not device_info.is_chassis():
-        return constants.DISPLAY_ALL
-    else:
-        return constants.DISPLAY_EXTERNAL
+    return constants.DISPLAY_EXTERNAL
 
 
 _multi_asic_click_option_display = click.option('--display',


### PR DESCRIPTION
Align the behavior of multi-asic and single-asic to only display external ports by default.
This will fix certain sonic-mgmt tests on single-asic systems with internal ports that don't expect them to be there.
See https://github.com/sonic-net/sonic-mgmt/issues/18249

Without this sonic-mgmt function calls like:
`duthost.show_interface(command="status", include_internal_intfs=False)['ansible_facts']['int_status']`
Would return internal ports on single-asic systems despite being passed `include_internal_intfs=False`

Without this change `qos/test_pfc_counters.py` fails on single-asic UT2 systems with:
```
        conn_facts = conn_graph_facts['device_conn'].get(duthost.hostname, {})
...
        int_status = asic.show_interface(command="status")[
            'ansible_facts']['int_status']
        """ We only test active physical interfaces """
        active_phy_intfs = [intf for intf in int_status if
                            intf.startswith('Ethernet') and
                            int_status[intf]['admin_state'] == 'up' and
                            int_status[intf]['oper_state'] == 'up']
...
                for intf in active_phy_intfs:
>                   peer_device = conn_facts[intf]['peerdevice']
E                   KeyError: 'Ethernet-Rec0'
```

With this change the test passes.
