### PR TITLE
Add subinterface support for IPv6 link-local commands

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1520,6 +1520,7 @@ def link_local_mode(verbose):
     config_db = ConfigDBConnector()
     config_db.connect()
     interface = ""
+    subintf_table = 'VLAN_SUB_INTERFACE'
 
     for table in tables:
         if table == "PORT":
@@ -1547,6 +1548,18 @@ def link_local_mode(verbose):
                 else:
                     body.append([port, 'Disabled'])
 
+    sub_intf_dict = config_db.get_table(subintf_table)
+    for subport in sub_intf_dict.keys():
+        if not isinstance(subport, tuple):
+            value = sub_intf_dict[subport]
+            if 'ipv6_use_link_local_only' in value:
+                link_local_data[subport] = value['ipv6_use_link_local_only']
+                if link_local_data[subport] == 'enable':
+                    body.append([subport, 'Enabled'])
+                else:
+                    body.append([subport, 'Disabled'])
+            else:
+                body.append([subport, 'Disabled'])
     click.echo(tabulate(body, header, tablefmt="grid"))
 
 #


### PR DESCRIPTION
#### What I did

Added subinterface support for the following commands:

```bash

sudo config interface ipv6 enable use-link-local-only <interface-name>
sudo config interface ipv6 disable use-link-local-only <interface-name>
sudo config ipv6 enable link-local
sudo config ipv6 disable link-local
show ipv6 link-local-mode
```

#### How I did it

1. Modified `config/main.py` to add compatibility for subinterfaces in the IPv6 link-local enable/disable commands.

2. Modified `show/main.py` to support subinterfaces in the `show ipv6 link-local-mode` command.

#### How to verify it

1. Connect two DUTs directly and configure subinterfaces on both.

2. Enable IPv6 link-local on the subinterfaces of both DUTs.

3. From either DUT, ping the link-local address of the peer's subinterface — the ping should succeed with no packet loss.

4. From either DUT, run `show ndp` — the peer DUT's link-local address should be present in the NDP table.

5. Configure IBGP on both DUTs:
       

    1. Use the command `neighbor <subinterface_name> interface remote-as internal` to set up the BGP neighbor, then advertise IPv6 routes.

    2. Verify the IBGP session is established successfully.

    3. Verify the local DUT learns the IPv6 routes advertised by the peer.

    4. Verify the next hop of the learned IPv6 routes is the link-local address of the peer's subinterface.

#### Previous command output

```text

sroot@sonic:/home/admin# show ipv6 link-local-mode 
+------------------+----------+
| Interface Name   | Mode     |
+==================+==========+
| Ethernet1        | Disabled |
+------------------+----------+
| Ethernet10       | Disabled |
+------------------+----------+
| Ethernet11       | Disabled |
+------------------+----------+
| Ethernet12       | Disabled |
+------------------+----------+
| Ethernet13       | Disabled |
+------------------+----------+
| Ethernet14       | Disabled |
+------------------+----------+
| Ethernet15       | Disabled |
+------------------+----------+
| Ethernet16       | Disabled |
+------------------+----------+
| Ethernet17       | Disabled |
+------------------+----------+
| Ethernet18       | Disabled |
+------------------+----------+
| Ethernet19       | Disabled |
+------------------+----------+
| Ethernet2        | Disabled |
+------------------+----------+
| Ethernet20       | Disabled |
+------------------+----------+
| Ethernet21       | Disabled |
+------------------+----------+
| Ethernet22       | Disabled |
+------------------+----------+
| Ethernet23       | Disabled |
+------------------+----------+
| Ethernet24       | Disabled |
+------------------+----------+
| Ethernet25       | Disabled |
+------------------+----------+
| Ethernet26       | Disabled |
+------------------+----------+
| Ethernet27       | Disabled |
+------------------+----------+
| Ethernet28       | Disabled |
+------------------+----------+
| Ethernet29       | Disabled |
+------------------+----------+
| Ethernet3        | Disabled |
+------------------+----------+
| Ethernet30       | Disabled |
+------------------+----------+
| Ethernet31       | Disabled |
+------------------+----------+
| Ethernet32       | Disabled |
+------------------+----------+
| Ethernet33       | Disabled |
+------------------+----------+
| Ethernet34       | Disabled |
+------------------+----------+
| Ethernet35       | Disabled |
+------------------+----------+
| Ethernet36       | Disabled |
+------------------+----------+
| Ethernet37       | Disabled |
+------------------+----------+
| Ethernet38       | Disabled |
+------------------+----------+
| Ethernet39       | Disabled |
+------------------+----------+
| Ethernet4        | Disabled |
+------------------+----------+
| Ethernet40       | Disabled |
+------------------+----------+
| Ethernet41       | Disabled |
+------------------+----------+
| Ethernet42       | Disabled |
+------------------+----------+
| Ethernet43       | Disabled |
+------------------+----------+
| Ethernet44       | Disabled |
+------------------+----------+
| Ethernet45       | Disabled |
+------------------+----------+
| Ethernet46       | Disabled |
+------------------+----------+
| Ethernet47       | Disabled |
+------------------+----------+
| Ethernet48       | Disabled |
+------------------+----------+
| Ethernet49       | Disabled |
+------------------+----------+
| Ethernet5        | Disabled |
+------------------+----------+
| Ethernet50       | Disabled |
+------------------+----------+
| Ethernet51       | Disabled |
+------------------+----------+
| Ethernet52       | Disabled |
+------------------+----------+
| Ethernet6        | Disabled |
+------------------+----------+
| Ethernet7        | Disabled |
+------------------+----------+
| Ethernet8        | Disabled |
+------------------+----------+
| Ethernet9        | Disabled |
+------------------+----------+
| Vlan1000         | Disabled |
+------------------+----------+
```

