### PR TITLE
Make 'show bfd {summary|peer}' commands work for software BFD sessions

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -8,6 +8,7 @@ import click
 import lazy_object_proxy
 import utilities_common.cli as clicommon
 from sonic_py_common import multi_asic
+from utilities_common import bfd_util
 import utilities_common.multi_asic as multi_asic_util
 from importlib import reload
 from natsort import natsorted
@@ -2671,7 +2672,7 @@ def bfd():
 def summary(db, namespace):
     """Show bfd session information"""
     bfd_headers = ["Peer Addr", "Interface", "Vrf", "State", "Type", "Local Addr",
-                "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
+                   "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
 
     if namespace is None:
         if multi_asic.is_multi_asic():
@@ -2684,17 +2685,47 @@ def summary(db, namespace):
     total_bfd_sessions = 0
     bfd_body = []
     for ns in namespace_list:
-        bfd_keys = db.db_clients[ns].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*")
-        if bfd_keys is None:
-            continue
-        total_bfd_sessions += len(bfd_keys)
-        for key in bfd_keys:
-            key_values = key.split('|')
-            values = db.db_clients[ns].get_all(db.db.STATE_DB, key)
-            if "local_discriminator" not in values.keys():
-                values["local_discriminator"] = "NA"
-            bfd_body.append([key_values[3], key_values[2], key_values[1], values["state"], values["type"], values["local_addr"],
-                                values["tx_interval"], values["rx_interval"], values["multiplier"], values["multihop"], values["local_discriminator"]])
+        # Check if software BFD is enabled
+        # Connect to config_db once and reuse the connection
+        config_db = multi_asic.connect_config_db_for_ns(ns)
+        if bfd_util.is_software_bfd_enabled(ns, config_db):
+            # Use vtysh to get BFD sessions from FRR
+            configured_peers = bfd_util.get_bfd_peers_from_config(ns, config_db)
+            frr_sessions = bfd_util.get_bfd_sessions_from_frr(ns)
+            filtered_sessions = bfd_util.filter_bfd_sessions_by_config(frr_sessions, configured_peers)
+            total_bfd_sessions += len(filtered_sessions)
+    
+            for session in filtered_sessions:
+                peer = session.get("peer", "")
+                interface = session.get("interface", "")
+                vrf = session.get("vrf", "default")
+                status = session.get("status", "")
+                session_type = session.get("type", "")
+                local_addr = session.get("local", "")
+                tx_interval = session.get("transmit-interval", "")
+                rx_interval = session.get("receive-interval", "")
+                multiplier = session.get("detect-multiplier", "")
+                multihop = "yes" if session.get("multihop") else "no"
+                local_disc = session.get("id", "NA")
+    
+                bfd_body.append([peer, interface, vrf, status, session_type,
+                                 local_addr, tx_interval, rx_interval, multiplier,
+                                 multihop, local_disc])
+        else:
+            # Use STATE_DB for hardware BFD
+            bfd_keys = db.db_clients[ns].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*")
+            if bfd_keys is None:
+                continue
+            total_bfd_sessions += len(bfd_keys)
+            for key in bfd_keys:
+                key_values = key.split('|')
+                values = db.db_clients[ns].get_all(db.db.STATE_DB, key)
+                if "local_discriminator" not in values.keys():
+                    values["local_discriminator"] = "NA"
+                bfd_body.append([key_values[3], key_values[2], key_values[1], values["state"],
+                                 values["type"], values["local_addr"], values["tx_interval"],
+                                 values["rx_interval"], values["multiplier"], values["multihop"],
+                                 values["local_discriminator"]])
 
     click.echo("Total number of BFD sessions: {}".format(total_bfd_sessions))
     click.echo(tabulate(bfd_body, bfd_headers))
@@ -2709,29 +2740,79 @@ def summary(db, namespace):
 def peer(db, peer_ip, namespace):
     """Show bfd session information for BFD peer"""
     bfd_headers = ["Peer Addr", "Interface", "Vrf", "State", "Type", "Local Addr",
-                "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
+                   "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
 
     if namespace is None:
         namespace = constants.DEFAULT_NAMESPACE
 
-    bfd_keys = db.db_clients[namespace].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*|{}".format(peer_ip))
-    delimiter = db.db_clients[namespace].get_db_separator(db.db.STATE_DB)
+    # Check if software BFD is enabled
+    # Connect to config_db once and reuse the connection
+    config_db = multi_asic.connect_config_db_for_ns(namespace)
+    if bfd_util.is_software_bfd_enabled(namespace, config_db):
+        # Use vtysh to get BFD sessions from FRR
+        configured_peers = bfd_util.get_bfd_peers_from_config(namespace, config_db)
 
-    if bfd_keys is None or len(bfd_keys) == 0:
-        click.echo("No BFD sessions found for peer IP {}".format(peer_ip))
-        return
+        # Check if the peer is configured
+        if peer_ip not in configured_peers:
+            click.echo("No BFD sessions found for peer IP {}".format(peer_ip))
+            return
 
-    click.echo("Total number of BFD sessions for peer IP {}: {}".format(peer_ip, len(bfd_keys)))
+        frr_sessions = bfd_util.get_bfd_sessions_from_frr(namespace)
 
-    bfd_body = []
-    if bfd_keys is not None:
-        for key in bfd_keys:
-            key_values = key.split(delimiter)
-            values = db.db_clients[namespace].get_all(db.db.STATE_DB, key)
-            if "local_discriminator" not in values.keys():
-                values["local_discriminator"] = "NA"
-            bfd_body.append([key_values[3], key_values[2], key_values[1], values.get("state"), values.get("type"), values.get("local_addr"),
-                                values.get("tx_interval"), values.get("rx_interval"), values.get("multiplier"), values.get("multihop"), values.get("local_discriminator")])
+        # Filter for the specific peer
+        peer_sessions = []
+        if peer_ip in frr_sessions:
+            peer_sessions.append(frr_sessions[peer_ip])
+
+        if not peer_sessions:
+            click.echo("No BFD sessions found for peer IP {}".format(peer_ip))
+            return
+
+        click.echo("Total number of BFD sessions for peer IP {}: {}".format(peer_ip, len(peer_sessions)))
+
+        bfd_body = []
+        for session in peer_sessions:
+            peer = session.get("peer", "")
+            interface = session.get("interface", "")
+            vrf = session.get("vrf", "default")
+            status = session.get("status", "")
+            session_type = session.get("type", "")
+            local_addr = session.get("local", "")
+            tx_interval = session.get("transmit-interval", "")
+            rx_interval = session.get("receive-interval", "")
+            multiplier = session.get("detect-multiplier", "")
+            multihop = "yes" if session.get("multihop") else "no"
+            local_disc = session.get("id", "NA")
+
+            bfd_body.append([peer, interface, vrf, status, session_type,
+                             local_addr, tx_interval, rx_interval, multiplier,
+                             multihop, local_disc])
+    else:
+        # Use STATE_DB for hardware BFD
+        bfd_keys = db.db_clients[namespace].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*|{}".format(peer_ip))
+        delimiter = db.db_clients[namespace].get_db_separator(db.db.STATE_DB)
+
+        if bfd_keys is None or len(bfd_keys) == 0:
+            click.echo("No BFD sessions found for peer IP {}".format(peer_ip))
+            return
+
+        click.echo("Total number of BFD sessions for peer IP {}: {}".format(peer_ip, len(bfd_keys)))
+
+        bfd_body = []
+        if bfd_keys is not None:
+            for key in bfd_keys:
+                key_values = key.split(delimiter)
+                values = db.db_clients[namespace].get_all(db.db.STATE_DB, key)
+                if "local_discriminator" not in values.keys():
+                    values["local_discriminator"] = "NA"
+                bfd_body.append([key_values[3], key_values[2], key_values[1],
+                                 values.get("state"), values.get("type"),
+                                 values.get("local_addr"),
+                                 values.get("tx_interval"),
+                                 values.get("rx_interval"),
+                                 values.get("multiplier"),
+                                 values.get("multihop"),
+                                 values.get("local_discriminator")])
 
     click.echo(tabulate(bfd_body, bfd_headers))
 

--- a/tests/test_bfd_util.py
+++ b/tests/test_bfd_util.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for utilities_common/bfd_util.py
+"""
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from utilities_common import bfd_util
+
+
+class TestBfdUtil:
+    """Test class for BFD utility functions"""
+
+    @pytest.fixture
+    def mock_config_db(self):
+        """Mock ConfigDBConnector"""
+        mock_db = MagicMock()
+        return mock_db
+
+    def test_is_software_bfd_enabled_true(self, mock_config_db):
+        """Test is_software_bfd_enabled returns True when enabled"""
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.is_software_bfd_enabled()
+
+        assert result is True
+        mock_config_db.get_entry.assert_called_once_with("SYSTEM_DEFAULTS", "software_bfd")
+
+    def test_is_software_bfd_enabled_false(self, mock_config_db):
+        """Test is_software_bfd_enabled returns False when disabled"""
+        mock_config_db.get_entry.return_value = {"status": "disabled"}
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.is_software_bfd_enabled()
+
+        assert result is False
+
+    def test_is_software_bfd_enabled_not_configured(self, mock_config_db):
+        """Test is_software_bfd_enabled returns False when not configured"""
+        mock_config_db.get_entry.return_value = {}
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.is_software_bfd_enabled()
+
+        assert result is False
+
+    def test_get_bfd_peers_from_config_bgp_neighbors(self, mock_config_db):
+        """Test get_bfd_peers_from_config extracts BGP neighbors with BFD enabled"""
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP table
+            {},
+            # BGP_NEIGHBOR table
+            {
+                ("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"},
+                ("default", "10.0.0.2"): {"bfd": "false", "asn": "65002"},
+                ("default", "10.0.0.3"): {"asn": "65003"},  # No BFD field
+            },
+            # BGP_INTERNAL_NEIGHBOR table
+            {
+                "fc00::1": {"bfd": "true", "asn": "65100"},
+            },
+            # STATIC_ROUTE table
+            {}
+        ]
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.get_bfd_peers_from_config()
+
+        assert result == {"10.0.0.1", "fc00::1"}
+
+    def test_get_bfd_peers_from_config_static_routes(self, mock_config_db):
+        """Test get_bfd_peers_from_config extracts static route nexthops with BFD enabled"""
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP table
+            {},
+            # BGP_NEIGHBOR table
+            {},
+            # BGP_INTERNAL_NEIGHBOR table
+            {},
+            # STATIC_ROUTE table
+            {
+                ("default", "192.168.0.0/24"): {"nexthop": "10.1.0.1,10.1.0.2", "bfd": "true"},
+                ("default", "192.168.1.0/24"): {"nexthop": "10.2.0.1", "bfd": "false"},
+                ("default", "192.168.2.0/24"): {"nexthop": "10.3.0.1"},  # No BFD field
+            }
+        ]
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.get_bfd_peers_from_config()
+
+        assert result == {"10.1.0.1", "10.1.0.2"}
+
+    def test_get_bfd_peers_from_config_combined(self, mock_config_db):
+        """Test get_bfd_peers_from_config with both BGP and static routes"""
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP table
+            {},
+            # BGP_NEIGHBOR table
+            {
+                ("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"},
+            },
+            # BGP_INTERNAL_NEIGHBOR table
+            {},
+            # STATIC_ROUTE table
+            {
+                ("default", "192.168.0.0/24"): {"nexthop": "10.1.0.1", "bfd": "true"},
+            }
+        ]
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.get_bfd_peers_from_config()
+
+        assert result == {"10.0.0.1", "10.1.0.1"}
+
+    def test_get_bfd_peers_from_config_peer_group(self, mock_config_db):
+        """Test get_bfd_peers_from_config with BGP peer group BFD inheritance"""
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP table
+            {
+                ("default", "PEER_V4"): {"bfd": "true", "asn": "65000"},
+                ("default", "PEER_V6"): {"bfd": "false", "asn": "65000"},
+            },
+            # BGP_NEIGHBOR table
+            {
+                ("default", "10.0.0.1"): {"peer_group": "PEER_V4", "asn": "65001"},
+                ("default", "10.0.0.2"): {"peer_group": "PEER_V6", "asn": "65002"},
+                ("default", "10.0.0.3"): {"bfd": "true", "asn": "65003"},  # Direct BFD
+            },
+            # BGP_INTERNAL_NEIGHBOR table
+            {},
+            # STATIC_ROUTE table
+            {}
+        ]
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.get_bfd_peers_from_config()
+
+        # Should include: 10.0.0.1 (from PEER_V4 group), 10.0.0.3 (direct BFD)
+        # Should NOT include: 10.0.0.2 (PEER_V6 has bfd=false)
+        assert result == {"10.0.0.1", "10.0.0.3"}
+
+    @patch('utilities_common.cli.run_command')
+    def test_run_bfd_command_success(self, mock_run_command):
+        """Test run_bfd_command executes vtysh successfully"""
+        mock_run_command.return_value = ('{"peers": []}', 0)
+
+        result = bfd_util.run_bfd_command("show bfd peers json")
+
+        assert result == '{"peers": []}'
+        mock_run_command.assert_called_once()
+
+    @patch('utilities_common.cli.run_command')
+    def test_run_bfd_command_failure(self, mock_run_command):
+        """Test run_bfd_command handles vtysh failure"""
+        mock_run_command.return_value = ('Error: command failed', 1)
+
+        result = bfd_util.run_bfd_command("show bfd peers json")
+
+        assert result is None
+
+    @patch('utilities_common.bfd_util.run_bfd_command')
+    def test_get_bfd_sessions_from_frr_success(self, mock_run_bfd_command):
+        """Test get_bfd_sessions_from_frr parses FRR output correctly"""
+        frr_output = json.dumps([
+            {"peer": "10.0.0.1", "status": "up", "interface": "Ethernet0"},
+            {"peer": "10.0.0.2", "status": "down", "interface": "Ethernet4"},
+        ])
+        mock_run_bfd_command.return_value = frr_output
+
+        result = bfd_util.get_bfd_sessions_from_frr()
+
+        assert len(result) == 2
+        assert "10.0.0.1" in result
+        assert "10.0.0.2" in result
+        assert result["10.0.0.1"]["status"] == "up"
+
+    @patch('utilities_common.bfd_util.run_bfd_command')
+    def test_get_bfd_sessions_from_frr_empty(self, mock_run_bfd_command):
+        """Test get_bfd_sessions_from_frr handles empty output"""
+        mock_run_bfd_command.return_value = ''
+
+        result = bfd_util.get_bfd_sessions_from_frr()
+
+        assert result == {}
+
+    @patch('utilities_common.bfd_util.run_bfd_command')
+    def test_get_bfd_sessions_from_frr_invalid_json(self, mock_run_bfd_command):
+        """Test get_bfd_sessions_from_frr handles invalid JSON"""
+        mock_run_bfd_command.return_value = 'invalid json'
+
+        result = bfd_util.get_bfd_sessions_from_frr()
+
+        assert result == {}
+
+    def test_filter_bfd_sessions_by_config(self):
+        """Test filter_bfd_sessions_by_config filters sessions correctly"""
+        frr_sessions = {
+            "10.0.0.1": {"peer": "10.0.0.1", "status": "up"},
+            "10.0.0.2": {"peer": "10.0.0.2", "status": "down"},
+            "10.0.0.3": {"peer": "10.0.0.3", "status": "up"},
+        }
+        configured_peers = {"10.0.0.1", "10.0.0.3"}
+
+        result = bfd_util.filter_bfd_sessions_by_config(frr_sessions, configured_peers)
+
+        assert len(result) == 2
+        assert any(s["peer"] == "10.0.0.1" for s in result)
+        assert any(s["peer"] == "10.0.0.3" for s in result)
+        assert not any(s["peer"] == "10.0.0.2" for s in result)
+
+    def test_filter_bfd_sessions_by_config_empty_configured(self):
+        """Test filter_bfd_sessions_by_config with no configured peers"""
+        frr_sessions = {
+            "10.0.0.1": {"peer": "10.0.0.1", "status": "up"},
+        }
+        configured_peers = set()
+
+        result = bfd_util.filter_bfd_sessions_by_config(frr_sessions, configured_peers)
+
+        assert len(result) == 0
+
+    def test_filter_bfd_sessions_by_config_empty_frr(self):
+        """Test filter_bfd_sessions_by_config with no FRR sessions"""
+        frr_sessions = {}
+        configured_peers = {"10.0.0.1"}
+
+        result = bfd_util.filter_bfd_sessions_by_config(frr_sessions, configured_peers)
+
+        assert len(result) == 0
+
+    def test_get_bfd_peers_from_config_empty_tables(self, mock_config_db):
+        """Test get_bfd_peers_from_config when all tables are empty"""
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP table - empty
+            {},
+            # BGP_NEIGHBOR table - empty
+            {},
+            # BGP_INTERNAL_NEIGHBOR table - empty
+            {},
+            # STATIC_ROUTE table - empty
+            {}
+        ]
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.get_bfd_peers_from_config()
+
+        assert result == set()
+
+    def test_get_bfd_peers_from_config_nonexistent_tables(self, mock_config_db):
+        """Test get_bfd_peers_from_config when tables don't exist (get_table returns {})"""
+        # When a table doesn't exist, ConfigDBConnector.get_table() returns {}
+        mock_config_db.get_table.return_value = {}
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.get_bfd_peers_from_config()
+
+        # Should not raise AttributeError when calling .items() on empty dict
+        assert result == set()
+
+    @patch('utilities_common.cli.run_command')
+    def test_run_bfd_command_returns_none_on_error(self, mock_run_command):
+        """Test run_bfd_command returns None when command fails"""
+        mock_run_command.return_value = ('Error: FRR not running', 127)
+
+        result = bfd_util.run_bfd_command("show bfd peers json")
+
+        assert result is None
+
+    @patch('utilities_common.bfd_util.run_bfd_command')
+    def test_get_bfd_sessions_from_frr_handles_none(self, mock_run_bfd_command):
+        """Test get_bfd_sessions_from_frr handles None return from run_bfd_command"""
+        mock_run_bfd_command.return_value = None
+
+        result = bfd_util.get_bfd_sessions_from_frr()
+
+        assert result == {}
+
+    def test_get_bfd_peers_legacy_key_format(self, mock_config_db):
+        """Test get_bfd_peers_from_config handles legacy key format (non-tuple)"""
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP table
+            {},
+            # BGP_NEIGHBOR table - legacy format with string keys
+            {
+                "10.0.0.1": {"bfd": "true", "asn": "65001"},
+                "10.0.0.2": {"asn": "65002"},
+            },
+            # BGP_INTERNAL_NEIGHBOR table
+            {},
+            # STATIC_ROUTE table
+            {}
+        ]
+
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = bfd_util.get_bfd_peers_from_config()
+
+        assert result == {"10.0.0.1"}
+
+    def test_is_software_bfd_enabled_with_config_db_handle(self, mock_config_db):
+        """Test is_software_bfd_enabled with pre-existing config_db handle"""
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+
+        # Pass config_db directly, should not call connect_config_db_for_ns
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns') as mock_connect:
+            result = bfd_util.is_software_bfd_enabled(config_db=mock_config_db)
+
+        assert result is True
+        # Should NOT have called connect_config_db_for_ns since we passed config_db
+        mock_connect.assert_not_called()
+        mock_config_db.get_entry.assert_called_once_with("SYSTEM_DEFAULTS", "software_bfd")
+
+    def test_get_bfd_peers_from_config_with_config_db_handle(self, mock_config_db):
+        """Test get_bfd_peers_from_config with pre-existing config_db handle"""
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP table
+            {},
+            # BGP_NEIGHBOR table
+            {
+                ("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"},
+            },
+            # BGP_INTERNAL_NEIGHBOR table
+            {},
+            # STATIC_ROUTE table
+            {}
+        ]
+
+        # Pass config_db directly, should not call connect_config_db_for_ns
+        with patch('sonic_py_common.multi_asic.connect_config_db_for_ns') as mock_connect:
+            result = bfd_util.get_bfd_peers_from_config(config_db=mock_config_db)
+
+        assert result == {"10.0.0.1"}
+        # Should NOT have called connect_config_db_for_ns since we passed config_db
+        mock_connect.assert_not_called()

