### PR TITLE
Modified dualtor_neighbor_check to use mux neighbor_mode

### DIFF
--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -375,7 +375,8 @@ class TestDualtorNeighborCheck(object):
         asic_neigh_table = \
             ["{\"ip\":\"192.168.0.1\",\"rif\":\"oid:0x6000000000671\"," +
              "\"switch_id\":\"oid:0x21000000000000\"}"]
-        asic_nexthop_table = {'oid:0x40000000005c0': {'nexthop_type': 'SAI_NEXT_HOP_TYPE_IP', 'nexthop_id': 'oid:0x40000000005c0'}}
+        asic_nexthop_table = \
+            {'oid:0x40000000005c0': {'nexthop_type': 'SAI_NEXT_HOP_TYPE_IP', 'nexthop_id': 'oid:0x40000000005c0'}}
         mux_server_to_port_map = {}
         expected_output = \
             ["192.168.0.1", "aa:bb:cc:dd:ee:ff", "Ethernet4", "active", "no", "yes", "yes", "NEIGHBOR", "consistent"]
@@ -394,8 +395,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -467,8 +468,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -503,8 +504,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -526,10 +527,15 @@ class TestDualtorNeighborCheck(object):
                 "nexthop_id": "oid:0x40000000005c0"
             }
         ]
-        asic_neigh_table = ["{\"ip\":\"192.168.0.2\",\"rif\":\"oid:0x6000000000671\",\"switch_id\":\"oid:0x21000000000000\"}"]
-        asic_nexthop_table = {'oid:0x40000000005c0': {'nexthop_type': 'SAI_NEXT_HOP_TYPE_IP', 'nexthop_id': 'oid:0x40000000005c0'}}
+        asic_neigh_table = [
+                            "{\"ip\":\"192.168.0.2\",\"rif\":\"oid:0x6000000000671\",\"switch_id\":" +
+                            "\"oid:0x21000000000000\" }"
+                           ]
+        asic_nexthop_table = \
+            {'oid:0x40000000005c0': {'nexthop_type': 'SAI_NEXT_HOP_TYPE_IP', 'nexthop_id': 'oid:0x40000000005c0'}}
         mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}
-        expected_output = ["192.168.0.2", "ee:86:d8:46:7d:01", "Ethernet4", "active", "no", "yes", "yes", "NEIGHBOR", "consistent"]
+        expected_output = ["192.168.0.2", "ee:86:d8:46:7d:01", "Ethernet4", "active", "no", "yes", "yes", "NEIGHBOR",
+                           "consistent"]
         expected_log_output = tabulate.tabulate(
             [expected_output],
             headers=dualtor_neighbor_check.NEIGHBOR_ATTRIBUTES_PREFIX_ROUTE,
@@ -545,8 +551,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -569,9 +575,12 @@ class TestDualtorNeighborCheck(object):
             }
         ]
         asic_neigh_table = []
-        asic_nexthop_table = {'oid:0x40000000005ae': {'nexthop_type': 'SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP', 'nexthop_id': 'oid:0x40000000005ae'}}
+        asic_nexthop_table = \
+            {'oid:0x40000000005ae': {'nexthop_type': 'SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP',
+                                     'nexthop_id': 'oid:0x40000000005ae'}}
         mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}
-        expected_output = ["192.168.0.2", "ee:86:d8:46:7d:01", "Ethernet4", "active", "no", "no", "yes", "TUNNEL", "inconsistent"]
+        expected_output = ["192.168.0.2", "ee:86:d8:46:7d:01", "Ethernet4", "active", "no", "no", "yes", "TUNNEL",
+                           "inconsistent"]
         expected_log_output = tabulate.tabulate(
             [expected_output],
             headers=dualtor_neighbor_check.NEIGHBOR_ATTRIBUTES_PREFIX_ROUTE,
@@ -579,6 +588,7 @@ class TestDualtorNeighborCheck(object):
         ).split("\n")
         expected_log_warn_calls = [call(line) for line in expected_log_output]
         expected_log_error_calls = [call("Found neighbors that are inconsistent with mux states: %s", ["192.168.0.2"])]
