### PR TITLE
Inform user that reload is required after suppress-fib-pending change

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2866,9 +2866,22 @@ def suppress_pending_fib(db, state):
     if multi_asic.get_num_asics() > 1:
         namespace_list = multi_asic.get_namespaces_from_linux()
 
+    changed = False
     for ns in namespace_list:
         config_db = db.cfgdb_clients[ns]
+        entry = config_db.get_entry('DEVICE_METADATA', 'localhost')
+        if entry.get('suppress-fib-pending') == state:
+            continue
         config_db.mod_entry('DEVICE_METADATA', 'localhost', {"suppress-fib-pending": state})
+        changed = True
+
+    if changed:
+        click.echo(f"""suppress-fib-pending set to '{state}' in CONFIG_DB. This does NOT take effect until a config reload.
+Persist and apply with:
+    config save -y
+    config reload -y""")
+    else:
+        click.echo(f"suppress-fib-pending is already '{state}'; no change made.")
 
 #
 # 'yang_config_validation' command ('config yang_config_validation ...')

--- a/tests/suppress_pending_fib_test.py
+++ b/tests/suppress_pending_fib_test.py
@@ -35,6 +35,23 @@ class TestSuppressFibPending:
         print(result.output)
         assert result.exit_code != 0
 
+    def test_config_suppress_fib_pending_no_change(self):
+        runner = CliRunner()
+
+        db = Db()
+
+        # An actual config change should notify that a config reload is required
+        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['disabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert 'This does NOT take effect until a config reload' in result.output
+
+        # Re-applying the same state should not prompt for a reload
+        result = runner.invoke(config.config.commands['suppress-fib-pending'], ['disabled'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == "suppress-fib-pending is already 'disabled'; no change made.\n"
+
 
 class TestSuppressFibPendingMultiAsic(object):
     @classmethod


### PR DESCRIPTION
## Summary

suppress-fib-pending config changes require a reload to take effect.

Changes:
- config/main.py: inform user that reload is required after
  changing suppress-fib-pending

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
This change needs to go together with
https://github.com/sonic-net/sonic-swss/pull/4333
https://github.com/sonic-net/sonic-buildimage/pull/26151
https://github.com/sonic-net/sonic-mgmt/pull/22916
https://github.com/sonic-net/SONiC/pull/2335