### PR TITLE
[warm-reboot][multi-asic] Added error-handling for faulty ASIC/s after orchagent freeze

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -117,8 +117,10 @@ function execute_in_namespaces()
             pid=$!
             wait "$pid" && rc=0 || rc=$?
             if [[ $rc -ne 0 ]]; then
-                error "Command $cmd failed returned $rc"
-                exit $rc
+                error "Command $cmd failed returned $rc in global namespace"
+                if [[ $FORCE == "no" ]]; then
+                    exit $rc
+                fi
             fi
         fi
 
@@ -130,7 +132,16 @@ function execute_in_namespaces()
             # If the command failed, remove the ASIC from the list
             if [[ $rc -ne 0 ]]; then
                 error "Command $cmd failed for $dev returned $rc"
-                exit $rc
+                if [[ $FORCE == "no" ]]; then
+                    exit $rc
+                else
+                    debug "Force disabling fast/warm-reboot for asic$dev"
+                    # Remove failed ASIC from the list
+                    ASIC_LIST=(${ASIC_LIST[@]/$dev})
+                    # Disable fast/warm-reboot for the failed ASIC
+                    sonic-db-cli -n "asic$dev" HSET "FAST_RESTART_ENABLE_TABLE|system" "enable" "false" &>/dev/null || /bin/true
+                    config warm_restart disable system -n "asic$dev" &>/dev/null || /bin/true
+                fi
             fi
         done
     else


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Aligned the error-handling logic for warm/fast reboot on multi-ASIC devices

#### How I did it
FORCE var is set to "yes" on multi-ASIC devices before pausing orchagents.
I added a condition to "execute_in_namespace" function that in case of failures:
- If FORCE is false (before non-return point) - exit (fallback to clear_boot)
- If FORCE is true - removes faulty ASIC from the operational ASIC list, clear state of this ASIC

#### How to verify it
Tested on a multi-ASIC simulation, added manual failures, and verified the behavior

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

