### PR TITLE
[SED] Change/Reset SED password CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -59,6 +59,7 @@ from . import kdump
 from . import kube
 from . import muxcable
 from . import nat
+from . import sed
 from . import vlan
 from . import vxlan
 from . import plugins
@@ -1738,6 +1739,9 @@ config.add_command(mclag.mclag_unique_ip)
 
 # syslog module
 config.add_command(syslog.syslog)
+
+# SED module
+config.add_command(sed.sed)
 
 # DNS module
 config.add_command(dns.dns)

--- a/config/sed.py
+++ b/config/sed.py
@@ -1,0 +1,50 @@
+import click
+
+
+@click.group()
+def sed():
+    """SED (Self-Encrypting Drive) password management commands"""
+    pass
+
+
+@sed.command('change-password')
+@click.option('-p', '--password', required=True, help='New SED password')
+def change_password(password):
+    """Change SED password"""
+    try:
+        from sonic_platform import platform
+        chassis = platform.Platform().get_chassis()
+        if not hasattr(chassis, 'change_sed_password'):
+            click.echo("Error: SED management not supported on this platform")
+            return
+        click.echo("Handling SED password change started...")
+        success = chassis.change_sed_password(password)
+        if success:
+            click.echo("SED password change process completed successfully")
+        else:
+            click.echo("Error: SED password change failed")
+    except NotImplementedError:
+        click.echo("Error: SED management not implemented on this platform")
+    except Exception as e:
+        click.echo(f"Error changing SED password: {str(e)}")
+
+
+@sed.command('reset-password')
+def reset_password():
+    """Reset SED password to default"""
+    try:
+        from sonic_platform import platform
+        chassis = platform.Platform().get_chassis()
+        if not hasattr(chassis, 'reset_sed_password'):
+            click.echo("Error: SED management not supported on this platform")
+            return
+        click.echo("Handling SED password reset started...")
+        success = chassis.reset_sed_password()
+        if success:
+            click.echo("SED password reset process completed successfully")
+        else:
+            click.echo("Error: SED password reset failed")
+    except NotImplementedError:
+        click.echo("Error: SED management not implemented on this platform")
+    except Exception as e:
+        click.echo(f"Error resetting SED password: {str(e)}")

--- a/config/sed.py
+++ b/config/sed.py
@@ -19,7 +19,8 @@ def change_password():
             return
         password = click.prompt(
             'New SED password',
-            hide_input=True
+            hide_input=True,
+            confirmation_prompt=True
         )
         click.echo("Handling SED password change started...")
         success = sed_mgmt.change_sed_password(password)

--- a/config/sed.py
+++ b/config/sed.py
@@ -8,8 +8,7 @@ def sed():
 
 
 @sed.command('change-password')
-@click.option('-p', '--password', required=True, help='New SED password')
-def change_password(password):
+def change_password():
     """Change SED password"""
     try:
         from sonic_platform import platform
@@ -18,6 +17,10 @@ def change_password(password):
         if sed_mgmt is None:
             click.echo("Error: SED management not supported on this platform")
             return
+        password = click.prompt(
+            'New SED password',
+            hide_input=True
+        )
         click.echo("Handling SED password change started...")
         success = sed_mgmt.change_sed_password(password)
         if success:

--- a/config/sed.py
+++ b/config/sed.py
@@ -14,17 +14,16 @@ def change_password(password):
     try:
         from sonic_platform import platform
         chassis = platform.Platform().get_chassis()
-        if not hasattr(chassis, 'change_sed_password'):
+        sed_mgmt = chassis.get_sed_mgmt()
+        if sed_mgmt is None:
             click.echo("Error: SED management not supported on this platform")
             return
         click.echo("Handling SED password change started...")
-        success = chassis.change_sed_password(password)
+        success = sed_mgmt.change_sed_password(password)
         if success:
             click.echo("SED password change process completed successfully")
         else:
             click.echo("Error: SED password change failed")
-    except NotImplementedError:
-        click.echo("Error: SED management not implemented on this platform")
     except Exception as e:
         click.echo(f"Error changing SED password: {str(e)}")
 
@@ -35,16 +34,15 @@ def reset_password():
     try:
         from sonic_platform import platform
         chassis = platform.Platform().get_chassis()
-        if not hasattr(chassis, 'reset_sed_password'):
+        sed_mgmt = chassis.get_sed_mgmt()
+        if sed_mgmt is None:
             click.echo("Error: SED management not supported on this platform")
             return
         click.echo("Handling SED password reset started...")
