### PR TITLE
GCU: Add path tracing support

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -33,6 +33,7 @@ from sonic_py_common import device_info, multi_asic
 from sonic_py_common.general import getstatusoutput_noshell
 from sonic_py_common.interface import get_interface_table_name, get_port_table_name, get_intf_longname
 from sonic_yang_cfg_generator import SonicYangCfgDbGenerator
+from typing import IO, Optional
 from utilities_common import util_base
 from swsscommon import swsscommon
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, ConfigDBPipeConnector, \
@@ -1387,12 +1388,21 @@ def multiasic_save_to_singlefile(db, filename):
         json.dump(all_current_config, file, indent=4)
 
 
-def apply_patch_wrapper(args):
-    return apply_patch_for_scope(*args)
+def apply_patch_wrapper(args, **kwargs):
+    return apply_patch_for_scope(*args, **kwargs)
 
 
 # Function to apply patch for a single ASIC.
-def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_path):
+def apply_patch_for_scope(
+    scope_changes,
+    results,
+    config_format,
+    verbose,
+    dry_run,
+    ignore_non_yang_tables,
+    ignore_path,
+    trace_io: Optional[IO] = None,
+):
     scope, changes = scope_changes
     # Replace localhost to DEFAULT_NAMESPACE which is db definition of Host
     if scope.lower() == HOST_NAMESPACE or scope == "":
@@ -1409,7 +1419,8 @@ def apply_patch_for_scope(scope_changes, results, config_format, verbose, dry_ru
                                                 verbose,
                                                 dry_run,
                                                 ignore_non_yang_tables,
-                                                ignore_path)
+                                                ignore_path,
+                                                trace_io=trace_io)
         results[scope_for_log] = {"success": True, "message": "Success"}
         log.log_notice(f"'apply-patch' executed successfully for {scope_for_log} by {changes} in thread:{thread_id}")
     except Exception as e:
@@ -1902,8 +1913,26 @@ def print_dry_run_message(dry_run):
 @click.option('-n', '--ignore-non-yang-tables', is_flag=True, default=False, help='ignore validation for tables without YANG models', hidden=True)
 @click.option('-i', '--ignore-path', multiple=True, help='ignore validation for config specified by given path which is a JsonPointer', hidden=True)
 @click.option('-v', '--verbose', is_flag=True, default=False, help='print additional details of what the operation is doing')
+@click.option(
+    '-t',
+    '--path-trace',
+    type=click.Path(writable=True),
+    help='filename to write decision path trace for patch generation as JSON',
+    hidden=True,
+)
+
 @click.pass_context
-def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang_tables, ignore_path, verbose):
+def apply_patch(
+    ctx,
+    patch_file_path,
+    format,
+    dry_run,
+    parallel,
+    ignore_non_yang_tables,
+    ignore_path,
+    verbose,
+    path_trace,
+):
     """Apply given patch of updates to Config. A patch is a JsonPatch which follows rfc6902.
        This command can be used do partial updates to the config with minimum disruption to running processes.
        It allows addition as well as deletion of configs. The patch file represents a diff of ConfigDb(ABNF)
@@ -1917,6 +1946,10 @@ def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang
             text = fh.read()
             patch_as_json = json.loads(text)
             patch_ops = patch_as_json
+
+        trace_io = None
+        if path_trace is not None:
+            trace_io = open(path_trace, 'w')
 
         all_running_config = get_all_running_config()
 
@@ -1968,7 +2001,7 @@ def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang
                              for scope_changes in changes_by_scope.items()]
 
                 # Submit all tasks and wait for them to complete
-                futures = [executor.submit(apply_patch_wrapper, args) for args in arguments]
+                futures = [executor.submit(apply_patch_wrapper, args, trace_io=trace_io) for args in arguments]
 
                 # Wait for all tasks to complete
                 concurrent.futures.wait(futures)
@@ -1979,10 +2012,14 @@ def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang
                                       config_format,
                                       verbose, dry_run,
                                       ignore_non_yang_tables,
-                                      ignore_path)
+                                      ignore_path,
+                                      trace_io=trace_io)
 
         # Check if any updates failed
         failures = [scope for scope, result in results.items() if not result['success']]
+
+        if trace_io is not None:
+            trace_io.close()
 
         if failures:
             failure_messages = '\n'.join([f"- {failed_scope}: {results[failed_scope]['message']}" for failed_scope in failures])
@@ -2004,8 +2041,15 @@ def apply_patch(ctx, patch_file_path, format, dry_run, parallel, ignore_non_yang
 @click.option('-n', '--ignore-non-yang-tables', is_flag=True, default=False, help='ignore validation for tables without YANG models', hidden=True)
 @click.option('-i', '--ignore-path', multiple=True, help='ignore validation for config specified by given path which is a JsonPointer', hidden=True)
 @click.option('-v', '--verbose', is_flag=True, default=False, help='print additional details of what the operation is doing')
+@click.option(
+    '-t',
+    '--path-trace',
+    type=click.Path(writable=True),
+    help='filename to output decision path trace for patch generation as JSON',
+    hidden=True,
+)
 @click.pass_context
-def replace(ctx, target_file_path, format, dry_run, ignore_non_yang_tables, ignore_path, verbose):
+def replace(ctx, target_file_path, format, dry_run, ignore_non_yang_tables, ignore_path, verbose, path_trace):
     """Replace the whole config with the specified config. The config is replaced with minimum disruption e.g.
        if ACL config is different between current and target config only ACL config is updated, and other config/services
        such as DHCP will not be affected.
@@ -2022,7 +2066,22 @@ def replace(ctx, target_file_path, format, dry_run, ignore_non_yang_tables, igno
 
         config_format = ConfigFormat[format.upper()]
 
-        GenericUpdater().replace(target_config, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_path)
+        trace_io = None
+        if path_trace is not None:
+            trace_io = open(path_trace, 'w')
+
+        GenericUpdater().replace(
+            target_config,
+            config_format,
+            verbose,
+            dry_run,
+            ignore_non_yang_tables,
+            ignore_path,
+            trace_io=trace_io,
+        )
+
+        if trace_io is not None:
+            trace_io.close()
 
         click.secho("Config replaced successfully.", fg="cyan", underline=True)
     except Exception as ex:

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -5,6 +5,7 @@ import subprocess
 
 from datetime import datetime, timezone
 from enum import Enum
+from typing import IO, Optional
 from .gu_common import HOST_NAMESPACE, GenericConfigUpdaterError, EmptyTableError, ConfigWrapper, \
                     DryRunConfigWrapper, PatchWrapper, genericUpdaterLogging
 from .patch_sorter import StrictPatchSorter, NonStrictPatchSorter, ConfigSplitter, \
@@ -101,7 +102,7 @@ class PatchApplier:
         self.patchsorter = patchsorter if patchsorter is not None else StrictPatchSorter(self.config_wrapper, self.patch_wrapper)
         self.changeapplier = changeapplier if changeapplier is not None else ChangeApplier(scope=self.scope)
 
-    def apply(self, patch, sort=True):
+    def apply(self, patch, sort=True, trace_io: Optional[IO] = None):
         scope = self.scope if self.scope else HOST_NAMESPACE
         self.logger.log_notice(f"{scope}: Patch application starting.")
         self.logger.log_notice(f"{scope}: Patch: {patch}")
@@ -130,7 +131,7 @@ class PatchApplier:
         # Generate list of changes to apply
         if sort:
             self.logger.log_notice(f"{scope}: sorting patch updates.")
-            changes = self.patchsorter.sort(patch)
+            changes = self.patchsorter.sort(patch, trace_io=trace_io)
         else:
             self.logger.log_notice(f"{scope}: converting patch to JsonChange.")
             changes = [JsonChange(jsonpatch.JsonPatch([element])) for element in patch]
@@ -166,7 +167,7 @@ class ConfigReplacer:
         self.config_wrapper = config_wrapper if config_wrapper is not None else ConfigWrapper(scope=self.scope)
         self.patch_wrapper = patch_wrapper if patch_wrapper is not None else PatchWrapper(scope=self.scope)
 
-    def replace(self, target_config):
+    def replace(self, target_config, trace_io: Optional[IO] = None):
         self.logger.log_notice("Config replacement starting.")
         self.logger.log_notice(f"Target config length: {len(json.dumps(target_config))}.")
 
@@ -178,7 +179,7 @@ class ConfigReplacer:
         self.logger.log_debug(f"Generated patch: {patch}.") # debug since the patch will printed again in 'patch_applier.apply'
 
         self.logger.log_notice("Applying patch using 'Patch Applier'.")
-        self.patch_applier.apply(patch)
+        self.patch_applier.apply(patch, trace_io=trace_io)
 
         self.logger.log_notice("Verifying config replacement is reflected on ConfigDB.")
         new_config = self.config_wrapper.get_config_db_as_json()
@@ -303,7 +304,7 @@ class MultiASICConfigReplacer(ConfigReplacer):
         self.scopelist = [HOST_NAMESPACE, *multi_asic.get_namespace_list()]
         super().__init__(patch_applier, config_wrapper, patch_wrapper, scope)
 
-    def replace(self, target_config):
+    def replace(self, target_config, trace_io: Optional[IO] = None):
         config_keys = set(target_config.keys())
         missing_scopes = set(self.scopelist) - config_keys
         if missing_scopes:
@@ -313,7 +314,7 @@ class MultiASICConfigReplacer(ConfigReplacer):
             scope_config = target_config.pop(scope)
             if scope.lower() == HOST_NAMESPACE:
                 scope = multi_asic.DEFAULT_NAMESPACE
-            ConfigReplacer(scope=scope).replace(scope_config)
+            ConfigReplacer(scope=scope).replace(scope_config, trace_io=trace_io)
 
 
 class MultiASICConfigRollbacker(FileSystemConfigRollbacker):
@@ -420,11 +421,11 @@ class Decorator(PatchApplier, ConfigReplacer, FileSystemConfigRollbacker):
         self.decorated_config_replacer = decorated_config_replacer
         self.decorated_config_rollbacker = decorated_config_rollbacker
 
-    def apply(self, patch):
-        self.decorated_patch_applier.apply(patch)
+    def apply(self, patch, sort=True, trace_io: Optional[IO] = None):
+        self.decorated_patch_applier.apply(patch, sort, trace_io=trace_io)
 
-    def replace(self, target_config):
-        self.decorated_config_replacer.replace(target_config)
+    def replace(self, target_config, trace_io: Optional[IO] = None):
+        self.decorated_config_replacer.replace(target_config, trace_io=trace_io)
 
     def rollback(self, checkpoint_name):
         self.decorated_config_rollbacker.rollback(checkpoint_name)
@@ -451,13 +452,13 @@ class SonicYangDecorator(Decorator):
         self.patch_wrapper = patch_wrapper
         self.config_wrapper = config_wrapper
 
-    def apply(self, patch):
+    def apply(self, patch, sort=True, trace_io: Optional[IO] = None):
         config_db_patch = self.patch_wrapper.convert_sonic_yang_patch_to_config_db_patch(patch)
-        Decorator.apply(self, config_db_patch)
+        Decorator.apply(self, config_db_patch, sort, trace_io=trace_io)
 
-    def replace(self, target_config):
+    def replace(self, target_config, trace_io: Optional[IO] = None):
         config_db_target_config = self.config_wrapper.convert_sonic_yang_to_config_db(target_config)
-        Decorator.replace(self, config_db_target_config)
+        Decorator.replace(self, config_db_target_config, trace_io=trace_io)
 
 
 class ConfigLockDecorator(Decorator):
@@ -474,11 +475,11 @@ class ConfigLockDecorator(Decorator):
                            scope=scope)
         self.config_lock = config_lock
 
