### PR TITLE
[multi-asic] Add namespace support for show/config subinterface commands

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -9566,16 +9566,22 @@ helper.load_and_register_plugins(plugins, config)
 # 'subinterface' group ('config subinterface ...')
 #
 @config.group()
-@click.pass_context
+@click.option('-n', '--namespace', help='Namespace name',
+              required=True if multi_asic.is_multi_asic() else False,
+              type=click.Choice(multi_asic.get_namespace_list()))
 @click.option('-s', '--redis-unix-socket-path', help='unix socket path for redis connection')
-def subinterface(ctx, redis_unix_socket_path):
+@click.pass_context
+def subinterface(ctx, namespace, redis_unix_socket_path):
     """subinterface-related configuration tasks"""
-    kwargs = {}
+    if namespace is None:
+        namespace = DEFAULT_NAMESPACE
+    kwargs = {'namespace': str(namespace)}
     if redis_unix_socket_path:
         kwargs['unix_socket_path'] = redis_unix_socket_path
+        kwargs['use_unix_socket_path'] = True
     config_db = ConfigDBConnector(**kwargs)
     config_db.connect(wait_for_init=False)
-    ctx.obj = {'db': config_db}
+    ctx.obj = {'db': config_db, 'namespace': str(namespace)}
 
 def subintf_vlan_check(config_db, parent_intf, vlan):
     subintf_db = config_db.get_table('VLAN_SUB_INTERFACE')

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6249,12 +6249,16 @@ The show interface errors command provides detailed statistics and error counter
 
 **show interfaces mpls**
 
-This command is used to display the configured MPLS state for the list of configured interfaces.
+This command is used to display the configured MPLS state for the list of configured parent interfaces. Subinterfaces are not listed by this command.
 
 - Usage:
   ```
-  show interfaces mpls [<interface_name>]
+  show interfaces mpls [<interface_name>] [-d <display>] [-n <namespace>]
   ```
+
+- Options:
+  - _-d,--display_: Show interfaces (all | frontend). Default is all on single-ASIC and frontend on multi-ASIC.
+  - _-n,--namespace_: Specify one namespace on multi-ASIC systems. Omit `-n` to query all applicable namespaces.
 
 - Example:
   ```
@@ -6274,6 +6278,15 @@ This command is used to display the configured MPLS state for the list of config
   admin@sonic:~$ show interfaces mpls Ethernet4
   Interface    MPLS State
   -----------  ------------
+  Ethernet4    enable
+  ```
+
+- Example (Multi-ASIC, show MPLS state for a specific namespace):
+  ```
+  admin@sonic:~$ show interfaces mpls -n asic0
+  Interface    MPLS State
+  -----------  ------------
+  Ethernet0    disable
   Ethernet4    enable
   ```
 
@@ -12057,8 +12070,12 @@ This command displays all the subinterfaces that are configured on the device an
 
 - Usage:
   ```
-  show subinterfaces status
+  show subinterfaces status [<subinterfacename>] [-d <display>] [-n <namespace>]
   ```
+
+- Options:
+  - _-d,--display_: Show interfaces (all | frontend). Default is all on single-ASIC and frontend on multi-ASIC.
+  - _-n,--namespace_: Specify one namespace on multi-ASIC systems. Omit `-n` to display subinterfaces from all namespaces. `all` is not an accepted value.
 
 - Example:
   ```
@@ -12069,35 +12086,103 @@ This command displays all the subinterfaces that are configured on the device an
       Ethernet0.100     100G   9100    100       up  dot1q-encapsulation
   ```
 
+- Example (Multi-ASIC, show subinterfaces from all namespaces):
+  ```
+  admin@sonic:~$ show subinterfaces status
+  Sub port interface    Namespace    Speed    MTU    Vlan    Admin                 Type
+  ------------------  -----------  -------  -----  ------  -------  -------------------
+      Eth1000.100        asic1      100G    9100    100       up  dot1q-encapsulation
+      Ethernet0.100      asic0      100G    9100    100       up  dot1q-encapsulation
+  ```
+
+- Example (Multi-ASIC, show subinterfaces for a specific namespace):
+  ```
+  admin@sonic:~$ show subinterfaces status -n asic0
+  Sub port interface    Speed    MTU    Vlan    Admin                 Type
+  ------------------  -------  -----  ------  -------  -------------------
+      Ethernet0.100     100G   9100    100       up  dot1q-encapsulation
+  ```
+
 ### Subinterfaces Config Commands
 
 This sub-section explains how to configure subinterfaces.
 
