### PR TITLE
scripts/generate_dump: Fix duplicate generate_dump entry

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2394,7 +2394,7 @@ main() {
     # Start with this script so its obvious what code is responsible
     $LN $V -s /usr/local/bin/generate_dump $TARDIR
     $TAR $V -chf $TARFILE -C $DUMPDIR $BASE
-    $RM $V -f $TARDIR/sonic_dump
+    $RM $V -f $TARDIR/generate_dump
 
     # Start populating timing data
     echo $BASE > $TECHSUPPORT_TIME_INFO


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
fixes #4292 
#### What I did
The `generate_dump` script creates a symlink to itself in the dump directory before generating the initial tar archive. However, due to a typo in the cleanup step, the symlink was not correctly removed. As a result, when the dump directory was appended later using `save_to_tar`, the `generate_dump` entry was added a second time.

This patch corrects the cleanup target so that `generate_dump` symlink is properly removed, preventing duplicate.
#### How I did it
Updated the cleanup step in `generate_dump`:
From:
`$RM $V -f $TARDIR/sonic_dump`
To:
`$RM $V -f $TARDIR/generate_dump`
#### How to verify it
1. Run `show techsupport` on a SONiC target device.
2. Inspect the resulting tar archive in the path `/var/dump`. It should look like `sonic_dump_sonic_20260116_001237.tar.gz`.
3. Confirm that the dump directory should only contain a single `generate_dump`. 

**Which release branch to backport**

- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505
- [x] 202511
- [x] 202605

Signed-off-by: Yi Xu <Yi.Xu@lumentum.com>