### PR TITLE
Fix route_check.py redis client high memory usage

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -877,6 +877,11 @@ def check_routes_for_namespace(namespace):
         # Look for subscribe updates for a second
         adds, deletes = get_subscribe_updates(selector, subs)
 
+    # Release the subscriber. If we keep the subscriber open then route updates will accumulate in the subscriber queue
+    # causing high client memory usage in redis.
+    del subs
+    del selector
+
     # Drop all those for which SET received
     rt_appl_miss, _ = diff_sorted_lists(rt_appl_miss, adds)
 


### PR DESCRIPTION
#### What I did
Close ASIC_DB subscriber in `route_check.py` after collecting updates to prevent queue accumulation. Previously, the subscriber remained open during the `check_frr_pending_routes`, causing route updates to accumulate in the redis subscriber queue and increase memory usage. That high memory usage cause `dbmemory` error in sonic-mgmt tests.

#### How I did it
Delete the subscriber object reference after it is no longer needed. This should kill the subscriber redis connection.

#### How to verify it
No more 'dbmemory' error after a config reload (see issue #4216). Also, you can monitor client memory usage using:
```while true; do date; redis-cli CLIENT LIST | grep -v "omem=0"; sleep 1; done ``` and verify no significant memory spikes when running `route_check.py`.

fixes #4216 
