### PR TITLE
[multi-asic] Add multi asic support for VRF and clear flowcnt-trap

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -683,9 +683,15 @@ def statistics(db):
 
 # ("sonic-clear flowcnt-trap")
 @cli.command()
-def flowcnt_trap():
+@click.option('--namespace', '-n', 'namespace', default=None,
+              type=click.Choice(multi_asic_util.multi_asic_ns_choices()),
+              show_default=True, help='Namespace name')
+def flowcnt_trap(namespace):
     """ Clear trap flow counters """
     command = ["flow_counters_stat", "-c", '-t', "trap"]
+    # None namespace means default namespace
+    if namespace is not None:
+        command += ['-n', str(namespace)]
     run_command(command)
 
 

--- a/config/main.py
+++ b/config/main.py
@@ -7671,13 +7671,19 @@ def remove_vrrp_v6(ctx, interface_name, vrrp_id):
 #
 
 @config.group(cls=clicommon.AbbreviationGroup, name='vrf')
+@click.option('-n', '--namespace', help='Namespace name',
+              required=True if multi_asic.is_multi_asic() else False,
+              type=click.Choice(multi_asic.get_namespace_list()))
 @click.pass_context
-def vrf(ctx):
-    """VRF-related configuration tasks"""
-    config_db = ConfigDBConnector()
+def vrf(ctx, namespace):
+    """ VRF-related configuration tasks """
+    if namespace is None:
+        namespace = DEFAULT_NAMESPACE
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=str(namespace))
     config_db.connect()
     ctx.obj = {}
     ctx.obj['config_db'] = config_db
+    ctx.obj['namespace'] = str(namespace)
 
 @vrf.command('add')
 @click.argument('vrf_name', metavar='<vrf_name>', required=True)

--- a/config/main.py
+++ b/config/main.py
@@ -7671,19 +7671,21 @@ def remove_vrrp_v6(ctx, interface_name, vrrp_id):
 #
 
 @config.group(cls=clicommon.AbbreviationGroup, name='vrf')
-@click.option('-n', '--namespace', help='Namespace name',
-              required=True if multi_asic.is_multi_asic() else False,
+@click.option('-n', '--namespace', help='Namespace name', default=None,
               type=click.Choice(multi_asic.get_namespace_list()))
 @click.pass_context
 def vrf(ctx, namespace):
     """ VRF-related configuration tasks """
-    if namespace is None:
-        namespace = DEFAULT_NAMESPACE
-    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=str(namespace))
+    # Data VRFs live in the per-ASIC CONFIG_DB; the management VRF lives
+    # in the host/global CONFIG_DB. Connect to the (optionally namespaced)
+    # DB here for data-VRF subcommands; the mgmt-VRF path re-targets the
+    # global DB and rejects -n at runtime.
+    ns = namespace if namespace else DEFAULT_NAMESPACE
+    config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=str(ns))
     config_db.connect()
     ctx.obj = {}
     ctx.obj['config_db'] = config_db
-    ctx.obj['namespace'] = str(namespace)
+    ctx.obj['namespace'] = namespace
 
 @vrf.command('add')
 @click.argument('vrf_name', metavar='<vrf_name>', required=True)
@@ -7695,9 +7697,18 @@ def add_vrf(ctx, vrf_name):
         ctx.fail("'vrf_name' must begin with 'Vrf' or named 'mgmt'/'management' in case of ManagementVRF.")
     if not isInterfaceNameValid(vrf_name):
         ctx.fail("'vrf_name' length should not exceed {} characters".format(IFACE_NAME_MAX_LEN))
+
+    is_mgmt = vrf_name in ('mgmt', 'management')
+    if is_mgmt:
+        if ctx.obj['namespace'] is not None:
+            ctx.fail("-n/--namespace is not applicable to the management VRF; it is configured in the host CONFIG_DB.")
+    else:
+        if multi_asic.is_multi_asic() and ctx.obj['namespace'] is None:
+            ctx.fail("-n/--namespace is required for data VRFs on multi-ASIC platforms.")
+
     if is_vrf_exists(config_db, vrf_name):
         ctx.fail("VRF {} already exists!".format(vrf_name))
