### PR TITLE
[sonic-utilities] Fix spelling errors in command output and help text

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -750,7 +750,7 @@ class AclLoader(object):
 
         rule_props["PRIORITY"] = str(self.max_priority - rule_idx)
 
-        # setup default ip type match to dataplane acl (could be overriden by rule later)
+        # setup default ip type match to dataplane acl (could be overridden by rule later)
         if self.is_table_l3v4v6(table_name):
             # ETHERTYPE must be passed and it should be one of IPv4 or IPv6
             try:

--- a/clear/main.py
+++ b/clear/main.py
@@ -76,7 +76,7 @@ class AliasedGroup(click.Group):
 
 
 # To be enhanced. Routing-stack information should be collected from a global
-# location (configdb?), so that we prevent the continous execution of this
+# location (configdb?), so that we prevent the continuous execution of this
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -492,7 +492,7 @@ class ConfigMgmtDPB(ConfigMgmt):
             # Get all dependecies for ports
             for port in ports:
                 xPathPort = self.sy.findXpathPortLeaf(port)
-                self.sysLog(doPrint=True, msg='Find dependecies for port {}'.\
+                self.sysLog(doPrint=True, msg='Find dependencies for port {}'.\
                     format(port))
                 dep = self.sy.find_data_dependencies(str(xPathPort))
                 if dep:

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -31,7 +31,7 @@ DEFAULT_CONFIG_DB_JSON_FILE = '/etc/sonic/port_breakout_config_db.json'
 
 class ConfigMgmt():
     '''
-    Class to handle config managment for SONIC, this class will use sonic_yang
+    Class to handle config management for SONIC, this class will use sonic_yang
     to verify config for the commands which are capable of change in config DB.
     '''
 
@@ -336,7 +336,7 @@ class ConfigMgmtDPB(ConfigMgmt):
 
         Parameters:
             db (SonicV2Connector): database.
-            key (str): key in ASIC DB, with table Seperator if applicable.
+            key (str): key in ASIC DB, with table Separator if applicable.
 
         Returns:
             (bool): True, if given key is present.
@@ -424,11 +424,11 @@ class ConfigMgmtDPB(ConfigMgmt):
             delPorts (list): ports to be deleted.
             portJson (dict): Config DB json Part of all Ports, generated from
                 platform.json.
-            force (bool): if false return dependecies, else delete dependencies.
+            force (bool): if false return dependencies, else delete dependencies.
             loadDefConfig: If loadDefConfig, add default config for ports as well.
 
         Returns:
-            (deps, ret) (tuple)[list, bool]: dependecies and success/failure.
+            (deps, ret) (tuple)[list, bool]: dependencies and success/failure.
         '''
         MAX_WAIT = 60
         try:
@@ -471,15 +471,15 @@ class ConfigMgmtDPB(ConfigMgmt):
 
     def _deletePorts(self, ports=list(), force=False):
         '''
-        Delete ports and dependecies from data tree, validate and return resultant
+        Delete ports and dependencies from data tree, validate and return resultant
         config.
 
         Parameters:
             ports (list): list of ports
-            force (bool): if false return dependecies, else delete dependencies.
+            force (bool): if false return dependencies, else delete dependencies.
 
         Returns:
-            (configToLoad, deps, ret) (tuple)[dict, list, bool]: config, dependecies
+            (configToLoad, deps, ret) (tuple)[dict, list, bool]: config, dependencies
             and success/fail.
         '''
         configToLoad = None; deps = None
@@ -489,7 +489,7 @@ class ConfigMgmtDPB(ConfigMgmt):
             self.sysLog(doPrint=True, msg='Start Port Deletion')
             deps = list()
 
-            # Get all dependecies for ports
+            # Get all dependencies for ports
             for port in ports:
                 xPathPort = self.sy.findXpathPortLeaf(port)
                 self.sysLog(doPrint=True, msg='Find dependencies for port {}'.\
@@ -502,7 +502,7 @@ class ConfigMgmtDPB(ConfigMgmt):
             if not force and deps:
                 return configToLoad, deps, False
 
-            # delets all deps, No topological sort is needed as of now, if deletion
+            # deletes all deps, No topological sort is needed as of now, if deletion
             # of deps fails, return immediately
             elif deps:
                 for dep in deps:
@@ -576,7 +576,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                 self._mergeConfigs(self.configdbJsonOut, defConfig, True)
 
             # create a tree with merged config and validate, if validation is
-            # sucessful, then configdbJsonOut contains final and valid config.
+            # successful, then configdbJsonOut contains final and valid config.
             self.sy.loadData(self.configdbJsonOut)
             if self.validateConfigData()==False:
                 return configToLoad, False
@@ -711,7 +711,7 @@ class ConfigMgmtDPB(ConfigMgmt):
 
     def configWithKeys(self, configIn=dict(), keys=list()):
         '''
-        This function returns the config with relavant keys in Input Config.
+        This function returns the config with relevant keys in Input Config.
         It calls _searchKeysInConfig.
 
         Parameters:
@@ -784,7 +784,7 @@ class ConfigMgmtDPB(ConfigMgmt):
 
     def _createConfigToLoad(self, diff, inp, outp):
         '''
-        Create the config to write in Config DB, i.e. compitible with mod_config()
+        Create the config to write in Config DB, i.e. compatible with mod_config()
         This functions has 3 inner functions:
         -- _deleteHandler: to handle delete in diff. See example below.
         -- _insertHandler: to handle insert in diff. See example below.
@@ -802,7 +802,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                 is applied.
 
         Returns:
-            configToLoad (dict): config in a format compitible with mod_Config().
+            configToLoad (dict): config in a format compatible with mod_Config().
         '''
 
         ### Internal Functions ###

--- a/config/console.py
+++ b/config/console.py
@@ -127,7 +127,7 @@ def upate_console_remote_device_name(db, linenum, devicename):
     data = config_db.get_entry(table, linenum)
     if data:
         if dataKey in data and devicename == data[dataKey]:
-            # do nothing if the device name is same with existing configurtion
+            # do nothing if the device name is same with existing configuration
             return
         elif not devicename:
             # remove configuration key from console setting if user not give a remote device name
@@ -166,7 +166,7 @@ def update_console_baud(db, linenum, baud):
     if data:
         baud = str(baud)
         if dataKey in data and baud == data[dataKey]:
-            # do nothing if the baud is same with existing configurtion
+            # do nothing if the baud is same with existing configuration
             return
         else:
             data[dataKey] = baud
@@ -197,7 +197,7 @@ def update_console_flow_control(db, mode, linenum):
     data = config_db.get_entry(table, linenum)
     if data:
         if dataKey in data and innerMode == data[dataKey]:
-            # do nothing if the flow control setting is same with existing configurtion
+            # do nothing if the flow control setting is same with existing configuration
             return
         else:
             data[dataKey] = innerMode

--- a/config/flow_counters.py
+++ b/config/flow_counters.py
@@ -95,7 +95,7 @@ def _update_route_flow_counter_config(db, vrf, max_allowed_match, prefix_pattern
 
 def _try_find_existing_pattern_by_ip_type(cfgdb, input_net, input_key, yes):
     """Try to find the same IP type pattern from CONFIG DB. 
-        1. If found a pattern with the same IP type, but the patter does not equal, ask user if need to replace the old with new one
+        1. If found a pattern with the same IP type, but the pattern does not equal, ask user if need to replace the old with new one
             a. If user types "yes", remove the old one, return False
             b. If user types "no", exit
         2. If found a pattern with the same IP type and the pattern equal, return True

--- a/config/main.py
+++ b/config/main.py
@@ -981,7 +981,7 @@ def _get_disabled_services_list(config_db):
             if state == "disabled":
                 disabled_services_list.append(feature_name)
     else:
-        log.log_warning("Unable to retreive FEATURE table")
+        log.log_warning("Unable to retrieve FEATURE table")
 
     return disabled_services_list
 
@@ -1200,7 +1200,7 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
             if not interface_name_is_valid(config_db, port):
                 ctx.fail("Error: Source Interface {} is invalid".format(port))
             if dst_port and dst_port == port:
-                ctx.fail("Error: Destination Interface cant be same as Source Interface")
+                ctx.fail("Error: Destination Interface can't be same as Source Interface")
 
     if interface_has_mirror_config(ctx, mirror_table, dst_port, src_port, direction):
         return False
@@ -2675,7 +2675,7 @@ def override_config_db(config_db, config_input):
     # Deserialized golden config to DB recognized format
     sonic_cfggen.FormatConverter.to_deserialized(config_input)
     # Delete table from DB then mod_config to apply golden config
-    click.echo("Removing configDB overriden table first ...")
+    click.echo("Removing configDB overridden table first ...")
     for table in config_input:
         config_db.delete_table(table)
     click.echo("Overriding input config to configDB ...")
@@ -6089,7 +6089,7 @@ def transceiver(ctx):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('frequency', metavar='<frequency>', required=True, type=int)
 def frequency(ctx, interface_name, frequency):
-    """Set transciever (only for 400G-ZR) frequency"""
+    """Set transceiver (only for 400G-ZR) frequency"""
     # Get the config_db connector
     config_db = ctx.obj['config_db']
 
@@ -6121,7 +6121,7 @@ def frequency(ctx, interface_name, frequency):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('tx-power', metavar='<tx-power>', required=True, type=float)
 def tx_power(ctx, interface_name, tx_power):
-    """Set transciever (only for 400G-ZR) Tx laser power"""
+    """Set transceiver (only for 400G-ZR) Tx laser power"""
     # Get the config_db connector
     config_db = ctx.obj['config_db']
 
@@ -6441,7 +6441,7 @@ def enable():
 
 @ipv6.group('disable')
 def disable():
-    """Disble IPv6 processing on interface"""
+    """Disable IPv6 processing on interface"""
     pass
 
 #
@@ -7470,7 +7470,7 @@ def add_vrf_vni_map(ctx, vrfname, vni):
     config_db = ctx.obj['config_db']
     found = 0
     if vrfname not in config_db.get_table('VRF').keys():
-        ctx.fail("vrf {} doesnt exists".format(vrfname))
+        ctx.fail("vrf {} doesn't exist".format(vrfname))
     if not vni.isdigit():
         ctx.fail("Invalid VNI {}. Only valid VNI is accepted".format(vni))
 
@@ -7508,7 +7508,7 @@ def add_vrf_vni_map(ctx, vrfname, vni):
 def del_vrf_vni_map(ctx, vrfname):
     config_db = ctx.obj['config_db']
     if vrfname not in config_db.get_table('VRF').keys():
-        ctx.fail("vrf {} doesnt exists".format(vrfname))
+        ctx.fail("vrf {} doesn't exist".format(vrfname))
 
     config_db.mod_entry('VRF', vrfname, {"vni": 0})
 
@@ -7616,7 +7616,7 @@ def del_route(ctx, command_str):
     keys = config_db.get_keys('STATIC_ROUTE')
 
     if not tuple(key.split("|")) in keys:
-        ctx.fail('Route {} doesnt exist'.format(key))
+        ctx.fail("Route {} doesn't exist".format(key))
     else:
         # If not defined nexthop or intf name remove entire route
         if not 'nexthop' in route and not 'ifname' in route:
@@ -9871,7 +9871,7 @@ def add_vnet_route(ctx, vnet_name, prefix, endpoint, vni, mac_address, endpoint_
     vnet_name_is_valid(ctx, vnet_name)
 
     if not is_vnet_exists(config_db, vnet_name):
-        ctx.fail("VNET {} doesnot exist, cannot add a route!".format(vnet_name))
+        ctx.fail("VNET {} does not exist, cannot add a route!".format(vnet_name))
     if not clicommon.is_ipprefix(prefix):
         ctx.fail("Invalid prefix {}".format(prefix))
     else:
@@ -9930,14 +9930,14 @@ def del_vnet_route(ctx, vnet_name, prefix):
     vnet_name_is_valid(ctx, vnet_name)
 
     if not is_vnet_exists(config_db, vnet_name):
-        ctx.fail("VNET {} doesnot exist, cannot delete the route!".format(vnet_name))
+        ctx.fail("VNET {} does not exist, cannot delete the route!".format(vnet_name))
     if not is_vnet_route_exists(config_db, vnet_name):
-        ctx.fail("Routes dont exist for the VNET {}, cant delete it!".format(vnet_name))
+        ctx.fail("Routes dont exist for the VNET {}, can't delete it!".format(vnet_name))
     if prefix:
         if not clicommon.is_ipprefix(prefix):
             ctx.fail("Invalid prefix {}".format(prefix))
         if not is_specific_vnet_route_exists(config_db, vnet_name, prefix):
-            ctx.fail("Route does not exist for the VNET {}, cant delete it!".format(vnet_name))
+            ctx.fail("Route does not exist for the VNET {}, can't delete it!".format(vnet_name))
         else:
             for key in config_db.get_table('VNET_ROUTE_TUNNEL'):
                 if key[0] == vnet_name and key[1] == prefix:

--- a/config/main.py
+++ b/config/main.py
@@ -258,7 +258,7 @@ def breakout_warnUser_extraTables(cm, final_delPorts, confirm=True):
         # check if any extra tables exist
         eTables = cm.tablesWithOutYang()
         if len(eTables):
-            # find relavent tables in extra tables, i.e. one which can have deleted
+            # find relevant tables in extra tables, i.e. one which can have deleted
             # ports
             tables = cm.configWithKeys(configIn=eTables, keys=final_delPorts)
             click.secho("Below Config can not be verified, It may cause harm "\
@@ -2389,7 +2389,7 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
         clicommon.run_command(command, display_cmd=True)
         client.set(config_db.INIT_INDICATOR, 1)
 
-    # Update SONiC environmnet file
+    # Update SONiC environment file
     update_sonic_environment()
 
     if os.path.isfile('/etc/sonic/acl.json'):
@@ -2505,7 +2505,7 @@ def override_config_by(golden_config_path):
     return
 
 
-# This funtion is to generate sysinfo if that is missing in config_input.
+# This function is to generate sysinfo if that is missing in config_input.
 # It will keep the same with sysinfo in cur_config if sysinfo exists.
 # Otherwise it will modify config_input with generated sysinfo.
 def generate_sysinfo(cur_config, config_input, ns=None):
@@ -2614,7 +2614,7 @@ def override_config_table(db, input_config_db, dry_run):
         # Use deepcopy by default to avoid modifying input config
         updated_config = update_config(current_config, ns_config_input)
 
-        # Enable YANG hard dependecy check to exit early if not satisfied
+        # Enable YANG hard dependency check to exit early if not satisfied
         table_hard_dependency_check(updated_config)
 
         yang_enabled = device_info.is_yang_config_validation_enabled(config_db)
@@ -2641,7 +2641,7 @@ def override_config_table(db, input_config_db, dry_run):
             except Exception as ex:
                 log.log_warning("Failed to validate running config. Alerting: {}".format(ex))
 
-            # YANG validate config of minigraph generated overriden by golden config
+            # YANG validate config of minigraph generated overridden by golden config
             if cm:
                 validate_config_by_cm_alerting(cm, updated_config, "updated_config")
 
@@ -3774,7 +3774,7 @@ def _qos_update_ports(ctx, ports, dry_run, json_data):
                         cable_length_from_template[port] = cable_len
                 # Reaching this point,
                 # - cable_length_from_template contains cable length rendered from the template, eg Ethernet0 and Ethernet4 in the above example
-                # - cable_length_from_db contains cable length existing in the CONFIG_DB, eg Ethernet8, Ethernet12, and Ethernet16 in the above exmaple
+                # - cable_length_from_db contains cable length existing in the CONFIG_DB, eg Ethernet8, Ethernet12, and Ethernet16 in the above example
 
                 if not items_to_apply.get(table_name):
                     items_to_apply[table_name] = {}
@@ -4769,7 +4769,7 @@ def all(verbose):
         namespaces = ns_list['front_ns']
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    # namespaces (in case of multi ASIC) and do the specified "action" on the BGP neighbor(s)
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -4794,7 +4794,7 @@ def neighbor(ipaddr_or_hostname, verbose):
         namespaces = ns_list['front_ns'] + ns_list['back_ns']
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    # namespaces (in case of multi ASIC) and do the specified "action" on the BGP neighbor(s)
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -4824,7 +4824,7 @@ def all(verbose):
         namespaces = ns_list['front_ns']
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    # namespaces (in case of multi ASIC) and do the specified "action" on the BGP neighbor(s)
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -4849,7 +4849,7 @@ def neighbor(ipaddr_or_hostname, verbose):
         namespaces = ns_list['front_ns'] + ns_list['back_ns']
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    # namespaces (in case of multi ASIC) and do the specified "action" on the BGP neighbor(s)
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -4882,7 +4882,7 @@ def remove_neighbor(neighbor_ip_or_hostname):
         namespaces = ns_list['front_ns'] + ns_list['back_ns']
 
     # Connect to CONFIG_DB in linux host (in case of single ASIC) or CONFIG_DB in all the
-    # namespaces (in case of multi ASIC) and do the sepcified "action" on the BGP neighbor(s)
+    # namespaces (in case of multi ASIC) and do the specified "action" on the BGP neighbor(s)
     for namespace in namespaces:
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
@@ -5850,7 +5850,7 @@ def remove_buffer_object_on_port(db, interface_name, buffer_object_map, is_pg=Tr
     if not ports:
         ctx.fail("Port {} doesn't exist".format(interface_name))
 
-    # Remvoe all dynamic lossless PGs on the port
+    # Remove all dynamic lossless PGs on the port
     buffer_table = "BUFFER_PG" if is_pg else "BUFFER_QUEUE"
     existing_buffer_objects = config_db.get_table(buffer_table)
     removed = False

--- a/config/mclag.py
+++ b/config/mclag.py
@@ -301,7 +301,7 @@ def add_mclag_member(ctx, domain_id, portchannel_names):
 def del_mclag_member(ctx, domain_id, portchannel_names):
     """Delete member MCLAG interfaces from MCLAG Domain"""
     db = ValidatedConfigDBConnector(ctx.obj['db'])
-    #split comma seperated portchannel names
+    #split comma separated portchannel names
     portchannel_list = portchannel_names.split(",")
     for portchannel_name in portchannel_list:
         if ADHOC_VALIDATION:
@@ -329,7 +329,7 @@ def add_mclag_unique_ip(ctx, interface_names):
     if len(mclag_domain_keys) == 0:
         ctx.fail("MCLAG not configured. MCLAG should be configured.")
 
-    #split comma seperated interface names
+    #split comma separated interface names
     interface_list = interface_names.split(",")
     for interface_name in interface_list:
         if not interface_name.startswith("Vlan"):
@@ -356,7 +356,7 @@ def add_mclag_unique_ip(ctx, interface_names):
 def del_mclag_unique_ip(ctx, interface_names):
     """Delete Unique IP from MCLAG Vlan interface"""
     db = ValidatedConfigDBConnector(ctx.obj['db'])
-    #split comma seperated interface names
+    #split comma separated interface names
     interface_list = interface_names.split(",")
     for interface_name in interface_list:
         if not interface_name.startswith("Vlan"):

--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -115,7 +115,7 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant perform firmware cmd".format(port))
+            click.echo("Got invalid asic index for port {}, can't perform firmware cmd".format(port))
             res_dict[0] = rc
             return res_dict
 
@@ -371,7 +371,7 @@ def mode(db, state, port, json_output):
             import sonic_platform_base.sonic_sfp.sfputilhelper
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
-                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+                click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port))
                 sys.exit(CONFIG_FAIL)
 
         if per_npu_statedb[asic_index] is not None:
@@ -459,7 +459,7 @@ def probertype(db, probertype, port):
             import sonic_platform_base.sonic_sfp.sfputilhelper
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
-                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+                click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port))
                 sys.exit(CONFIG_FAIL)
 
         if per_npu_statedb[asic_index] is not None:
@@ -542,7 +542,7 @@ def packetloss(db, action, port):
             import sonic_platform_base.sonic_sfp.sfputilhelper
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
-                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+                click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port))
                 sys.exit(CONFIG_FAIL)
 
         if per_npu_statedb[asic_index] is not None:

--- a/config/nat.py
+++ b/config/nat.py
@@ -201,7 +201,7 @@ def nat():
 #
 @nat.group('add')
 def add():
-    """Add NAT-related configutation tasks"""
+    """Add NAT-related configuration tasks"""
     pass
 
 #
@@ -209,7 +209,7 @@ def add():
 #
 @nat.group('remove')
 def remove():
-    """Remove NAT-related configutation tasks"""
+    """Remove NAT-related configuration tasks"""
     pass
 
 #
@@ -217,7 +217,7 @@ def remove():
 #
 @nat.group('set')
 def set():
-    """Set NAT-related timeout configutation tasks"""
+    """Set NAT-related timeout configuration tasks"""
     pass
 
 #
@@ -225,7 +225,7 @@ def set():
 #
 @nat.group('reset')
 def reset():
-    """Reset NAT-related timeout configutation tasks"""
+    """Reset NAT-related timeout configuration tasks"""
     pass
 
 #
@@ -233,7 +233,7 @@ def reset():
 #
 @add.group('static')
 def static():
-    """Add Static related configutation"""
+    """Add Static related configuration"""
     pass
 
 #
@@ -246,7 +246,7 @@ def static():
 @click.option('-nat_type', metavar='<nat_type>', required=False, type=click.Choice(["snat", "dnat"]), help="Set nat type")
 @click.option('-twice_nat_id', metavar='<twice_nat_id>', required=False, type=click.IntRange(1, 9999), help="Set the twice nat id")
 def add_basic(ctx, global_ip, local_ip, nat_type, twice_nat_id):
-    """Add Static NAT-related configutation"""
+    """Add Static NAT-related configuration"""
     if ADHOC_VALIDATION:
         # Verify the ip address format 
         if is_valid_ipv4_address(local_ip) is False:
@@ -340,7 +340,7 @@ def add_basic(ctx, global_ip, local_ip, nat_type, twice_nat_id):
 @click.option('-nat_type', metavar='<nat_type>', required=False, type=click.Choice(["snat", "dnat"]), help="Set nat type")
 @click.option('-twice_nat_id', metavar='<twice_nat_id>', required=False, type=click.IntRange(1, 9999), help="Set the twice nat id")
 def add_tcp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_nat_id):
-    """Add Static TCP Protocol NAPT-related configutation"""
+    """Add Static TCP Protocol NAPT-related configuration"""
     if ADHOC_VALIDATION: 
         # Verify the ip address format 
         if is_valid_ipv4_address(local_ip) is False:
@@ -432,7 +432,7 @@ def add_tcp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_n
 @click.option('-nat_type', metavar='<nat_type>', required=False, type=click.Choice(["snat", "dnat"]), help="Set nat type")
 @click.option('-twice_nat_id', metavar='<twice_nat_id>', required=False, type=click.IntRange(1, 9999), help="Set the twice nat id")
 def add_udp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_nat_id):
-    """Add Static UDP Protocol NAPT-related configutation"""
+    """Add Static UDP Protocol NAPT-related configuration"""
     
     if ADHOC_VALIDATION:
         # Verify the ip address format 
@@ -518,7 +518,7 @@ def add_udp(ctx, global_ip, global_port, local_ip, local_port, nat_type, twice_n
 #
 @remove.group('static')
 def static():
-    """Remove Static related configutation"""
+    """Remove Static related configuration"""
     pass
 
 #
@@ -529,7 +529,7 @@ def static():
 @click.argument('global_ip', metavar='<global_ip>', required=True)
 @click.argument('local_ip', metavar='<local_ip>', required=True)
 def remove_basic(ctx, global_ip, local_ip):
-    """Remove Static NAT-related configutation"""
+    """Remove Static NAT-related configuration"""
     
     if ADHOC_VALIDATION:
         # Verify the ip address format 
@@ -570,7 +570,7 @@ def remove_basic(ctx, global_ip, local_ip):
 @click.argument('local_ip', metavar='<local_ip>', required=True)
 @click.argument('local_port', metavar='<local_port>', type=click.IntRange(1, 65535), required=True)
 def remove_tcp(ctx, global_ip, global_port, local_ip, local_port):
-    """Remove Static TCP Protocol NAPT-related configutation"""
+    """Remove Static TCP Protocol NAPT-related configuration"""
     
     if ADHOC_VALIDATION:
         # Verify the ip address format 
@@ -609,7 +609,7 @@ def remove_tcp(ctx, global_ip, global_port, local_ip, local_port):
 @click.argument('local_ip', metavar='<local_ip>', required=True)
 @click.argument('local_port', metavar='<local_port>', type=click.IntRange(1, 65535), required=True)
 def remove_udp(ctx, global_ip, global_port, local_ip, local_port):
-    """Remove Static UDP Protocol NAPT-related configutation"""
+    """Remove Static UDP Protocol NAPT-related configuration"""
     
     if ADHOC_VALIDATION:
         # Verify the ip address format 
@@ -646,7 +646,7 @@ def remove_udp(ctx, global_ip, global_port, local_ip, local_port):
 @static.command('all')
 @click.pass_context
 def remove_static_all(ctx):
-    """Remove all Static related configutation"""
+    """Remove all Static related configuration"""
 
     config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
@@ -671,7 +671,7 @@ def remove_static_all(ctx):
 @click.argument('global_ip_range', metavar='<global_ip_range>', required=True)
 @click.argument('global_port_range', metavar='<global_port_range>', required=False)
 def add_pool(ctx, pool_name, global_ip_range, global_port_range):
-    """Add Pool for Dynamic NAT-related configutation"""
+    """Add Pool for Dynamic NAT-related configuration"""
 
     if len(pool_name) > 32:
         ctx.fail("Invalid pool name. Maximum allowed pool name is 32 characters !!")
@@ -783,7 +783,7 @@ def add_pool(ctx, pool_name, global_ip_range, global_port_range):
 @click.option('-nat_type', metavar='<nat_type>', required=False, type=click.Choice(["snat", "dnat"]), help="Set nat type")
 @click.option('-twice_nat_id', metavar='<twice_nat_id>', required=False, type=click.IntRange(1, 9999), help="Set the twice nat id")
 def add_binding(ctx, binding_name, pool_name, acl_name, nat_type, twice_nat_id):
-    """Add Binding for Dynamic NAT-related configutation"""
+    """Add Binding for Dynamic NAT-related configuration"""
 
     entryFound = False
     table = 'NAT_BINDINGS'
@@ -815,7 +815,7 @@ def add_binding(ctx, binding_name, pool_name, acl_name, nat_type, twice_nat_id):
 
     if nat_type is not None:
         if nat_type == "dnat":
-            click.echo("Ignored, DNAT is not yet suported for Binding ")
+            click.echo("Ignored, DNAT is not yet supported for Binding ")
             entryFound = True
     else:
         nat_type = "snat"
@@ -844,7 +844,7 @@ def add_binding(ctx, binding_name, pool_name, acl_name, nat_type, twice_nat_id):
 @click.pass_context
 @click.argument('pool_name', metavar='<pool_name>', required=True)
 def remove_pool(ctx, pool_name):
-    """Remove Pool for Dynamic NAT-related configutation"""
+    """Remove Pool for Dynamic NAT-related configuration"""
  
     entryFound = False
     table = "NAT_POOL"
@@ -881,7 +881,7 @@ def remove_pool(ctx, pool_name):
 @remove.command('pools')
 @click.pass_context
 def remove_pools(ctx):
-    """Remove all Pools for Dynamic configutation"""
+    """Remove all Pools for Dynamic configuration"""
 
     config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()
@@ -913,7 +913,7 @@ def remove_pools(ctx):
 @click.pass_context
 @click.argument('binding_name', metavar='<binding_name>', required=True)
 def remove_binding(ctx, binding_name):
-    """Remove Binding for Dynamic NAT-related configutation"""
+    """Remove Binding for Dynamic NAT-related configuration"""
 
     entryFound = False
     table = 'NAT_BINDINGS'
@@ -942,7 +942,7 @@ def remove_binding(ctx, binding_name):
 @remove.command('bindings')
 @click.pass_context
 def remove_bindings(ctx):
-    """Remove all Bindings for Dynamic configutation"""
+    """Remove all Bindings for Dynamic configuration"""
 
     config_db = ValidatedConfigBConnector(ConfigDBConnector())
     config_db.connect()
@@ -1063,7 +1063,7 @@ def feature():
 @feature.command('enable')
 @click.pass_context
 def enable(ctx):
-    """Enbale the NAT feature """
+    """Enable the NAT feature """
 
     config_db = ValidatedConfigDBConnector(ConfigDBConnector())
     config_db.connect()

--- a/config/plugins/auto_techsupport.py
+++ b/config/plugins/auto_techsupport.py
@@ -190,7 +190,7 @@ def AUTO_TECHSUPPORT_GLOBAL_rate_limit_interval(db, rate_limit_interval):
 )
 @clicommon.pass_db
 def AUTO_TECHSUPPORT_GLOBAL_max_techsupport_limit(db, max_techsupport_limit):
-    """ Max Limit in percentage for the cummulative size of ts dumps.
+    """ Max Limit in percentage for the cumulative size of ts dumps.
         No cleanup is performed if the value isn't configured or is 0.0
     """
 
@@ -213,7 +213,7 @@ def AUTO_TECHSUPPORT_GLOBAL_max_techsupport_limit(db, max_techsupport_limit):
 )
 @clicommon.pass_db
 def AUTO_TECHSUPPORT_GLOBAL_max_core_limit(db, max_core_limit):
-    """ Max Limit in percentage for the cummulative size of core dumps.
+    """ Max Limit in percentage for the cumulative size of core dumps.
         No cleanup is performed if the value isn't congiured or is 0.0
     """
 

--- a/config/plugins/nvgre_tunnel.py
+++ b/config/plugins/nvgre_tunnel.py
@@ -45,7 +45,7 @@ def add_entry_validated(db, table, key, data):
     """ Add new entry in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
         data (Dict): Entry data.
@@ -69,7 +69,7 @@ def update_entry_validated(db, table, key, data, create_if_not_exists=False):
     If attribute value in data is None, the attribute is deleted.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
         data (Dict): Entry data.
@@ -114,7 +114,7 @@ def del_entry_validated(db, table, key):
     """ Delete entry in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
     Raises:
@@ -136,7 +136,7 @@ def add_list_entry_validated(db, table, key, attr, data):
     """ Add new entry into list in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add data to.
         key (Union[str, Tuple]): Key name in the table.
         attr (str): Attribute name which represents a list the data needs to be added to.
@@ -163,7 +163,7 @@ def del_list_entry_validated(db, table, key, attr, data):
     """ Delete entry from list in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to remove data from.
         key (Union[str, Tuple]): Key name in the table.
         attr (str): Attribute name which represents a list the data needs to be removed from.
@@ -192,7 +192,7 @@ def clear_list_entry_validated(db, table, key, attr):
     """ Clear list in object and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to remove the list attribute from.
         key (Union[str, Tuple]): Key name in the table.
         attr (str): Attribute name which represents a list that needs to be removed.

--- a/config/plugins/sonic-fine-grained-ecmp_yang.py
+++ b/config/plugins/sonic-fine-grained-ecmp_yang.py
@@ -45,7 +45,7 @@ def add_entry_validated(db, table, key, data):
     """ Add new entry in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
         data (Dict): Entry data.
@@ -69,7 +69,7 @@ def update_entry_validated(db, table, key, data, create_if_not_exists=False):
     If attribute value in data is None, the attribute is deleted.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
         data (Dict): Entry data.
@@ -114,7 +114,7 @@ def del_entry_validated(db, table, key):
     """ Delete entry in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
     Raises:
@@ -136,7 +136,7 @@ def add_list_entry_validated(db, table, key, attr, data):
     """ Add new entry into list in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add data to.
         key (Union[str, Tuple]): Key name in the table.
         attr (str): Attribute name which represents a list the data needs to be added to.
@@ -163,7 +163,7 @@ def del_list_entry_validated(db, table, key, attr, data):
     """ Delete entry from list in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to remove data from.
         key (Union[str, Tuple]): Key name in the table.
         attr (str): Attribute name which represents a list the data needs to be removed from.
@@ -192,7 +192,7 @@ def clear_list_entry_validated(db, table, key, attr):
     """ Clear list in object and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to remove the list attribute from.
         key (Union[str, Tuple]): Key name in the table.
         attr (str): Attribute name which represents a list that needs to be removed.

--- a/config/plugins/sonic-passwh_yang.py
+++ b/config/plugins/sonic-passwh_yang.py
@@ -42,7 +42,7 @@ def update_entry_validated(db, table, key, data, create_if_not_exists=False):
     If attribute value in data is None, the attribute is deleted.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
         data (Dict): Entry data.

--- a/config/plugins/sonic-system-ldap_yang.py
+++ b/config/plugins/sonic-system-ldap_yang.py
@@ -46,7 +46,7 @@ def add_entry_validated(db, table, key, data):
     """ Add new entry in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
         data (Dict): Entry data.
@@ -70,7 +70,7 @@ def update_entry_validated(db, table, key, data, create_if_not_exists=False):
     If attribute value in data is None, the attribute is deleted.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
         data (Dict): Entry data.
@@ -115,7 +115,7 @@ def del_entry_validated(db, table, key):
     """ Delete entry in table and validate configuration.
 
     Args:
-        db (swsscommon.ConfigDBConnector): Config DB connector obect.
+        db (swsscommon.ConfigDBConnector): Config DB connector object.
         table (str): Table name to add new entry to.
         key (Union[str, Tuple]): Key name in the table.
     Raises:

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -65,7 +65,7 @@ def add_vlan(db, vid, multiple):
             # Multiple VLANs need to be referenced
             vlan = 'Vlan{}'.format(vid)
 
-            # Defualt VLAN checker
+            # Default VLAN checker
             if vid == 1:
                 ctx.fail("{} is default VLAN".format(vlan))  # TODO: MISSING CONSTRAINT IN YANG MODEL
 

--- a/dump/match_helper.py
+++ b/dump/match_helper.py
@@ -96,7 +96,7 @@ def fetch_lag_oid(match_engine, lag_name, ns):
     if lag_type_oids:
         if len(lag_type_oids) > 1:
             # Ideally, only one associated lag_oid should be present for a portchannel
-            handle_multiple_keys_matched_error("Multipe lag_oids matched for portchannel: {}, \
+            handle_multiple_keys_matched_error("Multiple lag_oids matched for portchannel: {}, \
                                                lag_oids matched {}".format(lag_name, lag_type_oids), lag_type_oids[-1])
         lag_type_oid = lag_type_oids[-1]
     return lag_type_oid

--- a/dump/match_infra.py
+++ b/dump/match_infra.py
@@ -47,7 +47,7 @@ class MatchRequest:
                           Only one of the db/file fields should have a non-empty string.
     "just_keys"         : If true, Only Returns the keys matched. Does not return field-value pairs. Defaults to True
     "ns"                : namespace argument, if nothing is provided, default namespace is used
-    "match_entire_list" : When this arg is set to true, entire list is matched incluing the ",".
+    "match_entire_list" : When this arg is set to true, entire list is matched including the ",".
                           When False, the values are split based on "," and individual items are matched with
     """
 
@@ -467,7 +467,7 @@ class MatchRequestOptimizer():
 
     def __mutate_request(self, req):
         """
-        Mutate the Request to fetch all the fv pairs, regardless of the orignal request
+        Mutate the Request to fetch all the fv pairs, regardless of the original request
         Save the return_fields and just_keys args of original request
         """
         fv_requested = []

--- a/dump/plugins/copp.py
+++ b/dump/plugins/copp.py
@@ -135,7 +135,7 @@ class Copp(Executor):
             err_str_tup = ("The Associated Trap_group for the trap_id found in APPL",
                            "and CONFIG_DB/CONFIG_FILE did not match.",
                            "In APPL_DB: {}, CONFIG_DB: {}",
-                           "\n Proceding with the trap group found in APPL DB")
+                           "\n Proceeding with the trap group found in APPL DB")
             err_str = " ".join(err_str_tup)
             err_str = err_str.format(tg, self.trap_group)
             handle_error(err_str, False)

