### PR TITLE
Revert "Add multi-asic support for sonic-clear queue wredcounters and counterpoll , --nonzero support for show queue wredcounters (#4012)"

### DIFF
--- a/scripts/wredstat
+++ b/scripts/wredstat
@@ -88,33 +88,17 @@ def build_json(port, cnstat):
         out.update(ports_stats(k))
     return out
 
-class WredstatWrapper(object):
-    """A wrapper to execute Wredstat cmd over the correct namespaces"""
-    def __init__(self, namespace, voq=False):
-        self.namespace = namespace
-        self.voq = voq
-
-        # Initialize the multi-asic namespace
-        self.multi_asic = multi_asic_util.MultiAsic(constants.DISPLAY_ALL, namespace_option=namespace)
-        self.db = None
-
-    @multi_asic_util.run_on_multi_asic
-    def run(self, save_fresh_stats, port_to_show_stats, json_opt, non_zero):
-        wredstat = Wredstat(self.multi_asic.current_namespace, self.db, self.voq)
-        if save_fresh_stats:
-           wredstat.save_fresh_stats()
-           return
-
-        if port_to_show_stats!=None:
-           wredstat.get_print_port_stat(port_to_show_stats, json_opt, non_zero)
-        else:
-           wredstat.get_print_all_stat(json_opt, non_zero)
-
 
 class Wredstat(object):
-    def __init__(self, namespace, db, voq):
-        self.db = db
-        self.namespace = namespace
+    def __init__(self, namespace, voq=False):
+        self.db = None
+        self.multi_asic = multi_asic_util.MultiAsic(constants.DISPLAY_ALL, namespace)
+        if namespace is not None:
+            for ns in self.multi_asic.get_ns_list_based_on_options():
+                self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
+        else:
+            self.db = SonicV2Connector(use_unix_socket_path=False)
+            self.db.connect(self.db.COUNTERS_DB)
         self.voq = voq
 
         def get_queue_port(table_id):
@@ -215,7 +199,7 @@ class Wredstat(object):
             cnstat_dict[queue] = get_counters(queue_map[queue])
         return cnstat_dict
 
-    def cnstat_print(self, port, cnstat_dict, json_opt, non_zero):
+    def cnstat_print(self, port, cnstat_dict, json_opt):
         """
         Print the cnstat. If JSON option is True, return data in
         JSON format.
@@ -228,25 +212,19 @@ class Wredstat(object):
                 if json_opt:
                     json_output[port][key] = data
                 continue
-            if not non_zero or (data['wredDrppacket'] != 'N/A' and data['wredDrppacket'] != '0') or \
-                               (data['wredDrpbytes'] != 'N/A' and data['wredDrpbytes'] != '0')  or \
-                               (data['ecnpacket'] != 'N/A' and data['ecnpacket'] != '0') or \
-                               (data['ecnbytes'] != 'N/A' and data['ecnbytes'] != '0'):
-                table.append((port, data['queuetype'] + str(data['queueindex']),
-                             data['wredDrppacket'], data['wredDrpbytes'],
-                             data['ecnpacket'], data['ecnbytes']))
+            table.append((port, data['queuetype'] + str(data['queueindex']),
+                        data['wredDrppacket'], data['wredDrpbytes'],
+                        data['ecnpacket'], data['ecnbytes']))
 
         if json_opt:
-            if table:
-                json_output[port].update(build_json(port, table))
+            json_output[port].update(build_json(port, table))
             return json_output
         else:
-            if table:
-                hdr = voq_header if self.voq else header
-                print(tabulate(table, hdr, tablefmt='simple', stralign='right'))
-                print()
+            hdr = voq_header if self.voq else header
+            print(tabulate(table, hdr, tablefmt='simple', stralign='right'))
+            print()
 
-    def cnstat_diff_print(self, port, cnstat_new_dict, cnstat_old_dict, json_opt, non_zero):
+    def cnstat_diff_print(self, port, cnstat_new_dict, cnstat_old_dict, json_opt):
         """
         Print the difference between two cnstat results. If JSON
         option is True, return data in JSON format.
