### PR TITLE
Fix counterpoll CLI when running in a namespace

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -31,7 +31,7 @@ def is_dpu(db):
 
 
 def connect_to_db(namespace):
-    if namespace is None:
+    if not namespace:
         namespace = DEFAULT_NAMESPACE
     else:
         if not SonicDBConfig.isGlobalInit():
@@ -50,7 +50,8 @@ def cli():
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def queue(ctx, namespace):
     """ Queue counter commands """
@@ -90,7 +91,8 @@ def queue_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def port(ctx, namespace):
     """ Port counter commands """
@@ -130,7 +132,8 @@ def port_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def port_buffer_drop(ctx, namespace):
     """ Port buffer drop  counter commands """
@@ -216,7 +219,8 @@ def disable(ctx):  # noqa: F811
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def pg_drop(ctx, namespace):
     """  Ingress PG drop counter commands """
@@ -258,7 +262,8 @@ def pg_drop_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def rif(ctx, namespace):
     """ RIF counter commands """
@@ -298,7 +303,8 @@ def rif_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def watermark(ctx, namespace):
     """ Watermark counter commands """
@@ -348,7 +354,8 @@ def watermark_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def acl(ctx, namespace):
     """  ACL counter commands """
@@ -390,7 +397,8 @@ def acl_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def tunnel(ctx, namespace):
     """ Tunnel counter commands """
@@ -429,7 +437,8 @@ def tunnel_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def flowcnt_trap(ctx, namespace):
     """ Trap flow counter commands """
@@ -468,7 +477,8 @@ def flowcnt_trap_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def flowcnt_route(ctx, namespace):
     """ Route flow counter commands """
@@ -508,7 +518,8 @@ def flowcnt_route_disable(ctx):
 @click.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def eni(ctx, namespace):
     """ ENI counter commands """
@@ -584,7 +595,8 @@ def ha_set_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def wredqueue(ctx, namespace):
     """ WRED queue counter commands """
@@ -623,7 +635,8 @@ def wredqueue_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def wredport(ctx, namespace):
     """ WRED port counter commands """
@@ -662,7 +675,8 @@ def wredport_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def srv6(ctx, namespace):
     """ SRv6 counter commands """
@@ -698,7 +712,8 @@ def srv6_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def switch(ctx, namespace):
     """ Switch counter commands """
@@ -752,7 +767,8 @@ def switch_disable(ctx):
 @cli.command()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(multi_asic.get_namespace_list()),
+              default=multi_asic.get_current_namespace())
 def show(namespace):
     """ Show the counter configuration """
     configdb = connect_to_db(namespace)


### PR DESCRIPTION
Fixes issue https://github.com/sonic-net/sonic-utilities/issues/4375

Currently when using `sudo ip netns exec <namespace> counterpoll <args>` it will ignore the namespace and use the default namespace. This patch fixes that behavior to use namespace that the command is running in.

This is how the command worked previously but a regression was introduced breaking this behaviour.


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I changed the default value of the -n arg to be the namespace we are running the command in.

#### How to verify it

I verified that with my change the namespace being run in will be the default namespace chosen.

```
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'enable'}
$ sudo ip netns exec asic0 counterpoll pg-drop disable
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'disable'}
```

 I also verified that the command exits gracefully if the user attempts to confuse it with 2 namespaces like so:
```
sudo ip netns exec asic0 counterpoll pg-drop -n asic1 disable
Usage: counterpoll pg-drop [OPTIONS] COMMAND [ARGS]...
Try 'counterpoll pg-drop --help' for help.

Error: Invalid value for '-n' / '--namespace': 'asic1' is not 'asic0'.
```

#### Previous command output (if the output of a command-line utility has changed)
```
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'enable'}
$ sudo ip netns exec asic0 counterpoll pg-drop disable
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'enable'}
```

#### New command output (if the output of a command-line utility has changed)
Seen above
