### PR TITLE
fix: show vrf returns clear error for unconfigured VRF

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -377,6 +377,9 @@ def vrf(vrf_name):
             vrfs = list(vrf_dict.keys())
         elif vrf_name in vrf_dict:
             vrfs = [vrf_name]
+        else:
+            click.echo("VRF '{}' not found.".format(vrf_name))
+            return
         for vrf in vrfs:
             intfs = get_interface_bind_to_vrf(config_db, vrf)
             intfs = natsorted(intfs)

--- a/tests/vrf_test.py
+++ b/tests/vrf_test.py
@@ -307,6 +307,19 @@ Error: 'vrf_name' length should not exceed 15 characters
         assert expected_output in result.output
 
 
+
+    def test_vrf_show_unconfigured(self):
+        from .mock_tables import dbconnector
+        jsonfile_config = os.path.join(mock_db_path, "config_db")
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands['vrf'], ["NonExistentVrf"], obj=db)
+        dbconnector.dedicated_dbs = {}
+        assert result.exit_code == 0
+        assert "VRF 'NonExistentVrf' not found." in result.output
+
 class TestVnet(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
#### What I did
Added a clear error message when `show vrf <name>` is called with a VRF name that does not exist in the database.

#### How I did it
Added an `else` clause in the `vrf` command in `show/main.py`. When the provided VRF name is not found in `vrf_dict`, the command now prints `VRF '<name>' not found.` and returns early instead of silently printing an empty table. Added a corresponding unit test in `tests/vrf_test.py`.

#### How to verify it
Run `show vrf NonExistentVrf` on a SONiC device where `NonExistentVrf` is not configured. The output should be `VRF 'NonExistentVrf' not found.`

#### Previous command output (if the output of a command-line utility has changed)
VRF    Interfaces
-----  ------------
(empty table, no feedback to the user)

#### New command output (if the output of a command-line utility has changed)
VRF 'NonExistentVrf' not found.

Fixes #4378

