### PR TITLE
Preserve per-ASIC subdirectory structure for sdk_dbg collection

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1532,14 +1532,22 @@ collect_mellanox() {
     done
 
     # collect the sdk dump
+    # Preserve per-ASIC subdirectory structure to avoid basename collisions
     local sdk_dbg_folder="/var/log/sdk_dbg"
     for file in $(find $sdk_dbg_folder -name "sx_sdk_*")
     do
+        local rel_dir
+        rel_dir=$(dirname "${file#$sdk_dbg_folder/}")
+        local dest_dir="sai_sdk_dump"
+        if [[ "$rel_dir" != "." ]]; then
+            dest_dir="sai_sdk_dump/$rel_dir"
+        fi
+
         if [[ $file != *.gz ]]
         then
-            save_file $file sai_sdk_dump true
+            save_file "$file" "$dest_dir" true
         else
-            save_file $file sai_sdk_dump false
+            save_file "$file" "$dest_dir" false
         fi
     done
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed `generate_dump` to preserve per-ASIC subdirectory structure when collecting `sdk_dbg` files into techsupport dumps.

#### How I did it

Extract the relative subdirectory from each file's path under `/var/log/sdk_dbg/` and use it as part of the dump destination (e.g., `sai_sdk_dump/0/`, `sai_sdk_dump/1/`), instead of saving all files flat into `sai_sdk_dump/`. This avoids basename collisions when multiple ASICs produce files with the same timestamp. Single-ASIC systems are unaffected.


#### How to verify it

1. Extract the dump and verify `sai_sdk_dump/` contains per-ASIC subdirectories (`0/`, `1/`, etc.) with each ASIC's pcap files preserved separately.
2. On a single-ASIC switch, verify `sai_sdk_dump/` remains flat with no regressions.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