-    elif (vrf_name == 'mgmt' or vrf_name == 'management'):
+    elif is_mgmt:
         vrf_add_management_vrf(config_db)
     else:
         try:
@@ -7715,6 +7726,15 @@ def del_vrf(ctx, vrf_name):
         ctx.fail("'vrf_name' must begin with 'Vrf' or named 'mgmt'/'management' in case of ManagementVRF.")
     if not isInterfaceNameValid(vrf_name):
         ctx.fail("'vrf_name' length should not exceed {} characters".format((IFACE_NAME_MAX_LEN)))
+
+    is_mgmt = vrf_name in ('mgmt', 'management')
+    if is_mgmt:
+        if ctx.obj['namespace'] is not None:
+            ctx.fail("-n/--namespace is not applicable to the management VRF; it is configured in the host CONFIG_DB.")
+    else:
+        if multi_asic.is_multi_asic() and ctx.obj['namespace'] is None:
+            ctx.fail("-n/--namespace is required for data VRFs on multi-ASIC platforms.")
+
     syslog_table = config_db.get_table("SYSLOG_SERVER")
     syslog_vrf_dev = "mgmt" if vrf_name == "management" else vrf_name
     for syslog_entry, syslog_data in syslog_table.items():
@@ -7729,7 +7749,7 @@ def del_vrf(ctx, vrf_name):
 
     if not is_vrf_exists(config_db, vrf_name):
         ctx.fail("VRF {} does not exist!".format(vrf_name))
-    elif (vrf_name == 'mgmt' or vrf_name == 'management'):
+    elif is_mgmt:
         vrf_delete_management_vrf(config_db)
     else:
         del_interface_bind_to_vrf(config_db, vrf_name)
@@ -7744,6 +7764,8 @@ def del_vrf(ctx, vrf_name):
 @click.argument('vni', metavar='<vni>', required=True)
 @click.pass_context
 def add_vrf_vni_map(ctx, vrfname, vni):
+    if multi_asic.is_multi_asic() and ctx.obj['namespace'] is None:
+        ctx.fail("-n/--namespace is required on multi-ASIC platforms.")
     config_db = ctx.obj['config_db']
     found = 0
     if vrfname not in config_db.get_table('VRF').keys():
@@ -7783,6 +7805,8 @@ def add_vrf_vni_map(ctx, vrfname, vni):
 @click.argument('vrfname', metavar='<vrf-name>', required=True, type=str)
 @click.pass_context
 def del_vrf_vni_map(ctx, vrfname):
+    if multi_asic.is_multi_asic() and ctx.obj['namespace'] is None:
+        ctx.fail("-n/--namespace is required on multi-ASIC platforms.")
     config_db = ctx.obj['config_db']
     if vrfname not in config_db.get_table('VRF').keys():
         ctx.fail("vrf {} doesn't exist".format(vrfname))

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -270,6 +270,7 @@
 
 | Version | Modification Date | Details |
 | --- | --- | --- |
+| v11 | May-13-2026 | Add multi-ASIC namespace support for `config vrf` and `sonic-clear flowcnt-trap` |
 | v10 | Mar-07-2026 | Update VxLAN and Vnet command reference for namespace-aware multi-ASIC behavior |
 | v9 | Sep-19-2024 | Add DPU serial console utility |
 | v8 | Oct-09-2023 | Add CMIS firmware upgrade commands |
@@ -5423,12 +5424,21 @@ This command is used to clear the current statistics for the registered host int
 
 - Usage:
   ```
-  sonic-clear flowcnt-trap
+  sonic-clear flowcnt-trap [-n|--namespace <namespace>]
   ```
+
+- Details:
+  - -n, --namespace: (Multi-ASIC) Namespace name (e.g. asic0). When omitted, the default namespace is targeted.
 
 - Example:
   ```
   admin@sonic:~$ sonic-clear flowcnt-trap
+  Trap Flow Counters were successfully cleared
+  ```
+
+- Example (multi-ASIC):
+  ```
+  admin@sonic:~$ sonic-clear flowcnt-trap -n asic0
   Trap Flow Counters were successfully cleared
   ```
 