-        success = chassis.reset_sed_password()
+        success = sed_mgmt.reset_sed_password()
         if success:
             click.echo("SED password reset process completed successfully")
         else:
             click.echo("Error: SED password reset failed")
-    except NotImplementedError:
-        click.echo("Error: SED management not implemented on this platform")
     except Exception as e:
         click.echo(f"Error resetting SED password: {str(e)}")

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -178,6 +178,8 @@
 * [sFlow](#sflow)
   * [sFlow Show commands](#sflow-show-commands)
   * [sFlow Config commands](#sflow-config-commands)
+* [SED](#sed)
+  * [SED Config commands](#sed-config-commands)
 * [SNMP](#snmp)
   * [SNMP Show commands](#snmp-show-commands)
   * [SNMP Config commands](#snmp-config-commands)
@@ -11039,6 +11041,49 @@ This command is used to set the counter polling interval. Default is 20 seconds.
 
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#sflow)
+
+## SED
+
+SED (Self-Encrypting Drive) commands are used to manage password changes for self-encrypting drives in the system.
+
+### SED Config commands
+
+**config sed change-password**
+
+This command changes the SED password. The new password must be provided using the `-p` or `--password` option.
+
+- Usage:
+  ```
+  config sed change-password -p <NEW_PASSWORD>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ config sed change-password -p NewSecurePassword123
+  Handling SED password change started...
+  SED password change process completed successfully
+  ```
+
+- Parameters:
+  - `-p, --password`: New SED password (required)
+
+**config sed reset-password**
+
+This command resets the SED password to the default value.
+
+- Usage:
+  ```
+  config sed reset-password
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ config sed reset-password
+  Handling SED password reset started...
+  SED password reset process completed successfully
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#sed)
 
 ## SNMP
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -11050,22 +11050,20 @@ SED (Self-Encrypting Drive) commands are used to manage password changes for sel
 
 **config sed change-password**
 
-This command changes the SED password. The new password must be provided using the `-p` or `--password` option.
+This command changes the SED password. The new password is entered at interactive prompts (hidden input).
 
 - Usage:
   ```
-  config sed change-password -p <NEW_PASSWORD>
+  config sed change-password
   ```
 
 - Example:
   ```
-  admin@sonic:~$ config sed change-password -p NewSecurePassword123
+  admin@sonic:~$ config sed change-password
+  New SED password:
   Handling SED password change started...
   SED password change process completed successfully
   ```
-
-- Parameters:
-  - `-p, --password`: New SED password (required)
 
 **config sed reset-password**
 

--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -1,0 +1,120 @@
+from click.testing import CliRunner
+from mock import patch, MagicMock
+import config.main as config
+
+
+class TestSed(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    @patch('sonic_platform.platform.Platform')
+    def test_change_password_success(self, mock_platform):
+        """Test successful password change"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.change_sed_password.return_value = True
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+        result = runner.invoke(
+            config.config.commands["sed"].commands["change-password"],
+            ["-p", "validpassword"]
+        )
+        assert "Handling SED password change started..." in result.output
+        assert "SED password change process completed successfully" in result.output
+        mock_chassis.change_sed_password.assert_called_once_with("validpassword")
+
+    @patch('sonic_platform.platform.Platform')
+    def test_change_password_failure(self, mock_platform):
+        """Test failed password change"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.change_sed_password.return_value = False
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+        result = runner.invoke(
+            config.config.commands["sed"].commands["change-password"],
+            ["-p", "validpassword"]
+        )
+        assert "Handling SED password change started..." in result.output
+        assert "Error: SED password change failed" in result.output
+
+    @patch('sonic_platform.platform.Platform')
+    def test_change_password_not_implemented(self, mock_platform):
+        """Test NotImplementedError handling"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.change_sed_password.side_effect = NotImplementedError
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+        result = runner.invoke(
+            config.config.commands["sed"].commands["change-password"],
+            ["-p", "validpassword"]
+        )
+        assert "Error: SED management not implemented on this platform" in result.output
+
+    @patch('sonic_platform.platform.Platform')
+    def test_change_password_exception(self, mock_platform):
+        """Test general exception handling"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.change_sed_password.side_effect = Exception("Test error")
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+        result = runner.invoke(
+            config.config.commands["sed"].commands["change-password"],
+            ["-p", "validpassword"]
+        )
+        assert "Error changing SED password: Test error" in result.output
+
+    @patch('sonic_platform.platform.Platform')
+    def test_reset_password_success(self, mock_platform):
+        """Test successful password reset"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.reset_sed_password.return_value = True
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+        result = runner.invoke(
+            config.config.commands["sed"].commands["reset-password"],
+            []
+        )
+        assert "Handling SED password reset started..." in result.output
+        assert "SED password reset process completed successfully" in result.output
+        mock_chassis.reset_sed_password.assert_called_once()
+
+    @patch('sonic_platform.platform.Platform')
+    def test_reset_password_failure(self, mock_platform):
+        """Test failed password reset"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.reset_sed_password.return_value = False
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+        result = runner.invoke(
+            config.config.commands["sed"].commands["reset-password"],
+            []
+        )
+        assert "Handling SED password reset started..." in result.output
+        assert "Error: SED password reset failed" in result.output
+
+    @patch('sonic_platform.platform.Platform')
+    def test_reset_password_not_implemented(self, mock_platform):
+        """Test NotImplementedError handling for reset"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.reset_sed_password.side_effect = NotImplementedError
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+
+        result = runner.invoke(
+            config.config.commands["sed"].commands["reset-password"],
+            []
+        )
+        assert "Error: SED management not implemented on this platform" in result.output
+
+    @patch('sonic_platform.platform.Platform')
+    def test_reset_password_exception(self, mock_platform):
+        """Test general exception handling for reset"""
+        runner = CliRunner()
+        mock_chassis = MagicMock()
+        mock_chassis.reset_sed_password.side_effect = Exception("Reset test error")
+        mock_platform.return_value.get_chassis.return_value = mock_chassis
+        result = runner.invoke(
+            config.config.commands["sed"].commands["reset-password"],
+            []
+        )
+        assert "Error resetting SED password: Reset test error" in result.output

--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -20,7 +20,7 @@ class TestSed(object):
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
             [],
-            input='validpassword\n',
+            input='validpassword\nvalidpassword\n',
         )
         assert "Handling SED password change started..." in result.output
         assert "SED password change process completed successfully" in result.output
@@ -38,7 +38,7 @@ class TestSed(object):
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
             [],
-            input='validpassword\n',
+            input='validpassword\nvalidpassword\n',
         )
         assert "Handling SED password change started..." in result.output
         assert "Error: SED password change failed" in result.output
@@ -66,7 +66,7 @@ class TestSed(object):
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
             [],
-            input='validpassword\n',
+            input='validpassword\nvalidpassword\n',
         )
         assert "Error changing SED password: Test error" in result.output
 

--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -19,7 +19,8 @@ class TestSed(object):
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
-            ["-p", "validpassword"]
+            [],
+            input='validpassword\n',
         )
         assert "Handling SED password change started..." in result.output
         assert "SED password change process completed successfully" in result.output
@@ -36,7 +37,8 @@ class TestSed(object):
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
-            ["-p", "validpassword"]
+            [],
+            input='validpassword\n',
         )
         assert "Handling SED password change started..." in result.output
         assert "Error: SED password change failed" in result.output
@@ -49,9 +51,7 @@ class TestSed(object):
         mock_chassis.get_sed_mgmt.return_value = None
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
-            config.config.commands["sed"].commands["change-password"],
-            ["-p", "validpassword"]
-        )
+            config.config.commands["sed"].commands["change-password"], [])
         assert "Error: SED management not supported on this platform" in result.output
 
     @patch('sonic_platform.platform.Platform')
@@ -65,7 +65,8 @@ class TestSed(object):
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
-            ["-p", "validpassword"]
+            [],
+            input='validpassword\n',
         )
         assert "Error changing SED password: Test error" in result.output
 

--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -13,7 +13,9 @@ class TestSed(object):
         """Test successful password change"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.change_sed_password.return_value = True
+        mock_sed_mgmt = MagicMock()
+        mock_sed_mgmt.change_sed_password.return_value = True
+        mock_chassis.get_sed_mgmt.return_value = mock_sed_mgmt
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
@@ -21,14 +23,16 @@ class TestSed(object):
         )
         assert "Handling SED password change started..." in result.output
         assert "SED password change process completed successfully" in result.output
-        mock_chassis.change_sed_password.assert_called_once_with("validpassword")
+        mock_sed_mgmt.change_sed_password.assert_called_once_with("validpassword")
 
     @patch('sonic_platform.platform.Platform')
     def test_change_password_failure(self, mock_platform):
         """Test failed password change"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.change_sed_password.return_value = False
+        mock_sed_mgmt = MagicMock()
+        mock_sed_mgmt.change_sed_password.return_value = False
+        mock_chassis.get_sed_mgmt.return_value = mock_sed_mgmt
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
@@ -38,24 +42,26 @@ class TestSed(object):
         assert "Error: SED password change failed" in result.output
 
     @patch('sonic_platform.platform.Platform')
-    def test_change_password_not_implemented(self, mock_platform):
-        """Test NotImplementedError handling"""
+    def test_change_password_not_supported(self, mock_platform):
+        """Test when SED management is not supported (get_sed_mgmt returns None)"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.change_sed_password.side_effect = NotImplementedError
+        mock_chassis.get_sed_mgmt.return_value = None
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
             ["-p", "validpassword"]
         )
-        assert "Error: SED management not implemented on this platform" in result.output
+        assert "Error: SED management not supported on this platform" in result.output
 
     @patch('sonic_platform.platform.Platform')
     def test_change_password_exception(self, mock_platform):
         """Test general exception handling"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.change_sed_password.side_effect = Exception("Test error")
+        mock_sed_mgmt = MagicMock()
+        mock_sed_mgmt.change_sed_password.side_effect = Exception("Test error")
+        mock_chassis.get_sed_mgmt.return_value = mock_sed_mgmt
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["change-password"],
@@ -68,7 +74,9 @@ class TestSed(object):
         """Test successful password reset"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.reset_sed_password.return_value = True
+        mock_sed_mgmt = MagicMock()
+        mock_sed_mgmt.reset_sed_password.return_value = True
+        mock_chassis.get_sed_mgmt.return_value = mock_sed_mgmt
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["reset-password"],
@@ -76,14 +84,16 @@ class TestSed(object):
         )
         assert "Handling SED password reset started..." in result.output
         assert "SED password reset process completed successfully" in result.output
-        mock_chassis.reset_sed_password.assert_called_once()
+        mock_sed_mgmt.reset_sed_password.assert_called_once()
 
     @patch('sonic_platform.platform.Platform')
     def test_reset_password_failure(self, mock_platform):
         """Test failed password reset"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.reset_sed_password.return_value = False
+        mock_sed_mgmt = MagicMock()
+        mock_sed_mgmt.reset_sed_password.return_value = False
+        mock_chassis.get_sed_mgmt.return_value = mock_sed_mgmt
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["reset-password"],
@@ -93,25 +103,26 @@ class TestSed(object):
         assert "Error: SED password reset failed" in result.output
 
     @patch('sonic_platform.platform.Platform')
-    def test_reset_password_not_implemented(self, mock_platform):
-        """Test NotImplementedError handling for reset"""
+    def test_reset_password_not_supported(self, mock_platform):
+        """Test when SED management is not supported (get_sed_mgmt returns None)"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.reset_sed_password.side_effect = NotImplementedError
+        mock_chassis.get_sed_mgmt.return_value = None
         mock_platform.return_value.get_chassis.return_value = mock_chassis
-
         result = runner.invoke(
             config.config.commands["sed"].commands["reset-password"],
             []
         )
-        assert "Error: SED management not implemented on this platform" in result.output
+        assert "Error: SED management not supported on this platform" in result.output
 
     @patch('sonic_platform.platform.Platform')
     def test_reset_password_exception(self, mock_platform):
         """Test general exception handling for reset"""
         runner = CliRunner()
         mock_chassis = MagicMock()
-        mock_chassis.reset_sed_password.side_effect = Exception("Reset test error")
+        mock_sed_mgmt = MagicMock()
+        mock_sed_mgmt.reset_sed_password.side_effect = Exception("Reset test error")
+        mock_chassis.get_sed_mgmt.return_value = mock_sed_mgmt
         mock_platform.return_value.get_chassis.return_value = mock_chassis
         result = runner.invoke(
             config.config.commands["sed"].commands["reset-password"],


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

HLD: https://github.com/sonic-net/SONiC/pull/2171
This PR is dependent on: https://github.com/sonic-net/sonic-platform-common/pull/620

#### What I did
I added 2 CLIs to change the SED password and reset the SED password.

#### How I did it
I added 'config sed' group with the 2 relevant methods, using the platform chassis.

#### How to verify it
config sed change-password
config sed reset-password

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

