### PR TITLE
[chassis] Fixed a bug in "show fabric isolation" output

### DIFF
--- a/scripts/fabricstat
+++ b/scripts/fabricstat
@@ -381,11 +381,11 @@ class FabricIsolation(FabricStat):
                 port_dict.update({port_number: port_data})
         # Create ordered table of fabric ports.
         header = ["Local Link", "Auto Isolated", "Manual Isolated", "Isolated"]
-        auto_isolated = 0
-        manual_isolated = 0
-        isolated = 0
         body = []
         for port_number in sorted(port_dict.keys()):
+            auto_isolated = 0
+            manual_isolated = 0
+            isolated = 0
             port_data = port_dict[port_number]
             if "AUTO_ISOLATED" in port_data:
                 auto_isolated = port_data["AUTO_ISOLATED"]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
https://github.com/sonic-net/sonic-buildimage/issues/24829
Fixed a bug in the "show fabric isolation" command output. 
When the fabric port sees CRC/FEC-Uncorrectable error, the Fabric monitor feature Isolates the port and sets the ISOALTED=1 and also AUTO_ISOLATED=1 in the STATE_DB for that port in the FABRIC_PORT_TABLE. The field ISOLATED and CONFIG_ISOLATED are always present for all the fabric ports in FABRIC_PORT_TABLE. However the field AUTO_ISOLATED is not present always and added only when the port is auto ISOLATED.
Due to the bug in the FabricIsolation cli script, the  Auto Isolated is shown 1 for all the ports printed in the show command after the port which is actually isolated. In the output shown below, the port 165 is isolated, however Auto-isolated is shown 1 for all the ports after 165 which is wrong.
<img width="415" height="245" alt="image" src="https://github.com/user-attachments/assets/26df22fd-615f-44c7-9b9a-3e7e44bef735" />

#### How I did it
Initialized the variable correctly inside the loop.
#### How to verify it
Induced the CRC error for one of the port and after that port is isolated, verified the "show fabric isolation" output shows the correct output.

<img width="342" height="239" alt="image" src="https://github.com/user-attachments/assets/749d13c0-9892-4f2c-af9a-70a49d7ee2e5" />

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

