### PR TITLE
[Secure Boot] Fix kexec error log on reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -135,7 +135,7 @@ function clear_warm_boot()
     if [[ -f ${WARM_DIR}/${REDIS_FILE} ]]; then
         mv -f ${WARM_DIR}/${REDIS_FILE} ${WARM_DIR}/${REDIS_FILE}.${TIMESTAMP} || /bin/true
     fi
-    /sbin/kexec -u || /bin/true
+    /sbin/kexec -u -a || /bin/true
 }
 
 SCRIPT=$0


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Doing a reboot on SB enabled systems and check dmesg, 

```
root@sonic/home/admin# dmesg -W
[33875.287197] ima: impossible to appraise a kernel image without a file descriptor; try using kexec_file_load syscall.
```

This is fixed in fast-reboot/warm-reboot script here https://github.com/sonic-net/sonic-utilities/commit/317e649514c9b205849ffb5ea96a6a233e38290c but was missed in reboot script

#### How I did it

Use the -a argument with kexec

```
 -a, --kexec-syscall-auto  Use file based syscall for kexec and fall
                      back to the compatibility syscall when file based
                      syscall is not supported or the kernel did not
                      understand the image
```

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

