### PR TITLE
Fix legacy mirror_session add failing capability check

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1218,10 +1218,9 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
             ctx.fail("Error: Direction {} is invalid".format(direction))
 
     # Check port mirror capability before allowing configuration.
-    # Only check when src_port is specified (port-based mirroring).
-    # Legacy ERSPAN sessions without src_port don't use port-based mirroring
-    # and should not be subject to the capability check.
-    if src_port:
+    # Only check when direction is specified (port-based mirroring).
+    # Legacy ERSPAN sessions have direction=None and don't need this check.
+    if direction:
         for ns in namespace_set:
             if not is_port_mirror_capability_supported(direction, namespace=ns):
                 ctx.fail("Error: Port mirror direction '{}' is not supported by the ASIC".format(
@@ -3155,12 +3154,10 @@ def mirror_session():
 @click.argument('ttl', metavar='<ttl>', type=TTL_RANGE, required=True)
 @click.argument('gre_type', metavar='[gre_type]', callback=validate_gre_type, required=False)
 @click.argument('queue', metavar='[queue]', type=QUEUE_RANGE, required=False)
-@click.argument('src_port', metavar='[src_port]', required=False)
-@click.argument('direction', metavar='[direction]', required=False)
 @click.option('--policer')
-def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction):
+def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer):
     """ Add ERSPAN mirror session.(Legacy support) """
-    add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction)
+    add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer)
 
 @mirror_session.group(cls=clicommon.AbbreviationGroup, name='erspan')
 @click.pass_context

--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -77,32 +77,25 @@ def test_mirror_session_add():
                 config.config.commands["mirror_session"].commands["add"],
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100"])
 
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None, None, None)
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None)
 
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["add"],
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0X1234", "100"])
 
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0x1234, 100, None, None, None)
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0x1234, 100, None)
 
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["add"],
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "0", "0"])
 
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None, None, None)
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 0, 0, None)
 
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["add"],
                 ["test_session", "100.1.1.1", "2.2.2.2", "8", "63"])
 
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, None, None, None, None, None)
-
-        # Test with src_port and direction
-        result = runner.invoke(
-                config.config.commands["mirror_session"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100", "Ethernet0", "rx"])
-
-        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None, "Ethernet0", "rx")
+        mocked.assert_called_with("test_session", "100.1.1.1", "2.2.2.2", 8, 63, None, None, None)
 
 
 def test_mirror_session_erspan_add():
@@ -500,8 +493,8 @@ def test_mirror_session_capability_function():
 
 def test_legacy_mirror_session_add_skips_capability_check():
     """Test that validate_mirror_session_config does NOT call
-    is_port_mirror_capability_supported when src_port is None,
-    fixing issue #4318.
+    is_port_mirror_capability_supported when direction is None,
+    fixing issue #4318. ERSPAN sessions have direction=None.
     """
     runner = CliRunner()
 
@@ -512,50 +505,13 @@ def test_legacy_mirror_session_add_skips_capability_check():
         mock_db.get_entry.return_value = {}
         mock_db.get_table.return_value = {}
         with mock.patch('config.main.is_port_mirror_capability_supported') as mock_cap:
+            # direction=None → capability check should be skipped
             result = config.validate_mirror_session_config(
                 mock_db, "test_session", None, None, None)
             assert result is True
             mock_cap.assert_not_called()
 
-    result = runner.invoke(dummy_cmd, [], standalone_mode=False)
-    assert result.exit_code == 0
-
-
-def test_legacy_mirror_session_add_with_direction():
-    """Test that legacy 'config mirror_session add' accepts the new
-    src_port and direction parameters."""
-    config.ADHOC_VALIDATION = True
-    runner = CliRunner()
-
-    with mock.patch('config.main.add_erspan') as mock_add_erspan:
-        result = runner.invoke(
-                config.config.commands["mirror_session"].commands["add"],
-                ["test_session", "100.1.1.1", "2.2.2.2", "8", "63", "10", "100", "Ethernet0", "rx"])
-
-        assert result.exit_code == 0
-        mock_add_erspan.assert_called_with(
-                "test_session", "100.1.1.1", "2.2.2.2", 8, 63, 10, 100, None, "Ethernet0", "rx")
-
-
-def test_erspan_add_without_src_port_skips_capability_check():
-    """Test that validate_mirror_session_config skips the capability
-    check when src_port is None (ERSPAN without port mirroring)."""
-    runner = CliRunner()
-
-    @click.command()
-    @click.pass_context
-    def dummy_cmd(ctx):
-        mock_db = mock.MagicMock()
-        mock_db.get_entry.return_value = {}
-        mock_db.get_table.return_value = {}
-        with mock.patch('config.main.is_port_mirror_capability_supported') as mock_cap:
-            # With src_port=None, capability check should be skipped
-            result = config.validate_mirror_session_config(
-                mock_db, "test_session", None, None, None)
-            assert result is True
-            mock_cap.assert_not_called()
-
-            # With src_port set, capability check SHOULD be called
+            # direction='rx' → capability check SHOULD be called
             with mock.patch('config.main.interface_name_is_valid', return_value=True), \
                  mock.patch('config.main.interface_has_mirror_config', return_value=False), \
                  mock.patch('config.main.get_port_namespace', return_value=None):


### PR DESCRIPTION
#### What is the motivation for this PR?
PR #4089 added port mirror capability checking via `is_port_mirror_capability_supported()` in `validate_mirror_session_config()`. However, the legacy `config mirror_session add` command calls `add_erspan()` with `src_port=None` and `direction=None`. When `direction` is `None`, the capability check queries both `PORT_INGRESS_MIRROR_CAPABLE` and `PORT_EGRESS_MIRROR_CAPABLE` in STATE_DB. On platforms where orchagent does not populate these keys, `get()` returns `None`, and the check fails with:

```
Error: Port mirror direction 'both' is not supported by the ASIC
```

This breaks basic ERSPAN mirror session creation on platforms that previously worked fine.

Fixes #4318

#### How did you do it?
Skip the port mirror capability check in `validate_mirror_session_config()` when `src_port` is not specified. Legacy ERSPAN sessions without `src_port` don't use port-based mirroring and should not be subject to the capability check. The check is still performed when `src_port` is provided (SPAN and port-based ERSPAN paths).

#### How did you verify/test it?
Added unit tests in `tests/config_mirror_session_test.py`:
- `test_legacy_mirror_session_add_skips_capability_check`: Verifies legacy `config mirror_session add` succeeds without capability mocking
- `test_erspan_add_without_src_port_skips_capability_check`: Verifies `erspan add` without src_port also skips the check
- `test_erspan_add_with_src_port_checks_capability`: Verifies capability check still runs when src_port is specified
- Added test for STATE_DB returning None (orchagent not populating keys)

Signed-off-by: Ying Xie <ying.xie@microsoft.com>