### PR TITLE
Fix route_check.py to not hog a lot of memory

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -51,7 +51,7 @@ import concurrent.futures
 from ipaddress import ip_network
 from swsscommon import swsscommon
 from utilities_common import chassis
-from sonic_py_common import multi_asic
+from sonic_py_common import multi_asic, device_info
 from utilities_common.general import load_db_config
 
 APPL_DB_NAME = 'APPL_DB'
@@ -61,8 +61,8 @@ ASIC_KEY_PREFIX = 'SAI_OBJECT_TYPE_ROUTE_ENTRY:'
 
 SUBSCRIBE_WAIT_SECS = 1
 
-# Max of 10 mins
-TIMEOUT_SECONDS = 600
+# Max of 2 minutes on normal devices and 5 minutes on virtual chassis
+TIMEOUT_SECONDS = 120 if not device_info.is_virtual_chassis() else 360
 
 # Chunk size to read
 CHUNK_SIZE = 5 * 1024 * 1024  # Read data in 5 MB chunks

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -65,9 +65,6 @@ SUBSCRIBE_WAIT_SECS = 1
 # Max of 2 minutes on normal devices and 5 minutes on virtual chassis
 TIMEOUT_SECONDS = 120 if not device_info.is_virtual_chassis() else 360
 
-# Chunk size to read
-CHUNK_SIZE = 5 * 1024 * 1024  # Read data in 5 MB chunks
-
 UNIT_TESTING = 0
 
 os.environ['PYTHONUNBUFFERED'] = 'True'
