### PR TITLE
Added FEC maxT to the fec stat CLI

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5647,12 +5647,14 @@ The "fec-stats" subcommand is used to disply the interface fec related statistic
 - Example:
   ```
   admin@ctd615:~$ show interfaces counters fec-stats
-        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
-  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------  --------  -------------------
-   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16  4.31e-10       7.81e-10 (89%)
-   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14         0       4.81e-10 (84%)
-  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13  1.24e-10       6.03e-09 (79%)
+        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
+  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------  --------  -------------------  -----------
+   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16  4.31e-10       7.81e-10 (89%)      2.34e-05
+   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14         0       4.81e-10 (84%)      1.87e-05
+  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13  1.24e-10       6.03e-09 (79%)      3.12e-05
   ```
+
+  FEC_MAX_T - Is the maximum NON-ZERO FEC histogram BIN (starting from Bin0). -1 indicates the value is invalid (For eg during link down)
 
 For debugging link related issues where you need to clear the FEC histogram and monitor the link again, use the following command
 

--- a/tests/portstat_db/counters_db.json
+++ b/tests/portstat_db/counters_db.json
@@ -974,7 +974,8 @@
             "TX_PPS": "183.e3",
             "FEC_FLR": "4.2068052397918e-10",
             "FEC_FLR_PREDICTED": "7.8068058627918e-10",
-            "FEC_FLR_R_SQUARED": "0.89447685070757"
+            "FEC_FLR_R_SQUARED": "0.89447685070757",
+            "FEC_MAX_T": "-1"
     },
     "RATES:oid:0x1000000000013": {
             "RX_BPS": "204800",
@@ -983,7 +984,8 @@
             "TX_PPS": "201",
             "FEC_FLR": "0",
             "FEC_FLR_PREDICTED": "0",
-            "FEC_FLR_R_SQUARED": "0"
+            "FEC_FLR_R_SQUARED": "0",
+            "FEC_MAX_T": "0"
     },
     "RATES:oid:0x1000000000014": {
             "RX_BPS": "1.35e6",
@@ -992,7 +994,8 @@
             "TX_PPS": "9000",
             "FEC_FLR": "0",
             "FEC_FLR_PREDICTED": "4.8055058627918e-10",
-            "FEC_FLR_R_SQUARED": "0.89447685070757"
+            "FEC_FLR_R_SQUARED": "0.89447685070757",
+            "FEC_MAX_T": "3"
     },
     "RATES:oid:0x1000000000015": {
             "RX_BPS": "0",

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -45,20 +45,20 @@ Ethernet9      N/A        0      0.00 B/s       0.00/s        N/A         0     
 """  # noqa: E501
 
 intf_fec_counters = """\
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
----------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------
-Ethernet0        D     130,402             3                 4            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)
-Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A         0                    0
-Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A         0       4.81e-10 (89%)
-Ethernet9      N/A           0             0                 0            N/A             N/A                N/A       N/A                  N/A
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
+---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------  -----------
+Ethernet0        D     130,402             3                 4            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)         -1.0
+Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A         0                    0          0.0
+Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A         0       4.81e-10 (89%)          3.0
+Ethernet9      N/A           0             0                 0            N/A             N/A                N/A       N/A                  N/A          N/A
 """  # noqa: E501
 
 intf_fec_counters_nonzero = """\
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
----------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------
-Ethernet0        D     130,402             3                 4            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)
-Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A  0                           0
-Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A  0              4.81e-10 (89%)
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
+---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------  -----------
+Ethernet0        D     130,402             3                 4            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)           -1
+Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A  0                           0            0
+Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A  0              4.81e-10 (89%)            3
 """  # noqa: E501
 
 intf_fec_counters_fec_hist = """\