--- a/dump/plugins/interface.py
+++ b/dump/plugins/interface.py
@@ -141,7 +141,7 @@ class RIF(object):
         # Sanity check to see if the TYPE is SAI_ROUTER_INTERFACE_TYPE_PORT
         _, recv_type = self.verify_valid_rif_type(ret, exp_type)
         if exp_type != recv_type:
-            err_str = "TYPE Mismatch on SAI_OBJECT_TYPE_ROUTER_INTERFACE, {} oid:{}, expected type:{}, recieved type:{}"
+            err_str = "TYPE Mismatch on SAI_OBJECT_TYPE_ROUTER_INTERFACE, {} oid:{}, expected type:{}, received type:{}"
             handle_error(err_str.format(str_name, rif_oid, exp_type, recv_type), False)
         return
 

--- a/flow_counter_util/route.py
+++ b/flow_counter_util/route.py
@@ -26,7 +26,7 @@ PATTERN_SEPARATOR = '|'
 
 
 def extract_route_pattern(route_pattern):
-    """Extract vrf and prefix from route pattern, route pattrn shall be formated like: "Vrf_1:1.1.1.1/24"
+    """Extract vrf and prefix from route pattern, route pattern shall be formatted like: "Vrf_1:1.1.1.1/24"
        or "1.1.1.1/24"
 
     Args:

