### PR TITLE
Fix delayed scapy import in lag_keepalive script when we have a lot of routes

### DIFF
--- a/scripts/lag_keepalive.py
+++ b/scripts/lag_keepalive.py
@@ -5,6 +5,9 @@ import json
 import os
 from scapy.config import conf
 conf.ipv6_enabled = False
+# Fixes delayed import when we have a lot of routes installed
+conf.route_autoload = False
+conf.route6_autoload = False
 from scapy.layers.l2 import Ether  # noqa: E402
 from scapy.sendrecv import sendp  # noqa: E402
 import scapy.contrib.lacp  # noqa: E402


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix scapy import delay in lag_keepalive script when there are a lot of routes installed

#### Why I did
lag_keepalive scripts timesout during warm-reboot when we have 100k routes installed. Check here: https://github.com/sonic-net/sonic-utilities/blob/137d594bdf2be4a4ff9c675f67377fd650178a9b/scripts/fast-reboot#L800
This is because scapy 2.6.1 in Debian 13 tries to create internal python objects for all the routes in route table. This process can take long time when we have a lot of routes installed thus breaching the 30sec timeout limit set in warm-reboot script.

#### How I did it
Turn off scapy to autoload routes

#### How to verify it
Install 100k routes on the the dut. warm-reboot script shouldn't fail because of timeout caused by lag_keepalive script.

#### Previous command output (if the output of a command-line utility has changed)
```
>>> import scapy
>>> import time
>>> start = time.perf_counter()
... from scapy.layers.l2 import Ether
... end = time.perf_counter()
... print(f"Import took {end - start:.6f} seconds")
...
Import took 82.801858 seconds

root@sonic:/home/admin# wc -l /proc/net/route
100006 
```

#### New command output (if the output of a command-line utility has changed)

```
>>> import scapy
>>> from scapy.config import conf
>>> conf.route_autoload = False
>>> import time
...
... start = time.perf_counter()
... from scapy.layers.l2 import Ether
... end = time.perf_counter()
...
... print(f"Import took {end - start:.6f} seconds")
...
Import took 0.356086 seconds
```