--- a/tests/test_show_bfd_software.py
+++ b/tests/test_show_bfd_software.py
@@ -1,0 +1,542 @@
+"""
+Unit tests for 'show bfd' commands with software BFD support
+"""
+import json
+import os
+import pytest
+from click.testing import CliRunner
+from unittest import mock
+from utilities_common.db import Db
+from utilities_common import bfd_util
+import show.main as show
+
+
+class TestShowBfdSoftware:
+    """Test class for show bfd commands with software BFD"""
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @pytest.fixture
+    def runner(self):
+        """Click test runner"""
+        return CliRunner()
+
+    @pytest.fixture
+    def db(self):
+        """Database object"""
+        return Db()
+
+    def test_show_bfd_summary_software_bfd_enabled(self, runner, db):
+        """Test show bfd summary with software BFD enabled"""
+        # Mock FRR output
+        frr_output = json.dumps([
+            {
+                "peer": "10.0.0.1",
+                "interface": "Ethernet0",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.0.0.2",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 1234567890
+            }
+        ])
+
+        # Mock config DB
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"}},
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        # Mock the functions
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        # Restore
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions: 1" in result.output
+        assert "10.0.0.1" in result.output
+        assert "Ethernet0" in result.output
+        assert "up" in result.output
+
+    def test_show_bfd_summary_software_bfd_filters_unconfigured(self, runner, db):
+        """Test show bfd summary filters out unconfigured peers"""
+        # Mock FRR output with two sessions (one not configured)
+        frr_output = json.dumps([
+            {
+                "peer": "10.0.0.1",
+                "interface": "Ethernet0",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.0.0.2",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 1234567890
+            },
+            {
+                "peer": "10.0.0.99",  # Not configured in CONFIG_DB
+                "interface": "Ethernet4",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.0.0.2",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 1234567891
+            }
+        ])
+
+        # Mock config DB - only one BGP neighbor configured
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"}},
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions: 1" in result.output
+        assert "10.0.0.1" in result.output
+        assert "10.0.0.99" not in result.output  # Should be filtered out
+
+    def test_show_bfd_summary_software_bfd_static_routes(self, runner, db):
+        """Test show bfd summary with static route BFD peers"""
+        # Mock FRR output
+        frr_output = json.dumps([
+            {
+                "peer": "10.1.0.1",
+                "interface": "default",
+                "vrf": "default",
+                "status": "down",
+                "type": "async_active",
+                "local": "10.1.0.2",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": True,
+                "id": 9876543210
+            }
+        ])
+
+        # Mock config DB - static route with BFD
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {},
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {("default", "192.168.0.0/24"): {"nexthop": "10.1.0.1", "bfd": "true"}}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions: 1" in result.output
+        assert "10.1.0.1" in result.output
+
+    def test_show_bfd_summary_hardware_bfd(self, runner, db):
+        """Test show bfd summary with hardware BFD (backward compatibility)"""
+        # Mock config DB - software BFD disabled
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "disabled"}
+
+        # Set up STATE_DB with hardware BFD sessions
+        dbconnector = db.db
+        dbconnector.set(dbconnector.STATE_DB,
+                        "BFD_SESSION_TABLE|default|Ethernet0|10.0.0.1",
+                        "state", "UP")
+        dbconnector.set(dbconnector.STATE_DB,
+                        "BFD_SESSION_TABLE|default|Ethernet0|10.0.0.1",
+                        "type", "async_active")
+        dbconnector.set(dbconnector.STATE_DB,
+                        "BFD_SESSION_TABLE|default|Ethernet0|10.0.0.1",
+                        "local_addr", "10.0.0.2")
+        dbconnector.set(dbconnector.STATE_DB,
+                        "BFD_SESSION_TABLE|default|Ethernet0|10.0.0.1",
+                        "tx_interval", "300")
+        dbconnector.set(dbconnector.STATE_DB,
+                        "BFD_SESSION_TABLE|default|Ethernet0|10.0.0.1",
+                        "rx_interval", "300")
+        dbconnector.set(dbconnector.STATE_DB,
+                        "BFD_SESSION_TABLE|default|Ethernet0|10.0.0.1",
+                        "multiplier", "3")
+        dbconnector.set(dbconnector.STATE_DB,
+                        "BFD_SESSION_TABLE|default|Ethernet0|10.0.0.1",
+                        "multihop", "false")
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        assert result.exit_code == 0
+        assert "10.0.0.1" in result.output
+        assert "Ethernet0" in result.output
+
+    def test_show_bfd_peer_software_bfd_found(self, runner, db):
+        """Test show bfd peer with software BFD - peer found"""
+        # Mock FRR output
+        frr_output = json.dumps([
+            {
+                "peer": "10.0.0.1",
+                "interface": "Ethernet0",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.0.0.2",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 1234567890
+            }
+        ])
+
+        # Mock config DB
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"}},
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['peer'], ['10.0.0.1'], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions for peer IP 10.0.0.1: 1" in result.output
+        assert "10.0.0.1" in result.output
+        assert "Ethernet0" in result.output
+
+    def test_show_bfd_peer_software_bfd_not_configured(self, runner, db):
+        """Test show bfd peer with software BFD - peer not configured"""
+        # Mock config DB - no BGP neighbors
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {},
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['peer'], ['10.0.0.99'], obj=db)
+
+        assert result.exit_code == 0
+        assert "No BFD sessions found for peer IP 10.0.0.99" in result.output
+
+    def test_show_bfd_peer_software_bfd_configured_but_not_in_frr(self, runner, db):
+        """Test show bfd peer - configured but session not up in FRR"""
+        # Mock FRR output - empty (session not established yet)
+        frr_output = json.dumps([])
+
+        # Mock config DB - BGP neighbor configured
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"}},
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['peer'], ['10.0.0.1'], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        # Should show no sessions because FRR doesn't have it yet
+        assert "No BFD sessions found for peer IP 10.0.0.1" in result.output
+
+    def test_show_bfd_summary_software_bfd_no_sessions(self, runner, db):
+        """Test show bfd summary with software BFD but no sessions"""
+        # Mock empty FRR output
+        frr_output = json.dumps([])
+
+        # Mock config DB - no configured peers
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {},
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions: 0" in result.output
+
+    def test_show_bfd_summary_software_bfd_ipv6_and_multihop(self, runner, db):
+        """Test show bfd summary with IPv6 peers and multihop sessions"""
+        # Mock FRR output with IPv6 and multihop
+        frr_output = json.dumps([
+            {
+                "peer": "fc00::1",
+                "interface": "Ethernet0",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "fc00::2",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 1111111111
+            },
+            {
+                "peer": "fc00::10",
+                "interface": "default",
+                "vrf": "default",
+                "status": "down",
+                "type": "async_active",
+                "local": "fc00::2",
+                "transmit-interval": 500,
+                "receive-interval": 500,
+                "detect-multiplier": 5,
+                "multihop": True,
+                "id": 2222222222
+            }
+        ])
+
+        # Mock config DB - IPv6 BGP neighbor and static route
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {},
+            # BGP_INTERNAL_NEIGHBOR
+            {("default", "fc00::1"): {"bfd": "true", "asn": "65100"}},
+            # STATIC_ROUTE
+            {("default", "2001:db8::/32"): {"nexthop": "fc00::10", "bfd": "true"}}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions: 2" in result.output
+        assert "fc00::1" in result.output
+        assert "fc00::10" in result.output
+        assert "yes" in result.output  # multihop = yes
+        assert "no" in result.output   # multihop = no
+
+    def test_show_bfd_summary_software_bfd_multiple_vrfs(self, runner, db):
+        """Test show bfd summary with multiple VRFs"""
+        # Mock FRR output with multiple VRFs
+        frr_output = json.dumps([
+            {
+                "peer": "10.0.0.1",
+                "interface": "Ethernet0",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.0.0.2",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 3333333333
+            },
+            {
+                "peer": "10.1.0.1",
+                "interface": "Ethernet4",
+                "vrf": "VrfRed",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.1.0.2",
+                "transmit-interval": 200,
+                "receive-interval": 200,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 4444444444
+            }
+        ])
+
+        # Mock config DB - BGP neighbors in different VRFs
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP
+            {},
+            # BGP_NEIGHBOR
+            {
+                ("default", "10.0.0.1"): {"bfd": "true", "asn": "65001"},
+                ("VrfRed", "10.1.0.1"): {"bfd": "true", "asn": "65002"},
+            },
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions: 2" in result.output
+        assert "10.0.0.1" in result.output
+        assert "10.1.0.1" in result.output
+        assert "VrfRed" in result.output
+
+    def test_show_bfd_summary_peer_group_inheritance(self, runner, db):
+        """Test show bfd summary with BGP peer group BFD inheritance"""
+        # Mock FRR output
+        frr_output = json.dumps([
+            {
+                "peer": "10.0.0.1",
+                "interface": "Ethernet0",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.0.0.10",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 1234567890
+            },
+            {
+                "peer": "10.0.0.3",
+                "interface": "Ethernet2",
+                "vrf": "default",
+                "status": "up",
+                "type": "async_active",
+                "local": "10.0.0.11",
+                "transmit-interval": 300,
+                "receive-interval": 300,
+                "detect-multiplier": 3,
+                "multihop": False,
+                "id": 1234567891
+            }
+        ])
+
+        # Mock config DB - peer group with BFD and neighbors inheriting from it
+        mock_config_db = mock.MagicMock()
+        mock_config_db.get_entry.return_value = {"status": "enabled"}
+        mock_config_db.get_table.side_effect = [
+            # BGP_PEER_GROUP - PEER_V4 has BFD enabled
+            {
+                ("default", "PEER_V4"): {"bfd": "true", "asn": "65000"},
+                ("default", "PEER_V6"): {"bfd": "false", "asn": "65000"},
+            },
+            # BGP_NEIGHBOR
+            {
+                ("default", "10.0.0.1"): {"peer_group": "PEER_V4", "asn": "65001"},  # Inherits BFD
+                ("default", "10.0.0.2"): {"peer_group": "PEER_V6", "asn": "65002"},  # No BFD
+                ("default", "10.0.0.3"): {"bfd": "true", "asn": "65003"},  # Direct BFD
+            },
+            # BGP_INTERNAL_NEIGHBOR
+            {},
+            # STATIC_ROUTE
+            {}
+        ]
+
+        _old_run_bfd_command = bfd_util.run_bfd_command
+        bfd_util.run_bfd_command = mock.MagicMock(return_value=frr_output)
+
+        with mock.patch('sonic_py_common.multi_asic.connect_config_db_for_ns', return_value=mock_config_db):
+            result = runner.invoke(show.cli.commands['bfd'].commands['summary'], [], obj=db)
+
+        bfd_util.run_bfd_command = _old_run_bfd_command
+
+        assert result.exit_code == 0
+        assert "Total number of BFD sessions: 2" in result.output
+        # Should show 10.0.0.1 (inherited from PEER_V4) and 10.0.0.3 (direct BFD)
+        assert "10.0.0.1" in result.output
+        assert "10.0.0.3" in result.output
+        # Should NOT show 10.0.0.2 (PEER_V6 has bfd=false)
+        assert "10.0.0.2" not in result.output

