### PR TITLE
Added cli commands for configuration and show status

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2089,6 +2089,30 @@ def list_checkpoints(ctx, time, verbose):
         click.secho("Failed to list config checkpoints", fg="red", underline=True, err=True)
         ctx.fail(ex)
 
+@config.group(cls=clicommon.AbbreviationGroup, name='monit-tx-errors')
+def monit_tx_errors():
+    """Configure TX error monitoring parameters"""
+    pass
+
+@monit_tx_errors.command('threshold')
+@click.argument('value', metavar='<value>', required=True, type=click.IntRange(min=1))
+@clicommon.pass_db
+def monit_tx_threshold(db, value):
+    """Set TX error threshold for monitoring"""
+    config_db = db.cfgdb
+    config_db.mod_entry("MONIT_TX_CONFIG", "error_threshold", {"value": str(value)})
+    click.echo("TX error threshold set to {}".format(value))
+
+@monit_tx_errors.command('interval')
+@click.argument('value', metavar='<seconds>', required=True, type=click.IntRange(min=1))
+@clicommon.pass_db
+def monit_tx_interval(db, value):
+    """Set TX error monitoring poll interval in seconds"""
+    config_db = db.cfgdb
+    config_db.mod_entry("MONIT_TX_CONFIG", "time_interval", {"value": str(value)})
+    click.echo("TX error monitoring interval set to {} seconds".format(value))
+
+
 @config.command()
 @click.option('-y', '--yes', is_flag=True)
 @click.option('-l', '--load-sysinfo', is_flag=True, help='load system default information (mac, portmap etc) first.')

--- a/show/main.py
+++ b/show/main.py
@@ -877,6 +877,31 @@ def wm_q_multi(namespace, json_output):
         command += ["-j"]
     run_command(command)
 
+
+@cli.command('monit-tx-status')
+@clicommon.pass_db
+def monit_tx_status(db):
+    """Show TX error monitoring status for interfaces"""
+    
+    table = "MONIT_TX_STATUS_TABLE"
+    header = ['Interface', 'TX Status']
+    body = []
+
+    keys = db.db.keys(db.db.STATE_DB, "{}|*".format(table))
+
+    if not keys:
+        click.echo("No TX monitoring status available")
+        return
+
+    for key in natsorted(keys):
+        interface = key.split('|')[-1]
+        entry = db.db.get_all(db.db.STATE_DB, key)
+        status = entry.get('tx_status', 'N/A')
+        body.append([interface, status])
+    
+    click.echo(tabulate(body, header, tablefmt="simple"))
+
+
 # 'all' subcommand ("show queue watermarks all")
 @watermark.command('all')
 @click.option('--namespace',


### PR DESCRIPTION
Added cli commands for configuration and show status

Configuration command: sudo config monit-tx-errors [threshold/interval] <value>
Update config DB to the new values - must be positive.

Show status command: show monit-tx-status
Prints a table of all ports and their status.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added CLI commands for new feature.
#### How I did it
Added a command in show/main.py and a group in config/main.py
#### How to verify it
Manual tests on switch
#### Previous command output (if the output of a command-line utility has changed)
No previous command
#### New command output (if the output of a command-line utility has changed)
Configuration command: on success - TX error monitoring [interval/threshold] set to X seconds
Show status command: Prints a table of all ports and their status (format: [Interface] [status]). 