### PR TITLE
[202511] [mellanox] [db_migrator] add a migration for tunnel ecn mode (#4132)

### DIFF
--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_expected.json
+++ b/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_expected.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE|IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_input.json
+++ b/tests/db_migrator_input/state_db/tunnel_table_ecn_mode_input.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE|IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE|IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1059,3 +1059,45 @@ class TestIPinIPTunnelMigrator(object):
             expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
             diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
             assert not diff
+
+
+class TestIPinIPTunnelEcnModeMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['APPL_DB'] = None
+        dbconnector.dedicated_dbs['STATE_DB'] = None
+
+    def compare_keys(self, expected_db, resulting_db, db_name):
+        expected_values = sorted(expected_db.keys(db_name, "*"))
+        resulting_values = sorted(resulting_db.keys(db_name, "*"))
+        assert expected_values == resulting_values
+        for key in expected_values:
+            expected_values = expected_db.get_all(db_name, key)
+            resulting_values = resulting_db.get_all(db_name, key)
+            diff = DeepDiff(resulting_values, expected_values, ignore_order=True)
+            assert not diff
+
+    def test_ipinip_tunnel_ecn_mode_migrator(self):
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_input')
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'tunnel_table_ecn_mode_input')
+
+        device_info.get_sonic_version_info = get_sonic_version_info_mlnx
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate_ipinip_tunnel_ecn_mode_mellanox()
+
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_expected')
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'tunnel_table_ecn_mode_expected')
+
+        expected_appl_db = SonicV2Connector(host='127.0.0.1')
+        expected_appl_db.connect(expected_appl_db.APPL_DB)
+        self.compare_keys(expected_appl_db, dbmgtr.appDB, 'APPL_DB')
+
+        expected_state_db = SonicV2Connector(host='127.0.0.1')
+        expected_state_db.connect(expected_state_db.STATE_DB)
+        self.compare_keys(expected_state_db, dbmgtr.stateDB, 'STATE_DB')


### PR DESCRIPTION
Cherry-pick https://github.com/sonic-net/sonic-utilities/pull/4132

What I did
In the 202511, the tunnel ECN mode for Mellanox platforms has changed from standard to copy_from_outer. This commit adds a migration that aligns APPL_DB to this change.

How I did it
Added a new migration for the Mellanox platform.

How to verify it
New unit test, manual tests.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