--- a/pcieutil/main.py
+++ b/pcieutil/main.py
@@ -271,7 +271,7 @@ def all_errors(ctx, device_key, verbose):
     pcie_aer_display(ctx, "non_fatal")
 
 
-#  Show PCIE Vender ID and Device ID
+#  Show PCIE Vendor ID and Device ID
 @cli.command()
 def check():
     '''Check PCIe Device '''

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -281,7 +281,7 @@ class PfcwdCli(object):
             return
 
         if overwrite:
-            # don't clear existing pfc history setting unless set explicitely
+            # don't clear existing pfc history setting unless set explicitly
             cur_pfc_history = self.config_db.get_entry(
                 CONFIG_DB_PFC_WD_TABLE_NAME, port
             ).get("pfc_stat_history", DEFAULT_PFC_HISTORY_STATUS)
@@ -416,7 +416,7 @@ class PfcwdCli(object):
 
         port_num = len(list(self.config_db.get_table('PORT').keys()))
 
-        # Paramter values positively correlate to the number of ports.
+        # Parameter values positively correlate to the number of ports.
         multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)
         pfcwd_info = {
             'detection_time': DEFAULT_DETECTION_TIME * multiply,

--- a/rcli/rexec.py
+++ b/rcli/rexec.py
@@ -21,7 +21,7 @@ def cli(linecard_names, command, username):
     :param username: The username to use to login to the linecard(s)
     """
     if not device_info.is_chassis():
-        click.echo("This commmand is only supported Chassis")
+        click.echo("This command is only supported Chassis")
         sys.exit(1)
 
     if not username:

--- a/rcli/rshell.py
+++ b/rcli/rshell.py
@@ -18,7 +18,7 @@ def cli(linecard_name, username):
     :param linecard_name: The name of the linecard to connect to
     """
     if not device_info.is_chassis():
-        click.echo("This commmand is only supported Chassis")
+        click.echo("This command is only supported Chassis")
         sys.exit(1)
 
     if not username:

--- a/scripts/boot_part
+++ b/scripts/boot_part
@@ -101,7 +101,7 @@ def set_boot_partition(blkdev, index):
 def main():
     parser = argparse.ArgumentParser(description='The default output is a list of partition information.')
     parser.add_argument('-i', '--index', type=int,
-        help='Set the index partition as boot partition. After reboot, GRUB will boot from that partion.')
+        help='Set the index partition as boot partition. After reboot, GRUB will boot from that partition.')
     parser.add_argument("-v", "--verbose", action="store_true",
         help="increase output verbosity")
     args = parser.parse_args()

