### PR TITLE
[Smartswitch] Prevent early exit of reboot status

### DIFF
--- a/scripts/reboot_smartswitch_helper
+++ b/scripts/reboot_smartswitch_helper
@@ -51,7 +51,7 @@ function get_reboot_status()
 {
     local dpu_ip=$1
     local port=$2
-    local reboot_output_file="reboot_status.txt"
+    local reboot_output_file="reboot_status_${dpu_ip}.txt"
 
     $(docker exec gnmi gnoi_client -target "${dpu_ip}:${port}" -logtostderr -notls -module System -rpc RebootStatus | tee "$reboot_output_file" &>/dev/null)
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
As the `get_reboot_status` function can be called by multiple DPUs in parallel, sometimes the same file is read by reboot_status function for multiple DPUs, as this will cause early exit from pre-shutdown for DPUs, this will cause fimrware upgrade/watchdog arm issues on DPU

#### How I did it
Create unique file based on dpu_ip so that multiple files are not created

#### How to verify it
Execute parallel reboots for multiple DPUs, and confirm that we dont get errors 
`reboot -d DPU0 &`
`reboot -d DPU1 &`
`reboot -d DPU2 &`
`reboot -d DPU3 &`
No errors seen like:
```
cat reboot_status.txt
cat: reboot_status.txt: No such file or directory
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

