### PR TITLE
[bash_completion.d] Update completion for newer click

### DIFF
--- a/sonic-utilities-data/bash_completion.d/acl-loader
+++ b/sonic-utilities-data/bash_completion.d/acl-loader
@@ -1,9 +1,28 @@
 _acl_loader_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _ACL_LOADER_COMPLETE=complete $1 ) )
-    return 1
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _ACL_LOADER_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
 }
 
-complete -F _acl_loader_completion -o default acl-loader;
+_acl_loader_completion_setup() {
+    complete -o nosort -F _acl_loader_completion acl-loader
+}
 
+_acl_loader_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/config
+++ b/sonic-utilities-data/bash_completion.d/config
@@ -1,8 +1,28 @@
 _config_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _CONFIG_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _CONFIG_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _config_completion -o default config;
+_config_completion_setup() {
+    complete -o nosort -F _config_completion config
+}
+
+_config_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/connect
+++ b/sonic-utilities-data/bash_completion.d/connect
@@ -1,8 +1,28 @@
 _connect_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _CONNECT_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _CONNECT_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _connect_completion -o default connect;
+_connect_completion_setup() {
+    complete -o nosort -F _connect_completion connect
+}
+
+_connect_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/consutil
+++ b/sonic-utilities-data/bash_completion.d/consutil
@@ -1,8 +1,28 @@
 _consutil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _CONSUTIL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _CONSUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _consutil_completion -o default consutil;
+_consutil_completion_setup() {
+    complete -o nosort -F _consutil_completion consutil
+}
+
+_consutil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/counterpoll
+++ b/sonic-utilities-data/bash_completion.d/counterpoll
@@ -1,8 +1,28 @@
 _counterpoll_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _COUNTERPOLL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _COUNTERPOLL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _counterpoll_completion -o default counterpoll;
+_counterpoll_completion_setup() {
+    complete -o nosort -F _counterpoll_completion counterpoll
+}
+
+_counterpoll_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/crm
+++ b/sonic-utilities-data/bash_completion.d/crm
@@ -1,8 +1,28 @@
 _crm_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _CRM_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _CRM_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _crm_completion -o default crm;
+_crm_completion_setup() {
+    complete -o nosort -F _crm_completion crm
+}
+
+_crm_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/debug
+++ b/sonic-utilities-data/bash_completion.d/debug
@@ -1,8 +1,28 @@
 _debug_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _DEBUG_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _DEBUG_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _debug_completion -o default debug;
+_debug_completion_setup() {
+    complete -o nosort -F _debug_completion debug
+}
+
+_debug_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/dump
+++ b/sonic-utilities-data/bash_completion.d/dump
@@ -1,8 +1,28 @@
 _dump_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _DUMP_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _DUMP_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _dump_completion -o default dump
+_dump_completion_setup() {
+    complete -o nosort -F _dump_completion dump
+}
+
+_dump_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/fwutil
+++ b/sonic-utilities-data/bash_completion.d/fwutil
@@ -1,11 +1,28 @@
-shopt -s extglob
-
 _fwutil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _FWUTIL_COMPLETE=complete $1 ) )