@@ -1082,7 +1079,6 @@ def main():
     with given interval in-between calls to check_route
     :return Same return value as returned by check_route.
     """
-    global CHUNK_SIZE
     global TIMEOUT_SECONDS
     interval = 0
     parser = argparse.ArgumentParser(
@@ -1105,10 +1101,6 @@ def main():
     parser.add_argument('-n', '--namespace',
                         default=multi_asic.DEFAULT_NAMESPACE,
                         help='Verify routes for this specific namespace')
-    parser.add_argument('-c',
-                        '--chunk',
-                        type=int,
-                        default=CHUNK_SIZE, help='Chunk size in bytes')
     parser.add_argument('-t',
                         '--timeout',
                         type=int,
@@ -1118,7 +1110,6 @@ def main():
 
     namespace = args.namespace
 
-    CHUNK_SIZE = args.chunk * 1024
     TIMEOUT_SECONDS = args.timeout
 
     if namespace is not multi_asic.DEFAULT_NAMESPACE and not multi_asic.is_multi_asic():

--- a/setup.py
+++ b/setup.py
@@ -247,6 +247,7 @@ setup(
         'docker-image-py>=0.1.10',
         'filelock>=3.0.12',
         'enlighten>=1.8.0',
+        'ijson>=3.2.3',
         'ipaddress>=1.0.23',
         'protobuf',
         'jinja2>=2.11.3',

--- a/tests/fetch_routes_chunk_test.py
+++ b/tests/fetch_routes_chunk_test.py
@@ -1,0 +1,955 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the chunk-based reading logic in fetch_routes() function.
+Tests various scenarios including:
+- Complete JSON in single chunk
+- JSON split across multiple chunks
+- Incomplete JSON objects at chunk boundaries
+- UTF-8 sequences split across chunks
+- Empty responses
+- Malformed JSON
+"""
+
+import json
+from unittest.mock import Mock, patch
+from io import BytesIO
+import sys
+
+sys.path.append("scripts")
+import route_check  # noqa: E402
+
+
+class TestFetchRoutes:
+    """Test suite for chunk-based reading in fetch_routes()"""
+
+    def setup_method(self):
+        """Setup for each test method"""
+        route_check.UNIT_TESTING = 1
+        route_check.FRR_WAIT_TIME = 0
+
+    def create_mock_process(self, data_bytes):
+        """
+        Create a mock subprocess.Popen object with stdout that returns data
+        in chunks.
+
+        Args:
+            data_bytes: bytes to return from stdout
+
+        Returns:
+            Mock Popen object
+        """
+        mock_proc = Mock()
+        mock_proc.stdout = BytesIO(data_bytes)
+        mock_proc.wait = Mock(return_value=0)
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+        return mock_proc
+
+    def test_complete_json_single_chunk(self):
+        """Test parsing when complete JSON fits in a single chunk"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == ["192.168.1.0/24"]
+
+    def test_json_split_across_chunks(self):
+        """Test parsing when JSON is split across multiple chunks"""
+        json_data = {
+            "10.0.0.0/8": [{
+                "prefix": "10.0.0.0/8",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "172.16.0.0/12": [{
+                "prefix": "172.16.0.0/12",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_str = json.dumps(json_data)
+
+        # Split the JSON string in the middle
+        split_point = len(json_str) // 2
+        chunk1 = json_str[:split_point].encode('utf-8')
+        chunk2 = json_str[split_point:].encode('utf-8')
+
+        # Create a custom BytesIO that returns data in specific chunk sizes
+        class ChunkedBytesIO:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def read(self, size):
+                if self.index >= len(self.chunks):
+                    return b''
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_proc = Mock()
+        mock_proc.stdout = ChunkedBytesIO([chunk1, chunk2])
+        mock_proc.wait = Mock(return_value=0)
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == {"10.0.0.0/8", "172.16.0.0/12"}
+
+    def test_routes_with_offloaded_flag(self):
+        """Test that routes with offloaded=True are not included in missing
+           routes"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": True  # This should NOT be in missing routes
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False  # This SHOULD be in missing routes
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == ["192.168.2.0/24"]
+
+    def test_filter_connected_kernel_static_protocols(self):
+        """Test that connected, kernel and static protocols are filtered out"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "connected",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "kernel",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.3.0/24": [{
+                "prefix": "192.168.3.0/24",
+                "protocol": "static",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.4.0/24": [{
+                "prefix": "192.168.4.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # Only BGP route should be in the result
+        assert result == ["192.168.4.0/24"]
+
+    def test_filter_non_default_vrf(self):
+        """Test that routes in non-default VRF are filtered out"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "Vrf_RED",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.3.0/24": [{
+                "prefix": "192.168.3.0/24",
+                "protocol": "bgp",
+                "vrfName": "mgmt",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # Only default VRF route should be in the result
+        assert result == ["192.168.2.0/24"]
+
+    def test_filter_not_selected_routes(self):
+        """Test that routes not selected as best are filtered out"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": False,
+                "offloaded": False
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # Only selected route should be in the result
+        assert result == ["192.168.2.0/24"]
+
+    def test_empty_json_response(self):
+        """Test handling of empty JSON response"""
+        json_data = {}
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == []
+
+    def test_utf8_split_across_chunks(self):
+        """Test handling of UTF-8 multibyte characters split across chunks"""
+        # Create JSON with UTF-8 characters
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": "Test route with émojis 🚀"
+            }]
+        }
+        json_str = json.dumps(json_data)
+        json_bytes = json_str.encode('utf-8')
+
+        # Find a multibyte character and split there
+        # The emoji 🚀 is 4 bytes in UTF-8
+        emoji_pos = json_bytes.find('🚀'.encode('utf-8'))
+        if emoji_pos > 0:
+            # Split in the middle of the emoji
+            split_point = emoji_pos + 2
+            chunk1 = json_bytes[:split_point]
+            chunk2 = json_bytes[split_point:]
+
+            class ChunkedBytesIO:
+                def __init__(self, chunks):
+                    self.chunks = chunks
+                    self.index = 0
+
+                def read(self, size):
+                    if self.index >= len(self.chunks):
+                        return b''
+                    chunk = self.chunks[self.index]
+                    self.index += 1
+                    return chunk
+
+            mock_proc = Mock()
+            mock_proc.stdout = ChunkedBytesIO([chunk1, chunk2])
+            mock_proc.wait = Mock(return_value=0)
+            mock_proc.__enter__ = Mock(return_value=mock_proc)
+            mock_proc.__exit__ = Mock(return_value=False)
+
+            with patch('route_check.subprocess.Popen', return_value=mock_proc):
+                result = route_check.fetch_routes(['show', 'ip', 'route',
+                                                   'json'])
+
+            assert result == ["192.168.1.0/24"]
+
+    def test_very_small_chunks(self):
+        """Test parsing with very small chunk sizes (byte-by-byte)"""
+        json_data = {
+            "10.0.0.0/8": [{
+                "prefix": "10.0.0.0/8",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        # Create chunks of 10 bytes each
+        chunks = [json_bytes[i:i+10] for i in range(0, len(json_bytes), 10)]
+
+        class ChunkedBytesIO:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def read(self, size):
+                if self.index >= len(self.chunks):
+                    return b''
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_proc = Mock()
+        mock_proc.stdout = ChunkedBytesIO(chunks)
+        mock_proc.wait = Mock(return_value=0)
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == ["10.0.0.0/8"]
+
+    def test_large_json_with_many_routes(self):
+        """Test parsing large JSON with many route entries"""
+        json_data = {}
+        expected_missing = []
+
+        # Create 100 routes
+        for i in range(100):
+            prefix = f"10.{i}.0.0/16"
+            json_data[prefix] = [{
+                "prefix": prefix,
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+            expected_missing.append(prefix)
+
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == set(expected_missing)
+        assert len(result) == 100
+
+    def test_ipv6_command(self):
+        """Test that IPv6 command is properly constructed"""
+        json_data = {
+            "2001:db8::/32": [{
+                "prefix": "2001:db8::/32",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc) \
+                as mock_popen:
+            result = route_check.fetch_routes(['show', 'ipv6',
+                                               'route', 'json'])
+
+            # Verify the correct command was called
+            mock_popen.assert_called_once()
+            call_args = mock_popen.call_args[0][0]
+            assert call_args == ["sudo", "vtysh", "-c", "show ipv6 route json"]
+
+        assert result == ["2001:db8::/32"]
+
+    def test_subprocess_non_zero_exit_code(self):
+        """Test handling of subprocess with non-zero exit code"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = Mock()
+        mock_proc.stdout = BytesIO(json_bytes)
+        mock_proc.wait = Mock(return_value=1)  # Non-zero exit code
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # Should still return the parsed routes
+        assert result == ["192.168.1.0/24"]
+
+    def test_file_not_found_error(self):
+        """Test handling of FileNotFoundError when vtysh is not found"""
+        with patch('route_check.subprocess.Popen',
+                   side_effect=FileNotFoundError("vtysh not found")):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # Should return empty list on error
+        assert result == []
+
+    def test_multiple_route_entries_per_prefix(self):
+        """Test handling of multiple route entries for the same prefix"""
+        json_data = {
+            "192.168.1.0/24": [
+                {
+                    "prefix": "192.168.1.0/24",
+                    "protocol": "bgp",
+                    "vrfName": "default",
+                    "selected": True,
+                    "offloaded": True
+                },
+                {
+                    "prefix": "192.168.1.0/24",
+                    "protocol": "bgp",
+                    "vrfName": "default",
+                    "selected": False,
+                    "offloaded": False
+                }
+            ]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # First entry is offloaded, second is not selected, so no missing
+        # routes
+        assert result == []
+
+    def test_json_with_nested_objects(self):
+        """Test parsing JSON with deeply nested objects"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "nexthops": [
+                    {
+                        "ip": "10.0.0.1",
+                        "interfaceName": "Ethernet0",
+                        "active": True
+                    }
+                ]
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == ["192.168.1.0/24"]
+
+    def test_variable_chunk_boundary(self):
+        """Test when chunk boundary falls at variious locations"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_str = json.dumps(json_data)
+        json_bytes = json_str.encode('utf-8')
+
+        class ChunkedBytesIO:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def read(self, size):
+                if self.index >= len(self.chunks):
+                    return b''
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        json_len = len(json_str)
+        for chunk_boundary in range(1, json_len):
+            # Find the position of the first closing brace
+            chunk1 = json_bytes[:chunk_boundary+1]
+            chunk2 = json_bytes[chunk_boundary+1:]
+
+            mock_proc = Mock()
+            mock_proc.stdout = ChunkedBytesIO([chunk1, chunk2])
+            mock_proc.wait = Mock(return_value=0)
+            mock_proc.__enter__ = Mock(return_value=mock_proc)
+            mock_proc.__exit__ = Mock(return_value=False)
+
+            with patch('route_check.subprocess.Popen', return_value=mock_proc):
+                result = route_check.fetch_routes(['show', 'ip', 'route',
+                                                   'json'])
+
+            assert result == ["192.168.1.0/24"]
+
+    def test_chunk_boundary_in_string_value(self):
+        """Test when chunk boundary falls in the middle of a string value"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": "This is a very long description that will be split across chunks"
+            }]
+        }
+        json_str = json.dumps(json_data)
+        json_bytes = json_str.encode('utf-8')
+
+        # Find the description and split in the middle of it
+        desc_start = json_str.find("This is a very long")
+        split_point = desc_start + 10
+        chunk1 = json_bytes[:split_point]
+        chunk2 = json_bytes[split_point:]
+
+        class ChunkedBytesIO:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def read(self, size):
+                if self.index >= len(self.chunks):
+                    return b''
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_proc = Mock()
+        mock_proc.stdout = ChunkedBytesIO([chunk1, chunk2])
+        mock_proc.wait = Mock(return_value=0)
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == ["192.168.1.0/24"]
+
+    def test_escaped_quotes_in_json(self):
+        """Test handling of escaped quotes in JSON strings"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": "Route with \"escaped\" quotes"
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == ["192.168.1.0/24"]
+
+    def test_whitespace_handling(self):
+        """Test handling of JSON with various whitespace"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        # Add extra whitespace
+        json_str = json.dumps(json_data, indent=4)
+        json_str = json_str.replace(',', '   \n,')
+        json_bytes = json_str.encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert result == ["192.168.1.0/24"]
+
+    def test_mixed_ipv4_and_ipv6_routes(self):
+        """Test parsing JSON with both IPv4 and IPv6 routes"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "2001:db8::/32": [{
+                "prefix": "2001:db8::/32",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == {"192.168.1.0/24", "2001:db8::/32"}
+
+    def test_malformed_json_in_buffer(self):
+        """Test handling of malformed JSON that cannot be parsed"""
+        malformed_json = b'{"192.168.1.0/24": [{"prefix": "192.168.1.0/24", "protocol": "bgp"'
+
+        mock_proc = self.create_mock_process(malformed_json)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # Should return empty list for malformed JSON
+        assert result == []
+
+    def test_incremental_parsing_multiple_prefixes(self):
+        """Test that multiple prefix entries are parsed one at a time"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.3.0/24": [{
+                "prefix": "192.168.3.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == {"192.168.1.0/24",
+                               "192.168.2.0/24",
+                               "192.168.3.0/24"}
+
+    def test_incremental_parsing_prefix_split_across_chunks(self):
+        """Test that a prefix entry split across chunks is parsed correctly"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": "This is a long description to make the entry larger"
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": "Another long description for the second prefix"
+            }]
+        }
+        json_str = json.dumps(json_data)
+        json_bytes = json_str.encode('utf-8')
+
+        # Split in the middle of the first prefix entry
+        # Find the position after the first prefix key
+        first_prefix_end = json_str.find(']', json_str.find('"192.168.1.0/24"'))
+        split_point = first_prefix_end - 20  # Split before the end of first entry
+
+        chunk1 = json_bytes[:split_point]
+        chunk2 = json_bytes[split_point:]
+
+        class ChunkedBytesIO:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def read(self, size):
+                if self.index >= len(self.chunks):
+                    return b''
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_proc = Mock()
+        mock_proc.stdout = ChunkedBytesIO([chunk1, chunk2])
+        mock_proc.wait = Mock(return_value=0)
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}
+
+    def test_incremental_parsing_across_multiple_chunks(self):
+        # Create a large JSON with many prefixes
+        json_data = {}
+        expected_missing = []
+
+        for i in range(50):
+            prefix = f"10.{i}.0.0/16"
+            json_data[prefix] = [{
+                "prefix": prefix,
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": f"Route {i} with some description text to make it larger"
+            }]
+            expected_missing.append(prefix)
+
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        # Split into multiple small chunks to test incremental parsing
+        chunk_size = 500
+        chunks = [json_bytes[i:i+chunk_size] for i in range(0, len(json_bytes), chunk_size)]
+
+        class ChunkedBytesIO:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def read(self, size):
+                if self.index >= len(self.chunks):
+                    return b''
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_proc = Mock()
+        mock_proc.stdout = ChunkedBytesIO(chunks)
+        mock_proc.wait = Mock(return_value=0)
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == set(expected_missing)
+        assert len(result) == 50
+
+    def test_incremental_parsing_prefix_boundary_at_comma(self):
+        """Test parsing when chunk boundary falls at comma between prefix entries"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False
+            }]
+        }
+        json_str = json.dumps(json_data)
+        json_bytes = json_str.encode('utf-8')
+
+        # Find the comma between the two entries
+        comma_pos = json_str.find('],') + 2  # Position after "],"
+
+        chunk1 = json_bytes[:comma_pos]
+        chunk2 = json_bytes[comma_pos:]
+
+        class ChunkedBytesIO:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def read(self, size):
+                if self.index >= len(self.chunks):
+                    return b''
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_proc = Mock()
+        mock_proc.stdout = ChunkedBytesIO([chunk1, chunk2])
+        mock_proc.wait = Mock(return_value=0)
+        mock_proc.__enter__ = Mock(return_value=mock_proc)
+        mock_proc.__exit__ = Mock(return_value=False)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}
+
+    def test_incremental_parsing_mixed_offloaded_states(self):
+        """Test incremental parsing with mixed offloaded states across multiple prefixes"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": True  # This one is offloaded
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False  # This one is missing
+            }],
+            "192.168.3.0/24": [{
+                "prefix": "192.168.3.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": True  # This one is offloaded
+            }],
+            "192.168.4.0/24": [{
+                "prefix": "192.168.4.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False  # This one is missing
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        # Only the non-offloaded routes should be in the result
+        assert set(result) == {"192.168.2.0/24", "192.168.4.0/24"}
+
+    def test_incremental_parsing_with_whitespace_variations(self):
+        """Test incremental parsing with various whitespace formatting"""
+        # Create JSON with extra whitespace and newlines
+        json_str = """{
+            "192.168.1.0/24": [
+                {
+                    "prefix": "192.168.1.0/24",
+                    "protocol": "bgp",
+                    "vrfName": "default",
+                    "selected": true,
+                    "offloaded": false
+                }
+            ],
+            "192.168.2.0/24": [
+                {
+                    "prefix": "192.168.2.0/24",
+                    "protocol": "bgp",
+                    "vrfName": "default",
+                    "selected": true,
+                    "offloaded": false
+                }
+            ]
+        }"""
+        json_bytes = json_str.encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}
+
+    def test_incremental_parsing_prefix_with_special_characters(self):
+        """Test incremental parsing of prefixes with special characters in descriptions"""
+        json_data = {
+            "192.168.1.0/24": [{
+                "prefix": "192.168.1.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": "Route with special chars: {}, [], \", \\"
+            }],
+            "192.168.2.0/24": [{
+                "prefix": "192.168.2.0/24",
+                "protocol": "bgp",
+                "vrfName": "default",
+                "selected": True,
+                "offloaded": False,
+                "description": "Another route with: commas, colons: and braces {}"
+            }]
+        }
+        json_bytes = json.dumps(json_data).encode('utf-8')
+
+        mock_proc = self.create_mock_process(json_bytes)
+
+        with patch('route_check.subprocess.Popen', return_value=mock_proc):
+            result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
+
+        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}

