### PR TITLE
[202511][cherry-pick] Fix `show ip route json` and `show ipv6 route json` when there is no IPv4 or IPv6 route

### DIFF
--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -415,10 +415,10 @@ def show_routes(args, namespace, display, verbose, ipver):
         else:
             combined_route = route_info
 
-    if not combined_route:
-        return
-
     if not found_json:
+        if len(combined_route) == 0:
+            return
+
         #print out the header if this is not a json request
         if not filter_by_ip:
             print_show_ip_route_hdr()

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -1704,4 +1704,63 @@ TEST_DATA = {
         },
         RET: -1,
     },
+    "33": {
+        DESCR: "Good test case, only IPv4 routes",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "10.10.196.20/31": {"ifname": "portchannel0"},
+                        "10.10.196.30/31": {"ifname": "lo"}
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.20/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                }
+            }
+        }
+    },
+    "34": {
+        DESCR: "Good test case, only IPv6 routes",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "::/0": {"ifname": "portchannel0"},
+                        "2603:10b0:503:df4::6c/126": {"ifname": "portchannel0"},
+                        "2603:10b0:503:df4::7c/126": {"ifname": "portchannel0"},
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::6c/126" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::7c/126" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "::/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                }
+            }
+        }
+    },
 }


### PR DESCRIPTION
Manual Cherry Pick: https://github.com/sonic-net/sonic-utilities/pull/4177

dependent on: https://github.com/sonic-net/sonic-utilities/pull/4362

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

MSFT ADO: 36173805

#### What I did

I change the output format from "" to "{}" of `show ip route json` and `show ipv6 route json` when there is no IPv4 or IPv6 route.

The reason why I did this is because "" is not a valid json string. Any application (such as route_check.py) uses the output of this command as a json string will encounter a JSON parsing error when the output is empty.

#### How I did it

I restricted the early termination in bgp_common.show_routes when the combined route is empty to the non-json case only.

#### How to verify it

* Run the new code on a device with IPv4/IPv6 only routes
* Run "show ip route json" or "show ipv6 route json"
* Verify that the command prints "{}"

#### Previous command output (if the output of a command-line utility has changed)

```
admin@vlab-01:~$ show ip route json
admin@vlab-01:~$
```

#### New command output (if the output of a command-line utility has changed)

```
admin@vlab-01:~$ show ip route json
{}
admin@vlab-01:~$
```