-    def apply(self, patch, sort=True):
-        self.execute_write_action(Decorator.apply, self, patch)
+    def apply(self, patch, sort=True, trace_io: Optional[IO] = None):
+        self.execute_write_action(Decorator.apply, self, patch, sort, trace_io=trace_io)
 
-    def replace(self, target_config):
-        self.execute_write_action(Decorator.replace, self, target_config)
+    def replace(self, target_config, trace_io: Optional[IO] = None):
+        self.execute_write_action(Decorator.replace, self, target_config, trace_io=trace_io)
 
     def rollback(self, checkpoint_name):
         self.execute_write_action(Decorator.rollback, self, checkpoint_name)
@@ -486,9 +487,9 @@ class ConfigLockDecorator(Decorator):
     def checkpoint(self, checkpoint_name):
         self.execute_write_action(Decorator.checkpoint, self, checkpoint_name)
 
-    def execute_write_action(self, action, *args):
+    def execute_write_action(self, action, *args, **kwargs):
         self.config_lock.acquire_lock()
-        action(*args)
+        action(*args, **kwargs)
         self.config_lock.release_lock()
 
 
@@ -496,7 +497,14 @@ class GenericUpdateFactory:
     def __init__(self, scope=multi_asic.DEFAULT_NAMESPACE):
         self.scope = scope
 
-    def create_patch_applier(self, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_paths):
+    def create_patch_applier(
+        self,
+        config_format,
+        verbose,
+        dry_run,
+        ignore_non_yang_tables,
+        ignore_paths,
+    ):
         self.init_verbose_logging(verbose)
         config_wrapper = self.get_config_wrapper(dry_run)
         change_applier = self.get_change_applier(dry_run, config_wrapper)
@@ -523,7 +531,14 @@ class GenericUpdateFactory:
 
         return patch_applier
 
-    def create_config_replacer(self, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_paths):
+    def create_config_replacer(
+        self,
+        config_format,
+        verbose,
+        dry_run,
+        ignore_non_yang_tables,
+        ignore_paths,
+    ):
         self.init_verbose_logging(verbose)
         config_wrapper = self.get_config_wrapper(dry_run)
         change_applier = self.get_change_applier(dry_run, config_wrapper)
@@ -622,13 +637,44 @@ class GenericUpdater:
         self.generic_update_factory = \
             generic_update_factory if generic_update_factory is not None else GenericUpdateFactory(scope=scope)
 
-    def apply_patch(self, patch, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_paths, sort=True):
-        patch_applier = self.generic_update_factory.create_patch_applier(config_format, verbose, dry_run, ignore_non_yang_tables, ignore_paths)
-        patch_applier.apply(patch, sort)
+    def apply_patch(
+        self,
+        patch,
+        config_format,
+        verbose,
+        dry_run,
+        ignore_non_yang_tables,
+        ignore_paths,
+        sort=True,
+        trace_io: Optional[IO] = None,
+    ):
+        patch_applier = self.generic_update_factory.create_patch_applier(
+            config_format,
+            verbose,
+            dry_run,
+            ignore_non_yang_tables,
+            ignore_paths,
+        )
+        patch_applier.apply(patch, sort, trace_io=trace_io)
 
-    def replace(self, target_config, config_format, verbose, dry_run, ignore_non_yang_tables, ignore_paths):
-        config_replacer = self.generic_update_factory.create_config_replacer(config_format, verbose, dry_run, ignore_non_yang_tables, ignore_paths)
-        config_replacer.replace(target_config)
+    def replace(
+        self,
+        target_config,
+        config_format,
+        verbose,
+        dry_run,
+        ignore_non_yang_tables,
+        ignore_paths,
+        trace_io: Optional[IO] = None,
+    ):
+        config_replacer = self.generic_update_factory.create_config_replacer(
+            config_format,
+            verbose,
+            dry_run,
+            ignore_non_yang_tables,
+            ignore_paths,
+        )
+        config_replacer.replace(target_config, trace_io=trace_io)
 
     def rollback(self, checkpoint_name, verbose, dry_run, ignore_non_yang_tables, ignore_paths):
         config_rollbacker = self.generic_update_factory.create_config_rollbacker(verbose, dry_run, ignore_non_yang_tables, ignore_paths)

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -152,7 +152,7 @@ class ConfigWrapper:
                 if not success:
                     return success, error
         except sonic_yang.SonicYangException as ex:
-            return False, ex
+            return False, str(ex)
 
         return True, None
 

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -4,6 +4,7 @@ import jsonpatch
 import sonic_yang
 from collections import deque, OrderedDict
 from enum import Enum
+from typing import IO, Optional, Tuple
 from .gu_common import OperationWrapper, OperationType, GenericConfigUpdaterError, \
                        JsonChange, PathAddressing, genericUpdaterLogging
 
@@ -321,7 +322,8 @@ class JsonMoveGroup:
     """
     Group of JsonMove objects to be applied together
     """
-    def __init__(self, move: JsonMove = None):
+    def __init__(self, generator_name: str, move: JsonMove = None):
+        self.generator_name = generator_name
         self.patches = []
         if move is not None:
             self.append(move)
@@ -464,14 +466,18 @@ class MoveWrapper:
                 extended_moves.add(move)
                 moves.extend(self._extend_moves(move, diff))
 
-    def validate(self, move, diff):
+    def validate(self, move, diff) -> Tuple[bool, Optional[str]]:
         # Generate simulated config once, not once per validator as this performs
         # a deep copy
         simulated_config = move.apply(diff.current_config)
         for validator in self.move_validators:
-            if not validator.validate(move, diff, simulated_config):
-                return False
-        return True
+            success, errmsg = validator.validate(move, diff, simulated_config)
+            if not success:
+                error = f"{validator.__class__.__name__} failed"
+                if errmsg is not None:
+                    error += ": " + errmsg
+                return False, error
+        return True, None
 
     def simulate(self, move, diff, in_place: bool = False):
         return diff.apply_move(move, in_place)
@@ -496,7 +502,7 @@ class MoveWrapper:
         for move in moveGroup:
             for extender in self.move_extenders:
                 for newmove in extender.extend(move, diff):
-                    yield JsonMoveGroup(newmove)
+                    yield JsonMoveGroup(f"{extender.__class__.__name__} extends {moveGroup.generator_name}", newmove)
 
 class JsonPointerFilter:
     """
@@ -743,7 +749,7 @@ class RemoveCreateOnlyDependencyMoveValidator:
         self.path_addressing = path_addressing
         self.create_only_filter = CreateOnlyFilter(path_addressing).get_filter()
 
-    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         # Note: group is not used by this validator
         current_config = diff.current_config
         target_config = diff.target_config # Final config after applying whole patch
@@ -780,12 +786,12 @@ class RemoveCreateOnlyDependencyMoveValidator:
                 if not self._validate_member(tokens, member_name,
                                              current_config, target_config, simulated_config,
                                              reload_config=reload_config):
-                    return False
+                    return False, None
 
                 # After first call, no need to reload again
                 reload_config = False
 
-        return True
+        return True, None
 
     def _validate_member(self, tokens, member_name, current_config, target_config, simulated_config,
                          reload_config: bool = True):
@@ -830,10 +836,10 @@ class DeleteWholeConfigMoveValidator:
     """
     A class to validate not deleting whole config as it is not supported by JsonPatch lib.
     """
-    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         if group.patches[0].op_type == OperationType.REMOVE and group.patches[0].path == "":
-            return False
-        return True
+            return False, None
+        return True, None
 
 class FullConfigMoveValidator:
     """
@@ -842,9 +848,9 @@ class FullConfigMoveValidator:
     def __init__(self, config_wrapper):
         self.config_wrapper = config_wrapper
 
