### PR TITLE
Fix spelling typos in show/ and clear/ modules

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -76,7 +76,7 @@ class AliasedGroup(click.Group):
 
 
 # To be enhanced. Routing-stack information should be collected from a global
-# location (configdb?), so that we prevent the continous execution of this
+# location (configdb?), so that we prevent the continuous execution of this
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'

--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -329,14 +329,14 @@ def show_routes(args, namespace, display, verbose, ipver):
     else:
         if multi_asic.is_multi_asic():
             if display not in multi_asic_util.multi_asic_display_choices():
-                print("dislay option '{}' is not a valid option.".format(display))
+                print("display option '{}' is not a valid option.".format(display))
                 return
             else:
                 if display == constants.DISPLAY_EXTERNAL:
                     filter_back_end = True
         else:
             if display not in ['frontend', 'all']:
-                print("dislay option '{}' is not a valid option.".format(display))
+                print("display option '{}' is not a valid option.".format(display))
                 return
 
     device = multi_asic_util.MultiAsic(display, namespace)

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -229,7 +229,7 @@ def breakout(ctx):
                 continue
             cur_brkout_mode = cur_brkout_tbl[port_name]["brkout_mode"]
 
-            # Update deafult breakout mode and current breakout mode to platform_dict
+            # Update default breakout mode and current breakout mode to platform_dict
             platform_dict[port_name].update(hwsku_dict[port_name])
             platform_dict[port_name]["Current Breakout Mode"] = cur_brkout_mode
 
@@ -531,7 +531,7 @@ def get_all_port_errors(interfacename):
 @click.argument('interfacename', required=True)
 @click.pass_context
 def errors(ctx, interfacename):
-    """Show Interface Erorrs <interfacename>"""
+    """Show Interface Errors <interfacename>"""
     # Try to convert interface name from alias
     interfacename = try_convert_interfacename_from_alias(click.get_current_context(), interfacename)
 

--- a/show/kdump.py
+++ b/show/kdump.py
@@ -174,7 +174,7 @@ def files():
 #
 # 'logging' subcommand (show kdump logging)
 #
-@kdump.command(name="logging", short_help="Show last 10 lines of lastest kernel dmesg file")
+@kdump.command(name="logging", short_help="Show last 10 lines of latest kernel dmesg file")
 @click.argument('filename', required=False)
 @click.option('-l', '--lines', default=10, show_default=True)
 def logging(filename, lines):

--- a/show/main.py
+++ b/show/main.py
@@ -87,7 +87,7 @@ GEARBOX_TABLE_PHY_PATTERN = r"_GEARBOX_TABLE:phy:*"
 COMMAND_TIMEOUT = 300
 
 # To be enhanced. Routing-stack information should be collected from a global
-# location (configdb?), so that we prevent the continous execution of this
+# location (configdb?), so that we prevent the continuous execution of this
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'

--- a/show/plugins/auto_techsupport.py
+++ b/show/plugins/auto_techsupport.py
@@ -17,7 +17,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:
@@ -33,7 +33,7 @@ def format_group_value(entry, attrs):
         attrs (List[Dict]): Attributes metadata that belongs to the same group.
 
     Returns:
-        str: fomatted group attributes.
+        str: formatted group attributes.
     """
 
     data = []
@@ -80,11 +80,17 @@ def AUTO_TECHSUPPORT_GLOBAL(db):
         ),
         format_attr_value(
             entry,
-            {'name': 'max_techsupport_limit', 'description': 'Max Limit in percentage for the cummulative size of ts dumps. No cleanup is performed if the value isn\'t configured or is 0.0', 'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
+            {'name': 'max_techsupport_limit',
+             'description': 'Max Limit in percentage for the cumulative size of ts dumps. '
+             'No cleanup is performed if the value isn\'t configured or is 0.0',
+             'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
         ),
         format_attr_value(
             entry,
-            {'name': 'max_core_limit', 'description': 'Max Limit in percentage for the cummulative size of core dumps. No cleanup is performed if the value isn\'t congiured or is 0.0', 'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
+            {'name': 'max_core_limit',
+             'description': 'Max Limit in percentage for the cumulative size of core dumps. '
+             'No cleanup is performed if the value isn\'t configured or is 0.0',
+             'is-leaf-list': False, 'is-mandatory': False, 'group': ''}
         ),
         format_attr_value(
             entry,

--- a/show/plugins/nvgre_tunnel.py
+++ b/show/plugins/nvgre_tunnel.py
@@ -16,7 +16,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:
@@ -32,7 +32,7 @@ def format_group_value(entry, attrs):
         attrs (List[Dict]): Attributes metadata that belongs to the same group.
 
     Returns:
-        str: fomatted group attributes.
+        str: formatted group attributes.
     """
 
     data = []

--- a/show/plugins/pbh.py
+++ b/show/plugins/pbh.py
@@ -36,7 +36,7 @@ def format_attr_value(entry, attr):
             attr (Dict): Attribute metadata.
 
         Returns:
-            str: fomatted attribute value.
+            str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:
@@ -53,7 +53,7 @@ def format_group_value(entry, attrs):
             attrs (List[Dict]): Attributes metadata that belongs to the same group.
 
         Returns:
-            str: fomatted group attributes.
+            str: formatted group attributes.
     """
 
     data = []

--- a/show/plugins/sonic-passwh_yang.py
+++ b/show/plugins/sonic-passwh_yang.py
@@ -20,7 +20,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:

--- a/show/plugins/sonic-system-ldap_yang.py
+++ b/show/plugins/sonic-system-ldap_yang.py
@@ -18,7 +18,7 @@ def format_attr_value(entry, attr):
         attr (Dict): Attribute metadata.
 
     Returns:
-        str: fomatted attribute value.
+        str: formatted attribute value.
     """
 
     if attr["is-leaf-list"]:


### PR DESCRIPTION
Fix spelling errors across 10 files in show/ and clear/:

- `dislay` → `display` (bgp_common.py)
- `lastest` → `latest` (kdump.py)
- `continous` → `continuous` (show/main.py, clear/main.py)
- `deafult` → `default` (interfaces/__init__.py)
- `Erorrs` → `Errors` (interfaces/__init__.py)
- `fomatted` → `formatted` (5 plugin files)
- `cummulative` → `cumulative` (auto_techsupport.py)

Found via codespell (ref: sonic-net/sonic-buildimage#25310).

Signed-off-by: Lih <lihua@whiterock>