@@ -264,36 +242,25 @@ class Wredstat(object):
                 old_cntr = cnstat_old_dict.get(key)
 
             if old_cntr is not None:
-                if not non_zero or \
-                    (cntr['wredDrppacket'] != 'N/A' and ns_diff(cntr['wredDrppacket'], old_cntr['wredDrppacket']) != '0') or \
-                    (cntr['wredDrpbytes'] != 'N/A' and ns_diff(cntr['wredDrpbytes'], old_cntr['wredDrpbytes']) != '0') or \
-                    (cntr['ecnpacket'] != 'N/A' and ns_diff(cntr['ecnpacket'], old_cntr['ecnpacket']) != '0') or \
-                    (cntr['ecnbytes'] != 'N/A' and  ns_diff(cntr['ecnbytes'], old_cntr['ecnbytes']) != '0'):
-                    table.append((port, cntr['queuetype'] + str(cntr['queueindex']),
-                             ns_diff(cntr['wredDrppacket'], old_cntr['wredDrppacket']),
-                             ns_diff(cntr['wredDrpbytes'], old_cntr['wredDrpbytes']),
-                             ns_diff(cntr['ecnpacket'], old_cntr['ecnpacket']),
-                             ns_diff(cntr['ecnbytes'], old_cntr['ecnbytes'])))
+                table.append((port, cntr['queuetype'] + str(cntr['queueindex']),
+                            ns_diff(cntr['wredDrppacket'], old_cntr['wredDrppacket']),
+                            ns_diff(cntr['wredDrpbytes'], old_cntr['wredDrpbytes']),
+                            ns_diff(cntr['ecnpacket'], old_cntr['ecnpacket']),
+                            ns_diff(cntr['ecnbytes'], old_cntr['ecnbytes'])))
             else:
-                if not non_zero or (cntr['wredDrppacket'] != 'N/A' and cntr['wredDrppacket'] != '0') or \
-                               (cntr['wredDrpbytes'] != 'N/A' and cntr['wredDrpbytes'] != '0')  or \
-                               (cntr['ecnpacket'] != 'N/A' and cntr['ecnpacket'] != '0') or \
-                               (cntr['ecnbytes'] != 'N/A' and cntr['ecnbytes'] != '0'):
-                    table.append((port, cntr['queuetype'] + str(cntr['queueindex']),
-                           cntr['wredDrppacket'], cntr['wredDrpbytes'],
-                           cntr['ecnpacket'], cntr['ecnbytes']))
+                table.append((port, cntr['queuetype'] + str(cntr['queueindex']),
+                        cntr['wredDrppacket'], cntr['wredDrpbytes'],
+                        cntr['ecnpacket'], cntr['ecnbytes']))
 
         if json_opt:
-            if table:
-                json_output[port].update(build_json(port, table))
+            json_output[port].update(build_json(port, table))
             return json_output
         else:
-            if table:
-                hdr = voq_header if self.voq else header
-                print(tabulate(table, hdr, tablefmt='simple', stralign='right'))
-                print()
+            hdr = voq_header if self.voq else header
+            print(tabulate(table, hdr, tablefmt='simple', stralign='right'))
+            print()
 
-    def get_print_all_stat(self, json_opt, non_zero):
+    def get_print_all_stat(self, json_opt):
         """
         Get stat for each port
         If JSON option is True, collect data for each port and
@@ -310,22 +277,22 @@ class Wredstat(object):
                     cnstat_cached_dict = json.load(open(cnstat_fqn_file_name, 'r'))
                     if json_opt:
                         json_output[port].update({"cached_time":cnstat_cached_dict.get('time')})
-                        json_output.update(self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt, non_zero))
+                        json_output.update(self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt))
                     else:
                         print(port + " Last cached time was " + str(cnstat_cached_dict.get('time')))
-                        self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt, non_zero)
+                        self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt)
                 except IOError as e:
                     print(e.errno, e)
             else:
                 if json_opt:
-                    json_output.update(self.cnstat_print(port, cnstat_dict, json_opt, non_zero))
+                    json_output.update(self.cnstat_print(port, cnstat_dict, json_opt))
                 else:
-                    self.cnstat_print(port, cnstat_dict, json_opt, non_zero)
+                    self.cnstat_print(port, cnstat_dict, json_opt)
 
         if json_opt:
             print(json_dump(json_output))
 
-    def get_print_port_stat(self, port, json_opt, non_zero):
+    def get_print_port_stat(self, port, json_opt):
         """
         Get stat for the port
         If JSON option is True  print data in JSON format