--- a/utilities_common/bfd_util.py
+++ b/utilities_common/bfd_util.py
@@ -1,0 +1,142 @@
+import json
+
+import utilities_common.cli as clicommon
+from sonic_py_common import multi_asic
+from utilities_common import constants
+
+
+def is_software_bfd_enabled(namespace=multi_asic.DEFAULT_NAMESPACE, config_db=None):
+    """
+    Check if software BFD is enabled in CONFIG_DB
+    :param namespace: namespace name
+    :param config_db: ConfigDBConnector instance (optional, will create if not provided)
+    :return: True if software BFD is enabled, False otherwise
+    """
+    if config_db is None:
+        config_db = multi_asic.connect_config_db_for_ns(namespace)
+    sys_defaults = config_db.get_entry("SYSTEM_DEFAULTS", "software_bfd")
+    if sys_defaults and "status" in sys_defaults:
+        return sys_defaults["status"] == "enabled"
+    return False
+
+
+def get_bfd_peers_from_config(namespace=multi_asic.DEFAULT_NAMESPACE, config_db=None):
+    """
+    Get all BFD-enabled peers from CONFIG_DB (BGP neighbors and static routes)
+    :param namespace: namespace name
+    :param config_db: ConfigDBConnector instance (optional, will create if not provided)
+    :return: set of peer IP addresses that have BFD configured
+    """
+    if config_db is None:
+        config_db = multi_asic.connect_config_db_for_ns(namespace)
+    bfd_peers = set()
+
+    # First, find peer groups with BFD enabled
+    bfd_peer_groups = set()
+    peer_groups = config_db.get_table("BGP_PEER_GROUP")
+    for key, data in peer_groups.items():
+        if data.get("bfd") == "true":
+            if isinstance(key, tuple):
+                # Unified mode: key is (vrf, peer_group_name)
+                peer_group_name = key[1] if len(key) > 1 else key[0]
+            else:
+                # Legacy mode: key is peer_group_name
+                peer_group_name = key
+            bfd_peer_groups.add(peer_group_name)
+
+    # Get BFD-enabled BGP neighbors (either directly or via peer group)
+    bgp_tables = [
+        multi_asic.BGP_NEIGH_CFG_DB_TABLE,
+        multi_asic.BGP_INTERNAL_NEIGH_CFG_DB_TABLE,
+    ]
+
+    for table in bgp_tables:
+        neighbors = config_db.get_table(table)
+        for key, data in neighbors.items():
+            if isinstance(key, tuple):
+                # Unified mode: key is (vrf, neighbor_ip)
+                neighbor_ip = key[1] if len(key) > 1 else key[0]
+            else:
+                # Legacy mode: key is neighbor_ip
+                neighbor_ip = key
+
+            # Check if BFD is enabled directly on the neighbor
+            if data.get("bfd") == "true":
+                bfd_peers.add(neighbor_ip)
+            # Or if the neighbor inherits BFD from its peer group
+            elif data.get("peer_group") in bfd_peer_groups:
+                bfd_peers.add(neighbor_ip)
+
+    # Get BFD-enabled static routes
+    static_routes = config_db.get_table("STATIC_ROUTE")
+    for key, data in static_routes.items():
+        if data.get("bfd") == "true":
+            # Extract nexthop IPs from the static route
+            nexthops = data.get("nexthop", "")
+            if nexthops:
+                for nh in nexthops.split(","):
+                    nh = nh.strip()
+                    if nh:
+                        bfd_peers.add(nh)
+
+    return bfd_peers
+
+
+def run_bfd_command(vtysh_cmd, namespace=multi_asic.DEFAULT_NAMESPACE):
+    """
+    Run a BFD command via vtysh
+    :param vtysh_cmd: vtysh command to run
+    :param namespace: namespace name
+    :return: command output (string), or None if command fails
+    """
+    bgp_instance_id = []
+    if namespace != multi_asic.DEFAULT_NAMESPACE:
+        bgp_instance_id = ['-n', str(multi_asic.get_asic_id_from_name(namespace))]
+
+    cmd = ['sudo', constants.RVTYSH_COMMAND] + bgp_instance_id + ['-c', vtysh_cmd]
+    output, ret = clicommon.run_command(cmd, return_cmd=True)
+
+    if ret != 0:
+        return None
+
+    return output
+
+
+def get_bfd_sessions_from_frr(namespace=multi_asic.DEFAULT_NAMESPACE):
+    """
+    Get BFD sessions from FRR via vtysh
+    :param namespace: namespace name
+    :return: dict of BFD sessions keyed by peer IP
+    """
+    vtysh_cmd = "show bfd peers json"
+    output = run_bfd_command(vtysh_cmd, namespace)
+
+    if not output:
+        return {}
+
+    try:
+        bfd_sessions = json.loads(output)
+        # FRR returns a list of sessions
+        # Convert to dict keyed by peer IP for easier lookup
+        sessions_by_peer = {}
+        for session in bfd_sessions:
+            peer = session.get("peer")
+            if peer:
+                sessions_by_peer[peer] = session
+        return sessions_by_peer
+    except (ValueError, json.JSONDecodeError):
+        return {}
+
+
+def filter_bfd_sessions_by_config(frr_sessions, configured_peers):
+    """
+    Filter FRR BFD sessions to only include those configured in CONFIG_DB
+    :param frr_sessions: dict of BFD sessions from FRR (keyed by peer IP)
+    :param configured_peers: set of peer IPs configured in CONFIG_DB
+    :return: list of filtered BFD sessions
+    """
+    filtered_sessions = []
+    for peer_ip, session in frr_sessions.items():
+        if peer_ip in configured_peers:
+            filtered_sessions.append(session)
+    return filtered_sessions


