### PR TITLE
improve unit test coverage for fast-reboot-dump script

### DIFF
--- a/tests/fast_reboot_dump_test.py
+++ b/tests/fast_reboot_dump_test.py
@@ -48,9 +48,12 @@ class TestFastRebootDump(object):
 
         conn.connect(conn.APPL_DB)
 
+        # Included: (Vlan2, mac) is present in all_available_macs
         key_included = 'NEIGH_TABLE:Vlan2:192.168.0.2'
         conn.set(conn.APPL_DB, key_included, 'neigh', '52:54:00:5D:FC:B7')
 
+        # Excluded: exists in DB, but (Vlan3, mac) is NOT present in all_available_macs
+        # so generate_neighbor_entries() skip it
         key_excluded = 'NEIGH_TABLE:Vlan3:192.168.0.3'
         conn.set(conn.APPL_DB, key_excluded, 'neigh', 'aa:bb:cc:dd:ee:ff')
 
@@ -75,6 +78,7 @@ class TestFastRebootDump(object):
         assert key_included in obj
         assert obj[key_included]['neigh'] == '52:54:00:5D:FC:B7'
         assert obj['OP'] == 'SET'
+        assert not any(key_excluded in item for item in data)
 
     @mock.patch.object(fast_reboot_dump, "SonicV2Connector")
     def test_generate_default_route_entries(self, mock_sonicv2):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
for hackathon week
#### What I did
enhances unit test coverage for scripts/fast-reboot-dump.py
- generate_default_route_entries
- generate_media_config
- generate_fdb_entries
- generate_neighbor_entries

This partially fixes https://github.com/sonic-net/sonic-utilities/issues/1175 by increasing coverage of the fast-reboot-dump, coverage improving from 48.5% to 70%
#### How I did it

#### How to verify it
coverage after this unit test
```
scripts/fast-reboot-dump.py                              270     71     82     12    70%
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