-    def validate(self, move, diff, simulated_config):
+    def validate(self, move, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
-        return is_valid
+        return is_valid, error
 
 class CreateOnlyMoveValidator:
     """
@@ -859,7 +865,7 @@ class CreateOnlyMoveValidator:
         # TODO: create-only fields are hard-coded for now, it should be moved to YANG models
         self.create_only_filter = CreateOnlyFilter(path_addressing).get_filter()
 
-    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         # NOTE: group not used by this validator
 
         # get create-only paths from current config, simulated config and also target config
@@ -872,19 +878,19 @@ class CreateOnlyMoveValidator:
         for path in paths:
             tokens = self.path_addressing.get_path_tokens(path)
             if self._value_exist_but_different(tokens, diff.current_config, simulated_config):
-                return False
+                return False, None
             if self._value_added_but_parent_exist(tokens, diff.current_config, simulated_config):
-                return False
+                return False, None
             if self._value_removed_but_parent_remain(tokens, diff.current_config, simulated_config):
-                return False
+                return False, None
 
             # if parent of create-only field is added, create-only field should be the same as target
             # i.e. if field is deleted in target, it should be deleted in the move, or
             #      if field is present in target, it should be present in the move
             if self._parent_added_child_not_as_target(tokens, diff.current_config, simulated_config, diff.target_config):
-                return False
+                return False, None
 
-        return True
+        return True, None
 
     def _parent_added_child_not_as_target(self, tokens, current_config, simulated_config, target_config):
         # if parent is not added, return false
@@ -958,14 +964,14 @@ class NoDependencyMoveValidator:
         self.path_addressing = path_addressing
         self.config_wrapper = config_wrapper
 
-    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         reload_config = True
         # Note: all moves in a group are guaranteed to be the same operation type
         for move in group:
             if not self.__validate_move(move, diff, simulated_config, reload_config=reload_config):
-                return False
+                return False, None
             reload_config = False
-        return True
+        return True, None
 
     def __validate_move(self, move, diff, simulated_config, reload_config: bool = True):
         operation_type = move.op_type
@@ -1116,8 +1122,8 @@ class NoEmptyTableMoveValidator:
     def validate(self, group, diff, simulated_config):
         for move in group:
             if not self.__validate_move(move, diff, simulated_config):
-                return False
-        return True
+                return False, None
+        return True, None
 
     def __validate_move(self, move, diff, simulated_config):
         op_path = move.path
@@ -1155,10 +1161,10 @@ class RequiredValueMoveValidator:
         self.path_addressing = path_addressing
         self.identifier = RequiredValueIdentifier(path_addressing)
 
-    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         # ignore full config removal because it is not possible by JsonPatch lib
         if group.patches[0].op_type == OperationType.REMOVE and group.patches[0].path == "":
-            return
+            return False, None
 
         current_config = diff.current_config
         target_config = diff.target_config # Final config after applying whole patch
@@ -1179,7 +1185,7 @@ class RequiredValueMoveValidator:
                     if actual_value is None: # current config does not have this value at all
                         continue
                     if actual_value != required_value:
-                        return False
+                        return False, None
 
         # If some changes to the requiring paths are still to take place and the move has changes
         # to the required path, reject the move
@@ -1194,9 +1200,9 @@ class RequiredValueMoveValidator:
                     if simulated_value is None: # Simulated config does not have this value at all.
                         continue
                     if current_value != simulated_value and simulated_value != required_value:
-                        return False
+                        return False, None
 
-        return True
+        return True, None
 
 class TableLevelMoveGenerator:
     """
@@ -1216,11 +1222,11 @@ class TableLevelMoveGenerator:
     def generate(self, diff):
         # Removing tables in current but not target
         for tokens in self._get_non_existing_tables_tokens(diff.current_config, diff.target_config, False):
-            yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE, tokens))
+            yield JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.REMOVE, tokens))
 
         # Adding tables in target but not current
         for tokens in self._get_non_existing_tables_tokens(diff.target_config, diff.current_config, True):
-            yield JsonMoveGroup(JsonMove(diff, OperationType.ADD, tokens, tokens))
+            yield JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.ADD, tokens, tokens))
 
     def _get_non_existing_tables_tokens(self, config1, config2, reverse):
         for table in self.path_addressing.configdb_sorted_keys_by_backlinks("/", config1, reverse=reverse):
@@ -1251,13 +1257,13 @@ class KeyLevelMoveGenerator:
             table = tokens[0]
             # if table has a single key, delete the whole table because empty tables are not allowed in ConfigDB
             if len(diff.current_config[table]) == 1:
-                yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE, [table]))
+                yield JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.REMOVE, [table]))
             else:
-                yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE, tokens))
+                yield JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.REMOVE, tokens))
 
         # Adding keys in target but not current
         for tokens in self._get_non_existing_keys_tokens(diff.target_config, diff.current_config, reverse=True):
-            yield JsonMoveGroup(JsonMove(diff, OperationType.ADD, tokens, tokens))
+            yield JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.ADD, tokens, tokens))
 
     def _get_non_existing_keys_tokens(self, config1, config2, reverse):
         for table in self.path_addressing.configdb_sorted_keys_by_backlinks("/", config1, reverse=reverse):
@@ -1295,7 +1301,7 @@ class BulkKeyLevelMoveGenerator:
             prev_table = table
             prev_num_separators = num_separators
             if group is None:
-                group = JsonMoveGroup()
+                group = JsonMoveGroup(self.__class__.__name__)
 
             group.append(JsonMove(diff, OperationType.REMOVE, tokens))
 
@@ -1328,7 +1334,7 @@ class BulkKeyLevelMoveGenerator:
             prev_table = table
             prev_num_separators = num_separators
             if group is None:
-                group = JsonMoveGroup()
+                group = JsonMoveGroup(self.__class__.__name__)
 
             group.append(JsonMove(diff, OperationType.ADD, tokens, tokens))
 
@@ -1523,7 +1529,7 @@ class BulkLowLevelMoveGenerator:
                     yield move
 
     def __output_bulk_add(self, current_ptr, target_ptr, tokens, min_moves, restricted_only):
-        group = JsonMoveGroup()
+        group = JsonMoveGroup(self.__class__.__name__,)
         for key in target_ptr:
             if current_ptr.get(key) is None and not self.__restricted_key(tokens, key, invert=restricted_only):
                 tokens.append(key)
@@ -1535,7 +1541,7 @@ class BulkLowLevelMoveGenerator:
             yield group
 
     def __output_bulk_remove(self, current_ptr, target_ptr, tokens, min_moves, restricted_only):
-        group = JsonMoveGroup()
+        group = JsonMoveGroup(self.__class__.__name__,)
         for key in current_ptr:
             if target_ptr.get(key) is None and not self.__restricted_key(tokens, key, invert=restricted_only):
                 tokens.append(key)
@@ -1547,7 +1553,7 @@ class BulkLowLevelMoveGenerator:
             yield group
 
     def __output_bulk_replace(self, current_ptr, target_ptr, tokens, min_moves, restricted_only):
-        group = JsonMoveGroup()
+        group = JsonMoveGroup(self.__class__.__name__,)
         for key in current_ptr:
             target_val = target_ptr.get(key)
             if (target_val is not None and target_val != current_ptr.get(key) and
@@ -1614,7 +1620,7 @@ class RemoveCreateOnlyDependencyMoveGenerator:
 
                 for ref_path in self.path_addressing.find_ref_paths(member_path, current_config,
                                                                     reload_config=reload_config):
-                    yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE,
+                    yield JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.REMOVE,
                                         self.path_addressing.get_path_tokens(ref_path)))
 
                 # No need to reload config after first call
@@ -1742,7 +1748,10 @@ class LowLevelMoveGenerator:
         if current_value == target_value:
             return
 
-        yield JsonMoveGroup(JsonMove(self.diff, OperationType.REPLACE, current_tokens, target_tokens))
+        yield JsonMoveGroup(
+            self.__class__.__name__,
+            JsonMove(self.diff, OperationType.REPLACE, current_tokens, target_tokens),
+        )
 
     def _traverse_current(self, ptr, current_tokens):
         if isinstance(ptr, list):
@@ -1752,7 +1761,7 @@ class LowLevelMoveGenerator:
 
         if isinstance(ptr, dict):
             if len(ptr) == 0:
-                yield JsonMoveGroup(JsonMove(self.diff, OperationType.REMOVE, current_tokens))
+                yield JsonMoveGroup(self.__class__.__name__, JsonMove(self.diff, OperationType.REMOVE, current_tokens))
                 return
 
             for key in ptr:
@@ -1769,7 +1778,7 @@ class LowLevelMoveGenerator:
 
     def _traverse_current_list(self, ptr, current_tokens):
         if len(ptr) == 0:
-            yield JsonMoveGroup(JsonMove(self.diff, OperationType.REMOVE, current_tokens))
+            yield JsonMoveGroup(self.__class__.__name__, JsonMove(self.diff, OperationType.REMOVE, current_tokens))
             return
 
         for index, val in enumerate(ptr):
@@ -1779,7 +1788,7 @@ class LowLevelMoveGenerator:
             current_tokens.pop()
 
     def _traverse_current_value(self, val, current_tokens):
-        yield JsonMoveGroup(JsonMove(self.diff, OperationType.REMOVE, current_tokens))
+        yield JsonMoveGroup(self.__class__.__name__, JsonMove(self.diff, OperationType.REMOVE, current_tokens))
 
     def _traverse_target(self, ptr, current_tokens, target_tokens):
         if isinstance(ptr, list):
@@ -1789,7 +1798,10 @@ class LowLevelMoveGenerator:
 
         if isinstance(ptr, dict):
             if len(ptr) == 0:
-                yield JsonMoveGroup(JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens))
+                yield JsonMoveGroup(
+                    self.__class__.__name__,
+                    JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens),
+                )
                 return
 
             for key in ptr:
@@ -1808,7 +1820,10 @@ class LowLevelMoveGenerator:
 
     def _traverse_target_list(self, ptr, current_tokens, target_tokens):
         if len(ptr) == 0:
-            yield JsonMoveGroup(JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens))
+            yield JsonMoveGroup(
+                self.__class__.__name__,
+                JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens),
+            )
             return
 
         for index, val in enumerate(ptr):
@@ -1822,7 +1837,10 @@ class LowLevelMoveGenerator:
             current_tokens.pop()
 
     def _traverse_target_value(self, val, current_tokens, target_tokens):
-        yield JsonMoveGroup(JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens))
+        yield JsonMoveGroup(
+            self.__class__.__name__,
+            JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens),
+        )
 
     def _list_to_dict_with_count(self, items):
         counts = dict()
@@ -2003,12 +2021,82 @@ class DeleteRefsMoveExtender:
             yield JsonMove(diff, OperationType.REMOVE, self.path_addressing.get_path_tokens(ref_path))
 
 