### PR DESCRIPTION
fixes# [4139](https://github.com/sonic-net/sonic-utilities/issues/4139)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When software BFD is enabled (CONFIG_DB:SYSTEM_DEFAULTS|software_bfd|status=enabled), the `show bfd summary` and `show bfd peer` commands now:

1. Query FRR directly via vtysh (similar to `show ip bgp` commands)
2. Filter BFD sessions to only show peers configured in CONFIG_DB:
   - BGP neighbors with bfd=true
   - Static routes with bfd=true
   
   This fixes the issue where software BFD sessions were not visible in 'show bfd summary' because they are not written to STATE_DB:BFD_SESSION_TABLE.

For hardware BFD, the commands continue to use STATE_DB as before.

#### How I did it

Changes:
- Added utilities_common/bfd_util.py with helper functions:
  - is_software_bfd_enabled(): Check if software BFD is configured
  - get_bfd_peers_from_config(): Get BFD-enabled peers from CONFIG_DB
  - get_bfd_sessions_from_frr(): Query FRR via vtysh
  - filter_bfd_sessions_by_config(): Filter FRR sessions by CONFIG_DB

- Updated show/main.py:
  - Modified 'show bfd summary' to use vtysh for software BFD
  - Modified 'show bfd peer' to use vtysh for software BFD
  - Both commands filter output to only show configured peers


