### PR TITLE
Fix spelling typos in scripts/

### DIFF
--- a/scripts/boot_part
+++ b/scripts/boot_part
@@ -101,7 +101,7 @@ def set_boot_partition(blkdev, index):
 def main():
     parser = argparse.ArgumentParser(description='The default output is a list of partition information.')
     parser.add_argument('-i', '--index', type=int,
-        help='Set the index partition as boot partition. After reboot, GRUB will boot from that partion.')
+        help='Set the index partition as boot partition. After reboot, GRUB will boot from that partition.')
     parser.add_argument("-v", "--verbose", action="store_true",
         help="increase output verbosity")
     args = parser.parse_args()

--- a/scripts/coredump_gen_handler.py
+++ b/scripts/coredump_gen_handler.py
@@ -48,7 +48,7 @@ class CriticalProcCoreDumpHandle():
             syslog.syslog(syslog.LOG_NOTICE, "auto_invoke_ts is disabled. No cleanup is performed: core {}".format(self.core_name))
             return
 
-        # Config made for the defaul instance applies to all the masic instances
+        # Config made for the default instance applies to all the masic instances
         self.container = trim_masic_suffix(self.container)
 
         FEATURE_KEY = FEATURE.format(self.container)

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -402,7 +402,7 @@ class DBMigrator():
                     abandon_method()
                     return True
             except Exception:
-                log.log_notice("Exception occured during parsing the profiles")
+                log.log_notice("Exception occurred during parsing the profiles")
                 abandon_method()
                 return True
 
