### PR TITLE
[LACP retry-count] Syntax Fix for Trixie

### DIFF
--- a/scripts/teamd_increase_retry_count.py
+++ b/scripts/teamd_increase_retry_count.py
@@ -15,13 +15,13 @@ import signal
 from sonic_py_common import logger, multi_asic
 from swsscommon.swsscommon import DBConnector, Table, SonicDBConfig, SonicDBKey
 
-conf.ipv6_enabled = False
-conf.verb = False
-from scapy.fields import ByteField, ShortField, MACField, XStrFixedLenField, ConditionalField  # noqa: E402
+from scapy.fields import ByteField, ShortField, MACField, XStrFixedLenField, ConditionalField, MultipleTypeField
 from scapy.layers.l2 import Ether  # noqa: E402
 from scapy.sendrecv import sendp, sniff  # noqa: E402
 from scapy.packet import Packet, split_layers, bind_layers  # noqa: E402
 import scapy.contrib.lacp  # noqa: E402
+
+conf.verb = False
 
 log = None
 revertTeamdRetryCountChanges = False
@@ -66,8 +66,13 @@ class LACPRetryCount(Packet):
         ConditionalField(XStrFixedLenField("partner_retry_count_reserved", "", 1), lambda pkt:pkt.version == 0xf1),
         ByteField("terminator_type", 0),
         ByteField("terminator_length", 0),
-        ConditionalField(XStrFixedLenField("reserved", "", 42), lambda pkt:pkt.version == 0xf1),
-        ConditionalField(XStrFixedLenField("reserved", "", 50), lambda pkt:pkt.version != 0xf1),
+        MultipleTypeField(
+            [
+                (XStrFixedLenField("reserved", "", 42), lambda pkt:pkt.version == 0xf1),
+                (XStrFixedLenField("reserved", "", 50), lambda pkt:pkt.version != 0xf1),
+            ],
+            XStrFixedLenField("reserved", "", 50)
+        ),
     ]
 
 split_layers(scapy.contrib.lacp.SlowProtocol, scapy.contrib.lacp.LACP, subtype=1)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed syntax issue in LACPRetryCount fields for newer scapy version (used in Trixie - 2.6.1),
This PR fixes this issue - [https://github.com/sonic-net/sonic-buildimage/issues/24931](https://github.com/sonic-net/sonic-buildimage/issues/24931).

#### How I did it
Replaced the double ConditionalField with MultipleTypeField.

#### How to verify it
Run teamd_increase_retry_count.py in Trixie image, verify retry-count increased, and peer updates his "partner retry-count".


