### PR TITLE
Fix 'show version' KeyError when sonic_version.yml has missing fields

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1695,10 +1695,10 @@ def version(verbose):
 
     sys_date = datetime.now()
 
-    click.echo("\nSONiC Software Version: SONiC.{}".format(version_info['build_version']))
-    click.echo("SONiC OS Version: {}".format(version_info['sonic_os_version']))
-    click.echo("Distribution: Debian {}".format(version_info['debian_version']))
-    click.echo("Kernel: {}".format(version_info['kernel_version']))
+    click.echo("\nSONiC Software Version: SONiC.{}".format(version_info.get('build_version', 'N/A')))
+    click.echo("SONiC OS Version: {}".format(version_info.get('sonic_os_version', 'N/A')))
+    click.echo("Distribution: Debian {}".format(version_info.get('debian_version', 'N/A')))
+    click.echo("Kernel: {}".format(version_info.get('kernel_version', os.uname().release)))
     click.echo("Build commit: {}".format(version_info['commit_id']))
     click.echo("Build date: {}".format(version_info['build_date']))
     click.echo("Built by: {}".format(version_info['built_by']))

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -249,6 +249,36 @@ def test_show_version():
     result = runner.invoke(show.cli.commands["version"])
     assert "SONiC OS Version: 11" in result.output
 
+
+@patch('sonic_py_common.device_info.get_sonic_version_info', MagicMock(return_value={
+        "build_version": "",
+        "commit_id": "46415d112",
+        "build_date": "Mon Mar  2 03:02:39 UTC 2026",
+        "built_by": "test@host",
+        "sonic_os_version": "13"}))
+@patch('sonic_py_common.device_info.get_platform_info', MagicMock(return_value={
+        "platform": "x86_64-kvm_x86_64-r0",
+        "hwsku": "Force10-S6000",
+        "asic_type": "vs",
+        "asic_count": 1}))
+@patch('sonic_py_common.device_info.get_chassis_info', MagicMock(return_value={
+        "serial": "N/A",
+        "model": "N/A",
+        "revision": "N/A"}))
+@patch('subprocess.Popen', MagicMock(side_effect=side_effect_subprocess_popen))
+def test_show_version_missing_fields():
+    """Test show version doesn't crash when debian_version and kernel_version are missing.
+
+    docker-sonic-vs containers may not have these fields in sonic_version.yml
+    since they are only populated during full image builds.
+    """
+    runner = CliRunner()
+    result = runner.invoke(show.cli.commands["version"])
+    assert result.exit_code == 0, "show version crashed: {}".format(result.output)
+    assert "Distribution: Debian N/A" in result.output
+    assert "Kernel:" in result.output
+    assert "Build commit: 46415d112" in result.output
+
 class TestShowAcl(object):
     def setup(self):
         print('SETUP')


### PR DESCRIPTION
## Description
`show version` crashes with `KeyError: 'debian_version'` in docker-sonic-vs containers because `sonic_version.yml` is missing `debian_version` and `kernel_version` fields.

### Root Cause
`sonic_version.yml.j2` conditionally includes these fields only when defined during the build. The full image build (`build_debian.sh`) sets them from the filesystem root, but docker-only VS builds skip that path, so the fields are omitted.

`show/main.py` accesses them with `[]` (raises KeyError) instead of `.get()`.

### Fix
Use `version_info.get()` with sensible fallbacks:
- `debian_version` → `'N/A'`
- `kernel_version` → `os.uname().release` (actual runtime kernel)
- `build_version` → `'N/A'`
- `sonic_os_version` → `'N/A'`

### Reproduction
```bash
docker exec <docker-sonic-vs-container> show version
# Traceback: KeyError: 'debian_version'
```

### Testing
Verified `show version` no longer crashes in docker-sonic-vs containers.

Fixes sonic-net/sonic-buildimage#25765

Signed-off-by: securely1g <securely1g@users.noreply.github.com>