### PR TITLE
The ZR transmit power cannot be set to zero

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -363,7 +363,7 @@ def main():
             port.list_params(args.port)
         elif args.speed or args.fec or args.mtu or args.link_training or args.autoneg or args.adv_speeds or \
             args.interface_type or args.adv_interface_types or args.tpid or \
-            args.tx_power or args.laser_freq:
+            args.tx_power is not None or args.laser_freq:
             if args.speed:
                 port.set_speed(args.port, args.speed)
             if args.fec:
@@ -382,7 +382,7 @@ def main():
                 port.set_adv_interface_types(args.port, args.adv_interface_types)
             if args.tpid:
                 port.set_tpid(args.port, args.tpid)
-            if args.tx_power:
+            if args.tx_power is not None:
                 d = decimal.Decimal(str(args.tx_power))
                 if d.as_tuple().exponent < -1:
                     print("Error: tx power must be with single decimal place")

--- a/tests/config_xcvr_test.py
+++ b/tests/config_xcvr_test.py
@@ -44,6 +44,8 @@ class TestConfigXcvr(object):
         assert "Setting target Tx output power" in result.output
         result = self.basic_check("tx_power", ["Ethernet0", "11.34"], ctx, op=operator.ne)
         assert "Error: tx power must be with single decimal place" in result.output
+        result = self.basic_check("tx_power", ["Ethernet0", "0"], ctx)
+        assert "Setting target Tx output power" in result.output
         # Setting tx power on a port channel is not supported
         result = self.basic_check("tx_power", ["PortChannel0001", "11.3"], ctx, operator.ne)
         assert 'Invalid port PortChannel0001' in result.output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
```
admin@sonic:~$ sudo config int transceiver tx_power Ethernet40 -- 0
usage: portconfig [-h] -p PORT [-l] [-s SPEED] [-f FEC] [-m MTU] [-tp TPID]
                  [-d DESCRIPTION] [-v] [-vv] [-n namespace details]
                  [-an AUTONEG] [-S ADV_SPEEDS] [-t INTERFACE_TYPE]
                  [-T ADV_INTERFACE_TYPES] [-lt LINK_TRAINING] [-P TX_POWER]
                  [-F LASER_FREQ] [-G GRID_SPACE] [-A APPLICATION_CODE]
                  [-V VENDOR_PART_NUMBER]
Set SONiC port parameters
optional arguments:
  -h, --help            show this help message and exit
  -p PORT, --port PORT  port name (e.g. Ethernet0)
  -l, --list            list port parametars
  -s SPEED, --speed SPEED
                        port speed value in Mbit
  -f FEC, --fec FEC     port fec mode value (default is: none, rs, fc)
  -m MTU, --mtu MTU     port mtu value in bytes
  -tp TPID, --tpid TPID
                        port TPID value in hex (e.g. 0x8100)
  -d DESCRIPTION, --description DESCRIPTION
                        port description
  -v, --version         show program's version number and exit
  -vv, --verbose        Verbose output
  -n namespace details, --namespace namespace details
                        The asic namespace whose DB instance we need to connect
  -an AUTONEG, --autoneg AUTONEG
                        port auto negotiation mode
  -S ADV_SPEEDS, --adv-speeds ADV_SPEEDS
                        port advertised speeds
  -t INTERFACE_TYPE, --interface-type INTERFACE_TYPE
                        port interface type
  -T ADV_INTERFACE_TYPES, --adv-interface-types ADV_INTERFACE_TYPES
                        port advertised interface types
  -lt LINK_TRAINING, --link-training LINK_TRAINING
                        port link training mode
  -P TX_POWER, --tx-power TX_POWER
                        Tx output power(dBm)
  -F LASER_FREQ, --laser-freq LASER_FREQ
                        Laser frequency(GHz)
  -G GRID_SPACE, --grid-space GRID_SPACE
                        Grid Space(GHz)
```
"if tx_power:" checks truthiness. It cannot distinguish None vs 0



#### How I did it
Use is None / is not None when 0 is a meaningful value

#### How to verify it
```
root@sonic:/# config interface transceiver tx_power Ethernet0 0
Setting target Tx output power to 0.0 dBm on port Ethernet0
root@sonic:/# redis-cli -n 4 hget "PORT|Ethernet0" tx_power
"0.0"
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>