### PR TITLE
Fix migrate_sonic_packages() crash on symlink resolv.conf

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -325,7 +325,6 @@ def migrate_sonic_packages(bootloader, binary_image_version):
     DOCKERD_SOCK = "docker.sock"
     VAR_RUN_PATH = "/var/run/"
     RESOLV_CONF_FILE = os.path.join("etc", "resolv.conf")
-    RESOLV_CONF_BACKUP_FILE = os.path.join("/", TMP_DIR, "resolv.conf.backup")
 
     packages_file = "packages.json"
     packages_path = os.path.join(PACKAGE_MANAGER_DIR, packages_file)
@@ -382,8 +381,19 @@ def migrate_sonic_packages(bootloader, binary_image_version):
                                 os.path.join(VAR_RUN_PATH, DOCKERD_SOCK),
                                 os.path.join(new_image_mount, "tmp", DOCKERD_SOCK)])
 
-            run_command_or_raise(["cp", os.path.join(new_image_mount, RESOLV_CONF_FILE), RESOLV_CONF_BACKUP_FILE])
-            run_command_or_raise(["cp", os.path.join("/", RESOLV_CONF_FILE), os.path.join(new_image_mount, RESOLV_CONF_FILE)])
+            # Inject host DNS into chroot for sonic-package-manager to resolve hostnames.
+            chroot_resolv = os.path.join(new_image_mount, RESOLV_CONF_FILE)
+            if os.path.islink(chroot_resolv):
+                # Symlink: populate the target inside the chroot so the symlink resolves.
+                # Cannot cp over the symlink because the absolute target path escapes
+                # the overlay mount to the host filesystem ("are the same file" error).
+                resolv_target = os.readlink(chroot_resolv)
+                chroot_target = os.path.join(new_image_mount, resolv_target.lstrip("/"))
+                run_command_or_raise(["mkdir", "-p", os.path.dirname(chroot_target)])
+                run_command_or_raise(["cp", "-L", os.path.join("/", RESOLV_CONF_FILE), chroot_target])
+            else:
+                # Regular file: overwrite with host DNS content.
+                run_command_or_raise(["cp", os.path.join("/", RESOLV_CONF_FILE), chroot_resolv])
 
             run_command_or_raise(["chroot", new_image_mount, "sh", "-c", "command -v {}".format(SONIC_PACKAGE_MANAGER)])
             run_command_or_raise(["chroot", new_image_mount, SONIC_PACKAGE_MANAGER, "migrate",
@@ -395,7 +405,6 @@ def migrate_sonic_packages(bootloader, binary_image_version):
                 run_command_or_raise(["chroot", new_image_mount, DOCKER_CTL_SCRIPT, "stop"], raise_exception=False)
             if os.path.exists(docker_default_config_backup):
                 run_command_or_raise(["mv", docker_default_config_backup, docker_default_config], raise_exception=False);
-            run_command_or_raise(["cp", RESOLV_CONF_BACKUP_FILE, os.path.join(new_image_mount, RESOLV_CONF_FILE)], raise_exception=False)
             umount(new_image_mount, recursive=True, read_only=False, remove_dir=False, raise_exception=False)
             umount(new_image_mount, raise_exception=False)
 

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -34,6 +34,8 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
     fs.create_dir(os.path.join(mounted_image_folder, "usr/lib/docker/docker.sh"))
     fs.create_file("/var/run/docker.pid", contents="15")
     fs.create_file("/proc/15/cmdline", contents="\x00".join(["dockerd"] + dockerd_opts))
+    # Simulate new image: /etc/resolv.conf is a dangling symlink (target doesn't exist in squashfs)
+    fs.create_symlink(f"{mounted_image_folder}/etc/resolv.conf", "/run/resolvconf/resolv.conf")
 
     # Setup bootloader mock
     mock_bootloader = Mock()
@@ -91,12 +93,12 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
              f"{mounted_image_folder}/var/lib/sonic-package-manager"]),
         call(["touch", f"{mounted_image_folder}/tmp/docker.sock"]),
         call(["mount", "--bind", "/var/run/docker.sock", f"{mounted_image_folder}/tmp/docker.sock"]),
