### PR TITLE
Limit PFC WD Detection time to maximum value of 1000[ms]

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -423,7 +423,7 @@ class PfcwdCli(object):
         pfc_wd_poll_interval_time = DEFAULT_POLL_INTERVAL * multiply
         if pfc_wd_poll_interval_time > MAX_POLL_INTERVAL_TIME:
             pfc_wd_poll_interval_time = MAX_POLL_INTERVAL_TIME
-        
+
         pfcwd_info = {
             'detection_time': DEFAULT_DETECTION_TIME * multiply,
             'restoration_time': DEFAULT_RESTORATION_TIME * multiply,

--- a/tests/pfcwd_input/pfcwd_test_vectors.py
+++ b/tests/pfcwd_input/pfcwd_test_vectors.py
@@ -61,6 +61,26 @@ Ethernet4      drop               200                 200    disable
 Ethernet8      drop               600                 600    disable
 """
 
+# 32-port system: multiply=1, detection/restoration=200, poll=200ms (same as default)
+pfcwd_show_start_default_32_ports = """\
+Changed polling interval to 200ms
+     PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
+---------  --------  ----------------  ------------------  ---------
+Ethernet0      drop               200                 200    disable
+Ethernet4      drop               200                 200    disable
+Ethernet8      drop               600                 600    disable
+"""
+
+# 512-port system: multiply=16, detection/restoration=3200, poll capped at 1000ms
+pfcwd_show_start_default_512_ports = """\
+Changed polling interval to 1000ms
+     PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
+---------  --------  ----------------  ------------------  ---------
+Ethernet0      drop              3200                3200    disable
+Ethernet4      drop              3200                3200    disable
+Ethernet8      drop               600                 600    disable
+"""
+
 pfcwd_show_start_history_output = """\
 Changed polling interval to 600ms
      PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -247,6 +247,68 @@ class TestPfcwd(object):
         assert result.output == test_vectors.pfcwd_show_start_default
 
     @patch('pfcwd.main.os')
+    def test_pfcwd_start_default_32_ports(self, mock_os):
+        """Test start_default on 32-port system: multiply=1, detection/restoration=200, poll=200ms"""
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        # Patch PORT table to have exactly 32 ports so multiply = (32-1)//32+1 = 1
+        original_get_table = db.cfgdb.get_table
+
+        def mock_get_table_32_ports(table):
+            if table == 'PORT':
+                return {'Ethernet%d' % i: {} for i in range(0, 32 * 4, 4)}  # 32 ports
+            return original_get_table(table)
+
+        mock_os.geteuid.return_value = 0
+        with patch.object(db.cfgdb, 'get_table', side_effect=mock_get_table_32_ports):
+            result = runner.invoke(
+                pfcwd.cli.commands["start_default"],
+                [],
+                obj=db
+            )
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            pfcwd.cli.commands["show"].commands["config"],
+            obj=db
+        )
+        assert result.exit_code == 0
+        assert result.output == test_vectors.pfcwd_show_start_default_32_ports
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_default_512_ports(self, mock_os):
+        """Test start_default on 512-port system: multiply=16, detection/restoration=3200, poll=1000ms"""
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        # Patch PORT table to have 512 ports so multiply = (512-1)//32+1 = 16
+        original_get_table = db.cfgdb.get_table
+
+        def mock_get_table_512_ports(table):
+            if table == 'PORT':
+                return {'Ethernet%d' % i: {} for i in range(512)}
+            return original_get_table(table)
+
+        mock_os.geteuid.return_value = 0
+        with patch.object(db.cfgdb, 'get_table', side_effect=mock_get_table_512_ports):
+            result = runner.invoke(
+                pfcwd.cli.commands["start_default"],
+                [],
+                obj=db
+            )
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            pfcwd.cli.commands["show"].commands["config"],
+            obj=db
+        )
+        assert result.exit_code == 0
+        assert result.output == test_vectors.pfcwd_show_start_default_512_ports
+
+    @patch('pfcwd.main.os')
     def test_pfcwd_start_history(self, mock_os):
         # pfcwd start all 600 --restoration-time 601 --pfc-stat-history
         import pfcwd.main as pfcwd


### PR DESCRIPTION
Fixing: https://github.com/sonic-net/sonic-buildimage/issues/25033
Should be merged before:  https://github.com/sonic-net/sonic-buildimage/pull/25034


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

PFC WD Detection time is defined by the following calculation:

DEFAULT_POLL_INTERVAL * multiply

where:

* multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
* port_num = len(list(self.config_db.get_table('PORT').keys()))
* DEFAULT_POLL_INTERVAL = 200
* DEFAULT_PORT_NUM = 32

There is an allowed range for this value which is between 100..3000 [ms].
For system with more than 448 ports, we will violate this range. 

In addition, there is no meaning to have detection time of more than 1000[ms], hence, this change limit the maximum detection time for PFC WD to 1000[ms]

#### How I did it

Calculate PFC WD Detection time, if it become bigger than 1000[ms], set it to 1000[ms]

#### How to verify it

Run PFC WD Tests on several platforms

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

