### PR TITLE
[acl-loader]: Wait for rules to be removed before installing new ones

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -5,6 +5,7 @@ import ipaddress
 import json
 import syslog
 import operator
+import time
 
 import openconfig_acl
 import tabulate
@@ -320,6 +321,34 @@ class AclLoader(object):
                 status[key]['status'] = state_db_info.get("status", "N/A") if state_db_info else "N/A"
 
         return status
+
+    def _check_if_state_db_items_are_empty(self, db, pattern):
+        try:
+            return not db.keys(db.STATE_DB, pattern)
+        except Exception:
+            return True
+
+    def _wait_until_state_acl_rules_empty(self, table_name=None):
+        """
+        Wait until STATE_DB entries for ACL rules are gone.
+        This checks `self.statedb` and any `self.per_npu_statedb` connectors.
+        Raises AclLoaderException on timeout.
+        """
+
+        pattern = f"{self.STATE_ACL_RULE}|{table_name}|*" if table_name else f"{self.STATE_ACL_RULE}|*"
+
+        for i in range(60):
+            if self._check_if_state_db_items_are_empty(self.statedb, pattern):
+                # Check per-npu statedb connectors
+                if all(
+                    self._check_if_state_db_items_are_empty(ns_statedb, pattern)
+                    for _, ns_statedb in self.per_npu_statedb.items()
+                ):
+                    return
+            time.sleep(1)
+
+        raise AclLoaderException(
+            f"Timed out waiting for STATE_DB to be empty (pattern={pattern})")
 
     def get_sessions_db_info(self):
         return self.sessions_db_info
@@ -841,6 +870,13 @@ class AclLoader(object):
                 for namespace_configdb in self.per_npu_configdb.values():
                     namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
+        # After removing entries from Config DB, wait for orchestration to
+        # process and clear corresponding STATE_DB entries before inserting
+        # new rules into Config DB.
+        try:
+            self._wait_until_state_acl_rules_empty(self.current_table)
+        except AclLoaderException as e:
+            warning(str(e))
 
         self.configdb.mod_config({self.ACL_RULE: self.rules_info})
         # Program for per front asic namespace also if present
@@ -888,6 +924,13 @@ class AclLoader(object):
             for namespace_configdb in self.per_npu_configdb.values():
                 namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
+        # After removing entries from Config DB, wait for orchestration to
+        # process and clear corresponding STATE_DB entries before inserting
+        # new rules into Config DB.
+        try:
+            self._wait_until_state_acl_rules_empty(self.current_table)
+        except AclLoaderException as e:
+            warning(str(e))
 
         # Add all new dataplane rules
         for key in new_dataplane_rules:


### PR DESCRIPTION
When running `acl-loader update full` multiple times consecutively, with an ACL rule set that exceeds the TCAM's capacity, the installed ACL rules differ between iterations.

#### What I did
full_update() now waits for the existing rules to be removed.
incremental_update() has also been modified as it handles dataplane rules in the same way.

This results in a deterministic rule set between runs.

#### How I did it
By polling the State DB before installing the new ones. 

#### How to verify it
1. Have a /etc/sonic/config.db with a large amount of rules.
2. Run `acl-loader update full` with a JSON file containing a large amount of rules, multiple times.
3. If the rule set provided is large enough to saturate the TCAM's capacity, you'll see differences between runs in `show acl rule`.