-        call(["cp", f"{mounted_image_folder}/etc/resolv.conf", "/tmp/resolv.conf.backup"]),
-        call(["cp", "/etc/resolv.conf", f"{mounted_image_folder}/etc/resolv.conf"]),
+        # /etc/resolv.conf is a dangling symlink -> /run/resolvconf/resolv.conf, populate its target
+        call(["mkdir", "-p", f"{mounted_image_folder}/run/resolvconf"]),
+        call(["cp", "-L", "/etc/resolv.conf", f"{mounted_image_folder}/run/resolvconf/resolv.conf"]),
         call(["chroot", mounted_image_folder, "sh", "-c", "command -v sonic-package-manager"]),
         call(["chroot", mounted_image_folder, "sonic-package-manager", "migrate", "/tmp/packages.json", "--dockerd-socket", "/tmp/docker.sock", "-y"], capture=False),
         call(["chroot", mounted_image_folder, "/usr/lib/docker/docker.sh", "stop"], raise_exception=False),
-        call(["cp", "/tmp/resolv.conf.backup", f"{mounted_image_folder}/etc/resolv.conf"], raise_exception=False),
         call(["umount", "-f", "-R", mounted_image_folder], raise_exception=False),
         call(["umount", "-r", "-f", mounted_image_folder], raise_exception=False),
         call(["rm", "-rf", mounted_image_folder], raise_exception=False),


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed `sonic-installer install` failing during `migrate_sonic_packages()` when `/etc/resolv.conf` in the new image is a symlink to `/run/resolvconf/resolv.conf`.

The failure occurs because the `cp` command at `main.py:386` follows the symlink through the overlay mount. Since the symlink target is an absolute path, it resolves to the **host's** `/run/resolvconf/resolv.conf` — the same file as the source. `cp` detects same source and destination inode and exits with:

```
cp: '/etc/resolv.conf' and '/tmp/image-<version>-fs/etc/resolv.conf' are the same file
```

This was introduced by the `build_debian.sh` change that replaced `touch` with `ln -sf /run/resolvconf/resolv.conf` for `/etc/resolv.conf` in the image filesystem.

#### How I did it

Check whether `/etc/resolv.conf` in the chroot is a symlink or a regular file, and handle each case appropriately:

- **Symlink** (images with `resolvconf` package installed): Read the symlink target via `readlink` (e.g. `/run/resolvconf/resolv.conf`), then create the target file inside the chroot with the host's DNS content. The symlink then resolves correctly inside the chroot. This avoids touching the symlink itself, so the overlay upper dir's `etc/resolv.conf` is never modified and the new image boots with the symlink intact. No cleanup is needed — the target lives under `/run`, which is a tmpfs recreated at every boot.

- **Regular file** (images without `resolvconf`, or where the build process explicitly creates a regular file via `touch`): Overwrite directly with the host's DNS content. No backup/restore is needed — the original file is empty (cleared during build), and after reboot the `resolv-config` service reconfigures DNS from CONFIG_DB.

The previous backup-overwrite-restore pattern has been removed since it is unnecessary in both cases.

#### How to verify it

1. Start with a switch running an image where `/etc/resolv.conf` is a symlink:
   ```bash
   # Confirm symlink exists
   ls -la /etc/resolv.conf
   # Expected: /etc/resolv.conf -> /run/resolvconf/resolv.conf

   # Ensure only one image is installed (clean state)
   sudo sonic-installer list
   # If the target image is already present, remove it:
   sudo sonic-installer remove <target-image> -y
   ```

2. Run `sonic-installer install` with an image that also has the symlink:
   ```bash
   sudo sonic-installer install <image-path> -y
   ```

3. Verify:
   - Installation completes without `cp: ... are the same file` error
   - `sonic-installer list` shows the new image as default
   - After reboot, `/etc/resolv.conf` is still a symlink to `/run/resolvconf/resolv.conf`
   - DNS resolution works

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

