### PR TITLE
Fix JsonMove._get_value to Support Both String and Integer List Indices

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -98,8 +98,9 @@ class JsonMove:
     @staticmethod
     def _get_value(config, tokens):
         for token in tokens:
+            if isinstance(config, list):
+                token = int(token)
             config = config[token]
-
         return copy.deepcopy(config)
 
     @staticmethod

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -98,8 +98,6 @@ class JsonMove:
     @staticmethod
     def _get_value(config, tokens):
         for token in tokens:
-            if isinstance(token, str) and token.isnumeric():
-                token = int(token)
             config = config[token]
 
         return copy.deepcopy(config)

--- a/tests/generic_config_updater/test_patch_sorter_get_value.py
+++ b/tests/generic_config_updater/test_patch_sorter_get_value.py
@@ -48,3 +48,8 @@ class TestJsonMoveGetValue(unittest.TestCase):
         tokens = ["table1", "key1", "field", "extra"]
         with self.assertRaises(TypeError):
             JsonMove._get_value(self.config, tokens)
+
+    def test_get_value_dict_numeric_keys(self):
+        self.config["7"] = {"8": "30"}
+        tokens = ["7", "8"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "30")

--- a/tests/generic_config_updater/test_patch_sorter_get_value.py
+++ b/tests/generic_config_updater/test_patch_sorter_get_value.py
@@ -1,5 +1,6 @@
 import unittest
-from generic_config_updater.patch_sorter import JsonMove, GenericConfigUpdaterError
+from generic_config_updater.patch_sorter import JsonMove
+
 
 class TestJsonMoveGetValue(unittest.TestCase):
     def setUp(self):
@@ -49,5 +50,3 @@ class TestJsonMoveGetValue(unittest.TestCase):
         with self.assertRaises(TypeError):
             JsonMove._get_value(self.config, tokens)
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/generic_config_updater/test_patch_sorter_get_value.py
+++ b/tests/generic_config_updater/test_patch_sorter_get_value.py
@@ -28,10 +28,9 @@ class TestJsonMoveGetValue(unittest.TestCase):
         self.assertEqual(JsonMove._get_value(self.config, tokens), "value2")
 
     def test_get_value_list(self):
+        # Should allow both int and string index for list
         tokens = ["table2", 1, "name"]
-        with self.assertRaises(TypeError):
-            JsonMove._get_value(self.config, tokens)
-        # Should use string index for list
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "item1")
         tokens = ["table2", "1", "name"]
         self.assertEqual(JsonMove._get_value(self.config, tokens), "item1")
 

--- a/tests/generic_config_updater/test_patch_sorter_get_value.py
+++ b/tests/generic_config_updater/test_patch_sorter_get_value.py
@@ -1,0 +1,53 @@
+import unittest
+from generic_config_updater.patch_sorter import JsonMove, GenericConfigUpdaterError
+
+class TestJsonMoveGetValue(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "table1": {
+                "key1": {
+                    "field": "value1"
+                },
+                "1": {
+                    "field": "value2"
+                }
+            },
+            "table2": [
+                {"name": "item0"},
+                {"name": "item1"}
+            ]
+        }
+
+    def test_get_value_dict(self):
+        tokens = ["table1", "key1", "field"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "value1")
+
+    def test_get_value_dict_numeric_string(self):
+        tokens = ["table1", "1", "field"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "value2")
+
+    def test_get_value_list(self):
+        tokens = ["table2", 1, "name"]
+        with self.assertRaises(TypeError):
+            JsonMove._get_value(self.config, tokens)
+        # Should use string index for list
+        tokens = ["table2", "1", "name"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "item1")
+
+    def test_get_value_missing_key(self):
+        tokens = ["table1", "not_exist"]
+        with self.assertRaises(KeyError):
+            JsonMove._get_value(self.config, tokens)
+
+    def test_get_value_list_invalid_index(self):
+        tokens = ["table2", "10", "name"]
+        with self.assertRaises(IndexError):
+            JsonMove._get_value(self.config, tokens)
+
+    def test_get_value_non_container(self):
+        tokens = ["table1", "key1", "field", "extra"]
+        with self.assertRaises(TypeError):
+            JsonMove._get_value(self.config, tokens)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/generic_config_updater/test_patch_sorter_get_value.py
+++ b/tests/generic_config_updater/test_patch_sorter_get_value.py
@@ -49,4 +49,3 @@ class TestJsonMoveGetValue(unittest.TestCase):
         tokens = ["table1", "key1", "field", "extra"]
         with self.assertRaises(TypeError):
             JsonMove._get_value(self.config, tokens)
-


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

### What I did:

Issue: https://github.com/sonic-net/sonic-utilities/issues/4221

- Updated [JsonMove._get_value](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to handle both string and integer indices when traversing lists in config data.
- Adjusted related unit tests to reflect the new behavior.

### How I did it:

- Modified the traversal logic to convert string tokens to integers when accessing lists, allowing both "1" and 1 as valid indices.
- Removed the test expecting a TypeError for integer indices and added assertions for both string and integer index access.

### How to verify it:

Patched change in lab device, confirmed. 

```shell
admin@STR-SN5640-RDMA-1:~$ cat /usr/local/lib/python3.11/dist-packages/generic_config_updater/patch_sorter.py | grep -C 2 "int(token)"
        for token in tokens:
            if isinstance(config, list):
                token = int(token)
            config = config[token]

admin@STR-SN5640-RDMA-1:~$ cat t_tc_to_queue_map_modify.json 
[
  {
    "op": "replace",
    "path": "/TC_TO_QUEUE_MAP/AZURE/8",
    "value": "8"
  },
  {
    "op": "add",
    "path": "/TC_TO_QUEUE_MAP/AZURE/7",
    "value": "7"
  }
]

admin@STR-SN5640-RDMA-1:~$ sudo config apply-patch -v t_tc_to_queue_map_modify.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "replace", "path": "/TC_TO_QUEUE_MAP/AZURE/8", "value": "8"}, {"op": "add", "path": "/TC_TO_QUEUE_MAP/AZURE/7", "value": "7"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Sorter - Strict: Validating patch is not making changes to tables without YANG models.
Patch Sorter - Strict: Validating target config according to YANG models.
Patch Sorter - Strict: Sorting patch updates.
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier: localhost: applying 1 change in order:
Patch Applier:   * [{"op": "replace", "path": "/TC_TO_QUEUE_MAP/AZURE/7", "value": "7"}, {"op": "replace", "path": "/TC_TO_QUEUE_MAP/AZURE/8", "value": "8"}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
```
Also run the updated unit tests and all tests should pass, confirming the fix.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

