### PR TITLE
Fix spelling typos in config/config_mgmt.py

### DIFF
--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -31,7 +31,7 @@ DEFAULT_CONFIG_DB_JSON_FILE = '/etc/sonic/port_breakout_config_db.json'
 
 class ConfigMgmt():
     '''
-    Class to handle config managment for SONIC, this class will use sonic_yang
+    Class to handle config management for SONIC, this class will use sonic_yang
     to verify config for the commands which are capable of change in config DB.
     '''
 
@@ -336,7 +336,7 @@ class ConfigMgmtDPB(ConfigMgmt):
 
         Parameters:
             db (SonicV2Connector): database.
-            key (str): key in ASIC DB, with table Seperator if applicable.
+            key (str): key in ASIC DB, with table Separator if applicable.
 
         Returns:
             (bool): True, if given key is present.
@@ -424,11 +424,11 @@ class ConfigMgmtDPB(ConfigMgmt):
             delPorts (list): ports to be deleted.
             portJson (dict): Config DB json Part of all Ports, generated from
                 platform.json.
-            force (bool): if false return dependecies, else delete dependencies.
+            force (bool): if false return dependencies, else delete dependencies.
             loadDefConfig: If loadDefConfig, add default config for ports as well.
 
         Returns:
-            (deps, ret) (tuple)[list, bool]: dependecies and success/failure.
+            (deps, ret) (tuple)[list, bool]: dependencies and success/failure.
         '''
         MAX_WAIT = 60
         try:
@@ -471,15 +471,15 @@ class ConfigMgmtDPB(ConfigMgmt):
 
     def _deletePorts(self, ports=list(), force=False):
         '''
-        Delete ports and dependecies from data tree, validate and return resultant
+        Delete ports and dependencies from data tree, validate and return resultant
         config.
 
         Parameters:
             ports (list): list of ports
-            force (bool): if false return dependecies, else delete dependencies.
+            force (bool): if false return dependencies, else delete dependencies.
 
         Returns:
-            (configToLoad, deps, ret) (tuple)[dict, list, bool]: config, dependecies
+            (configToLoad, deps, ret) (tuple)[dict, list, bool]: config, dependencies
             and success/fail.
         '''
         configToLoad = None; deps = None
@@ -489,11 +489,11 @@ class ConfigMgmtDPB(ConfigMgmt):
             self.sysLog(doPrint=True, msg='Start Port Deletion')
             deps = list()
 
-            # Get all dependecies for ports
+            # Get all dependencies for ports
             for port in ports:
                 xPathPort = self.sy.findXpathPortLeaf(port)
-                self.sysLog(doPrint=True, msg='Find dependecies for port {}'.\
-                    format(port))
+                self.sysLog(doPrint=True,
+                           msg='Find dependencies for port {}'.format(port))
                 dep = self.sy.find_data_dependencies(str(xPathPort))
                 if dep:
                     deps.extend(dep)
@@ -502,7 +502,7 @@ class ConfigMgmtDPB(ConfigMgmt):
             if not force and deps:
                 return configToLoad, deps, False
 
-            # delets all deps, No topological sort is needed as of now, if deletion
+            # deletes all deps, No topological sort is needed as of now, if deletion
             # of deps fails, return immediately
             elif deps:
                 for dep in deps:
@@ -576,7 +576,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                 self._mergeConfigs(self.configdbJsonOut, defConfig, True)
 
             # create a tree with merged config and validate, if validation is
-            # sucessful, then configdbJsonOut contains final and valid config.
+            # successful, then configdbJsonOut contains final and valid config.
             self.sy.loadData(self.configdbJsonOut)
             if self.validateConfigData()==False:
                 return configToLoad, False
@@ -711,7 +711,7 @@ class ConfigMgmtDPB(ConfigMgmt):
 
     def configWithKeys(self, configIn=dict(), keys=list()):
         '''
-        This function returns the config with relavant keys in Input Config.
+        This function returns the config with relevant keys in Input Config.
         It calls _searchKeysInConfig.
 
         Parameters:
@@ -784,7 +784,7 @@ class ConfigMgmtDPB(ConfigMgmt):
 
     def _createConfigToLoad(self, diff, inp, outp):
         '''
-        Create the config to write in Config DB, i.e. compitible with mod_config()
+        Create the config to write in Config DB, i.e. compatible with mod_config()
         This functions has 3 inner functions:
         -- _deleteHandler: to handle delete in diff. See example below.
         -- _insertHandler: to handle insert in diff. See example below.
@@ -802,7 +802,7 @@ class ConfigMgmtDPB(ConfigMgmt):
                 is applied.
 
         Returns:
-            configToLoad (dict): config in a format compitible with mod_Config().
+            configToLoad (dict): config in a format compatible with mod_Config().
         '''
 
         ### Internal Functions ###


### PR DESCRIPTION
Fix misspellings in config/config_mgmt.py:
- `managment` → `management`
- `Seperator` → `Separator`
- `dependecies` → `dependencies` (7 occurrences)
- `delets` → `deletes`
- `sucessful` → `successful`
- `relavant` → `relevant`
- `compitible` → `compatible` (2 occurrences)

Found via codespell (ref: sonic-net/sonic-buildimage#25310).

Signed-off-by: Lih <lihua@whiterock>