### PR TITLE
ipintutil to get address data for a ns in bulk and process efficiently

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -6,6 +6,8 @@ import sys
 
 import netaddr
 import netifaces
+import ipaddress
+
 from natsort import natsorted
 from tabulate import tabulate
 
@@ -160,43 +162,75 @@ def get_ip_intfs_in_namespace(af, namespace, display):
             ipaddresses = multi_asic_util.multi_asic_get_ip_intf_addr_from_ns(namespace, iface)
         except ValueError:
             continue
-        if af in ipaddresses:
-            ifaddresses = []
-            bgp_neighs = {}
-            ip_intf_attr = []
-            for ipaddr in ipaddresses[af]:
-                neighbor_name = 'N/A'
-                neighbor_ip = 'N/A'
-                local_ip = str(ipaddr['addr'])
-                if af == netifaces.AF_INET:
-                    netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
+        
+        ifaddresses = []
+        bgp_neighs = {}
+        
+        # Get addresses for the specified address family
+        af_addresses = ipaddresses.get(af, [])
+        for addr_info in af_addresses:
+            neighbor_name = 'N/A'
+            neighbor_ip = 'N/A'
+            local_ip = addr_info['addr']
+            
+            # Handle IPv6 link-local addresses with scope
+            if '%' in local_ip:
+                ip_parts = local_ip.split('%')
+                local_ip_no_scope = ip_parts[0]
+                netmask = addr_info['netmask'].split('/')[0] if '/' in addr_info['netmask'] else addr_info['netmask']
+                # Extract prefix length from netmask
+                if '/' in addr_info['netmask']:
+                    prefixlen = addr_info['netmask'].split('/')[-1]
                 else:
-                    netmask = ipaddr['netmask'].split('/', 1)[-1]
-                local_ip_with_mask = "{}/{}".format(local_ip, str(netmask))
-                ifaddresses.append(["", local_ip_with_mask])
-                try:
-                    neighbor_name = bgp_peer[local_ip][0]
-                    neighbor_ip = bgp_peer[local_ip][1]
-                except KeyError:
-                    pass
+                    # Calculate prefix length from netmask
+                    if ':' in netmask:
+                        prefixlen = str(ipaddress.IPv6Network(f'::{netmask}', strict=False).prefixlen)
+                    else:
+                        prefixlen = str(ipaddress.IPv4Network(f'0.0.0.0/{netmask}', strict=False).prefixlen)
+                local_ip_with_mask = f"{local_ip}/{prefixlen}"
+            else:
+                # Handle regular addresses
+                netmask = addr_info['netmask']
+                # Extract prefix length from netmask
+                if '/' in netmask:
+                    prefixlen = netmask.split('/')[-1]
+                else:
+                    # Calculate prefix length from netmask
+                    if ':' in netmask:
+                        prefixlen = str(ipaddress.IPv6Network(f'::{netmask}', strict=False).prefixlen)
+                    else:
+                        prefixlen = str(ipaddress.IPv4Network(f'0.0.0.0/{netmask}', strict=False).prefixlen)
+                local_ip_with_mask = f"{local_ip}/{prefixlen}"
+            
+            ifaddresses.append(["", local_ip_with_mask])
+            
+            # Look up BGP peer by IP without scope
+            lookup_ip = local_ip.split('%')[0] if '%' in local_ip else local_ip
+            try:
+                neighbor_name = bgp_peer[lookup_ip][0]
+                neighbor_ip = bgp_peer[lookup_ip][1]
+            except KeyError:
+                pass
 
-                bgp_neighs.update({local_ip_with_mask: [neighbor_name, neighbor_ip]})
+            bgp_neighs.update({local_ip_with_mask: [neighbor_name, neighbor_ip]})
 
-            if len(ifaddresses) > 0:
-                admin = get_if_admin_state(iface, namespace)
-                oper = get_if_oper_state(iface, namespace)
-                master = get_if_master(iface)
+        if len(ifaddresses) > 0:
+            admin = get_if_admin_state(iface, namespace)
+            oper = get_if_oper_state(iface, namespace)
+            master = get_if_master(iface)
+        else:
+            continue
 
-            ip_intf_attr = {
-                "vrf": master,
-                "ipaddr": natsorted(ifaddresses),
-                "admin": admin,
-                "oper": oper,
-                "bgp_neighs": bgp_neighs,
-                "ns": namespace
-            }
+        ip_intf_attr = {
+            "vrf": master,
+            "ipaddr": natsorted(ifaddresses),
+            "admin": admin,
+            "oper": oper,
+            "bgp_neighs": bgp_neighs,
+            "ns": namespace
+        }
 
-            ip_intfs[iface] = ip_intf_attr
+        ip_intfs[iface] = ip_intf_attr
     return ip_intfs
 
 