@@ -554,7 +554,7 @@ class DBMigrator():
 
     def migrate_qos_fieldval_reference_format(self):
         '''
-        This is to change for first time to remove field refernces of ABNF format
+        This is to change for first time to remove field references of ABNF format
         in APPL DB for warm boot.
         i.e "[Tabale_name:name]" to string in APPL_DB. Reasons for doing this
          - To consistent with all other SoNIC CONFIG_DB/APPL_DB tables and fields
@@ -1219,7 +1219,9 @@ class DBMigrator():
                             self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
                             self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
                     except Exception as err:
-                        log.log_warning('Error occured during LOGLEVEL_DB migration for {}. Ignoring key {}'.format(err, key))
+                        log.log_warning(
+                            'Error occurred during LOGLEVEL_DB migration for {}. '
+                            'Ignoring key {}'.format(err, key))
                     finally:
                         self.loglevelDB.delete(self.loglevelDB.LOGLEVEL_DB, key)
         self.set_version('version_3_0_6')

--- a/scripts/debug_voq_chassis_packet_drops.sh
+++ b/scripts/debug_voq_chassis_packet_drops.sh
@@ -34,7 +34,7 @@ print_pqp_reasons() {
     if [ $(($disc_reasons & 64)) -ne 0 ] ; then echo "6- Per queue disable bit">> $log ; fi
     if [ $(($disc_reasons & 128)) -ne 0 ] ; then echo "7- Undefined">> $log ; fi
     if [ $(($disc_reasons & 256)) -ne 0 ] ; then echo "8- Total PDs MC pool size threshold">> $log ; fi
-    if [ $(($disc_reasons & 512)) -ne 0 ] ; then echo "9- Per interface PDs threhold">> $log; fi
+    if [ $(($disc_reasons & 512)) -ne 0 ] ; then echo "9- Per interface PDs threshold">> $log; fi
     if [ $(($disc_reasons & 1024)) -ne 0 ] ; then echo "10- MC SP threshold">> $log ; fi
     if [ $(($disc_reasons & 2048)) -ne 0 ] ; then echo "11- per MC-TC threshold">> $log ; fi
     if [ $(($disc_reasons & 4096)) -ne 0 ] ; then echo "12- MC PDs per port threshold">> $log ; fi

--- a/scripts/dropstat
+++ b/scripts/dropstat
@@ -389,7 +389,7 @@ class DropStat(object):
             return configured_counters
 
         #Switch level standard drop counters are added by default and added to DEBUG_COUNTER_SWITCH_STAT_MAP table,
-        #so remove it from configrued counters
+        #so remove it from configured counters
         if object_stat_map == DEBUG_COUNTER_SWITCH_STAT_MAP:
            if std_switch_cntr:
               new_cntrs = {k:counters[k] for k in counters if SWITCH_LEVEL_COUNTER_PREFIX in k}

--- a/scripts/fabricstat
+++ b/scripts/fabricstat
@@ -55,7 +55,7 @@ class FabricStat(object):
     @multi_asic_util.run_on_multi_asic
     def collect_stat(self):
         """
-        Collect the statisitics from all the asics present on the
+        Collect the statistics from all the asics present on the
         device and store in a dict
         """
         self.cnstat_dict.update(self.get_cnstat())

--- a/scripts/flow_counters_stat
+++ b/scripts/flow_counters_stat
@@ -29,7 +29,7 @@ from utilities_common import constants
 from utilities_common.netstat import format_number_with_comma, table_as_json, ns_diff, format_prate
 from utilities_common.cli import UserCache
 
-# Flow counter meta data, new type of flow counters can extend this dictinary to reuse existing logic
+# Flow counter meta data, new type of flow counters can extend this dictionary to reuse existing logic
 flow_counter_meta = {
     'trap': {
         'headers': ['Trap Name', 'Packets', 'Bytes', 'PPS'],

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -150,7 +150,7 @@ save_bcmcmd() {
 }
 
 ###############################################################################
-# Runs a given bcmcmd command in all namesapces in case of multi ASIC platform
+# Runs a given bcmcmd command in all namespaces in case of multi ASIC platform
 # Globals:
 #  NUM_ASICS
 # Arguments:
@@ -178,7 +178,7 @@ save_bcmcmd_all_ns() {
 }
 
 ###############################################################################
-# Runs a comamnd and saves its output to the file.
+# Runs a command and saves its output to the file.
 # Command gets timedout if it runs for more than TIMEOUT_MIN minutes.
 # Globals:
 #  LOGDIR
@@ -298,7 +298,7 @@ dummy_cleanup_method() {
 }
 
 ###############################################################################
-# Runs a given command in all namesapces in case of multi ASIC platform, in
+# Runs a given command in all namespaces in case of multi ASIC platform, in
 # default (host) namespace in single ASIC platform
 # Globals:
 #  NUM_ASICS
@@ -400,7 +400,7 @@ copy_from_masic_docker() {
 }
 
 ###############################################################################
-# Returns namespace option to be used with vtysh commmand, based on the ASIC ID.
+# Returns namespace option to be used with vtysh command, based on the ASIC ID.
 # Returns empty string if no ASIC ID is provided
 # Globals:
 #  None
@@ -422,7 +422,7 @@ get_vtysh_namespace() {
 }
 
 ###############################################################################
-# Runs a vtysh command in all namesapces for a multi ASIC platform, and in
+# Runs a vtysh command in all namespaces for a multi ASIC platform, and in
 # default (host) namespace in single ASIC platforms. Saves its output to the
 # file.
 # Globals:
@@ -1169,7 +1169,7 @@ with open('$filepath') as json_file:
 # SAI DUMP based on the route table size
 # if the route table has more than ROUTE_TAB_LIMIT_DIRECT_ITERATION
 # then dump by Redis Save command,
-# otherwize, dump it by directly iteration the Redis
+# otherwise, dump it by directly iteration the Redis
 #
 # Globals:
 #  NUM_ASICS
@@ -1263,7 +1263,7 @@ save_chassis_modules_info() {
 }
 
 ###############################################################################
-# Runs a comamnd and saves its output to the incrementally built tar.
+# Runs a command and saves its output to the incrementally built tar.
 # Globals:
 #  LOGDIR
 #  BASE
@@ -1640,7 +1640,7 @@ collect_nvidia_sdk_dumps() {
 }
 
 ###############################################################################
-# Runs a given marvellcmd command in all namesapces in case of multi ASIC platform
+# Runs a given marvellcmd command in all namespaces in case of multi ASIC platform
 # Globals:
 #  NUM_ASICS
 # Arguments:
@@ -2605,7 +2605,7 @@ main() {
     # Remove secret from /etc files before tar
     remove_secret_from_etc_files $TARDIR
 
-    # Remove unecessary files
+    # Remove unnecessary files
     $RM $V -rf $TARDIR/etc/alternatives $TARDIR/etc/passwd* \
     $TARDIR/etc/shadow* $TARDIR/etc/group* $TARDIR/etc/gshadow* \
     $TARDIR/etc/ssh* $TARDIR/etc/mlnx $TARDIR/etc/mft \
@@ -2893,7 +2893,7 @@ if $MKDIR "${LOCKDIR}" &>/dev/null; then
     # Trap configured on EXIT will be triggered by the exit from handle_signal function
     trap 'handle_sigterm' SIGHUP SIGQUIT SIGTERM
     trap 'handle_sigint' SIGINT
-    echo "Lock succesfully accquired and installed signal handlers"
+    echo "Lock successfully acquired and installed signal handlers"
     # Proceed with the actual code
     if [[ ! -z "${V}" ]]; then
         set -v
@@ -2910,7 +2910,7 @@ else
 
     if ! kill -0 $PID_PROG &>/dev/null; then
         # Lock is stale
-        echo "Removing stale lock of nonexistant PID ${PID_PROG}"
+        echo "Removing stale lock of nonexistent PID ${PID_PROG}"
         rm_lock_and_exit
     else
         # Lock is valid and the other instance is active. Exit Now

--- a/scripts/lldpshow
+++ b/scripts/lldpshow
@@ -60,7 +60,7 @@ class Lldpshow(object):
             per_asic_configdb[front_asic_namespaces] = ConfigDBConnector(
                 use_unix_socket_path=True, namespace=front_asic_namespaces)
             per_asic_configdb[front_asic_namespaces].connect()
-            # Initalize Interface list to be ''. We will do string append of the interfaces below.
+            # Initialize Interface list to be ''. We will do string append of the interfaces below.
             self.lldp_interface.append(LLDP_DEFAULT_INTERFACE_LIST_IN_ASIC_NAMESPACE)
             self.lldp_instance.append(instance_num)
             keys = per_asic_configdb[front_asic_namespaces].get_keys("PORT")
@@ -126,7 +126,7 @@ class Lldpshow(object):
 
     def parse_info(self, lldp_detail_info):
         """
-        Parse the lldp detailed infomation into dict
+        Parse the lldp detailed information into dict
         """
         if lldp_detail_info:
             return

--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -340,7 +340,7 @@ class MellanoxBufferMigrator():
                                          "Mellanox-SN2700": "spc1_2700_t1_pool_shp"}
             },
             "pool_mapped_from_old_version": {
-                # MSFT SKUs and generic SKUs may have different pool seetings
+                # MSFT SKUs and generic SKUs may have different pool settings
                 "spc1_t0_pool": ("sku", "spc1_t0_pool_sku_map"),
                 "spc1_t1_pool": ("sku", "spc1_t1_pool_sku_map"),
                 "spc1_2700_t0_pool": "spc1_2700_t0_single_pool_shp",
@@ -790,7 +790,7 @@ class MellanoxBufferMigrator():
             for name, profile in profiles.items():
                 if name in configdb_buffer_profiles.keys() and profile == configdb_buffer_profiles[name]:
                     continue
-                # return if any default profile isn't in cofiguration
+                # return if any default profile isn't in configuration
                 profile_matched = False
                 break
 

--- a/scripts/mmuconfig
+++ b/scripts/mmuconfig
@@ -11,7 +11,7 @@ optional arguments:
   -vv    --verbose         verbose output
   -l     --list            show mmu configuration
   -p     --profile         specify buffer profile name
-  -a     --alpha           set n for dyanmic threshold alpha 2^(n)
+  -a     --alpha           set n for dynamic threshold alpha 2^(n)
   -s     --staticth        set static threshold
 
 """
@@ -171,7 +171,7 @@ class TrimTypeValidator(click.ParamType):
 @click.command(help='Show and change: mmu configuration')
 @click.option('-l', '--list', 'show_config', is_flag=True, help='show mmu configuration')
 @click.option('-p', '--profile', type=str, help='specify buffer profile name', default=None)
-@click.option('-a', '--alpha', type=click.IntRange(DYNAMIC_THRESHOLD_MIN, DYNAMIC_THRESHOLD_MAX), help='set n for dyanmic threshold alpha 2^(n)', default=None)
+@click.option('-a', '--alpha', type=click.IntRange(DYNAMIC_THRESHOLD_MIN, DYNAMIC_THRESHOLD_MAX), help='set n for dynamic threshold alpha 2^(n)', default=None)
 @click.option('-s', '--staticth', type=click.IntRange(min=STATIC_THRESHOLD_MIN), help='set static threshold', default=None)
 @click.option('-t', '--trim', 'trim', type=TrimTypeValidator(), help='Configures packet trimming eligibility')
 @click.option('-n', '--namespace', type=click.Choice(multi_asic.get_namespace_list()), help='Namespace name or skip for all', default=None)

--- a/scripts/nbrshow
+++ b/scripts/nbrshow
@@ -6,9 +6,9 @@
     usage: nbrshow [-h] [-ip IPADDR] [-if IFACE] v
     optional arguments:
         -ip IPADDR, --ipaddr IPADDR
-                        Neigbhor for a specific address
+                        Neighbor for a specific address
         -if IFACE, --iface IFACE
-                        Neigbhors learned on specific L3 interface
+                        Neighbors learned on specific L3 interface
 
     Example of the output:
     admin@str~$nbrshow -4
@@ -246,12 +246,12 @@ class NeighShow(NbrBase):
 
 def main():
 
-    parser = argparse.ArgumentParser(description='Show Neigbhor entries',
+    parser = argparse.ArgumentParser(description='Show Neighbor entries',
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('-ip', '--ipaddr', type=str,
-                        help='Neigbhor for a specific address', default=None)
+                        help='Neighbor for a specific address', default=None)
     parser.add_argument('-if', '--iface', type=str,
-                        help='Neigbhors learned on specific L3 interface', default=None)
+                        help='Neighbors learned on specific L3 interface', default=None)
     parser.add_argument('v', help='IP Version -4 or -6')
 
     args = parser.parse_args()

--- a/scripts/pcmping
+++ b/scripts/pcmping
@@ -159,7 +159,7 @@ def main():
     sockets, exp_socket = create_socket(interface, portchannel)
     pkt, exp_pkt = find_probe_packet(interface, decap_ip, portchannel_ip, sockets, exp_socket, max_trial)
     print("Preparation done! Start probing ............")
-    print("PORTCHANNEL Member PING %d btyes of data. PORTCHANNEL: %s, INTERFACE: %s" % (PROBE_PACKET_LEN, portchannel_name, interface))
+    print("PORTCHANNEL Member PING %d bytes of data. PORTCHANNEL: %s, INTERFACE: %s" % (PROBE_PACKET_LEN, portchannel_name, interface))
     recv_count = 0
     total_count = 0
     try:

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -17,7 +17,7 @@ optional arguments:
   -f     --fec                 port fec mode
   -m     --mtu                 port mtu in bytes
   -tp    --tpid                interface tpid (0x8100, 9100, 9200, 88A8)
-  -n     --namesapce           Namespace name
+  -n     --namespace           Namespace name
   -an    --autoneg             port auto negotiation mode
   -S     --adv-speeds          port advertised speeds
   -t     --interface-type      port interface type
@@ -117,7 +117,7 @@ class portconfig(object):
             raise Exception("Invalid port %s" % (port))
 
     def list_params(self, port):
-        # chack whether table for this port exists
+        # check whether table for this port exists
         port_tables = self.db.get_table(PORT_TABLE_NAME)
         if port in port_tables:
             print(port_tables[port])
@@ -261,7 +261,7 @@ class portconfig(object):
         if not self.namespace:
             state_db = SonicV2Connector(host="127.0.0.1")
         else:
-            state_db = SonicV2Connector(host="127.0.0.1", namesapce=self.namespace, use_unix_socket_path=True)
+            state_db = SonicV2Connector(host="127.0.0.1", namespace=self.namespace, use_unix_socket_path=True)
         state_db.connect(state_db.STATE_DB)
         return state_db.get(state_db.STATE_DB, '{}|{}'.format(PORT_STATE_TABLE_NAME, port), PORT_STATE_SUPPORTED_SPEEDS)
 

--- a/scripts/queuestat
+++ b/scripts/queuestat
@@ -644,7 +644,7 @@ class Queuestat(object):
 
 
 @click.command()
-@click.option('-p', '--port', type=str, help='Show the queue conters for just one port', default=None)
+@click.option('-p', '--port', type=str, help='Show the queue counters for just one port', default=None)
 @click.option('-c', '--clear', is_flag=True, default=False, help='Clear previous stats and save new ones')
 @click.option('-d', '--delete', is_flag=True, default=False, help='Delete saved stats')
 @click.option('-j', '--json_opt',  is_flag=True, default=False, help='Print in JSON format')

--- a/scripts/reboot
+++ b/scripts/reboot
@@ -267,7 +267,7 @@ function parse_config_file
                     [ "${value}" = "true" ] && SHOW_TIMER="yes"
                     ;;
                 *)
-                    debug "WARNING: Unknown config ${key}=${value} finded in config file ${REBOOT_CONFIG_FILE}" 
+                    debug "WARNING: Unknown config ${key}=${value} found in config file ${REBOOT_CONFIG_FILE}" 
                     ;;
             esac
         done < "$REBOOT_CONFIG_FILE"
@@ -403,7 +403,7 @@ else
             CURRENT_TIME=$(date +%s)
             ELAPSED=$((CURRENT_TIME - REBOOT_START_TIME))
             if (( ELAPSED >= BLOCKING_MODE_TIMEOUT_IN_SECOND )); then
-                echo "[REBOOT FAILED] The reboot used $(ELAPSED)seconds while the timeout is configed as $(BLOCKING_MODE_TIMEOUT_IN_SECOND)seconds"
+                echo "[REBOOT FAILED] The reboot used $(ELAPSED)seconds while the timeout is configured as $(BLOCKING_MODE_TIMEOUT_IN_SECOND)seconds"
                 exit ${EXIT_TIMEOUT}
             fi
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -875,7 +875,7 @@ def check_routes_for_namespace(namespace):
     If there are FRR routes that aren't marked offloaded but all APPL & ASIC DB
     routes are in sync report failure and perform a mitigation action.
 
-    :return (0, None) on sucess, else (-1, results) where results holds
+    :return (0, None) on success, else (-1, results) where results holds
     the unjustifiable entries.
     """
 
@@ -1013,7 +1013,7 @@ def check_sids_for_namespace(namespace):
     this function does not wait for subscriber updates, as SIDs are not
     expected to change frequently.
 
-    :return (0, None) on sucess, else (-1, results) where results holds
+    :return (0, None) on success, else (-1, results) where results holds
     the unjustifiable entries.
     """
 

--- a/scripts/sonic-kdump-config
+++ b/scripts/sonic-kdump-config
@@ -43,7 +43,7 @@ def print_err(*args):
 
 ## Run an external command, either from the shell or not
 #  The function capture the output of stdout and stderr,
-#  and return then a tupple with exit code, stdout, stderr
+#  and return then a tuple with exit code, stdout, stderr
 #
 #  @param cmd   Command to execute (full path needed ig not using the shell)
 def run_command(cmd, use_shell=False):
@@ -197,7 +197,7 @@ def modify_crashkernel_param_uboot_env(crashkernel_value):
 #
 #  @param  lines Lines read from grub.cfg/cmdline file
 #  @param  img   String we are looking for ("loop=image...")
-#  @return       Index in lines array wehere we found the string
+#  @return       Index in lines array where we found the string
 def locate_image(lines, img):
     for num in range(len(lines)):
         try:
@@ -469,7 +469,7 @@ def read_use_kdump():
         try:
             return int(lines[0])
         except Exception as e:
-            print('Error! Exception[%s] occured while reading from %s' %(str(e), kdump_cfg))
+            print('Error! Exception[%s] occurred while reading from %s' %(str(e), kdump_cfg))
             sys.exit(1)
     else:
         print_err("Unable to read USE_KDUMP from %s" % kdump_cfg)
@@ -507,7 +507,7 @@ def read_num_dumps():
         try:
             return int(lines[0])
         except Exception as e:
-            print_err('Error! Exception[%s] occured while reading from %s' %(str(e), kdump_cfg))
+            print_err('Error! Exception[%s] occurred while reading from %s' %(str(e), kdump_cfg))
             sys.exit(1)
     else:
         print_err("Unable to read KDUMP_NUM_DUMPS from %s" % kdump_cfg)
@@ -614,7 +614,7 @@ def write_ssh_path(ssh_path):
 
 ## Enable kdump
 #
-#  @param verbose If True, the function will display a few additinal information
+#  @param verbose If True, the function will display a few additional information
 #  @return        True if the grub/cmdline cfg has changed, and False if it has not
 def kdump_enable(verbose, kdump_enabled, memory, num_dumps, image, cmdline_file, remote, ssh_string, ssh_path):
 
@@ -720,7 +720,7 @@ def get_kdump_config_json(config_param):
 
 ## Command: Enable kdump
 #
-#  @param verbose If True, the function will display a few additinal information
+#  @param verbose If True, the function will display a few additional information
 #  @param image   The image on which kdump settings are changed
 #  @return        True if the grub/cmdline cfg has changed, and False if it has not
 def cmd_kdump_enable(verbose, image):
@@ -1007,7 +1007,7 @@ def main():
             parser.print_help()
             sys.exit(1)
     except Exception as e:
-        print_err('Error! Exception[%s] occured while processing the command sonic-kdump-config %s.' %(str(e), sys.argv[1]))
+        print_err('Error! Exception[%s] occurred while processing the command sonic-kdump-config %s.' %(str(e), sys.argv[1]))
         sys.exit(1)
 
     if changed:

--- a/scripts/sonic_sku_create.py
+++ b/scripts/sonic_sku_create.py
@@ -556,7 +556,7 @@ class SkuCreate(object):
         self.num_of_fpp = len(list(self.fpp_split.keys()))
 
     def get_default_lanes(self):
-        #Internal function to get lanes of the ports accroding to the base default SKU 
+        # Internal function to get lanes of the ports according to the base default SKU
         try:
             with open(self.base_file_path,"r") as f:
                 line_header = next(f).split() # get the file header split into columns
@@ -589,7 +589,7 @@ class SkuCreate(object):
             lanes = [_.strip() for _ in self.default_lanes_per_port[fp - 1].split(",")]
             lanes_count = len(lanes)
             if lanes_count % splt != 0:
-                print("Lanes(%s) could not be evenly splitted by %d." % (self.default_lanes_per_port[fp - 1], splt))
+                print("Lanes(%s) could not be evenly split by %d." % (self.default_lanes_per_port[fp - 1], splt))
                 sys.exit(1)
 
             # split the lanes

--- a/scripts/storyteller
+++ b/scripts/storyteller
@@ -104,7 +104,7 @@ def main():
                         type=int, required=False, default=0)
     parser.add_argument('-s', '--since', help='Filter logs since the given date',
                         type=str, required=False, default="@0")
-    parser.add_argument('-f', '--sortfield', help='Use Nth field separted by "." in file name to sort. e.g. syslog.1.gz: -f 2, swss.rec.2.gz: -f 3, default 0: sort by timestamp',
+    parser.add_argument('-f', '--sortfield', help='Use Nth field separated by "." in file name to sort. e.g. syslog.1.gz: -f 2, swss.rec.2.gz: -f 3, default 0: sort by timestamp',
                         type=int, required=False, default=0)
 
     args = parser.parse_args()

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -7,15 +7,15 @@ import subprocess
 import argparse
 from swsscommon import swsscommon
 
-''' vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
+''' vnet_route_check.py: tool that verifies VNET routes consistency between SONiC and vendor SDK DBs.
 
 Logically VNET route verification logic consists of 3 parts:
 1. Get VNET routes entries that are missed in ASIC_DB but present in APP_DB.
 2. Get VNET routes entries that are missed in APP_DB but present in ASIC_DB.
 3. Get VNET routes entries that are missed in SDK but present in ASIC_DB.
 
-Returns 0 if there is no inconsistancy found and all VNET routes are aligned in all DBs.
-Returns -1 if there is incosistancy found and prints differences between DBs in JSON format to standart output.
+Returns 0 if there is no inconsistency found and all VNET routes are aligned in all DBs.
+Returns -1 if there is inconsistency found and prints differences between DBs in JSON format to standard output.
 
 Format of differences output:
 {
@@ -179,7 +179,7 @@ def filter_out_vnet_ip2me_routes(vnet_routes):
             continue
 
         # rif_attrs[0] - RIF name
-        # rif_attrs[1] - IP prefix and prefix legth
+        # rif_attrs[1] - IP prefix and prefix length
         # IP2ME routes have '/32' prefix length so replace it and add to the list
         if rif_attrs[0] in vnet_intfs:
             rif_ip, _ = rif_attrs[1].split('/')
@@ -394,7 +394,7 @@ def main():
 
     rc = RC_OK
 
-    # Don't run VNET routes consistancy logic if there is no VNET configuration
+    # Don't run VNET routes consistency logic if there is no VNET configuration
     if not check_vnet_cfg():
         return rc
     asic_db = swsscommon.DBConnector('ASIC_DB', 0, True)

--- a/show/stp.py
+++ b/show/stp.py
@@ -55,7 +55,7 @@ def stp_get_key_from_pattern(db_connect, db, pattern):
         return None
 
 
-# get_all doesnt accept regex patterns, it requires exact key
+# get_all doesn't accept regex patterns, it requires exact key
 def stp_get_all_from_pattern(db_connect, db, pattern):
     key = stp_get_key_from_pattern(db_connect, db, pattern)
     if key:


### PR DESCRIPTION
Fix spelling errors across 22 files in scripts/:

- `dyanmic` → `dynamic` (mmuconfig, buffershow)
- `Neigbhor` → `Neighbor` (nbrshow)
- `statisitics` → `statistics` (fabricstat)
- `configrued` → `configured` (dropstat)
- `tupple` → `tuple`, `wehere` → `where`, `occured` → `occurred`, `additinal` → `additional` (sonic-kdump-config)
- `partion` → `partition` (boot_part)
- `accroding` → `according`, `splitted` → `split` (sonic_sku_create.py)
- `dictinary` → `dictionary` (flow_counters_stat)
- `finded` → `found`, `configed` → `configured` (reboot)
- `btyes` → `bytes` (pcmping)
- `consistancy` → `consistency`, `standart` → `standard`, `legth` → `length` (vnet_route_check.py)
- `seetings` → `settings`, `cofiguration` → `configuration` (mellanox_buffer_migrator.py)
- `threhold` → `threshold` (debug_voq_chassis_packet_drops.sh)
- `defaul` → `default` (coredump_gen_handler.py)
- `separted` → `separated` (storyteller)
- `sucess` → `success` (route_check.py)
- `Initalize` → `Initialize`, `infomation` → `information` (lldpshow)
- `conters` → `counters` (queuestat)
- `chack` → `check`, `namesapce` → `namespace` (portconfig)
- `occured` → `occurred`, `refernces` → `references` (db_migrator.py)
- `namesapces` → `namespaces`, `comamnd`/`commmand` → `command`, `otherwize` → `otherwise`, `unecessary` → `unnecessary`, `succesfully` → `successfully`, `accquired` → `acquired`, `nonexistant` → `nonexistent` (generate_dump)

Found via codespell (ref: sonic-net/sonic-buildimage#25310).

Signed-off-by: Lih <lihua@whiterock>