### PR TITLE
[multi-asic][warm_restart] add Multi-ASIC support for warm_restart commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3825,9 +3825,9 @@ def warm_restart(ctx, redis_unix_socket_path):
     ctx.obj["state_db"] = {}
     ctx.obj["config_db"] = {}
     for namespace in all_namespaces:
-        config_db = ConfigDBConnector(namespace=namespace, use_unix_socket_path=use_unix_socket_path);
+        config_db = ConfigDBConnector(namespace=namespace, use_unix_socket_path=use_unix_socket_path)
         config_db.connect(wait_for_init=False)
-        state_db = SonicV2Connector(namespace=namespace, use_unix_socket_path=use_unix_socket_path);
+        state_db = SonicV2Connector(namespace=namespace, use_unix_socket_path=use_unix_socket_path)
         state_db.connect(state_db.STATE_DB, False)
         ctx.obj["state_db"][namespace] = state_db
         ctx.obj["config_db"][namespace] = config_db
@@ -3935,7 +3935,7 @@ def warm_restart_teamsyncd_timer(ctx, namespace, seconds):
 
     if ADHOC_VALIDATION:
         if seconds not in range(1, 3600):
-            ctx.fail("bgp warm restart timer must be in range 1-3600")
+            ctx.fail("teamsyncd warm restart timer must be in range 1-3600")
 
     for namespace in namespaces:
         db = ValidatedConfigDBConnector(ctx.obj["config_db"][namespace])

--- a/show/warm_restart.py
+++ b/show/warm_restart.py
@@ -106,6 +106,7 @@ def config(namespace, redis_unix_socket_path):
 
         show_warm_restart_config_for_namespace(namespace, **kwargs)
 
+
 def show_warm_restart_config_for_namespace(namespace, **kwargs):
     config_db = ConfigDBConnector(namespace=namespace, **kwargs)
     config_db.connect(wait_for_init=False)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -3015,7 +3015,7 @@ class TestConfigWarmRestart(object):
         config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db': {'': db.cfgdb}, 'asic_namespaces': ['']}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["neighsyncd_timer"], ["2000"], obj=obj)
         print(result.exit_code)
@@ -3027,7 +3027,7 @@ class TestConfigWarmRestart(object):
         config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db': {'': db.cfgdb}, 'asic_namespaces': ['']}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["neighsyncd_timer"], ["0"], obj=obj)
         print(result.exit_code)
@@ -3041,7 +3041,7 @@ class TestConfigWarmRestart(object):
         config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db': {'': db.cfgdb}, 'asic_namespaces': ['']}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["bgp_timer"], ["2000"], obj=obj)
         print(result.exit_code)
@@ -3053,7 +3053,7 @@ class TestConfigWarmRestart(object):
         config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db': {'': db.cfgdb}, 'asic_namespaces': ['']}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["bgp_timer"], ["0"], obj=obj)
         print(result.exit_code)
@@ -3067,7 +3067,7 @@ class TestConfigWarmRestart(object):
         config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db': {'': db.cfgdb}, 'asic_namespaces': ['']}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["teamsyncd_timer"], ["2000"], obj=obj)
         print(result.exit_code)
@@ -3079,7 +3079,7 @@ class TestConfigWarmRestart(object):
         config.ADHOC_VALIDATION = True
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db': {'': db.cfgdb}, 'asic_namespaces': ['']}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["teamsyncd_timer"], ["0"], obj=obj)
         print(result.exit_code)
@@ -3093,7 +3093,7 @@ class TestConfigWarmRestart(object):
         config.ADHOC_VALIDATION = False
         runner = CliRunner()
         db = Db()
-        obj = {'db':db.cfgdb}
+        obj = {'config_db': {'': db.cfgdb}, 'asic_namespaces': ['']}
 
         result = runner.invoke(config.config.commands["warm_restart"].commands["bgp_eoiu"], ["true"], obj=obj)
         print(result.exit_code)

--- a/tests/test_warm_restart.py
+++ b/tests/test_warm_restart.py
@@ -148,7 +148,8 @@ def test_config_warm_restart_neighsyncd_timer(configdbconnector_mock, sonicv2con
         "swss"]["neighsyncd_timer"] == "180"
 
 
-def test_config_warm_restart_neighsyncd_timer_multi_asic(configdbconnector_mock, sonicv2connector_mock, multi_asic):
+def test_config_warm_restart_neighsyncd_timer_multi_asic(
+        configdbconnector_mock, sonicv2connector_mock, multi_asic):
     runner = CliRunner()
     result = runner.invoke(
         config_cli.commands["warm_restart"], ["neighsyncd_timer", "180"],
@@ -160,7 +161,8 @@ def test_config_warm_restart_neighsyncd_timer_multi_asic(configdbconnector_mock,
             "swss"]["neighsyncd_timer"] == "180"
 
 
-def test_config_warm_restart_neighsyncd_timer_multi_asic_one_asic(configdbconnector_mock, sonicv2connector_mock, multi_asic):
+def test_config_warm_restart_neighsyncd_timer_multi_asic_one_asic(
+        configdbconnector_mock, sonicv2connector_mock, multi_asic):
     runner = CliRunner()
     result = runner.invoke(
         config_cli.commands["warm_restart"], ["neighsyncd_timer", "180"],
@@ -238,7 +240,8 @@ def test_config_warm_restart_disable_bgp_eoiu_multi_asic(configdbconnector_mock,
         assert cfg_db.get_table("WARM_RESTART")["bgp"]["bgp_eoiu"] == "true"
 
 
-def test_config_warm_restart_disable_bgp_eoiu_multi_asic_one_asic(configdbconnector_mock, sonicv2connector_mock, multi_asic):
+def test_config_warm_restart_disable_bgp_eoiu_multi_asic_one_asic(
+        configdbconnector_mock, sonicv2connector_mock, multi_asic):
     runner = CliRunner()
     result = runner.invoke(
         config_cli.commands["warm_restart"], ["bgp_eoiu", "true"],
@@ -369,12 +372,12 @@ def test_show_warm_restart_state_invalid_namespace(setup_state_db_multi_asic):
     )
     expected_output = textwrap.dedent("""\
         Usage: warm_restart state [OPTIONS]
+        Try 'warm_restart state --help' for help.
 
         Error: Invalid namespace: asicX
     """)
     assert result.exit_code == 2
     assert result.output == expected_output
-
 
 
 def test_show_warm_restart_state_unix_sock_usage(setup_state_db):
@@ -474,6 +477,7 @@ def test_show_warm_restart_config_invalid_namespace(setup_state_db_multi_asic):
     )
     expected_output = textwrap.dedent("""\
         Usage: warm_restart config [OPTIONS]
+        Try 'warm_restart config --help' for help.
 
         Error: Invalid namespace: asicX
     """)
@@ -489,6 +493,7 @@ def test_show_warm_restart_config_unix_sock_usage_and_namespace(setup_state_db_m
     )
     expected_output = textwrap.dedent("""\
         Usage: warm_restart config [OPTIONS]
+        Try 'warm_restart config --help' for help.
 
         Error: Cannot specify both namespace and redis unix socket path
     """)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
HLD - [Warm-reboot multi-ASIC HLD](https://github.com/sonic-net/SONiC/pull/2153)

#### What I did
Added Multi-ASIC support for warm_restart commands.

#### How I did it
Updated the warm restart commands to operate per ASIC namespace and handle multi-ASIC execution consistently.

#### How to verify it

- Run warm_restart commands on a Multi-ASIC system and confirm per-ASIC namespaces are handled.
- Verify warm restart flags/status are correct per namespace.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

