### PR TITLE
Fix issue: pmon services's restart count is not cleared during config reload

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1005,14 +1005,21 @@ def _stop_services():
     clicommon.run_command(['sudo', 'systemctl', 'stop', 'sonic.target', '--job-mode', 'replace-irreversibly'])
 
 
-def _get_sonic_services():
+def _get_sonic_services(reverse=False):
     cmd = ['systemctl', 'list-dependencies', '--plain', 'sonic.target']
+    if reverse:
+        cmd.append('--reverse')
+
     out, _ = clicommon.run_command(cmd, return_cmd=True)
     out = out.strip().split('\n')[1:]
     return (unit.strip() for unit in out)
 
+
 def _reset_failed_services():
-    for service in _get_sonic_services():
+    services = set(_get_sonic_services())
+    services.update(set(_get_sonic_services(True)))
+
+    for service in services:
         clicommon.run_command(['systemctl', 'reset-failed', str(service)])
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -1009,6 +1009,7 @@ def _get_sonic_services(reverse=False):
     cmd = ['systemctl', 'list-dependencies', '--plain', 'sonic.target']
     if reverse:
         cmd.append('--reverse')
+        cmd.append('--type=service')
 
     out, _ = clicommon.run_command(cmd, return_cmd=True)
     out = out.strip().split('\n')[1:]

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1067,7 +1067,7 @@ class TestLoadMinigraph(object):
                 (load_minigraph_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 19
+            assert mock_run_command.call_count == 20
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
                 mock.MagicMock(return_value=("dummy_path", None)))
@@ -1111,7 +1111,7 @@ class TestLoadMinigraph(object):
                 assert result.exit_code == 0
                 assert result.output == \
                     load_minigraph_command_bypass_lock_output.format(config.SYSTEM_RELOAD_LOCK)
-                assert mock_run_command.call_count == 15
+                assert mock_run_command.call_count == 16
             finally:
                 flock.release_flock(fd)
 
@@ -1129,7 +1129,7 @@ class TestLoadMinigraph(object):
                 (load_minigraph_platform_plugin_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 15
+            assert mock_run_command.call_count == 16
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_false_path, None)))
     def test_load_minigraph_platform_plugin_fail(self, get_cmd_module, setup_single_broadcom_asic):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -317,6 +317,8 @@ def mock_run_command_side_effect(*args, **kwargs):
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
             return 'sonic.target\nswss\nfeatured.timer', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
@@ -343,6 +345,8 @@ def mock_run_command_cat_failed_side_effect(*args, **kwargs):
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
             return 'sonic.target\nswss', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
@@ -365,6 +369,8 @@ def mock_run_command_kill_failed_side_effect(*args, **kwargs):
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
             return 'sonic.target\nswss', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
@@ -389,6 +395,8 @@ def mock_run_command_side_effect_disabled_timer(*args, **kwargs):
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
             return 'sonic.target\nswss', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'masked', 0
         elif command == "systemctl show swss.service --property ActiveState --value":
@@ -1067,7 +1075,8 @@ class TestLoadMinigraph(object):
                 (load_minigraph_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 20
+            mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'pmon'])
+            assert mock_run_command.call_count == 21
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
                 mock.MagicMock(return_value=("dummy_path", None)))
@@ -1111,7 +1120,9 @@ class TestLoadMinigraph(object):
                 assert result.exit_code == 0
                 assert result.output == \
                     load_minigraph_command_bypass_lock_output.format(config.SYSTEM_RELOAD_LOCK)
-                assert mock_run_command.call_count == 16
+                mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
+                mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'pmon'])
+                assert mock_run_command.call_count == 17
             finally:
                 flock.release_flock(fd)
 
@@ -1129,7 +1140,8 @@ class TestLoadMinigraph(object):
                 (load_minigraph_platform_plugin_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 16
+            mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'pmon'])
+            assert mock_run_command.call_count == 17
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_false_path, None)))
     def test_load_minigraph_platform_plugin_fail(self, get_cmd_module, setup_single_broadcom_asic):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Currently, when "config reload" is executed, services' restart count are cleared to avoid reaching restart limit. This is done by listing all services using command systemctl list-dependencies --plain .target. However, this doesn't include pmon service, neither all other services that don't have WantedBy=sonic.target, which means pmon's start count is not cleared.

#### How I did it

Sometimes pmon fails to restart due to reaching start limit (3 times in 1200 seconds). The pmon service can be started by featured, syncd during config reload. Before multi-ASIC, pmon depends on syncd. The dependency is removed after multi-ASIC, which means pmon can restart immediately triggered by sonic.target which is once more restarting. As a result the pmon service is more likely to reach the restart limit.

#### How to verify it

Clear restart count also for services that have reverse dependency on sonic.target.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

