### PR TITLE
[DPU] Add CLI to trigger and dump flows

### DIFF
--- a/scripts/sonic-dpu-flow-dump.py
+++ b/scripts/sonic-dpu-flow-dump.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""
+SONiC DPU Flow Dump Utility
+
+This script triggers a flow dump session, waits for completion, and extracts/prints the results.
+It automatically creates the configuration file in /etc/sonic/ha/flow_dump.json.
+
+Usage:
+    sonic-dpu-flow-dump.py [-f FLOW_STATE] [-t TIMEOUT] [-m MAX_FLOWS] [-v]
+
+Options:
+    -f, --flow-state    Flow state (true/false), default: true
+    -t, --timeout       Timeout in seconds, default: 60
+    -m, --max-flows     Maximum number of flows to dump, default: 1000
+    -v, --verbose       Enable verbose output
+"""
+
+import json
+import sys
+import subprocess
+import os
+import gzip
+import time
+import random
+import string
+import argparse
+import signal
+import netifaces
+from swsscommon import swsscommon
+
+
+STATE_TABLE_NAME = "DASH_FLOW_SYNC_SESSION_STATE_TABLE"
+CONFIG_FILE_PATH = "/etc/sonic/ha/flow_dump.json"
+CONFIG_DIR = "/etc/sonic/ha"
+SWSS_CONTAINER = "swss"
+SWSS_CONFIG_CMD = "swssconfig"
+MIDPLANE_INTERFACE = "eth0-midplane"
+
+_interrupted = False
+_verbose = False
+
+
+def signal_handler(signum, frame):
+    """Handle SIGINT (Ctrl+C) signal."""
+    global _interrupted
+    _interrupted = True
+
+
+def print_verbose(*args, **kwargs):
+    """Print only if verbose is True."""
+    if _verbose:
+        print(*args, **kwargs)
+
+
+def print_error(*args, **kwargs):
+    """Print error message to stderr."""
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def get_midplane_ip(interface=MIDPLANE_INTERFACE):
+    """Get IPv4 address from the specified interface with 169.254.200 prefix."""
+    try:
+        addresses = netifaces.ifaddresses(interface)
+        if netifaces.AF_INET in addresses:
+            ipv4_addrs = addresses[netifaces.AF_INET]
+            for addr_info in ipv4_addrs:
+                ip = addr_info.get('addr')
+                if ip and ip.startswith('169.254.200'):
+                    return ip
+    except (ValueError, KeyError, IndexError):
+        pass
+    return None
+
+
+def get_swss_config_endpoint():
+    """Get the swssconfig endpoint based on midplane IP."""
+    midplane_ip = get_midplane_ip()
+    if midplane_ip:
+        return f"tcp://{midplane_ip}"
+    return "tcp://169.254.200.1"
+
+
+def generate_session_name():
+    """Generate a random session name."""
+    random_suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    return f"flow_dump_session_{random_suffix}"
+
+
+def ensure_config_directory(config_dir=CONFIG_DIR):
+    """Ensure the configuration directory exists."""
+    try:
+        os.makedirs(config_dir, exist_ok=True)
+        return True
+    except Exception as e:
+        print_error(f"Error creating config directory {config_dir}: {e}")
+        return False
+
+
+def create_config_file(config_path, session_name=None, max_flows=1000, timeout=60, flow_state=True):
+    """Create the flow dump config file."""
+    try:
+        if session_name is None:
+            session_name = generate_session_name()
+
+        if not ensure_config_directory():
+            return None
+
+        config = [
+            {
+                f"DASH_FLOW_SYNC_SESSION_TABLE:{session_name}": {
+                    "type": "flow_dump",
+                    "flow_state": "true" if flow_state else "false",
+                    "max_flows": str(max_flows),
+                    "timeout": str(timeout)
+                },
+                "OP": "SET"
+            }
+        ]
+
+        with open(config_path, 'w') as f:
+            json.dump(config, f, indent=4)
+
+        return session_name
+    except Exception as e:
+        print_error(f"Error creating config file: {e}")
+        return None
+
+
+def trigger_flow_dump(config_path):
+    """Trigger the flow dump using docker exec swss swssconfig."""
+    endpoint = get_swss_config_endpoint()
+    cmd = ["docker", "exec", SWSS_CONTAINER, SWSS_CONFIG_CMD, "-e", endpoint, config_path]
+
+    print_verbose(f"Triggering flow dump: {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        print_verbose("Flow dump triggered successfully")
+        if result.stdout:
+            print_verbose(f"Output: {result.stdout}")
+        return True
+    except subprocess.CalledProcessError as e:
+        print_error(f"Error triggering flow dump: {e}")
+        if e.stdout:
+            print_verbose(f"stdout: {e.stdout}", file=sys.stderr)
+        if e.stderr:
+            print_verbose(f"stderr: {e.stderr}", file=sys.stderr)
+        return False
+
+
+def check_session_state(table, session_name):
+    """Check current session state from the table."""
+    exists, fvs = table.get(session_name)
+    if not exists:
+        return None, None
+
+    state = None
+    output_file = None
+    for field, value in fvs:
+        if field == "state":
+            state = value
+        elif field == "output_file":
+            output_file = value
+
+    return state, output_file
+
+
+def process_notification(key, op, fvs, session_name, table):
+    """Process a notification event and return updated state."""
+    if key != session_name:
+        return None, None
+
+    print_verbose(f"[Notification] Received update for session '{session_name}': op={op}")
+    for field, value in fvs:
+        print_verbose(f"  {field} = {value}")
+
+    db_state, db_output_file = check_session_state(table, session_name)
+    if db_state:
+        print_verbose(f"[Notification] Current DB state: {db_state}")
+        return db_state, db_output_file
+
+    return None, None
+
+
+def wait_for_completion(session_name, timeout=60):
+    """Wait for the flow dump session to complete using SubscriberStateTable."""
+    global _interrupted
+    _interrupted = False
+
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # Add 5 second buffer to timeout to ensure we capture even the failed notification from orchagent
+    timeout_with_buffer = timeout + 5
+
+    print_verbose(f"Waiting for session '{session_name}' to complete (timeout: {timeout}s)...")
+
+    db = swsscommon.DBConnector("DPU_STATE_DB", 0, True)
+    subscriber_table = swsscommon.SubscriberStateTable(db, STATE_TABLE_NAME)
+    select = swsscommon.Select()
+    select.addSelectable(subscriber_table)
+
+    start_time = time.time()
+    state = None
+    output_file = None
+    table = swsscommon.Table(db, STATE_TABLE_NAME)
+
+    while True:
+        if _interrupted:
+            print_error("\nInterrupted by user (Ctrl+C)")
+            break
+
+        if time.time() - start_time >= timeout_with_buffer:
+            print_verbose(f"Timeout waiting for session completion (waited {timeout_with_buffer}s)", file=sys.stderr)
+            print_verbose(f"Last known state: {state}")
+            return state, output_file
+
+        (status, selectable) = select.select(timeout=1000)
+
+        if status == swsscommon.Select.TIMEOUT:
+            continue
+        elif status == swsscommon.Select.ERROR:
+            print_verbose("Error in select", file=sys.stderr)
+            break
+
+        (key, op, fvs) = subscriber_table.pop()
+
+        if key is None:
+            continue
+
+        # Skip if this notification is not for our session
+        if key != session_name:
+            continue
+
+        new_state, new_output_file = process_notification(key, op, fvs, session_name, table)
+        if new_state:
+            state = new_state
+            if new_output_file:
+                output_file = new_output_file
+
+            if state == "completed":
+                return state, output_file
+            elif state == "failed":
+                print_error("Session failed!")
+                return state, output_file
+
+    return state, output_file
+
+
+# Mapping from numeric attribute IDs to attribute names
+FLOW_ENTRY_ATTR_MAP = {
+    0: "SAI_FLOW_ENTRY_ATTR_ACTION",
+    1: "SAI_FLOW_ENTRY_ATTR_VERSION",
+    2: "SAI_FLOW_ENTRY_ATTR_DASH_DIRECTION",
+    3: "SAI_FLOW_ENTRY_ATTR_DASH_FLOW_ACTION",
+    4: "SAI_FLOW_ENTRY_ATTR_METER_CLASS",
+    5: "SAI_FLOW_ENTRY_ATTR_IS_UNIDIRECTIONAL_FLOW",
+    6: "SAI_FLOW_ENTRY_ATTR_REVERSE_FLOW_ENI_MAC",
+    7: "SAI_FLOW_ENTRY_ATTR_REVERSE_FLOW_VNET_ID",
+    8: "SAI_FLOW_ENTRY_ATTR_REVERSE_FLOW_IP_PROTO",
+    9: "SAI_FLOW_ENTRY_ATTR_REVERSE_FLOW_SRC_IP",
+    10: "SAI_FLOW_ENTRY_ATTR_REVERSE_FLOW_DST_IP",
+    11: "SAI_FLOW_ENTRY_ATTR_REVERSE_FLOW_SRC_PORT",
+    12: "SAI_FLOW_ENTRY_ATTR_REVERSE_FLOW_DST_PORT",
+    13: "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_VNET_ID",
+    14: "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SIP",
+    15: "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DIP",
+    16: "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DASH_ENCAPSULATION",
+    17: "SAI_FLOW_ENTRY_ATTR_UNDERLAY1_VNET_ID",
+    18: "SAI_FLOW_ENTRY_ATTR_UNDERLAY1_SIP",
+    19: "SAI_FLOW_ENTRY_ATTR_UNDERLAY1_DIP",
+    20: "SAI_FLOW_ENTRY_ATTR_UNDERLAY1_SMAC",
+    21: "SAI_FLOW_ENTRY_ATTR_UNDERLAY1_DMAC",
+    22: "SAI_FLOW_ENTRY_ATTR_UNDERLAY1_DASH_ENCAPSULATION",
+    23: "SAI_FLOW_ENTRY_ATTR_DST_MAC",
+    24: "SAI_FLOW_ENTRY_ATTR_SIP",
+    25: "SAI_FLOW_ENTRY_ATTR_DIP",
+    26: "SAI_FLOW_ENTRY_ATTR_SIP_MASK",
+    27: "SAI_FLOW_ENTRY_ATTR_DIP_MASK",
+    28: "SAI_FLOW_ENTRY_ATTR_VENDOR_METADATA",
+    29: "SAI_FLOW_ENTRY_ATTR_FLOW_DATA_PB",
+    30: "SAI_FLOW_ENTRY_ATTR_IP_ADDR_FAMILY",
+    31: "SAI_FLOW_ENTRY_ATTR_DASH_FLOW_SYNC_STATE",
+    32: "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SMAC",
+    33: "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DMAC",
+}
+
+# Mapping from key field abbreviations to full names
+KEY_FIELD_MAP = {
+    "em": "ENI_MAC",
+    "vn": "VNET_ID",
+    "pr": "IP_PROTO",
+    "si": "SRC_IP",
+    "di": "DST_IP",
+    "sp": "SRC_PORT",
+    "dp": "DST_PORT",
+}
+
+
+def convert_flow_attributes(flow_data):
+    """Convert numeric attribute IDs and key field abbreviations to string names."""
+    converted = {}
+    for key, value in flow_data.items():
+        if key in KEY_FIELD_MAP:
+            converted[KEY_FIELD_MAP[key]] = value
+        elif key == "switch_id":
+            converted["SWITCH_ID"] = value
+        else:
+            try:
+                attr_id = int(key)
+                attr_name = FLOW_ENTRY_ATTR_MAP.get(attr_id, key)
+                converted[attr_name] = value
+            except (ValueError, TypeError):
+                converted[key] = value
+    return converted
+
+
+def extract_flows_from_file(file_path):
+    """Extract flows from gzipped JSONL file and return as list of JSON objects with converted attribute names."""
+    if not file_path or not os.path.exists(file_path):
+        return []
+
+    flows = []
+    try:
+        with gzip.open(file_path, 'rt', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        flow_data = json.loads(line)
+                        converted_flow = convert_flow_attributes(flow_data)
+                        flows.append(converted_flow)
+                    except json.JSONDecodeError:
+                        continue
+    except Exception:
+        pass
+
+    return flows
+
+
+def print_flows(file_path, file_only=False):
+    """Print the output file path and flows."""
+    if not file_path:
+        return
+
+    if file_only:
+        print(file_path)
+        return
+
+    if not os.path.exists(file_path):
+        print_verbose(f"Output file does not exist: {file_path}", file=sys.stderr)
+        print_verbose("This may indicate that no flows were dumped (empty result)", file=sys.stderr)
+        return
+
+    flows = extract_flows_from_file(file_path)
+    if len(flows) == 0:
+        print_verbose("No flows found in dump file", file=sys.stderr)
+        print("[]")
+        return
+
+    print(json.dumps(flows, indent=2))
+
+
+def is_dpu_type():
+    """Check if switch type is DPU from CONFIG_DB."""
+    try:
+        config_db = swsscommon.DBConnector("CONFIG_DB", 0, True)
+        table = swsscommon.Table(config_db, "DEVICE_METADATA")
+        exists, switch_type = table.hget("localhost", "switch_type")
+
+        if not exists:
+            print_error("Error: switch_type not found in DEVICE_METADATA")
+            return False
+
+        if switch_type.upper() != "DPU":
+            print_error(f"Error: This script is only for DPU switches. Current switch_type: {switch_type}")
+            return False
+
+        return True
+    except Exception as e:
+        print_error(f"Error checking switch type: {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Trigger DPU flow dump session and dump the flows to stdout'
+    )
+    parser.add_argument(
+        '--no-flow-state',
+        action='store_false',
+        dest='flow_state',
+        default=True,
+        help='Disable flow state (default: enabled)'
+    )
+    parser.add_argument(
+        '-f', '--file-only',
+        action='store_true',
+        help='Print only the output file path'
+    )
+    parser.add_argument(
+        '-t', '--timeout',
+        type=int,
+        default=60,
+        help='Timeout in seconds (default: 60)'
+    )
+    parser.add_argument(
+        '-m', '--max-flows',
+        type=int,
+        default=1000,
+        help='Maximum number of flows to dump (default: 1000)'
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Enable verbose output'
+    )
+
+    args = parser.parse_args()
+
+    global _verbose
+    _verbose = args.verbose
+
+    # Check switch type before proceeding
+    if not is_dpu_type():
+        sys.exit(1)
+
+    session_name = create_config_file(
+        CONFIG_FILE_PATH,
+        max_flows=args.max_flows,
+        timeout=args.timeout,
+        flow_state=args.flow_state
+    )
+
+    if session_name is None:
+        sys.exit(1)
+
+    print_verbose(f"Using session name: {session_name}")
+
+    if not trigger_flow_dump(CONFIG_FILE_PATH):
+        sys.exit(1)
+
+    state, output_file = wait_for_completion(session_name, args.timeout)
+
+    if state == "completed":
+        if output_file:
+            print_flows(output_file, args.file_only)
+        else:
+            print_verbose("Session completed but no output file specified.")
+            print_verbose("This may indicate that no flows matched the criteria or no flows exist.")
+    elif state == "failed":
+        print_error("Flow dump session failed. Check logs for details.")
+        sys.exit(1)
+    else:
+        print_verbose(f"Flow dump session ended with state: {state}")
+        if output_file:
+            print_flows(output_file, args.file_only)
+        elif state:
+            print_verbose(f'Session state is "{state}" but no output file available.')
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,8 @@ setup(
         'scripts/sysreadyshow',
         'scripts/wredstat',
         'scripts/sonic-error-report',
-        'scripts/chassis_db_consistency_checker.py'
+        'scripts/chassis_db_consistency_checker.py',
+        'scripts/sonic-dpu-flow-dump.py'
     ],
     entry_points={
         'console_scripts': [

--- a/tests/sonic_dpu_flow_dump_test.py
+++ b/tests/sonic_dpu_flow_dump_test.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+Unit tests for sonic-dpu-flow-dump.py
+"""
+
+import os
+import sys
+import json
+import gzip
+import tempfile
+import subprocess
+import pytest
+from unittest.mock import Mock, patch, MagicMock, mock_open
+from io import BytesIO
+
+# Add the scripts directory to the path
+test_path = os.path.dirname(os.path.abspath(__file__))
+scripts_path = os.path.join(os.path.dirname(test_path), 'scripts')
+sys.path.insert(0, scripts_path)
+
+# Dynamically load the module since it has hyphens in the filename
+import importlib.util
+script_path = os.path.join(scripts_path, 'sonic-dpu-flow-dump.py')
+spec = importlib.util.spec_from_file_location("sonic_dpu_flow_dump", script_path)
+flow_dump = importlib.util.module_from_spec(spec)
+sys.modules["sonic_dpu_flow_dump"] = flow_dump
+spec.loader.exec_module(flow_dump)
+
+
+class TestGenerateSessionName:
+    """Test session name generation."""
+
+    def test_generate_session_name_format(self):
+        """Test that session name has correct format."""
+        name = flow_dump.generate_session_name()
+        assert name.startswith("flow_dump_session_")
+        assert len(name) == len("flow_dump_session_") + 8
+
+    def test_generate_session_name_unique(self):
+        """Test that generated names are unique."""
+        names = {flow_dump.generate_session_name() for _ in range(100)}
+        assert len(names) == 100
+
+
+class TestCheckSwitchType:
+    """Test switch type checking."""
+
+    @patch.object(flow_dump.swsscommon, 'DBConnector')
+    @patch.object(flow_dump.swsscommon, 'Table')
+    def test_is_dpu_type_dpu(self, mock_table_class, mock_db_connector):
+        """Test switch type check for DPU."""
+        mock_table = Mock()
+        mock_table.hget.return_value = (True, "DPU")
+        mock_table_class.return_value = mock_table
+
+        result = flow_dump.is_dpu_type()
+
+        assert result is True
+        mock_db_connector.assert_called_once_with("CONFIG_DB", 0, True)
+        mock_table_class.assert_called_once_with(mock_db_connector.return_value, "DEVICE_METADATA")
+        mock_table.hget.assert_called_once_with("localhost", "switch_type")
+
+    @patch.object(flow_dump.swsscommon, 'DBConnector')
+    @patch.object(flow_dump.swsscommon, 'Table')
+    def test_is_dpu_type_dpu_lowercase(self, mock_table_class, mock_db_connector):
+        """Test switch type check for DPU (lowercase)."""
+        mock_table = Mock()
+        mock_table.hget.return_value = (True, "dpu")
+        mock_table_class.return_value = mock_table
+
+        result = flow_dump.is_dpu_type()
+
+        assert result is True
+
+    @patch.object(flow_dump.swsscommon, 'DBConnector')
+    @patch.object(flow_dump.swsscommon, 'Table')
+    def test_is_dpu_type_not_dpu(self, mock_table_class, mock_db_connector):
+        """Test switch type check for non-DPU switch."""
+        mock_table = Mock()
+        mock_table.hget.return_value = (True, "switch")
+        mock_table_class.return_value = mock_table
+
+        result = flow_dump.is_dpu_type()
+
+        assert result is False
+
+    @patch.object(flow_dump.swsscommon, 'DBConnector')
+    @patch.object(flow_dump.swsscommon, 'Table')
+    def test_is_dpu_type_not_found(self, mock_table_class, mock_db_connector):
+        """Test switch type check when field not found."""
+        mock_table = Mock()
+        mock_table.hget.return_value = (False, None)
+        mock_table_class.return_value = mock_table
+
+        result = flow_dump.is_dpu_type()
+
+        assert result is False
+
+    @patch.object(flow_dump.swsscommon, 'DBConnector')
+    def test_is_dpu_type_exception(self, mock_db_connector):
+        """Test switch type check when exception occurs."""
+        mock_db_connector.side_effect = Exception("DB connection failed")
+
+        result = flow_dump.is_dpu_type()
+
+        assert result is False
+
+
+class TestEnsureConfigDirectory:
+    """Test config directory creation."""
+
+    @patch('os.makedirs')
+    def test_create_directory_success(self, mock_makedirs):
+        """Test successful directory creation."""
+        result = flow_dump.ensure_config_directory("/tmp/test_ha")
+        assert result is True
+        mock_makedirs.assert_called_once_with("/tmp/test_ha", exist_ok=True)
+
+    @patch('os.makedirs')
+    def test_create_directory_failure(self, mock_makedirs):
+        """Test directory creation failure."""
+        mock_makedirs.side_effect = OSError("Permission denied")
+        result = flow_dump.ensure_config_directory("/tmp/test_ha")
+        assert result is False
+
+
+class TestCreateConfigFile:
+    """Test config file creation."""
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('json.dump')
+    def test_create_config_file_success(self, mock_json_dump, mock_file):
+        """Test successful config file creation."""
+        with patch.object(flow_dump.os, 'makedirs') as mock_makedirs:
+            mock_makedirs.return_value = None
+
+            session_name = flow_dump.create_config_file(
+                "/tmp/test_flow_dump.json",
+                session_name="test_session",
+                max_flows=500,
+                timeout=120,
+                flow_state=True
+            )
+
+            assert session_name == "test_session"
+            mock_makedirs.assert_called_once()
+            mock_file.assert_called_once_with("/tmp/test_flow_dump.json", 'w')
+            mock_json_dump.assert_called_once()
+
+    def test_create_config_file_directory_failure(self):
+        """Test config file creation when directory creation fails."""
+        with patch.object(flow_dump.os, 'makedirs') as mock_makedirs:
+            mock_makedirs.side_effect = OSError("Permission denied")
+
+            session_name = flow_dump.create_config_file("/tmp/test_flow_dump.json")
+            assert session_name is None
+
+    @patch('builtins.open', new_callable=mock_open)
+    def test_create_config_file_write_error(self, mock_file):
+        """Test config file creation when write fails."""
+        with patch.object(flow_dump.os, 'makedirs') as mock_makedirs:
+            mock_makedirs.return_value = None
+            mock_file.side_effect = IOError("Write failed")
+
+            session_name = flow_dump.create_config_file("/tmp/test_flow_dump.json")
+            assert session_name is None
+
+
+class TestExtractFlowsFromFile:
+    """Test flow extraction from gzipped JSONL file."""
+
+    def test_extract_flows_empty_file(self):
+        """Test extraction from empty file."""
+        with tempfile.NamedTemporaryFile(suffix='.jsonl.gz', delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+            with gzip.open(tmp_path, 'wt') as f:
+                f.write("")
+
+        try:
+            flows = flow_dump.extract_flows_from_file(tmp_path)
+            assert flows == []
+        finally:
+            os.unlink(tmp_path)
+
+    def test_extract_flows_single_flow(self):
+        """Test extraction of single flow."""
+        flow_data = {"flow_id": "1", "eni": "eni1", "action": "forward"}
+
+        with tempfile.NamedTemporaryFile(suffix='.jsonl.gz', delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+            with gzip.open(tmp_path, 'wt') as f:
+                f.write(json.dumps(flow_data) + "\n")
+
+        try:
+            flows = flow_dump.extract_flows_from_file(tmp_path)
+            assert len(flows) == 1
+            assert flows[0] == flow_data
+        finally:
+            os.unlink(tmp_path)
+
+    def test_extract_flows_multiple_flows(self):
+        """Test extraction of multiple flows."""
+        flow1 = {"flow_id": "1", "eni": "eni1"}
+        flow2 = {"flow_id": "2", "eni": "eni2"}
+        flow3 = {"flow_id": "3", "eni": "eni3"}
+
+        with tempfile.NamedTemporaryFile(suffix='.jsonl.gz', delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+            with gzip.open(tmp_path, 'wt') as f:
+                f.write(json.dumps(flow1) + "\n")
+                f.write(json.dumps(flow2) + "\n")
+                f.write(json.dumps(flow3) + "\n")
+
+        try:
+            flows = flow_dump.extract_flows_from_file(tmp_path)
+            assert len(flows) == 3
+            assert flows[0] == flow1
+            assert flows[1] == flow2
+            assert flows[2] == flow3
+        finally:
+            os.unlink(tmp_path)
+
+    def test_extract_flows_invalid_json_skipped(self):
+        """Test that invalid JSON lines are skipped."""
+        flow1 = {"flow_id": "1", "eni": "eni1"}
+        invalid_line = "not a json object"
+        flow2 = {"flow_id": "2", "eni": "eni2"}
+
+        with tempfile.NamedTemporaryFile(suffix='.jsonl.gz', delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+            with gzip.open(tmp_path, 'wt') as f:
+                f.write(json.dumps(flow1) + "\n")
+                f.write(invalid_line + "\n")
+                f.write(json.dumps(flow2) + "\n")
+
+        try:
+            flows = flow_dump.extract_flows_from_file(tmp_path)
+            assert len(flows) == 2
+            assert flows[0] == flow1
+            assert flows[1] == flow2
+        finally:
+            os.unlink(tmp_path)
+
+    def test_extract_flows_nonexistent_file(self):
+        """Test extraction from nonexistent file."""
+        flows = flow_dump.extract_flows_from_file("/nonexistent/file.jsonl.gz")
+        assert flows == []
+
+    def test_extract_flows_empty_path(self):
+        """Test extraction with empty path."""
+        flows = flow_dump.extract_flows_from_file("")
+        assert flows == []
+
+
+class TestCheckSessionState:
+    """Test session state checking."""
+
+    def test_check_session_state_exists(self):
+        """Test checking state when session exists."""
+        mock_table = Mock()
+        mock_table.get.return_value = (True, [
+            ("state", "completed"),
+            ("output_file", "/var/dump/flows/flow_dump_0x001800800000002a.jsonl.gz"),
+            ("creation_time_in_ms", "0")
+        ])
+
+        state, output_file = flow_dump.check_session_state(mock_table, "test_session")
+
+        assert state == "completed"
+        assert output_file == "/var/dump/flows/flow_dump_0x001800800000002a.jsonl.gz"
+
+    def test_check_session_state_not_exists(self):
+        """Test checking state when session doesn't exist."""
+        mock_table = Mock()
+        mock_table.get.return_value = (False, [])
+
+        state, output_file = flow_dump.check_session_state(mock_table, "test_session")
+
+        assert state is None
+        assert output_file is None
+
+    def test_check_session_state_failed(self):
+        """Test checking state for failed session."""
+        mock_table = Mock()
+        mock_table.get.return_value = (True, [
+            ("state", "failed"),
+            ("creation_time_in_ms", "0")
+        ])
+
+        state, output_file = flow_dump.check_session_state(mock_table, "test_session")
+
+        assert state == "failed"
+        assert output_file is None
+
+
+class TestProcessNotification:
+    """Test notification processing."""
+
+    def test_process_notification_matching_session(self):
+        """Test processing notification for matching session."""
+        mock_table = Mock()
+        mock_table.get.return_value = (True, [
+            ("state", "completed"),
+            ("output_file", "/var/dump/flows/flow_dump.jsonl.gz")
+        ])
+
+        fvs = [("state", "in_progress"), ("type", "flow_dump")]
+        state, output_file = flow_dump.process_notification(
+            "test_session", "SET", fvs, "test_session", mock_table
+        )
+
+        assert state == "completed"
+        assert output_file == "/var/dump/flows/flow_dump.jsonl.gz"
+
+    def test_process_notification_non_matching_session(self):
+        """Test processing notification for different session."""
+        mock_table = Mock()
+
+        fvs = [("state", "completed")]
+        state, output_file = flow_dump.process_notification(
+            "other_session", "SET", fvs, "test_session", mock_table
+        )
+
+        assert state is None
+        assert output_file is None
+
+
+class TestTriggerFlowDump:
+    """Test flow dump triggering."""
+
+    @patch('subprocess.run')
+    def test_trigger_flow_dump_success(self, mock_run):
+        """Test successful flow dump trigger."""
+        mock_run.return_value = Mock(returncode=0, stdout="Success", stderr="")
+
+        result = flow_dump.trigger_flow_dump("/tmp/test.json")
+
+        assert result is True
+        mock_run.assert_called_once()
+
+    @patch('subprocess.run')
+    def test_trigger_flow_dump_failure(self, mock_run):
+        """Test flow dump trigger failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "docker")
+
+        result = flow_dump.trigger_flow_dump("/tmp/test.json")
+
+        assert result is False
+
+
+class TestPrintFlows:
+    """Test flow printing."""
+
+    @patch('builtins.print')
+    @patch('os.path.exists')
+    def test_print_flows_file_exists(self, mock_exists, mock_print):
+        """Test printing flows when file exists."""
+        mock_exists.return_value = True
+
+        flow1 = {"flow_id": "1", "eni": "eni1"}
+        flow2 = {"flow_id": "2", "eni": "eni2"}
+
+        with tempfile.NamedTemporaryFile(suffix='.jsonl.gz', delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+            with gzip.open(tmp_path, 'wt') as f:
+                f.write(json.dumps(flow1) + "\n")
+                f.write(json.dumps(flow2) + "\n")
+
+        try:
+            flow_dump.print_flows(tmp_path, file_only=False)
+
+            # Check that file path was printed
+            assert mock_print.call_count >= 1
+            # Check that flows were printed
+            printed_calls = [str(call) for call in mock_print.call_args_list]
+            assert any("flow_id" in str(call) for call in mock_print.call_args_list)
+        finally:
+            os.unlink(tmp_path)
+
+    @patch('builtins.print')
+    @patch('os.path.exists')
+    def test_print_flows_file_not_exists(self, mock_exists, mock_print):
+        """Test printing flows when file doesn't exist."""
+        mock_exists.return_value = False
+
+        flow_dump.print_flows("/nonexistent/file.jsonl.gz", file_only=False)
+
+        # When file doesn't exist and file_only=False, nothing is printed
+        # (only verbose messages which require verbose=True)
+        mock_print.assert_not_called()
+
+    @patch('builtins.print')
+    def test_print_flows_empty_path(self, mock_print):
+        """Test printing flows with empty path."""
+        flow_dump.print_flows("", file_only=False)
+
+        # Should not print anything
+        mock_print.assert_not_called()
+
+
+class TestIntegration:
+    """Integration tests with sample file."""
+
+    def test_extract_flows_from_sample_file(self):
+        """Test extraction from a sample flow dump file."""
+        # Create sample flow dump data similar to real file
+        sample_flows = [
+            {
+                "sai_flow_entry": {
+                    "eni_id": "eni-001",
+                    "vni": 100,
+                    "src_ip": "10.1.0.10",
+                    "dst_ip": "10.1.0.20"
+                },
+                "action": "forward",
+                "priority": 100
+            },
+            {
+                "sai_flow_entry": {
+                    "eni_id": "eni-002",
+                    "vni": 200,
+                    "src_ip": "10.2.0.10",
+                    "dst_ip": "10.2.0.20"
+                },
+                "action": "drop",
+                "priority": 200
+            }
+        ]
+
+        with tempfile.NamedTemporaryFile(suffix='.jsonl.gz', delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+            with gzip.open(tmp_path, 'wt') as f:
+                for flow in sample_flows:
+                    f.write(json.dumps(flow) + "\n")
+
+        try:
+            flows = flow_dump.extract_flows_from_file(tmp_path)
+
+            assert len(flows) == 2
+            assert flows[0] == sample_flows[0]
+            assert flows[1] == sample_flows[1]
+
+            # Verify structure
+            assert "sai_flow_entry" in flows[0]
+            assert flows[0]["sai_flow_entry"]["eni_id"] == "eni-001"
+            assert flows[1]["sai_flow_entry"]["eni_id"] == "eni-002"
+        finally:
+            os.unlink(tmp_path)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add CLI to trigger and dump flows to stdout

#### How I did it

Trigger DUMP session, wait until the status is completed and dump the flows

#### How to verify it

```
root@sonic:/home/admin# ./sonic-dpu-flow-dump.py
[
  {
    "SAI_FLOW_ENTRY_ATTR_ACTION": "SAI_FLOW_ENTRY_ACTION_SET_FLOW_ENTRY_ATTR",
    "SAI_FLOW_ENTRY_ATTR_VERSION": "1",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_VNET_ID": "100",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SIP": "3.2.1.0",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DIP": "101.1.2.3",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DASH_ENCAPSULATION": "SAI_DASH_ENCAPSULATION_NVGRE",
    "SAI_FLOW_ENTRY_ATTR_DASH_DIRECTION": "SAI_DASH_DIRECTION_OUTBOUND",
    "SAI_FLOW_ENTRY_ATTR_SIP": "fd41:108:20:d107:64:ff71:a00:b",
    "SAI_FLOW_ENTRY_ATTR_DIP": "2603:10e1:100:2::3401:203",
    "SAI_FLOW_ENTRY_ATTR_DASH_FLOW_ACTION": "65",
    "SAI_FLOW_ENTRY_ATTR_IP_ADDR_FAMILY": "SAI_IP_ADDR_FAMILY_IPV4",
    "SAI_FLOW_ENTRY_ATTR_DASH_FLOW_SYNC_STATE": "SAI_DASH_FLOW_SYNC_STATE_FLOW_CREATED",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SMAC": "B0:CF:0E:20:8E:DE",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DMAC": "B0:CF:0E:20:8E:00",
    "SAI_FLOW_ENTRY_ATTR_METER_CLASS": "3634",
    "SAI_FLOW_ENTRY_ATTR_IS_UNIDIRECTIONAL_FLOW": "true",
    "DST_IP": "10.2.0.100",
    "DST_PORT": 55057,
    "ENI_MAC": "F4:93:9F:EF:C4:7E",
    "IP_PROTO": 17,
    "SRC_IP": "10.0.0.11",
    "SRC_PORT": 34074,
    "VNET_ID": 0
  },
  {
    "SAI_FLOW_ENTRY_ATTR_ACTION": "SAI_FLOW_ENTRY_ACTION_SET_FLOW_ENTRY_ATTR",
    "SAI_FLOW_ENTRY_ATTR_VERSION": "1",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_VNET_ID": "4321",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SIP": "3.2.1.0",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DIP": "25.1.1.1",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DASH_ENCAPSULATION": "SAI_DASH_ENCAPSULATION_VXLAN",
    "SAI_FLOW_ENTRY_ATTR_DASH_DIRECTION": "SAI_DASH_DIRECTION_INBOUND",
    "SAI_FLOW_ENTRY_ATTR_SIP": "10.2.0.100",
    "SAI_FLOW_ENTRY_ATTR_DIP": "10.0.0.11",
    "SAI_FLOW_ENTRY_ATTR_DASH_FLOW_ACTION": "129",
    "SAI_FLOW_ENTRY_ATTR_IP_ADDR_FAMILY": "SAI_IP_ADDR_FAMILY_IPV6",
    "SAI_FLOW_ENTRY_ATTR_DASH_FLOW_SYNC_STATE": "SAI_DASH_FLOW_SYNC_STATE_FLOW_CREATED",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_SMAC": "B0:CF:0E:20:8E:DE",
    "SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DMAC": "B0:CF:0E:20:8E:00",
    "SAI_FLOW_ENTRY_ATTR_METER_CLASS": "3634",
    "SAI_FLOW_ENTRY_ATTR_IS_UNIDIRECTIONAL_FLOW": "true",
    "DST_IP": "fd41:108:20:d107:64:ff71:a00:b",
    "DST_PORT": 34074,
    "ENI_MAC": "F4:93:9F:EF:C4:7E",
    "IP_PROTO": 17,
    "SRC_IP": "2603:10e1:100:2::3401:203",
    "SRC_PORT": 55057,
    "VNET_ID": 0
  }
]

root@sonic:/home/admin# ./sonic-dpu-flow-dump.py -f
/var/dump/flows/flow_dump_0x0018008000000035.jsonl.gz


root@sonic:/home/admin# ./sonic-dpu-flow-dump.py -m 20000 -t 100 -v
Using session name: flow_dump_session_ipglzd7m
Triggering flow dump: docker exec swss swssconfig -e tcp://169.254.200.1 /etc/sonic/ha/flow_dump.json
Flow dump triggered successfully
Waiting for session 'flow_dump_session_ipglzd7m' to complete (timeout: 100s)...
[Notification] Received update for session 'flow_dump_session_ipglzd7m': op=SET
  type = flow_dump
  state = created
  creation_time_in_ms = 0
  last_state_start_time_in_ms = 36772876
[Notification] Current DB state: created
[Notification] Received update for session 'flow_dump_session_ipglzd7m': op=SET
  type = flow_dump
  state = completed
  creation_time_in_ms = 0
  last_state_start_time_in_ms = 36772958
  output_file = /var/dump/flows/flow_dump_0x0018008000000036.jsonl.gz
[Notification] Current DB state: completed
Output file does not exist: /var/dump/flows/flow_dump_0x0018008000000036.jsonl.gz
This may indicate that no flows were dumped (empty result)
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

