### PR TITLE
restart mgmt over-usb interface if not RUNNING

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -11,6 +11,8 @@ import sys
 import unittest
 import ipaddress
 
+import config.main as cfg
+
 from datetime import timezone
 from unittest import mock
 from jsonpatch import JsonPatchConflict
@@ -397,6 +399,25 @@ def mock_run_command_side_effect_disabled_timer(*args, **kwargs):
             return '0', 0
         else:
             return '', 0
+
+
+def test__VRF():
+    cfg._iface_vrf("eth0")
+    cfg._iface_vrf("lo")
+    cfg._iface_vrf("bla")
+
+
+def test__capture_restore_default_routes():
+    routes1 = cfg._capture_default_routes("bla")
+    routes1.append({"fam": [-4], "vrf": 0, "gw": "255.255.255.255", "metric": 1})
+    cfg._restore_default_routes("bla", routes1)
+    routes2 = cfg._capture_default_routes("lo")
+    routes2.append({"fam": [-4], "vrf": 0, "gw": "255.255.255.255", "metric": 1})
+    cfg._restore_default_routes("lo", routes2)
+    routes3 = cfg._capture_default_routes("eth0")
+    routes3.append({"fam": [-4], "vrf": 0, "gw": "255.255.255.255", "metric": 1})
+    cfg._restore_default_routes("eth0", routes3)
+
 
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')


### PR DESCRIPTION
#### What I did
PROBLEM:
Sometimes after "config reload" command the management interface (eth0) connected over ETH-USB device
is UP/RUNNING on a remote peer side, but stays UP/not-running on the local side.
Well-known negotiation problem of ETH-over-USB devices (ASIX).

This patch is cherry-pick/rebase for the original  https://github.com/sonic-net/sonic-utilities/pull/3999

#### How I did it
SOLUTION:
If the management interface is a USB device and is not RUNNING (/sys/class/net/${if}/operstate is not "up") at
the end of the "config reload" command bring it down and up with delay to trigger renegotiation.
Before bringing it down, save default route and restore them after bringing the interface up again

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

