### PR TITLE
Add --brief flag to 'show version' to omit docker image output

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1708,8 +1708,8 @@ def logging(process, lines, follow, verbose):
 #
 
 @cli.command()
-@click.option("--verbose", is_flag=True, help="Enable verbose output")
-def version(verbose):
+@click.option("--brief", is_flag=True, help="Brief output, omit docker image information")
+def version(brief):
     """Show version information"""
     version_info = device_info.get_sonic_version_info()
     platform_info = device_info.get_platform_info()
@@ -1737,7 +1737,7 @@ def version(verbose):
     click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
     click.echo("Date: {}".format(sys_date.strftime("%a %d %b %Y %X")))
 
-    if verbose:
+    if not brief:
         click.echo("\nDocker images:")
         cmd = ['sudo', 'docker', 'images', '--format', "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"]
         p = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -248,6 +248,34 @@ def test_show_version():
     runner = CliRunner()
     result = runner.invoke(show.cli.commands["version"])
     assert "SONiC OS Version: 11" in result.output
+    assert "Docker images:" in result.output
+    assert "REPOSITORY   TAG" in result.output
+
+
+@patch('sonic_py_common.device_info.get_sonic_version_info', MagicMock(return_value={  # noqa: E501
+        "build_version": "release-1.1-7d94c0c28",
+        "sonic_os_version": "11",
+        "debian_version": "11.6",
+        "kernel_version": "5.10",
+        "commit_id": "7d94c0c28",
+        "build_date": "Wed Feb 15 06:17:08 UTC 2023",
+        "built_by": "AzDevOps"}))
+@patch('sonic_py_common.device_info.get_platform_info', MagicMock(return_value={  # noqa: E501
+        "platform": "x86_64-kvm_x86_64-r0",
+        "hwsku": "Force10-S6000",
+        "asic_type": "vs",
+        "asic_count": 1}))
+@patch('sonic_py_common.device_info.get_chassis_info', MagicMock(return_value={
+        "serial": "N/A",
+        "model": "N/A",
+        "revision": "N/A"}))
+@patch('subprocess.Popen', MagicMock(side_effect=side_effect_subprocess_popen))
+def test_show_version_brief():
+    runner = CliRunner()
+    result = runner.invoke(show.cli.commands["version"], ["--brief"])
+    assert "SONiC OS Version: 11" in result.output
+    assert "Docker images:" not in result.output
+    assert "REPOSITORY   TAG" not in result.output
 
 
 @patch('sonic_py_common.device_info.get_sonic_version_info', MagicMock(return_value={


### PR DESCRIPTION
#### What I did

Added a `--brief` flag to the `show version` command that omits Docker image information from the output.

#### How I did it

Updated the `version` function in `src/sonic-utilities/show/main.py`. Wrapped the Docker images retrieval and display code in an `[if not brief]` conditional so that Docker images are shown by default but omitted when `--brief` is passed.

Updated test_show_version to assert Docker image output is present by default.
Added test_show_version_brief to verify Docker image output is suppressed with `--brief`

#### How to verify it

1. Run `show version` and verify that the output shows the version/platform information with Docker image versions.
2. Run `show version --brief` and verify that the output does not include the "Docker images:" section with the list of images at the end.

#### Previous command output (if the output of a command-line utility has changed)

[show-ver-brief-output.txt](https://github.com/user-attachments/files/25857524/show-ver-brief-output.txt)

#### New command output (if the output of a command-line utility has changed)

[show-ver-brief-output.txt](https://github.com/user-attachments/files/25857528/show-ver-brief-output.txt)


Signed-off-by: Ashwin Srinivasan <ashwin.srinivasan@hpe.com>