### PR TITLE
config: allow golden config to override mac, platform, asic_id

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2635,10 +2635,14 @@ def generate_sysinfo(cur_config, config_input, ns=None):
         asic_name = multi_asic.get_asic_id_from_name(ns)
         asic_id = multi_asic.get_asic_device_id(asic_name)
 
-    device_metadata['localhost']['mac'] = mac.rstrip('\n')
-    device_metadata['localhost']['platform'] = platform.rstrip('\n')
+    # Only backfill sysinfo fields if not explicitly provided in golden config
+    if 'mac' not in device_metadata['localhost']:
+        device_metadata['localhost']['mac'] = mac.rstrip('\n')
+    if 'platform' not in device_metadata['localhost']:
+        device_metadata['localhost']['platform'] = platform.rstrip('\n')
     if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE and asic_id:
-        device_metadata['localhost']['asic_id'] = asic_id.rstrip('\n')
+        if 'asic_id' not in device_metadata['localhost']:
+            device_metadata['localhost']['asic_id'] = asic_id.rstrip('\n')
 
     return
 

--- a/tests/config_override_input/multi_asic_dm_explicit_sysinfo.json
+++ b/tests/config_override_input/multi_asic_dm_explicit_sysinfo.json
@@ -1,0 +1,61 @@
+{
+    "localhost": {
+        "DEVICE_METADATA": {
+            "localhost": {
+                "default_bgp_status": "down",
+                "default_pfcwd_status": "enable",
+                "deployment_id": "1",
+                "docker_routing_config_mode": "separated",
+                "hostname": "sonic-switch",
+                "hwsku": "Mellanox-SN3800-D112C8",
+                "peer_switch": "sonic-switch",
+                "type": "ToRRouter",
+                "suppress-fib-pending": "enabled",
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "platform": "custom-platform"
+            }
+        }
+    },
+    "asic0": {
+        "DEVICE_METADATA": {
+            "localhost": {
+                "asic_name": "asic0",
+                "bgp_asn": "65100",
+                "cloudtype": "None",
+                "default_bgp_status": "down",
+                "default_pfcwd_status": "enable",
+                "deployment_id": "None",
+                "docker_routing_config_mode": "separated",
+                "hostname": "sonic",
+                "hwsku": "multi_asic",
+                "region": "None",
+                "sub_role": "FrontEnd",
+                "type": "LeafRouter",
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "platform": "custom-platform",
+                "asic_id": "ff:00:00"
+            }
+        }
+    },
+    "asic1": {
+        "DEVICE_METADATA": {
+            "localhost": {
+                "asic_name": "asic1",
+                "bgp_asn": "65100",
+                "cloudtype": "None",
+                "default_bgp_status": "down",
+                "default_pfcwd_status": "enable",
+                "deployment_id": "None",
+                "docker_routing_config_mode": "separated",
+                "hostname": "sonic",
+                "hwsku": "multi_asic",
+                "region": "None",
+                "sub_role": "BackEnd",
+                "type": "LeafRouter",
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "platform": "custom-platform",
+                "asic_id": "ff:00:00"
+            }
+        }
+    }
+}

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -24,6 +24,7 @@ FINAL_CONFIG_YANG_FAILURE = os.path.join(DATA_DIR, "final_config_yang_failure.js
 MULTI_ASIC_MACSEC_OV = os.path.join(DATA_DIR, "multi_asic_macsec_ov.json")
 MULTI_ASIC_FEATURE_RM = os.path.join(DATA_DIR, "multi_asic_feature_rm.json")
 MULTI_ASIC_DEVICE_METADATA_GEN_SYSINFO = os.path.join(DATA_DIR, "multi_asic_dm_gen_sysinfo.json")
+MULTI_ASIC_DEVICE_METADATA_EXPLICIT_SYSINFO = os.path.join(DATA_DIR, "multi_asic_dm_explicit_sysinfo.json")
 MULTI_ASIC_MISSING_LOCALHOST_OV = os.path.join(DATA_DIR, "multi_asic_missing_localhost.json")
 MULTI_ASIC_MISSING_ASIC_OV = os.path.join(DATA_DIR, "multi_asic_missing_asic.json")
 
@@ -443,6 +444,41 @@ class TestConfigOverrideMultiasic(object):
             if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
                 asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
                 assert asic_id is None
+
+    def test_device_metadata_explicit_sysinfo_override(self):
+        """Test that explicit mac/platform/asic_id in golden config are preserved."""
+        def read_json_file_side_effect(filename):
+            with open(MULTI_ASIC_DEVICE_METADATA_EXPLICIT_SYSINFO, "r") as f:
+                device_metadata = json.load(f)
+            return device_metadata
+        db = Db()
+        cfgdb_clients = db.cfgdb_clients
+
+        with mock.patch('config.main.read_json_file',
+                        mock.MagicMock(side_effect=read_json_file_side_effect)),\
+             mock.patch('sonic_py_common.device_info.get_platform',
+                        return_value="multi_asic"),\
+             mock.patch('sonic_py_common.device_info.get_system_mac',
+                        return_value="11:22:33:44:55:66\n"),\
+             mock.patch('sonic_py_common.multi_asic.get_asic_device_id',
+                        return_value="06:00:00\n"):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["override-config-table"],
+                                   ['golden_config_db.json'], obj=db)
+            assert result.exit_code == 0
+
+        for ns, config_db in cfgdb_clients.items():
+            mac = config_db.get_config()['DEVICE_METADATA']['localhost'].get('mac')
+            platform = config_db.get_config()['DEVICE_METADATA']['localhost'].get('platform')
+            # Golden config explicit values should be preserved, not overwritten
+            assert mac == "aa:bb:cc:dd:ee:ff", \
+                f"Expected golden config mac 'aa:bb:cc:dd:ee:ff' but got '{mac}' for namespace '{ns}'"
+            assert platform == "custom-platform", \
+                f"Expected golden config platform 'custom-platform' but got '{platform}' for namespace '{ns}'"
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
+                assert asic_id == "ff:00:00", \
+                    f"Expected golden config asic_id 'ff:00:00' but got '{asic_id}' for namespace '{ns}'"
 
     def test_masic_missig_localhost_override(self):
         def read_json_file_side_effect(filename):


### PR DESCRIPTION
## Description
Currently `generate_sysinfo()` unconditionally overwrites `mac`, `platform`, and `asic_id` in the golden config with values from the running config or hardware detection. This prevents users from intentionally overriding these fields via `config load_minigraph -o` or `config override-config-table`.

### Problem
When a user provides an explicit `mac` in their golden config (e.g., for MAC migration, virtual environments, or chassis scenarios), it gets silently overwritten before the override is applied:

1. `load_minigraph` calls `sonic-cfggen -H` which sets MAC from hardware
2. `override_config_by()` → `override_config_table()` → `generate_sysinfo()`
3. `generate_sysinfo()` reads MAC from running config (set by step 1) and **unconditionally overwrites** the golden config's MAC

### Fix
Change `generate_sysinfo()` to only backfill `mac`, `platform`, and `asic_id` when they are **not explicitly present** in the golden config. If the golden config provides these values, they are preserved.

This maintains backward compatibility — golden configs without these fields (the common case) still get auto-populated from hardware/running config.

## Motivation and Context
Users cannot override `DEVICE_METADATA.localhost.mac` via golden config override, even when explicitly specified.

## How Has This Been Tested?
Code review and manual verification of the logic change.

## Type of change
- [x] Bug fix