+class PatchStatus(str, Enum):
+    # Topmost Node
+    TOPLEVEL = "toplevel"
+    # During testing, should never see this in a final result
+    TESTING = "testing"
+    # This is the valid tree, the entire chain should be valid
+    VALID = "valid"
+    # Validation failed at this node
+    INVALID = "invalid"
+    # Validation failed at a child node
+    PATH_ISSUE = "path_issue"
+    # original and target diffs already seen, prevent recursion
+    RECURSE_REJECT = "recurse_reject"
+
+
+class PatchSorterPath:
+    """Class containing path elements for debugging/tracking"""
+    def __init__(self, diff: Optional[Diff] = None, moves: Optional[JsonMoveGroup] = None):
+        if diff is not None:
+            self.status = PatchStatus.TOPLEVEL
+            self.patch = json.loads(jsonpatch.make_patch(diff.current_config, diff.target_config).to_string())
+            self.children = []
+            return
+
+        if moves is None:
+            raise RuntimeError("Must specify diff or moves")
+
+        self.generator = moves.generator_name
+        self.patch = json.loads(str(moves.get_jsonpatch()))
+        self.status = PatchStatus.TESTING
+        self.error = None
+        self.children = []
+
+    def __len__(self):
+        return len(self.children)
+
+    def append(self, moves: JsonMoveGroup) -> 'PatchSorterPath':
+        item = PatchSorterPath(moves=moves)
+        self.children.append(item)
+        return item
+
+    @staticmethod
+    def json_encoder(o):
+        if isinstance(o, PatchSorterPath):
+            if o.status == PatchStatus.TOPLEVEL:
+                mydict = {
+                    "requested": o.patch,
+                    "generated": o.children,
+                }
+                return mydict
+
+            mydict = {
+                "generator": o.generator,
+                "status": o.status,
+                "patch": o.patch,
+            }
+            if o.children is not None and len(o.children):
+                mydict["children"] = o.children
+            if o.error is not None:
+                mydict["error"] = o.error
+            return mydict
+        raise TypeError(f'Type {type(o)} not serializable')
+
+
 class DfsSorter:
-    def __init__(self, move_wrapper):
+    def __init__(self, move_wrapper, path_trace: bool = False):
         self.visited = {}
         self.move_wrapper = move_wrapper
+        self.path_trace = path_trace
+        self.path_tracker = None
 
-    def sort(self, diff):
+    def sort(self, diff, path_tracker: Optional[PatchSorterPath] = None):
+        if path_tracker is None and self.path_trace:
+            self.path_tracker = PatchSorterPath(diff=diff)
+            path_tracker = self.path_tracker
+
         if diff.has_no_diff():
             return []
 
@@ -2020,21 +2108,40 @@ class DfsSorter:
         moves = self.move_wrapper.generate(diff)
 
         for move in moves:
-            if self.move_wrapper.validate(move, diff):
+            path_item = None
+            if path_tracker is not None:
+                path_item = path_tracker.append(move)
+
+            success, errmsg = self.move_wrapper.validate(move, diff)
+            if success:
                 # NOTE: due to the recursive nature, we can't modify in-place as on error we will
                 #       receive "RuntimeError: dictionary changed size during iteration"
                 new_diff = self.move_wrapper.simulate(move, diff, in_place=False)
-                new_moves = self.sort(new_diff)
+                new_moves = self.sort(new_diff, path_item)
                 if new_moves is not None:
+                    if path_item is not None:
+                        path_item.status = PatchStatus.VALID
                     return [move] + new_moves
+                else:
+                    if path_item is not None:
+                        if len(path_item.children):
+                            path_item.status = PatchStatus.PATH_ISSUE
+                        else:
+                            path_item.status = PatchStatus.RECURSE_REJECT
+            else:
+                if path_item is not None:
+                    path_item.status = PatchStatus.INVALID
+                    path_item.error = errmsg
 
         return None
 
 
 class BfsSorter:
-    def __init__(self, move_wrapper):
+    def __init__(self, move_wrapper, path_trace: bool = False):
         self.visited = {}
         self.move_wrapper = move_wrapper
+        # Not currently supported
+        self.path_tracker = None
 
     def sort(self, diff):
         diff_queue = deque([])
@@ -2057,7 +2164,8 @@ class BfsSorter:
 
             moves = self.move_wrapper.generate(diff)
             for move in moves:
-                if self.move_wrapper.validate(move, diff):
+                success, errmsg = self.move_wrapper.validate(move, diff)
+                if success:
                     new_diff = self.move_wrapper.simulate(move, diff)
                     new_prv_moves = prv_moves + [move]
 
@@ -2068,10 +2176,12 @@ class BfsSorter:
 
 
 class MemoizationSorter:
-    def __init__(self, move_wrapper):
+    def __init__(self, move_wrapper, path_trace: bool = False):
         self.visited = {}
         self.move_wrapper = move_wrapper
         self.mem = {}
+        # Not currently supported
+        self.path_tracker = None
 
     def sort(self, diff):
         if diff.has_no_diff():
@@ -2088,7 +2198,8 @@ class MemoizationSorter:
 
         bst_moves = None
         for move in moves:
-            if self.move_wrapper.validate(move, diff):
+            success, errmsg = self.move_wrapper.validate(move, diff)
+            if success:
                 new_diff = self.move_wrapper.simulate(move, diff)
                 new_moves = self.sort(new_diff)
                 if new_moves != None and (bst_moves is None or len(bst_moves) > len(new_moves)+1):
@@ -2110,7 +2221,7 @@ class SortAlgorithmFactory:
         self.config_wrapper = config_wrapper
         self.path_addressing = path_addressing
 
-    def create(self, algorithm=Algorithm.DFS):
+    def create(self, algorithm=Algorithm.DFS, path_trace: bool = False):
         move_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
                            LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
@@ -2133,11 +2244,11 @@ class SortAlgorithmFactory:
         move_wrapper = MoveWrapper(move_generators, move_non_extendable_generators, move_extenders, move_validators)
 
         if algorithm == Algorithm.DFS:
-            sorter = DfsSorter(move_wrapper)
+            sorter = DfsSorter(move_wrapper, path_trace=path_trace)
         elif algorithm == Algorithm.BFS:
-            sorter = BfsSorter(move_wrapper)
+            sorter = BfsSorter(move_wrapper, path_trace=path_trace)
         elif algorithm == Algorithm.MEMOIZATION:
-            sorter = MemoizationSorter(move_wrapper)
+            sorter = MemoizationSorter(move_wrapper, path_trace=path_trace)
         else:
             raise ValueError(f"Algorithm {algorithm} is not supported")
 
@@ -2151,7 +2262,7 @@ class StrictPatchSorter:
         self.patch_wrapper = patch_wrapper
         self.inner_patch_sorter = inner_patch_sorter if inner_patch_sorter else PatchSorter(config_wrapper, patch_wrapper)
 
-    def sort(self, patch, algorithm=Algorithm.DFS):
+    def sort(self, patch, algorithm=Algorithm.DFS, trace_io: Optional[IO] = None):
         current_config = self.config_wrapper.get_config_db_as_json()
 
         # Validate patch is only updating tables with yang models
@@ -2169,7 +2280,7 @@ class StrictPatchSorter:
 
         # Generate list of changes to apply
         self.logger.log_info("Sorting patch updates.")
-        changes = self.inner_patch_sorter.sort(patch, algorithm)
+        changes = self.inner_patch_sorter.sort(patch, algorithm, trace_io=trace_io)
 
         return changes
 
@@ -2206,12 +2317,17 @@ class IgnorePathsFromYangConfigSplitter:
 
             # Add to config_without_yang from config_with_yang
             tokens = self.path_addressing.get_path_tokens(path)
-            add_move = JsonMoveGroup(JsonMove(Diff(config_without_yang, config_with_yang), OperationType.ADD, tokens,
-                                              tokens))
+            add_move = JsonMoveGroup(
+                self.__class__.__name__,
+                JsonMove(Diff(config_without_yang, config_with_yang), OperationType.ADD, tokens, tokens),
+            )
             config_without_yang = add_move.apply(config_without_yang)
 
             # Remove from config_with_yang
-            remove_move = JsonMoveGroup(JsonMove(Diff(config_with_yang, {}), OperationType.REMOVE, tokens))
+            remove_move = JsonMoveGroup(
+                self.__class__.__name__,
+                JsonMove(Diff(config_with_yang, {}), OperationType.REMOVE, tokens),
+            )
             config_with_yang = remove_move.apply(config_with_yang)
 
         # Splitting the config based on 'ignore_paths_from_yang_list' can result in empty tables.
@@ -2342,7 +2458,7 @@ class NonStrictPatchSorter:
         self.change_wrapper = change_wrapper if change_wrapper else ChangeWrapper(patch_wrapper, config_splitter)
         self.inner_patch_sorter = patch_sorter if patch_sorter else PatchSorter(config_wrapper, patch_wrapper)
 
-    def sort(self, patch, algorithm=Algorithm.DFS):
+    def sort(self, patch, algorithm=Algorithm.DFS, trace_io: Optional[IO] = None):
         current_config = self.config_wrapper.get_config_db_as_json()
         target_config = self.patch_wrapper.simulate_patch(patch, current_config)
 
@@ -2379,7 +2495,7 @@ class NonStrictPatchSorter:
 
         # Generating changes associated with YANG covered configs
         self.logger.log_info("Sorting YANG-covered configs patch updates.")
-        yang_changes = self.inner_patch_sorter.sort(yang_patch, algorithm, current_config_yang)
+        yang_changes = self.inner_patch_sorter.sort(yang_patch, algorithm, current_config_yang, trace_io=trace_io)
         changes_len = len(yang_changes)
         self.logger.log_debug(f"The YANG covered config update was sorted into {changes_len} " \
                              f"change{'s' if changes_len != 1 else ''}{':' if changes_len > 0 else '.'}")
@@ -2402,15 +2518,19 @@ class PatchSorter:
         self.path_addressing = PathAddressing(self.config_wrapper)
         self.sort_algorithm_factory = sort_algorithm_factory if sort_algorithm_factory else \
             SortAlgorithmFactory(self.operation_wrapper, config_wrapper, self.path_addressing)
+        self.logger = genericUpdaterLogging.get_logger(title="Patch Sorter", print_all_to_console=True)
 
