### PR TITLE
[show] Fix 'show vrf <vrfname>' to return error for unconfigured VRFs…

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -377,6 +377,9 @@ def vrf(vrf_name):
             vrfs = list(vrf_dict.keys())
         elif vrf_name in vrf_dict:
             vrfs = [vrf_name]
+        else:
+            click.echo("Error: VRF {} is not configured".format(vrf_name))
+            raise SystemExit(1)
         for vrf in vrfs:
             intfs = get_interface_bind_to_vrf(config_db, vrf)
             intfs = natsorted(intfs)
@@ -386,6 +389,9 @@ def vrf(vrf_name):
                 body.append([vrf, intfs[0]])
                 for intf in intfs[1:]:
                     body.append(["", intf])
+    elif vrf_name is not None:
+        click.echo("Error: VRF {} is not configured".format(vrf_name))
+        raise SystemExit(1)
     click.echo(tabulate(body, header))
 
 #

--- a/tests/vrf_test.py
+++ b/tests/vrf_test.py
@@ -307,6 +307,29 @@ Error: 'vrf_name' length should not exceed 15 characters
         assert expected_output in result.output
 
 
+    def test_vrf_show_unconfigured(self):
+        """Test that 'show vrf <name>' returns an error for unconfigured VRF (issue #4378)."""
+        from .mock_tables import dbconnector
+        jsonfile_config = os.path.join(mock_db_path, "config_db")
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands['vrf'], ['VrfNonExistent'], obj=db)
+        dbconnector.dedicated_dbs = {}
+        assert result.exit_code != 0
+        assert "Error: VRF VrfNonExistent is not configured" in result.output
+
+    def test_vrf_show_unconfigured_empty_table(self):
+        """Test that 'show vrf <name>' returns an error when no VRFs exist at all (issue #4378)."""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands['vrf'], ['VrfDoesNotExist'], obj=db)
+        assert result.exit_code != 0
+        assert "Error: VRF VrfDoesNotExist is not configured" in result.output
+
+
 class TestVnet(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
… (#4378)

Currently, 'show vrf <vrfname>' returns exit code 0 and prints an empty VRF table when the specified VRF is not configured. This is confusing because:
- The exit code is misleading (success for a failed lookup)
- No message informs the user that the VRF does not exist

This change adds proper error handling:
- When a specific VRF name is given but not found in CONFIG_DB, print 'Error: VRF <name> is not configured' to stderr and exit with code 1
- Handles both cases: VRF table exists but name not found, and VRF table is completely empty

Added unit tests:
- test_vrf_show_unconfigured: VRF not found when other VRFs exist
- test_vrf_show_unconfigured_empty_table: VRF not found when no VRFs are configured

Fixes: sonic-net/sonic-utilities#4378

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

