### PR TITLE
Add CLI support for "show interfaces <intf> <phy-signal/phy-serdes>"c…

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -16,6 +16,7 @@ import sonic_platform_base.sonic_sfp.sfputilhelper
 
 from . import portchannel
 from collections import OrderedDict
+from datetime import datetime
 
 HWSKU_JSON = 'hwsku.json'
 
@@ -1214,3 +1215,250 @@ def dhcp_mitigation_rate(db, interfacename):
 
     header = ['Interface', 'DHCP Mitigation Rate']
     click.echo(tabulate(tablelize(keys), header, tablefmt="simple", stralign='left'))
+
+
+def display_phy_signal_attribute(attr_display_name, attr_json):
+    """
+    Display PHY signal attribute per lane for an interface.
+
+    Expected format: {"0": ["F", 0, 0], "1": ["T", 1234567890, 2], ...}
+    Array elements: [state, timestamp_ms, change_count]
+    - state: "T" (True), "F" (False), "T*" (True, just changed), "F*" (False, just changed)
+    - timestamp_ms: milliseconds since epoch of last change (0 = never changed)
+    - change_count: total number of state changes
+    """
+    if not attr_json:
+        click.echo("{}: No data available".format(attr_display_name))
+        click.echo("")
+        return
+
+    try:
+        lane_data = json.loads(attr_json)
+    except json.JSONDecodeError:
+        click.echo("{}: Invalid data format".format(attr_display_name))
+        return
+
+    # Prepare table headers
+    header = [f"{attr_display_name}:", 'Current State', 'Changes', 'Last Change (UTC)']
+    body = []
+
+    # Build table rows
+    for lane_num in sorted(lane_data.keys(), key=int):
+        lane_info = lane_data[lane_num]
+        if isinstance(lane_info, list) and len(lane_info) == 3:
+            status = lane_info[0]  # "T*", "F*", "T", or "F"
+            timestamp_ms = lane_info[1]
+            change_count = lane_info[2]
+
+            if timestamp_ms > 0:
+                dt = datetime.utcfromtimestamp(timestamp_ms / 1000.0)
+                last_change = dt.strftime('%Y-%m-%d %H:%M:%S')
+            else:
+                last_change = 'Never'
+
+            body.append(['Lane{}:'.format(lane_num), status, change_count, last_change])
+
+    # Display table if there's data
+    if not body:
+        click.echo("{}: No data available".format(attr_display_name))
+    else:
+        click.echo(tabulate(body, header, tablefmt='simple', numalign='left'))
+    click.echo("")
+
+
+@interfaces.command('phy-signal')
+@click.argument('interfacename', required=True)
+@multi_asic_util.multi_asic_click_options
+@click.option('--rxsig', is_flag=True, help='Show RX signal detect status')
+@click.option('--feclock', is_flag=True, help='Show FEC alignment lock status')
+@click.pass_context
+@clicommon.pass_db
+def phy_signal(db, ctx, interfacename, namespace, display, rxsig, feclock):
+    """Show PHY signal attributes status for interface"""
+
+    if not any([rxsig, feclock]):
+        ctx.fail("At least one option must be specified.")
+
+    if namespace is None:
+        namespace = constants.DEFAULT_NAMESPACE
+
+    interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
+
+    # Convert to alias for display if in alias mode
+    display_name = interfacename
+    if clicommon.get_interface_naming_mode() == "alias":
+        display_name = clicommon.InterfaceAliasConverter().name_to_alias(interfacename)
+
+    port_dict = multi_asic.get_port_table(namespace=namespace)
+    if interfacename not in port_dict:
+        ctx.fail("Invalid interface name {}".format(interfacename))
+
+    # Get port OID from COUNTERS_PORT_NAME_MAP
+    port_name_map = db.db_clients[namespace].get_all(db.db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
+    if interfacename not in port_name_map:
+        ctx.fail("Interface {} not found in COUNTERS_PORT_NAME_MAP".format(interfacename))
+
+    vid_str = port_name_map[interfacename]
+    table_key = 'PORT_PHY_ATTR:{}'.format(vid_str)
+    port_phy_data = db.db_clients[namespace].get_all(db.db.COUNTERS_DB, table_key)
+
+    if not port_phy_data:
+        click.echo("No PHY attribute data available for {}".format(display_name))
+        click.echo("Ensure 'counterpoll phy enable' has been run")
+        return
+
+    click.echo("Interface: {}".format(display_name))
+    click.echo("=" * 80)
+
+    # Display all requested attributes
+    if rxsig:
+        attr_data = port_phy_data.get('phy_rx_signal_detect')
+        display_phy_signal_attribute('RX Signal Detect', attr_data)
+
+    if feclock:
+        attr_data = port_phy_data.get('pcs_fec_lane_alignment_lock')
+        display_phy_signal_attribute('FEC Alignment Lock', attr_data)
+
+
+def display_phy_numeric_attribute(attr_display_name, attr_json, val_header="Value"):
+    """
+    Display simple per-lane numeric values (SNR, VGA) in horizontal format for an interface.
+
+    Expected format: {"0": 36697, "1": 35200, "2": 34500, "3": 36000}
+    """
+    if not attr_json:
+        click.echo("{}: No data available".format(attr_display_name))
+        click.echo("")
+        return
+
+    try:
+        lane_data = json.loads(attr_json)
+    except json.JSONDecodeError:
+        click.echo("{}: Invalid data format".format(attr_display_name))
+        return
+
+    click.echo("{}:".format(attr_display_name))
+    click.echo("-" * 80)
+
+    lanes = sorted(lane_data.keys(), key=int)
+
+    # If no lanes, show "No data available"
+    if not lanes:
+        click.echo("No data available")
+        click.echo("")
+        return
+
+    lane_row = ['Lane:'] + lanes
+
+    value_row = [val_header+":"]
+    for lane in lanes:
+        lane_value = lane_data[lane]
+        value_row.append(str(lane_value))
+
+    body = [lane_row, value_row]
+
+    click.echo(tabulate(body, tablefmt='plain', numalign='left'))
+    click.echo("")
+
+
+def display_phy_taps_attribute(attr_display_name, attr_json):
+    """
+    Display per lane tap attribute values for an interface.
+
+    Input format: {"0": [{"tap0": -10}, {"tap1": 5}, ...], "1": [...], ...}
+    """
+    if not attr_json:
+        click.echo("{}: No data available".format(attr_display_name))
+        click.echo("")
+        return
+
+    try:
+        tap_data = json.loads(attr_json)
+    except json.JSONDecodeError:
+        click.echo("{}: Invalid data format".format(attr_display_name))
+        return
+
+    click.echo("{}:".format(attr_display_name))
+
+    lanes = sorted(tap_data.keys(), key=int)
+    if not lanes:
+        click.echo("No tap data available")
+        return
+
+    first_lane_data = tap_data[lanes[0]]
+    if isinstance(first_lane_data, list) and len(first_lane_data) > 0:
+        num_taps = len(first_lane_data)
+        header = ['Lane'] + ['Tap{}'.format(i) for i in range(num_taps)]
+        body = []
+
+        for lane in lanes:
+            lane_taps = tap_data[lane]
+            row = ['{}'.format(lane)]
+            if isinstance(lane_taps, list):
+                for tap_dict in lane_taps:
+                    if isinstance(tap_dict, dict):
+                        for tap_name, tap_val_list in tap_dict.items():
+                            row.append(str(tap_val_list))
+                            break  # There should only be one val.
+            body.append(row)
+        click.echo(tabulate(body, header, tablefmt='simple', numalign="left"))
+    click.echo("")
+
+
+@interfaces.command('phy-serdes')
+@click.argument('interfacename', required=True)
+@multi_asic_util.multi_asic_click_options
+@click.option('--snr', is_flag=True, help='Show RX SNR values')
+@click.option('--rxvga', is_flag=True, help='Show RX VGA values')
+@click.option('--txfir', is_flag=True, help='Show TX FIR tap values')
+@click.pass_context
+@clicommon.pass_db
+def phy_serdes(db, ctx, interfacename, namespace, display, snr, rxvga, txfir):
+    """Show PHY SERDES parameters for interface"""
+
+    if not any([snr, rxvga, txfir]):
+        ctx.fail("At least one option must be specified.")
+
+    if namespace is None:
+        namespace = constants.DEFAULT_NAMESPACE
+
+    interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
+
+    # Convert to alias for display if in alias mode
+    display_name = interfacename
+    if clicommon.get_interface_naming_mode() == "alias":
+        display_name = clicommon.InterfaceAliasConverter().name_to_alias(interfacename)
+
+    port_dict = multi_asic.get_port_table(namespace=namespace)
+    if interfacename not in port_dict:
+        ctx.fail("Invalid interface name {}".format(interfacename))
+
+    # Get port OID from COUNTERS_PORT_NAME_MAP
+    port_name_map = db.db_clients[namespace].get_all(db.db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
+    if interfacename not in port_name_map:
+        ctx.fail("Interface {} not found in COUNTERS_PORT_NAME_MAP".format(interfacename))
+
+    vid_str = port_name_map[interfacename]
+    table_key = 'PORT_PHY_ATTR:{}'.format(vid_str)
+    port_phy_data = db.db_clients[namespace].get_all(db.db.COUNTERS_DB, table_key)
+
+    if not port_phy_data:
+        click.echo("No PHY SERDES data available for {}".format(display_name))
+        click.echo("Ensure 'counterpoll phy enable' has been run")
+        return
+
+    click.echo("Interface: {}".format(display_name))
+    click.echo("=" * 80)
+
+    # Display all requested attributes
+    if snr:
+        attr_data = port_phy_data.get('rx_snr')
+        display_phy_numeric_attribute('RX SNR', attr_data, "SNR")
+
+    if rxvga:
+        attr_data = port_phy_data.get('rx_vga')
+        display_phy_numeric_attribute('RX VGA', attr_data, "VGA")
+
+    if txfir:
+        attr_data = port_phy_data.get('tx_fir_taps_list')
+        display_phy_taps_attribute('TX FIR Taps', attr_data)

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -388,7 +388,75 @@ oper error status                   0  Never
 signal local error                  0  Never
 """
 
+# PHY Signal expected outputs
+phy_signal_all_options_output = """\
+Interface: Ethernet0
+================================================================================
+RX Signal Detect:    Current State    Changes    Last Change (UTC)
+-------------------  ---------------  ---------  -------------------
+Lane0:               T                5          2023-03-15 13:20:00
+Lane1:               F                0          Never
 
+FEC Alignment Lock:    Current State    Changes    Last Change (UTC)
+---------------------  ---------------  ---------  -------------------
+Lane0:                 T*               10         2023-03-15 13:20:00
+Lane1:                 T                3          2023-03-15 13:20:00
+
+"""
+
+phy_signal_no_data_output = """\
+No PHY attribute data available for Ethernet4
+Ensure 'counterpoll phy enable' has been run
+"""
+
+# PHY SERDES expected outputs
+phy_serdes_all_options_output = """\
+Interface: Ethernet0
+================================================================================
+RX SNR:
+--------------------------------------------------------------------------------
+Lane:  0      1      2      3
+SNR:   36697  35200  34500  36000
+
+RX VGA:
+--------------------------------------------------------------------------------
+Lane:  0    1   2   3
+VGA:   100  95  98  102
+
+TX FIR Taps:
+Lane    Tap0    Tap1
+------  ------  ------
+0       -10     5
+1       -8      6
+
+"""
+
+phy_serdes_no_data_output = """\
+No PHY SERDES data available for Ethernet4
+Ensure 'counterpoll phy enable' has been run
+"""
+
+# PHY Signal alias mode expected output
+phy_signal_alias_mode_output = """\
+Interface: etp1
+================================================================================
+RX Signal Detect:    Current State    Changes    Last Change (UTC)
+-------------------  ---------------  ---------  -------------------
+Lane0:               T                5          2023-03-15 13:20:00
+Lane1:               F                0          Never
+
+"""
+
+# PHY SERDES alias mode expected output
+phy_serdes_alias_mode_output = """\
+Interface: etp1
+================================================================================
+RX SNR:
+--------------------------------------------------------------------------------
+Lane:  0      1      2      3
+SNR:   36697  35200  34500  36000
+
+"""
 
 
 class TestInterfaces(object):
@@ -700,6 +768,170 @@ class TestInterfaces(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == intf_errors_Ethernet48
+
+    # PHY Signal Tests
+    def test_phy_signal_no_options(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-signal"],
+            ["Ethernet0"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "At least one option must be specified" in result.output
+
+    def test_phy_signal_invalid_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-signal"],
+            ["Eth-invalid", "--rxsig"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid interface name" in result.output
+
+    @mock.patch('show.interfaces.multi_asic.get_port_table')
+    def test_phy_signal_not_in_port_map(self, mock_port_table):
+        runner = CliRunner()
+        # Use Ethernet100 which is NOT in COUNTERS_PORT_NAME_MAP
+        mock_port_table.return_value = {'Ethernet100': {}}
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-signal"],
+            ["Ethernet100", "--rxsig"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "not found in COUNTERS_PORT_NAME_MAP" in result.output
+
+    def test_phy_signal_no_data(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-signal"],
+            ["Ethernet4", "--rxsig"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == phy_signal_no_data_output
+
+    def test_phy_signal_all_options(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-signal"],
+            ["Ethernet0", "--rxsig", "--feclock"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == phy_signal_all_options_output
+
+    def test_phy_signal_alias_mode(self):
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-signal"],
+            ["etp1", "--rxsig"]
+        )
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == phy_signal_alias_mode_output
+
+    def test_phy_signal_namespace(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-signal"],
+            ["Ethernet0", "--rxsig", "-n", ""]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+    # PHY SERDES Tests
+    def test_phy_serdes_no_options(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-serdes"],
+            ["Ethernet0"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "At least one option must be specified" in result.output
+
+    def test_phy_serdes_invalid_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-serdes"],
+            ["Eth-invalid", "--snr"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid interface name" in result.output
+
+    @mock.patch('show.interfaces.multi_asic.get_port_table')
+    def test_phy_serdes_not_in_port_map(self, mock_port_table):
+        runner = CliRunner()
+        # Use Ethernet100 which is NOT in COUNTERS_PORT_NAME_MAP
+        mock_port_table.return_value = {'Ethernet100': {}}
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-serdes"],
+            ["Ethernet100", "--snr"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "not found in COUNTERS_PORT_NAME_MAP" in result.output
+
+    def test_phy_serdes_no_data(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-serdes"],
+            ["Ethernet4", "--snr"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == phy_serdes_no_data_output
+
+    def test_phy_serdes_all_options(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-serdes"],
+            ["Ethernet0", "--snr", "--rxvga", "--txfir"]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == phy_serdes_all_options_output
+
+    def test_phy_serdes_alias_mode(self):
+        runner = CliRunner()
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-serdes"],
+            ["etp1", "--snr"]
+        )
+        os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == phy_serdes_alias_mode_output
+
+    def test_phy_serdes_namespace(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["phy-serdes"],
+            ["Ethernet0", "--snr", "-n", ""]
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -2988,5 +2988,14 @@
     "PERSISTENT_DROP_ALERTS":{
         "DEBUG_0|1746495543": "Persistent packet drops detected on Ethernet0",
         "DEBUG_0|1746495767": "Persistent packet drops detected on Ethernet1"
+    },
+    "PORT_PHY_ATTR:oid:0x1000000000012": {
+        "phy_rx_signal_detect": "{\"0\": [\"T\", 1678886400000, 5], \"1\": [\"F\", 0, 0]}",
+        "pcs_fec_lane_alignment_lock": "{\"0\": [\"T*\", 1678886400000, 10], \"1\": [\"T\", 1678886400000, 3]}",
+        "rx_snr": "{\"0\": 36697, \"1\": 35200, \"2\": 34500, \"3\": 36000}",
+        "rx_vga": "{\"0\": 100, \"1\": 95, \"2\": 98, \"3\": 102}",
+        "tx_fir_taps_list": "{\"0\": [{\"tap0\": -10}, {\"tap1\": 5}], \"1\": [{\"tap0\": -8}, {\"tap1\": 6}]}"
+    },
+    "PORT_PHY_ATTR:oid:0x1000000000013": {
     }
 }


### PR DESCRIPTION
#### What I did
added support for "show interfaces <intf> <phy-signal/phy-serdes>" CLI show command with the following details -

The command has two subcommands:
1 `phy-signal` - Displays boolean link/signal status indicators (quick health check) with following options:
         --rxsig   - RX signal detect per lane (SAI_PORT_ATTR_RX_SIGNAL_DETECT)
        --feclock - FEC alignment lock per lane (SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK)

2 `phy-serdes` - Displays analog/digital signal quality metrics (deeper diagnostics) with following options:
        --snr     - RX Signal-to-Noise Ratio per lane (SAI_PORT_ATTR_RX_SNR)
        --txfir   - TX FIR tap values per lane (SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST)
        --rxvga   - RX VGA values per lane (SAI_PORT_SERDES_ATTR_RX_VGA)

(At least one option must be specified for each subcommand.)

#### How I did it
Added new commands to show interfaces 

#### How to verify it
Enable PHY polling - 
`counterpoll phy enable`

Execute show commands - 
```
show interfaces phy-serdes <interface-name> --snr --rxvga --txfir
show interfaces phy-signal <interface-name>  --rxsig --feclock
```

#### New command output (if the output of a command-line utility has changed)
Output From DUT- 

```
$ show interfaces phy-signal Ethernet64 --rxsig --feclock
Interface: Ethernet64
================================================================================
RX Signal Detect:    Current State    Changes    Last Change (UTC)
-------------------  ---------------  ---------  -------------------
Lane0:               T                3          2026-03-05 08:58:13
Lane1:               T                3          2026-03-05 08:58:13
Lane2:               T                3          2026-03-05 08:58:13
Lane3:               T                3          2026-03-05 08:58:13

FEC Alignment Lock:    Current State    Changes    Last Change (UTC)
---------------------  ---------------  ---------  -------------------
Lane0:                 F                0          Never
Lane1:                 F                0          Never
Lane2:                 F                0          Never
Lane3:                 F                0          Never

$ show interfaces phy-serdes Ethernet64 --snr --rxvga --txfir
Interface: Ethernet64
================================================================================
RX SNR:
--------------------------------------------------------------------------------
Lane:  0     1     2     3
SNR:   7278  7173  6952  6952

RX VGA:
--------------------------------------------------------------------------------
Lane:  0   1   2   3
VGA:   42  45  41  44

TX FIR Taps:
Lane    Tap0    Tap1    Tap2    Tap3    Tap4    Tap5
------  ------  ------  ------  ------  ------  ------
0       -4      14      -36     112     0       0
1       -4      14      -36     112     0       0
2       -4      14      -36     112     0       0
3       -4      14      -36     112     0       0

$ show interfaces phy-signal Ethernet512 --rxsig --feclock
Interface: Ethernet512
================================================================================
RX Signal Detect: No data available

FEC Alignment Lock: No data available

$ show interfaces phy-serdes Ethernet512 --snr --rxvga --txfir
Interface: Ethernet512
================================================================================
RX SNR: No data available

RX VGA:
--------------------------------------------------------------------------------
Lane:  0
VGA:   30

TX FIR Taps:
Lane    Tap0    Tap1    Tap2
------  ------  ------  ------
0       5       31      0

```

Note- Here current state can represent following states:
    `T` = True (signal detected / locked)
    `F` = False (no signal / not locked)
    `*` suffix = Value changed since last poll (e.g., `T*` means it became True recently)