+        expected_log_error_calls.extend([call("Failed PREFIX-ROUTE neighbors:")])
         expected_log_error_calls.extend([call(line) for line in expected_log_output])
 
         check_results = dualtor_neighbor_check.check_neighbor_consistency(
@@ -589,8 +599,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -605,18 +615,28 @@ class TestDualtorNeighborCheck(object):
         hw_mux_states = {"Ethernet4": "active"}
         port_neighbor_modes = {"Ethernet4": "host-route"}
         mac_to_port_name_map = {"ee:86:d8:46:7d:01": "Ethernet4"}
-        asic_route_table = ["{\"dest\":\"192.168.0.2/32\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000024\"}"]
+        asic_route_table = [
+            {
+                "route_details": "{\"dest\":\"192.168.0.2/32\",\"switch_id\":\"oid:0x21000000000000\"," +
+                                 "\"vr\":\"oid:0x3000000000024\"}",
+                "nexthop_id": "oid:0x40000000005ae"
+            }
+        ]
         asic_neigh_table = []
         asic_nexthop_table = {}
         mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}
         expected_output = ["192.168.0.2", "ee:86:d8:46:7d:01", "Ethernet4", "active", "no", "no", "yes", "inconsistent"]
-        expected_log_output = tabulate.tabulate(
-            [expected_output],
-            headers=dualtor_neighbor_check.NEIGHBOR_ATTRIBUTES_HOST_ROUTE,
-            tablefmt="simple"
-        ).split("\n")
-        expected_log_warn_calls = [call(line) for line in expected_log_output]
+        expected_log_output = tabulate.tabulate([expected_output],
+                                                headers=dualtor_neighbor_check.NEIGHBOR_ATTRIBUTES_HOST_ROUTE,
+                                                tablefmt="simple").split("\n")
+        expected_log_warn_calls = \
+            [call("================================================================================")]
+        expected_log_warn_calls.extend([call("Neighbors in HOST-ROUTE mode:")])
+        expected_log_warn_calls.extend([call("=====================================================================" +
+                                             "===========")])
+        expected_log_warn_calls.extend([call(line) for line in expected_log_output])
         expected_log_error_calls = [call("Found neighbors that are inconsistent with mux states: %s", ["192.168.0.2"])]
+        expected_log_error_calls.extend([call("Failed HOST-ROUTE neighbors:")])
         expected_log_error_calls.extend([call(line) for line in expected_log_output])
 
         check_results = dualtor_neighbor_check.check_neighbor_consistency(
@@ -627,8 +647,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -663,8 +683,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -679,7 +699,13 @@ class TestDualtorNeighborCheck(object):
         hw_mux_states = {"Ethernet4": "standby"}
         port_neighbor_modes = {"Ethernet4": "host-route"}
         mac_to_port_name_map = {"ee:86:d8:46:7d:01": "Ethernet4"}
-        asic_route_table = ["{\"dest\":\"192.168.0.2/32\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000024\"}"]
+        asic_route_table = [
+            {
+                "route_details": "{\"dest\":\"192.168.0.2/32\",\"switch_id\":\"oid:0x21000000000000\"," +
+                                 "\"vr\":\"oid:0x3000000000024\"}",
+                "nexthop_id": "oid:0x40000000005ae"
+            }
+        ]
         asic_neigh_table = []
         asic_nexthop_table = {}
         mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}
@@ -699,8 +725,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -727,6 +753,7 @@ class TestDualtorNeighborCheck(object):
         ).split("\n")
         expected_log_warn_calls = [call(line) for line in expected_log_output]
         expected_log_error_calls = [call("Found neighbors that are inconsistent with mux states: %s", ["192.168.0.2"])]
+        expected_log_error_calls.extend([call("Failed HOST-ROUTE neighbors:")])
         expected_log_error_calls.extend([call(line) for line in expected_log_output])
 
         check_results = dualtor_neighbor_check.check_neighbor_consistency(
@@ -737,8 +764,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -754,17 +781,25 @@ class TestDualtorNeighborCheck(object):
         port_neighbor_modes = {"Ethernet4": "host-route"}
         mac_to_port_name_map = {"ee:86:d8:46:7d:01": "Ethernet4"}
         asic_route_table = []
-        asic_neigh_table = ["{\"ip\":\"192.168.0.2\",\"rif\":\"oid:0x6000000000671\",\"switch_id\":\"oid:0x21000000000000\"}"]
+        asic_neigh_table = ["{\"ip\":\"192.168.0.2\",\"rif\":\"oid:0x6000000000671\",\"switch_id\":" +
+                            "\"oid:0x21000000000000\"}"]
         asic_nexthop_table = {}
         mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}
-        expected_output = ["192.168.0.2", "ee:86:d8:46:7d:01", "Ethernet4", "standby", "no", "yes", "no", "inconsistent"]
+        expected_output = ["192.168.0.2", "ee:86:d8:46:7d:01", "Ethernet4", "standby", "no", "yes", "no",
+                           "inconsistent"]
         expected_log_output = tabulate.tabulate(
             [expected_output],
             headers=dualtor_neighbor_check.NEIGHBOR_ATTRIBUTES_HOST_ROUTE,
             tablefmt="simple"
         ).split("\n")
