### PR TITLE
[202511] Backport PR4159: Fix issue that namespace is not correctly fetched in Multi ASIC environment for mirror capability checking

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1203,6 +1203,10 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
     mirror_table = config_db.get_table('MIRROR_SESSION')
     portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
 
+    # Determine namespaces to validate: always include None (single-ASIC/back-compat),
+    # and for multi-ASIC include namespaces for dst/src ports if present.
+    namespace_set = set()
+
     if dst_port:
         if not interface_name_is_valid(config_db, dst_port):
             ctx.fail("Error: Destination Interface {} is invalid".format(dst_port))
@@ -1219,12 +1223,16 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
         if clicommon.is_port_router_interface(config_db, dst_port):
             ctx.fail("Error: Destination Interface {} is a L3 interface".format(dst_port))
 
+        namespace_set.add(get_port_namespace(dst_port))
+
     if src_port:
         for port in src_port.split(","):
             if not interface_name_is_valid(config_db, port):
                 ctx.fail("Error: Source Interface {} is invalid".format(port))
             if dst_port and dst_port == port:
                 ctx.fail("Error: Destination Interface cant be same as Source Interface")
+
+            namespace_set.add(get_port_namespace(port))
 
     if interface_has_mirror_config(ctx, mirror_table, dst_port, src_port, direction):
         return False
@@ -1235,9 +1243,11 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
 
     # Check port mirror capability before allowing configuration
     # If direction is provided, check the specific direction
-    if not is_port_mirror_capability_supported(direction):
-        ctx.fail("Error: Port mirror direction '{}' is not supported by the ASIC".format(
-            direction if direction else 'both'))
+
+    for ns in namespace_set:
+        if not is_port_mirror_capability_supported(direction, namespace=ns):
+            ctx.fail("Error: Port mirror direction '{}' is not supported by the ASIC".format(
+                direction if direction else 'both'))
 
     return True
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Backporting https://github.com/sonic-net/sonic-utilities/pull/4159/ due to cherry pick conflicts.

Fix issue that namespace is not correctly fetched in Multi ASIC environment for mirror capability checking
@stephenxs 

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

