### PR TITLE
[202511][cherry-pick] Add FRR failed route check in route_check.py (#4119)

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -676,9 +676,10 @@ def check_frr_pending_routes(namespace):
     retries = FRR_CHECK_RETRIES
     for i in range(retries):
         missed_rt = []
+        failed_rt = []
         frr_routes = get_frr_routes_parallel(namespace)
 
-        for _, entries in frr_routes.items():
+        for route_prefix, entries in frr_routes.items():
             for entry in entries:
                 if entry['protocol'] in ('connected', 'kernel', 'static'):
                     continue
@@ -695,12 +696,16 @@ def check_frr_pending_routes(namespace):
                 if not entry.get('offloaded', False):
                     missed_rt.append(entry)
 
-        if not missed_rt:
+                if entry.get('failed', False):
+                    failed_rt.append(route_prefix)
+
+        if not missed_rt and not failed_rt:
             break
 
         time.sleep(FRR_WAIT_TIME)
-    print_message(syslog.LOG_DEBUG, "FRR missed routes: {}".format(missed_rt, indent=4))
-    return missed_rt
+    print_message(syslog.LOG_DEBUG, "FRR missed routes: {}".format(json.dumps(missed_rt, indent=4)))
+    print_message(syslog.LOG_DEBUG, "FRR failed routes: {}".format(json.dumps(failed_rt, indent=4)))
+    return missed_rt, failed_rt
 
 
 def mitigate_installed_not_offloaded_frr_routes(namespace, missed_frr_rt, rt_appl):
@@ -837,6 +842,7 @@ def check_routes_for_namespace(namespace):
     rt_appl_miss = []
     rt_asic_miss = []
     rt_frr_miss = []
+    rt_frr_failed = []
 
     selector, subs, rt_asic = get_asicdb_routes(namespace)
 
@@ -895,10 +901,13 @@ def check_routes_for_namespace(namespace):
     if rt_asic_miss:
         results["Unaccounted_ROUTE_ENTRY_TABLE_entries"] = rt_asic_miss
 
-    rt_frr_miss = check_frr_pending_routes(namespace)
+    rt_frr_miss, rt_frr_failed = check_frr_pending_routes(namespace)
 
     if rt_frr_miss:
         results["missed_FRR_routes"] = rt_frr_miss
+
+    if rt_frr_failed:
+        results["failed_FRR_routes"] = rt_frr_failed
 
     if results:
         if rt_frr_miss and not rt_appl_miss and not rt_asic_miss:
@@ -906,6 +915,9 @@ def check_routes_for_namespace(namespace):
                           but all routes in APPL_DB and ASIC_DB are in sync".format(namespace))
             if is_suppress_fib_pending_enabled(namespace):
                 mitigate_installed_not_offloaded_frr_routes(namespace, rt_frr_miss, rt_appl)
+        if rt_frr_failed:
+            print_message(syslog.LOG_ERR, "Some routes have failed state in FRR {} \
+                          : {}".format(namespace, rt_frr_failed))
 
     return results, adds, deletes
 

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -1354,4 +1354,354 @@ TEST_DATA = {
             }
         }
     },