--- a/scripts/coredump_gen_handler.py
+++ b/scripts/coredump_gen_handler.py
@@ -48,7 +48,7 @@ class CriticalProcCoreDumpHandle():
             syslog.syslog(syslog.LOG_NOTICE, "auto_invoke_ts is disabled. No cleanup is performed: core {}".format(self.core_name))
             return
 
-        # Config made for the defaul instance applies to all the masic instances
+        # Config made for the default instance applies to all the masic instances
         self.container = trim_masic_suffix(self.container)
 
         FEATURE_KEY = FEATURE.format(self.container)

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -402,7 +402,7 @@ class DBMigrator():
                     abandon_method()
                     return True
             except Exception:
-                log.log_notice("Exception occured during parsing the profiles")
+                log.log_notice("Exception occurred during parsing the profiles")
                 abandon_method()
                 return True
 
@@ -1219,7 +1219,7 @@ class DBMigrator():
                             self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
                             self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
                     except Exception as err:
-                        log.log_warning('Error occured during LOGLEVEL_DB migration for {}. Ignoring key {}'.format(err, key))
+                        log.log_warning('Error occurred during LOGLEVEL_DB migration for {}. Ignoring key {}'.format(err, key))
                     finally:
                         self.loglevelDB.delete(self.loglevelDB.LOGLEVEL_DB, key)
         self.set_version('version_3_0_6')

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -554,7 +554,7 @@ class DBMigrator():
 
     def migrate_qos_fieldval_reference_format(self):
         '''
-        This is to change for first time to remove field refernces of ABNF format
+        This is to change for first time to remove field references of ABNF format
         in APPL DB for warm boot.
         i.e "[Tabale_name:name]" to string in APPL_DB. Reasons for doing this
          - To consistent with all other SoNIC CONFIG_DB/APPL_DB tables and fields

--- a/scripts/debug_voq_chassis_packet_drops.sh
+++ b/scripts/debug_voq_chassis_packet_drops.sh
@@ -34,7 +34,7 @@ print_pqp_reasons() {
     if [ $(($disc_reasons & 64)) -ne 0 ] ; then echo "6- Per queue disable bit">> $log ; fi
     if [ $(($disc_reasons & 128)) -ne 0 ] ; then echo "7- Undefined">> $log ; fi
     if [ $(($disc_reasons & 256)) -ne 0 ] ; then echo "8- Total PDs MC pool size threshold">> $log ; fi
-    if [ $(($disc_reasons & 512)) -ne 0 ] ; then echo "9- Per interface PDs threhold">> $log; fi
+    if [ $(($disc_reasons & 512)) -ne 0 ] ; then echo "9- Per interface PDs threshold">> $log; fi
     if [ $(($disc_reasons & 1024)) -ne 0 ] ; then echo "10- MC SP threshold">> $log ; fi
     if [ $(($disc_reasons & 2048)) -ne 0 ] ; then echo "11- per MC-TC threshold">> $log ; fi
     if [ $(($disc_reasons & 4096)) -ne 0 ] ; then echo "12- MC PDs per port threshold">> $log ; fi

--- a/scripts/dropstat
+++ b/scripts/dropstat
@@ -389,7 +389,7 @@ class DropStat(object):
             return configured_counters
 
         #Switch level standard drop counters are added by default and added to DEBUG_COUNTER_SWITCH_STAT_MAP table,
-        #so remove it from configrued counters
+        #so remove it from configured counters
         if object_stat_map == DEBUG_COUNTER_SWITCH_STAT_MAP:
            if std_switch_cntr:
               new_cntrs = {k:counters[k] for k in counters if SWITCH_LEVEL_COUNTER_PREFIX in k}

--- a/scripts/fabricstat
+++ b/scripts/fabricstat
@@ -55,7 +55,7 @@ class FabricStat(object):
     @multi_asic_util.run_on_multi_asic
     def collect_stat(self):
         """
-        Collect the statisitics from all the asics present on the
+        Collect the statistics from all the asics present on the
         device and store in a dict
         """
         self.cnstat_dict.update(self.get_cnstat())

--- a/scripts/flow_counters_stat
+++ b/scripts/flow_counters_stat
@@ -29,7 +29,7 @@ from utilities_common import constants
 from utilities_common.netstat import format_number_with_comma, table_as_json, ns_diff, format_prate
 from utilities_common.cli import UserCache
 
-# Flow counter meta data, new type of flow counters can extend this dictinary to reuse existing logic
+# Flow counter meta data, new type of flow counters can extend this dictionary to reuse existing logic
 flow_counter_meta = {
     'trap': {
         'headers': ['Trap Name', 'Packets', 'Bytes', 'PPS'],

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -150,7 +150,7 @@ save_bcmcmd() {
 }
 
 ###############################################################################
-# Runs a given bcmcmd command in all namesapces in case of multi ASIC platform
+# Runs a given bcmcmd command in all namespaces in case of multi ASIC platform
 # Globals:
 #  NUM_ASICS
 # Arguments:
@@ -178,7 +178,7 @@ save_bcmcmd_all_ns() {
 }
 
 ###############################################################################
-# Runs a comamnd and saves its output to the file.
+# Runs a command and saves its output to the file.
 # Command gets timedout if it runs for more than TIMEOUT_MIN minutes.
 # Globals:
 #  LOGDIR
@@ -298,7 +298,7 @@ dummy_cleanup_method() {
 }
 
 ###############################################################################
-# Runs a given command in all namesapces in case of multi ASIC platform, in
+# Runs a given command in all namespaces in case of multi ASIC platform, in
 # default (host) namespace in single ASIC platform
 # Globals:
 #  NUM_ASICS
@@ -400,7 +400,7 @@ copy_from_masic_docker() {
 }
 
 ###############################################################################
-# Returns namespace option to be used with vtysh commmand, based on the ASIC ID.
+# Returns namespace option to be used with vtysh command, based on the ASIC ID.
 # Returns empty string if no ASIC ID is provided
 # Globals:
 #  None
@@ -422,7 +422,7 @@ get_vtysh_namespace() {
 }
 
 ###############################################################################
-# Runs a vtysh command in all namesapces for a multi ASIC platform, and in
+# Runs a vtysh command in all namespaces for a multi ASIC platform, and in
 # default (host) namespace in single ASIC platforms. Saves its output to the
 # file.
 # Globals:
@@ -1169,7 +1169,7 @@ with open('$filepath') as json_file:
 # SAI DUMP based on the route table size
 # if the route table has more than ROUTE_TAB_LIMIT_DIRECT_ITERATION
 # then dump by Redis Save command,
-# otherwize, dump it by directly iteration the Redis
+# otherwise, dump it by directly iteration the Redis
 #
 # Globals:
 #  NUM_ASICS
@@ -1263,7 +1263,7 @@ save_chassis_modules_info() {
 }
 
 ###############################################################################
-# Runs a comamnd and saves its output to the incrementally built tar.
+# Runs a command and saves its output to the incrementally built tar.
 # Globals:
 #  LOGDIR
 #  BASE
@@ -1599,7 +1599,7 @@ collect_nvidia_sdk_dumps() {
 }
 
 ###############################################################################
-# Runs a given marvellcmd command in all namesapces in case of multi ASIC platform
+# Runs a given marvellcmd command in all namespaces in case of multi ASIC platform
 # Globals:
 #  NUM_ASICS
 # Arguments:
@@ -2563,7 +2563,7 @@ main() {
     # Remove secret from /etc files before tar
     remove_secret_from_etc_files $TARDIR
 
-    # Remove unecessary files
+    # Remove unnecessary files
     $RM $V -rf $TARDIR/etc/alternatives $TARDIR/etc/passwd* \
     $TARDIR/etc/shadow* $TARDIR/etc/group* $TARDIR/etc/gshadow* \
     $TARDIR/etc/ssh* $TARDIR/etc/mlnx $TARDIR/etc/mft \

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2851,7 +2851,7 @@ if $MKDIR "${LOCKDIR}" &>/dev/null; then
     # Trap configured on EXIT will be triggered by the exit from handle_signal function
     trap 'handle_sigterm' SIGHUP SIGQUIT SIGTERM
     trap 'handle_sigint' SIGINT
-    echo "Lock succesfully accquired and installed signal handlers"
+    echo "Lock successfully acquired and installed signal handlers"
     # Proceed with the actual code
     if [[ ! -z "${V}" ]]; then
         set -v
@@ -2868,7 +2868,7 @@ else
 
     if ! kill -0 $PID_PROG &>/dev/null; then
         # Lock is stale
-        echo "Removing stale lock of nonexistant PID ${PID_PROG}"
+        echo "Removing stale lock of nonexistent PID ${PID_PROG}"
         rm_lock_and_exit
     else
         # Lock is valid and the other instance is active. Exit Now

--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -60,7 +60,7 @@ class Lldpshow(object):
             per_asic_configdb[front_asic_namespaces] = ConfigDBConnector(
                 use_unix_socket_path=True, namespace=front_asic_namespaces)
             per_asic_configdb[front_asic_namespaces].connect()
-            # Initalize Interface list to be ''. We will do string append of the interfaces below.
+            # Initialize Interface list to be ''. We will do string append of the interfaces below.
             self.lldp_interface.append(LLDP_DEFAULT_INTERFACE_LIST_IN_ASIC_NAMESPACE)
             self.lldp_instance.append(instance_num)
             keys = per_asic_configdb[front_asic_namespaces].get_keys("PORT")
@@ -126,7 +126,7 @@ class Lldpshow(object):
 
     def parse_info(self, lldp_detail_info):
         """
-        Parse the lldp detailed infomation into dict
+        Parse the lldp detailed information into dict
         """
         if lldp_detail_info:
             return

--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -340,7 +340,7 @@ class MellanoxBufferMigrator():
                                          "Mellanox-SN2700": "spc1_2700_t1_pool_shp"}
             },
             "pool_mapped_from_old_version": {
-                # MSFT SKUs and generic SKUs may have different pool seetings
+                # MSFT SKUs and generic SKUs may have different pool settings
                 "spc1_t0_pool": ("sku", "spc1_t0_pool_sku_map"),
                 "spc1_t1_pool": ("sku", "spc1_t1_pool_sku_map"),
                 "spc1_2700_t0_pool": "spc1_2700_t0_single_pool_shp",
@@ -790,7 +790,7 @@ class MellanoxBufferMigrator():
             for name, profile in profiles.items():
                 if name in configdb_buffer_profiles.keys() and profile == configdb_buffer_profiles[name]:
                     continue
-                # return if any default profile isn't in cofiguration
+                # return if any default profile isn't in configuration
                 profile_matched = False
                 break
 

--- a/scripts/mmuconfig
+++ b/scripts/mmuconfig
@@ -11,7 +11,7 @@ optional arguments:
   -vv    --verbose         verbose output
   -l     --list            show mmu configuration
   -p     --profile         specify buffer profile name
-  -a     --alpha           set n for dyanmic threshold alpha 2^(n)
+  -a     --alpha           set n for dynamic threshold alpha 2^(n)
   -s     --staticth        set static threshold
 
 """
@@ -171,7 +171,7 @@ class TrimTypeValidator(click.ParamType):
 @click.command(help='Show and change: mmu configuration')
 @click.option('-l', '--list', 'show_config', is_flag=True, help='show mmu configuration')
 @click.option('-p', '--profile', type=str, help='specify buffer profile name', default=None)
-@click.option('-a', '--alpha', type=click.IntRange(DYNAMIC_THRESHOLD_MIN, DYNAMIC_THRESHOLD_MAX), help='set n for dyanmic threshold alpha 2^(n)', default=None)
+@click.option('-a', '--alpha', type=click.IntRange(DYNAMIC_THRESHOLD_MIN, DYNAMIC_THRESHOLD_MAX), help='set n for dynamic threshold alpha 2^(n)', default=None)
 @click.option('-s', '--staticth', type=click.IntRange(min=STATIC_THRESHOLD_MIN), help='set static threshold', default=None)
 @click.option('-t', '--trim', 'trim', type=TrimTypeValidator(), help='Configures packet trimming eligibility')
 @click.option('-n', '--namespace', type=click.Choice(multi_asic.get_namespace_list()), help='Namespace name or skip for all', default=None)

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -246,7 +246,7 @@ class NeighShow(NbrBase):
 
 def main():
 
-    parser = argparse.ArgumentParser(description='Show Neigbhor entries',
+    parser = argparse.ArgumentParser(description='Show Neighbor entries',
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-ip', '--ipaddr', type=str,
                         help='Neigbhor for a specific address', default=None)

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -6,9 +6,9 @@
     usage: nbrshow [-h] [-ip IPADDR] [-if IFACE] v
     optional arguments:
         -ip IPADDR, --ipaddr IPADDR
-                        Neigbhor for a specific address
+                        Neighbor for a specific address
         -if IFACE, --iface IFACE
-                        Neigbhors learned on specific L3 interface
+                        Neighbors learned on specific L3 interface
 
     Example of the output:
     admin@str~$nbrshow -4

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -159,7 +159,7 @@ def main():
     sockets, exp_socket = create_socket(interface, portchannel)
     pkt, exp_pkt = find_probe_packet(interface, decap_ip, portchannel_ip, sockets, exp_socket, max_trial)
     print("Preparation done! Start probing ............")
-    print("PORTCHANNEL Member PING %d btyes of data. PORTCHANNEL: %s, INTERFACE: %s" % (PROBE_PACKET_LEN, portchannel_name, interface))
+    print("PORTCHANNEL Member PING %d bytes of data. PORTCHANNEL: %s, INTERFACE: %s" % (PROBE_PACKET_LEN, portchannel_name, interface))
     recv_count = 0
     total_count = 0
     try:

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -114,7 +114,7 @@ class portconfig(object):
             raise Exception("Invalid port %s" % (port))
 
     def list_params(self, port):
-        # chack whether table for this port exists
+        # check whether table for this port exists
         port_tables = self.db.get_table(PORT_TABLE_NAME)
         if port in port_tables:
             print(port_tables[port])

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -258,7 +258,7 @@ class portconfig(object):
         if not self.namespace:
             state_db = SonicV2Connector(host="127.0.0.1")
         else:
-            state_db = SonicV2Connector(host="127.0.0.1", namesapce=self.namespace, use_unix_socket_path=True)
+            state_db = SonicV2Connector(host="127.0.0.1", namespace=self.namespace, use_unix_socket_path=True)
         state_db.connect(state_db.STATE_DB)
         return state_db.get(state_db.STATE_DB, '{}|{}'.format(PORT_STATE_TABLE_NAME, port), PORT_STATE_SUPPORTED_SPEEDS)
 

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -641,7 +641,7 @@ class Queuestat(object):
 
 
 @click.command()
-@click.option('-p', '--port', type=str, help='Show the queue conters for just one port', default=None)
+@click.option('-p', '--port', type=str, help='Show the queue counters for just one port', default=None)
 @click.option('-c', '--clear', is_flag=True, default=False, help='Clear previous stats and save new ones')
 @click.option('-d', '--delete', is_flag=True, default=False, help='Delete saved stats')
 @click.option('-j', '--json_opt',  is_flag=True, default=False, help='Print in JSON format')

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -267,7 +267,7 @@ function parse_config_file
                     [ "${value}" = "true" ] && SHOW_TIMER="yes"
                     ;;
                 *)
-                    debug "WARNING: Unknown config ${key}=${value} finded in config file ${REBOOT_CONFIG_FILE}" 
+                    debug "WARNING: Unknown config ${key}=${value} found in config file ${REBOOT_CONFIG_FILE}"
                     ;;
             esac
         done < "$REBOOT_CONFIG_FILE"
@@ -403,7 +403,7 @@ else
             CURRENT_TIME=$(date +%s)
             ELAPSED=$((CURRENT_TIME - REBOOT_START_TIME))
             if (( ELAPSED >= BLOCKING_MODE_TIMEOUT_IN_SECOND )); then
-                echo "[REBOOT FAILED] The reboot used $(ELAPSED)seconds while the timeout is configed as $(BLOCKING_MODE_TIMEOUT_IN_SECOND)seconds"
+                echo "[REBOOT FAILED] The reboot used $(ELAPSED)seconds while the timeout is configured as $(BLOCKING_MODE_TIMEOUT_IN_SECOND)seconds"
                 exit ${EXIT_TIMEOUT}
             fi
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -831,7 +831,7 @@ def check_routes_for_namespace(namespace):
     If there are FRR routes that aren't marked offloaded but all APPL & ASIC DB
     routes are in sync report failure and perform a mitigation action.
 
-    :return (0, None) on sucess, else (-1, results) where results holds
+    :return (0, None) on success, else (-1, results) where results holds
     the unjustifiable entries.
     """
 
@@ -969,7 +969,7 @@ def check_sids_for_namespace(namespace):
     this function does not wait for subscriber updates, as SIDs are not
     expected to change frequently.
 
-    :return (0, None) on sucess, else (-1, results) where results holds
+    :return (0, None) on success, else (-1, results) where results holds
     the unjustifiable entries.
     """
 

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -469,7 +469,7 @@ def read_use_kdump():
         try:
             return int(lines[0])
         except Exception as e:
-            print('Error! Exception[%s] occured while reading from %s' %(str(e), kdump_cfg))
+            print('Error! Exception[%s] occurred while reading from %s' %(str(e), kdump_cfg))
             sys.exit(1)
     else:
         print_err("Unable to read USE_KDUMP from %s" % kdump_cfg)
@@ -507,7 +507,7 @@ def read_num_dumps():
         try:
             return int(lines[0])
         except Exception as e:
-            print_err('Error! Exception[%s] occured while reading from %s' %(str(e), kdump_cfg))
+            print_err('Error! Exception[%s] occurred while reading from %s' %(str(e), kdump_cfg))
             sys.exit(1)
     else:
         print_err("Unable to read KDUMP_NUM_DUMPS from %s" % kdump_cfg)
@@ -1007,7 +1007,7 @@ def main():
             parser.print_help()
             sys.exit(1)
     except Exception as e:
-        print_err('Error! Exception[%s] occured while processing the command sonic-kdump-config %s.' %(str(e), sys.argv[1]))
+        print_err('Error! Exception[%s] occurred while processing the command sonic-kdump-config %s.' %(str(e), sys.argv[1]))
         sys.exit(1)
 
     if changed:

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -43,7 +43,7 @@ def print_err(*args):
 
 ## Run an external command, either from the shell or not
 #  The function capture the output of stdout and stderr,
-#  and return then a tupple with exit code, stdout, stderr
+#  and return then a tuple with exit code, stdout, stderr
 #
 #  @param cmd   Command to execute (full path needed ig not using the shell)
 def run_command(cmd, use_shell=False):
@@ -197,7 +197,7 @@ def modify_crashkernel_param_uboot_env(crashkernel_value):
 #
 #  @param  lines Lines read from grub.cfg/cmdline file
 #  @param  img   String we are looking for ("loop=image...")
-#  @return       Index in lines array wehere we found the string
+#  @return       Index in lines array where we found the string
 def locate_image(lines, img):
     for num in range(len(lines)):
         try:
@@ -614,7 +614,7 @@ def write_ssh_path(ssh_path):
 
 ## Enable kdump
 #
-#  @param verbose If True, the function will display a few additinal information
+#  @param verbose If True, the function will display a few additional information
 #  @return        True if the grub/cmdline cfg has changed, and False if it has not
 def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file, remote, ssh_string, ssh_path):
 
@@ -720,7 +720,7 @@ def get_kdump_config_json(config_param):
 
 ## Command: Enable kdump
 #
-#  @param verbose If True, the function will display a few additinal information
+#  @param verbose If True, the function will display a few additional information
 #  @param image   The image on which kdump settings are changed
 #  @return        True if the grub/cmdline cfg has changed, and False if it has not
 def cmd_kdump_enable(verbose, image):

--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -589,7 +589,7 @@ class SkuCreate(object):
             lanes = [_.strip() for _ in self.default_lanes_per_port[fp - 1].split(",")]
             lanes_count = len(lanes)
             if lanes_count % splt != 0:
-                print("Lanes(%s) could not be evenly splitted by %d." % (self.default_lanes_per_port[fp - 1], splt))
+                print("Lanes(%s) could not be evenly split by %d." % (self.default_lanes_per_port[fp - 1], splt))
                 sys.exit(1)
 
             # split the lanes

--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -556,7 +556,7 @@ class SkuCreate(object):
         self.num_of_fpp = len(list(self.fpp_split.keys()))
 
     def get_default_lanes(self):
-        #Internal function to get lanes of the ports accroding to the base default SKU 
+        #Internal function to get lanes of the ports according to the base default SKU
         try:
             with open(self.base_file_path,"r") as f:
                 line_header = next(f).split() # get the file header split into columns

--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -104,7 +104,7 @@ def main():
                         type=int, required=False, default=0)
     parser.add_argument('-s', '--since', help='Filter logs since the given date',
                         type=str, required=False, default="@0")
-    parser.add_argument('-f', '--sortfield', help='Use Nth field separted by "." in file name to sort. e.g. syslog.1.gz: -f 2, swss.rec.2.gz: -f 3, default 0: sort by timestamp',
+    parser.add_argument('-f', '--sortfield', help='Use Nth field separated by "." in file name to sort. e.g. syslog.1.gz: -f 2, swss.rec.2.gz: -f 3, default 0: sort by timestamp',
                         type=int, required=False, default=0)
 
     args = parser.parse_args()

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -7,15 +7,15 @@ import subprocess
 import argparse
 from swsscommon import swsscommon
 
-''' vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
+''' vnet_route_check.py: tool that verifies VNET routes consistency between SONiC and vendor SDK DBs.
 
 Logically VNET route verification logic consists of 3 parts:
 1. Get VNET routes entries that are missed in ASIC_DB but present in APP_DB.
 2. Get VNET routes entries that are missed in APP_DB but present in ASIC_DB.
 3. Get VNET routes entries that are missed in SDK but present in ASIC_DB.
 
-Returns 0 if there is no inconsistancy found and all VNET routes are aligned in all DBs.
-Returns -1 if there is incosistancy found and prints differences between DBs in JSON format to standart output.
+Returns 0 if there is no inconsistency found and all VNET routes are aligned in all DBs.
+Returns -1 if there is incosistancy found and prints differences between DBs in JSON format to standard output.
 
 Format of differences output:
 {
@@ -179,7 +179,7 @@ def filter_out_vnet_ip2me_routes(vnet_routes):
             continue
 
         # rif_attrs[0] - RIF name
-        # rif_attrs[1] - IP prefix and prefix legth
+        # rif_attrs[1] - IP prefix and prefix length
         # IP2ME routes have '/32' prefix length so replace it and add to the list
         if rif_attrs[0] in vnet_intfs:
             rif_ip, _ = rif_attrs[1].split('/')
@@ -394,7 +394,7 @@ def main():
 
     rc = RC_OK
 
-    # Don't run VNET routes consistancy logic if there is no VNET configuration
+    # Don't run VNET routes consistency logic if there is no VNET configuration
     if not check_vnet_cfg():
         return rc
     asic_db = swsscommon.DBConnector('ASIC_DB', 0, True)

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -727,7 +727,7 @@ def eeprom(port, dump_dom, namespace):
 # 'eeprom-hexdump' subcommand
 @show.command()
 @click.option('-p', '--port', metavar='<port_name>', help="Display SFP EEPROM hexdump for port <port_name>")
-@click.option('-n', '--page', metavar='<page_number>', help="Display SFP EEEPROM hexdump for <page_number_in_hex>")
+@click.option('-n', '--page', metavar='<page_number>', help="Display SFP EEPROM hexdump for <page_number_in_hex>")
 def eeprom_hexdump(port, page):
     """Display EEPROM hexdump of SFP transceiver(s)"""
     if port:

--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -342,7 +342,7 @@ def show_routes(args, namespace, display, verbose, ipver):
     device = multi_asic_util.MultiAsic(display, namespace)
     arg_strg = ""
     found_json = 0
-    found_other_parms = 0
+    found_other_params = 0
     ns_l = []
     print_ns_str = False
     filter_by_ip = False
@@ -377,10 +377,10 @@ def show_routes(args, namespace, display, verbose, ipver):
                 filter_by_ip = ipaddress.ip_network(arg)
             except ValueError:
                 # Not ip address just ignore it
-                found_other_parms = 1
+                found_other_params = 1
 
     # using the same format for both multiasic or non-multiasic
-    if not found_json and not found_other_parms:
+    if not found_json and not found_other_params:
         arg_strg += "json"
 
     combined_route = {}
@@ -402,8 +402,8 @@ def show_routes(args, namespace, display, verbose, ipver):
             print(error_msg)
             return
 
-        # Multi-asic show ip route with additional parms are handled by going to FRR directly and get those outputs from each namespace
-        if found_other_parms and not found_json:
+        # Multi-asic show ip route with additional params are handled by going to FRR directly and get those outputs from each namespace
+        if found_other_params and not found_json:
             print("{}:".format(ns))
             print(output)
             continue

--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -329,14 +329,14 @@ def show_routes(args, namespace, display, verbose, ipver):
     else:
         if multi_asic.is_multi_asic():
             if display not in multi_asic_util.multi_asic_display_choices():
-                print("dislay option '{}' is not a valid option.".format(display))
+                print("display option '{}' is not a valid option.".format(display))
                 return
             else:
                 if display == constants.DISPLAY_EXTERNAL:
                     filter_back_end = True
         else:
             if display not in ['frontend', 'all']:
-                print("dislay option '{}' is not a valid option.".format(display))
+                print("display option '{}' is not a valid option.".format(display))
                 return
 
     device = multi_asic_util.MultiAsic(display, namespace)

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -229,7 +229,7 @@ def breakout(ctx):
                 continue
             cur_brkout_mode = cur_brkout_tbl[port_name]["brkout_mode"]
 
-            # Update deafult breakout mode and current breakout mode to platform_dict
+            # Update default breakout mode and current breakout mode to platform_dict
             platform_dict[port_name].update(hwsku_dict[port_name])
             platform_dict[port_name]["Current Breakout Mode"] = cur_brkout_mode
 

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -531,7 +531,7 @@ def get_all_port_errors(interfacename):
 @click.argument('interfacename', required=True)
 @click.pass_context
 def errors(ctx, interfacename):
-    """Show Interface Erorrs <interfacename>"""
+    """Show Interface Errors <interfacename>"""
     # Try to convert interface name from alias
     interfacename = try_convert_interfacename_from_alias(click.get_current_context(), interfacename)
 

--- a/show/kdump.py
+++ b/show/kdump.py
@@ -174,7 +174,7 @@ def files():
 #
 # 'logging' subcommand (show kdump logging)
 #
-@kdump.command(name="logging", short_help="Show last 10 lines of lastest kernel dmesg file")
+@kdump.command(name="logging", short_help="Show last 10 lines of latest kernel dmesg file")
 @click.argument('filename', required=False)
 @click.option('-l', '--lines', default=10, show_default=True)
 def logging(filename, lines):

--- a/show/main.py
+++ b/show/main.py
@@ -87,7 +87,7 @@ GEARBOX_TABLE_PHY_PATTERN = r"_GEARBOX_TABLE:phy:*"
 COMMAND_TIMEOUT = 300
 
 # To be enhanced. Routing-stack information should be collected from a global
-# location (configdb?), so that we prevent the continous execution of this
+# location (configdb?), so that we prevent the continuous execution of this
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -52,7 +52,7 @@ def get_asic_index_for_port(port):
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
                 port_name = platform_sfputil_helper.get_interface_alias(port, db)
-                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port_name))
+                click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port_name))
                 return 0
     return asic_index
 
@@ -110,7 +110,7 @@ def check_port_in_mux_cable_table(port):
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant retrieve mux cable table entries".format(port))
+            click.echo("Got invalid asic index for port {}, can't retrieve mux cable table entries".format(port))
             return False
 
     if port in port_mux_tbl_keys[asic_index]:
@@ -142,7 +142,7 @@ def get_per_port_firmware(port):
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant retrieve mux cable table entries".format(port))
+            click.echo("Got invalid asic index for port {}, can't retrieve mux cable table entries".format(port))
             return False
 
 
@@ -189,7 +189,7 @@ def get_response_for_version(port, mux_info_dict):
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+            click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port))
             rc = CONFIG_FAIL
             res_dict[1] = rc
             return mux_info_dict
@@ -234,7 +234,7 @@ def get_event_logs(port, res_dict, mux_info_dict):
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+            click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port))
             rc = CONFIG_FAIL
             res_dict[1] = rc
             return mux_info_dict
@@ -273,7 +273,7 @@ def get_result(port, res_dict, cmd ,result, table_name):
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+            click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port))
             rc = CONFIG_FAIL
             res_dict[1] = rc
             return result
@@ -335,7 +335,7 @@ def update_and_get_response_for_xcvr_cmd(cmd_name, rsp_name, exp_rsp, cmd_table_
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant perform firmware cmd".format(port))
+            click.echo("Got invalid asic index for port {}, can't perform firmware cmd".format(port))
             res_dict[0] = rc
             return res_dict
 
@@ -482,7 +482,7 @@ def get_switch_name(config_db):
     if switch_name is not None:
         return switch_name
     else:
-        click.echo("could not retreive switch name")
+        click.echo("could not retrieve switch name")
         sys.exit(STATUS_FAIL)
 
 
@@ -728,7 +728,7 @@ def status(db, port, json_output):
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
                 port_name = platform_sfputil_helper.get_interface_alias(port, db)
-                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port_name))
+                click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port_name))
                 sys.exit(STATUS_FAIL)
 
         muxcable_info_dict[asic_index] = per_npu_appl_db[asic_index].get_all(
@@ -867,7 +867,7 @@ def config(db, port, json_output):
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
                 port_name = platform_sfputil_helper.get_interface_alias(port, db)
-                click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port_name))
+                click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port_name))
                 sys.exit(CONFIG_FAIL)
 
         port_status_dict = {}
@@ -1384,7 +1384,7 @@ def hwmode():
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
 def muxdirection(db, port, json_output):
-    """Shows the current direction of the muxcable {active/standy}"""
+    """Shows the current direction of the muxcable {active/standby}"""
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 
@@ -1641,7 +1641,7 @@ def get_single_port_firmware_version(port, res_dict, mux_info_dict):
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port))
+            click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port))
             rc = CONFIG_FAIL
             res_dict[1] = rc
             return
@@ -1888,7 +1888,7 @@ def metrics(db, port, json_output):
                 asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
                 if asic_index is None:
                     port_name = platform_sfputil_helper.get_interface_alias(port, db)
-                    click.echo("Got invalid asic index for port {}, cant retreive mux status".format(port_name))
+                    click.echo("Got invalid asic index for port {}, can't retrieve mux status".format(port_name))
 
         metrics_dict[asic_index] = per_npu_statedb[asic_index].get_all(
             per_npu_statedb[asic_index].STATE_DB, 'MUX_METRICS_TABLE|{}'.format(port))
@@ -1917,7 +1917,7 @@ def metrics(db, port, json_output):
 def event_log(db, port, json_output):
     """Show muxcable event log <port>"""
 
-    click.confirm(('Muxcable at port {} will retreive cable logs from MCU, Caution: approx wait time could be ~2 minutes Continue?'.format(port)), abort=True)
+    click.confirm(('Muxcable at port {} will retrieve cable logs from MCU, Caution: approx wait time could be ~2 minutes Continue?'.format(port)), abort=True)
     port = platform_sfputil_helper.get_interface_name(port, db)
     delete_all_keys_in_db_table("APPL_DB", "XCVRD_EVENT_LOG_CMD")
     delete_all_keys_in_db_table("STATE_DB", "XCVRD_EVENT_LOG_RSP")
@@ -2038,7 +2038,7 @@ def packetloss(db, port, json_output):
                 asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
                 if asic_index is None:
                     port_name = platform_sfputil_helper.get_interface_alias(port, db)
-                    click.echo("Got invalid asic index for port {}, cant retreive pck loss info".format(port_name))
+                    click.echo("Got invalid asic index for port {}, can't retrieve pck loss info".format(port_name))
 
         pckloss_dict[asic_index] = per_npu_statedb[asic_index].get_all(
             per_npu_statedb[asic_index].STATE_DB, 'LINK_PROBE_STATS|{}'.format(port))
@@ -2115,7 +2115,7 @@ def tunnel_route(db, port, json_output):
             asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
             if asic_index is None:
                 port_name = platform_sfputil_helper.get_interface_alias(port, db)
-                click.echo("Got invalid asic index for port {}, cant retreive tunnel route info".format(port_name))
+                click.echo("Got invalid asic index for port {}, can't retrieve tunnel route info".format(port_name))
                 sys.exit(STATUS_FAIL)
         
         if mux_tbl_keys[asic_index] is not None and "MUX_CABLE|{}".format(port) in mux_tbl_keys[asic_index]:
@@ -2194,7 +2194,7 @@ def get_grpc_cached_version_mux_direction_per_port(db, port):
         import sonic_platform_base.sonic_sfp.sfputilhelper
         asic_index = sonic_platform_base.sonic_sfp.sfputilhelper.SfpUtilHelper().get_asic_id_for_logical_port(port)
         if asic_index is None:
-            click.echo("Got invalid asic index for port {}, cant retrieve mux cable table entries".format(port))
+            click.echo("Got invalid asic index for port {}, can't retrieve mux cable table entries".format(port))
             return mux_info_dict
 
 
@@ -2232,7 +2232,7 @@ def grpc():
 @click.option('--json', 'json_output', required=False, is_flag=True, type=click.BOOL, help="display the output in json format")
 @clicommon.pass_db
 def muxdirection(db, port, json_output):
-    """Shows the current direction of the FPGA facing port on Tx Side {active/standy}"""
+    """Shows the current direction of the FPGA facing port on Tx Side {active/standby}"""
 
     port = platform_sfputil_helper.get_interface_name(port, db)
 

--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -2362,7 +2362,7 @@ def health(db, port, json_output):
     """Show muxcable health information as Ok or Not Ok"""
 
     """
-    in order to detemine whether the health of the cable is Ok
+    in order to determine whether the health of the cable is Ok
     the following are checked
      - the vendor name is correct able to be read
      - the FW is correctly loaded for SerDes by reading the appropriate register val

--- a/show/plugins/auto_techsupport.py
+++ b/show/plugins/auto_techsupport.py
@@ -17,7 +17,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:
@@ -33,7 +33,7 @@ def format_group_value(entry, attrs):
         attrs (List[Dict]): Attributes metadata that belongs to the same group.
 
     Returns:
-        str: fomatted group attributes.
+        str: formatted group attributes.
     """
 
     data = []

--- a/show/plugins/auto_techsupport.py
+++ b/show/plugins/auto_techsupport.py
@@ -80,11 +80,11 @@ def AUTO_TECHSUPPORT_GLOBAL(db):
         ),
         format_attr_value(
             entry,
-            {'name': 'max_techsupport_limit', 'description': 'Max Limit in percentage for the cummulative size of ts dumps. No cleanup is performed if the value isn\'t configured or is 0.0', 'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
+            {'name': 'max_techsupport_limit', 'description': 'Max Limit in percentage for the cumulative size of ts dumps. No cleanup is performed if the value isn\'t configured or is 0.0', 'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
         ),
         format_attr_value(
             entry,
-            {'name': 'max_core_limit', 'description': 'Max Limit in percentage for the cummulative size of core dumps. No cleanup is performed if the value isn\'t congiured or is 0.0', 'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
+            {'name': 'max_core_limit', 'description': 'Max Limit in percentage for the cumulative size of core dumps. No cleanup is performed if the value isn\'t congiured or is 0.0', 'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
         ),
         format_attr_value(
             entry,

--- a/show/plugins/nvgre_tunnel.py
+++ b/show/plugins/nvgre_tunnel.py
@@ -16,7 +16,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:
@@ -32,7 +32,7 @@ def format_group_value(entry, attrs):
         attrs (List[Dict]): Attributes metadata that belongs to the same group.
 
     Returns:
-        str: fomatted group attributes.
+        str: formatted group attributes.
     """
 
     data = []

--- a/show/plugins/pbh.py
+++ b/show/plugins/pbh.py
@@ -36,7 +36,7 @@ def format_attr_value(entry, attr):
             attr (Dict): Attribute metadata.
 
         Returns:
-            str: fomatted attribute value.
+            str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:
@@ -53,7 +53,7 @@ def format_group_value(entry, attrs):
             attrs (List[Dict]): Attributes metadata that belongs to the same group.
 
         Returns:
-            str: fomatted group attributes.
+            str: formatted group attributes.
     """
 
     data = []

--- a/show/plugins/sonic-passwh_yang.py
+++ b/show/plugins/sonic-passwh_yang.py
@@ -20,7 +20,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:

--- a/show/plugins/sonic-system-ldap_yang.py
+++ b/show/plugins/sonic-system-ldap_yang.py
@@ -18,7 +18,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:

--- a/show/stp.py
+++ b/show/stp.py
@@ -55,7 +55,7 @@ def stp_get_key_from_pattern(db_connect, db, pattern):
         return None
 
 
-# get_all doesnt accept regex patterns, it requires exact key
+# get_all doesn't accept regex patterns, it requires exact key
 def stp_get_all_from_pattern(db_connect, db, pattern):
     key = stp_get_key_from_pattern(db_connect, db, pattern)
     if key:

--- a/sonic_cli_gen/yang_parser.py
+++ b/sonic_cli_gen/yang_parser.py
@@ -425,7 +425,7 @@ def get_list_keys(y_list: OrderedDict) -> list:
     """ Parse YANG the 'key' entity.
         If YANG model has a 'list' entity, inside the 'list'
         there is 'key' entity. The 'key' - whitespace
-        separeted list of 'leafs'
+        separated list of 'leafs'
 
         Args:
             y_list: reference to the 'list'
@@ -447,7 +447,7 @@ def change_dyn_obj_struct(dynamic_objects: list):
     """ Rearrange self.yang_2_dict['dynamic_objects'] structure.
         If YANG model have a 'list' entity - inside the 'list'
         it has 'key' entity. The 'key' entity it is whitespace
-        separeted list of 'leafs', those 'leafs' was parsed by
+        separated list of 'leafs', those 'leafs' was parsed by
         'on_leaf()' function and placed under 'attrs' in
         self.yang_2_dict['dynamic_objects'] need to move 'leafs'
         from 'attrs' and put them into 'keys' section of

--- a/sonic_installer/exception.py
+++ b/sonic_installer/exception.py
@@ -3,7 +3,7 @@ Module sonic-installer exceptions
 """
 
 class SonicRuntimeException(Exception):
-    """SONiC Runtime Excpetion class used to report SONiC related errors
+    """SONiC Runtime Exception class used to report SONiC related errors
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -186,7 +186,7 @@ def get_container_image_name(container_name):
 
 
 def get_container_image_id(image_tag):
-    # TODO: extract commond docker info fetching functions
+    # TODO: extract command docker info fetching functions
     # this is image_id for image with tag, like 'docker-teamd:latest'
     cmd = ["docker", "images", "--format", '{{.ID}}', image_tag]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
@@ -419,7 +419,7 @@ class SWAPAllocator(object):
             - disk has enough space(> DISK_MEM_THRESHOLD)
             - either system total memory < total_mem_threshold or system available memory < available_mem_threshold
 
-        @param allocate: True to allocate SWAP memory if necessarry
+        @param allocate: True to allocate SWAP memory if necessary
         @param swap_mem_size: the size of SWAP memory to allocate(in MiB)
         @param total_mem_threshold: the system totla memory threshold(in MiB)
         @param available_mem_threshold: the system available memory threshold(in MiB)
@@ -851,7 +851,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
             if proc.returncode != 0:
                 if not skip_check:
                     echo_and_log("Orchagent is not in clean state, RESTARTCHECK failed", LOG_ERR)
-                    # Restore orignal config before exit
+                    # Restore original config before exit
                     if warm_configured is False and warm:
                         run_command(["config", "warm_restart", "disable", "%s" % container_name])
                     # Clean the image loaded earlier
@@ -884,7 +884,7 @@ def upgrade_docker(container_name, url, cleanup_image, skip_check, tag, warm):
             warm_app_names = ["teamsyncd"]
             echo_and_log("Stopped  teamd ...")
 
-        # clean app reconcilation state from last warm start if exists
+        # clean app reconciliation state from last warm start if exists
         for warm_app_name in warm_app_names:
             hdel_warm_restart_table("STATE_DB", "WARM_RESTART_TABLE", warm_app_name, "state")
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -534,7 +534,7 @@ def sonic_installer():
               cls=clicommon.MutuallyExclusiveOption, mutually_exclusive=['skip_setup_swap'],
               callback=validate_positive_int)
 @click.option('--available-mem-threshold', default=1200, type=int, show_default='1200 MiB',
-              help='If system available memory is lower than threhold, setup SWAP memory',
+              help='If system available memory is lower than threshold, setup SWAP memory',
               cls=clicommon.MutuallyExclusiveOption, mutually_exclusive=['skip_setup_swap'],
               callback=validate_positive_int)
 @click.argument('url')
@@ -583,7 +583,7 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
             raise click.Abort()
 
         if bootloader.is_secure_upgrade_image_verification_supported():
-            echo_and_log("Verifing image {} signature...".format(binary_image_version))
+            echo_and_log("Verifying image {} signature...".format(binary_image_version))
             if not bootloader.verify_image_sign(image_path):
                 echo_and_log('Error: Failed verify image signature', LOG_ERR)
                 raise click.Abort()

--- a/sonic_package_manager/constraint.py
+++ b/sonic_package_manager/constraint.py
@@ -39,7 +39,7 @@ class VersionConstraint:
         Args:
             version: Version to check against this constraint.
         Returns:
-            Boolean wether this constraint allows version.
+            Boolean whether this constraint allows version.
         """
 
         return self._constraint.match(version._version)
@@ -48,7 +48,7 @@ class VersionConstraint:
         """ Is the version constraint exact, meaning only one version is allowed.
 
         Returns:
-            Boolean wether this constraint is exact.
+            Boolean whether this constraint is exact.
         """
 
         clause = self._constraint.clause
@@ -164,13 +164,13 @@ class PackageConstraint:
         {
             "name": "swss",
             "version": "^1.0.0",
-            "componenets": {
+            "components": {
                 "libswsscommon": "^1.0.0"
             }
         }
 
         Args:
-            constraint_dict: Dictionary of constraint infromation.
+            constraint_dict: Dictionary of constraint information.
 
         Returns:
             PackageConstraint object.

--- a/sonic_package_manager/metadata.py
+++ b/sonic_package_manager/metadata.py
@@ -13,7 +13,7 @@ from sonic_package_manager.version import Version
 
 def translate_plain_to_tree(plain: Dict[str, str], sep='.') -> Dict:
     """ Convert plain key/value dictionary into
-    a tree by spliting the key with '.'
+    a tree by splitting the key with '.'
 
     Args:
         plain: Dictionary to convert into tree-like structure.
@@ -28,7 +28,7 @@ def translate_plain_to_tree(plain: Dict[str, str], sep='.') -> Dict:
                         }
                     }
                 }
-        sep: Seperator string
+        sep: Separator string
 
     Returns:
         Tree like structure

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -169,7 +169,7 @@ class ServiceCreator:
 
         Args:
             package: Package object to install.
-            register_feature: Wether to register this package in FEATURE table.
+            register_feature: Whether to register this package in FEATURE table.
             state: Default feature state.
             owner: Default feature owner.
 
@@ -204,7 +204,7 @@ class ServiceCreator:
 
         Args:
             package: Package object to uninstall.
-            deregister_feature: Wether to deregister this package from FEATURE table.
+            deregister_feature: Whether to deregister this package from FEATURE table.
             keep_config: Whether to remove package configuration.
 
         Returns:

--- a/sonic_package_manager/source.py
+++ b/sonic_package_manager/source.py
@@ -43,7 +43,7 @@ class PackageSource(object):
 
     def install(self, package: Package):
         """ Install image based on package source,
-        record installation infromation in PackageEntry..
+        record installation information in PackageEntry..
 
         Args:
             package: SONiC Package

--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -260,7 +260,7 @@ def test_mirror_session_span_add():
             config.config.commands["mirror_session"].commands["span"].commands["add"],
             ["test_session", "Ethernet52", "Ethernet52", "rx", "100"])
     assert result.exit_code != 0
-    assert "Error: Destination Interface cant be same as Source Interface" in result.stdout
+    assert "Error: Destination Interface can't be same as Source Interface" in result.stdout
 
     # Verify destination port not have mirror config
     result = runner.invoke(

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -155,7 +155,7 @@ class TestRemoteExec(object):
             rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 1, result.output
-        assert "This commmand is only supported Chassis" in result.output
+        assert "This command is only supported Chassis" in result.output
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
@@ -318,4 +318,4 @@ class TestRemoteCLI(object):
         result = runner.invoke(rshell.cli, [LINECARD_NAME])
         print(result.output)
         assert result.exit_code == 1, result.output
-        assert "This commmand is only supported Chassis" in result.output
+        assert "This command is only supported Chassis" in result.output

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -794,7 +794,7 @@ namespace 'asic7' is not valid. valid name spaces are:
 """
 
 show_ip_route_multi_asic_invalid_display_err_output = """\
-dislay option 'everything' is not a valid option.
+display option 'everything' is not a valid option.
 """
 
 show_ip_route_multi_asic_specific_route_output = """\

--- a/tests/sku_create_test.py
+++ b/tests/sku_create_test.py
@@ -525,7 +525,7 @@ class TestSkuCreate(object):
             sku.fpp_split = {1: [['etp1a', 'etp1b'], [1, 2]]}
             sku.default_lanes_per_port = ['0,1,2', '3,4,5', '6,7,8']
             sku.set_lanes()
-        mock_print.assert_called_once_with("Lanes(0,1,2) could not be evenly splitted by 2.")
+        mock_print.assert_called_once_with("Lanes(0,1,2) could not be evenly split by 2.")
         assert e.value.code == 1
 
     @patch('builtins.print')

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -19,7 +19,7 @@ ERROR_STR_MISS_NEXTHOP = '''
 Error: argument is incomplete, nexthop not found!
 '''
 ERROR_STR_DEL_NONEXIST_KEY = '''