@@ -344,17 +311,17 @@ class Wredstat(object):
                 cnstat_cached_dict = json.load(open(cnstat_fqn_file_name, 'r'))
                 if json_opt:
                     json_output[port].update({"cached_time":cnstat_cached_dict.get('time')})
-                    json_output.update(self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt, non_zero))
+                    json_output.update(self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt))
                 else:
                     print("Last cached time was " + str(cnstat_cached_dict.get('time')))
-                    self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt, non_zero)
+                    self.cnstat_diff_print(port, cnstat_dict, cnstat_cached_dict, json_opt)
             except IOError as e:
                 print(e.errno, e)
         else:
             if json_opt:
-                json_output.update(self.cnstat_print(port, cnstat_dict, json_opt, non_zero))
+                json_output.update(self.cnstat_print(port, cnstat_dict, json_opt))
             else:
-                self.cnstat_print(port, cnstat_dict, json_opt, non_zero)
+                self.cnstat_print(port, cnstat_dict, json_opt)
 
         if json_opt:
             print(json_dump(json_output))
@@ -391,7 +358,6 @@ Examples:
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     parser.add_argument('-j', '--json_opt', action='store_true', help='Print in JSON format')
     parser.add_argument('-V', '--voq', action='store_true', help='display voq stats')
-    parser.add_argument('-nz', '--non_zero', action='store_true', help='display non-zero wred queue stats')
     parser.add_argument('-n', '--namespace', default=None, help='Display queue counters for specific namespace')
     args = parser.parse_args()
 
@@ -400,7 +366,6 @@ Examples:
     voq = args.voq
     json_opt = args.json_opt
     namespace = args.namespace
-    non_zero = args.non_zero
 
     port_to_show_stats = args.port
 
@@ -412,8 +377,17 @@ Examples:
     if delete_stats:
         cache.remove()
 
-    wredstat_wrapper = WredstatWrapper(namespace, voq)
-    wredstat_wrapper.run(save_fresh_stats, port_to_show_stats, json_opt, non_zero)
+    wredstat = Wredstat( namespace, voq )
+
+    if save_fresh_stats:
+        wredstat.save_fresh_stats()
+        sys.exit(0)
+
+
+    if port_to_show_stats!=None:
+        wredstat.get_print_port_stat(port_to_show_stats, json_opt)
+    else:
+        wredstat.get_print_all_stat(json_opt)
 
     sys.exit(0)
 

