### PR TITLE
[202511 Backport] Fix counterpoll CLI when running in a namespace

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -32,7 +32,7 @@ def is_dpu(db):
 
 
 def connect_to_db(namespace):
-    if namespace is None:
+    if not namespace:
         namespace = DEFAULT_NAMESPACE
     else:
         if not SonicDBConfig.isGlobalInit():
@@ -40,6 +40,14 @@ def connect_to_db(namespace):
     configdb = ConfigDBConnector(use_unix_socket_path=True, namespace=str(namespace))
     configdb.connect()
     return configdb
+
+
+def get_valid_namespace_choices():
+    current_ns = multi_asic.get_current_namespace()
+    if current_ns:
+        return [current_ns]
+
+    return multi_asic.get_namespace_list() + [DEFAULT_NAMESPACE]
 
 
 @click.group()
@@ -51,7 +59,8 @@ def cli():
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def queue(ctx, namespace):
     """ Queue counter commands """
@@ -91,7 +100,8 @@ def queue_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def port(ctx, namespace):
     """ Port counter commands """
@@ -131,7 +141,8 @@ def port_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def port_buffer_drop(ctx, namespace):
     """ Port buffer drop  counter commands """
@@ -177,7 +188,8 @@ def port_buffer_drop_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def phy(ctx, namespace):
     """ PHY counter commands """
@@ -216,7 +228,8 @@ def disable(ctx):  # noqa: F811
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def pg_drop(ctx, namespace):
     """  Ingress PG drop counter commands """
@@ -258,7 +271,8 @@ def pg_drop_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def rif(ctx, namespace):
     """ RIF counter commands """
@@ -298,7 +312,8 @@ def rif_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def watermark(ctx, namespace):
     """ Watermark counter commands """
@@ -348,7 +363,8 @@ def watermark_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def acl(ctx, namespace):
     """  ACL counter commands """
@@ -390,7 +406,8 @@ def acl_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def tunnel(ctx, namespace):
     """ Tunnel counter commands """
@@ -429,7 +446,8 @@ def tunnel_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def flowcnt_trap(ctx, namespace):
     """ Trap flow counter commands """
@@ -468,7 +486,8 @@ def flowcnt_trap_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def flowcnt_route(ctx, namespace):
     """ Route flow counter commands """
@@ -508,7 +527,8 @@ def flowcnt_route_disable(ctx):
 @click.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def eni(ctx, namespace):
     """ ENI counter commands """
@@ -547,7 +567,8 @@ def eni_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def wredqueue(ctx, namespace):
     """ WRED queue counter commands """
@@ -586,7 +607,8 @@ def wredqueue_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def wredport(ctx, namespace):
     """ WRED port counter commands """
@@ -625,7 +647,8 @@ def wredport_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def srv6(ctx, namespace):
     """ SRv6 counter commands """
@@ -661,7 +684,8 @@ def srv6_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def switch(ctx, namespace):
     """ Switch counter commands """
@@ -715,7 +739,8 @@ def switch_disable(ctx):
 @cli.command()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 def show(namespace):
     """ Show the counter configuration """
     configdb = connect_to_db(namespace)


### PR DESCRIPTION
This is a manual backport of https://github.com/sonic-net/sonic-utilities/pull/4376 and https://github.com/sonic-net/sonic-utilities/pull/4404

due to differences between master and 202511

Fixes issue https://github.com/sonic-net/sonic-utilities/issues/4375

Currently when using `sudo ip netns exec <namespace> counterpoll <args>` it will ignore the namespace and use the default namespace. This patch fixes that behavior to use namespace that the command is running in.

This is how the command worked previously but a regression was introduced breaking this behaviour.


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I changed the default value of the -n arg to be the namespace we are running the command in.

#### How to verify it

I verified that with my change the namespace being run in will be the default namespace chosen.

```
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'enable'}
$ sudo ip netns exec asic0 counterpoll pg-drop disable
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'disable'}
```

 I also verified that the command exits gracefully if the user attempts to confuse it with 2 namespaces like so:
```
sudo ip netns exec asic0 counterpoll pg-drop -n asic1 disable
Usage: counterpoll pg-drop [OPTIONS] COMMAND [ARGS]...
Try 'counterpoll pg-drop --help' for help.

Error: Invalid value for '-n' / '--namespace': 'asic1' is not 'asic0'.
```

#### Previous command output (if the output of a command-line utility has changed)
```
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'enable'}
$ sudo ip netns exec asic0 counterpoll pg-drop disable
$ sonic-db-cli -n asic0 CONFIG_DB hgetall "FLEX_COUNTER_TABLE|PG_DROP"
{'FLEX_COUNTER_STATUS': 'enable'}
```

#### New command output (if the output of a command-line utility has changed)
Seen above
