### PR TITLE
Add FEC histograms to generate_dump output

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2307,6 +2307,12 @@ save_counter_snapshot() {
     save_cmd "echo $counter_t" "date.counter_$idx"
     save_cmd "show interface counters" "interface.counters_$idx"
     save_cmd "show interface counters fec-stats" "interface.counters.fec-stats_$idx"
+
+    for netdev in /sys/class/net/Ethernet* ; do
+        iface=$(basename $netdev)
+        save_cmd "show interface counters fec-histogram $iface" "interface.counters.fec-histogram.$iface.$idx"
+    done
+
     if ! $IS_SUPERVISOR; then
        save_cmd "show queue counters" "queue.counters_$idx"
     fi


### PR DESCRIPTION
The dump tarball now contains a series of `interface.counters.fec-histogram.Ethernet*` files with the output of `show interface counters fec-histogram`, as requested in issue [813](https://github.com/aristanetworks/sonic-qual.msft/issues/813).