### PR TITLE
[generic_config_updater]: Skip patch sorting for ACL_TABLE/DENY_NEW_INGRESS_TABLE

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -1,4 +1,5 @@
 import json
+import jsonpatch
 import jsonpointer
 import os
 import subprocess
@@ -7,7 +8,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import IO, Optional
 from .gu_common import HOST_NAMESPACE, GenericConfigUpdaterError, EmptyTableError, ConfigWrapper, \
-                    DryRunConfigWrapper, PatchWrapper, genericUpdaterLogging
+                    DryRunConfigWrapper, JsonChange, PatchWrapper, genericUpdaterLogging
 from .patch_sorter import StrictPatchSorter, NonStrictPatchSorter, ConfigSplitter, \
                         TablesWithoutYangConfigSplitter, IgnorePathsFromYangConfigSplitter
 from .change_applier import ChangeApplier, DryRunChangeApplier
@@ -129,6 +130,20 @@ class PatchApplier:
                                 which is not allowed in ConfigDb. \
                                 Table{'s' if len(empty_tables) != 1 else ''}: {empty_tables_txt}")
         # Generate list of changes to apply
+
+        # Skip sorting for DENY_NEW_INGRESS_TABLE patches
+        if sort:
+            deny_path = "/ACL_TABLE/DENY_NEW_INGRESS_TABLE"
+            for operation in patch:
+                path = operation.get("path", "")
+                if path.startswith(deny_path):
+                    self.logger.log_notice(
+                        f"{scope}: patch targets "
+                        f"{deny_path}, skipping sort."
+                    )
+                    sort = False
+                    break
+
         if sort:
             self.logger.log_notice(f"{scope}: sorting patch updates.")
             changes = self.patchsorter.sort(patch, trace_io=trace_io)

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -1,4 +1,5 @@
 import json
+import jsonpatch
 import os
 import shutil
 import unittest
@@ -46,6 +47,82 @@ class TestPatchApplier(unittest.TestCase):
         patch_applier.changeapplier.apply.assert_called()
         patch_applier.patch_wrapper.verify_same_json.assert_has_calls(
             [call(Files.CONFIG_DB_AFTER_MULTI_PATCH, Files.CONFIG_DB_AFTER_MULTI_PATCH)])
+
+    def test_apply__deny_new_ingress_table__sort_skipped(self):
+        """Patch targeting ACL_TABLE/DENY_NEW_INGRESS_TABLE
+        should skip sorting."""
+        # Arrange
+        deny_patch = jsonpatch.JsonPatch([
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/DENY_NEW_INGRESS_TABLE/ports",
+                "value": ["Ethernet0", "Ethernet1"]
+            }
+        ])
+        patch_applier = self.__create_patch_applier_for_patch(
+            deny_patch
+        )
+
+        # Act
+        patch_applier.apply(deny_patch)
+
+        # Assert - sort should NOT be called
+        patch_applier.patchsorter.sort.assert_not_called()
+
+    def test_apply__non_deny_ingress_table__sort_not_skipped(self):
+        """Patch NOT targeting ACL_TABLE/DENY_NEW_INGRESS_TABLE
+        should still sort."""
+        # Arrange
+        normal_patch = jsonpatch.JsonPatch([
+            {
+                "op": "add",
+                "path": "/ACL_TABLE/SOME_OTHER_TABLE/ports",
+                "value": ["Ethernet0"]
+            }
+        ])
+        changes = [Mock()]
+        patch_applier = self.__create_patch_applier_for_patch(
+            normal_patch, changes=changes
+        )
+
+        # Act
+        patch_applier.apply(normal_patch)
+
+        # Assert - sort SHOULD be called
+        patch_applier.patchsorter.sort.assert_called_once()
+
+    def __create_patch_applier_for_patch(
+        self, patch_obj, changes=None
+    ):
+        """Helper to create PatchApplier with mocks for any patch."""
+        config_wrapper = Mock()
+        old_config = {"ACL_TABLE": {}}
+        new_config = {"ACL_TABLE": {
+            "DENY_NEW_INGRESS_TABLE": {
+                "ports": ["Ethernet0", "Ethernet1"]
+            }
+        }}
+        config_wrapper.get_config_db_as_json.side_effect = [
+            old_config, new_config
+        ]
+        config_wrapper.get_empty_tables.return_value = []
+
+        patch_wrapper = Mock()
+        patch_wrapper.simulate_patch.return_value = new_config
+        patch_wrapper.verify_same_json.return_value = True
+
+        if changes is None:
+            changes = [Mock()]
+        patchsorter = Mock()
+        patchsorter.sort.return_value = changes
+
+        changeapplier = Mock()
+        changeapplier.apply.return_value = new_config
+
+        return gu.PatchApplier(
+            patchsorter, changeapplier,
+            config_wrapper, patch_wrapper
+        )
 
     def __create_patch_applier(self,
                                changes=None,


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

## What I did
Skip patch sorting when the JSON patch targets ACL_TABLE/DENY_NEW_INGRESS_TABLE. When GCU (Generic Config Updater) applies a patch that operates on the DENY_NEW_INGRESS_TABLE under ACL_TABLE, the patch is now applied directly without going through the patch sorter, preserving the original operation order.

## How I did it

In PatchApplier.apply() (generic_updater.py), added a check before the sort step that iterates over the patch operations. If any operation's path starts with /ACL_TABLE/DENY_NEW_INGRESS_TABLE, the sort flag is set to False, which causes the patch to bypass patchsorter.sort() and instead convert each operation directly into a JsonChange.


## How to verify it
1. Unit tests: Two new test cases were added in generic_updater_test.py:
- test_apply__deny_new_ingress_table__sort_skipped — verifies that patchsorter.sort() is not called when the patch targets /ACL_TABLE/DENY_NEW_INGRESS_TABLE/ports.
- test_apply__non_deny_ingress_table__sort_not_skipped — verifies that patchsorter.sort() is still called for patches targeting other ACL tables (e.g., /ACL_TABLE/SOME_OTHER_TABLE/ports).

2. lab

admin@str4-sn5640-2:~$ sudo config apply-patch patch2.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "add", "path": "/ACL_TABLE/DENY_NEW_INGRESS_TABLE/ports", "value": ["Ethernet0", "Ethernet1"]}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
> /usr/local/lib/python3.11/dist-packages/generic_config_updater/generic_updater.py(133)apply()
-> if sort:
(Pdb) c
**Patch Applier: localhost: patch targets /ACL_TABLE/DENY_NEW_INGRESS_TABLE, skipping sort.**
Patch Applier: localhost: converting patch to JsonChange.
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier: localhost: applying 1 change in order:
Patch Applier:   * [{"op": "add", "path": "/ACL_TABLE/DENY_NEW_INGRESS_TABLE/ports", "value": ["Ethernet0", "Ethernet1"]}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

