### PR TITLE
[202505] Fix missing FEC stats columns

### DIFF
--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -81,12 +81,12 @@ Ethernet8        N/A      N/A      N/A      N/A      N/A      N/A      N/A      
 
 intf_fec_counters_period = """\
 The rates are calculated within 3 seconds period
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR
----------  -------  ----------  ------------  ----------------
-Ethernet0        D           0             0                 0
-Ethernet4      N/A           0             0                 0
-Ethernet8      N/A           0             0                 0
-"""
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
+---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------
+Ethernet0        D           0             0                 0            N/A             N/A                N/A         0                    0
+Ethernet4      N/A           0             0                 0            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)
+Ethernet8      N/A           0             0                 0            N/A             N/A                N/A       N/A                  N/A
+"""  # noqa: E501
 
 intf_counters_period = """\
 The rates are calculated within 3 seconds period
@@ -453,8 +453,6 @@ class TestPortStat(object):
         print("result = {}".format(result))
         assert return_code == 0
         assert result == intf_fec_counters_period
-
-
 
     def test_show_intf_counters_period(self):
         runner = CliRunner()

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -760,12 +760,22 @@ class Portstat(object):
                     table.append((key, self.get_port_state(key),
                                   ns_diff(cntr['fec_corr'], old_cntr['fec_corr']),
                                   ns_diff(cntr['fec_uncorr'], old_cntr['fec_uncorr']),
-                                  ns_diff(cntr['fec_symbol_err'], old_cntr['fec_symbol_err'])))
+                                  ns_diff(cntr['fec_symbol_err'], old_cntr['fec_symbol_err']),
+                                  format_fec_ber(rates.fec_pre_ber),
+                                  format_fec_ber(rates.fec_post_ber),
+                                  format_fec_ber(rates.fec_pre_ber_max),
+                                  format_fec_flr(rates.fec_flr),
+                                  format_fec_flr_predicted(rates.fec_flr_predicted, rates.fec_flr_r_squared)))
                 else:
                     table.append((key, self.get_port_state(key),
                                   format_number_with_comma(cntr['fec_corr']),
                                   format_number_with_comma(cntr['fec_uncorr']),
-                                  format_number_with_comma(cntr['fec_symbol_err'])))
+                                  format_number_with_comma(cntr['fec_symbol_err']),
+                                  format_fec_ber(rates.fec_pre_ber),
+                                  format_fec_ber(rates.fec_post_ber),
+                                  format_fec_ber(rates.fec_pre_ber_max),
+                                  format_fec_flr(rates.fec_flr),
+                                  format_fec_flr_predicted(rates.fec_flr_predicted, rates.fec_flr_r_squared)))
             elif fec_hist_only:
                 header = header_fec_hist_only
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added the missing columns for "show interface counters fec-stats" 

PS. This issue is NOT seen on master/202511 due to difference in code for portstat.py

#### How I did it
Unlike `cnstat_print`,  `cnstat_diff_print` was missing all the fec-stats columns

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
root@str-sonic:~# portstat -f 
Last cached time was 2025-12-06T00:29:18.073371
      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR
-----------  -------  ----------  ------------  ----------------
  Ethernet0        X           0             0                 0
  Ethernet1        X           0             0                 0
  Ethernet2        X           0             0                 0
```

#### New command output (if the output of a command-line utility has changed)
```
root@str-sonic:~# portstat -f
Last cached time was 2025-12-06T00:29:18.073371
      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FLR(O)    FLR(P) (Accuracy)
-----------  -------  ----------  ------------  ----------------  -------------  --------------  --------  -------------------
  Ethernet0        X           0             0                 0       0.00e+00        0.00e+00         0                    0
  Ethernet1        X           0             0                 0       0.00e+00        0.00e+00         0                    0
  Ethernet2        X           0             0                 0       0.00e+00        0.00e+00         0                    0
  Ethernet3        X           0             0                 0       0.00e+00        0.00e+00         0                    0
  Ethernet4        X           0             0                 0       0.00e+00        0.00e+00         0                    0
```