--- a/show/main.py
+++ b/show/main.py
@@ -801,8 +801,7 @@ def counters(interfacename, namespace, display, all, trim, voq, nonzero, json, v
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--json', is_flag=True, help="JSON output")
 @click.option('--voq', is_flag=True, help="VOQ counters")
-@click.option('-nz', '--nonzero', is_flag=True, help="Non Zero Counters")
-def wredcounters(interfacename, namespace, display, verbose, json, voq, nonzero):
+def wredcounters(interfacename, namespace, display, verbose, json, voq):
     """Show queue wredcounters"""
 
     cmd = ["wredstat"]
@@ -822,9 +821,6 @@ def wredcounters(interfacename, namespace, display, verbose, json, voq, nonzero)
 
     if voq:
         cmd += ["-V"]
-
-    if nonzero:
-        cmd += ["-nz"]
 
     run_command(cmd, display_cmd=verbose)
 

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -368,7 +368,7 @@ class TestCounterpoll(object):
         runner = CliRunner()
         db = Db()
 
-        result = runner.invoke(counterpoll.cli.commands["switch"].commands[status], [], obj=db.cfgdb)
+        result = runner.invoke(counterpoll.cli.commands["switch"].commands[status], [], obj=db)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
 
@@ -380,104 +380,12 @@ class TestCounterpoll(object):
         db = Db()
         test_interval = "20000"
 
-        result = runner.invoke(counterpoll.cli.commands["switch"].commands["interval"], [test_interval], obj=db.cfgdb)
+        result = runner.invoke(counterpoll.cli.commands["switch"].commands["interval"], [test_interval], obj=db)
         print(result.exit_code, result.output)
         assert result.exit_code == 0
 
         table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
         assert test_interval == table["SWITCH"]["POLL_INTERVAL"]
-
-    @pytest.mark.parametrize("status", ["disable", "enable"])
-    def test_queue_status(self, status):
-        runner = CliRunner()
-        db = Db()
-        result = runner.invoke(counterpoll.cli.commands["queue"].commands[status],
-                               [], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert status == table["QUEUE"]["FLEX_COUNTER_STATUS"]
-
-    def test_queue_interval(self):
-        runner = CliRunner()
-        db = Db()
-        test_interval = "8888"
-        result = runner.invoke(counterpoll.cli.commands["queue"].commands["interval"],
-                               [test_interval], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert test_interval == table["QUEUE"]["POLL_INTERVAL"]
-
-    @pytest.mark.parametrize("status", ["disable", "enable"])
-    def test_port_status(self, status):
-        runner = CliRunner()
-        db = Db()
-        result = runner.invoke(counterpoll.cli.commands["port"].commands[status],
-                               [], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert status == table["PORT"]["FLEX_COUNTER_STATUS"]
-
-    def test_port_interval(self):
-        runner = CliRunner()
-        db = Db()
-        test_interval = "6565"
-        result = runner.invoke(counterpoll.cli.commands["port"].commands["interval"],
-                               [test_interval], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert test_interval == table["PORT"]["POLL_INTERVAL"]
-
-    @pytest.mark.parametrize("status", ["disable", "enable"])
-    def test_watermark_status(self, status):
-        runner = CliRunner()
-        db = Db()
-        result = runner.invoke(counterpoll.cli.commands["watermark"].commands[status],
-                               [], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert status == table["QUEUE_WATERMARK"]["FLEX_COUNTER_STATUS"]
-        assert status == table["PG_WATERMARK"]["FLEX_COUNTER_STATUS"]
-        assert status == table["BUFFER_POOL_WATERMARK"]["FLEX_COUNTER_STATUS"]
-
-    def test_watermark_interval(self):
-        runner = CliRunner()
-        db = Db()
-        test_interval = "8888"
-        result = runner.invoke(counterpoll.cli.commands["watermark"].commands["interval"],
-                               [test_interval], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert test_interval == table["QUEUE_WATERMARK"]["POLL_INTERVAL"]
-        assert test_interval == table["PG_WATERMARK"]["POLL_INTERVAL"]
-        assert test_interval == table["BUFFER_POOL_WATERMARK"]["POLL_INTERVAL"]
-
-    @pytest.mark.parametrize("status", ["disable", "enable"])
-    def test_tunnel_status(self, status):
-        runner = CliRunner()
-        db = Db()
-        result = runner.invoke(counterpoll.cli.commands["tunnel"].commands[status],
-                               [], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert status == table["TUNNEL"]["FLEX_COUNTER_STATUS"]
-
-    def test_tunnel_interval(self):
-        runner = CliRunner()
-        db = Db()
-        test_interval = "5565"
-        result = runner.invoke(counterpoll.cli.commands["tunnel"].commands["interval"],
-                               [test_interval], obj=db.cfgdb)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
-        assert test_interval == table["TUNNEL"]["POLL_INTERVAL"]
 
     @classmethod
     def teardown_class(cls):

--- a/tests/wred_queue_counter_test.py
+++ b/tests/wred_queue_counter_test.py
@@ -117,75 +117,6 @@ Ethernet8  ALL29             N/A              N/A               N/A             
 
 """
 
-show_wred_queue_counters_nz = """\
-     Port    TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
----------  -----  --------------  ---------------  ----------------  -----------------
-Ethernet0    UC1              60               43                39                  1
-Ethernet0    UC2              82                7                39                 21
-Ethernet0    UC3              52               70                19                 76
-Ethernet0    UC4              11               59                12                 94
-Ethernet0    UC5              36               62                35                 40
-Ethernet0    UC6              49               91                 2                 88
-Ethernet0    UC7              33               17                94                 74
-Ethernet0    UC8              40               71                95                 33
-Ethernet0    UC9              54                8                93                 78
-Ethernet0   MC10              83               96                74                  9
-Ethernet0   MC11              15               60                61                 31
-Ethernet0   MC12              45               52                82                 94
-Ethernet0   MC13              55               88                89                 52
-Ethernet0   MC14              14               70                95                 79
-Ethernet0   MC15              68               60                66                 81
-Ethernet0   MC16              63                4                48                 76
-Ethernet0   MC17              41               73                77                 74
-Ethernet0   MC18              60               21                56                 54
-Ethernet0   MC19              57               31                12                 39
-
-     Port    TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
----------  -----  --------------  ---------------  ----------------  -----------------
-Ethernet4    UC0              41               96                70                 98
-Ethernet4    UC1              18               49                63                 36
-Ethernet4    UC2              99               90                 3                 15
-Ethernet4    UC3              60               89                48                 41
-Ethernet4    UC4               8               84                82                 94
-Ethernet4    UC5              83               15                75                 92
-Ethernet4    UC6              84               26                50                 71
-Ethernet4    UC7              27               19                49                 80
-Ethernet4    UC8              13               89                13                 33
-Ethernet4    UC9              43               48                86                 31
-Ethernet4   MC10              50                1                57                 82
-Ethernet4   MC11              67               99                84                 59
-Ethernet4   MC12               4               58                27                  5
-Ethernet4   MC13              74                5                57                 39
-Ethernet4   MC14              21               59                 4                 14
-Ethernet4   MC15              24               61                19                 53
-Ethernet4   MC16              51               15                15                 32
-Ethernet4   MC17              98               18                23                 15
-Ethernet4   MC18              41               34                 9                 57
-Ethernet4   MC19              57                7                18                 99
-
-     Port    TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
----------  -----  --------------  ---------------  ----------------  -----------------
-Ethernet8    UC1              38               17                68                 91
-Ethernet8    UC2              16               65                79                 51
-Ethernet8    UC3              11               97                63                 72
-Ethernet8    UC4              54               89                62                 62
-Ethernet8    UC5              13               84                30                 59
-Ethernet8    UC6              49               67                99                 85
-Ethernet8    UC7               2               63                38                 88
-Ethernet8    UC8               0               82                93                 43
-Ethernet8    UC9              80               17                91                 61
-Ethernet8   MC10              81               63                76                 73
-Ethernet8   MC11              29               16                29                 66
-Ethernet8   MC12              32               12                61                 35
-Ethernet8   MC13              79               17                72                 93
-Ethernet8   MC14              23               21                67                 50
-Ethernet8   MC15              37               10                97                 14
-Ethernet8   MC16              30               17                74                 43
-Ethernet8   MC17               0               63                54                 84
-Ethernet8   MC18              69               88                24                 79
-Ethernet8   MC19              20               12                84                  3
-
-"""
 
 show_wred_queue_counters_port = """\
      Port    TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
@@ -223,30 +154,6 @@ Ethernet8  ALL29             N/A              N/A               N/A             
 
 """
 
-show_wred_queue_counters_port_nz = """\
-     Port    TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
----------  -----  --------------  ---------------  ----------------  -----------------
-Ethernet8    UC1              38               17                68                 91
-Ethernet8    UC2              16               65                79                 51
-Ethernet8    UC3              11               97                63                 72
-Ethernet8    UC4              54               89                62                 62
-Ethernet8    UC5              13               84                30                 59
-Ethernet8    UC6              49               67                99                 85
-Ethernet8    UC7               2               63                38                 88
-Ethernet8    UC8               0               82                93                 43
-Ethernet8    UC9              80               17                91                 61
-Ethernet8   MC10              81               63                76                 73
-Ethernet8   MC11              29               16                29                 66
-Ethernet8   MC12              32               12                61                 35
-Ethernet8   MC13              79               17                72                 93
-Ethernet8   MC14              23               21                67                 50
-Ethernet8   MC15              37               10                97                 14
-Ethernet8   MC16              30               17                74                 43
-Ethernet8   MC17               0               63                54                 84
-Ethernet8   MC18              69               88                24                 79
-Ethernet8   MC19              20               12                84                  3
-
-"""
 show_queue_counters_json = """\
 {
   "Ethernet0": {
@@ -983,126 +890,6 @@ show_queue_counters_port_json = """\
   }
 }"""
 
-show_queue_counters_port_json_nz = """\
-{
-  "Ethernet8": {
-    "MC10": {
-      "ecnmarkedbytes": "73",
-      "ecnmarkedpacket": "76",
-      "wreddropbytes": "63",
-      "wreddroppacket": "81"
-    },
-    "MC11": {
-      "ecnmarkedbytes": "66",
-      "ecnmarkedpacket": "29",
-      "wreddropbytes": "16",
-      "wreddroppacket": "29"
-    },
-    "MC12": {
-      "ecnmarkedbytes": "35",
-      "ecnmarkedpacket": "61",
-      "wreddropbytes": "12",
-      "wreddroppacket": "32"
-    },
-    "MC13": {
-      "ecnmarkedbytes": "93",
-      "ecnmarkedpacket": "72",
-      "wreddropbytes": "17",
-      "wreddroppacket": "79"
-    },
-    "MC14": {
-      "ecnmarkedbytes": "50",
-      "ecnmarkedpacket": "67",
-      "wreddropbytes": "21",
-      "wreddroppacket": "23"
-    },
-    "MC15": {
-      "ecnmarkedbytes": "14",
-      "ecnmarkedpacket": "97",
-      "wreddropbytes": "10",
-      "wreddroppacket": "37"
-    },
-    "MC16": {
-      "ecnmarkedbytes": "43",
-      "ecnmarkedpacket": "74",
-      "wreddropbytes": "17",
-      "wreddroppacket": "30"
-    },
-    "MC17": {
-      "ecnmarkedbytes": "84",
-      "ecnmarkedpacket": "54",
-      "wreddropbytes": "63",
-      "wreddroppacket": "0"
-    },
-    "MC18": {
-      "ecnmarkedbytes": "79",
-      "ecnmarkedpacket": "24",
-      "wreddropbytes": "88",
-      "wreddroppacket": "69"
-    },
-    "MC19": {
-      "ecnmarkedbytes": "3",
-      "ecnmarkedpacket": "84",
-      "wreddropbytes": "12",
-      "wreddroppacket": "20"
-    },
-    "UC1": {
-      "ecnmarkedbytes": "91",
-      "ecnmarkedpacket": "68",
-      "wreddropbytes": "17",
-      "wreddroppacket": "38"
-    },
-    "UC2": {
-      "ecnmarkedbytes": "51",
-      "ecnmarkedpacket": "79",
-      "wreddropbytes": "65",
-      "wreddroppacket": "16"
-    },
-    "UC3": {
-      "ecnmarkedbytes": "72",
-      "ecnmarkedpacket": "63",
-      "wreddropbytes": "97",
-      "wreddroppacket": "11"
-    },
-    "UC4": {
-      "ecnmarkedbytes": "62",
-      "ecnmarkedpacket": "62",
-      "wreddropbytes": "89",
-      "wreddroppacket": "54"
-    },
-    "UC5": {
-      "ecnmarkedbytes": "59",
-      "ecnmarkedpacket": "30",
-      "wreddropbytes": "84",
-      "wreddroppacket": "13"
-    },
-    "UC6": {
-      "ecnmarkedbytes": "85",
-      "ecnmarkedpacket": "99",
-      "wreddropbytes": "67",
-      "wreddroppacket": "49"
-    },
-    "UC7": {
-      "ecnmarkedbytes": "88",
-      "ecnmarkedpacket": "38",
-      "wreddropbytes": "63",
-      "wreddroppacket": "2"
-    },
-    "UC8": {
-      "ecnmarkedbytes": "43",
-      "ecnmarkedpacket": "93",
-      "wreddropbytes": "82",
-      "wreddroppacket": "0"
-    },
-    "UC9": {
-      "ecnmarkedbytes": "61",
-      "ecnmarkedpacket": "91",
-      "wreddropbytes": "17",
-      "wreddroppacket": "80"
-    }
-  }
-}"""
-
 show_queue_voq_counters = """\
             Port    Voq    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
 ----------------  -----  --------------  ---------------  ----------------  -----------------
@@ -1386,16 +1173,6 @@ class TestWredQueue(object):
         assert result.exit_code == 0
         assert result.output == show_wred_queue_counters
 
-    def test_queue_counters_nz(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            show.cli.commands["queue"].commands["wredcounters"],
-            ["-nz"]
-        )
-        print(result.output)
-        assert result.exit_code == 0
-        assert result.output == show_wred_queue_counters_nz
-
     def test_queue_counters_port(self):
         runner = CliRunner()
         result = runner.invoke(
@@ -1405,16 +1182,6 @@ class TestWredQueue(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_wred_queue_counters_port
-
-    def test_queue_counters_port_nz(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            show.cli.commands["queue"].commands["wredcounters"],
-            ["Ethernet8", "-nz"]
-        )
-        print(result.output)
-        assert result.exit_code == 0
-        assert result.output == show_wred_queue_counters_port_nz
 
     def test_queue_counters_json(self):
         runner = CliRunner()
@@ -1445,22 +1212,6 @@ class TestWredQueue(object):
         for _, v in json_output.items():
             del v["time"]
         assert json_dump(json_output) == show_queue_counters_port_json
-
-    def test_queue_counters_port_json_nz(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            show.cli.commands["queue"].commands["wredcounters"],
-            ["Ethernet8", "--json", "-nz"]
-        )
-        print(result.output)
-        print()
-        assert result.exit_code == 0
-        json_output = json.loads(result.output)
-
-        # remove "time" from the output
-        for _, v in json_output.items():
-            del v["time"]
-        assert json_dump(json_output) == show_queue_counters_port_json_nz
 
     def test_queue_voq_counters(self):
         runner = CliRunner()
@@ -1522,30 +1273,6 @@ class TestWredQueue(object):
         print(result.output)
         assert result.exit_code == 0
         assert (wredstat_clear_str in result.output)
-
-    def test_queue_counters_after_clear(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            show.cli.commands["queue"].commands["wredcounters"],
-            ["-nz"]
-        )
-        print(result.output)
-        assert result.exit_code == 0
-        output = result.output.splitlines()
-        f_output = [item for item in output if "time" not in item]
-        assert len(f_output) == 0
-
-    def test_queue_counters_port_after_clear(self):
-        runner = CliRunner()
-        result = runner.invoke(
-            show.cli.commands["queue"].commands["wredcounters"],
-            ["Ethernet8", "-nz"]
-        )
-        print(result.output)
-        assert result.exit_code == 0
-        output = result.output.splitlines()
-        f_output = [item for item in output if "time" not in item]
-        assert len(f_output) == 0
 
     def test_invalid_port(self):
         wredstat_inv_port = "Port does not exist"


### PR DESCRIPTION


This reverts commit e668f7a59b0d7743934a47b4bf07e0c15061e6c9.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Seems PR https://github.com/sonic-net/sonic-utilities/pull/4012 causes regression and so reverted the PR
#### How I did it
Reverted PR https://github.com/sonic-net/sonic-utilities/pull/4012
#### How to verify it
Reverted successfully
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