--- a/tests/test_multi_asic_addr_info.py
+++ b/tests/test_multi_asic_addr_info.py
@@ -1,0 +1,117 @@
+import json
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+from utilities_common import constants
+import utilities_common.multi_asic as multi_asic_util
+
+
+def _get_target_function():
+    if hasattr(multi_asic_util, "multi_asic_get_addr_info_from_ns"):
+        return multi_asic_util.multi_asic_get_addr_info_from_ns
+    if hasattr(multi_asic_util, "multi_asic_get_ip_addr_db_from_ns"):
+        return multi_asic_util.multi_asic_get_ip_addr_db_from_ns
+    pytest.skip("No addr info helper found in utilities_common.multi_asic")
+
+
+def _call_target(target_func, namespace, iface=None):
+    params = inspect.signature(target_func).parameters
+    if len(params) == 1:
+        return target_func(namespace)
+    if iface is None:
+        return target_func(namespace)
+    return target_func(namespace, iface)
+
+
+def _assert_ip_json_cmd(mock_check_output, namespace):
+    called_cmd = mock_check_output.call_args[0][0]
+    called_cmd_as_str = " ".join(called_cmd) if isinstance(called_cmd, (list, tuple)) else str(called_cmd)
+
+    assert "ip -json addr show" in called_cmd_as_str
+    if namespace == constants.DEFAULT_NAMESPACE:
+        assert "netns exec" not in called_cmd_as_str
+    else:
+        assert f"netns exec {namespace}" in called_cmd_as_str
+
+    assert mock_check_output.call_args[1] == {"shell": True}
+
+
+@patch("utilities_common.multi_asic.subprocess.check_output", create=True)
+def test_get_addr_info_from_ns_default_ns(mock_check_output):
+    payload = [
+        {
+            "ifname": "Ethernet0",
+            "addr_info": [
+                {"family": "inet", "local": "10.0.0.1", "prefixlen": 24},
+                {"family": "inet6", "local": "fc00::1", "prefixlen": 64},
+            ],
+        },
+        {
+            "ifname": "lo",
+            "addr_info": [{"family": "inet", "local": "127.0.0.1", "prefixlen": 8}],
+        },
+    ]
+    mock_check_output.return_value = json.dumps(payload).encode("utf-8")
+
+    target_func = _get_target_function()
+
+    result = _call_target(target_func, constants.DEFAULT_NAMESPACE, "Ethernet0")
+
+    if isinstance(result, dict):
+        assert set(result.keys()) == {"Ethernet0", "lo"}
+        assert result["Ethernet0"]["ifname"] == "Ethernet0"
+        assert result["lo"]["addr_info"][0]["local"] == "127.0.0.1"
+    else:
+        assert isinstance(result, list)
+        assert any(item.get("local") == "10.0.0.1" for item in result)
+        assert any(item.get("family") == "inet6" for item in result)
+
+    _assert_ip_json_cmd(mock_check_output, constants.DEFAULT_NAMESPACE)
+
+
+@patch("utilities_common.multi_asic.subprocess.check_output", create=True)
+def test_get_addr_info_from_ns_asic_ns(mock_check_output):
+    payload = [
+        {
+            "ifname": "Ethernet-BP0",
+            "addr_info": [{"family": "inet6", "local": "fe80::1", "prefixlen": 64}],
+        }
+    ]
+    mock_check_output.return_value = json.dumps(payload).encode("utf-8")
+
+    target_func = _get_target_function()
+
+    result = _call_target(target_func, "asic0", "Ethernet-BP0")
+
+    if isinstance(result, dict):
+        assert list(result.keys()) == ["Ethernet-BP0"]
+        assert result["Ethernet-BP0"]["addr_info"][0]["prefixlen"] == 64
+    else:
+        assert isinstance(result, list)
+        assert any(item.get("local") == "fe80::1" for item in result)
+
+    _assert_ip_json_cmd(mock_check_output, "asic0")
+
+
+@patch("utilities_common.multi_asic.subprocess.check_output", create=True)
+def test_get_addr_info_from_ns_missing_interface(mock_check_output):
+    payload = [
+        {
+            "ifname": "Ethernet0",
+            "addr_info": [{"family": "inet", "local": "10.0.0.1", "prefixlen": 24}],
+        }
+    ]
+    mock_check_output.return_value = json.dumps(payload).encode("utf-8")
+
+    target_func = _get_target_function()
+
+    result = _call_target(target_func, constants.DEFAULT_NAMESPACE, "Ethernet999")
+
+    if isinstance(result, dict):
+        assert "Ethernet999" not in result
+    else:
+        assert result in ([], None)
+
+    _assert_ip_json_cmd(mock_check_output, constants.DEFAULT_NAMESPACE)

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -7,6 +7,8 @@ from natsort import natsorted
 from sonic_py_common import multi_asic, device_info
 from utilities_common import constants
 from utilities_common.general import load_db_config
+import subprocess
+import json
 
 
 class MultiAsic(object):
@@ -164,6 +166,19 @@ def multi_asic_args(parser=None):
     parser.add_argument('-n', '--namespace', default=None,
                         help='Display interfaces for specific namespace')
     return parser
+
+
+# Function to get the address info for all interfaces in a namespace
+def multi_asic_get_addr_info_from_ns(namespace):
+    ip_addr_db_ns_cmd = f"ip netns exec {namespace} " if namespace != constants.DEFAULT_NAMESPACE else ""
+    ip_addr_db_ns_cmd += " ip -json addr show"
+    out = subprocess.check_output(ip_addr_db_ns_cmd, shell=True)
+    data = json.loads(out)
+    if_db = {}
+    for item in data:
+        if_db[item["ifname"]] = item
+    return if_db
+
 
 def multi_asic_get_ip_intf_from_ns(namespace):
     import pyroute2


### PR DESCRIPTION
Summary/Description
The show commands "show ip interface" and "show ipv6 interface" consumes high cpu for a prelonged time period (200-300s for 4K interfaces). These show commands internally uses ipintutil for these show commands. This tool used python netifaces calls for each interface to populate the interface details. This lead to .06s time delay per interface leading to the showness in show output inaddition to high cpu utilization.
Type of change
The fix now gets the complete namespace addressing database on a single call from system and then populate the show database in a single parse. This reduces the overall time duration from >300s to <2s.
Approach
Do bulk processing
What is the motivation for this PR?
Performance improvement
How did you do it?
How did you verify/test it?
Show command executions before and after along with UT. PTF suite run. 
Any platform specific information?
None


- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511 
