### PR TITLE
feat: validate crm high and low threshold input

### DIFF
--- a/crm/main.py
+++ b/crm/main.py
@@ -428,13 +428,13 @@ def low(ctx, value):
     if threshold_type == 'percentage':
         if value < 0 or value > 100:
             raise click.ClickException(
-                'Error: Low threshold value must be between 0 and 100 for '
+                'Low threshold value must be between 0 and 100 for '
                 'percentage type.')
 
         high_value = crm_info.get(high_attr, None)
         if high_value is not None and value >= int(high_value):
             raise click.ClickException(
-                'Error: Low threshold value must be less than high threshold '
+                'Low threshold value must be less than high threshold '
                 f'value: {high_value} for percentage type.')
 
     attr = ''
@@ -464,13 +464,13 @@ def high(ctx, value):
     if threshold_type == 'percentage':
         if value < 0 or value > 100:
             raise click.ClickException(
-                'Error: High threshold value must be between 0 and 100 for '
+                'High threshold value must be between 0 and 100 for '
                 'percentage type.')
 
         low_value = crm_info.get(low_attr, None)
         if low_value is not None and value <= int(low_value):
             raise click.ClickException(
-                'Error: High threshold value must be greater than low threshold '
+                'High threshold value must be greater than low threshold '
                 f'value: {low_value} for percentage type.')
 
     attr = ''

--- a/tests/crm_test.py
+++ b/tests/crm_test.py
@@ -1973,7 +1973,7 @@ class TestCrmMultiAsic(object):
         assert result.exit_code == 1
         assert (
             "Error: Low threshold value must be less than high threshold value: "
-            f" {high_value} for percentage type." in result.output
+            f"{high_value} for percentage type." in result.output
         )
 
     def test_crm_config_thresholds_high_less_than_low(self):


### PR DESCRIPTION
#### What I did

Resolved issue https://github.com/sonic-net/sonic-utilities/issues/2931 by validating the high and low threshold input values.

#### How I did it

Updated the high and low threshold config functions to validate both thresholds are between 0 and 100 for percentage type as well as validate the low threshold if smaller than the high threshold.

#### How to verify it

Run new implemented tests to verify the validation logic is enforced.
