### PR TITLE
Fix warning messages due to nose test deprecation

### DIFF
--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from unittest.mock import patch, MagicMock
 
 class TestClear(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('clear.main.run_command')
@@ -115,12 +115,12 @@ class TestClear(object):
         assert result.exit_code == 0
         run_command.assert_called_with(['switchstat', '-c'])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestClearQuaggav4(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('clear.main.run_command')
@@ -176,12 +176,12 @@ class TestClearQuaggav4(object):
         assert result.exit_code == 0
         run_command.assert_called_with(['sudo', 'vtysh', '-c', "clear ip bgp 10.0.0.1 soft out"])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestClearQuaggav6(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('clear.main.run_command')
@@ -237,12 +237,12 @@ class TestClearQuaggav6(object):
         assert result.exit_code == 0
         run_command.assert_called_with(['sudo', 'vtysh', '-c', "clear ipv6 bgp 10.0.0.1 soft out"])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestClearFrr(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('clear.main.run_command')
@@ -298,12 +298,12 @@ class TestClearFrr(object):
         assert result.exit_code == 0
         run_command.assert_called_with(['sudo', 'vtysh', '-c', "clear bgp ipv6 10.0.0.1 soft out"])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestClearFlowcnt(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -330,6 +330,6 @@ class TestClearFlowcnt(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_with(['flow_counters_stat', '-c', '-t', 'route', '--prefix', '3.3.0.0/16', '--vrf', str('Vrf_1'), '-n', 'asic0'])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -402,7 +402,7 @@ def mock_run_command_side_effect_disabled_timer(*args, **kwargs):
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
 
 class TestHelper(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('config.main.subprocess.Popen')
@@ -417,11 +417,11 @@ class TestHelper(object):
         mock_subprocess.assert_called_with(['/usr/local/bin/sonic-cfggen', '-m', '-v', 'DEVICE_METADATA.localhost.type'], text=True, stdout=-1)
         assert device_type == "Unknown"
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
 
 class TestConfig(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('config.main.subprocess.check_call')
@@ -3463,7 +3463,7 @@ class TestConfigNtp(object):
 
 
 class TestConfigPfcwd(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('utilities_common.cli.run_command')
@@ -3520,12 +3520,12 @@ class TestConfigPfcwd(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['pfcwd', 'start_default'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
 
 
 class TestConfigAclUpdate(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('utilities_common.cli.run_command')
@@ -3548,12 +3548,12 @@ class TestConfigAclUpdate(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['acl-loader', 'update', 'incremental', file_name])
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
 
 
 class TestConfigDropcounters(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('utilities_common.cli.run_command')
@@ -3620,12 +3620,12 @@ class TestConfigDropcounters(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['dropconfig', '-c', 'remove', '-n', str(counter_name), '-r', str(reasons)], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
 
 
 class TestConfigDropcountersMasic(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
         os.environ['UTILITIES_UNIT_TESTING'] = "1"
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
@@ -3746,7 +3746,7 @@ class TestConfigDropcountersMasic(object):
         dbconnector.load_namespace_config()
 
 class TestConfigWatermarkTelemetry(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('utilities_common.cli.run_command')
@@ -3759,12 +3759,12 @@ class TestConfigWatermarkTelemetry(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['watermarkcfg', '--config-interval', str(interval)])
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
 
 
 class TestConfigZtp(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('utilities_common.cli.run_command')
@@ -3794,7 +3794,7 @@ class TestConfigZtp(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['ztp', 'enable'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
 
 
@@ -3820,7 +3820,7 @@ def test_change_hostname(mock_run_command):
 
 
 class TestConfigInterface(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('utilities_common.cli.run_command')
@@ -3960,7 +3960,7 @@ class TestConfigInterface(object):
         assert result.exit_code == 0
         assert db.cfgdb.get_table('LOOPBACK_INTERFACE')['Loopback0']['admin_status'] == 'up'
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
 
 

--- a/tests/disk_check_test.py
+++ b/tests/disk_check_test.py
@@ -126,7 +126,7 @@ def swap_work(tc):
 
 
 class TestDiskCheck(object):
-    def setup(self):
+    def setup_method(self):
         pass
 
 

--- a/tests/dropconfig_test.py
+++ b/tests/dropconfig_test.py
@@ -11,7 +11,7 @@ dropconfig_path = os.path.join(scripts_path, 'dropconfig')
 dropconfig = load_module_from_source('dropconfig', dropconfig_path)
 
 class TestDropConfig(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('builtins.print')
@@ -169,5 +169,5 @@ class TestDropConfig(object):
         mock_print.assert_called_once_with(err_msg)
         assert e.value.code == 1
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEARDOWN')

--- a/tests/fast_reboot_filter_routes_test.py
+++ b/tests/fast_reboot_filter_routes_test.py
@@ -5,7 +5,7 @@ from mock import patch
 fast_reboot_filter_routes = importlib.import_module("scripts.fast-reboot-filter-routes")
 
 class TestFastRebootFilterRoutes(object):
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
 
     @patch('utilities_common.cli.run_command')
@@ -22,5 +22,5 @@ class TestFastRebootFilterRoutes(object):
             fast_reboot_filter_routes.get_connected_routes()
         mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', "show ip route connected json"], return_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEAR DOWN")

--- a/tests/flock_test.py
+++ b/tests/flock_test.py
@@ -28,7 +28,7 @@ def dummy_f2(bypass_lock=True):
 
 
 class TestFLock:
-    def setup(self):
+    def setup_method(self):
         print("SETUP")
         f0_exit.clear()
         f1_exit.clear()
@@ -180,7 +180,7 @@ class TestFLock:
                 f2_exit.set()
                 thrd.join()
 
-    def teardown(self):
+    def teardown_method(self):
         print("TEARDOWN")
         f0_exit.clear()
         f1_exit.clear()

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -7,7 +7,7 @@ sys.modules['sonic_platform.platform'] = MagicMock()
 import fwutil.lib as fwutil_lib
 
 class TestSquashFs(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('fwutil.lib.check_output_pipe')
@@ -75,12 +75,12 @@ class TestSquashFs(object):
             call(sqfs.fs_mountpoint)
         ]
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEARDOWN')
 
 
 class TestComponentUpdateProvider(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch("glob.glob", MagicMock(side_effect=[[], ['abc'], [], ['abc']]))
@@ -242,7 +242,7 @@ class TestComponentUpdateProvider(object):
             )
         assert "Module names mismatch" in str(excinfo.value)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEARDOWN')
 
 

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -216,7 +216,7 @@ class TestRouteCheck(object):
                 return args[i + 1]
         return DEFAULTNS
 
-    def setup(self):
+    def setup_method(self):
         pass
 
     def init(self):

--- a/tests/show_barefoot_test.py
+++ b/tests/show_barefoot_test.py
@@ -7,7 +7,7 @@ from unittest.mock import call, patch, mock_open, MagicMock
 
 
 class TestShowBarefoot(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('subprocess.run')
@@ -48,6 +48,6 @@ class TestShowBarefoot(object):
         mock_open_file.assert_called_once_with('/usr/share/sonic/hwsku_dir/switch-tna-sai.conf')
         assert mock_cmd.call_args_list == expected_calls
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEARDOWN')
 

--- a/tests/show_mlnx_test.py
+++ b/tests/show_mlnx_test.py
@@ -6,7 +6,7 @@ from unittest.mock import call, patch, mock_open, MagicMock
 
 
 class TestShowMlnx(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('click.style')
@@ -113,6 +113,6 @@ class TestShowMlnx(object):
         result = show.is_issu_status_enabled()
         assert result is status
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEARDOWN')
 

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -250,7 +250,7 @@ def test_show_version():
     assert "SONiC OS Version: 11" in result.output
 
 class TestShowAcl(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -271,12 +271,12 @@ class TestShowAcl(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['acl-loader', 'show', 'table', 'EVERFLOW'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowChassis(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -306,12 +306,12 @@ class TestShowChassis(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['voqutil', '-c', 'system_lags', '-n', 'asic0', '-l', 'Linecard6'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowFabric(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -334,12 +334,12 @@ class TestShowFabric(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(["fabricstat", '-q', '-n', 'asic0'])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowFlowCounters(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -382,12 +382,12 @@ class TestShowFlowCounters(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['flow_counters_stat', '-t', 'route', '--prefix', '2001::/64', '--vrf', 'Vrf_1', '-n', 'asic0'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowInterfaces(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -639,12 +639,12 @@ class TestShowInterfaces(object):
             display_cmd=True,
         )
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowIp(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -665,12 +665,12 @@ class TestShowIp(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['sudo', 'ipintutil', '-a', 'ipv6', '-d', 'all'])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowVxlan(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -682,12 +682,12 @@ class TestShowVxlan(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['tunnelstat', '-T', 'vxlan', '-p', '3', '-i', 'tunnel1'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowNat(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -780,12 +780,12 @@ class TestShowNat(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['sudo', 'natconfig', '-z'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowProcesses(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -815,12 +815,12 @@ class TestShowProcesses(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['top', '-bn', '1', '-o', '%MEM'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShowPlatform(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -881,11 +881,11 @@ class TestShowPlatform(object):
         assert result.exit_code == 0
         mock_check_call.assert_called_with(["sudo", "fwutil", "show"])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 class TestShowQuagga(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('show.main.run_command')
@@ -920,12 +920,12 @@ class TestShowQuagga(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_with(['sudo', constants.RVTYSH_COMMAND, '-c', "show ipv6 bgp neighbor 0.0.0.0 routes"])
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
 class TestShow(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('show.main.run_command')
@@ -1216,7 +1216,7 @@ class TestShow(object):
                           call(['sudo', 'ip', 'vrf', 'exec', 'mgmt', 'chronyc', '-n', 'sources'], display_cmd=False)]
         mock_run_command.assert_has_calls(expected_calls)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 
@@ -1260,7 +1260,7 @@ class TestShowRunningconfiguration(object):
 
 
 class TestShowSRv6Counters(object):
-    def setup(self):
+    def setup_method(self):
         print('SETUP')
 
     @patch('utilities_common.cli.run_command')
@@ -1281,7 +1281,7 @@ class TestShowSRv6Counters(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['srv6stat', '-s', '1000:2:30::/48'], display_cmd=True)
 
-    def teardown(self):
+    def teardown_method(self):
         print('TEAR DOWN')
 
 

--- a/tests/swap_allocator_test.py
+++ b/tests/swap_allocator_test.py
@@ -10,7 +10,7 @@ from sonic_installer.main import SWAPAllocator
 class TestSWAPAllocator(object):
 
     @classmethod
-    def setup(cls):
+    def setup_class(cls):
         print("SETUP")
 
     def test_read_from_meminfo(self):

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -730,7 +730,7 @@ def set_mock(mock_table, mock_conn):
 
 
 class TestVnetRouteCheck(object):
-    def setup(self):
+    def setup_method(self):
         pass
 
     def init(self):


### PR DESCRIPTION
#### What I did

Multiple warnings similar to the below are emitted during test execution:
```
tests/vnet_route_check_test.py::TestVnetRouteCheck::test_vnet_route_check
  /usr/lib/python3/dist-packages/_pytest/fixtures.py:901: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  tests/vnet_route_check_test.py::TestVnetRouteCheck::test_vnet_route_check is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
  See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
```

#### How I did it

Rename `def setup(self)` to `def setup_method(self)` and `def teardown(self)` to `def teardown_method(self)` as per documentation.

#### How to verify it

Observe when running unit tests these warnings are no longer output

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

