### PR TITLE
Add multi-asic support for counterpoll phy command

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -177,11 +177,14 @@ def port_buffer_drop_disable(ctx):
 
 # PHY counter commands
 @cli.group()
+@click.option('-n', '--namespace', help='Namespace name',
+              required=False,
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
-def phy(ctx):
+def phy(ctx, namespace):
     """ PHY counter commands """
-    ctx.obj = ConfigDBConnector()
-    ctx.obj.connect()
+    ctx.obj = connect_to_db(namespace)
 
 
 @phy.command()
@@ -189,30 +192,27 @@ def phy(ctx):
 @click.pass_context
 def interval(ctx, poll_interval):  # noqa: F811
     """ Set PHY counter query interval """
-    configdb = ctx.obj
     port_info = {}
     port_info['POLL_INTERVAL'] = poll_interval
-    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
+    ctx.obj.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
 
 
 @phy.command()
 @click.pass_context
 def enable(ctx):  # noqa: F811
     """ Enable PHY counter query """
-    configdb = ctx.obj
     port_info = {}
     port_info['FLEX_COUNTER_STATUS'] = ENABLE
-    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
+    ctx.obj.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
 
 
 @phy.command()
 @click.pass_context
 def disable(ctx):  # noqa: F811
     """ Disable PHY counter query """
-    configdb = ctx.obj
     port_info = {}
     port_info['FLEX_COUNTER_STATUS'] = DISABLE
-    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
+    ctx.obj.mod_entry("FLEX_COUNTER_TABLE", PORT_PHY_ATTR, port_info)
 
 
 # Ingress PG drop packet stat


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The PR https://github.com/sonic-net/sonic-utilities/pull/4152 added multi-asic support for the counterpoll commands. But since the command "phy" was added after the PR 4152 was created, the multi-asic support was not added for it. Adding the support in this PR.
Nore: The PR https://github.com/sonic-net/sonic-swss/pull/4232 added DASH HA-set command and not sure if it needs multi-asic support.
#### How I did it
Added multi-asic support for counterpoll phy command
#### How to verify it
verified the command in multi-asic and single asic platforms
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

