### PR TITLE
[GCU]: Restart telemetry container on port speed change via GCU to handle OID update

### DIFF
--- a/generic_config_updater/gcu_services_validator.conf.json
+++ b/generic_config_updater/gcu_services_validator.conf.json
@@ -58,7 +58,7 @@
             "validate_commands": [ ]
         },
         "port_service": {
-            "validate_commands": [ ]
+            "validate_commands": [ "generic_config_updater.services_validator.port_speed_change_validator" ]
         },
         "rsyslog": {
             "validate_commands": [ "generic_config_updater.services_validator.rsyslog_validator" ]

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -94,6 +94,17 @@ def rsyslog_validator(old_config, upd_config, keys):
     return True
 
 
+def port_speed_change_validator(old_config, upd_config, keys):
+    old_ports = old_config.get("PORT", {})
+    upd_ports = upd_config.get("PORT", {})
+    for key in set(old_ports.keys()).union(set(upd_ports.keys())):
+        old_speed = old_ports.get(key, {}).get("speed", "")
+        upd_speed = upd_ports.get(key, {}).get("speed", "")
+        if old_speed != upd_speed:
+            return _service_restart("telemetry")
+    return True
+
+
 def dhcp_validator(old_config, upd_config, keys):
     return _service_restart("dhcp_relay")
 

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -100,7 +100,15 @@ def port_speed_change_validator(old_config, upd_config, keys):
     for key in set(old_ports.keys()).union(set(upd_ports.keys())):
         old_speed = old_ports.get(key, {}).get("speed", "")
         upd_speed = upd_ports.get(key, {}).get("speed", "")
-        if old_speed != upd_speed:
+        if old_speed != "" and upd_speed != "" and old_speed != upd_speed:
+            logger.log(
+                logger.LOG_PRIORITY_NOTICE,
+                (
+                    f"port_speed_change_validator: port speed changed for {key} "
+                    f"from {old_speed} to {upd_speed}, restart telemetry service"
+                ),
+                print_to_console
+            )
             return _service_restart("telemetry")
     return True
 

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -347,10 +347,13 @@ class TestServiceValidator(unittest.TestCase):
         result = port_speed_change_validator(old_config, upd_config, None)
         self.assertTrue(result)
 
-        # Case 2: Speed changed, should call systemctl restart telemetry
+        # Case 2: Speed changed, should call systemctl restart telemetry (with nsenter)
         old_config = {"PORT": {"Ethernet0": {"speed": "10000"}}}
         upd_config = {"PORT": {"Ethernet0": {"speed": "25000"}}}
-        subprocess_calls = [{"cmd": "systemctl restart telemetry", "rc": 0}]
+        subprocess_calls = [{
+            "cmd": "nsenter --target 1 --pid --mount --uts --ipc --net systemctl restart telemetry",
+            "rc": 0
+        }]
         subprocess_call_index = 0
         result = port_speed_change_validator(old_config, upd_config, None)
         self.assertTrue(result)
@@ -372,10 +375,13 @@ class TestServiceValidator(unittest.TestCase):
         result = port_speed_change_validator(old_config, upd_config, None)
         self.assertTrue(result)
 
-        # Case 5: Multiple ports, one speed changed
+        # Case 5: Multiple ports, one speed changed (with nsenter)
         old_config = {"PORT": {"Ethernet0": {"speed": "10000"}, "Ethernet1": {"speed": "25000"}}}
         upd_config = {"PORT": {"Ethernet0": {"speed": "40000"}, "Ethernet1": {"speed": "25000"}}}
-        subprocess_calls = [{"cmd": "systemctl restart telemetry", "rc": 0}]
+        subprocess_calls = [{
+            "cmd": "nsenter --target 1 --pid --mount --uts --ipc --net systemctl restart telemetry",
+            "rc": 0
+        }]
         subprocess_call_index = 0
         result = port_speed_change_validator(old_config, upd_config, None)
         self.assertTrue(result)

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -1,13 +1,13 @@
-import copy
-import json
-import jsondiff
-import os
 import unittest
-from collections import defaultdict
 from unittest.mock import patch
 
-from generic_config_updater.services_validator import vlan_validator, rsyslog_validator, caclmgrd_validator, vlanintf_validator, port_speed_change_validator
-import generic_config_updater.gu_common
+from generic_config_updater.services_validator import (
+    vlan_validator,
+    rsyslog_validator,
+    caclmgrd_validator,
+    vlanintf_validator,
+    port_speed_change_validator,
+)
 from generic_config_updater.services_validator import ntp_validator
 
 # Mimics subprocess.run call

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -339,6 +339,8 @@ class TestServiceValidator(unittest.TestCase):
         """Test port_speed_change_validator for port speed changes and no changes"""
         global subprocess_calls, subprocess_call_index
 
+        mock_subprocess.side_effect = mock_subprocess_run
+
         # Case 1: No speed change, should not call systemctl
         old_config = {"PORT": {"Ethernet0": {"speed": "100000"}}}
         upd_config = {"PORT": {"Ethernet0": {"speed": "100000"}}}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
- Updated port_speed_change_validator to restart the telemetry container when a port speed is changed via GCU.
- Added unit tests to verify the correct behavior for port speed changes and no-change scenarios.

Microsoft ADO: 36692456

This is short term plan to restart telemetry in GCU. 

Long term plan is telemetry reload automatically. Microsoft ADO: 36496651
#### How I did it
- Modified the validator to detect any port speed change and call _service_restart("telemetry") when detected, ensuring telemetry restarts and picks up the new port OID.
- Implemented tests using mocks for subprocess calls to simulate and verify the restart logic.

#### How to verify it
- Run the unit tests in service_validator_test.py to confirm that telemetry is restarted only when a port speed changes, and not for unrelated changes.
- Check that all tests pass, indicating correct validator and restart behavior.
- Test bed
```shell
stli@STG02-0101-0400-02T2-lc03:~$ show int sta
      Interface                                    Lanes    Speed    MTU    FEC                    Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------------------------------  -------  -----  -----  -----------------------  ---------------  ------  -------  ------  ----------
...
     Ethernet64          264,265,266,267,268,269,270,271     400G   9100     rs   FourHundredGigE0/3/0/8           routed    down     down     N/A         off

stli@STG02-0101-0400-02T2-lc03:~$ cat gcu_patch.json 
  [
    {
      "op": "add",
      "path": "/asic0/PORT/Ethernet64",
      "value": {
        "index": "8",
        "description": "STG02-0101-0110-17T1:etp12",
        "alias": "HundredGigE0/3/0/8",
        "pfc_asym": "off",
        "fec": "rs",
        "speed": "100000",
        "mtu": "9100",
        "tpid": "0x8100",
        "lanes": "264,265,266,267",
        "asic_port_name": "Eth64-ASIC0",
        "role": "Ext",
        "admin_status": "up"
       }
   }
  ]


stli@STG02-0101-0400-02T2-lc03:~$ sudo config apply-patch gcu_patch.json 
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: [{"op": "add", "path": "/PORT/Ethernet64", "value": {"index": "8", "description": "STG02-0101-0110-17T1:etp12", "alias": "HundredGigE0/3/0/8", "pfc_asym": "off", "fec": "rs", "speed": "100000", "mtu": "9100", "tpid": "0x8100", "lanes": "264,265,266,267", "asic_port_name": "Eth64-ASIC0", "role": "Ext", "admin_status": "up"}}]
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic0: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: asic0: sorting patch updates.
Patch Applier: The asic0 patch was converted into 6 changes:
Patch Applier: asic0: applying 6 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/CABLE_LENGTH/AZURE/Ethernet64"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet64/description", "value": "STG02-0101-0110-17T1:etp12"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet64/speed", "value": "100000"}]
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/services_validator.py(71)port_speed_change_validator()
-> return _service_restart("telemetry")
(Pdb) old_speed
'400000'
(Pdb) upd_speed
'100000'
(Pdb) c
Job for telemetry.service failed because start of the service was attempted too often.
See "systemctl status telemetry.service" and "journalctl -xeu telemetry.service" for details.
To force a start use "systemctl reset-failed telemetry.service"
followed by "systemctl start telemetry.service" again.
Patch Applier:   * [{"op": "remove", "path": "/PORT/Ethernet64"}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet64", "value": {"index": "8", "description": "STG02-0101-0110-17T1:etp12", "alias": "HundredGigE0/3/0/8", "pfc_asym": "off", "fec": "rs", "speed": "100000", "mtu": "9100", "tpid": "0x8100", "lanes": "264,265,266,267", "asic_port_name": "Eth64-ASIC0", "role": "Ext", "admin_status": "up"}}]
Patch Applier:   * [{"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet64", "value": "300m"}]
Patch Applier: asic0: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic0 patch application completed.
Patch applied successfully.

stli@STG02-0101-0400-02T2-lc03:~$ show int sta
      Interface                                    Lanes    Speed    MTU    FEC                    Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  ---------------------------------------  -------  -----  -----  -----------------------  ---------------  ------  -------  ------  ----------
...
     Ethernet64                          264,265,266,267     100G   9100     rs   HundredGigE0/3/0/8           routed    down       up     N/A         off

stli@STG02-0101-0400-02T2-lc03:~$ docker ps -a
CONTAINER ID   IMAGE                                                       COMMAND                  CREATED       STATUS                   PORTS     NAMES
aec6bcdb096d   soniccr1.azurecr.io/chassis-port-counter-monitor:20260122   "/usr/local/bin/dock…"   7 days ago    Up 7 days                          chassis-port-counter-monitor
2bb42c2ef60a   docker-sonic-telemetry:latest                               "/usr/local/bin/supe…"   7 weeks ago   Up About a minute                  telemetry
84e4a349cd4f   docker-snmp:latest                                          "/usr/bin/docker-snm…"   7 weeks ago   Up 7 weeks                         snmp


stli@STG02-0101-0400-02T2-lc03:~$ sudo grep -i "spawned: 'telemetry'" /var/log/syslog
2026 Feb  5 02:08:13.183970 STG02-0101-0400-02T2-lc03 INFO telemetry#supervisord 2026-02-05 02:08:13,183 INFO spawned: 'telemetry' with pid 24
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