-    def sort(self, patch, algorithm=Algorithm.DFS, preloaded_current_config=None):
+    def sort(self, patch, algorithm=Algorithm.DFS, preloaded_current_config=None, trace_io: Optional[IO] = None):
         current_config = preloaded_current_config if preloaded_current_config else self.config_wrapper.get_config_db_as_json()
         target_config = self.patch_wrapper.simulate_patch(patch, current_config)
 
         diff = Diff(copy.deepcopy(current_config), target_config)
 
-        sort_algorithm = self.sort_algorithm_factory.create(algorithm)
+        sort_algorithm = self.sort_algorithm_factory.create(algorithm, path_trace=False if trace_io is None else True)
         moves = sort_algorithm.sort(diff)
+
+        if trace_io is not None:
+            json.dump(sort_algorithm.path_tracker, trace_io, default=PatchSorterPath.json_encoder, indent=2)
 
         if moves is None:
             raise GenericConfigUpdaterError("There is no possible sorting")

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1983,7 +1983,15 @@ class TestGenericUpdateCommands(unittest.TestCase):
         # Arrange
         expected_exit_code = 0
         expected_output = "Patch applied successfully"
-        expected_call_with_default_values = mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, False, False, ())
+        expected_call_with_default_values = mock.call(
+            mock.ANY,
+            ConfigFormat.CONFIGDB,
+            False,
+            False,
+            False,
+            (),
+            trace_io=None,
+        )
         mock_generic_updater = mock.Mock()
         with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
             with mock.patch('builtins.open', mock.mock_open(read_data=self.any_patch_as_text)):
@@ -2008,7 +2016,7 @@ class TestGenericUpdateCommands(unittest.TestCase):
         expected_output = "Patch applied successfully"
         expected_ignore_path_tuple = ('/ANY_TABLE', '/ANY_OTHER_TABLE/ANY_FIELD', '')
         expected_call_with_non_default_values = \
-            mock.call(mock.ANY, ConfigFormat.SONICYANG, True, True, True, expected_ignore_path_tuple)
+            mock.call(mock.ANY, ConfigFormat.SONICYANG, True, True, True, expected_ignore_path_tuple, trace_io=None)
         mock_generic_updater = mock.Mock()
         with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
             with mock.patch('builtins.open', mock.mock_open(read_data=self.any_patch_as_text)):
@@ -2057,19 +2065,67 @@ class TestGenericUpdateCommands(unittest.TestCase):
     def test_apply_patch__optional_parameters_passed_correctly(self):
         self.validate_apply_patch_optional_parameter(
             ["--format", ConfigFormat.SONICYANG.name],
-            mock.call(mock.ANY, ConfigFormat.SONICYANG, False, False, False, ()))
+            mock.call(mock.ANY, ConfigFormat.SONICYANG, False, False, False, (), trace_io=None))
         self.validate_apply_patch_optional_parameter(
             ["--verbose"],
-            mock.call(mock.ANY, ConfigFormat.CONFIGDB, True, False, False, ()))
+            mock.call(mock.ANY, ConfigFormat.CONFIGDB, True, False, False, (), trace_io=None))
         self.validate_apply_patch_optional_parameter(
             ["--dry-run"],
-            mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, True, False, ()))
+            mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, True, False, (), trace_io=None))
         self.validate_apply_patch_optional_parameter(
             ["--ignore-non-yang-tables"],
-            mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, False, True, ()))
+            mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, False, True, (), trace_io=None))
         self.validate_apply_patch_optional_parameter(
             ["--ignore-path", "/ANY_TABLE"],
-            mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, False, False, ("/ANY_TABLE",)))
+            mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, False, False, ("/ANY_TABLE",), trace_io=None))
+
+    @patch('subprocess.Popen', mock.Mock(return_value=mock.Mock(
+        communicate=mock.Mock(return_value=('{"some": "config"}', None)),
+        returncode=0
+    )))
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
+    def test_apply_patch__path_trace_option__trace_file_opened_and_passed(self):
+        # Arrange
+        import tempfile
+        expected_exit_code = 0
+        expected_output = "Patch applied successfully"
+        mock_generic_updater = mock.Mock()
+        mock_file_handle = mock.MagicMock()
+
+        # Create a temporary file for the trace output
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as trace_file:
+            trace_file_path = trace_file.name
+
+        try:
+            with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
+                with mock.patch('builtins.open', mock.mock_open(read_data=self.any_patch_as_text)) as mock_open_func:
+                    # Configure mock to return different handles for patch file and trace file
+                    def open_side_effect(filename, mode='r'):
+                        if filename == trace_file_path:
+                            return mock_file_handle
+                        else:
+                            return mock.mock_open(read_data=self.any_patch_as_text).return_value
+                    mock_open_func.side_effect = open_side_effect
+
+                    # Act
+                    result = self.runner.invoke(config.config.commands["apply-patch"],
+                                                [self.any_path, "--path-trace", trace_file_path],
+                                                catch_exceptions=False)
+
+            # Assert
+            self.assertEqual(expected_exit_code, result.exit_code)
+            self.assertIn(expected_output, result.output)
+            mock_generic_updater.apply_patch.assert_called_once()
+            # Verify that trace_io parameter is not None when --path-trace is used
+            call_args = mock_generic_updater.apply_patch.call_args
+            self.assertIsNotNone(call_args[1]['trace_io'])
+            # Verify the file handle was closed
+            mock_file_handle.close.assert_called_once()
+        finally:
+            # Clean up the temporary file
+            import os
+            if os.path.exists(trace_file_path):
+                os.unlink(trace_file_path)
 
     @patch('subprocess.Popen', mock.Mock(return_value=mock.Mock(
         communicate=mock.Mock(return_value=('{"some": "config"}', None)),
@@ -2247,7 +2303,15 @@ class TestGenericUpdateCommands(unittest.TestCase):
         # Arrange
         expected_exit_code = 0
         expected_output = "Config replaced successfully"
-        expected_call_with_default_values = mock.call(mock.ANY, ConfigFormat.CONFIGDB, False, False, False, ())
+        expected_call_with_default_values = mock.call(
+            mock.ANY,
+            ConfigFormat.CONFIGDB,
+            False,
+            False,
+            False,
+            (),
+            trace_io=None
+        )
         mock_generic_updater = mock.Mock()
         with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
             with mock.patch('builtins.open', mock.mock_open(read_data=self.any_target_config_as_text)):
@@ -2267,7 +2331,15 @@ class TestGenericUpdateCommands(unittest.TestCase):
         expected_output = "Config replaced successfully"
         expected_ignore_path_tuple = ('/ANY_TABLE', '/ANY_OTHER_TABLE/ANY_FIELD', '')
         expected_call_with_non_default_values = \
-            mock.call(self.any_target_config, ConfigFormat.SONICYANG, True, True, True, expected_ignore_path_tuple)
+            mock.call(
+                self.any_target_config,
+                ConfigFormat.SONICYANG,
+                True,
+                True,
+                True,
+                expected_ignore_path_tuple,
+                trace_io=None
+            )
         mock_generic_updater = mock.Mock()
         with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
             with mock.patch('builtins.open', mock.mock_open(read_data=self.any_target_config_as_text)):
@@ -2311,19 +2383,74 @@ class TestGenericUpdateCommands(unittest.TestCase):
     def test_replace__optional_parameters_passed_correctly(self):
         self.validate_replace_optional_parameter(
             ["--format", ConfigFormat.SONICYANG.name],
-            mock.call(self.any_target_config, ConfigFormat.SONICYANG, False, False, False, ()))
+            mock.call(self.any_target_config, ConfigFormat.SONICYANG, False, False, False, (), trace_io=None))
         self.validate_replace_optional_parameter(
             ["--verbose"],
-            mock.call(self.any_target_config, ConfigFormat.CONFIGDB, True, False, False, ()))
+            mock.call(self.any_target_config, ConfigFormat.CONFIGDB, True, False, False, (), trace_io=None))
         self.validate_replace_optional_parameter(
             ["--dry-run"],
-            mock.call(self.any_target_config, ConfigFormat.CONFIGDB, False, True, False, ()))
+            mock.call(self.any_target_config, ConfigFormat.CONFIGDB, False, True, False, (), trace_io=None))
         self.validate_replace_optional_parameter(
             ["--ignore-non-yang-tables"],
-            mock.call(self.any_target_config, ConfigFormat.CONFIGDB, False, False, True, ()))
+            mock.call(self.any_target_config, ConfigFormat.CONFIGDB, False, False, True, (), trace_io=None))
         self.validate_replace_optional_parameter(
             ["--ignore-path", "/ANY_TABLE"],
-            mock.call(self.any_target_config, ConfigFormat.CONFIGDB, False, False, False, ("/ANY_TABLE",)))
+            mock.call(
+                self.any_target_config,
+                ConfigFormat.CONFIGDB,
+                False,
+                False,
+                False,
+                ("/ANY_TABLE",),
+                trace_io=None,
+            )
+        )
+
+    def test_replace__path_trace_option__trace_file_opened_and_passed(self):
+        # Arrange
+        import tempfile
+        expected_exit_code = 0
+        expected_output = "Config replaced successfully"
+        mock_generic_updater = mock.Mock()
+        mock_file_handle = mock.MagicMock()
+
+        # Create a temporary file for the trace output
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as trace_file:
+            trace_file_path = trace_file.name
+
+        try:
+            with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
+                with (
+                    mock.patch('builtins.open', mock.mock_open(read_data=self.any_target_config_as_text)) as
+                    mock_open_func
+                ):
+                    # Configure mock to return different handles for config file and trace file
+                    def open_side_effect(filename, mode='r'):
+                        if filename == trace_file_path:
+                            return mock_file_handle
+                        else:
+                            return mock.mock_open(read_data=self.any_target_config_as_text).return_value
+                    mock_open_func.side_effect = open_side_effect
+
+                    # Act
+                    result = self.runner.invoke(config.config.commands["replace"],
+                                                [self.any_path, "--path-trace", trace_file_path],
+                                                catch_exceptions=False)
+
+            # Assert
+            self.assertEqual(expected_exit_code, result.exit_code)
+            self.assertIn(expected_output, result.output)
+            mock_generic_updater.replace.assert_called_once()
+            # Verify that trace_io parameter is not None when --path-trace is used
+            call_args = mock_generic_updater.replace.call_args
+            self.assertIsNotNone(call_args[1]['trace_io'])
+            # Verify the file handle was closed
+            mock_file_handle.close.assert_called_once()
+        finally:
+            # Clean up the temporary file
+            import os
+            if os.path.exists(trace_file_path):
+                os.unlink(trace_file_path)
 
     def validate_replace_optional_parameter(self, param_args, expected_call):
         # Arrange