#### How to verify it

Unit tests are added.

Manual verification:
```
vtysh output:
admin@vlab-01:~$ vtysh -c "show bfd peers json" | jq .
[
  {
    "multihop": false,
    "peer": "10.0.0.33",
    "local": "10.0.0.32",
    "vrf": "default",
    "interface": "Ethernet4",
    "id": 3483190008,
    "remote-id": 0,
    "passive-mode": false,
    "status": "down",
    "downtime": 1697,
    "diagnostic": "ok",
    "remote-diagnostic": "ok",
    "type": "dynamic",
    "receive-interval": 300,
    "transmit-interval": 300,
    "echo-receive-interval": 50,
    "echo-transmit-interval": 0,
    "detect-multiplier": 3,
    "remote-receive-interval": 1000,
    "remote-transmit-interval": 1000,
    "remote-echo-receive-interval": 0,
    "remote-detect-multiplier": 3,
    "rtt-min": 0,
    "rtt-avg": 0,
    "rtt-max": 0
  }
]
```

sonic command output after the change:
```
admin@vlab-01:~$ show bfd summary
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type     Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  -------  ------------  -------------  -------------  ------------  ----------  ---------------------
10.0.0.33    Ethernet4    default  down     dynamic  10.0.0.32               300            300             3  no                     3483190008

admin@vlab-01:~$ show bfd peer 10.0.0.33
Total number of BFD sessions for peer IP 10.0.0.33: 1
Peer Addr    Interface    Vrf      State    Type     Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  -------  ------------  -------------  -------------  ------------  ----------  ---------------------
10.0.0.33    Ethernet4    default  down     dynamic  10.0.0.32               300            300             3  no                     3483190008
admin@vlab-01:~$
```