@@ -84,12 +84,12 @@ BIN15                                   0
 
 intf_fec_counters_period = """\
 The rates are calculated within 3 seconds period
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
----------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------
-Ethernet0        D           0             0                 0            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)
-Ethernet4      N/A           0             0                 0            N/A             N/A                N/A         0                    0
-Ethernet8      N/A           0             0                 0            N/A             N/A                N/A         0       4.81e-10 (89%)
-Ethernet9      N/A           0             0                 0            N/A             N/A                N/A       N/A                  N/A
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
+---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------  -----------
+Ethernet0        D           0             0                 0            N/A             N/A                N/A  4.21e-10       7.81e-10 (89%)         -1.0
+Ethernet4      N/A           0             0                 0            N/A             N/A                N/A         0                    0          0.0
+Ethernet8      N/A           0             0                 0            N/A             N/A                N/A         0       4.81e-10 (89%)          3.0
+Ethernet9      N/A           0             0                 0            N/A             N/A                N/A       N/A                  N/A          N/A
 """  # noqa: E501
 
 intf_counters_period = """\

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -38,16 +38,16 @@ header_std = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP'
               'TX_OK', 'TX_BPS', 'TX_UTIL', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_errors_only = ['IFACE', 'STATE', 'RX_ERR', 'RX_DRP', 'RX_OVR', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_fec_only = ['IFACE', 'STATE', 'FEC_CORR', 'FEC_UNCORR', 'FEC_SYMBOL_ERR', 'FEC_PRE_BER',
-                   'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FLR(O)', 'FLR(P) (Accuracy)']
+                   'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FLR(O)', 'FLR(P) (Accuracy)', 'FEC_MAX_T']
 header_fec_hist_only = ['IFACE', 'BIN0', 'BIN1', 'BIN2', 'BIN3', 'BIN4', 'BIN5', 'BIN6', 'BIN7',
                         'BIN8', 'BIN9', 'BIN10', 'BIN11', 'BIN12', 'BIN13', 'BIN14', 'BIN15']
 header_rates_only = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_OK', 'TX_BPS', 'TX_PPS', 'TX_UTIL']
 header_trim_only = ['IFACE', 'STATE', 'TRIM_PKTS', 'TRIM_TX_PKTS', 'TRIM_DRP_PKTS']
 
 rates_key_list = ['RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_BPS', 'TX_PPS', 'TX_UTIL', 'FEC_PRE_BER',
-                  'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FEC_FLR', 'FEC_FLR_PREDICTED', 'FEC_FLR_R_SQUARED']
+                  'FEC_POST_BER', 'FEC_PRE_BER_MAX', 'FEC_FLR', 'FEC_FLR_PREDICTED', 'FEC_FLR_R_SQUARED', 'FEC_MAX_T']
 ratestat_fields = ("rx_bps",  "rx_pps", "rx_util", "tx_bps", "tx_pps", "tx_util", "fec_pre_ber", "fec_post_ber",
-                   "fec_pre_ber_max", "fec_flr", "fec_flr_predicted", "fec_flr_r_squared")
+                   "fec_pre_ber_max", "fec_flr", "fec_flr_predicted", "fec_flr_r_squared", "fec_max_t")
 RateStats = namedtuple("RateStats", ratestat_fields)
 
 """
@@ -271,12 +271,13 @@ class Portstat(object):
             fec_flr = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr")
             fec_flr_predicted = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr_predicted")
             fec_flr_r_squared = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_flr_r_squared")
+            fec_max_t = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_max_t")
             port_alias = key.split("|")[-1]
             cnstat_dict[port_alias] = NStats._make([rx_ok, rx_err, rx_drop, rx_ovr, tx_ok, tx_err, tx_drop, tx_ovr] +
                                                    [STATUS_NA] * (len(NStats._fields) - 8))._asdict()
             ratestat_dict[port_alias] = RateStats._make([rx_bps, rx_pps, rx_util, tx_bps,
                                                         tx_pps, tx_util, fec_pre_ber, fec_post_ber, fec_pre_ber_max,
-                                                        fec_flr, fec_flr_predicted, fec_flr_r_squared])
+                                                        fec_flr, fec_flr_predicted, fec_flr_r_squared, fec_max_t])
         self.cnstat_dict.update(cnstat_dict)
         self.ratestat_dict.update(ratestat_dict)
 
@@ -357,7 +358,7 @@ class Portstat(object):
             """
                 Get the rates from specific table.
             """
-            fields = ["0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"]
+            fields = ["0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"]
             for pos, name in enumerate(rates_key_list):
                 full_table_id = RATES_TABLE_PREFIX + table_id
                 counter_data = self.db.get(self.db.COUNTERS_DB, full_table_id, name)
@@ -663,7 +664,9 @@ class Portstat(object):
                                   format_fec_ber(rates.fec_post_ber),
                                   format_fec_ber(rates.fec_pre_ber_max),
                                   format_fec_flr(rates.fec_flr),
-                                  format_fec_flr_predicted(rates.fec_flr_predicted, rates.fec_flr_r_squared)))
+                                  format_fec_flr_predicted(rates.fec_flr_predicted,
+                                                           rates.fec_flr_r_squared),
+                                  rates.fec_max_t))
             elif fec_hist_only:
                 header = header_fec_hist_only
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support to show the FEC maxT

#### How I did it
Added the column for maxT in "show interface fec-stats"

#### How to verify it
`portstat -f`

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic~# portstat -f
      IFACE    STATE        FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)
-----------  -------  --------------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------
  Ethernet0        U           1,147           785                 0       0                      0           3.94e-08         0                    0
  Ethernet4        U           2,291           686                 0       0                      0           6.78e-08         0                    0
  Ethernet8        D               0             0                 0       0                      0                N/A         0                    0
 Ethernet12        D               0             0                 0       0                      0                N/A         0                    0
 Ethernet16        U           3,733           558                 0       0                      0           5.54e-08         0                    0
 Ethernet20        U           9,184           735                 0       0                      0           1.32e-07         0                    0
 Ethernet24        D               0             0                 0       0                      0                N/A         0                    0
```

#### New command output (if the output of a command-line utility has changed)

```
root@sonic:~# portstat -f
      IFACE    STATE        FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
-----------  -------  --------------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------  -----------
  Ethernet0        U           1,147           785                 0       0                      0           3.94e-08         0                    0            0
  Ethernet4        U           2,291           686                 0       0                      0           6.78e-08         0                    0            0
  Ethernet8        D               0             0                 0       0                      0                N/A         0                    0           -1
 Ethernet12        D               0             0                 0       0                      0                N/A         0                    0           -1
 Ethernet16        U           3,733           558                 0       0                      0           5.54e-08         0                    0            0
 Ethernet20        U           9,184           735                 0       0                      0           1.32e-07         0                    0            0
 Ethernet24        D               0             0                 0       0                      0                N/A         0                    0           -1
```