#### New command output

Subinterfaces (Eth51.1, Eth51.2) are now displayed with their link-local modes.

```text

sroot@sonic:/home/admin# show ipv6 link-local-mode 
+------------------+----------+
| Interface Name   | Mode     |
+==================+==========+
| Ethernet1        | Disabled |
+------------------+----------+
| Ethernet10       | Disabled |
+------------------+----------+
| Ethernet11       | Disabled |
+------------------+----------+
| Ethernet12       | Disabled |
+------------------+----------+
| Ethernet13       | Disabled |
+------------------+----------+
| Ethernet14       | Disabled |
+------------------+----------+
| Ethernet15       | Disabled |
+------------------+----------+
| Ethernet16       | Disabled |
+------------------+----------+
| Ethernet17       | Disabled |
+------------------+----------+
| Ethernet18       | Disabled |
+------------------+----------+
| Ethernet19       | Disabled |
+------------------+----------+
| Ethernet2        | Disabled |
+------------------+----------+
| Ethernet20       | Disabled |
+------------------+----------+
| Ethernet21       | Disabled |
+------------------+----------+
| Ethernet22       | Disabled |
+------------------+----------+
| Ethernet23       | Disabled |
+------------------+----------+
| Ethernet24       | Disabled |
+------------------+----------+
| Ethernet25       | Disabled |
+------------------+----------+
| Ethernet26       | Disabled |
+------------------+----------+
| Ethernet27       | Disabled |
+------------------+----------+
| Ethernet28       | Disabled |
+------------------+----------+
| Ethernet29       | Disabled |
+------------------+----------+
| Ethernet3        | Disabled |
+------------------+----------+
| Ethernet30       | Disabled |
+------------------+----------+
| Ethernet31       | Disabled |
+------------------+----------+
| Ethernet32       | Disabled |
+------------------+----------+
| Ethernet33       | Disabled |
+------------------+----------+
| Ethernet34       | Disabled |
+------------------+----------+
| Ethernet35       | Disabled |
+------------------+----------+
| Ethernet36       | Disabled |
+------------------+----------+
| Ethernet37       | Disabled |
+------------------+----------+
| Ethernet38       | Disabled |
+------------------+----------+
| Ethernet39       | Disabled |
+------------------+----------+
| Ethernet4        | Disabled |
+------------------+----------+
| Ethernet40       | Disabled |
+------------------+----------+
| Ethernet41       | Disabled |
+------------------+----------+
| Ethernet42       | Disabled |
+------------------+----------+
| Ethernet43       | Disabled |
+------------------+----------+
| Ethernet44       | Disabled |
+------------------+----------+
| Ethernet45       | Disabled |
+------------------+----------+
| Ethernet46       | Disabled |
+------------------+----------+
| Ethernet47       | Disabled |
+------------------+----------+
| Ethernet48       | Disabled |
+------------------+----------+
| Ethernet49       | Disabled |
+------------------+----------+
| Ethernet5        | Disabled |
+------------------+----------+
| Ethernet50       | Disabled |
+------------------+----------+
| Ethernet51       | Disabled |
+------------------+----------+
| Ethernet52       | Disabled |
+------------------+----------+
| Ethernet6        | Disabled |
+------------------+----------+
| Ethernet7        | Disabled |
+------------------+----------+
| Ethernet8        | Disabled |
+------------------+----------+
| Ethernet9        | Disabled |
+------------------+----------+
| Vlan1000         | Disabled |
+------------------+----------+
| Eth51.1          | Disabled |
+------------------+----------+
| Eth51.2          | Enabled  |
+------------------+----------+
```