@@ -8466,15 +8476,30 @@ If vrf-name is also provided as part of the command, if the vrf is created it wi
 
 ### VRF config commands
 
+The `config vrf` command group accepts an optional `-n|--namespace` option that targets a specific ASIC's config DB on multi-ASIC platforms. On multi-ASIC platforms the option is required; on single-ASIC platforms it can be omitted and the default namespace is used.
+
+- Usage:
+  ```
+  config vrf [-n|--namespace <namespace>] <subcommand> ...
+  ```
+
+- Details:
+  - -n, --namespace: (Multi-ASIC, required) Namespace name (e.g. asic0). On single-ASIC platforms this option is optional and defaults to the default namespace.
+
 **config vrf add**
 
 This command creates vrf in SONiC system with provided vrf-name.
 
 - Usage:
   ```
-  config vrf add <vrf-name>
+  config vrf [-n|--namespace <namespace>] add <vrf-name>
   ```
 Note: vrf-name should always start with keyword "Vrf"
+
+- Example (multi-ASIC):
+  ```
+  admin@sonic:~$ sudo config vrf -n asic0 add Vrf-red
+  ```
 
 **config vrf del <vrf-name>**
 
@@ -8482,7 +8507,12 @@ This command deletes vrf with name vrf-name.
 
 - Usage:
   ```
-  config vrf del <vrf-name>
+  config vrf [-n|--namespace <namespace>] del <vrf-name>
+  ```
+
+- Example (multi-ASIC):
+  ```
+  admin@sonic:~$ sudo config vrf -n asic0 del Vrf-red
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#vrf-configuration)
@@ -8602,12 +8632,17 @@ This command enables the management VRF in the system. This command restarts the
 
 - Usage:
   ```
-  config vrf add mgmt
+  config vrf [-n|--namespace <namespace>] add mgmt
   ```
 
 - Example:
   ```
   admin@sonic:~$ sudo config vrf add mgmt
+  ```
+
+- Example (multi-ASIC):
+  ```
+  admin@sonic:~$ sudo config vrf -n asic0 add mgmt
   ```
 
 **config vrf del mgmt**
@@ -8616,7 +8651,7 @@ This command disables the management VRF in the system. This command restarts th
 
 - Usage:
   ```
-  config vrf del mgmt
+  config vrf [-n|--namespace <namespace>] del mgmt
   ```
 
 - Example:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5420,7 +5420,7 @@ The "route" subcommand is used to display the route flow counter statistics by r
 
 **sonic-clear flowcnt-trap**
 
-This command is used to clear the current statistics for the registered host interface traps. This is done on a per-user basis.
+This command is used to clear the current statistics for the registered host interface traps. This is done on a per-user basis. On multi-ASIC platforms, an optional namespace can be supplied to clear counters for a specific ASIC; when omitted, counters are cleared across all ASIC namespaces.
 
 - Usage:
   ```
@@ -5428,7 +5428,7 @@ This command is used to clear the current statistics for the registered host int
   ```
 
 - Details:
-  - -n, --namespace: (Multi-ASIC) Namespace name (e.g. asic0). When omitted, the default namespace is targeted.
+  - -n, --namespace: Namespace name (e.g. asic0). On multi-ASIC platforms, omit this option to target all ASIC namespaces; on single-ASIC platforms, the default namespace is used.
 
 - Example:
   ```
@@ -8476,7 +8476,7 @@ If vrf-name is also provided as part of the command, if the vrf is created it wi
 
 ### VRF config commands
 
-The `config vrf` command group accepts an optional `-n|--namespace` option that targets a specific ASIC's config DB on multi-ASIC platforms. On multi-ASIC platforms the option is required; on single-ASIC platforms it can be omitted and the default namespace is used.
+The `config vrf` command group accepts an optional `-n|--namespace` option that targets a specific ASIC's CONFIG_DB on multi-ASIC platforms. For data-VRF subcommands (`add <Vrf-*>`, `del <Vrf-*>`, `add_vrf_vni_map`, `del_vrf_vni_map`) the option is required on multi-ASIC platforms. The management-VRF subcommands (`add mgmt`/`del mgmt`) operate on the host/global CONFIG_DB and reject `-n` with an error.
 
 - Usage:
   ```
@@ -8484,7 +8484,7 @@ The `config vrf` command group accepts an optional `-n|--namespace` option that 
   ```
 
 - Details:
