### PR TITLE
Fix unit test assertions broken by spelling typo PRs

### DIFF
--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -260,7 +260,7 @@ def test_mirror_session_span_add():
             config.config.commands["mirror_session"].commands["span"].commands["add"],
             ["test_session", "Ethernet52", "Ethernet52", "rx", "100"])
     assert result.exit_code != 0
-    assert "Error: Destination Interface cant be same as Source Interface" in result.stdout
+    assert "Error: Destination Interface can't be same as Source Interface" in result.stdout
 
     # Verify destination port not have mirror config
     result = runner.invoke(

--- a/tests/remote_cli_test.py
+++ b/tests/remote_cli_test.py
@@ -155,7 +155,7 @@ class TestRemoteExec(object):
             rexec.cli, [LINECARD_NAME, "-c", "show version"])
         print(result.output)
         assert result.exit_code == 1, result.output
-        assert "This commmand is only supported Chassis" in result.output
+        assert "This command is only supported Chassis" in result.output
 
     @mock.patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @mock.patch("os.getlogin", mock.MagicMock(return_value="admin"))
@@ -318,4 +318,4 @@ class TestRemoteCLI(object):
         result = runner.invoke(rshell.cli, [LINECARD_NAME])
         print(result.output)
         assert result.exit_code == 1, result.output
-        assert "This commmand is only supported Chassis" in result.output
+        assert "This command is only supported Chassis" in result.output

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -794,7 +794,7 @@ namespace 'asic7' is not valid. valid name spaces are:
 """
 
 show_ip_route_multi_asic_invalid_display_err_output = """\
-dislay option 'everything' is not a valid option.
+display option 'everything' is not a valid option.
 """
 
 show_ip_route_multi_asic_specific_route_output = """\

--- a/tests/sku_create_test.py
+++ b/tests/sku_create_test.py
@@ -525,7 +525,7 @@ class TestSkuCreate(object):
             sku.fpp_split = {1: [['etp1a', 'etp1b'], [1, 2]]}
             sku.default_lanes_per_port = ['0,1,2', '3,4,5', '6,7,8']
             sku.set_lanes()
-        mock_print.assert_called_once_with("Lanes(0,1,2) could not be evenly splitted by 2.")
+        mock_print.assert_called_once_with("Lanes(0,1,2) could not be evenly split by 2.")
         assert e.value.code == 1
 
     @patch('builtins.print')

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -19,7 +19,7 @@ ERROR_STR_MISS_NEXTHOP = '''
 Error: argument is incomplete, nexthop not found!
 '''
 ERROR_STR_DEL_NONEXIST_KEY = '''
-Error: Route {} doesnt exist
+Error: Route {} doesn't exist
 '''
 ERROR_STR_DEL_NONEXIST_ENTRY = '''
 Error: Not found {} in {}

--- a/tests/vnet_test.py
+++ b/tests/vnet_test.py
@@ -285,7 +285,7 @@ Error: 'vnet_name' must begin with 'Vnet'.
         # Test vnet add route when vnet doesnt exist
         args = ["Vnet_6", "10.10.10.10/32", "10.10.10.1"]
         result = runner.invoke(config.config.commands["vnet"].commands["add-route"], args, obj=vnet_obj)
-        assert "VNET Vnet_6 doesnot exist, cannot add a route!" in result.output
+        assert "VNET Vnet_6 does not exist, cannot add a route!" in result.output
         assert result.exit_code != 0
 
         # Test vnet add route using length of vnet name
@@ -348,13 +348,13 @@ Error: 'vnet_name' must begin with 'Vnet'.
         result = runner.invoke(config.config.commands["vnet"].commands["del-route"], args, obj=vnet_obj)
         assert result.exit_code != 0
         assert ('Vnet_100') not in db.cfgdb.get_table('VNET')
-        assert "VNET Vnet_100 doesnot exist, cannot delete the route!" in result.output
+        assert "VNET Vnet_100 does not exist, cannot delete the route!" in result.output
 
         # Test vnet del route with non existent route
         args = ["Vnet3", "10.10.10.10/32"]
         result = runner.invoke(config.config.commands["vnet"].commands["del-route"], args, obj=vnet_obj)
         assert result.exit_code != 0
-        assert "Routes dont exist for the VNET Vnet3, cant delete it!" in result.output
+        assert "Routes dont exist for the VNET Vnet3, can't delete it!" in result.output
 
     def test_vnet_add_del_2(self):
         runner = CliRunner()

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -333,10 +333,10 @@ def display_bgp_summary(bgp_summary, af):
 
     '''
 
-    # "Neighbor" is a known typo,
+    # "Neighbhor" is a known typo,
     # but fix it will impact lots of automation scripts that the community users may have developed for years
     # for now, let's keep it as it is.
-    headers = ["Neighbor", "V", "AS", "MsgRcvd", "MsgSent", "TblVer",
+    headers = ["Neighbhor", "V", "AS", "MsgRcvd", "MsgSent", "TblVer",
                "InQ", "OutQ", "Up/Down", "State/PfxRcd", "NeighborName"]
 
     try:


### PR DESCRIPTION
## Description
Fix unit test assertion strings that were broken by recent spelling correction PRs (#4258, #4261, #4262, #4263, #4264). The source code strings were corrected but the corresponding test assertions were not updated.

Also reverts the `Neighbhor` → `Neighbor` header change in `bgp_util.py` since the source code explicitly notes this known typo is intentionally preserved for backward compatibility with community automation scripts.

### Changes
| File | Fix |
|------|-----|
| `tests/vnet_test.py` | `doesnot` → `does not`, `cant` → `can't` |
| `tests/config_mirror_session_test.py` | `cant` → `can't` |
| `tests/static_routes_test.py` | `doesnt` → `doesn't` |
| `tests/remote_cli_test.py` | `commmand` → `command` |
| `tests/sku_create_test.py` | `splitted` → `split` |
| `tests/show_ip_route_common.py` | `dislay` → `display` |
| `utilities_common/bgp_util.py` | Revert `Neighbhor` header (intentionally kept) |

### Fixes
Resolves unit test failures in: `vnet_test`, `config_mirror_session_test`, `static_routes_test`, `bgp_commands_test` (18 tests), `remote_cli_test`, `sku_create_test`, `ip_show_routes_multi_asic_test`

Supersedes #4320

Signed-off-by: Rustiqly <rustiqly@users.noreply.github.com>