### PR TITLE
fast-reboot warm-reboot prohibit from root and sudo-su

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -897,10 +897,14 @@ parseOptions $@
 # Filter ASIC list based on -m option
 filter_asic_list
 
+if [[ -z "$SUDO_USER" || "$SUDO_USER" == "root" ]]; then
+    echo "This command must be run as admin#sudo... but not as root" >&2
+    exit "${EXIT_FAILURE}"
+fi
 # Check root privileges
 if [[ "$EUID" -ne 0 ]]
 then
-    echo "This command must be run as root" >&2
+    echo "This command must be run as sudo" >&2
     exit "${EXIT_FAILURE}"
 fi
 


### PR DESCRIPTION
#### What I did
Prohibit call for warm-reboot and fast-reboot from "root"
since x-reboot called from "root" fails on either:
- x-reboot stuck forever or till watchdog expiry
- "fast-reboot" passes over full system-reset (including reset-BIOS-GRUB)
- after successful Linux start the SONiC dockers/services started (with saved warmboot/dump.rdb)
   improperly or/and failed

#### How I did it
If the fast-reboot script (the warm-reboot is sym-link) is called from environment
without SUDO_USER or with $SUDO_USER=root - print error message and exit

#### How to verify it
Login as "root", call for warm-reboot or fast-reboot and check exit with error
       This command must be run as admin#sudo... but not as root or <sudo su>
Login as "admin", call for warm-reboot or fast-reboot and check SONiC restarted successfully

#### Previous command output (if the output of a command-line utility has changed)
- x-reboot stuck forever or till watchdog expiry
- "fast-reboot" passes over full system-reset (including reset-BIOS-GRUB)
- after successful Linux start the SONiC dockers/services started (with saved warmboot/dump.rdb)
   improperly or/and failed

#### New command output (if the output of a command-line utility has changed)
-

#### Backport
Backport to 202511 required