-Error: Route {} doesnt exist
+Error: Route {} doesn't exist
 '''
 ERROR_STR_DEL_NONEXIST_ENTRY = '''
 Error: Not found {} in {}

--- a/tests/vnet_test.py
+++ b/tests/vnet_test.py
@@ -285,7 +285,7 @@ Error: 'vnet_name' must begin with 'Vnet'.
         # Test vnet add route when vnet doesnt exist
         args = ["Vnet_6", "10.10.10.10/32", "10.10.10.1"]
         result = runner.invoke(config.config.commands["vnet"].commands["add-route"], args, obj=vnet_obj)
-        assert "VNET Vnet_6 doesnot exist, cannot add a route!" in result.output
+        assert "VNET Vnet_6 does not exist, cannot add a route!" in result.output
         assert result.exit_code != 0
 
         # Test vnet add route using length of vnet name
@@ -348,13 +348,13 @@ Error: 'vnet_name' must begin with 'Vnet'.
         result = runner.invoke(config.config.commands["vnet"].commands["del-route"], args, obj=vnet_obj)
         assert result.exit_code != 0
         assert ('Vnet_100') not in db.cfgdb.get_table('VNET')
-        assert "VNET Vnet_100 doesnot exist, cannot delete the route!" in result.output
+        assert "VNET Vnet_100 does not exist, cannot delete the route!" in result.output
 
         # Test vnet del route with non existent route
         args = ["Vnet3", "10.10.10.10/32"]
         result = runner.invoke(config.config.commands["vnet"].commands["del-route"], args, obj=vnet_obj)
         assert result.exit_code != 0
