### PR TITLE
[202511][fast-reboot][cosmetic] Fixed debug/error prints with the correct reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -57,7 +57,7 @@ EXIT_LEFTOVER_CPA_TUNNEL=30
 function error()
 {
     echo $@ >&2
-    logger -p user.err "Error seen during warm-reboot shutdown process: $@"
+    logger -p user.err "Error seen during $REBOOT_SCRIPT_NAME shutdown process: $@"
 }
 
 function debug()
@@ -147,7 +147,7 @@ function parseOptions()
 function clear_boot()
 {
     # common_clear
-    debug "${REBOOT_TYPE} failure ($?) cleanup ..."
+    debug "${REBOOT_SCRIPT_NAME} failure ($?) cleanup ..."
 
     /sbin/kexec -u -a || /bin/true
 
@@ -520,9 +520,9 @@ function check_pfc_storm_active()
     debug "Checking for active PFC storms..."
     
     if pfcwd show stats --check-storm >/dev/null 2>&1; then
-        debug "No active PFC storms detected. Safe to proceed with warm-reboot..."
+        debug "No active PFC storms detected. Safe to proceed with $REBOOT_SCRIPT_NAME..."
     else
-        error "PFC storm detected. Aborting warm-reboot to prevent failure in recovery path..."
+        error "PFC storm detected. Aborting $REBOOT_SCRIPT_NAME to prevent failure in recovery path..."
         exit ${EXIT_PFC_STORM_DETECTED}
     fi
 }


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Updated reboot type in debug/error prints

#### How I did it
By using REBOOT_SCRIPT_NAME var instead of a hard-coded warm-reboot

#### How to verify it
Run warm-reboot -v and fast-reboot -v and check the logs

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

