### PR TITLE
yang validation fails after config reload

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -745,13 +745,18 @@ class DBMigrator():
             return
         device_metadata_old = self.configDB.get_entry('DEVICE_METADATA', 'localhost')
         device_metadata_new = self.config_src_data['DEVICE_METADATA']['localhost']
+        new_routing_mode = device_metadata_new.get('docker_routing_config_mode')
+        # Skip migration if the new value is None or empty - this prevents overwriting
+        # a valid config with an invalid value when minigraph doesn't have this field
+        if not new_routing_mode:
+            return
         # overwrite the routing-config-mode as per minigraph parser
         # Criteria for update:
         # if config mode is missing in base OS or if base and target modes are not same
         #  Eg. in 201811 mode is "unified", and in newer branches mode is "separated"
-        if ('docker_routing_config_mode' not in device_metadata_old and 'docker_routing_config_mode' in device_metadata_new) or \
-        (device_metadata_old.get('docker_routing_config_mode') != device_metadata_new.get('docker_routing_config_mode')):
-            device_metadata_old['docker_routing_config_mode'] = device_metadata_new.get('docker_routing_config_mode')
+        if ('docker_routing_config_mode' not in device_metadata_old) or \
+                (device_metadata_old.get('docker_routing_config_mode') != new_routing_mode):
+            device_metadata_old['docker_routing_config_mode'] = new_routing_mode
             self.configDB.set_entry('DEVICE_METADATA', 'localhost', device_metadata_old)
 
     def update_edgezone_aggregator_config(self):


### PR DESCRIPTION
Able to reproduce the issue when we run test_bgp_suppress_fib.py test for multiple times.

Root-cause:
The docker_routing_config_mode was being set to the string "None" in both config_db.json and redis after config reload, which corrupted the configuration. This happened because:

1. When minigraph.xml doesn't have <DockerRoutingConfigMode> element, or the element has no text content, child.text returns Python None
2. This None value was then serialized as the string "None" when written to Redis

Resolution:
- Added a safety check to skip migration if new_routing_mode is None or empty
- This provides defense-in-depth to prevent overwriting a valid config with an invalid value

fixes https://github.com/sonic-net/sonic-utilities/issues/4307
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