-        assert "Routes dont exist for the VNET Vnet3, cant delete it!" in result.output
+        assert "Routes dont exist for the VNET Vnet3, can't delete it!" in result.output
 
     def test_vnet_add_del_2(self):
         runner = CliRunner()

--- a/utilities_common/auto_techsupport_helper.py
+++ b/utilities_common/auto_techsupport_helper.py
@@ -8,7 +8,7 @@ import math
 import syslog
 from os.path import basename, splitext
 
-__all__ = [  # Contants
+__all__ = [  # Constants
             "CORE_DUMP_DIR", "CORE_DUMP_PTRN", "TS_DIR", "TS_PTRN",
             "CFG_DB", "AUTO_TS", "CFG_STATE", "CFG_MAX_TS", "COOLOFF",
             "CFG_CORE_USAGE", "CFG_SINCE", "FEATURE", "STATE_DB",
@@ -70,7 +70,7 @@ TIME_BUF = 20
 SINCE_DEFAULT = "2 days ago"
 TS_GLOBAL_TIMEOUT = "60"
 
-# Explicity Pass this to the subprocess invoking techsupport
+# Explicitly Pass this to the subprocess invoking techsupport
 ENV_VAR = os.environ
 if ('CROSS_BUILD_ENVIRON' not in ENV_VAR) or (ENV_VAR['CROSS_BUILD_ENVIRON'] != 'y'):
 	# Add native system directories to PATH variable only if it is not cross-compilation build 

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -412,7 +412,7 @@ def process_bgp_summary_json(bgp_summary, cmd_output, device, has_bgp_neighbors=
             bgp_summary['peerGroupMemory'] = bgp_summary.get(
                 'peerCount', 0) + 0
 
-        # store instance level field is seperate dict
+        # store instance level field is separate dict
         router_info = {}
         router_info['router_id'] = cmd_output['routerId']
         router_info['vrf'] = cmd_output['vrfId']
@@ -444,7 +444,7 @@ def process_bgp_summary_json(bgp_summary, cmd_output, device, has_bgp_neighbors=
                 else:
                     peers.append(value['state'])
 
-                # Get the bgp neighbour name ans store it
+                # Get the bgp neighbour name and store it
                 neigh_name = get_bgp_neighbor_ip_to_name(
                     peer_ip, static_neighbors, dynamic_neighbors)
                 peers.append(neigh_name)

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -282,7 +282,7 @@ def is_vlanid_in_range(vid):
 
 
 def check_if_vlanid_exist(config_db, vlan, table_name='VLAN'):
-    """Check if vlan id exits in the config db or ot"""
+    """Check if vlan id exits in the config db or not"""
 
     if len(config_db.get_entry(table_name, vlan)) != 0:
         return True

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -317,7 +317,7 @@ def is_rj45_port(port_name):
     except (ModuleNotFoundError, FileNotFoundError) as e:
         # This method is referenced by intfutil which is called on vs image
         # sonic_platform API support is added for vs image(required for chassis), it expects a metadata file, which
-        # wont be available on vs pizzabox duts, So False is returned(if either ModuleNotFound or FileNotFound)
+        # won't be available on vs pizzabox duts, So False is returned(if either ModuleNotFound or FileNotFound)
         return False
 
     if platform_chassis and platform_sfp_base:

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -181,7 +181,7 @@ def get_sfp_object(port_name):
         sys.exit(EXIT_FAIL)
 
     if sfp is None:
-        click.echo(f"{port_name}: SFP object is not retreived")
+        click.echo(f"{port_name}: SFP object is not retrieved")
         sys.exit(EXIT_FAIL)
 
     return sfp
@@ -192,7 +192,7 @@ def get_host_lane_count(port_name):
     lane_count = get_value_from_db_by_field("STATE_DB", "TRANSCEIVER_INFO", "host_lane_count", port_name)
 
     if lane_count == 0 or lane_count is None or lane_count == '':
-        click.echo(f"{port_name}: unable to retreive correct host lane count")
+        click.echo(f"{port_name}: unable to retrieve correct host lane count")
         sys.exit(EXIT_FAIL)
 
     return lane_count
@@ -203,7 +203,7 @@ def get_media_lane_count(port_name):
     lane_count = get_value_from_db_by_field("STATE_DB", "TRANSCEIVER_INFO", "media_lane_count", port_name)
 
     if lane_count == 0 or lane_count is None or lane_count == '':
-        click.echo(f"{port_name}: unable to retreive correct media lane count")
+        click.echo(f"{port_name}: unable to retrieve correct media lane count")
         sys.exit(EXIT_FAIL)
 
     return lane_count

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -284,7 +284,7 @@ class Portstat(object):
     @multi_asic_util.run_on_multi_asic
     def collect_stat(self):
         """
-        Collect the statisitics from all the asics present on the
+        Collect the statistics from all the asics present on the
         device and store in a dict
         """
 

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -53,7 +53,7 @@ C_CMIS_DELTA_DATA_MAP = {
 CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP}
 C_CMIS_DATA_MAP = {**CMIS_DATA_MAP, **C_CMIS_DELTA_DATA_MAP}
 
-# Common fileds for all types:
+# Common fields for all types:
 # For non-CMIS, only first 1 or 4 lanes are applicable.
 # For CMIS, all 8 lanes are applicable.
 QSFP_STATUS_MAP = {

--- a/utilities_common/util_base.py
+++ b/utilities_common/util_base.py
@@ -7,7 +7,7 @@ from sonic_py_common import logger
 # Constants ====================================================================
 PDDF_SUPPORT_FILE = '/usr/share/sonic/platform/pddf_support'
 
-# Helper classs
+# Helper class
 
 log = logger.Logger()
 


### PR DESCRIPTION
#### What I did

Fixed some spelling errors that were visible to users in command help text and output. This required some adjustments in various tests which were expecting the spelling errors. Additionally fixed some internal spelling errors in code comments.

#### How I did it

Using codespell 2.2.2

#### How to verify it

Build sonic-utilities which will run the unit tests

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

There are some changes in the command output due to the spelling changes.

