### PR TITLE
Fix the psushow error message on platform without psu at all

### DIFF
--- a/scripts/psushow
+++ b/scripts/psushow
@@ -10,8 +10,6 @@ from tabulate import tabulate
 
 VERSION = '1.0'
 
-
-
 def get_psu_status_list():
     psu_status_list = []
 
@@ -23,7 +21,6 @@ def get_psu_status_list():
     chassis_name = "chassis {}".format(chassis_num)
     num_psus = db.get(db.STATE_DB, 'CHASSIS_INFO|{}'.format(chassis_name), 'psu_num')
     if not num_psus:
-        print('Error: Failed to get the number of PSUs')
         return None
 
     for psu_idx, psu_key in enumerate(natsorted(db.keys(db.STATE_DB, "PSU_INFO|*")), start = 1):
@@ -67,7 +64,6 @@ def psu_status_show_table(index):
     psu_status_list = get_psu_status_list()
 
     if not psu_status_list:
-        print('Error: Failed to get PSU status')
         return None
 
     header = ['PSU',  'Model', 'Serial', 'HW Rev', 'Voltage (V)', 'Current (A)', 'Power (W)', 'Status', 'LED']
@@ -102,7 +98,6 @@ def psu_status_show_json(index):
     psu_status_list = get_psu_status_list()
 
     if not psu_status_list:
-        print('Error: Failed to get PSU status')
         return None
 
     if index > 0:
@@ -144,7 +139,7 @@ Examples:
             ret = psu_status_show_table(psu_index)
 
         if ret != 0:
-            print("Error: failed to get PSU status from state DB")
+            print("PSU not detected")
             return 1
 
     return 0

--- a/tests/psushow_test.py
+++ b/tests/psushow_test.py
@@ -98,7 +98,7 @@ PSU 2  0J6J4K   CN-0J6J4K-17972-5AF-008M-A00  A                 12.18          1
         # Test trying to display a non-existent PSU
         expected_output = '''\
 Error: PSU 3 is not available. Number of supported PSUs: 2
-Error: failed to get PSU status from state DB
+PSU not detected
 '''
         for arg in ['-s', '--status']:
             with mock.patch('sys.argv', ['psushow', arg, '-i', '3']):
@@ -196,7 +196,7 @@ Error: failed to get PSU status from state DB
         # Test trying to display a non-existent PSU
         expected_output = '''\
 Error: PSU 3 is not available. Number of supported PSUs: 2
-Error: failed to get PSU status from state DB
+PSU not detected
 '''
         for arg in ['-j', '--json']:
             with mock.patch('sys.argv', ['psushow', '-s', '-i', '3', arg]):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
de-escalate the message when no psu had been detected at all from error to more moderate info.

#### How I did it
simply change the print output and remove the redundance ones

#### How to verify it
UT as well as manual test

#### Previous command output (if the output of a command-line utility has changed)
```
Error: Failed to get the number of PSUs
Error: Failed to get PSU status
Error: failed to get PSU status from state DB
```

#### New command output (if the output of a command-line utility has changed)
`PSU not detected`