-**config subinterface**
+**config subinterface add**
+
+This command is used to add a subinterface.
 
 - Usage:
   ```
-  config subinterface (add | del) <subinterface_name> [vlan <1-4094>]
+  config subinterface [-n <namespace>] [-s <redis_unix_socket_path>] add <subinterface_name> [<vid>]
   ```
 
-- Example (Create the subinterfces with name "Ethernet0.100"):
+- Options:
+  - _-n,--namespace_: Namespace name (required on multi-ASIC systems)
+  - _-s,--redis-unix-socket-path_: Unix socket path for redis connection
+
+- Arguments:
+  - _subinterface_name_: Name of the subinterface (e.g., Ethernet0.100, Eth64.100)
+  - _vid_: VLAN ID (1-4094). Required for short name subinterfaces (e.g., Eth64.100, Po1.100). Optional for long name subinterfaces (e.g., Ethernet0.100, PortChannel1.100) where the VLAN ID can be inferred from the name suffix.
+
+- Notes:
+  - The total subinterface name length must not exceed 15 characters.
+  - On platforms with large interface indices (for example, `Ethernet1000`), use the short name form (for example, `Eth1000.100`) if the long name would exceed 15 characters.
+  - For long name subinterfaces, the extra `<vid>` argument can be omitted even though `config subinterface add --help` prints `<vid>`.
+
+- Example (Create the subinterface with name "Ethernet0.100"):
   ```
   admin@sonic:~$ sudo config subinterface add Ethernet0.100
   ```
 
-- Example (Create the subinterfces with name "Eth64.100"):
+- Example (Create the subinterface with name "Eth64.100" with explicit VLAN ID):
   ```
   admin@sonic:~$ sudo config subinterface add Eth64.100 100
   ```
 
-- Example (Delete the subinterfces with name "Ethernet0.100"):
+- Example (Multi-ASIC, create a subinterface in a specific namespace):
+  ```
+  admin@sonic:~$ sudo config subinterface -n asic0 add Ethernet0.100
+  ```
+
+- Example (Multi-ASIC, create a subinterface using a Redis unix socket path):
+  ```
+  admin@sonic:~$ sudo config subinterface -n asic1 -s /var/run/redis1/redis.sock add Eth1000.100 100
+  ```
+
+**config subinterface del**
+
+This command is used to delete a subinterface.
+
+- Usage:
+  ```
+  config subinterface [-n <namespace>] [-s <redis_unix_socket_path>] del <subinterface_name>
+  ```
+
+- Options:
+  - _-n,--namespace_: Namespace name (required on multi-ASIC systems)
+  - _-s,--redis-unix-socket-path_: Unix socket path for redis connection
+
+- Arguments:
+  - _subinterface_name_: Name of the subinterface to delete
+
+- Example (Delete the subinterface with name "Ethernet0.100"):
   ```
   admin@sonic:~$ sudo config subinterface del Ethernet0.100
   ```
 