-  - -n, --namespace: (Multi-ASIC, required) Namespace name (e.g. asic0). On single-ASIC platforms this option is optional and defaults to the default namespace.
+  - -n, --namespace: (Multi-ASIC) Namespace name (e.g. asic0). Required for data-VRF subcommands on multi-ASIC platforms; not applicable to `add mgmt`/`del mgmt`.
 
 **config vrf add**
 
@@ -8630,9 +8630,11 @@ This command displays the configured SNMP Trap server IP addresses.
 
 This command enables the management VRF in the system. This command restarts the "interfaces-config" service which in turn regenerates the /etc/network/interfaces file and restarts the "networking" service. This creates a new interface and l3mdev CGROUP with the name as "mgmt" and enslaves the management interface "eth0" into this master interface "mgmt". Note that the VRFName "mgmt" (or "management") is reserved for management VRF. i.e. Data VRFs should not use these reserved VRF names.
 
+The management VRF is host-level state stored in the global CONFIG_DB, so the `-n|--namespace` option is not applicable; supplying it returns an error.
+
 - Usage:
   ```
-  config vrf [-n|--namespace <namespace>] add mgmt
+  config vrf add mgmt
   ```
 
 - Example:
@@ -8640,18 +8642,15 @@ This command enables the management VRF in the system. This command restarts the
   admin@sonic:~$ sudo config vrf add mgmt
   ```
 
-- Example (multi-ASIC):
-  ```
-  admin@sonic:~$ sudo config vrf -n asic0 add mgmt
-  ```
-
 **config vrf del mgmt**
 
 This command disables the management VRF in the system. This command restarts the "interfaces-config" service which in turn regenerates the /etc/network/interfaces file and restarts the "networking" service. This deletes the interface "mgmt" and deletes the l3mdev CGROUP named "mgmt" and puts back the management interface "eth0" into the default VRF. Note that the VRFName "mgmt" (or "management") is reserved for management VRF. i.e. Data VRFs should not use these reserved VRF names.
 
+The management VRF is host-level state stored in the global CONFIG_DB, so the `-n|--namespace` option is not applicable; supplying it returns an error.
+
 - Usage:
   ```
