### PR TITLE
[multi-asic] fix utilities_common Db helper

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,31 @@
+"""Unit tests for utilities_common.db.Db class"""
+from unittest import mock
+
+from .mock_tables import dbconnector
+from utilities_common.db import Db
+
+
+class TestUtilitiesDb(object):
+    @classmethod
+    def setup_class(cls):
+        dbconnector.load_database_config()
+
+    @mock.patch('utilities_common.db.multi_asic_ns_choices', return_value=[])
+    @mock.patch('utilities_common.db.SonicDBConfig')
+    @mock.patch('utilities_common.db.multi_asic')
+    def test_utilities_db_init_multi_asic(self, mock_multi_asic, mock_sonic_db_config, mock_ns_choices):
+        mock_multi_asic.is_multi_asic.return_value = True
+        mock_sonic_db_config.isGlobalInit.return_value = False
+        Db()
+        mock_multi_asic.is_multi_asic.assert_called()
+        mock_sonic_db_config.isGlobalInit.assert_called()
+        mock_sonic_db_config.initializeGlobalConfig.assert_called_once()
+
+    @mock.patch('utilities_common.db.SonicDBConfig')
+    @mock.patch('utilities_common.db.multi_asic')
+    def test_utilities_db_init_single_asic(self, mock_multi_asic, mock_sonic_db_config):
+        mock_multi_asic.is_multi_asic.return_value = False
+        Db()
+        mock_multi_asic.is_multi_asic.assert_called()
+        mock_sonic_db_config.isGlobalInit.assert_not_called()
+        mock_sonic_db_config.initializeGlobalConfig.assert_not_called()

--- a/utilities_common/db.py
+++ b/utilities_common/db.py
@@ -1,5 +1,5 @@
 from sonic_py_common import multi_asic, device_info
-from swsscommon.swsscommon import ConfigDBConnector, ConfigDBPipeConnector, SonicV2Connector
+from swsscommon.swsscommon import ConfigDBConnector, ConfigDBPipeConnector, SonicV2Connector, SonicDBConfig
 from utilities_common import constants
 from utilities_common.multi_asic import multi_asic_ns_choices
 
@@ -30,6 +30,8 @@ class Db(object):
         self.db_clients[constants.DEFAULT_NAMESPACE] = self.db
 
         if multi_asic.is_multi_asic():
+            if not SonicDBConfig.isGlobalInit():
+                SonicDBConfig.initializeGlobalConfig()
             self.ns_list = multi_asic_ns_choices()
             for ns in self.ns_list:
                 self.cfgdb_clients[ns] = (


### PR DESCRIPTION
#### What I did
This is to fix the utilities_common.Db() helper class.

Using it now in the multi-asic environment leads to an error:
```
RuntimeError: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig
```

This impacts the `counterpoll switch` CLI command.

#### How I did it
Added a proper DB config initialization

#### How to verify it
* Manual test for the Db() helper
* Running counterpoll switch disable in multi-asic environment

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

