### PR TITLE
[warm-reboot] Fix probe failure with non-SONiC peers

### DIFF
--- a/scripts/teamd_increase_retry_count.py
+++ b/scripts/teamd_increase_retry_count.py
@@ -266,9 +266,10 @@ def main(probeOnly=False, namespace=""):
                     log.log_warning("WARNING: No peer description available via LLDP for {}; skipping".format(portName))
                     continue
                 portChannelChecked = True
+                # Don't fail the port channel for non-SONiC peers, just skip the probe
                 if "sonic" not in peerInfo["descr"].lower():
-                    log.log_warning("WARNING: Peer device is not a SONiC device; skipping")
-                    failedPortChannels.append(portChannel)
+                    log.log_warning("WARNING: Peer device {} is not a SONiC device; "
+                                    "skipping teamd retry count probe".format(peerName))
                     break
 
                 sendReadyEvent = Event()


### PR DESCRIPTION
#### What I did

Fixes [issues #21996](https://github.com/sonic-net/sonic-buildimage/issues/21996)

Fix issue where warm-reboot fails when port channels are connected to non-SONiC peer devices (e.g., Arista cEOS, vEOS).

The `teamd_increase_retry_count.py` script was incorrectly marking port channels as failed when detecting non-SONiC peers. Since the teamd retry count feature is SONiC-specific, the script should skip the probe for non-SONiC devices rather than failing.

#### How I did it

- Remove `failedPortChannels.append()` for non-SONiC peers
- Improve warning message to include peer device name and context

#### How to verify it

Run the teamd probe on a T0 topology with non-SONiC T1 peers (e.g., Arista cEOS).

**Expected behavior:** Script logs warnings for non-SONiC peers and exits with code 0. Previously, it would append to `failedPortChannels` and exit with code 2, blocking warm-reboot.

**Manual probe test:**
```shell
admin@sonic:~$ sudo /usr/local/bin/teamd_increase_retry_count.py --probe-only
admin@sonic:~$ echo $?
0
admin@sonic:~$ sudo journalctl --since "1 minute ago" | grep -i "Peer device"
Feb 25 08:28:33 sonic teamd_increase_retry_count.py[30253]: WARNING: Peer device ARISTA01T1 is not a SONiC device; skipping teamd retry count probe
Feb 25 08:28:33 sonic teamd_increase_retry_count.py[30253]: WARNING: Peer device ARISTA02T1 is not a SONiC device; skipping teamd retry count probe
Feb 25 08:28:33 sonic teamd_increase_retry_count.py[30253]: WARNING: Peer device ARISTA03T1 is not a SONiC device; skipping teamd retry count probe
Feb 25 08:28:34 sonic teamd_increase_retry_count.py[30253]: WARNING: Peer device ARISTA04T1 is not a SONiC device; skipping teamd retry count probe
```

**Warm-reboot test (capture logs):**
```shell
admin@sonic:~$ sudo journalctl -f -t teamd_increase_retry_count.py > /home/admin/teamd_probe_logs.txt &
admin@sonic:~$ sudo warm-reboot
...
admin@sonic:~$ cat teamd_probe_logs.txt
Feb 25 08:31:38 sonic teamd_increase_retry_count.py[33915]: WARNING: Peer device ARISTA01T1 is not a SONiC device; skipping teamd retry count probe
Feb 25 08:31:39 sonic teamd_increase_retry_count.py[33915]: WARNING: Peer device ARISTA02T1 is not a SONiC device; skipping teamd retry count probe
Feb 25 08:31:39 sonic teamd_increase_retry_count.py[33915]: WARNING: Peer device ARISTA03T1 is not a SONiC device; skipping teamd retry count probe
Feb 25 08:31:39 sonic teamd_increase_retry_count.py[33915]: WARNING: Peer device ARISTA04T1 is not a SONiC device; skipping teamd retry count probe
```

#### Previous command output (if the output of a command-line utility has changed)

```shell
admin@sonic:~$ sudo warm-reboot
ERROR: There are port channels/peer devices that failed the probe: ['PortChannel101', 'PortChannel102', 'PortChannel103', 'PortChannel104']
```