#### Previous command output (if the output of a command-line utility has changed)
```
admin@vlab-01:~$ show bfd summary
show bfd summary
Total number of BFD sessions: 0
Peer Addr    Interface    Vrf    State    Type    Local Addr    TX Interval    RX Interval    Multiplier    Multihop    Local Discriminator
-----------  -----------  -----  -------  ------  ------------  -------------  -------------  ------------  ----------  ---------------------

admin@vlab-01:~$ show bfd peer 10.0.0.33
No BFD sessions found for peer IP 10.0.0.33
admin@vlab-01:~$
```

#### New command output (if the output of a command-line utility has changed)

```
admin@vlab-01:~$ show bfd summary
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type     Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  -------  ------------  -------------  -------------  ------------  ----------  ---------------------
10.0.0.33    Ethernet4    default  down     dynamic  10.0.0.32               300            300             3  no                     3483190008

admin@vlab-01:~$ show bfd peer 10.0.0.33
Total number of BFD sessions for peer IP 10.0.0.33: 1
Peer Addr    Interface    Vrf      State    Type     Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  -------  ------------  -------------  -------------  ------------  ----------  ---------------------
10.0.0.33    Ethernet4    default  down     dynamic  10.0.0.32               300            300             3  no                     3483190008
admin@vlab-01:~$
```

