### PR TITLE
[Mellanox] Added CLI to show MPO interfaces mapping and status

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9457,7 +9457,32 @@ config platform mlnx
 
 This command is valid only on mellanox devices. The sub-commands for "config platform" gets populated only on mellanox platforms. There are no other subcommands on non-Mellanox devices and hence this command appears empty and useless in other platforms. 
 
-The platform mellanox command currently includes no sub command.
+The platform mellanox section also includes `show` subcommands described below.
+
+**show platform mlnx mpo-status**
+
+This command displays the MPO → lane mapping for CPO ports on Mellanox platforms. Each lane cell shows the interface and its current oper status.
+
+- Usage:
+  ```
+  show platform mlnx mpo-status
+  ```
+
+- Example (single-ASIC):
+  ```
+  MPO  Lane 1           Lane 2           Lane 3           Lane 4
+  ---- ---------------- ---------------- ---------------- ----------------
+    1  Ethernet0(UP)     Ethernet0(UP)    Ethernet0(UP)    Ethernet0(UP)
+    2  Ethernet4(DOWN)   Ethernet4(DOWN)  Ethernet6(UP)    Ethernet7(UP)
+  ```
+
+- Example (multi-ASIC):
+  ```
+  MPO  Lane 1                 Lane 2                  Lane 3                  Lane 4
+  ---- ---------------------- ----------------------- ----------------------- ----------------------
+    1  Ethernet0/asic0(UP)    Ethernet512/asic1(UP)   Ethernet1024/asic2(UP)  Ethernet1536/asic3(UP)
+    2  Ethernet1/asic0(DOWN)  Ethernet513/asic1(UP)   Ethernet1025/asic2(UP)  Ethernet1537/asic3(UP)
+  ```
 
 ### Barefoot Platform Specific Commands
 

--- a/show/plugins/mlnx.py
+++ b/show/plugins/mlnx.py
@@ -28,7 +28,9 @@ try:
     import click
     from shlex import join
     from lxml import etree as ET
-    from sonic_py_common import device_info
+    from sonic_py_common import device_info, multi_asic
+    from tabulate import tabulate
+    from utilities_common.db import Db
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -41,6 +43,140 @@ TMP_SNIFFER_CONF_FILE = '/tmp/tmp.conf'
 HWSKU_PATH = '/usr/share/sonic/hwsku/'
 
 SAI_PROFILE_DELIMITER = '='