@@ -2376,7 +2503,8 @@ class TestGenericUpdateCommands(unittest.TestCase):
         mock_generic_updater = mock.Mock()
         with mock.patch('config.main.GenericUpdater', return_value=mock_generic_updater):
             # Act
-            result = self.runner.invoke(config.config.commands["rollback"], [self.any_checkpoint_name], catch_exceptions=False)
+            result = self.runner.invoke(
+                config.config.commands["rollback"], [self.any_checkpoint_name], catch_exceptions=False)
 
         # Assert
         self.assertEqual(expected_exit_code, result.exit_code)
@@ -4881,6 +5009,104 @@ class TestApplyPatchMultiAsic(unittest.TestCase):
             # Assertions and verifications
             self.assertEqual(result.exit_code, 0, "Command should succeed")
             self.assertIn("Checkpoint deleted successfully.", result.output)
+
+    @patch('subprocess.Popen', mock.Mock(return_value=mock.Mock(
+        communicate=mock.Mock(return_value=('{"some": "config"}', None)),
+        returncode=0
+    )))
+    @patch('config.main.validate_patch', mock.Mock(return_value=True))
+    def test_apply_patch__path_trace_option_multiasic__trace_file_opened_and_passed(self):
+        # Arrange
+        import tempfile
+        mock_file_handle = mock.MagicMock()
+
+        # Create a temporary file for the trace output
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as trace_file:
+            trace_file_path = trace_file.name
+
+        try:
+            # Mock open to simulate file reading
+            with (
+                patch('builtins.open', mock_open(read_data=json.dumps(self.patch_content)), create=True) as
+                mock_open_func
+            ):
+                # Configure mock to return different handles for patch file and trace file
+                def open_side_effect(filename, mode='r'):
+                    if filename == trace_file_path:
+                        return mock_file_handle
+                    else:
+                        return mock.mock_open(read_data=json.dumps(self.patch_content)).return_value
+                mock_open_func.side_effect = open_side_effect
+
+                # Mock GenericUpdater to avoid actual patch application
+                with patch('config.main.GenericUpdater') as mock_generic_updater:
+                    mock_generic_updater.return_value.apply_patch = MagicMock()
+
+                    print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                    # Invocation of the command with the CliRunner
+                    result = self.runner.invoke(config.config.commands["apply-patch"],
+                                                [self.patch_file_path, "--path-trace", trace_file_path],
+                                                catch_exceptions=False)
+
+                    print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                    # Assertions and verifications
+                    self.assertEqual(result.exit_code, 0, "Command should succeed")
+                    self.assertIn("Patch applied successfully.", result.output)
+
+                    # Verify the file handle was closed
+                    mock_file_handle.close.assert_called_once()
+        finally:
+            # Clean up the temporary file
+            import os
+            if os.path.exists(trace_file_path):
+                os.unlink(trace_file_path)
+
+    @patch('generic_config_updater.generic_updater.ConfigReplacer.replace', MagicMock())
+    def test_replace__path_trace_option_multiasic__trace_file_opened_and_passed(self):
+        # Arrange
+        import tempfile
+        mock_file_handle = mock.MagicMock()
+        mock_replace_content = copy.deepcopy(self.all_config)
+
+        # Create a temporary file for the trace output
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as trace_file:
+            trace_file_path = trace_file.name
+
+        try:
+            with (
+                patch('builtins.open', mock_open(read_data=json.dumps(mock_replace_content)), create=True) as
+                mock_open_func
+            ):
+                # Configure mock to return different handles for config file and trace file
+                def open_side_effect(filename, mode='r'):
+                    if filename == trace_file_path:
+                        return mock_file_handle
+                    else:
+                        return mock.mock_open(read_data=json.dumps(mock_replace_content)).return_value
+                mock_open_func.side_effect = open_side_effect
+
+                # Mock GenericUpdater to avoid actual replace operation
+                with patch('config.main.GenericUpdater') as mock_generic_updater:
+                    mock_generic_updater.return_value.replace_all = MagicMock()
+
+                    print("Multi ASIC: {}".format(multi_asic.is_multi_asic()))
+                    # Invocation of the command with the CliRunner
+                    result = self.runner.invoke(config.config.commands["replace"],
+                                                [self.replace_file_path, "--path-trace", trace_file_path],
+                                                catch_exceptions=False)
+
+                    print("Exit Code: {}, output: {}".format(result.exit_code, result.output))
+                    # Assertions and verifications
+                    self.assertEqual(result.exit_code, 0, "Command should succeed")
+                    self.assertIn("Config replaced successfully.", result.output)
+
+                    # Verify the file handle was closed
+                    mock_file_handle.close.assert_called_once()
+        finally:
+            # Clean up the temporary file
+            import os
+            if os.path.exists(trace_file_path):
+                os.unlink(trace_file_path)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import sys
+import unittest
 from unittest import mock
 
 import pytest
@@ -21,6 +22,8 @@ from .bgp_commands_input.bgp_network_test_vector import (
 from . import config_int_ip_common
 import utilities_common.constants as constants
 import config.main as config
+
+unittest.TestCase.maxDiff = None
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -42,7 +42,7 @@ class TestPatchApplier(unittest.TestCase):
         patch_applier.config_wrapper.get_config_db_as_json.assert_has_calls([call(), call()])
         patch_applier.patch_wrapper.simulate_patch.assert_has_calls(
             [call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, Files.CONFIG_DB_AS_JSON)])
-        patch_applier.patchsorter.sort.assert_has_calls([call(Files.MULTI_OPERATION_CONFIG_DB_PATCH)])
+        patch_applier.patchsorter.sort.assert_has_calls([call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, trace_io=None)])
         patch_applier.changeapplier.apply.assert_called()
         patch_applier.patch_wrapper.verify_same_json.assert_has_calls(
             [call(Files.CONFIG_DB_AFTER_MULTI_PATCH, Files.CONFIG_DB_AFTER_MULTI_PATCH)])
@@ -99,7 +99,9 @@ class TestConfigReplacer(unittest.TestCase):
         config_replacer.config_wrapper.get_config_db_as_json.assert_has_calls([call(), call()])
         config_replacer.patch_wrapper.generate_patch.assert_has_calls(
             [call(Files.CONFIG_DB_AS_JSON, Files.CONFIG_DB_AFTER_MULTI_PATCH)])
-        config_replacer.patch_applier.apply.assert_has_calls([call(Files.MULTI_OPERATION_CONFIG_DB_PATCH)])
+        config_replacer.patch_applier.apply.assert_has_calls(
+            [call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, trace_io=None)]
+        )
         config_replacer.patch_wrapper.verify_same_json.assert_has_calls(
             [call(Files.CONFIG_DB_AFTER_MULTI_PATCH, Files.CONFIG_DB_AFTER_MULTI_PATCH)])
 
@@ -640,7 +642,7 @@ class TestGenericUpdater(unittest.TestCase):
                                     self.any_ignore_paths)
 
         # Assert
-        patch_applier.apply.assert_has_calls([call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH, True)])
+        patch_applier.apply.assert_has_calls([call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH, True, trace_io=None)])
 
     def test_replace__creates_replacer_and_replace(self):
         # Arrange
@@ -667,7 +669,7 @@ class TestGenericUpdater(unittest.TestCase):
                                 self.any_ignore_paths)
 
         # Assert
-        config_replacer.replace.assert_has_calls([call(Files.SONIC_YANG_AS_JSON)])
+        config_replacer.replace.assert_has_calls([call(Files.SONIC_YANG_AS_JSON, trace_io=None)])
 
     def test_rollback__creates_rollbacker_and_rollback(self):
         # Arrange
@@ -784,14 +786,16 @@ class TestDecorator(unittest.TestCase):
         self.decorator.apply(Files.SINGLE_OPERATION_SONIC_YANG_PATCH)
 
         # Assert
-        self.decorated_patch_applier.apply.assert_has_calls([call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH)])
+        self.decorated_patch_applier.apply.assert_has_calls(
+            [call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH, True, trace_io=None)]
+        )
 
     def test_replace__calls_decorated_replacer(self):
         # Act
         self.decorator.replace(Files.SONIC_YANG_AS_JSON)
 
         # Assert
-        self.decorated_config_replacer.replace.assert_has_calls([call(Files.SONIC_YANG_AS_JSON)])
+        self.decorated_config_replacer.replace.assert_has_calls([call(Files.SONIC_YANG_AS_JSON, trace_io=None)])
 
     def test_rollback__calls_decorated_rollbacker(self):
         # Act
@@ -835,9 +839,11 @@ class TestSonicYangDecorator(unittest.TestCase):
 
         # Assert
         sonic_yang_decorator.patch_wrapper.convert_sonic_yang_patch_to_config_db_patch.assert_has_calls(
-            [call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH)])
+            [call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH)]
+        )
         sonic_yang_decorator.decorated_patch_applier.apply.assert_has_calls(
-            [call(Files.SINGLE_OPERATION_CONFIG_DB_PATCH)])
+            [call(Files.SINGLE_OPERATION_CONFIG_DB_PATCH, True, trace_io=None)]
+        )
 
     def test_replace__converts_to_config_db_and_calls_decorated_class(self):
         # Arrange
@@ -849,11 +855,15 @@ class TestSonicYangDecorator(unittest.TestCase):
         # Assert
         sonic_yang_decorator.config_wrapper.convert_sonic_yang_to_config_db.assert_has_calls(
             [call(Files.SONIC_YANG_AS_JSON)])
-        sonic_yang_decorator.decorated_config_replacer.replace.assert_has_calls([call(Files.CONFIG_DB_AS_JSON)])
+        sonic_yang_decorator.decorated_config_replacer.replace.assert_has_calls(
+            [call(Files.CONFIG_DB_AS_JSON, trace_io=None)]
+        )
 
     def __create_sonic_yang_decorator(self):
         patch_applier = Mock()