-        expected_log_warn_calls = [call(line) for line in expected_log_output]
+        expected_log_warn_calls = [call("===========================================================================" +
+                                        "=====")]
+        expected_log_warn_calls.extend([call("Neighbors in HOST-ROUTE mode:")])
+        expected_log_warn_calls.extend([call("=======================================================================" +
+                                             "=========")])
+        expected_log_warn_calls.extend([call(line) for line in expected_log_output])
         expected_log_error_calls = [call("Found neighbors that are inconsistent with mux states: %s", ["192.168.0.2"])]
+        expected_log_error_calls.extend([call("Failed HOST-ROUTE neighbors:")])
         expected_log_error_calls.extend([call(line) for line in expected_log_output])
 
         check_results = dualtor_neighbor_check.check_neighbor_consistency(
@@ -775,8 +810,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -811,8 +846,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -827,7 +862,13 @@ class TestDualtorNeighborCheck(object):
         hw_mux_states = {"Ethernet4": "active"}
         port_neighbor_modes = {}
         mac_to_port_name_map = {"ee:86:d8:46:7d:01": "Ethernet4"}
-        asic_route_table = ["{\"dest\":\"192.168.0.102/32\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000024\"}"]
+        asic_route_table = [
+            {
+                "route_details": "{\"dest\":\"192.168.0.102/32\",\"switch_id\":\"oid:0x21000000000000\"," +
+                                 "\"vr\":\"oid:0x3000000000024\"}",
+                "nexthop_id": "oid:0x40000000005ae"
+            }
+        ]
         asic_neigh_table = []
         asic_nexthop_table = {}
         mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}
@@ -847,8 +888,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -883,8 +924,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 
@@ -911,6 +952,7 @@ class TestDualtorNeighborCheck(object):
         ).split("\n")
         expected_log_warn_calls = [call(line) for line in expected_log_output]
         expected_log_error_calls = [call("Found neighbors that are inconsistent with mux states: %s", ["192.168.0.102"])]
+        expected_log_error_calls.extend([call("Failed HOST-ROUTE neighbors:")])
         expected_log_error_calls.extend([call(line) for line in expected_log_output])
 
         check_results = dualtor_neighbor_check.check_neighbor_consistency(
@@ -921,8 +963,8 @@ class TestDualtorNeighborCheck(object):
             asic_route_table,
             asic_neigh_table,
             asic_nexthop_table,
-            port_neighbor_modes,
-            mux_server_to_port_map
+            mux_server_to_port_map,
+            port_neighbor_modes
         )
         res = dualtor_neighbor_check.parse_check_results(check_results)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Adjusted the dualtor_neighbor_check.py based on mux neighbor_mode described in HLD : https://github.com/sonic-net/SONiC/pull/2176

Output of dualtor_neighbor_check will now depend on neighbor_mode set in STATE_DB|MUX_CABLE_TABLE

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
NEIGHBOR      MAC                PORT         MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    TUNNEL_IN_ASIC    HWSTATUS
------------  -----------------  -----------  -----------  ---------------  ------------------  ----------------  ----------
192.168.0.3   16:8d:06:da:8d:0d  Ethernet8    active       no               yes                 no                consistent
192.168.0.5   42:85:ce:ff:2b:7a  Ethernet16   active       no               yes                 no                consistent
```
#### New command output (if the output of a command-line utility has changed)
```
================================================================================
Neighbors in PREFIX-ROUTE mode:
================================================================================
NEIGHBOR      MAC                PORT         MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    PREFIX_ROUTE    NEXTHOP_TYPE    HWSTATUS
------------  -----------------  -----------  -----------  ---------------  ------------------  --------------  --------------  ----------
192.168.0.7   5e:9d:89:07:66:83  Ethernet24   active       no               yes                 yes             NEIGHBOR        consistent
192.168.0.9   e2:2a:a8:65:1e:50  Ethernet32   active       no               yes                 yes             NEIGHBOR        consistent
================================================================================
Neighbors in HOST-ROUTE mode:
================================================================================
NEIGHBOR     MAC                PORT        MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    TUNNEL_IN_ASIC    HWSTATUS
-----------  -----------------  ----------  -----------  ---------------  ------------------  ----------------  ----------
192.168.0.3  16:8d:06:da:8d:0d  Ethernet8   active       no               yes                 no                consistent
192.168.0.5  42:85:ce:ff:2b:7a  Ethernet16  active       no               yes                 no                consistent
```