### PR TITLE
[tempershow] Add SFP transceiver temperature support with DOM table fallback

### DIFF
--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -31,34 +31,13 @@ class TemperShow(object):
         self.db = SonicV2Connector(host="127.0.0.1")
         self.db.connect(self.db.STATE_DB)
 
-    def _get_transceiver_temperature_data(self, port_name):
-        """
-        Get temperature data for a transceiver/SFP module with fallback logic.
-        Try TRANSCEIVER_DOM_TEMPERATURE first, fall back to TRANSCEIVER_DOM_SENSOR.
-        :param: port_name: port name (e.g., 'Ethernet0')
-        :return: dict with temperature and threshold fields, or None if not available
-        """
-        # Try new TRANSCEIVER_DOM_TEMPERATURE table first
-        temp_entry_key = TRANSCEIVER_DOM_TEMPERATURE_TABLE_NAME + '|' + port_name
-        temp_data = self.db.get_all(self.db.STATE_DB, temp_entry_key)
-        if temp_data and TEMPER_FIELD_NAME in temp_data:
-            return temp_data
-
-        # Fall back to TRANSCEIVER_DOM_SENSOR table
-        sensor_entry_key = TRANSCEIVER_DOM_SENSOR_TABLE_NAME + '|' + port_name
-        sensor_data = self.db.get_all(self.db.STATE_DB, sensor_entry_key)
-        if sensor_data and TEMPER_FIELD_NAME in sensor_data:
-            return sensor_data
-
-        return None
-
     def _add_sensor_to_output(self, sensor_name, data_dict, json_output, table):
         """
         Helper method to add sensor data to output in both JSON and table format.
-        :param: sensor_name: name of the sensor
-        :param: data_dict: dict with temperature and optional threshold fields
-        :param: json_output: list to append JSON output to
-        :param: table: list to append table rows to
+        :param sensor_name: name of the sensor
+        :param data_dict: dict with temperature and optional threshold fields
+        :param json_output: list to append JSON output to
+        :param table: list to append table rows to
         """
         temperature = data_dict.get(TEMPER_FIELD_NAME, 'N/A')
         high_th = data_dict.get(HIGH_THRESH_FIELD_NAME, 'N/A')
@@ -82,13 +61,9 @@ class TemperShow(object):
         table.append((sensor_name, temperature, high_th, low_th, crit_high_th,
                      crit_low_th, warning, timestamp))
 
-    def show(self, output_json):
-        table = []
-        json_output = []
-
-        # Collect thermal sensor data from TEMPERATURE_INFO table
-        thermal_keys = self.db.keys(self.db.STATE_DB, TEMPER_TABLE_NAME + '*')
-        for key in natsorted(thermal_keys or []):
+    def _process_keys(self, keys, json_output, table):
+        """Process keys and add sensor data to output."""
+        for key in keys:
             key_list = key.split('|')
             if len(key_list) != 2:
                 print('Warn: Invalid key in table {}: {}'.format(TEMPER_TABLE_NAME, key))
@@ -96,22 +71,23 @@ class TemperShow(object):
 
             name = key_list[1]
             data_dict = self.db.get_all(self.db.STATE_DB, key)
-            self._add_sensor_to_output(name, data_dict, json_output, table)
+            if data_dict:
+                self._add_sensor_to_output(name, data_dict, json_output, table)
+
+    def show(self, output_json):
+        table = []
+        json_output = []
+
+        # Collect thermal sensor data from TEMPERATURE_INFO table
+        thermal_keys = self.db.keys(self.db.STATE_DB, TEMPER_TABLE_NAME + '*')
+        self._process_keys(natsorted(thermal_keys or []), json_output, table)
 
         # Collect transceiver temperature data for SFP modules
         transceiver_keys = self.db.keys(self.db.STATE_DB, TRANSCEIVER_DOM_TEMPERATURE_TABLE_NAME + '*')
         if not transceiver_keys:
             transceiver_keys = self.db.keys(self.db.STATE_DB, TRANSCEIVER_DOM_SENSOR_TABLE_NAME + '*')
 
-        for key in natsorted(transceiver_keys or []):
-            key_list = key.split('|')
-            if len(key_list) != 2:
-                continue
-
-            port_name = key_list[1]
-            temp_data = self._get_transceiver_temperature_data(port_name)
-            if temp_data:
-                self._add_sensor_to_output(port_name, temp_data, json_output, table)
+        self._process_keys(natsorted(transceiver_keys or []), json_output, table)
 
         # Output results
         if not json_output:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added SFP/transceiver temperature display support to the `tempershow` utility (used by `show platform temperature` command). The change enables users to view transceiver module temperatures alongside existing platform sensors.

#### How I did it

1. Enhanced `tempershow` script to read transceiver temperature data from STATE_DB
2. Implemented fallback logic:
   - First tries `TRANSCEIVER_DOM_TEMPERATURE` table (preferred/new table)
   - Falls back to `TRANSCEIVER_DOM_SENSOR` table if temperature not found in the first table
3. Added helper method `_get_transceiver_temperature_data()` for clean abstraction of the fallback logic
4. Transceiver temperatures are displayed with sensor names based on port names (e.g., Ethernet0, Ethernet4)
5. Added comprehensive unit tests covering:
   - Platform-only temperature data
   - Transceiver-only temperature data  
   - Combined platform and transceiver data
   - Fallback from TRANSCEIVER_DOM_TEMPERATURE to TRANSCEIVER_DOM_SENSOR
   - JSON output format
   - Edge cases (empty tables, missing fields)

#### How to verify it

1. Run unit tests:
   ```bash
   python3 -m pytest tests/tempershow_test.py -v
   ```
2. On a SONiC device with SFP modules installed:
# Verify tables have data
sonic-db-cli STATE_DB keys "TEMPERATURE_INFO|*"
sonic-db-cli STATE_DB keys "TRANSCEIVER_DOM_TEMPERATURE|*"
sonic-db-cli STATE_DB keys "TRANSCEIVER_DOM_SENSOR|*"

# Test the command
show platform temperature
show platform temperature -j
#### Previous command output (if the output of a command-line utility has changed)
<img width="760" height="323" alt="image" src="https://github.com/user-attachments/assets/39321061-52f9-4465-b892-c4371c4abdb1" />

#### New command output (if the output of a command-line utility has changed)
<img width="770" height="520" alt="image" src="https://github.com/user-attachments/assets/1c0c1bc1-1ef7-4d1a-9be8-b4a7dd754480" />
.
.