-- Example (Delete the subinterfces with name "Eth64.100"):
+- Example (Delete the subinterface with name "Eth64.100"):
   ```
-  admin@sonic:~$ sudo config subinterface del Eth64.100 100
+  admin@sonic:~$ sudo config subinterface del Eth64.100
+  ```
+
+- Example (Multi-ASIC, delete a subinterface in a specific namespace):
+  ```
+  admin@sonic:~$ sudo config subinterface -n asic0 del Ethernet0.100
+  ```
+
+- Example (Multi-ASIC, delete a subinterface using a Redis unix socket path):
+  ```
+  admin@sonic:~$ sudo config subinterface -n asic1 -s /var/run/redis1/redis.sock del Eth1000.100
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#subinterfaces)

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -492,7 +492,12 @@ class IntfStatus(object):
 
     def display_intf_status(self):
         self.get_intf_status()
-        header_status = header_stat if not self.sub_intf_only else header_stat_sub_intf
+        if not self.sub_intf_only:
+            header_status = header_stat
+        elif self.multi_asic.is_multi_asic and self.multi_asic.namespace_option is None:
+            header_status = [header_stat_sub_intf[0], 'Namespace'] + header_stat_sub_intf[1:]
+        else:
+            header_status = header_stat_sub_intf
         display_table(self.table, header_status, self.use_json)
 
     def generate_intf_status(self):
@@ -546,15 +551,28 @@ class IntfStatus(object):
                                 appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_OPTICS_TYPE, self.portchannel_speed_dict),
                                 appl_db_portchannel_status_get(self.db, self.config_db, po, PORT_PFC_ASYM_STATUS, self.portchannel_speed_dict)))
         else:
+            show_namespace = self.multi_asic.is_multi_asic and self.multi_asic.namespace_option is None
             for key in self.appl_db_sub_intf_keys:
                 sub_intf = re.split(':', key, maxsplit=1)[-1].strip()
                 if sub_intf in self.sub_intf_list:
-                    table.append((sub_intf,
+                    sub_intf_sep_idx = sub_intf.find(VLAN_SUB_INTERFACE_SEPARATOR)
+                    if sub_intf_sep_idx != -1:
+                        parent_port = get_intf_longname(sub_intf[:sub_intf_sep_idx])
+                        if parent_port.startswith("Ethernet"):
+                            if self.multi_asic.skip_display(constants.PORT_OBJ, parent_port):
+                                continue
+                        elif parent_port.startswith("PortChannel"):
+                            if self.multi_asic.skip_display(constants.PORT_CHANNEL_OBJ, parent_port):
+                                continue
+                    row = (sub_intf,
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_SPEED),
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_MTU_STATUS),
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, "vlan"),
                                 appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_ADMIN_STATUS),
-                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_OPTICS_TYPE)))
+                                appl_db_sub_intf_status_get(self.db, self.config_db, self.front_panel_ports_list, self.portchannel_speed_dict, sub_intf, PORT_OPTICS_TYPE))
+                    if show_namespace:
+                        row = (row[0], self.multi_asic.current_namespace) + row[1:]
+                    table.append(row)
         return table
 
 

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -411,6 +411,10 @@ def mpls(ctx, interfacename, namespace, display):
 
                 intf_found = True
 
+            # Skip subinterfaces (e.g., Ethernet0.100) - they are not in PORT table
+            if clicommon.VLAN_SUB_INTERFACE_SEPARATOR in ifname:
+                continue
+
             if (display != "all"):
                 if ("Loopback" in ifname):
                     continue

--- a/show/main.py
+++ b/show/main.py
@@ -624,8 +624,9 @@ def subinterfaces():
 # 'subinterfaces' subcommand ("show subinterfaces status")
 @subinterfaces.command()
 @click.argument('subinterfacename', type=str, required=False)
+@multi_asic_util.multi_asic_click_options
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def status(subinterfacename, verbose):
+def status(subinterfacename, namespace, display, verbose):
     """Show sub port interface status information"""
     cmd = ['intfutil', '-c', 'status']
 
@@ -641,6 +642,12 @@ def status(subinterfacename, verbose):
         cmd += ['-i', str(subinterfacename)]
     else:
         cmd += ['-i', 'subport']
+
+    if multi_asic.is_multi_asic():
+        cmd += ['-d', str(display)]
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
+
     run_command(cmd, display_cmd=verbose)
 
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import os
 import re
@@ -464,3 +465,75 @@ def mock_restart_dhcp_relay_service():
 
     config.vlan.dhcp_relay_util.restart_dhcp_relay_service = origin_funcs[0]
     config.vlan.is_dhcp_relay_running = origin_funcs[1]
+
+
+@pytest.fixture(scope='class')
+def setup_multi_asic_env():
+    """Set up multi-asic environment for testing.
+
+    This fixture:
+    1. Sets environment variables for multi-asic mode
+    2. Loads multi-asic mock patches via mock_multi_asic module
+    3. Reloads dependent modules to pick up patched functions
+    4. Restores single-asic state on teardown
+    """
+    # Set environment variables
+    os.environ['UTILITIES_UNIT_TESTING'] = "2"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+
+    # Import and reload to apply multi-asic patches
+    from .mock_tables import mock_multi_asic
+    importlib.reload(mock_multi_asic)
+
+    dbconnector.load_namespace_config()
+
+    # Reload dependent modules to pick up patched functions
+    importlib.reload(sys.modules['utilities_common.multi_asic'])
+    importlib.reload(sys.modules['config.main'])
+
+    yield
+
+    # Restore single-asic state
+    from .mock_tables import mock_single_asic
+    importlib.reload(mock_single_asic)
+
+    dbconnector.load_database_config()
+
+    # Reload modules to pick up restored single-asic state
+    importlib.reload(sys.modules['utilities_common.multi_asic'])
+    importlib.reload(sys.modules['config.main'])
+
+    # Reset environment
+    os.environ['UTILITIES_UNIT_TESTING'] = "0"
+    os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+
+
+@pytest.fixture(scope='class')
+def setup_env_paths(request):
+    """Add directories to PATH environment variable for subprocess-based tests.
+
+    This fixture reads 'env_paths' from the test class, which should be a list
+    of paths to add to the PATH environment variable.
+
+    Usage:
+        @pytest.mark.usefixtures("setup_env_paths")
+        class TestSomething:
+            env_paths = [scripts_path, other_path]  # List of paths to add
+    """
+    paths_to_add = getattr(request.cls, 'env_paths', None)
+    if paths_to_add is None:
+        yield
+        return
+
+    # Ensure paths_to_add is a list
+    if isinstance(paths_to_add, str):
+        paths_to_add = [paths_to_add]
+
+    original_path = os.environ.get("PATH", "")
+
+    for path in paths_to_add:
+        os.environ["PATH"] += os.pathsep + path
+
+    yield
+
+    os.environ["PATH"] = original_path

--- a/tests/mock_tables/asic0/appl_db.json
+++ b/tests/mock_tables/asic0/appl_db.json
@@ -169,5 +169,13 @@
     "NEIGH_TABLE:Ethernet20:10.0.1.1": {
         "neigh": "00:11:22:33:44:bb",
         "family": "IPv4"
+    },
+    "INTF_TABLE:PortChannel1002.10": {
+        "admin_status": "up",
+        "vlan": "10"
+    },
+    "INTF_TABLE:PortChannel4001.20": {
+        "admin_status": "up",
+        "vlan": "20"
     }
 }

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -435,5 +435,13 @@
     },
     "INTERFACE|Ethernet20": {
         "vnet_name": "Vnet_3000"
+    },
+    "VLAN_SUB_INTERFACE|PortChannel1002.10": {
+        "admin_status": "up",
+        "vlan": "10"
+    },
+    "VLAN_SUB_INTERFACE|PortChannel4001.20": {
+        "admin_status": "up",
+        "vlan": "20"
     }
 }

--- a/tests/mock_tables/asic1/appl_db.json
+++ b/tests/mock_tables/asic1/appl_db.json
@@ -123,5 +123,21 @@
     "NEIGH_TABLE:Ethernet64:10.0.2.1": {
         "neigh": "00:11:22:33:44:cc",
         "family": "IPv4"
+    },
+    "INTF_TABLE:Ethernet64.10": {
+        "admin_status": "up",
+        "vlan": "10"
+    },
+    "INTF_TABLE:Ethernet64.20": {
+        "admin_status": "up",
+        "vlan": "20"
+    },
+    "INTF_TABLE:Ethernet-BP256.20": {
+        "admin_status": "up",
+        "vlan": "20"
+    },
+    "INTF_TABLE:Eth64.30": {
+        "admin_status": "up",
+        "vlan": "30"
     }
 }

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -337,5 +337,21 @@
     },
     "INTERFACE|Ethernet64": {
         "vnet_name": "Vnet_4000"
+    },
+    "VLAN_SUB_INTERFACE|Ethernet64.10": {
+        "admin_status": "up",
+        "vlan": "10"
+    },
+    "VLAN_SUB_INTERFACE|Ethernet64.20": {
+        "admin_status": "up",
+        "vlan": "20"
+    },
+    "VLAN_SUB_INTERFACE|Ethernet-BP256.20": {
+        "admin_status": "up",
+        "vlan": "20"
+    },
+    "VLAN_SUB_INTERFACE|Eth64.30": {
+        "admin_status": "up",
+        "vlan": "30"
     }
 }

--- a/tests/multi_asic_intfutil_test.py
+++ b/tests/multi_asic_intfutil_test.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from click.testing import CliRunner
+import pytest
 
 from .utils import get_result_and_return_code
 
@@ -97,18 +97,14 @@ Ethernet-BP0      up       up  Ethernet-BP0          ASIC1:Eth0-ASIC1
 Ethernet-BP4      up       up  Ethernet-BP4          ASIC1:Eth1-ASIC1
 """
 
-intf_invalid_asic_error="""ValueError: Unknown Namespace asic99"""
+intf_invalid_asic_error = """ValueError: Unknown Namespace asic99"""
 
+
+@pytest.mark.usefixtures("setup_multi_asic_env", "setup_env_paths")
 class TestInterfacesMultiAsic(object):
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
-        os.environ["PATH"] += os.pathsep + scripts_path
-        os.environ["UTILITIES_UNIT_TESTING"] = "2"
-        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+    """Test interface utilities on multi-asic platforms."""
 
-    def setUp(self):
-        self.runner = CliRunner()
+    env_paths = [scripts_path]
 
     def test_multi_asic_interface_status_all(self):
         return_code, result = get_result_and_return_code(['intfutil', '-c', 'status', '-d', 'all'])
@@ -200,9 +196,129 @@ class TestInterfacesMultiAsic(object):
         assert return_code == 1
         assert result == intf_invalid_asic_error
 
-    def teardown_class(cls):
-        print("TEARDOWN")
-        os.environ["PATH"] = os.pathsep.join(
-            os.environ["PATH"].split(os.pathsep)[:-1])
-        os.environ["UTILITIES_UNIT_TESTING"] = "0"
-        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+
+@pytest.mark.usefixtures("setup_multi_asic_env", "setup_env_paths")
+class TestSubinterfacesMultiAsic(object):
+    """Test subinterface status display on multi-asic platforms.
+
+    These tests verify that subinterfaces on internal ports are filtered
+    correctly when display option is 'frontend' (external only).
+    Uses subprocess-based testing with static mock data to avoid namespace pollution.
+    """
+
+    env_paths = [scripts_path]
+
+    def test_subintf_status_asic1_frontend(self):
+        """Subinterfaces on internal ports filtered when display=frontend."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport', '-n', 'asic1']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        # External port subinterfaces should be present
+        assert 'Ethernet64.10' in result
+        assert 'Ethernet64.20' in result
+        assert 'Eth64.30' in result
+        # Internal port subinterface should NOT be present (filtered)
+        assert 'Ethernet-BP256.20' not in result
+
+    def test_subintf_status_asic1_all(self):
+        """All subinterfaces shown when display=all."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport', '-n', 'asic1', '-d', 'all']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        # All subinterfaces should be present including internal
+        assert 'Ethernet64.10' in result
+        assert 'Ethernet64.20' in result
+        assert 'Eth64.30' in result
+        assert 'Ethernet-BP256.20' in result
+
+    def test_subintf_status_asic0_frontend(self):
+        """PortChannel subinterfaces on internal ports filtered."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport', '-n', 'asic0']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        # External PortChannel subinterface should be present
+        assert 'PortChannel1002.10' in result
+        # Internal PortChannel subinterface should NOT be present (filtered)
+        assert 'PortChannel4001.20' not in result
+
+    def test_subintf_status_asic0_all(self):
+        """All PortChannel subinterfaces shown when display=all."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport', '-n', 'asic0', '-d', 'all']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        # All subinterfaces should be present including internal
+        assert 'PortChannel1002.10' in result
+        assert 'PortChannel4001.20' in result
+
+    def test_subintf_status_namespace_isolation(self):
+        """Subinterfaces only appear in their own namespace."""
+        # asic1 subinterfaces should not appear in asic0
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport', '-n', 'asic0', '-d', 'all']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert 'Ethernet64.10' not in result
+        assert 'Eth64.30' not in result
+
+    def test_subintf_status_specific_name(self):
+        """Query specific subinterface by name - should only show that one."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'Ethernet64.10', '-n', 'asic1', '-d', 'all']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert 'Ethernet64.10' in result
+        # Should NOT include Ethernet64.20 (different subinterface on same parent)
+        assert 'Ethernet64.20' not in result
+
+    def test_subintf_short_name_format(self):
+        """Short name format subinterface (Eth64.30) shown correctly."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport', '-n', 'asic1', '-d', 'all']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert 'Eth64.30' in result
+
+    def test_subintf_status_all_namespaces(self):
+        """Without -n, subinterfaces shown with Namespace column (frontend only)."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert 'Namespace' in result
+        assert 'asic0' in result
+        assert 'PortChannel1002.10' in result
+        assert 'PortChannel4001.20' not in result
+
+    def test_subintf_status_all_namespaces_display_all(self):
+        """Without -n and display=all, subinterfaces from all namespaces shown."""
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'subport', '-d', 'all']
+        )
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert 'Namespace' in result
+        assert 'asic0' in result
+        assert 'asic1' in result
+        assert 'PortChannel1002.10' in result
+        assert 'Ethernet64.10' in result

--- a/tests/multi_asic_subintf_test.py
+++ b/tests/multi_asic_subintf_test.py
@@ -1,0 +1,286 @@
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+
+@pytest.mark.usefixtures("setup_multi_asic_env")
+class TestSubinterfaceMultiAsic(object):
+    """Test subinterface operations on multi-asic platforms."""
+
+    def test_add_del_subintf_with_namespace(self):
+        """Test adding and deleting subinterface with namespace option"""
+        runner = CliRunner()
+        db = Db()
+        # asic1 has Ethernet64 which is not a member of any portchannel or vlan
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Add subinterface on asic1
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.100"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Ethernet64.100' in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+        assert cfgdb1.get_table('VLAN_SUB_INTERFACE')['Ethernet64.100']['admin_status'] == 'up'
+
+        # Delete subinterface on asic1
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Ethernet64.100"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Ethernet64.100' not in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+
+    def test_subintf_with_vlan_id_and_namespace(self):
+        """Test adding subinterface with VLAN ID using namespace option"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Add subinterface with VLAN ID on asic1
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Eth64.200", "200"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Eth64.200' in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+        assert cfgdb1.get_table('VLAN_SUB_INTERFACE')['Eth64.200']['vlan'] == '200'
+        assert cfgdb1.get_table('VLAN_SUB_INTERFACE')['Eth64.200']['admin_status'] == 'up'
+
+        # Delete subinterface on asic1
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Eth64.200"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Eth64.200' not in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+
+    def test_subintf_namespace_isolation(self):
+        """Test that subinterfaces are isolated between namespaces"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Add subinterface on asic1 with two different subinterfaces
+        # to verify they are properly stored
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.100"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.200"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # Verify both subinterfaces exist in asic1
+        assert 'Ethernet64.100' in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+        assert 'Ethernet64.200' in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+
+        # Cleanup
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Ethernet64.100"], obj=obj)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Ethernet64.200"], obj=obj)
+        assert result.exit_code == 0
+
+    def test_subintf_invalid_parent_in_namespace(self):
+        """Test that creating subinterface on non-existent parent interface fails"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb0 = db.cfgdb_clients['asic0']
+        obj = {'db': cfgdb0, 'namespace': 'asic0'}
+
+        # Try to add subinterface on a port that doesn't exist in asic0
+        # Ethernet64 exists only in asic1
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.100"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert "parent interface not found" in result.output
+
+    def test_subintf_portchannel_with_namespace(self):
+        """Test adding subinterface on PortChannel with namespace option"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Add subinterface on PortChannel4009 in asic1
+        # PortChannel4009 exists in asic1 and is not a VLAN member
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Po4009.300", "300"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Po4009.300' in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+        assert cfgdb1.get_table('VLAN_SUB_INTERFACE')['Po4009.300']['vlan'] == '300'
+        assert cfgdb1.get_table('VLAN_SUB_INTERFACE')['Po4009.300']['admin_status'] == 'up'
+
+        # Delete subinterface
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Po4009.300"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Po4009.300' not in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+
+    def test_subintf_on_lag_member_with_namespace(self):
+        """Test that creating subinterface on LAG member fails with namespace"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb0 = db.cfgdb_clients['asic0']
+        obj = {'db': cfgdb0, 'namespace': 'asic0'}
+
+        # Ethernet0 is a member of PortChannel1002 in asic0
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet0.100"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert "member of portchannel" in result.output
+
+    def test_del_nonexistent_subintf_with_namespace(self):
+        """Test deleting non-existent subinterface with namespace fails"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Try to delete a subinterface that doesn't exist
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Ethernet64.999"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+
+    def test_add_existing_subintf_with_namespace(self):
+        """Test that adding duplicate subinterface fails with namespace"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Add subinterface first time
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.400"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Ethernet64.400' in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+
+        # Try to add same subinterface again - should fail
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.400"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+
+        # Cleanup
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Ethernet64.400"], obj=obj)
+        assert result.exit_code == 0
+
+    def test_subintf_name_too_long_with_namespace(self):
+        """Test that subinterface name exceeding 15 characters fails with namespace"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Subinterface name > 15 characters should fail
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.000001", "1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert "Subinterface name length should not exceed 15 characters" in result.output
+
+    def test_subintf_short_name_without_vid_with_namespace(self):
+        """Test that short name subinterface without VLAN ID fails with namespace"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Short name (Eth64.500) without vid should fail
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Eth64.500"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert "Encap vlan is mandatory" in result.output
+
+    def test_subintf_duplicate_encap_vlan_with_namespace(self):
+        """Test that duplicate encap VLAN on same parent interface fails with namespace"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Add first subinterface with vlan 600
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64.600"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert 'Ethernet64.600' in cfgdb1.get_table('VLAN_SUB_INTERFACE')
+
+        # Try to add another subinterface with same encap vlan 600 - should fail
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Eth64.601", "600"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert "encap already configured" in result.output
+
+        # Cleanup
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Ethernet64.600"], obj=obj)
+        assert result.exit_code == 0
+
+    def test_subintf_invalid_format_with_namespace(self):
+        """Test that invalid subinterface format fails with namespace"""
+        runner = CliRunner()
+        db = Db()
+        cfgdb1 = db.cfgdb_clients['asic1']
+        obj = {'db': cfgdb1, 'namespace': 'asic1'}
+
+        # Missing dot separator - invalid format for add
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Ethernet64"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+
+        # Invalid prefix (not Eth or Po)
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"],
+                               ["Vlan100.10"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+
+        # Missing dot separator - invalid format for del
+        result = runner.invoke(config.config.commands["subinterface"].commands["del"],
+                               ["Ethernet64"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+
+    def test_show_subinterfaces_status_multi_asic(self):
+        """Test show subinterfaces status builds correct command in multi-asic mode"""
+        status_cmd = show.cli.commands["subinterfaces"].commands["status"]
+        with mock.patch.object(show, 'run_command') as mock_run, \
+             mock.patch.object(show.multi_asic, 'is_multi_asic', return_value=True):
+            status_cmd.callback(
+                subinterfacename=None, namespace=None,
+                display="frontend", verbose=True
+            )
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ['intfutil', '-c', 'status', '-i', 'subport',
+                           '-d', 'frontend']
+
+    def test_show_subinterfaces_status_multi_asic_with_namespace(self):
+        """Test show subinterfaces status passes namespace in multi-asic mode"""
+        status_cmd = show.cli.commands["subinterfaces"].commands["status"]
+        with mock.patch.object(show, 'run_command') as mock_run, \
+             mock.patch.object(show.multi_asic, 'is_multi_asic', return_value=True):
+            status_cmd.callback(
+                subinterfacename=None, namespace="asic0",
+                display="frontend", verbose=True
+            )
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ['intfutil', '-c', 'status', '-i', 'subport',
+                           '-d', 'frontend', '-n', 'asic0']

--- a/tests/subintf_test.py
+++ b/tests/subintf_test.py
@@ -323,6 +323,19 @@ class TestSubinterface(object):
         assert result.exit_code == 0
         assert ('Po0004.1004') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
+    def test_subintf_via_group_command(self):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["subinterface"],
+                               ["add", "Ethernet0.102"])
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+    def test_subintf_via_group_command_with_redis_socket(self):
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["subinterface"],
+                               ["-s", "/tmp/test.sock", "add", "Ethernet0.103"])
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added multi-ASIC namespace support for `show subinterfaces status` and `config subinterface (add | del)` commands.

On multi-ASIC platforms, subinterfaces belong to a specific ASIC namespace. Previously, these commands did not accept a namespace option, so they could only operate on the default (host) namespace. This change enables users to target a specific ASIC namespace when showing or configuring subinterfaces.

#### How I did it
- **`config subinterface`** (`config/main.py`): Added `-n/--namespace` option to the `config subinterface` group command. The namespace is required on multi-ASIC systems and is passed to `ConfigDBConnector` so that add/del operations target the correct per-ASIC config DB.

- **`show subinterfaces status`** (`show/main.py`): Added `@multi_asic_click_options` decorator to inject the standard `-n/--namespace` and `-d/--display` options. These are forwarded to the `intfutil` script.

- **`intfutil`** (`scripts/intfutil`): Updated the subinterface status display logic to:
  - Add a "Namespace" column when displaying subinterfaces across all namespaces on a multi-ASIC system.
  - Filter subinterfaces based on the multi-ASIC display rules (frontend vs. all) by checking parent port visibility via `skip_display`.
  - Include the current namespace value in each row when showing all namespaces.

- **`show interfaces mpls`** (`show/interfaces/__init__.py`): Added a guard to skip subinterface entries (e.g., `Ethernet0.100`) when iterating PORT table keys, preventing `KeyError` on multi-ASIC systems where subinterface keys may appear alongside port keys.

- **Command Reference** (`doc/Command-Reference.md`): Updated documentation for `show subinterfaces status` and `config subinterface add/del` to reflect the new namespace options, usage syntax, and multi-ASIC examples.

- **Unit tests**: Added comprehensive multi-ASIC unit tests in `tests/multi_asic_subintf_test.py` covering:
  - `show subinterfaces status` with namespace filtering and "all" display
  - `config subinterface add/del` with namespace for Ethernet and PortChannel parent interfaces (both long and short names)
  - Namespace isolation, invalid parent interface, duplicate subinterface, duplicate encap VLAN, name length validation, LAG member check, and invalid format scenarios
  - Added mock table entries in `tests/mock_tables/asic0/` and `tests/mock_tables/asic1/` for subinterface testing
  - Updated `tests/conftest.py` with a `setup_multi_asic_db` fixture for multi-ASIC DB initialization
  - Extended `tests/multi_asic_intfutil_test.py` with subinterface status test cases

#### How to verify it
1. On a multi-ASIC system, run:
   ```
   show subinterfaces status
   show subinterfaces status -n asic0
   show subinterfaces status -n asic1
   show subinterfaces status -d all
   ```
2. Configure subinterfaces with namespace:
   ```
   sudo config subinterface -n asic0 add Ethernet0.100
   sudo config subinterface -n asic0 del Ethernet0.100
   sudo config subinterface -n asic1 add Eth64.200 200
   sudo config subinterface -n asic1 del Eth64.200
   ```
3. Run unit tests:
   ```
   python -m pytest tests/multi_asic_subintf_test.py -v
   python -m pytest tests/multi_asic_intfutil_test.py -v
   ```

#### Previous command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show subinterfaces status
Sub port interface    Speed    MTU    Vlan    Admin                 Type
------------------  -------  -----  ------  -------  -------------------
    Ethernet0.100     100G   9100    100       up  dot1q-encapsulation
```

#### New command output (if the output of a command-line utility has changed)
Single namespace query:
```
admin@sonic:~$ show subinterfaces status -n asic0
Sub port interface    Speed    MTU    Vlan    Admin                 Type
------------------  -------  -----  ------  -------  -------------------
    Ethernet0.100     100G   9100    100       up  dot1q-encapsulation
```

All namespaces (no `-n` option on a multi-ASIC system):
```
admin@sonic:~$ show subinterfaces status
Sub port interface    Namespace    Speed    MTU    Vlan    Admin                 Type
------------------  -----------  -------  -----  ------  -------  -------------------
    Ethernet0.100        asic0     100G   9100    100       up  dot1q-encapsulation
   Ethernet64.10        asic1     100G   9100     10       up  dot1q-encapsulation
```
