### PR TITLE
[202511] Fix issue: pmon services restart count is not cleared during config reload (#4314)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -999,14 +999,22 @@ def _stop_services():
     clicommon.run_command(['sudo', 'systemctl', 'stop', 'sonic.target', '--job-mode', 'replace-irreversibly'])
 
 
-def _get_sonic_services():
+def _get_sonic_services(reverse=False):
     cmd = ['systemctl', 'list-dependencies', '--plain', 'sonic.target']
+    if reverse:
+        cmd.append('--reverse')
+        cmd.append('--type=service')
+
     out, _ = clicommon.run_command(cmd, return_cmd=True)
     out = out.strip().split('\n')[1:]
     return (unit.strip() for unit in out)
 
+
 def _reset_failed_services():
-    for service in _get_sonic_services():
+    services = set(_get_sonic_services())
+    services.update(set(_get_sonic_services(True)))
+
+    for service in services:
         clicommon.run_command(['systemctl', 'reset-failed', str(service)])
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -307,7 +307,9 @@ def mock_run_command_side_effect(*args, **kwargs):
         if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
-            return 'sonic.target\nswss', 0
+            return 'sonic.target\nswss\nfeatured.timer', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
@@ -334,6 +336,8 @@ def mock_run_command_cat_failed_side_effect(*args, **kwargs):
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
             return 'sonic.target\nswss', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
@@ -356,6 +360,8 @@ def mock_run_command_kill_failed_side_effect(*args, **kwargs):
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
             return 'sonic.target\nswss', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'enabled', 0
         elif command == 'cat /var/run/dhclient.eth0.pid':
@@ -380,6 +386,8 @@ def mock_run_command_side_effect_disabled_timer(*args, **kwargs):
             return 'snmp.timer', 0
         elif command == "systemctl list-dependencies --plain sonic.target":
             return 'sonic.target\nswss', 0
+        elif command == "systemctl list-dependencies --plain sonic.target --reverse --type=service":
+            return 'sonic.target\npmon', 0
         elif command == "systemctl is-enabled snmp.timer":
             return 'masked', 0
         elif command == "systemctl show swss.service --property ActiveState --value":
@@ -1058,7 +1066,8 @@ class TestLoadMinigraph(object):
                 (load_minigraph_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 16
+            mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'pmon'])
+            assert mock_run_command.call_count == 19
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
                 mock.MagicMock(return_value=("dummy_path", None)))
@@ -1102,7 +1111,7 @@ class TestLoadMinigraph(object):
                 assert result.exit_code == 0
                 assert result.output == \
                     load_minigraph_command_bypass_lock_output.format(config.SYSTEM_RELOAD_LOCK)
-                assert mock_run_command.call_count == 12
+                assert mock_run_command.call_count == 15
             finally:
                 flock.release_flock(fd)
 
@@ -1120,7 +1129,8 @@ class TestLoadMinigraph(object):
                 (load_minigraph_platform_plugin_command_output.format(config.SYSTEM_RELOAD_LOCK))
             # Verify "systemctl reset-failed" is called for services under sonic.target
             mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'swss'])
-            assert mock_run_command.call_count == 12
+            mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'pmon'])
+            assert mock_run_command.call_count == 15
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=(load_minigraph_platform_false_path, None)))
     def test_load_minigraph_platform_plugin_fail(self, get_cmd_module, setup_single_broadcom_asic):


### PR DESCRIPTION
## Description
This PR is a corrected version of #4336 (by @stephenxs), cherry-picked to the 202511 branch with fixed test assertion counts.

**Purpose:** Unblock 202511 CI testing while the original PR author addresses the test count issue.

### Problem
During \config reload\, \_reset_failed_services()\ only resets services that are **forward** dependencies of \sonic.target\. Services like \pmon\ that have a **reverse** dependency (\BindsTo\) on \sonic.target\ are not reset, causing \start-limit-hit\ failures after repeated reloads.

### Fix
- \_get_sonic_services(reverse=False)\ — adds \--reverse --type=service\ flags when \everse=True\
- \_reset_failed_services()\ — unions forward + reverse dependencies before resetting

### What changed vs #4336
PR #4336 had an **off-by-one error** in 3 test call count assertions. The first mock was updated to return \eatured.timer\ as an additional forward dependency, which adds one more \eset-failed\ call. The corrected counts are:

| Test | PR #4336 (wrong) | This PR (correct) |
|---|---|---|
| \	est_load_minigraph\ | 18 | **19** |
| \	est_load_minigraph_bypass_lock\ | 14 | **15** |
| \	est_load_minigraph_platform_plugin\ | 14 | **15** |

### Related
- Original main branch PR: https://github.com/sonic-net/sonic-utilities/pull/4314
- Original 202511 cherry-pick: #4336
- Root cause analysis: ADO #36811868

Signed-off-by: Storm Liang <stormliang@microsoft.com>