+
+UP_STATUS = 'UP'
+DOWN_STATUS = 'DOWN'
+ETHERNET_PREFIX = 'Ethernet'
+PORT_TABLE = 'PORT'
+PORT_TYPE_CPO = 'CPO'
+MPO_LANES = 4
+
+# ------------------------ MPO helpers ------------------------
+
+
+def is_cpo_port(rdb, port):
+    """
+    Determine whether a given port is a CPO type port.
+    Fetch 'type' from STATE_DB 'TRANSCEIVER_INFO|<port>' and match 'CPO'.
+    """
+    try:
+        val = rdb.get(rdb.STATE_DB, f"TRANSCEIVER_INFO|{port}", "type")
+        return val == PORT_TYPE_CPO
+    except Exception:
+        return False
+
+
+def get_cpo_ports_sorted(port_tbl, ns=None):
+    """
+    Return Ethernet ports in this namespace which are CPO type, sorted by numeric index.
+    """
+    try:
+        # Use Db helper to get per-namespace STATE_DB connector
+        db = Db()
+        rdb = db.db if ns is None else db.db_clients[ns]
+        cpo_ports = [p for p in port_tbl if p.startswith(ETHERNET_PREFIX) and is_cpo_port(rdb, p)]
+    except Exception as e:
+        click.echo(f"Warning: failed to get CPO ports list: {e}", err=True)
+        return []
+    return sorted(cpo_ports, key=lambda p: int(p.replace(ETHERNET_PREFIX, '')))
+
+
+def get_ports_oper_status(ports, ns=None):
+    """
+    Fetch oper_status for ports from APPL_DB and return mapping to 'UP'/'DOWN'.
+    """
+    status_map = {}
+    try:
+        db = Db()
+        rdb = db.db if ns is None else db.db_clients[ns]
+        for p in ports:
+            v = rdb.get(rdb.APPL_DB, f"PORT_TABLE:{p}", "oper_status")
+            status_map[p] = UP_STATUS if v and v.upper() == UP_STATUS else DOWN_STATUS
+    except Exception:
+        pass
+    return status_map
+
+
+def create_single_asic_mpo_rows():
+    """
+    Build rows for single-ASIC: MPO from CONFIG_DB PORT.lanes for CPO ports only.
+    """
+    try:
+        db = Db()
+        cfg_db = db.cfgdb
+        port_tbl = cfg_db.get_table(PORT_TABLE)
+    except Exception as e:
+        raise click.ClickException(f"Failed to read {PORT_TABLE} from CONFIG_DB: {e}")
+    # Pre-fetch status for all CPO ports
+    cpo_ports = get_cpo_ports_sorted(port_tbl=port_tbl)
+    if len(cpo_ports) == 0:
+        raise click.ClickException("No CPO ports found")
+    status_map = get_ports_oper_status(ports=cpo_ports)
+    mpo_to_lanes = {}
+    for port_name in cpo_ports:
+        attrs = port_tbl[port_name]
+        lanes_str = attrs.get('lanes')
+        if not lanes_str:
+            continue
+        try:
+            lane_nums = [int(x.strip()) for x in lanes_str.split(',') if x.strip() != '']
+        except Exception:
+            continue
+        for ln in lane_nums:
+            mpo_idx = (ln // MPO_LANES) + 1
+            lane_pos = ln % MPO_LANES
+            if mpo_idx not in mpo_to_lanes:
+                mpo_to_lanes[mpo_idx] = ['-', '-', '-', '-']
+            mpo_to_lanes[mpo_idx][lane_pos] = f"{port_name}({status_map.get(port_name, DOWN_STATUS)})"
+    # Build final rows, ordered by MPO index
+    rows = [[mpo] + mpo_to_lanes[mpo] for mpo in sorted(mpo_to_lanes.keys())]
+    return rows
+
+
+def create_multi_asic_mpo_rows():
+    """
+    Build rows for multi-ASIC: MPO m = m-th CPO port of each ASIC in order.
+    """
+    namespaces = multi_asic.get_namespace_list()
+    per_ns_port_lists = []
+    per_ns_status = {}
+    try:
+        db = Db()
+        for ns in namespaces:
+            cfg_ns = db.cfgdb_clients[ns]
+            port_tbl = cfg_ns.get_table(PORT_TABLE)
+            cpo_list = get_cpo_ports_sorted(port_tbl=port_tbl, ns=ns)
+            if len(cpo_list) == 0:
+                click.echo(f"Warning: no CPO ports found in namespace {ns}", err=True)
+                continue
+            per_ns_port_lists.append((ns, cpo_list))
+            per_ns_status[ns] = get_ports_oper_status(ports=cpo_list, ns=ns)
+    except Exception as e:
+        raise click.ClickException(f"Failed to read DBs for namespaces: {e}")
+    if len(per_ns_port_lists) == 0:
+        raise click.ClickException("No CPO ports found across namespaces")
+    ports_number = max(len(port_list) for _, port_list in per_ns_port_lists)
+    # Build MPO data structure: mapping from mpo index to a list of interfaces per lane
+    # For multi-asic, mpo index and lane are determined as instructed
+    mpo_to_lanes = {}
+    total_interfaces = []
+    # Collect the (ns, port_name) pairs across all namespaces
+    for ns, port_list in per_ns_port_lists:
+        for port in port_list:
+            total_interfaces.append((ns, port))
+    total_interfaces.sort(key=lambda x: int(x[1].replace(ETHERNET_PREFIX, '')))
+    # Now for each interface, calculate its MPO index and lane position
+    for lane, (ns, port) in enumerate(total_interfaces):
+        mpo_idx = (lane % ports_number) + 1
+        lane_pos = (lane // ports_number)
+        if mpo_idx not in mpo_to_lanes:
+            mpo_to_lanes[mpo_idx] = ['-', '-', '-', '-']
+        status = per_ns_status.get(ns, {}).get(port, DOWN_STATUS)
+        name_with_ns = f"{port}/{ns}" if ns else port
+        mpo_to_lanes[mpo_idx][lane_pos] = f"{name_with_ns}({status})"
+    # Build final rows, ordered by MPO index
+    rows = [[mpo] + mpo_to_lanes[mpo] for mpo in sorted(mpo_to_lanes.keys())]
+    return rows
 
 # run command
 def run_command(command, display_cmd=False, ignore_error=False, print_to_console=True):
@@ -140,6 +276,19 @@ def issu_status():
 
     click.echo('ISSU is enabled' if res else 'ISSU is disabled')
 
+
+@mlnx.command('mpo-status')
+def mpo_status():
+    """Show MPO → interface mapping status (CPO ports only)."""
+    headers = ['MPO', 'Lane 1', 'Lane 2', 'Lane 3', 'Lane 4']
+    multi = multi_asic.is_multi_asic()
+    if not multi:
+        # Single-ASIC: derive mapping directly from lanes
+        rows = create_single_asic_mpo_rows()
+    else:
+        # Multi-ASIC: MPO m is composed of the m-th port on each ASIC (namespace)
+        rows = create_multi_asic_mpo_rows()
+    click.echo(tabulate(rows, headers, tablefmt="outline"))
 
 def register(cli):
     version_info = device_info.get_sonic_version_info()

--- a/tests/test_mlnx_mpo_status.py
+++ b/tests/test_mlnx_mpo_status.py
@@ -1,0 +1,179 @@
+import pytest
+import click
+
+# Import the plugin module
+from show.plugins import mlnx as mlnx_mod
+
+
+class MockCfgDB:
+    def __init__(self, tbl):
+        self._tbl = tbl
+
+    def connect(self, *args, **kwargs):
+        return
+
+    def get_table(self, name):
+        return self._tbl if name == 'PORT' else {}
+
+
+class MockDb:
+    def __init__(self, state=None, appl=None):
+        self.STATE_DB = 6
+        self.APPL_DB = 0
+        self._state = state or {}
+        self._appl = appl or {}
+
+    def connect(self, *args, **kwargs):
+        return
+
+    def get(self, dbid, key, field):
+        if dbid == self.STATE_DB:
+            return self._state.get((key, field))
+        if dbid == self.APPL_DB:
+            return self._appl.get((key, field))
+        return None
+
+
+class TestDb:
+    def __init__(self, cfgdb=None, rdb=None, cfgdb_by_ns=None, rdb_by_ns=None):
+        self.cfgdb = cfgdb
+        self.db = rdb
+        self.cfgdb_clients = cfgdb_by_ns or {}
+        self.db_clients = rdb_by_ns or {}
+
+
+def test_single_asic_rows(monkeypatch):
+    # CONFIG_DB PORT table
+    port_tbl = {
+        'Ethernet0': {'lanes': '0,1,2,3'},
+        'Ethernet4': {'lanes': '4,5'},
+        'Ethernet6': {'lanes': '6'},
+        'Ethernet7': {'lanes': '7'},
+    }
+    # STATE_DB CPO type
+    state_map = {
+        ('TRANSCEIVER_INFO|Ethernet0', 'type'): 'CPO',
+        ('TRANSCEIVER_INFO|Ethernet4', 'type'): 'CPO',
+        ('TRANSCEIVER_INFO|Ethernet6', 'type'): 'CPO',
+        ('TRANSCEIVER_INFO|Ethernet7', 'type'): 'CPO',
+    }
+    # APPL_DB oper status
+    appl_map = {
+        ('PORT_TABLE:Ethernet0', 'oper_status'): 'up',
+        ('PORT_TABLE:Ethernet4', 'oper_status'): 'down',
+        ('PORT_TABLE:Ethernet6', 'oper_status'): 'up',
+        ('PORT_TABLE:Ethernet7', 'oper_status'): 'up',
+    }
+
+    # Patch Db() factory used inside mlnx.py
+    def db_factory():
+        return TestDb(cfgdb=MockCfgDB(port_tbl), rdb=MockDb(state=state_map, appl=appl_map))
+    monkeypatch.setattr(mlnx_mod, 'Db', db_factory)
+
+    rows = mlnx_mod.create_single_asic_mpo_rows()
+    # Expect:
+    # MPO 1 -> Ethernet0 in all lanes
+    # MPO 2 -> Ethernet4, Ethernet4, Ethernet6, Ethernet7
+    assert rows[0] == [1, 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)']
+    assert rows[1] == [2, 'Ethernet4(DOWN)', 'Ethernet4(DOWN)', 'Ethernet6(UP)', 'Ethernet7(UP)']
+
+
+def test_multi_asic_rows(monkeypatch):
+    # Namespaces
+    monkeypatch.setattr(mlnx_mod.multi_asic, 'get_namespace_list', lambda: ['asic0', 'asic1', 'asic2', 'asic3'])
+    # Per namespace PORT tables
+    cfg_by_ns = {
+        'asic0': {'Ethernet0': {}, 'Ethernet1': {}},
+        'asic1': {'Ethernet512': {}, 'Ethernet513': {}},
+        'asic2': {'Ethernet1024': {}, 'Ethernet1025': {}},
+        'asic3': {'Ethernet1536': {}, 'Ethernet1537': {}},
+    }
+    # Build per-namespace cfgdb and db clients
+    cfgdb_clients = {ns: MockCfgDB(cfg_by_ns[ns]) for ns in cfg_by_ns}
+    db_clients = {}
+    for ns, ports in cfg_by_ns.items():
+        state_map = {}
+        appl_map = {}
+        for p in ports:
+            state_map[(f'TRANSCEIVER_INFO|{p}', 'type')] = 'CPO'
+            appl_map[(f'PORT_TABLE:{p}', 'oper_status')] = 'up'
+        db_clients[ns] = MockDb(state=state_map, appl=appl_map)
+
+    def db_factory():
+        return TestDb(cfgdb_by_ns=cfgdb_clients, rdb_by_ns=db_clients)
+    monkeypatch.setattr(mlnx_mod, 'Db', db_factory)
+
+    rows = mlnx_mod.create_multi_asic_mpo_rows()
+    # Expect:
+    # MPO 1: Ethernet0/asic0, Ethernet512/asic1, Ethernet1024/asic2, Ethernet1536/asic3
+    # MPO 2: Ethernet1/asic0, Ethernet513/asic1, Ethernet1025/asic2, Ethernet1537/asic3
+    assert rows[0] == [1, 'Ethernet0/asic0(UP)', 'Ethernet512/asic1(UP)', 'Ethernet1024/asic2(UP)',
+                       'Ethernet1536/asic3(UP)']
+    assert rows[1] == [2, 'Ethernet1/asic0(UP)', 'Ethernet513/asic1(UP)', 'Ethernet1025/asic2(UP)',
+                       'Ethernet1537/asic3(UP)']
+
+
+def test_single_asic_excludes_non_cpo(monkeypatch):
+    # CONFIG_DB: include one CPO and one non-CPO "service" (simulated by type != CPO)
+    port_tbl = {
+        'Ethernet0': {'lanes': '0,1,2,3'},
+        'Ethernet100': {'lanes': '100,101,102,103'},  # not CPO
+    }
+    state_map = {
+        ('TRANSCEIVER_INFO|Ethernet0', 'type'): 'CPO',
+        ('TRANSCEIVER_INFO|Ethernet100', 'type'): 'QSFP',  # non-CPO
+    }
+    appl_map = {
+        ('PORT_TABLE:Ethernet0', 'oper_status'): 'up',
+        ('PORT_TABLE:Ethernet100', 'oper_status'): 'up',
+    }
+    # Patch Db() factory
+
+    def db_factory():
+        return TestDb(cfgdb=MockCfgDB(port_tbl), rdb=MockDb(state=state_map, appl=appl_map))
+    monkeypatch.setattr(mlnx_mod, 'Db', db_factory)
+    rows = mlnx_mod.create_single_asic_mpo_rows()
+    # Only Ethernet0 should appear; Ethernet100 (non-CPO) must be excluded
+    assert rows == [[1, 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)']]
+
+
+def test_single_asic_no_cpo_raises(monkeypatch):
+    # CONFIG_DB ports but none are CPO
+    port_tbl = {
+        'Ethernet0': {'lanes': '0,1,2,3'},
+        'Ethernet4': {'lanes': '4,5,6,7'},
+    }
+    state_map = {
+        ('TRANSCEIVER_INFO|Ethernet0', 'type'): 'QSFP',
+        ('TRANSCEIVER_INFO|Ethernet4', 'type'): 'QSFP',
+    }
+    appl_map = {}
+
+    def db_factory():
+        return TestDb(cfgdb=MockCfgDB(port_tbl), rdb=MockDb(state=state_map, appl=appl_map))
+    monkeypatch.setattr(mlnx_mod, 'Db', db_factory)
+    with pytest.raises(click.ClickException):
+        _ = mlnx_mod.create_single_asic_mpo_rows()
+
+
+def test_multi_asic_no_cpo_raises(monkeypatch):
+    # No CPO in any namespace
+    monkeypatch.setattr(mlnx_mod.multi_asic, 'get_namespace_list', lambda: ['asic0', 'asic1'])
+    cfg_by_ns = {
+        'asic0': {'Ethernet0': {}},
+        'asic1': {'Ethernet512': {}},
+    }
+    # Build per-namespace cfgdb and db clients with non-CPO types
+    cfgdb_clients = {ns: MockCfgDB(cfg_by_ns[ns]) for ns in cfg_by_ns}
+    db_clients = {}
+    for ns, ports in cfg_by_ns.items():
+        state_map = {}
+        for p in ports:
+            state_map[(f'TRANSCEIVER_INFO|{p}', 'type')] = 'QSFP'
+        db_clients[ns] = MockDb(state=state_map, appl={})
+
+    def db_factory():
+        return TestDb(cfgdb_by_ns=cfgdb_clients, rdb_by_ns=db_clients)
+    monkeypatch.setattr(mlnx_mod, 'Db', db_factory)
+    with pytest.raises(click.ClickException):
+        _ = mlnx_mod.create_multi_asic_mpo_rows()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added a new Mellanox CLI: show platform mlnx mpo-status that prints the Interfaces → MPO mapping for CPO ports, including per-port oper status.

#### How I did it
Single-ASIC:
- Read PORT from CONFIG_DB, filter CPO ports.
- For each CPO port, parse lanes and map lane ln to MPO floor(ln/4)+1 and Lane column (ln%4).
- Fetch oper_status from APPL_DB and print as EthernetX(UP|DOWN).

Multi-ASIC:
- For each ASIC namespace, read PORT from CONFIG_DB, filter the CPO ports, and fetch oper_status from APPL_DB.
- Compose MPO rows by index: MPO m uses the m-th CPO port from each ASIC in order (Lane1=asic0, Lane2=asic1, Lane3=asic2, Lane4=asic3).
- Print EthernetX/asicN(UP|DOWN).
#### How to verify it
By running "show platform mlnx mpo-status" command

#### New command output (if the output of a command-line utility has changed)
show platform mlnx mpo-status
Single-ASIC:
```
+-------+-----------------+-----------------+-----------------+-----------------+
|   MPO | Lane 1          | Lane 2          | Lane 3          | Lane 4          |
+=======+=================+=================+=================+=================+
|     1 | Ethernet0(UP)   | Ethernet0(UP)   | Ethernet0(UP)   | Ethernet0(UP)   |
|     2 | Ethernet4(UP)   | Ethernet4(UP)   | Ethernet4(UP)   | Ethernet4(UP)   |
|     3 | Ethernet8(UP)   | Ethernet8(UP)   | Ethernet8(UP)   | Ethernet8(UP)   |
...
|   127 | Ethernet504(UP) | Ethernet504(UP) | Ethernet504(UP) | Ethernet504(UP) |
|   128 | Ethernet508(UP) | Ethernet508(UP) | Ethernet508(UP) | Ethernet508(UP) |
+-------+-----------------+-----------------+-----------------+-----------------+
```

Multi-ASIC:
```
show platform mlnx mpo-status
+-------+-----------------------+------------------------+------------------------+------------------------+
|   MPO | Lane 1                | Lane 2                 | Lane 3                 | Lane 4                 |
+=======+=======================+========================+========================+========================+
|     1 | Ethernet0/asic0(UP)   | Ethernet512/asic1(UP)  | Ethernet1024/asic2(UP) | Ethernet1536/asic3(UP) |
|     2 | Ethernet1/asic0(UP)   | Ethernet513/asic1(UP)  | Ethernet1025/asic2(UP) | Ethernet1537/asic3(UP) |
...
|   511 | Ethernet510/asic0(UP) | Ethernet1022/asic1(UP) | Ethernet1534/asic2(UP) | Ethernet2046/asic3(UP) |
|   512 | Ethernet511/asic0(UP) | Ethernet1023/asic1(UP) | Ethernet1535/asic2(UP) | Ethernet2047/asic3(UP) |
+-------+-----------------------+------------------------+------------------------+------------------------+
```
