### PR TITLE
Clearing /tmp/tmp* is unsafe with parallel builds

### DIFF
--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -248,5 +248,5 @@ class TestDiskCheck(object):
 
     @classmethod
     def teardown_class(cls):
-        subprocess.run("rm -rf /tmp/tmpx /tmp/tmpy", shell=True)  # cleanup the temporary dirs
+        subprocess.run(["rm", "-rf", "/tmp/tmpx", "/tmp/tmpy"])  # cleanup the temporary dirs
         print("TEARDOWN")


### PR DESCRIPTION
#### Why I did it

Many tests for various packages use /tmp/tmp.XXXXXXXX or /tmp/tmpi_XXXXX as the temporary file or directory pattern for mktemp.  Since the same slave container is used for multiple simultaneous builds, destroying an in-progress build's temporary file or directory will cause those builds to fail.

While this has existed for a year, it appears the introduction of Trixie has reordered the builds a bit so that packages using the temp file patterns impacted are built simultaneously.

#### How I did it

It appears /tmp/tmpx and /tmp/tmpy are the toplevel directories created, clear those.

#### How to verify it

Run a trixie build with high parallelism.

#### Which release branch to backport

- [x] 202511

Fixes https://github.com/sonic-net/sonic-buildimage/issues/25424