--- a/tests/fetch_routes_chunk_test.py
+++ b/tests/fetch_routes_chunk_test.py
@@ -63,7 +63,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == ["192.168.1.0/24"]
+        assert result == (["192.168.1.0/24"], [])
 
     def test_json_split_across_chunks(self):
         """Test parsing when JSON is split across multiple chunks"""
@@ -112,7 +112,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == {"10.0.0.0/8", "172.16.0.0/12"}
+        assert set(result[0]) == {"10.0.0.0/8", "172.16.0.0/12"}
 
     def test_routes_with_offloaded_flag(self):
         """Test that routes with offloaded=True are not included in missing
@@ -140,7 +140,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == ["192.168.2.0/24"]
+        assert result == (["192.168.2.0/24"], [])
 
     def test_filter_connected_kernel_static_protocols(self):
         """Test that connected, kernel and static protocols are filtered out"""
@@ -182,7 +182,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         # Only BGP route should be in the result
-        assert result == ["192.168.4.0/24"]
+        assert result == (["192.168.4.0/24"], [])
 
     def test_filter_non_default_vrf(self):
         """Test that routes in non-default VRF are filtered out"""
@@ -217,7 +217,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         # Only default VRF route should be in the result
-        assert result == ["192.168.2.0/24"]
+        assert result == (["192.168.2.0/24"], [])
 
     def test_filter_not_selected_routes(self):
         """Test that routes not selected as best are filtered out"""
@@ -245,7 +245,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         # Only selected route should be in the result
-        assert result == ["192.168.2.0/24"]
+        assert result == (["192.168.2.0/24"], [])
 
     def test_empty_json_response(self):
         """Test handling of empty JSON response"""
@@ -257,7 +257,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == []
+        assert result == ([], [])
 
     def test_utf8_split_across_chunks(self):
         """Test handling of UTF-8 multibyte characters split across chunks"""
@@ -306,7 +306,7 @@ class TestFetchRoutes:
                 result = route_check.fetch_routes(['show', 'ip', 'route',
                                                    'json'])
 
-            assert result == ["192.168.1.0/24"]
+            assert result == (["192.168.1.0/24"], [])
 
     def test_very_small_chunks(self):
         """Test parsing with very small chunk sizes (byte-by-byte)"""
@@ -345,7 +345,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == ["10.0.0.0/8"]
+        assert result == (["10.0.0.0/8"], [])
 
     def test_large_json_with_many_routes(self):
         """Test parsing large JSON with many route entries"""
@@ -371,8 +371,8 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == set(expected_missing)
-        assert len(result) == 100
+        assert set(result[0]) == set(expected_missing)
+        assert len(result[0]) == 100
 
     def test_ipv6_command(self):
         """Test that IPv6 command is properly constructed"""
@@ -399,7 +399,7 @@ class TestFetchRoutes:
             call_args = mock_popen.call_args[0][0]
             assert call_args == ["sudo", "vtysh", "-c", "show ipv6 route json"]
 
-        assert result == ["2001:db8::/32"]
+        assert result == (["2001:db8::/32"], [])
 
     def test_subprocess_non_zero_exit_code(self):
         """Test handling of subprocess with non-zero exit code"""
@@ -424,7 +424,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         # Should still return the parsed routes
-        assert result == ["192.168.1.0/24"]
+        assert result == (["192.168.1.0/24"], [])
 
     def test_file_not_found_error(self):
         """Test handling of FileNotFoundError when vtysh is not found"""
@@ -433,7 +433,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         # Should return empty list on error
-        assert result == []
+        assert result == ([], [])
 
     def test_multiple_route_entries_per_prefix(self):
         """Test handling of multiple route entries for the same prefix"""
@@ -464,7 +464,7 @@ class TestFetchRoutes:
 
         # First entry is offloaded, second is not selected, so no missing
         # routes
-        assert result == []
+        assert result == ([], [])
 
     def test_json_with_nested_objects(self):
         """Test parsing JSON with deeply nested objects"""
@@ -491,7 +491,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == ["192.168.1.0/24"]
+        assert result == (["192.168.1.0/24"], [])
 
     def test_variable_chunk_boundary(self):
         """Test when chunk boundary falls at variious locations"""
@@ -535,7 +535,7 @@ class TestFetchRoutes:
                 result = route_check.fetch_routes(['show', 'ip', 'route',
                                                    'json'])
 
-            assert result == ["192.168.1.0/24"]
+            assert result == (["192.168.1.0/24"], [])
 
     def test_chunk_boundary_in_string_value(self):
         """Test when chunk boundary falls in the middle of a string value"""
@@ -579,7 +579,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == ["192.168.1.0/24"]
+        assert result == (["192.168.1.0/24"], [])
 
     def test_escaped_quotes_in_json(self):
         """Test handling of escaped quotes in JSON strings"""
@@ -600,7 +600,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == ["192.168.1.0/24"]
+        assert result == (["192.168.1.0/24"], [])
 
     def test_whitespace_handling(self):
         """Test handling of JSON with various whitespace"""
@@ -623,7 +623,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert result == ["192.168.1.0/24"]
+        assert result == (["192.168.1.0/24"], [])
 
     def test_mixed_ipv4_and_ipv6_routes(self):
         """Test parsing JSON with both IPv4 and IPv6 routes"""
@@ -650,7 +650,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == {"192.168.1.0/24", "2001:db8::/32"}
+        assert set(result[0]) == {"192.168.1.0/24", "2001:db8::/32"}
 
     def test_malformed_json_in_buffer(self):
         """Test handling of malformed JSON that cannot be parsed"""
@@ -662,7 +662,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         # Should return empty list for malformed JSON
-        assert result == []
+        assert result == ([], [])
 
     def test_incremental_parsing_multiple_prefixes(self):
         """Test that multiple prefix entries are parsed one at a time"""
@@ -696,7 +696,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == {"192.168.1.0/24",
+        assert set(result[0]) == {"192.168.1.0/24",
                                "192.168.2.0/24",
                                "192.168.3.0/24"}
 
@@ -752,7 +752,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
 
     def test_incremental_parsing_across_multiple_chunks(self):
         # Create a large JSON with many prefixes
@@ -798,8 +798,8 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == set(expected_missing)
-        assert len(result) == 50
+        assert set(result[0]) == set(expected_missing)
+        assert len(result[0]) == 50
 
     def test_incremental_parsing_prefix_boundary_at_comma(self):
         """Test parsing when chunk boundary falls at comma between prefix entries"""
@@ -849,7 +849,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
 
     def test_incremental_parsing_mixed_offloaded_states(self):
         """Test incremental parsing with mixed offloaded states across multiple prefixes"""
@@ -891,7 +891,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         # Only the non-offloaded routes should be in the result
-        assert set(result) == {"192.168.2.0/24", "192.168.4.0/24"}
+        assert set(result[0]) == {"192.168.2.0/24", "192.168.4.0/24"}
 
     def test_incremental_parsing_with_whitespace_variations(self):
         """Test incremental parsing with various whitespace formatting"""
@@ -923,7 +923,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
 
     def test_incremental_parsing_prefix_with_special_characters(self):
         """Test incremental parsing of prefixes with special characters in descriptions"""
@@ -952,4 +952,4 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
-        assert set(result) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}

--- a/tests/fetch_routes_chunk_test.py
+++ b/tests/fetch_routes_chunk_test.py
@@ -697,8 +697,8 @@ class TestFetchRoutes:
             result = route_check.fetch_routes(['show', 'ip', 'route', 'json'])
 
         assert set(result[0]) == {"192.168.1.0/24",
-                               "192.168.2.0/24",
-                               "192.168.3.0/24"}
+                                  "192.168.2.0/24",
+                                  "192.168.3.0/24"}
 
     def test_incremental_parsing_prefix_split_across_chunks(self):
         """Test that a prefix entry split across chunks is parsed correctly"""

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -279,8 +279,9 @@ class TestRouteCheck(object):
         ns = args[0]
         routes = ct_data.get(FRR_ROUTES, {}).get(ns, {})
         if not routes:
-            return []
-        route_list = []
+            return [], []  # Return tuple of (missed_routes, failed_routes)
+        missed_route_list = []
+        failed_route_list = []
         for r, v in routes.items():
             for e in v:
                 if e.get('protocol') in ('connected', 'kernel', 'static'):
@@ -290,8 +291,10 @@ class TestRouteCheck(object):
                 if not e.get('selected', False):
                     continue
                 if not e.get('offloaded', False):
-                    route_list.append(r)
-        return route_list
+                    missed_route_list.append(r)
+                if e.get('failed', False):
+                    failed_route_list.append(r)
+        return missed_route_list, failed_route_list  # Return tuple of (missed_routes, failed_routes)
 
     def assert_results(self, ct_data, ret, res):
         expect_ret = ct_data.get(RET, 0)

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -9,7 +9,7 @@ from sonic_py_common import device_info
 from unittest.mock import MagicMock, patch
 from tests.route_check_test_data import (
     APPL_DB, MULTI_ASIC, NAMESPACE, DEFAULTNS, ARGS, ASIC_DB, CONFIG_DB,
-    DEFAULT_CONFIG_DB, APPL_STATE_DB, DESCR, OP_DEL, OP_SET, PRE, RESULT, RET, TEST_DATA,
+    DEFAULT_CONFIG_DB, APPL_STATE_DB, OP_DEL, OP_SET, PRE, RESULT, RET, TEST_DATA,
     UPD, FRR_ROUTES
 )
 
@@ -18,18 +18,20 @@ import pytest
 logger = logging.getLogger(__name__)
 
 sys.path.append("scripts")
-import route_check
+import route_check  # noqa: E402
 
 current_test_data = None
 selector_returned = None
 subscribers_returned = {}
 db_conns = {}
 
+
 def set_test_case_data(ctdata):
     global current_test_data, db_conns, selector_returned, subscribers_returned
     current_test_data = ctdata
     selector_returned = None
     subscribers_returned = {}
+
 
 def recursive_update(d, t):
     assert type(t) is dict
@@ -41,6 +43,7 @@ def recursive_update(d, t):
             d[k] = {}
         recursive_update(d[k], t[k])
 
+
 class Table:
     def __init__(self, db, tbl):
         self.db = db
@@ -49,9 +52,13 @@ class Table:
 
     def update(self):
         t = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
-            [self.db["namespace"], self.db["name"], self.tbl, OP_SET]))
+                          [self.db["namespace"],
+                          self.db["name"],
+                          self.tbl, OP_SET]))
         drop = copy.deepcopy(self.get_val(current_test_data.get(UPD, {}),
-                        [self.db["namespace"], self.db["name"], self.tbl, OP_DEL]))
+                             [self.db["namespace"],
+                             self.db["name"],
+                             self.tbl, OP_DEL]))
         if t:
             recursive_update(self.data, t)
 
@@ -75,8 +82,10 @@ class Table:
         ret = copy.deepcopy(self.data.get(key, {}).get(field, {}))
         return True, ret
 
+
 def conn_side_effect(arg, _1, _2, namespace):
     return db_conns[namespace][arg]
+
 
 def init_db_conns(namespaces):
     for ns in namespaces:
@@ -87,8 +96,9 @@ def init_db_conns(namespaces):
             "CONFIG_DB": ConfigDB(ns)
             }
 
+
 def table_side_effect(db, tbl):
-    if not tbl in db.keys():
+    if tbl not in db.keys():
         db[tbl] = Table(db, tbl)
     return db[tbl]
 
@@ -155,12 +165,14 @@ class MockSubscriber:
 
         return (k, op, v)
 
+
 def subscriber_side_effect(db, tbl):
     global subscribers_returned
     key = "db_{}_{}_tbl_{}".format(db["namespace"], db["name"], tbl)
-    if not key in subscribers_returned:
+    if key not in subscribers_returned:
         subscribers_returned[key] = MockSubscriber(db, tbl)
     return subscribers_returned[key]
+
 
 def select_side_effect():
     global selector_returned
@@ -169,8 +181,10 @@ def select_side_effect():
         selector_returned = MockSelector()
     return selector_returned
 
+
 def config_db_side_effect(namespace):
     return db_conns[namespace]["CONFIG_DB"]
+
 
 class ConfigDB:
     def __init__(self, namespace):
@@ -184,12 +198,14 @@ class ConfigDB:
     def get_entry(self, table, key):
         return self.get_table(table).get(key, {})
 
+
 def set_mock(mock_table, mock_conn, mock_sel, mock_subs, mock_config_db):
     mock_conn.side_effect = conn_side_effect
     mock_table.side_effect = table_side_effect
     mock_sel.side_effect = select_side_effect
     mock_subs.side_effect = subscriber_side_effect
     mock_config_db.side_effect = config_db_side_effect
+
 
 class TestRouteCheck(object):
     @staticmethod
@@ -234,18 +250,22 @@ class TestRouteCheck(object):
     def test_route_check(self, mock_dbs, test_num):
         logger.debug("test_route_check: test_num={}".format(test_num))
         self.init()
-        ret = 0
         ct_data = TEST_DATA[test_num]
         set_test_case_data(ct_data)
         self.run_test(ct_data)
 
     def run_test(self, ct_data):
         with patch('sys.argv', ct_data[ARGS].split()), \
-            patch('sonic_py_common.multi_asic.get_namespace_list', return_value= ct_data[NAMESPACE]), \
-            patch('sonic_py_common.multi_asic.is_multi_asic', return_value= ct_data[MULTI_ASIC]), \
+            patch('sonic_py_common.multi_asic.get_namespace_list', return_value=ct_data[NAMESPACE]), \
+            patch('sonic_py_common.multi_asic.is_multi_asic', return_value=ct_data[MULTI_ASIC]), \
             patch('route_check.subprocess.check_output', side_effect=lambda *args, **kwargs: self.mock_check_output(ct_data, *args, **kwargs)), \
-            patch('route_check.mitigate_installed_not_offloaded_frr_routes', side_effect=lambda *args, **kwargs: None), \
-            patch('route_check.load_db_config', side_effect=lambda: init_db_conns(ct_data[NAMESPACE])):
+            patch('route_check.check_frr_pending_routes',
+                  side_effect=lambda *args, **kwargs:
+                  self.mock_fetch_routes(ct_data, *args, **kwargs)), \
+            patch('route_check.mitigate_installed_not_offloaded_frr_routes',
+                  side_effect=lambda *args, **kwargs: None), \
+            patch('route_check.load_db_config',
+                  side_effect=lambda: init_db_conns(ct_data[NAMESPACE])):
 
             ret, res = route_check.main()
             self.assert_results(ct_data, ret, res)
@@ -254,6 +274,24 @@ class TestRouteCheck(object):
         ns = self.extract_namespace_from_args(args[0])
         routes = ct_data.get(FRR_ROUTES, {}).get(ns, {})
         return json.dumps(routes)
+
+    def mock_fetch_routes(self, ct_data, *args, **kwargs):
+        ns = args[0]
+        routes = ct_data.get(FRR_ROUTES, {}).get(ns, {})
+        if not routes:
+            return []
+        route_list = []
+        for r, v in routes.items():
+            for e in v:
+                if e.get('protocol') in ('connected', 'kernel', 'static'):
+                    continue
+                if e.get('vrfName') != 'default':
+                    continue
+                if not e.get('selected', False):
+                    continue
+                if not e.get('offloaded', False):
+                    route_list.append(r)
+        return route_list
 
     def assert_results(self, ct_data, ret, res):
         expect_ret = ct_data.get(RET, 0)
@@ -275,7 +313,8 @@ class TestRouteCheck(object):
         set_test_case_data(ct_data)
         try:
             with patch('sys.argv', [route_check.__file__.split('/')[-1]]), \
-                patch('route_check.load_db_config', side_effect=lambda: init_db_conns(ct_data[NAMESPACE])):
+                 patch('route_check.load_db_config',
+                       side_effect=lambda: init_db_conns(ct_data[NAMESPACE])):
 
                 ret, res = route_check.main()
 
@@ -300,8 +339,8 @@ class TestRouteCheck(object):
 
     def test_mitigate_routes(self, mock_dbs):
         namespace = DEFAULTNS
-        missed_frr_rt = [ { 'prefix': '192.168.0.1', 'protocol': 'bgp' } ]
-        rt_appl = [ '192.168.0.1' ]
+        missed_frr_rt = [{'prefix': '192.168.0.1', 'protocol': 'bgp'}]
+        rt_appl = ['192.168.0.1']
         init_db_conns([namespace])
         with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
             route_check.mitigate_installed_not_offloaded_frr_routes(namespace, missed_frr_rt, rt_appl)

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -561,11 +561,7 @@ TEST_DATA = {
             },
         },
         RESULT: {
-            DEFAULTNS: {
-                "missed_FRR_routes": [
-                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp", "selected": True}
-                ],
-            },
+            DEFAULTNS: {"missed_FRR_routes": ['10.10.196.12/31']}
         },
         RET: -1,
     },
@@ -975,11 +971,7 @@ TEST_DATA = {
             },
         },
         RESULT: {
-            ASIC1: {
-                "missed_FRR_routes": [
-                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp", "selected": True}
-                ],
-            },
+            ASIC1: {"missed_FRR_routes": ['10.10.196.12/31']},
         },
         RET: -1,
     },
@@ -1505,8 +1497,7 @@ TEST_DATA = {
         RESULT: {
             ASIC0: {
                 "missed_FRR_routes": [
-                    {"prefix": "10.10.196.20/31", "vrfName": "default", "protocol": "bgp",
-                     "selected": True, "offloaded": False, "failed": True}
+                    "10.10.196.20/31"
                 ],
                 "failed_FRR_routes": [
                     "10.10.196.12/31",
@@ -1599,10 +1590,8 @@ TEST_DATA = {
         RESULT: {
             DEFAULTNS: {
                 "missed_FRR_routes": [
-                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp",
-                     "selected": True, "offloaded": False},
-                    {"prefix": "192.168.1.0/24", "vrfName": "default", "protocol": "bgp",
-                     "selected": True, "offloaded": False, "failed": True}
+                    "10.10.196.12/31",
+                    "192.168.1.0/24"
                 ],
                 "failed_FRR_routes": [
                     "10.10.196.20/31",


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The route_check.py script launches a sonic "show ip route json" to detect any missing routes between FRR and app-db. This causes the show python program to hog a lot of memory (in one test I have noticed it went to 15G), causing the system to OOM. The issue is due to the fact that the show script is reading all the json content (using vtysh) in one shot and is attempting to interpret the json (using json.loads()).


#### How I did it
This diff modifies the route_check.py to not
invoke "show" and rather invoke the vtysh cmd directly. It then attempt to interpret one route at
a time in a paginated manner. This prevents a sudden transient memory buildup. The zebra process already does the right thing and backs off when the output socket buffers are full. There is probably scope to improve that further
(Refer to
https://sonicfoundation.dev/2025-sonic-hackathon-most-impactful-award-spotlight-optimizing-output-buffer-memory-for-show-commands/)

#### How to verify it
Earlier with a very high route-scale (or path scale when ECMP was high), route_check.py used to hog a lot of memory even causing OOMs. With this fix, the same route-scale is operating just fine.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

