### PR TITLE
Fix STP CLI commands to use list format for run_command

### DIFF
--- a/clear/stp.py
+++ b/clear/stp.py
@@ -17,7 +17,7 @@ def spanning_tree(ctx):
 @click.pass_context
 def stp_clr_stats(ctx):
     if ctx.invoked_subcommand is None:
-        command = 'sudo stpctl clrstsall'
+        command = ['sudo', 'stpctl', 'clrstsall']
         clicommon.run_command(command)
 
 
@@ -25,7 +25,7 @@ def stp_clr_stats(ctx):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_intf(ctx, interface_name):
-    command = 'sudo stpctl clrstsintf ' + interface_name
+    command = ['sudo', 'stpctl', 'clrstsintf', interface_name]
     clicommon.run_command(command)
 
 
@@ -33,7 +33,7 @@ def stp_clr_stats_intf(ctx, interface_name):
 @click.argument('vlan_id', metavar='<vlan_id>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan(ctx, vlan_id):
-    command = 'sudo stpctl clrstsvlan ' + vlan_id
+    command = ['sudo', 'stpctl', 'clrstsvlan', vlan_id]
     clicommon.run_command(command)
 
 
@@ -42,5 +42,5 @@ def stp_clr_stats_vlan(ctx, vlan_id):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan_intf(ctx, vlan_id, interface_name):
-    command = 'sudo stpctl clrstsvlanintf ' + vlan_id + ' ' + interface_name
+    command = ['sudo', 'stpctl', 'clrstsvlanintf', vlan_id, interface_name]
     clicommon.run_command(command)

--- a/debug/main.py
+++ b/debug/main.py
@@ -3,6 +3,7 @@ import sys
 import click
 import subprocess
 from shlex import join
+from . import stp
 
 
 def run_command(command, pager=False):
@@ -280,6 +281,10 @@ else:
         command = ['sudo', 'vtysh', '-c', "debug zebra rib"]
         run_command(command)
 
+#
+# 'STP' group
+#
+cli.add_command(stp.spanning_tree)
 
 if __name__ == '__main__':
     cli()

--- a/debug/stp.py
+++ b/debug/stp.py
@@ -5,30 +5,30 @@ import utilities_common.cli as clicommon
 #
 # This group houses Spanning_tree commands and subgroups
 #
-@click.group(cls=clicommon.AliasedGroup, default_if_no_args=False, invoke_without_command=True)
+@click.group(cls=clicommon.AliasedGroup, invoke_without_command=True)
 @click.pass_context
 def spanning_tree(ctx):
     '''debug spanning_tree commands'''
     if ctx.invoked_subcommand is None:
-        command = 'sudo stpctl dbg enable'
+        command = ['sudo', 'stpctl', 'dbg', 'enable']
         clicommon.run_command(command)
 
 
-@spanning_tree.group('dump', cls=clicommon.AliasedGroup, default_if_no_args=False, invoke_without_command=True)
+@spanning_tree.group('dump', cls=clicommon.AliasedGroup, invoke_without_command=True)
 def stp_debug_dump():
     pass
 
 
 @stp_debug_dump.command('global')
 def stp_debug_dump_global():
-    command = 'sudo stpctl global'
+    command = ['sudo', 'stpctl', 'global']
     clicommon.run_command(command)
 
 
 @stp_debug_dump.command('vlan')
 @click.argument('vlan_id', metavar='<vlan_id>', required=True)
 def stp_debug_dump_vlan(vlan_id):
-    command = 'sudo stpctl vlan ' + vlan_id
+    command = ['sudo', 'stpctl', 'vlan', vlan_id]
     clicommon.run_command(command)
 
 
@@ -36,19 +36,19 @@ def stp_debug_dump_vlan(vlan_id):
 @click.argument('vlan_id', metavar='<vlan_id>', required=True)
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 def stp_debug_dump_vlan_intf(vlan_id, interface_name):
-    command = 'sudo stpctl port ' + vlan_id + " " + interface_name
+    command = ['sudo', 'stpctl', 'port', vlan_id, interface_name]
     clicommon.run_command(command)
 
 
 @spanning_tree.command('show')
 def stp_debug_show():
-    command = 'sudo stpctl dbg show'
+    command = ['sudo', 'stpctl', 'dbg', 'show']
     clicommon.run_command(command)
 
 
 @spanning_tree.command('reset')
 def stp_debug_reset():
-    command = 'sudo stpctl dbg disable'
+    command = ['sudo', 'stpctl', 'dbg', 'disable']
     clicommon.run_command(command)
 
 
@@ -56,23 +56,27 @@ def stp_debug_reset():
 @click.argument('mode', metavar='{rx|tx}', required=False)
 @click.option('-d', '--disable', is_flag=True)
 def stp_debug_bpdu(mode, disable):
-    command = 'sudo stpctl dbg bpdu {}{}'.format(
-        ('rx-' if mode == 'rx' else 'tx-' if mode == 'tx' else ''),
-        ('off' if disable else 'on'))
+    bpdu_mode = ''
+    if mode == 'rx':
+        bpdu_mode = 'rx-'
+    elif mode == 'tx':
+        bpdu_mode = 'tx-'
+    state = 'off' if disable else 'on'
+    command = ['sudo', 'stpctl', 'dbg', 'bpdu', bpdu_mode + state]
     clicommon.run_command(command)
 
 
 @spanning_tree.command('verbose')
 @click.option('-d', '--disable', is_flag=True)
 def stp_debug_verbose(disable):
-    command = 'sudo stpctl dbg verbose {}'.format("off" if disable else "on")
+    command = ['sudo', 'stpctl', 'dbg', 'verbose', 'off' if disable else 'on']
     clicommon.run_command(command)
 
 
 @spanning_tree.command('event')
 @click.option('-d', '--disable', is_flag=True)
 def stp_debug_event(disable):
-    command = 'sudo stpctl dbg event {}'.format("off" if disable else "on")
+    command = ['sudo', 'stpctl', 'dbg', 'event', 'off' if disable else 'on']
     clicommon.run_command(command)
 
 
@@ -80,7 +84,7 @@ def stp_debug_event(disable):
 @click.argument('vlan_id', metavar='<vlan_id/all>', required=True)
 @click.option('-d', '--disable', is_flag=True)
 def stp_debug_vlan(vlan_id, disable):
-    command = 'sudo stpctl dbg vlan {} {}'.format(vlan_id, "off" if disable else "on")
+    command = ['sudo', 'stpctl', 'dbg', 'vlan', vlan_id, 'off' if disable else 'on']
     clicommon.run_command(command)
 
 
@@ -88,5 +92,5 @@ def stp_debug_vlan(vlan_id, disable):
 @click.argument('interface_name', metavar='<interface_name/all>', required=True)
 @click.option('-d', '--disable', is_flag=True)
 def stp_debug_intf(interface_name, disable):
-    command = 'sudo stpctl dbg port {} {}'.format(interface_name, "off" if disable else "on")
+    command = ['sudo', 'stpctl', 'dbg', 'port', interface_name, 'off' if disable else 'on']
     clicommon.run_command(command)

--- a/tests/stp_test.py
+++ b/tests/stp_test.py
@@ -2371,3 +2371,140 @@ class TestStpInterfaceBpduGuardEnable:
 
         assert result.exit_code != 0
         assert "Invalid interface" in result.output
+
+
+class TestDebugStp:
+    """Tests for debug spanning-tree commands"""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'enable'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_show(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["show"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'show'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_reset(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["reset"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'disable'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_bpdu(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["bpdu"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'bpdu', 'on'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_bpdu_rx(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["bpdu"], ['rx'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'bpdu', 'rx-on'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_bpdu_tx_disable(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["bpdu"], ['tx', '-d'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'bpdu', 'tx-off'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_verbose(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["verbose"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'verbose', 'on'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_verbose_disable(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["verbose"], ['-d'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'verbose', 'off'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_event(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(debug.cli.commands["spanning-tree"].commands["event"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'dbg', 'event', 'on'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_dump_global(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(
+            debug.cli.commands["spanning-tree"].commands["dump"].commands["global"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'global'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_dump_vlan(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(
+            debug.cli.commands["spanning-tree"].commands["dump"].commands["vlan"], ['100'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'vlan', '100'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_debug_spanning_tree_dump_interface(self, mock_run_command):
+        import debug.main as debug
+        result = self.runner.invoke(
+            debug.cli.commands["spanning-tree"].commands["dump"].commands["interface"],
+            ['100', 'Ethernet0'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'port', '100', 'Ethernet0'])
+
+
+class TestClearStp:
+    """Tests for clear spanning-tree commands"""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch('utilities_common.cli.run_command')
+    def test_clear_spanning_tree_statistics(self, mock_run_command):
+        import clear.main as clear
+        result = self.runner.invoke(
+            clear.cli.commands["spanning-tree"].commands["statistics"], [])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'clrstsall'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_clear_spanning_tree_statistics_interface(self, mock_run_command):
+        import clear.main as clear
+        result = self.runner.invoke(
+            clear.cli.commands["spanning-tree"].commands["statistics"].commands["interface"],
+            ['Ethernet0'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'clrstsintf', 'Ethernet0'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_clear_spanning_tree_statistics_vlan(self, mock_run_command):
+        import clear.main as clear
+        result = self.runner.invoke(
+            clear.cli.commands["spanning-tree"].commands["statistics"].commands["vlan"],
+            ['100'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'clrstsvlan', '100'])
+
+    @patch('utilities_common.cli.run_command')
+    def test_clear_spanning_tree_statistics_vlan_interface(self, mock_run_command):
+        import clear.main as clear
+        result = self.runner.invoke(
+            clear.cli.commands["spanning-tree"].commands["statistics"].commands["vlan-interface"],
+            ['100', 'Ethernet0'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'stpctl', 'clrstsvlanintf', '100', 'Ethernet0'])


### PR DESCRIPTION
#### What I did
Fixed STP CLI commands in `debug` and `clear` modules to work correctly with `run_command()`.

#### How I did it
1. Removed invalid `default_if_no_args` parameter from `debug/stp.py` (not supported by click/AliasedGroup)
2. Converted command strings to lists in `debug/stp.py` and `clear/stp.py` (`run_command()` with `shell=False` expects list format)
3. Added missing STP import and command registration in `debug/main.py`

#### How to verify it
```bash
# Before fix - these commands fail with TypeError/FileNotFoundError
sudo debug spanning-tree
sudo sonic-clear spanning-tree statistics

# After fix - commands execute correctly
sudo debug spanning-tree
sudo debug spanning-tree show
sudo sonic-clear spanning-tree statistics

# Previous command output 
TypeError: __init__() got an unexpected keyword argument 'default_if_no_args'
# or
FileNotFoundError: [Errno 2] No such file or directory: 'sudo stpctl dbg enable'
# New command output 
Commands execute successfully and invoke stpctl as expected.