-    COMPREPLY=( ${COMPREPLY[*]//*(-install|-update)/} )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _FWUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _fwutil_completion -o default fwutil;
+_fwutil_completion_setup() {
+    complete -o nosort -F _fwutil_completion fwutil
+}
+
+_fwutil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/pddf_fanutil
+++ b/sonic-utilities-data/bash_completion.d/pddf_fanutil
@@ -1,8 +1,28 @@
 _pddf_fanutil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _PDDF_FANUTIL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PDDF_FANUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _pddf_fanutil_completion -o default pddf_fanutil;
+_pddf_fanutil_completion_setup() {
+    complete -o nosort -F _pddf_fanutil_completion pddf_fanutil
+}
+
+_pddf_fanutil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/pddf_ledutil
+++ b/sonic-utilities-data/bash_completion.d/pddf_ledutil
@@ -1,8 +1,28 @@
 _pddf_ledutil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _PDDF_LEDUTIL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PDDF_LEDUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _pddf_ledutil_completion -o default pddf_ledutil;
+_pddf_ledutil_completion_setup() {
+    complete -o nosort -F _pddf_ledutil_completion pddf_ledutil
+}
+
+_pddf_ledutil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/pddf_psuutil
+++ b/sonic-utilities-data/bash_completion.d/pddf_psuutil
@@ -1,8 +1,28 @@
 _pddf_psuutil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _PDDF_PSUUTIL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PDDF_PSUUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _pddf_psuutil_completion -o default pddf_psuutil;
+_pddf_psuutil_completion_setup() {
+    complete -o nosort -F _pddf_psuutil_completion pddf_psuutil
+}
+
+_pddf_psuutil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/pddf_thermalutil
+++ b/sonic-utilities-data/bash_completion.d/pddf_thermalutil
@@ -1,8 +1,28 @@
 _pddf_thermalutil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _PDDF_THERMALUTIL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PDDF_THERMALUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _pddf_thermalutil_completion -o default pddf_thermalutil;
+_pddf_thermalutil_completion_setup() {
+    complete -o nosort -F _pddf_thermalutil_completion pddf_thermalutil
+}
+
+_pddf_thermalutil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/pfc
+++ b/sonic-utilities-data/bash_completion.d/pfc
@@ -1,8 +1,28 @@
 _pfc_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _PFC_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PFC_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _pfc_completion -o default pfc;
+_pfc_completion_setup() {
+    complete -o nosort -F _pfc_completion pfc
+}
+
+_pfc_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/pfcwd
+++ b/sonic-utilities-data/bash_completion.d/pfcwd
@@ -1,8 +1,28 @@
 _pfcwd_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _PFCWD_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PFCWD_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _pfcwd_completion -o default pfcwd;
+_pfcwd_completion_setup() {
+    complete -o nosort -F _pfcwd_completion pfcwd
+}
+
+_pfcwd_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/psuutil
+++ b/sonic-utilities-data/bash_completion.d/psuutil
@@ -1,8 +1,28 @@
 _psuutil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _PSUUTIL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _PSUUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _psuutil_completion -o default psuutil;
+_psuutil_completion_setup() {
+    complete -o nosort -F _psuutil_completion psuutil
+}
+
+_psuutil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/rexec
+++ b/sonic-utilities-data/bash_completion.d/rexec
@@ -1,21 +1,28 @@
 _rexec_completion() {
-    local IFS=$'
-'
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _REXEC_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _REXEC_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-_rexec_completionetup() {
-    local COMPLETION_OPTIONS=""
-    local BASH_VERSION_ARR=(${BASH_VERSION//./ })
-    # Only BASH version 4.4 and later have the nosort option.
-    if [ ${BASH_VERSION_ARR[0]} -gt 4 ] || ([ ${BASH_VERSION_ARR[0]} -eq 4 ] && [ ${BASH_VERSION_ARR[1]} -ge 4 ]); then
-        COMPLETION_OPTIONS="-o nosort"
-    fi
-
-    complete $COMPLETION_OPTIONS -F _rexec_completion rexec
+_rexec_completion_setup() {
+    complete -o nosort -F _rexec_completion rexec
 }
 
-_rexec_completionetup;
+_rexec_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/rshell
+++ b/sonic-utilities-data/bash_completion.d/rshell
@@ -1,21 +1,28 @@
 _rshell_completion() {
-    local IFS=$'
-'
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _RSHELL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _RSHELL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-_rshell_completionetup() {
-    local COMPLETION_OPTIONS=""
-    local BASH_VERSION_ARR=(${BASH_VERSION//./ })
-    # Only BASH version 4.4 and later have the nosort option.
-    if [ ${BASH_VERSION_ARR[0]} -gt 4 ] || ([ ${BASH_VERSION_ARR[0]} -eq 4 ] && [ ${BASH_VERSION_ARR[1]} -ge 4 ]); then
-        COMPLETION_OPTIONS="-o nosort"
-    fi
-
-    complete $COMPLETION_OPTIONS -F _rshell_completion rshell
+_rshell_completion_setup() {
+    complete -o nosort -F _rshell_completion rshell
 }
 
-_rshell_completionetup;
+_rshell_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/sfputil
+++ b/sonic-utilities-data/bash_completion.d/sfputil
@@ -1,8 +1,28 @@
 _sfputil_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _SFPUTIL_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _SFPUTIL_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _sfputil_completion -o default sfputil;
+_sfputil_completion_setup() {
+    complete -o nosort -F _sfputil_completion sfputil
+}
+
+_sfputil_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/show
+++ b/sonic-utilities-data/bash_completion.d/show
@@ -1,8 +1,28 @@
 _show_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _SHOW_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _SHOW_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _show_completion -o default show;
+_show_completion_setup() {
+    complete -o nosort -F _show_completion show
+}
+
+_show_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/sonic-clear
+++ b/sonic-utilities-data/bash_completion.d/sonic-clear
@@ -1,9 +1,28 @@
 _sonic_clear_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _SONIC_CLEAR_COMPLETE=complete sonic-clear ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _SONIC_CLEAR_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _sonic_clear_completion -o default sonic-clear;
-complete -F _sonic_clear_completion clear;
+_sonic_clear_completion_setup() {
+    complete -o nosort -F _sonic_clear_completion sonic-clear
+}
+
+_sonic_clear_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/sonic-cli-gen
+++ b/sonic-utilities-data/bash_completion.d/sonic-cli-gen
@@ -1,8 +1,28 @@
 _sonic_cli_gen_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _SONIC_CLI_GEN_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _SONIC_CLI_GEN_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _sonic_cli_gen_completion -o default sonic-cli-gen;
+_sonic_cli_gen_completion_setup() {
+    complete -o nosort -F _sonic_cli_gen_completion sonic-cli-gen
+}
+
+_sonic_cli_gen_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/sonic-installer
+++ b/sonic-utilities-data/bash_completion.d/sonic-installer
@@ -1,8 +1,28 @@
 _sonic_installer_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _SONIC_INSTALLER_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _SONIC_INSTALLER_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _sonic_installer_completion -o default sonic-installer;
+_sonic_installer_completion_setup() {
+    complete -o nosort -F _sonic_installer_completion sonic-installer
+}
+
+_sonic_installer_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/sonic-package-manager
+++ b/sonic-utilities-data/bash_completion.d/sonic-package-manager
@@ -1,8 +1,28 @@
 _sonic_package_manager_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _SONIC_PACKAGE_MANAGER_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _SONIC_PACKAGE_MANAGER_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _sonic_package_manager_completion -o default sonic-package-manager;
+_sonic_package_manager_completion_setup() {
+    complete -o nosort -F _sonic_package_manager_completion sonic-package-manager
+}
+
+_sonic_package_manager_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/sonic_installer
+++ b/sonic-utilities-data/bash_completion.d/sonic_installer
@@ -1,8 +1,28 @@
 _sonic_installer_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _SONIC_INSTALLER_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _SONIC_INSTALLER_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _sonic_installer_completion -o default sonic_installer;
+_sonic_installer_completion_setup() {
+    complete -o nosort -F _sonic_installer_completion sonic_installer
+}
+
+_sonic_installer_completion_setup;

--- a/sonic-utilities-data/bash_completion.d/undebug
+++ b/sonic-utilities-data/bash_completion.d/undebug
@@ -1,8 +1,28 @@
 _undebug_completion() {
-    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   _UNDEBUG_COMPLETE=complete $1 ) )
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _UNDEBUG_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
     return 0
 }
 
-complete -F _undebug_completion -o default undebug;
+_undebug_completion_setup() {
+    complete -o nosort -F _undebug_completion undebug
+}
+
+_undebug_completion_setup;


### PR DESCRIPTION
As of click 8.0.0 the way shell completion works for bash hash changed. Update the completion files for the new method.

Fixes #4211
