### PR TITLE
Fix dump port state CLI command crash on multi-asic platforms

### DIFF
--- a/dump/match_infra.py
+++ b/dump/match_infra.py
@@ -6,6 +6,7 @@ from dump.helper import verbose_print
 from swsscommon.swsscommon import SonicV2Connector, SonicDBConfig
 from sonic_py_common import multi_asic
 from utilities_common.constants import DEFAULT_NAMESPACE
+from utilities_common.general import load_db_config
 import redis
 
 
@@ -290,12 +291,7 @@ class ConnectionPool:
         self.cache = dict()  # Pool of SonicV2Connector objects
 
     def initialize_connector(self, ns):
-        if multi_asic.is_multi_asic():
-            if not SonicDBConfig.isGlobalInit():
-                SonicDBConfig.load_sonic_global_db_config()
-        else:
-            if not SonicDBConfig.isInit():
-                SonicDBConfig.load_sonic_db_config()
+        load_db_config()
         return SonicV2Connector(namespace=ns, use_unix_socket_path=True)
 
     def initialize_redis_conn(self, ns):


### PR DESCRIPTION
#### What I did

Currently `sudo dump state -d APPL_DB -n asic0 port Ethernet16` CLI command crashes on multi-asic platforms. 

The error occurs because the code checks if any database configuration is initialized and loaded which is falsy value on multi-asic system. This results in following runtime error:
```
RuntimeError: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig.
```
The multi-ASIC platforms specifically needs the global database configuration to be initialized. The pull request fixes the condition on loading expected database configuration based on single or multi-asic system.

#### How I did it

Fixed it by using isGlobalInit() check for multi-asic and isInit() for single-asic to ensure the correct DB configuration is loaded before creating connectors.

#### How to verify it

Verified on single and multi-asic linecard. After fix, dump port state command no longer result in a crash and returns the expected results.
 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

#### Command output after fix
```
sudo dump state -d APPL_DB -n asic0 port Ethernet16
{
    "Ethernet16": {
        "APPL_DB": {
            "keys": [
                {
                    "PORT_TABLE:Ethernet16": {
                        "admin_status": "up",
                        "alias": "etp3",
                        "asic_port_name": "Eth16",
                        "core_id": "1",
                        "core_port_id": "3",
                        "description": "Ethernet16-connected-to-@Ethernet4/1",
                        "fec": "rs",
                        "flap_count": "1",
                        "index": "3",
                        "lanes": "88,89,90,91,92,93,94,95",
                        "last_up_time": "Mon Jan 26 22:11:46 2026",
                        "mtu": "9100",
                        "num_voq": "8",
                        "oper_status": "up",
                        "pfc_asym": "off",
                        "role": "Ext",
                        "speed": "400000",
                        "tpid": "0x8100"
                    }
                }
            ],
            "tables_not_found": []
        }
    }
}
```

Requesting to backport this fix to 202511 and msft-202503 