### PR TITLE
[warm/fast-reboot] check per-ASIC FW upgrade status

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -775,6 +775,20 @@ if [[ "$sonic_asic_type" == "mellanox" ]]; then
         error "Failed to burn MLNX FW: errno=${MLNX_EXIT_CODE}"
         exit "${MLNX_EXIT_FW_ERROR}"
     fi
+
+    function check_fw_upgrade_status() {
+        debug "Checking FW upgrade status for ASIC $DEV"
+        ${MLNX_FW_UPGRADE_SCRIPT} --status=$DEV && {
+            debug "FW upgrade successful for ASIC $DEV"
+        } || {
+            debug "FW upgrade failed for ASIC $DEV"
+            exit "${MLNX_EXIT_FW_ERROR}"
+        }
+    }
+
+    if [[ $NUM_ASIC -gt 1 ]]; then
+        execute_in_namespaces asic check_fw_upgrade_status
+    fi
 fi
 
 if is_secureboot && grep -q aboot_machine= /host/machine.conf; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

HLD - [Warm-reboot multi-ASIC HLD](https://github.com/sonic-net/SONiC/pull/2153)

#### What I did
Added per-ASIC firmware upgrade status checks during warm/fast reboot.

#### How I did it
Updated the warm/fast reboot flow to query and validate FW upgrade status per ASIC namespace instead of relying on a single/global check.

#### How to verify it

- Trigger warm/fast reboot on a Multi-ASIC system with mixed FW upgrade states and confirm the per-ASIC check reflects each namespace.
- Confirm reboot proceeds only when all ASICs report FW upgrade completion.
- Run existing warm reboot tests and ensure they pass.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

