### PR TITLE
Fix spelling errors in sonic-utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Currently, this list of dependencies is as follows:
 - python-swsscommon_1.0.0_amd64.deb
 
 
-A convenient alternative is to let the SONiC build system configure a build enviroment for you. This can be done by cloning the [sonic-buildimage](https://github.com/sonic-net/sonic-buildimage) repo, building the sonic-utilities package inside the Debian Buster slave container, and staying inside the container once the build finishes. During the build process, the SONiC build system will build and install all the necessary dependencies inside the container. After following the instructions to clone and initialize the sonic-buildimage repo, this can be done as follows:
+A convenient alternative is to let the SONiC build system configure a build environment for you. This can be done by cloning the [sonic-buildimage](https://github.com/sonic-net/sonic-buildimage) repo, building the sonic-utilities package inside the Debian Buster slave container, and staying inside the container once the build finishes. During the build process, the SONiC build system will build and install all the necessary dependencies inside the container. After following the instructions to clone and initialize the sonic-buildimage repo, this can be done as follows:
 
 1. Configure the build environment for an ASIC type (any type will do, here we use `generic`)
     ```

--- a/config/aaa.py
+++ b/config/aaa.py
@@ -560,7 +560,7 @@ def add(db, address, retransmit, timeout, key, auth_type, auth_port, pri, use_mg
                     source_interface == "eth0"):
                     data['src_intf'] = source_interface
                 else:
-                    click.echo('Not supported interface name (valid interface name: Etherent<id>/PortChannel<id>/Vlan<id>/Loopback<id>/eth0)')
+                    click.echo('Not supported interface name (valid interface name: Ethernet<id>/PortChannel<id>/Vlan<id>/Loopback<id>/eth0)')
         else:
             if source_interface:
                 data['src_intf'] = source_interface

--- a/config/main.py
+++ b/config/main.py
@@ -981,7 +981,7 @@ def _get_disabled_services_list(config_db):
             if state == "disabled":
                 disabled_services_list.append(feature_name)
     else:
-        log.log_warning("Unable to retreive FEATURE table")
+        log.log_warning("Unable to retrieve FEATURE table")
 
     return disabled_services_list
 
@@ -1200,7 +1200,7 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
             if not interface_name_is_valid(config_db, port):
                 ctx.fail("Error: Source Interface {} is invalid".format(port))
             if dst_port and dst_port == port:
-                ctx.fail("Error: Destination Interface cant be same as Source Interface")
+                ctx.fail("Error: Destination Interface can't be same as Source Interface")
 
     if interface_has_mirror_config(ctx, mirror_table, dst_port, src_port, direction):
         return False
@@ -5850,7 +5850,7 @@ def remove_buffer_object_on_port(db, interface_name, buffer_object_map, is_pg=Tr
     if not ports:
         ctx.fail("Port {} doesn't exist".format(interface_name))
 
-    # Remvoe all dynamic lossless PGs on the port
+    # Remove all dynamic lossless PGs on the port
     buffer_table = "BUFFER_PG" if is_pg else "BUFFER_QUEUE"
     existing_buffer_objects = config_db.get_table(buffer_table)
     removed = False

--- a/scripts/fabricstat
+++ b/scripts/fabricstat
@@ -55,7 +55,7 @@ class FabricStat(object):
     @multi_asic_util.run_on_multi_asic
     def collect_stat(self):
         """
-        Collect the statisitics from all the asics present on the
+        Collect the statistics from all the asics present on the
         device and store in a dict
         """
         self.cnstat_dict.update(self.get_cnstat())

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -531,7 +531,7 @@ def get_all_port_errors(interfacename):
 @click.argument('interfacename', required=True)
 @click.pass_context
 def errors(ctx, interfacename):
-    """Show Interface Erorrs <interfacename>"""
+    """Show Interface Errors <interfacename>"""
     # Try to convert interface name from alias
     interfacename = try_convert_interfacename_from_alias(click.get_current_context(), interfacename)
 

--- a/show/main.py
+++ b/show/main.py
@@ -87,7 +87,7 @@ GEARBOX_TABLE_PHY_PATTERN = r"_GEARBOX_TABLE:phy:*"
 COMMAND_TIMEOUT = 300
 
 # To be enhanced. Routing-stack information should be collected from a global
-# location (configdb?), so that we prevent the continous execution of this
+# location (configdb?), so that we prevent the continuous execution of this
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'


### PR DESCRIPTION
- Fixed 273 spelling errors identified by codespell
- Corrected typos in command help text, error messages, and log output
- Fixed user-facing text including 'Erorrs' -> 'Errors' in show interfaces
- Corrected common misspellings: retreive->retrieve, cant->can't, 
  configutation->configuration, doesnt->doesn't, etc.
- No functional code changes, only spelling corrections

Fixes: sonic-net/sonic-buildimage#25310

#### What I did
Fixed 273 spelling errors across 98 files in the sonic-utilities codebase that were identified using the codespell tool. These errors were in command help text, error messages, log output, and code comments.

#### How I did it
1. Used codespell tool to identify all spelling errors in the codebase
2. Applied automated fixes using `codespell -w` for straightforward corrections
3. Manually fixed remaining errors using sed commands, choosing appropriate corrections based on context
4. Verified all fixes by running codespell again to ensure 0 errors remain

#### How to verify it
Run codespell on the repository:
```bash
codespell -L ist,hel | grep -v './tests\|./doc'

