### PR TITLE
Show error message when FEC histogram is not available

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -882,7 +882,7 @@ def fetch_fec_histogram(db, namespace, port_oid_map, target_port):
     if asic_db_kvp is not None:
 
         fec_errors = {f'BIN{i}': asic_db_kvp.get
-                      (f'SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S{i}', '0') for i in range(16)}
+                      (f'SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S{i}', 'UNDEFINED') for i in range(16)}
 
         # Prepare the data for tabulation
         table_data = [(bin_label, error_value) for bin_label, error_value in fec_errors.items()]
@@ -892,6 +892,11 @@ def fetch_fec_histogram(db, namespace, port_oid_map, target_port):
 
         # Print FEC histogram using tabulate
         click.echo(tabulate(table_data, headers=headers))
+
+        # Show a message where there are missing histogram data
+        bins_count = sum(key.startswith('SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S') for key in asic_db_kvp)
+        if bins_count == 0:
+            click.echo('FEC histogram data for port {} not found'.format(target_port), err=True)
     else:
         click.echo('No kvp found in ASIC DB for port {}, exiting'.format(target_port), err=True)
         raise click.Abort()

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -82,6 +82,28 @@ BIN14                                   0
 BIN15                                   0
 """
 
+intf_fec_counters_fec_hist_unsupported = """\
+Symbol Errors Per Codeword    Codewords
+----------------------------  -----------
+BIN0                          UNDEFINED
+BIN1                          UNDEFINED
+BIN2                          UNDEFINED
+BIN3                          UNDEFINED
+BIN4                          UNDEFINED
+BIN5                          UNDEFINED
+BIN6                          UNDEFINED
+BIN7                          UNDEFINED
+BIN8                          UNDEFINED
+BIN9                          UNDEFINED
+BIN10                         UNDEFINED
+BIN11                         UNDEFINED
+BIN12                         UNDEFINED
+BIN13                         UNDEFINED
+BIN14                         UNDEFINED
+BIN15                         UNDEFINED
+FEC histogram data for port Ethernet4 not found
+"""
+
 intf_fec_counters_period = """\
 The rates are calculated within 3 seconds period
     IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
@@ -496,6 +518,15 @@ class TestPortStat(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == intf_fec_counters_fec_hist
+
+    def test_show_intf_counters_fec_histogram_unsupported(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["fec-histogram"], ["Ethernet4"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == intf_fec_counters_fec_hist_unsupported
 
     def test_show_intf_fec_counters_period(self):
         runner = CliRunner()


### PR DESCRIPTION
When the SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S[0-15] counter is not available on COUNTERS_DB, the command `show interfaces counters fec-histogram` prints all bins with value equals zero without any error message. This change fixes this behavior.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modified the output of `show interfaces counters fec-histogram` command when the histogram bins data are not found in the COUNTERS_DB (this is likely to be a bug on modular switches which is under investigation on a separate topic).

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
$ show interfaces counters fec-histogram Ethernet104 -n asic0
Symbol Errors Per Codeword      Codewords
----------------------------  -----------
BIN0                                    0
BIN1                                    0
BIN2                                    0
BIN3                                    0
BIN4                                    0
BIN5                                    0
BIN6                                    0
BIN7                                    0
BIN8                                    0
BIN9                                    0
BIN10                                   0
BIN11                                   0
BIN12                                   0
BIN13                                   0
BIN14                                   0
BIN15                                   0
```

#### New command output (if the output of a command-line utility has changed)
```
$ show interfaces counters fec-histogram Ethernet104 -n asic0
Symbol Errors Per Codeword    Codewords
----------------------------  -----------
BIN0                          UNDEFINED
BIN1                          UNDEFINED
BIN2                          UNDEFINED
BIN3                          UNDEFINED
BIN4                          UNDEFINED
BIN5                          UNDEFINED
BIN6                          UNDEFINED
BIN7                          UNDEFINED
BIN8                          UNDEFINED
BIN9                          UNDEFINED
BIN10                         UNDEFINED
BIN11                         UNDEFINED
BIN12                         UNDEFINED
BIN13                         UNDEFINED
BIN14                         UNDEFINED
BIN15                         UNDEFINED
FEC histogram data for port Ethernet104 not found
```