-        patch_applier.apply.side_effect = create_side_effect_dict({(str(Files.SINGLE_OPERATION_CONFIG_DB_PATCH),): 0})
+        patch_applier.apply.side_effect = create_side_effect_dict(
+            {(str(Files.SINGLE_OPERATION_CONFIG_DB_PATCH), 'True'): 0}
+        )
 
         patch_wrapper = Mock()
         patch_wrapper.convert_sonic_yang_patch_to_config_db_patch.side_effect = \
@@ -886,7 +896,8 @@ class TestConfigLockDecorator(unittest.TestCase):
         # Assert
         config_lock_decorator.config_lock.acquire_lock.assert_called_once()
         config_lock_decorator.decorated_patch_applier.apply.assert_has_calls(
-            [call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH)])
+            [call(Files.SINGLE_OPERATION_SONIC_YANG_PATCH, True, trace_io=None)]
+        )
         config_lock_decorator.config_lock.release_lock.assert_called_once()
 
     def test_replace__lock_config(self):
@@ -898,7 +909,9 @@ class TestConfigLockDecorator(unittest.TestCase):
 
         # Assert
         config_lock_decorator.config_lock.acquire_lock.assert_called_once()
-        config_lock_decorator.decorated_config_replacer.replace.assert_has_calls([call(Files.SONIC_YANG_AS_JSON)])
+        config_lock_decorator.decorated_config_replacer.replace.assert_has_calls(
+            [call(Files.SONIC_YANG_AS_JSON, trace_io=None)]
+        )
         config_lock_decorator.config_lock.release_lock.assert_called_once()
 
     def test_rollback__lock_config(self):
@@ -929,7 +942,9 @@ class TestConfigLockDecorator(unittest.TestCase):
         config_lock = Mock()
 
         patch_applier = Mock()
-        patch_applier.apply.side_effect = create_side_effect_dict({(str(Files.SINGLE_OPERATION_SONIC_YANG_PATCH),): 0})
+        patch_applier.apply.side_effect = create_side_effect_dict(
+            {(str(Files.SINGLE_OPERATION_SONIC_YANG_PATCH), 'True'): 0}
+        )
 
         config_replacer = Mock()
         config_replacer.replace.side_effect = create_side_effect_dict({(str(Files.SONIC_YANG_AS_JSON),): 0})

--- a/tests/generic_config_updater/gutest_helpers.py
+++ b/tests/generic_config_updater/gutest_helpers.py
@@ -11,7 +11,7 @@ class MockSideEffectDict:
     def __init__(self, map):
         self.map = map
 
-    def side_effect_func(self, *args):
+    def side_effect_func(self, *args, **kwargs):
         l = [str(arg) for arg in args]
         key = tuple(l)
         value = self.map.get(key)
@@ -47,7 +47,7 @@ class MockSideEffectDict:
 
         rv = []
         for val in value:
-            rv.append(JsonMoveGroup(val))
+            rv.append(JsonMoveGroup(self.__class__.__name__, val))
         return rv
 
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
+import io
 import jsonpatch
+import sys
 import unittest
 from unittest.mock import MagicMock, Mock
 import generic_config_updater.patch_sorter as ps
@@ -490,11 +492,11 @@ class TestMoveWrapper(unittest.TestCase):
 
         self.fail_move_validator = Mock()
         self.fail_move_validator.validate.side_effect = create_side_effect_skiplastarg_dict(
-            {(str(self.any_move), str(self.any_diff)): False})
+            {(str(self.any_move), str(self.any_diff)): (False, None)})
 
         self.success_move_validator = Mock()
         self.success_move_validator.validate.side_effect = create_side_effect_skiplastarg_dict(
-            {(str(self.any_move), str(self.any_diff)): True})
+            {(str(self.any_move), str(self.any_diff)): (True, None)})
 
     def test_ctor__assigns_values_correctly(self):
         # Arrange
@@ -516,7 +518,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [JsonMoveGroup(self.any_move)]
+        expected = [JsonMoveGroup("", self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -528,8 +530,11 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.multiple_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1),
-                    JsonMoveGroup(self.any_other_move2)]
+        expected = [
+            JsonMoveGroup("", self.any_move),
+            JsonMoveGroup("", self.any_other_move1),
+            JsonMoveGroup("", self.any_other_move2),
+        ]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -541,7 +546,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.single_move_generator, self.another_single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1)]
+        expected = [JsonMoveGroup("", self.any_move), JsonMoveGroup("", self.any_other_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -553,7 +558,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.single_move_generator, self.single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [JsonMoveGroup(self.any_move)]
+        expected = [JsonMoveGroup("", self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -565,7 +570,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_non_extendable_generators = [self.single_move_generator, self.another_single_move_generator]
         move_wrapper = ps.MoveWrapper([], move_non_extendable_generators, [], [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1)]
+        expected = [JsonMoveGroup("", self.any_move), JsonMoveGroup("", self.any_other_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -577,7 +582,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_non_extendable_generators = [self.single_move_generator, self.single_move_generator]
         move_wrapper = ps.MoveWrapper([], move_non_extendable_generators, [], [])
-        expected = [JsonMoveGroup(self.any_move)]
+        expected = [JsonMoveGroup("", self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -590,7 +595,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_non_extendable_generators = [self.single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, move_non_extendable_generators, [], [])
-        expected = [JsonMoveGroup(self.any_move)]
+        expected = [JsonMoveGroup("", self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -603,7 +608,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move)]
+        expected = [JsonMoveGroup("", self.any_move), JsonMoveGroup("", self.any_extended_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -616,8 +621,8 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.multiple_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move),
-                    JsonMoveGroup(self.any_other_extended_move1), JsonMoveGroup(self.any_other_extended_move2)]
+        expected = [JsonMoveGroup("", self.any_move), JsonMoveGroup("", self.any_extended_move),
+                    JsonMoveGroup("", self.any_other_extended_move1), JsonMoveGroup("", self.any_other_extended_move2)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -630,8 +635,8 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender, self.another_single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move),
-                    JsonMoveGroup(self.any_other_extended_move1)]
+        expected = [JsonMoveGroup("", self.any_move), JsonMoveGroup("", self.any_extended_move),
+                    JsonMoveGroup("", self.any_other_extended_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -644,7 +649,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender, self.single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move)]
+        expected = [JsonMoveGroup("", self.any_move), JsonMoveGroup("", self.any_extended_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -657,11 +662,11 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator, self.another_single_move_generator]
         move_extenders = [self.mixed_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move),
-                    JsonMoveGroup(self.any_other_move1),
-                    JsonMoveGroup(self.any_extended_move),
-                    JsonMoveGroup(self.any_other_extended_move1),
-                    JsonMoveGroup(self.any_other_extended_move2)]
+        expected = [JsonMoveGroup("", self.any_move),
+                    JsonMoveGroup("", self.any_other_move1),
+                    JsonMoveGroup("", self.any_extended_move),
+                    JsonMoveGroup("", self.any_other_extended_move1),
+                    JsonMoveGroup("", self.any_other_extended_move2)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -674,7 +679,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_non_extendable_generators = [self.single_move_generator, self.another_single_move_generator]
         move_extenders = [self.mixed_move_extender]
         move_wrapper = ps.MoveWrapper([], move_non_extendable_generators, move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1)]
+        expected = [JsonMoveGroup("", self.any_move), JsonMoveGroup("", self.any_other_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -688,9 +693,9 @@ class TestMoveWrapper(unittest.TestCase):
         move_non_extendable_generators = [self.single_move_generator] # generates: any_move
         move_extenders = [self.mixed_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, move_non_extendable_generators, move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move),
-                    JsonMoveGroup(self.any_other_move1),
-                    JsonMoveGroup(self.any_other_extended_move1)]
+        expected = [JsonMoveGroup("", self.any_move),
+                    JsonMoveGroup("", self.any_other_move1),
+                    JsonMoveGroup("", self.any_other_extended_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -704,8 +709,8 @@ class TestMoveWrapper(unittest.TestCase):
         move_non_extendable_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, move_non_extendable_generators, move_extenders, [])
-        expected = [JsonMoveGroup(self.any_move),
-                    JsonMoveGroup(self.any_extended_move)]
+        expected = [JsonMoveGroup("", self.any_move),
+                    JsonMoveGroup("", self.any_extended_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -719,7 +724,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_wrapper = ps.MoveWrapper([], [], [], move_validators)
 
         # Act and assert
-        self.assertFalse(move_wrapper.validate(self.any_move, self.any_diff))
+        self.assertFalse(move_wrapper.validate(self.any_move, self.any_diff)[0])
 
     def test_validate__validation_succeed__true_returned(self):
         # Arrange
@@ -727,7 +732,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_wrapper = ps.MoveWrapper([], [], [], move_validators)
 
         # Act and assert
-        self.assertTrue(move_wrapper.validate(self.any_move, self.any_diff))
+        self.assertTrue(move_wrapper.validate(self.any_move, self.any_diff)[0])
 
     def test_validate__multiple_validators_last_fail___false_returned(self):
         # Arrange
@@ -735,7 +740,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_wrapper = ps.MoveWrapper([], [], [], move_validators)
 
         # Act and assert
-        self.assertFalse(move_wrapper.validate(self.any_move, self.any_diff))
+        self.assertFalse(move_wrapper.validate(self.any_move, self.any_diff)[0])
 
     def test_validate__multiple_validators_succeed___true_returned(self):
         # Arrange
@@ -743,7 +748,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_wrapper = ps.MoveWrapper([], [], [], move_validators)
 
         # Act and assert
-        self.assertTrue(move_wrapper.validate(JsonMoveGroup(self.any_move), self.any_diff))
+        self.assertTrue(move_wrapper.validate(JsonMoveGroup("", self.any_move), self.any_diff)[0])
 
     def test_simulate__applies_move(self):
         # Arrange
@@ -904,7 +909,7 @@ class TestDeleteWholeConfigMoveValidator(unittest.TestCase):
         move = ps.JsonMove.from_operation(operation)
 
         # Act
-        actual = self.validator.validate(JsonMoveGroup(move), self.any_diff, self.any_target_config)
+        actual, _ = self.validator.validate(JsonMoveGroup("", move), self.any_diff, self.any_target_config)
 
         # Assert
         self.assertEqual(expected, actual)
@@ -927,7 +932,8 @@ class TestFullConfigMoveValidator(unittest.TestCase):
         validator = ps.FullConfigMoveValidator(config_wrapper)
 
         # Act and assert
-        self.assertFalse(validator.validate(JsonMoveGroup(self.any_move), self.any_diff, self.any_simulated_config))
+        self.assertFalse(
+                validator.validate(JsonMoveGroup("", self.any_move), self.any_diff, self.any_simulated_config)[0])
 
     def test_validate__valid_config_db_after_applying_move__success(self):
         # Arrange
@@ -937,7 +943,8 @@ class TestFullConfigMoveValidator(unittest.TestCase):
         validator = ps.FullConfigMoveValidator(config_wrapper)
 
         # Act and assert
-        self.assertTrue(validator.validate(JsonMoveGroup(self.any_move), self.any_diff, self.any_simulated_config))
+        self.assertTrue(
+                validator.validate(JsonMoveGroup("", self.any_move), self.any_diff, self.any_simulated_config)[0])
 
 class TestCreateOnlyMoveValidator(unittest.TestCase):
     def setUp(self):
@@ -1199,7 +1206,7 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
         diff = ps.Diff(current_config, target_config)
         move = ps.JsonMove.from_operation({"op":"add", "path":"/BGP_NEIGHBOR/10.0.0.57", "value": added_parent_value})
 
-        actual = self.validator.validate(move, diff, move.apply(diff.current_config))
+        actual, _ = self.validator.validate(move, diff, move.apply(diff.current_config))
 
         self.assertEqual(expected, actual)
 
@@ -1211,7 +1218,7 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
         move = ps.JsonMove(diff, OperationType.REPLACE, current_config_tokens, target_config_tokens)
 
         # Act
-        actual = self.validator.validate(move, diff, move.apply(diff.current_config))
+        actual, _ = self.validator.validate(move, diff, move.apply(diff.current_config))
 
         # Assert
         self.assertEqual(expected, actual)
@@ -1226,17 +1233,17 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # Arrange
         # CROPPED_CONFIG_DB_AS_JSON has dependencies between PORT and ACL_TABLE
         diff = ps.Diff(Files.EMPTY_CONFIG_DB, Files.CROPPED_CONFIG_DB_AS_JSON)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, [], []))
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__add_full_config_no_dependencies__success(self):
         # Arrange
         diff = ps.Diff(Files.EMPTY_CONFIG_DB, Files.CONFIG_DB_NO_DEPENDENCIES)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__add_table_has_no_dependencies__success(self):
         # Arrange
@@ -1246,10 +1253,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
             {"op": "remove", "path":"/ACL_TABLE"}
         ]))
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"]))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__remove_table_has_no_dependencies__success(self):
         # Arrange
@@ -1258,10 +1265,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
             {"op": "remove", "path":"/ACL_TABLE"}
         ]))
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"]))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__replace_whole_config_item_added_ref_added__failure(self):
         # Arrange
@@ -1273,10 +1280,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__replace_whole_config_item_removed_ref_removed__false(self):
         # Arrange
@@ -1288,10 +1295,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__replace_whole_config_item_same_ref_added__true(self):
         # Arrange
@@ -1302,10 +1309,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__replace_whole_config_item_same_ref_removed__true(self):
         # Arrange
@@ -1316,10 +1323,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__replace_whole_config_item_same_ref_same__true(self):
         # Arrange
@@ -1328,10 +1335,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         target_config = current_config
 
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__replace_list_item_different_location_than_target_and_no_deps__true(self):
         # Arrange
@@ -1359,11 +1366,18 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         diff = ps.Diff(current_config, target_config)
         # the target tokens point to location 0 which exist in target_config
         # but the replace operation is operating on location 1 in current_config
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["VLAN", "Vlan100", "dhcp_servers", 1],
-                                         ["VLAN", "Vlan100", "dhcp_servers", 0]))
+        move = JsonMoveGroup(
+            "",
+            ps.JsonMove(
+                diff,
+                OperationType.REPLACE,
+                ["VLAN", "Vlan100", "dhcp_servers", 1],
+                ["VLAN", "Vlan100", "dhcp_servers", 0]
+            ),
+        )
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def prepare_config(self, config, patch):
         return patch.apply(config)
@@ -1378,110 +1392,116 @@ class TestNoEmptyTableMoveValidator(unittest.TestCase):
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{"key1":"value1", "key2":"value22"}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key1"], ["some_table", "key1"]))
+        move = JsonMoveGroup(
+            "",
+            ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key1"], ["some_table", "key1"])
+        )
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__change_but_no_empty_table__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{"key1":"value1", "key2":"value22"}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key2"], ["some_table", "key2"]))
+        move = JsonMoveGroup(
+            "",
+            ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key2"], ["some_table", "key2"]),
+        )
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__single_empty_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["some_table"], ["some_table"]))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, ["some_table"], ["some_table"]))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__whole_config_replace_single_empty_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__whole_config_replace_mix_of_empty_and_non_empty__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{"key1":"value1"}, "other_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__whole_config_multiple_empty_tables__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{}, "other_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__remove_key_empties_a_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{"key1":"value1"}, "other_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__remove_key_but_table_has_other_keys__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2", "key3":"value3"}}
         target_config = {"some_table":{"key1":"value1"}, "other_table":{"key3":"value3"}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__remove_whole_table__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{"key1":"value1"}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["other_table"], []))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REMOVE, ["other_table"], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__add_empty_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"new_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"]))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"]))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def test_validate__add_non_empty_table__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"new_table":{"key3":"value3"}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"]))
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
 class TestRequiredValueMoveValidator(unittest.TestCase):
     def setUp(self):
