### PR TITLE
Fix mirror session SPAN test apostrophe mismatch

### DIFF
--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -260,7 +260,7 @@ def test_mirror_session_span_add():
             config.config.commands["mirror_session"].commands["span"].commands["add"],
             ["test_session", "Ethernet52", "Ethernet52", "rx", "100"])
     assert result.exit_code != 0
-    assert "Error: Destination Interface cant be same as Source Interface" in result.stdout
+    assert "Error: Destination Interface can't be same as Source Interface" in result.output
 
     # Verify destination port not have mirror config
     result = runner.invoke(


### PR DESCRIPTION
#### What is the motivation for this PR?
The SPAN mirror session test `test_mirror_session_span_add` has a broken assertion that silently fails to match the error string. The test asserts:

```
"Error: Destination Interface cant be same as Source Interface"
```

But the actual error message in `config/main.py` uses an apostrophe:

```
"Error: Destination Interface can't be same as Source Interface"
```

Since `cant` is NOT a substring of `can't` (the apostrophe breaks contiguity: `c-a-n-'-t` vs `c-a-n-t`), the assertion always fails.

#### How did you do it?
- Fixed the test string to include the apostrophe: `can't`
- Changed `result.stdout` to `result.output` to correctly capture click's error output (which may include both stdout and stderr)

#### How did you verify/test it?
Verified with Python that the substring match now works:
```python
>>> "cant" in "can't"
False  # broken
>>> "can't" in "can't"
True   # fixed
```

Signed-off-by: Ying Xie <ying.xie@microsoft.com>