+    "29": {
+        DESCR: "failure test case, failed FRR routes",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_ROUTES: {
+            DEFAULTNS: {
+                "0.0.0.0/0": [
+                    {
+                        "prefix": "0.0.0.0/0",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                    },
+                ],
+                "10.10.196.12/31": [
+                    {
+                        "prefix": "10.10.196.12/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                        "failed": True,
+                    },
+                ],
+                "10.10.196.20/31": [
+                    {
+                        "prefix": "10.10.196.20/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                        "failed": True,
+                    },
+                ],
+                "10.10.196.24/31": [
+                    {
+                        "protocol": "connected",
+                        "selected": True,
+                    },
+                ],
+            },
+        },
+        RESULT: {
+            DEFAULTNS: {
+                "failed_FRR_routes": [
+                    "10.10.196.12/31",
+                    "10.10.196.20/31"
+                ],
+            },
+        },
+        RET: -1,
+    },
+    "30": {
+        DESCR: "multi-asic failure test case, failed FRR routes",
+        MULTI_ASIC: True,
+        NAMESPACE: ['asic0', 'asic1'],
+        ARGS: "route_check -n asic0 -m INFO -i 1000",
+        PRE: {
+            ASIC0: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_ROUTES: {
+            ASIC0: {
+                "0.0.0.0/0": [
+                    {
+                        "prefix": "0.0.0.0/0",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                    },
+                ],
+                "10.10.196.12/31": [
+                    {
+                        "prefix": "10.10.196.12/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                        "failed": True,
+                    },
+                ],
+                "10.10.196.20/31": [
+                    {
+                        "prefix": "10.10.196.20/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": False,
+                        "failed": True,
+                    },
+                ],
+                "10.10.196.24/31": [
+                    {
+                        "protocol": "connected",
+                        "selected": True,
+                    },
+                ],
+            },
+        },
+        RESULT: {
+            ASIC0: {
+                "missed_FRR_routes": [
+                    {"prefix": "10.10.196.20/31", "vrfName": "default", "protocol": "bgp",
+                     "selected": True, "offloaded": False, "failed": True}
+                ],
+                "failed_FRR_routes": [
+                    "10.10.196.12/31",
+                    "10.10.196.20/31"
+                ],
+            },
+        },
+        RET: -1,
+    },
+    "31": {
+        DESCR: "missed and failed FRR routes with APPL_DB and ASIC_DB in sync (mitigation case)",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "192.168.1.0/24": {"ifname": "portchannel0"},
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "192.168.1.0/24" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_ROUTES: {
+            DEFAULTNS: {
+                "0.0.0.0/0": [
+                    {
+                        "prefix": "0.0.0.0/0",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                    },
+                ],
+                "10.10.196.12/31": [
+                    {
+                        "prefix": "10.10.196.12/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": False,  # Missing offload flag
+                    },
+                ],
+                "10.10.196.20/31": [
+                    {
+                        "prefix": "10.10.196.20/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                        "failed": True,  # Failed route
+                    },
+                ],
+                "192.168.1.0/24": [
+                    {
+                        "prefix": "192.168.1.0/24",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": False,  # Missing offload flag
+                        "failed": True,  # Failed route
+                    },
+                ],
+                "10.10.196.24/31": [
+                    {
+                        "protocol": "connected",
+                        "selected": True,
+                    },
+                ],
+            },
+        },
+        RESULT: {
+            DEFAULTNS: {
+                "missed_FRR_routes": [
+                    {"prefix": "10.10.196.12/31", "vrfName": "default", "protocol": "bgp",
+                     "selected": True, "offloaded": False},
+                    {"prefix": "192.168.1.0/24", "vrfName": "default", "protocol": "bgp",
+                     "selected": True, "offloaded": False, "failed": True}
+                ],
+                "failed_FRR_routes": [
+                    "10.10.196.20/31",
+                    "192.168.1.0/24"
+                ],
+            },
+        },
+        RET: -1,
+    },
+    "32": {
+        DESCR: "failure test case, only failed FRR routes (no missing routes)",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "192.168.1.0/24": {"ifname": "portchannel0"},
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "192.168.1.0/24" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_ROUTES: {
+            DEFAULTNS: {
+                "0.0.0.0/0": [
+                    {
+                        "prefix": "0.0.0.0/0",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                    },
+                ],
+                "10.10.196.12/31": [
+                    {
+                        "prefix": "10.10.196.12/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                        "failed": True,
+                    },
+                ],
+                "10.10.196.20/31": [
+                    {
+                        "prefix": "10.10.196.20/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                        "failed": True,
+                    },
+                ],
+                "192.168.1.0/24": [
+                    {
+                        "prefix": "192.168.1.0/24",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "offloaded": True,
+                        "failed": True,
+                    },
+                ],
+                "10.10.196.24/31": [
+                    {
+                        "protocol": "connected",
+                        "selected": True,
+                    },
+                ],
+            },
+        },
+        RESULT: {
+            DEFAULTNS: {
+                "failed_FRR_routes": [
+                    "10.10.196.12/31",
+                    "10.10.196.20/31",
+                    "192.168.1.0/24"
+                ],
+            },
+        },
+        RET: -1,
+    },
 }


### PR DESCRIPTION
Manual Cherry-Pick: https://github.com/sonic-net/sonic-utilities/pull/4119

What I did
It supports to detect the route with offload False or without offload, which can capture queued route, because queued route doesn’t have offload, but for rejected route, the offload is True. It can’t detect the rejected route. So, we add a new detection check for the value of key failed for route entries, which can cover both rejected and queued routes. It will help to detect rejected route and queued route on device.

How I did it
Append failed route prefix into failed list, if it's not empty, script will print error message into syslog

        # Check for failed state
        if entry.get('failed', False):
            failed_rt.append(route_prefix)
How to verify it
For rejected route:
The output of route_check.py

