### PR TITLE
show version: replace --verbose with --brief flag to show docker images by default

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1708,8 +1708,8 @@ def logging(process, lines, follow, verbose):
 #
 
 @cli.command()
-@click.option("--verbose", is_flag=True, help="Enable verbose output")
-def version(verbose):
+@click.option("--brief", is_flag=True, help="Brief output, omit docker image information")
+def version(brief):
     """Show version information"""
     version_info = device_info.get_sonic_version_info()
     platform_info = device_info.get_platform_info()
@@ -1736,10 +1736,12 @@ def version(verbose):
     click.echo("Hardware Revision: {}".format(chassis_info['revision']))
     click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
     click.echo("Date: {}".format(sys_date.strftime("%a %d %b %Y %X")))
-    click.echo("\nDocker images:")
-    cmd = ['sudo', 'docker', 'images', '--format', "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"]
-    p = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
-    click.echo(p.stdout.read())
+
+    if not brief:
+        click.echo("\nDocker images:")
+        cmd = ['sudo', 'docker', 'images', '--format', "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"]
+        p = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
+        click.echo(p.stdout.read())
 
 #
 # 'environment' command ("show environment")

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -247,7 +247,52 @@ def side_effect_subprocess_popen(*args, **kwargs):
 def test_show_version():
     runner = CliRunner()
     result = runner.invoke(show.cli.commands["version"])
+    assert result.exit_code == 0
+    assert "SONiC Software Version: SONiC.release-1.1-7d94c0c28" in result.output
     assert "SONiC OS Version: 11" in result.output
+    assert "Distribution: Debian 11.6" in result.output
+    assert "Kernel: 5.10" in result.output
+    assert "Build commit: 7d94c0c28" in result.output
+    assert "Build date: Wed Feb 15 06:17:08 UTC 2023" in result.output
+    assert "Built by: AzDevOps" in result.output
+    assert "Platform: x86_64-kvm_x86_64-r0" in result.output
+    assert "HwSKU: Force10-S6000" in result.output
+    assert "ASIC: vs" in result.output
+    assert "ASIC Count: 1" in result.output
+    assert "Serial Number: N/A" in result.output
+    assert "Docker images:" in result.output
+    assert "REPOSITORY   TAG" in result.output
+
+
+@patch('sonic_py_common.device_info.get_sonic_version_info', MagicMock(return_value={
+        "build_version": "release-1.1-7d94c0c28",
+        "sonic_os_version": "11",
+        "debian_version": "11.6",
+        "kernel_version": "5.10",
+        "commit_id": "7d94c0c28",
+        "build_date": "Wed Feb 15 06:17:08 UTC 2023",
+        "built_by": "AzDevOps"}))
+@patch('sonic_py_common.device_info.get_platform_info', MagicMock(return_value={
+        "platform": "x86_64-kvm_x86_64-r0",
+        "hwsku": "Force10-S6000",
+        "asic_type": "vs",
+        "asic_count": 1}))
+@patch('sonic_py_common.device_info.get_chassis_info', MagicMock(return_value={
+        "serial": "N/A",
+        "model": "N/A",
+        "revision": "N/A"}))
+@patch('subprocess.Popen', MagicMock(side_effect=side_effect_subprocess_popen))
+def test_show_version_brief():
+    """Test that --brief flag omits docker image information."""
+    runner = CliRunner()
+    result = runner.invoke(show.cli.commands["version"], ["--brief"])
+    assert result.exit_code == 0
+    assert "SONiC Software Version: SONiC.release-1.1-7d94c0c28" in result.output
+    assert "SONiC OS Version: 11" in result.output
+    assert "Platform: x86_64-kvm_x86_64-r0" in result.output
+    assert "HwSKU: Force10-S6000" in result.output
+    assert "Docker images:" not in result.output
+    assert "REPOSITORY" not in result.output
 
 
 @patch('sonic_py_common.device_info.get_sonic_version_info', MagicMock(return_value={


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Replaced the `--verbose` flag on `show version` with a `--brief` flag. Docker image information is now displayed by default and can be omitted by passing `--brief`.

#### How I did it

- Changed the Click option in `show/main.py` from `--verbose` to `--brief` on the `version` command.
- Inverted the conditional logic: docker images are now printed unless `--brief` is specified (`if not brief:` instead of `if verbose:`).
- Updated `test_show_version` in `tests/show_test.py` to assert that docker image information is present in the default output.
- Added a new `test_show_version_brief` test that passes `--brief` and asserts docker image information is not present.

#### How to verify it

Default output includes docker images:

    `show version`

Brief output omits docker images:

    `show version --brief`

Run the unit tests:

    `pytest tests/show_test.py::test_show_version tests/show_test.py::test_show_version_brief -v`

#### Previous command output (if the output of a command-line utility has changed)

[show-ver-orig-output.txt](https://github.com/user-attachments/files/25921854/show-ver-orig-output.txt)


#### New command output (if the output of a command-line utility has changed)

[show-ver-new-output.txt](https://github.com/user-attachments/files/25921856/show-ver-new-output.txt)