@@ -1516,12 +1536,12 @@ class TestRequiredValueMoveValidator(unittest.TestCase):
         # Arrange
         expected = test_case['expected']
         current_config = test_case['config']
-        move = JsonMoveGroup(test_case['move'])
+        move = JsonMoveGroup("", test_case['move'])
         target_config = test_case.get('target_config', move.apply(current_config))
         diff = ps.Diff(current_config, target_config)
 
         # Act and Assert
-        self.assertEqual(expected, self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertEqual(expected, self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def _get_critical_port_change_test_cases(self):
         # port-up  status-changing  under-port  port-exist  verdict
@@ -1980,12 +2000,12 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
         # Arrange
         expected = test_case['expected']
         current_config = test_case['config']
-        move = JsonMoveGroup(test_case['move'])
+        move = JsonMoveGroup("", test_case['move'])
         target_config = test_case.get('target_config', move.apply(current_config))
         diff = ps.Diff(current_config, target_config)
 
         # Act and Assert
-        self.assertEqual(expected, self.validator.validate(move, diff, move.apply(diff.current_config)))
+        self.assertEqual(expected, self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
     def _apply_operations(self, config, operations):
         return jsonpatch.JsonPatch(operations).apply(config)
@@ -3317,12 +3337,11 @@ class TestPatchSorter(unittest.TestCase):
         #     .
         # }
         data = Files.PATCH_SORTER_TEST_SUCCESS
-        skip_exact_change_list_match = False
         for test_case_name in data:
             with self.subTest(name=test_case_name):
-                self.run_single_success_case(data[test_case_name], skip_exact_change_list_match)
+                self.run_single_success_case(test_case_name, data[test_case_name])
 
-    def run_single_success_case(self, data, skip_exact_change_list_match):
+    def run_single_success_case(self, test_case_name, data):
         current_config = data["current_config"]
         patch = jsonpatch.JsonPatch(data["patch"])
         expected_changes = []
@@ -3331,19 +3350,15 @@ class TestPatchSorter(unittest.TestCase):
 
         sorter = self.create_patch_sorter(current_config)
 
-        actual_changes = sorter.sort(patch)
+        trace_io = io.StringIO()
+        actual_changes = sorter.sort(patch, trace_io=trace_io)
+        trace = trace_io.getvalue()
+        trace_io.close()
 
-        if not skip_exact_change_list_match:
-            self.assertEqual(expected_changes, actual_changes)
+        if expected_changes != actual_changes:
+            print(f"{test_case_name} failed, trace: \n{trace}", file=sys.stderr)
 
-        target_config = patch.apply(current_config)
-        simulated_config = current_config
-        for change in actual_changes:
-            simulated_config = change.apply(simulated_config)
-            is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
-            self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
-
-        self.assertEqual(target_config, simulated_config)
+        self.assertEqual(expected_changes, actual_changes)
 
     def test_patch_sorter_failure(self):
         # Format of the JSON file containing the test-cases:
@@ -3389,7 +3404,8 @@ class TestPatchSorter(unittest.TestCase):
         any_patch = Files.SINGLE_OPERATION_CONFIG_DB_PATCH
         target_config = any_patch.apply(current_config)
         sort_algorithm = Mock()
-        sort_algorithm.sort = lambda diff: [JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))]
+        sort_algorithm.sort = lambda diff: [JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))]
+        sort_algorithm.path_tracker = None
         patch_sorter = self.create_patch_sorter(current_config, sort_algorithm)
         expected = [JsonChange(jsonpatch.JsonPatch([OperationWrapper().create(OperationType.REPLACE, "", target_config)]))]
 


### PR DESCRIPTION
#### What I did

GCU uses a very complex set of generators and validators.  When a suboptimal plan is created, it can be hard to determine why the path was generated the way it was and how best to optimize the generators.

This patch adds the ability to pass an IO object to all attempted paths with annotations such as `valid`, `invalid`, `recurse_reject` (source and target were already attempted), and `path_issue` (patch was good, but a generator further down the hierarchy failed).  It will also list the generator used for each patch, and if `invalid` it will list the validator which failed it with a possibly extended error message.

For callers to `config replace` or `config apply-patch` a new command line option of `--path-trace` which takes a filename to dump the json output.

This patch also increases the diff output shown during test run failures to make it easier to debug issues based on logging generated via CI/CD.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/25748

#### How I did it

Modified various classes and functions to pass around objects and metadata needed to generate the trace.

#### How to verify it

Run `config replace` or `config apply-patch` with the `--path-trace` argument.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Example output showing a suboptimal plan: 
[trace.json](https://github.com/user-attachments/files/25622544/trace.json)