-  config vrf [-n|--namespace <namespace>] del mgmt
+  config vrf del mgmt
   ```
 
 - Example:

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -334,6 +334,65 @@ class TestClearFlowcnt(object):
         print('TEAR DOWN')
 
 
+class TestClearFlowcntTrap(object):
+    def setup(self):
+        print('SETUP')
+
+    @patch('clear.main.run_command')
+    @patch('utilities_common.multi_asic.multi_asic_ns_choices', MagicMock(return_value=['']))
+    def test_clear_flowcnt_trap_single_asic(self, mock_run_command):
+        """Test flowcnt-trap clear on single ASIC without namespace option"""
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['flowcnt-trap'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['flow_counters_stat', '-c', '-t', 'trap'])
+
+    @patch('clear.main.run_command')
+    @patch('utilities_common.multi_asic.multi_asic_ns_choices',
+           MagicMock(return_value=['asic0', 'asic1', 'asic2', 'asic3']))
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='asic0'))
+    def test_clear_flowcnt_trap_multi_asic_with_namespace(self, mock_run_command):
+        """Test flowcnt-trap clear on multi-ASIC with specific namespace"""
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['flowcnt-trap'], ['-n', 'asic0'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['flow_counters_stat', '-c', '-t', 'trap', '-n', 'asic0'])
+
+    @patch('clear.main.run_command')
+    @patch('utilities_common.multi_asic.multi_asic_ns_choices',
+           MagicMock(return_value=['asic0', 'asic1', 'asic2', 'asic3']))
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='asic1'))
+    def test_clear_flowcnt_trap_multi_asic_different_namespace(self, mock_run_command):
+        """Test flowcnt-trap clear on multi-ASIC with different namespace"""
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['flowcnt-trap'], ['-n', 'asic1'])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['flow_counters_stat', '-c', '-t', 'trap', '-n', 'asic1'])
+
+    @patch('clear.main.run_command')
+    @patch('utilities_common.multi_asic.multi_asic_ns_choices',
+           MagicMock(return_value=['asic0', 'asic1', 'asic2', 'asic3']))
+    def test_clear_flowcnt_trap_multi_asic_without_namespace(self, mock_run_command):
+        """Test flowcnt-trap clear on multi-ASIC without namespace (default behavior)"""
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['flowcnt-trap'])
+        assert result.exit_code == 0
+        # When no namespace is specified, command runs without -n flag
+        mock_run_command.assert_called_with(['flow_counters_stat', '-c', '-t', 'trap'])
+
+    @patch('utilities_common.multi_asic.multi_asic_ns_choices', MagicMock(return_value=['asic0', 'asic1']))
+    def test_clear_flowcnt_trap_multi_asic_invalid_namespace(self):
+        """Test flowcnt-trap clear with invalid namespace should fail"""
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['flowcnt-trap'], ['-n', 'invalid_asic'])
+        # Click.Choice should reject invalid namespace
+        assert result.exit_code != 0
+        assert 'Invalid value' in result.output or 'invalid_asic' in result.output
+
+    def teardown(self):
+        print('TEAR DOWN')
+
+
 class TestClearArp(object):
     def setup(self):
         print('SETUP')

--- a/tests/vrf_test.py
+++ b/tests/vrf_test.py
@@ -308,6 +308,21 @@ Error: 'vrf_name' length should not exceed 15 characters
         assert ('VrfNameTooLong!!!') not in db.cfgdb.get_table('VRF')
         assert expected_output in result.output
 
+    @patch('config.main.ValidatedConfigDBConnector')
+    @patch('config.main.ConfigDBConnector')
+    def test_vrf_group_no_namespace_defaults(self, mock_cdb, mock_vcdb):
+        """Single-ASIC: vrf group without -n defaults namespace to DEFAULT_NAMESPACE ('')."""
+        mock_db_instance = MagicMock()
+        mock_cdb.return_value = mock_db_instance
+        mock_vcdb_instance = MagicMock()
+        mock_vcdb_instance.get_keys.return_value = []
+        mock_vcdb.return_value = mock_vcdb_instance
+        runner = CliRunner()
+        result = runner.invoke(config.config.commands["vrf"], ['add', 'Vrf200'])
+        assert result.exit_code == 0
+        mock_cdb.assert_called_once_with(use_unix_socket_path=True, namespace='')
+        mock_db_instance.connect.assert_called_once()
+
 
 class TestVrfMultiAsic(object):
 

--- a/tests/vrf_test.py
+++ b/tests/vrf_test.py
@@ -1,6 +1,7 @@
 import os
-import sys
+import importlib
 from click.testing import CliRunner
+from unittest.mock import patch, MagicMock
 from swsscommon.swsscommon import SonicV2Connector
 from utilities_common.db import Db
 
@@ -12,6 +13,7 @@ DEFAULT_NAMESPACE = ''
 test_path = os.path.dirname(os.path.abspath(__file__))
 mock_db_path = os.path.join(test_path, "vrf_input")
 mock_db_path_vnet = os.path.join(test_path, "vnet_input")
+
 
 class TestShowVrf(object):
     @classmethod
@@ -305,6 +307,64 @@ Error: 'vrf_name' length should not exceed 15 characters
         assert result.exit_code != 0
         assert ('VrfNameTooLong!!!') not in db.cfgdb.get_table('VRF')
         assert expected_output in result.output
+
+
+class TestVrfMultiAsic(object):
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    def test_vrf_add_multi_asic_with_namespace(self):
+        """Add VRF with namespace in context."""
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db': db.cfgdb, 'namespace': 'asic0'}
+
+        result = runner.invoke(config.config.commands["vrf"].commands["add"], ["Vrf100"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert 'Vrf100' in db.cfgdb.get_table('VRF')
+
+    def test_vrf_del_multi_asic_with_namespace(self):
+        """Del VRF with namespace in context."""
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db': db.cfgdb, 'namespace': 'asic0'}
+
+        # Add then del (same db, so state is shared)
+        result = runner.invoke(config.config.commands["vrf"].commands["add"], ["Vrf100"], obj=vrf_obj)
+        assert result.exit_code == 0
+        result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf100"], obj=vrf_obj)
+        assert result.exit_code == 0
+        assert 'Vrf100' not in db.cfgdb.get_table('VRF')
+
+    @patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    @patch('config.main.multi_asic.get_namespace_list', MagicMock(return_value=['asic0', 'asic1']))
+    def test_vrf_multi_asic_without_namespace_fails(self):
+        """Multi-ASIC: config vrf add without -n must fail (namespace required)."""
+        import config.main as config_main
+        importlib.reload(config_main)
+        runner = CliRunner()
+        result = runner.invoke(config_main.config.commands["vrf"], ['add', 'Vrf100'])
+        importlib.reload(config_main)
+        assert result.exit_code != 0
+        assert 'Missing option' in result.output or '-n' in result.output or 'namespace' in result.output.lower()
+
+    @patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    @patch('config.main.multi_asic.get_namespace_list', MagicMock(return_value=['asic0', 'asic1']))
+    def test_vrf_invalid_namespace_fails(self):
+        """Multi-ASIC: config vrf with wrong/invalid ASIC namespace must fail."""
+        import config.main as config_main
+        importlib.reload(config_main)
+        runner = CliRunner()
+        result = runner.invoke(config_main.config.commands["vrf"], ['-n', 'invalid_asic', 'add', 'Vrf100'])
+        importlib.reload(config_main)
+        assert result.exit_code != 0
+        assert 'Invalid value' in result.output or 'invalid_asic' in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
 
 
 class TestVnet(object):

--- a/tests/vrf_test.py
+++ b/tests/vrf_test.py
@@ -353,27 +353,36 @@ class TestVrfMultiAsic(object):
         assert result.exit_code == 0
         assert 'Vrf100' not in db.cfgdb.get_table('VRF')
 
-    @patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
-    @patch('config.main.multi_asic.get_namespace_list', MagicMock(return_value=['asic0', 'asic1']))
     def test_vrf_multi_asic_without_namespace_fails(self):
         """Multi-ASIC: config vrf add without -n must fail (namespace required)."""
         import config.main as config_main
-        importlib.reload(config_main)
-        runner = CliRunner()
-        result = runner.invoke(config_main.config.commands["vrf"], ['add', 'Vrf100'])
-        importlib.reload(config_main)
+        try:
+            with patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True)), \
+                 patch('config.main.multi_asic.get_namespace_list',
+                       MagicMock(return_value=['asic0', 'asic1'])):
+                importlib.reload(config_main)
+                runner = CliRunner()
+                result = runner.invoke(config_main.config.commands["vrf"], ['add', 'Vrf100'])
+        finally:
+            # Restore the module to its non-mocked state for subsequent tests.
+            importlib.reload(config_main)
         assert result.exit_code != 0
         assert 'Missing option' in result.output or '-n' in result.output or 'namespace' in result.output.lower()
 
-    @patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
-    @patch('config.main.multi_asic.get_namespace_list', MagicMock(return_value=['asic0', 'asic1']))
     def test_vrf_invalid_namespace_fails(self):
         """Multi-ASIC: config vrf with wrong/invalid ASIC namespace must fail."""
         import config.main as config_main
-        importlib.reload(config_main)
-        runner = CliRunner()
-        result = runner.invoke(config_main.config.commands["vrf"], ['-n', 'invalid_asic', 'add', 'Vrf100'])
-        importlib.reload(config_main)
+        try:
+            with patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True)), \
+                 patch('config.main.multi_asic.get_namespace_list',
+                       MagicMock(return_value=['asic0', 'asic1'])):
+                importlib.reload(config_main)
+                runner = CliRunner()
+                result = runner.invoke(config_main.config.commands["vrf"],
+                                       ['-n', 'invalid_asic', 'add', 'Vrf100'])
+        finally:
+            # Restore the module to its non-mocked state for subsequent tests.
+            importlib.reload(config_main)
         assert result.exit_code != 0
         assert 'Invalid value' in result.output or 'invalid_asic' in result.output
 

--- a/tests/vrf_test.py
+++ b/tests/vrf_test.py
@@ -386,6 +386,56 @@ class TestVrfMultiAsic(object):
         assert result.exit_code != 0
         assert 'Invalid value' in result.output or 'invalid_asic' in result.output
 
+    def test_vrf_add_mgmt_with_namespace_fails(self):
+        """config vrf add mgmt with -n must fail: mgmt VRF lives in the host CONFIG_DB."""
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db': db.cfgdb, 'namespace': 'asic0'}
+        result = runner.invoke(config.config.commands["vrf"].commands["add"], ["mgmt"], obj=vrf_obj)
+        assert result.exit_code != 0
+        assert '-n' in result.output or 'namespace' in result.output.lower()
+
+    def test_vrf_del_mgmt_with_namespace_fails(self):
+        """config vrf del mgmt with -n must fail: mgmt VRF lives in the host CONFIG_DB."""
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db': db.cfgdb, 'namespace': 'asic0'}
+        result = runner.invoke(config.config.commands["vrf"].commands["del"], ["mgmt"], obj=vrf_obj)
+        assert result.exit_code != 0
+        assert '-n' in result.output or 'namespace' in result.output.lower()
+
+    def test_vrf_del_multi_asic_without_namespace_fails(self):
+        """Multi-ASIC: config vrf del without -n must fail for data VRFs."""
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db': db.cfgdb, 'namespace': None}
+        with patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True)):
+            result = runner.invoke(config.config.commands["vrf"].commands["del"], ["Vrf100"], obj=vrf_obj)
+        assert result.exit_code != 0
+        assert '-n' in result.output or 'namespace' in result.output.lower()
+
+    def test_add_vrf_vni_map_multi_asic_without_namespace_fails(self):
+        """Multi-ASIC: config vrf add_vrf_vni_map without -n must fail."""
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db': db.cfgdb, 'namespace': None}
+        with patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True)):
+            result = runner.invoke(config.config.commands["vrf"].commands["add_vrf_vni_map"],
+                                   ["Vrf100", "1000"], obj=vrf_obj)
+        assert result.exit_code != 0
+        assert '-n' in result.output or 'namespace' in result.output.lower()
+
+    def test_del_vrf_vni_map_multi_asic_without_namespace_fails(self):
+        """Multi-ASIC: config vrf del_vrf_vni_map without -n must fail."""
+        runner = CliRunner()
+        db = Db()
+        vrf_obj = {'config_db': db.cfgdb, 'namespace': None}
+        with patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True)):
+            result = runner.invoke(config.config.commands["vrf"].commands["del_vrf_vni_map"],
+                                   ["Vrf100"], obj=vrf_obj)
+        assert result.exit_code != 0
+        assert '-n' in result.output or 'namespace' in result.output.lower()
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added multi-ASIC support to two CLI commands so they operate on a specific ASIC namespace on multi-ASIC devices:

- config vrf — VRF configuration (group plus add, del, add_vrf_vni_map, del_vrf_vni_map subcommands).
- sonic-clear flowcnt-trap — clear trap flow counters.

#### How I did it
Modified the vrf and clear flowcnt-trap commands to add muti-asic support

#### How to verify it
Verified the commands in a multi asic device using the namespace flag

#### Previous command output (if the output of a command-line utility has changed)
- sonic-clear flowcnt-trap
- sudo config vrf add Vrf_red
- sudo config vrf del Vrf_red

#### New command output (if the output of a command-line utility has changed)
On a multi-asic device:
- sudo config vrf -n asic0 add Vrf_red → entry created in asic0's CONFIG_DB only.
- sudo config vrf -n asic1 add Vrf_red → entry created in asic1's CONFIG_DB only.
- sudo config vrf add Vrf_red (no -n on multi-ASIC) → click rejects with a "Missing option '-n' / '--namespace'" error.
- sudo sonic-clear flowcnt-trap -n asic0 → trap counters cleared for asic0 only.