Some routes have failed state in FRR : ['0.0.0.0/0', '192.168.128.0/25', '192.168.128.128/25', '192.168.136.0/25', '192.168.136.128/25', '192.168.144.0/25', '192.168.144.128/25', '192.168.152.0/25', '192.168.152.128/25', '192.168.160.0/25', '192.168.160.128/25', '192.168.168.0/25', '192.168.168.128/25', '192.168.176.0/25', '192.168.176.128/25', '192.168.184.0/25', '192.168.184.128/25', '192.168.192.0/25', '192.168.192.128/25', '192.168.200.0/25', '192.168.200.128/25', '192.168.208.0/25', '192.168.208.128/25', '192.168.216.0/25', '192.168.216.128/25', '192.168.224.0/25', '192.168.224.128/25', '192.168.232.0/25', '192.168.232.128/25', '192.168.240.0/25', '192.168.240.128/25', '192.168.248.0/25', '192.168.248.128/25', '192.169.0.0/25', '192.169.0.128/25', '192.169.104.0/25', '192.169.104.128/25', '192.169.112.0/25', '192.169.112.128/25', '192.169.120.0/25', '192.169.120.128/25', '192.169.128.0/25', '192.169.128.128/25', '192.169.136.0/25', '192.169.136.128/25', '192.169.144.0/25', '192.16 Failure results: {{
    "": {
        "failed_FRR_routes": [
            "0.0.0.0/0",
            "192.168.128.0/25",
            "192.168.128.128/25",
            "192.168.136.0/25",
            "192.168.136.128/25",
            "192.168.144.0/25",
            "192.168.144.128/25",
            "192.168.152.0/25",
            "192.168.152.128/25",
            "192.168.160.0/25",
            "192.168.160.128/25",
            "192.168.168.0/25",
            "192.168.168.128/25",
            "192.168.176.0/25",
            "192.168.176.128/25",
            "192.168.184.0/25",
            "192.168.184.128/25",
            "192.168.192.0/25",
            "192.168.192.128/25",
            "192.168.200.0/25",
            "192.168.200.128/25",
            "192.168.208.0/25",
            "192.168.208.128/25",
            "192.168.216.0/25",
            "192.168.216.128/25",
            "192.168.224.0/25",
            "192.168.224.128/25",
            "192.168.232.0/25",
            "192.168.232
Failed. Look at reported mismatches above
For rejected route:
the output of route_check.py

Some routes have failed state in FRR : ['0.0.0.0/0', '192.168.128.0/25', '192.168.128.128/25', '192.168.136.0/25', '192.168.136.128/25', '192.168.144.0/25', '192.168.144.128/25', '192.168.152.0/25', '192.168.152.128/25', '192.168.160.0/25', '192.168.160.128/25', '192.168.168.0/25', '192.168.168.128/25', '192.168.176.0/25', '192.168.176.128/25', '192.168.184.0/25', '192.168.184.128/25', '192.168.192.0/25', '192.168.192.128/25', '192.168.200.0/25', '192.168.200.128/25', '192.168.208.0/25', '192.168.208.128/25', '192.168.216.0/25', '192.168.216.128/25', '192.168.224.0/25', '192.168.224.128/25', '192.168.232.0/25', '192.168.232.128/25', '192.168.240.0/25', '192.168.240.128/25', '192.168.248.0/25', '192.168.248.128/25', '192.169.0.0/25', '192.169.0.128/25', '192.169.104.0/25', '192.169.104.128/25', '192.169.112.0/25', '192.169.112.128/25', '192.169.120.0/25', '192.169.120.128/25', '192.169.128.0/25', '192.169.128.128/25', '192.169.136.0/25', '192.169.136.128/25', '192.169.144.0/25', '192.16 Failure results: {{
    "": {
        "missed_FRR_routes": [
            {
                "destSelected": true,
                "distance": 20,
                "failed": true,
                "installedNexthopGroupId": 39146,
                "internalFlags": 8,
                "internalNextHopActiveNum": 4,
                "internalNextHopNum": 4,
                "internalStatus": 168,
                "metric": 0,
                "nexthopGroupId": 39146,
                "nexthops": [
                    {
                        "active": true,
                        "afi": "ipv4",
                        "fib": true,
                        "flags": 3,
                        "interfaceIndex": 6,
                        "interfaceName": "PortChannel102",
                        "ip": "10.0.0.1",
                        "rmapSource": "10.1.0.32",
                        "weight": 1
                    },
                    {
                        "active": true,

Failed. Look at reported mismatches above

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

