### PR TITLE
Fix namespace typo in portconfig and related files

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -226,14 +226,14 @@ class PfcwdCli(object):
         ).get('POLL_INTERVAL')
 
         current_ns = self.multi_asic.current_namespace
-        asic_namesapce = \
+        asic_namespace = \
             "" if current_ns is None or current_ns == "" else " on {}".format(
                 current_ns
             )
         if poll_interval is not None:
             click.echo(
                 "Changed polling interval to {}ms{}".format(
-                    poll_interval, asic_namesapce
+                    poll_interval, asic_namespace
                 )
             )
 
@@ -243,7 +243,7 @@ class PfcwdCli(object):
 
         if big_red_switch is not None:
             click.echo("BIG_RED_SWITCH status is {}{}".format(
-                big_red_switch, asic_namesapce
+                big_red_switch, asic_namespace
             ))
 
         self.table += table

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -150,7 +150,7 @@ save_bcmcmd() {
 }
 
 ###############################################################################
-# Runs a given bcmcmd command in all namesapces in case of multi ASIC platform
+# Runs a given bcmcmd command in all namespaces in case of multi ASIC platform
 # Globals:
 #  NUM_ASICS
 # Arguments:
@@ -298,7 +298,7 @@ dummy_cleanup_method() {
 }
 
 ###############################################################################
-# Runs a given command in all namesapces in case of multi ASIC platform, in
+# Runs a given command in all namespaces in case of multi ASIC platform, in
 # default (host) namespace in single ASIC platform
 # Globals:
 #  NUM_ASICS
@@ -422,7 +422,7 @@ get_vtysh_namespace() {
 }
 
 ###############################################################################
-# Runs a vtysh command in all namesapces for a multi ASIC platform, and in
+# Runs a vtysh command in all namespaces for a multi ASIC platform, and in
 # default (host) namespace in single ASIC platforms. Saves its output to the
 # file.
 # Globals:
@@ -1557,7 +1557,7 @@ collect_nvidia_sdk_dumps() {
 }
 
 ###############################################################################
-# Runs a given marvellcmd command in all namesapces in case of multi ASIC platform
+# Runs a given marvellcmd command in all namespaces in case of multi ASIC platform
 # Globals:
 #  NUM_ASICS
 # Arguments:

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -16,7 +16,7 @@ optional arguments:
   -f     --fec                 port fec mode
   -m     --mtu                 port mtu in bytes
   -tp    --tpid                interface tpid (0x8100, 9100, 9200, 88A8)
-  -n     --namesapce           Namespace name
+  -n     --namespace           Namespace name
   -an    --autoneg             port auto negotiation mode
   -S     --adv-speeds          port advertised speeds
   -t     --interface-type      port interface type
@@ -258,7 +258,7 @@ class portconfig(object):
         if not self.namespace:
             state_db = SonicV2Connector(host="127.0.0.1")
         else:
-            state_db = SonicV2Connector(host="127.0.0.1", namesapce=self.namespace, use_unix_socket_path=True)
+            state_db = SonicV2Connector(host="127.0.0.1", namespace=self.namespace, use_unix_socket_path=True)
         state_db.connect(state_db.STATE_DB)
         return state_db.get(state_db.STATE_DB, '{}|{}'.format(PORT_STATE_TABLE_NAME, port), PORT_STATE_SUPPORTED_SPEEDS)
 

--- a/tests/ip_show_routes_multi_asic_test.py
+++ b/tests/ip_show_routes_multi_asic_test.py
@@ -135,7 +135,7 @@ class TestMultiAiscShowIpRouteDisplayAllCommands(object):
             show.cli.commands["ip"].commands["route"], ["-nasic7"])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ip_route_multi_asic_invalid_namesapce_err_output
+        assert result.output == show_ip_route_common.show_ip_route_multi_asic_invalid_namespace_err_output
 
     @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
                              ['ip_route'], indirect=['setup_multi_asic_bgp_instance'])
@@ -163,7 +163,7 @@ class TestMultiAiscShowIpRouteDisplayAllCommands(object):
             show.cli.commands["ipv6"].commands["route"], ["-dfrontend"])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_all_namesapce_output
+        assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_all_namespace_output
 
     @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
                              ['ipv6_route'], indirect=['setup_multi_asic_bgp_instance'])
@@ -179,7 +179,7 @@ class TestMultiAiscShowIpRouteDisplayAllCommands(object):
         os.environ['SONIC_CLI_IFACE_MODE'] = "default"
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_all_namesapce_alias_output
+        assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_all_namespace_alias_output
 
     @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
                              ['ipv6_route'], indirect=['setup_multi_asic_bgp_instance'])
@@ -193,7 +193,7 @@ class TestMultiAiscShowIpRouteDisplayAllCommands(object):
             show.cli.commands["ipv6"].commands["route"], ["-nasic2"])
         print("{}".format(result.output))
         assert result.exit_code == 0
-        assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_single_namesapce_output
+        assert result.output == show_ip_route_common.show_ipv6_route_multi_asic_single_namespace_output
 
     @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
                              ['ipv6_specific_route'], indirect=['setup_multi_asic_bgp_instance'])

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -665,7 +665,7 @@ B>*192.168.0.241/32 [20/0] via 10.0.0.5, PortChannel0005, 2d22h00m
   *                        via 10.0.0.16, PortChannel1016, 2d22h00m
 """
 
-show_ipv6_route_multi_asic_all_namesapce_output = """\
+show_ipv6_route_multi_asic_all_namespace_output = """\
 Codes: K - kernel route, C - connected, S - static, R - RIP,
        O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
        T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
@@ -711,7 +711,7 @@ C *fe80::/64 is directly connected, PortChannel1016, 2d22h02m
 C *fe80::/64 is directly connected, Ethernet24, 2d22h02m
 """
 
-show_ipv6_route_multi_asic_all_namesapce_alias_output = """\
+show_ipv6_route_multi_asic_all_namespace_alias_output = """\
 Codes: K - kernel route, C - connected, S - static, R - RIP,
        O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
        T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
@@ -757,7 +757,7 @@ C *fe80::/64 is directly connected, PortChannel1016, 2d22h02m
 C *fe80::/64 is directly connected, Ethernet1/7, 2d22h02m
 """
 
-show_ipv6_route_multi_asic_single_namesapce_output = """\
+show_ipv6_route_multi_asic_single_namespace_output = """\
 Codes: K - kernel route, C - connected, S - static, R - RIP,
        O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
        T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
@@ -788,7 +788,7 @@ C *fe80::/64 is directly connected, Ethernet20, 2d22h02m
 C *fe80::/64 is directly connected, PortChannel1016, 2d22h02m
 """
 
-show_ip_route_multi_asic_invalid_namesapce_err_output = """\
+show_ip_route_multi_asic_invalid_namespace_err_output = """\
 namespace 'asic7' is not valid. valid name spaces are:
 ['asic0', 'asic1', 'asic2']
 """


### PR DESCRIPTION
#### What I did

Fix https://github.com/sonic-net/sonic-buildimage/issues/24836
Fix https://github.com/sonic-net/sonic-utilities/issues/2795

Corrected `namesapce` -> `namespace` across portconfig/docs/tests.
This prevents the `scripts/portconfig` script from crashing due to this line:
https://github.com/sonic-net/sonic-utilities/blob/d17d124ebd1fd2a631be7f8ba24aef82906c9e3d/scripts/portconfig#L259

#### How I did it
Updated the `SonicV2Connector` initialization that referenced the wrong argument name, also did key word find-and-replace on the documentation.

#### How to verify it
The code change here should be self-explanatory.

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A
