### PR TITLE
Add multi-asic support for mirror_session commands

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -274,22 +274,43 @@ class AclLoader(object):
         :return:
         """
 
-        # For multi-npu platforms we will read from any one of front asic namespace
-        # config db as the information should be same across all config db
+        # For multi-npu platforms, merge sessions from all front asic
+        # namespace config dbs and track per-session namespaces so that
+        # state_db queries only target relevant namespaces.
         if self.per_npu_configdb:
-            namespace_configdb = list(self.per_npu_configdb.values())[0]
-            self.sessions_db_info = namespace_configdb.get_table(self.CFG_MIRROR_SESSION_TABLE)
+            self.sessions_db_info = {}
+            session_namespaces = {}
+            for namespace, namespace_configdb in self.per_npu_configdb.items():
+                ns_sessions = namespace_configdb.get_table(self.CFG_MIRROR_SESSION_TABLE)
+                for key, val in ns_sessions.items():
+                    if key not in self.sessions_db_info:
+                        self.sessions_db_info[key] = val
+                        session_namespaces[key] = []
+                    else:
+                        # For ERSPAN with src_port in some namespaces:
+                        # merge src_port from all namespaces that have it.
+                        if 'src_port' in val:
+                            existing = self.sessions_db_info[key]
+                            if 'src_port' in existing:
+                                existing['src_port'] += ',' + val['src_port']
+                            else:
+                                existing['src_port'] = val['src_port']
+                                if 'direction' in val:
+                                    existing['direction'] = val['direction']
+                    session_namespaces[key].append(namespace)
         else:
             self.sessions_db_info = self.configdb.get_table(self.CFG_MIRROR_SESSION_TABLE)
         for key in self.sessions_db_info:
             if self.per_npu_statedb:
-                # For multi-npu platforms we will read from all front asic name space
-                # statedb as the monitor port will be different for each asic
-                # and it's status also might be different (ideally should not happen)
-                # We will store them as dict of 'asic' : value
+                # For multi-npu platforms we read state_db only from namespaces
+                # where the session exists in config_db. ERSPAN sessions exist
+                # in all namespaces so we query all; SPAN sessions exist in only
+                # one namespace (destination port's ASIC).
                 self.sessions_db_info[key]["status"] = {}
                 self.sessions_db_info[key]["monitor_port"] = {}
-                for namespace_key, namespace_statedb in self.per_npu_statedb.items():
+                relevant_namespaces = session_namespaces.get(key, self.per_npu_statedb.keys())
+                for namespace_key in relevant_namespaces:
+                    namespace_statedb = self.per_npu_statedb[namespace_key]
                     state_db_info = namespace_statedb.get_all(self.statedb.STATE_DB, "{}|{}".format(self.STATE_MIRROR_SESSION_TABLE, key))
                     self.sessions_db_info[key]["status"][namespace_key] = state_db_info.get("status", "inactive") if state_db_info else "error"
                     self.sessions_db_info[key]["monitor_port"][namespace_key] = state_db_info.get("monitor_port", "") if state_db_info else ""

--- a/config/main.py
+++ b/config/main.py
@@ -544,10 +544,15 @@ def get_port_namespace(port):
     if not multi_asic.is_multi_asic() or port == 'eth0':
         return DEFAULT_NAMESPACE
 
-    # Get the table to check for interface presence
+    # Get the table to check for interface presence.
+    # Physical port aliases do not look like "Ethernet*" so in alias mode we
+    # need to fall back to scanning PORT aliases across namespaces.
     table_name = get_port_table_name(port)
     if table_name == "":
-        return None
+        if clicommon.get_interface_naming_mode() == "alias":
+            table_name = 'PORT'
+        else:
+            return None
 
     ns_list = multi_asic.get_all_namespaces()
     namespaces = ns_list['front_ns'] + ns_list['back_ns']
@@ -555,12 +560,16 @@ def get_port_namespace(port):
         config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db.connect()
 
-        # If the interface naming mode is alias, search the tables for alias_name.
-        if clicommon.get_interface_naming_mode() == "alias":
+        # Physical ports should resolve by either canonical name or alias, regardless
+        # of the CLI naming mode. Other interface types (for example PortChannel)
+        # are stored by name and should use direct lookup.
+        if table_name == 'PORT':
             port_dict = config_db.get_table(table_name)
             if port_dict:
                 for port_name in port_dict:
-                    if port == port_dict[port_name]['alias']:
+                    if port == port_name:
+                        return namespace
+                    if clicommon.get_interface_naming_mode() == "alias" and port == port_dict[port_name].get('alias'):
                         return namespace
         else:
             entry = config_db.get_entry(table_name, port)
@@ -1158,18 +1167,46 @@ def check_mirror_direction_config(v, direction):
     else:
         return True
 
+
+def split_mirror_ports(port_list):
+    """Return normalized mirror port tokens from a comma-separated string."""
+    if not port_list:
+        return []
+
+    return [port.strip() for port in port_list.split(",") if port.strip()]
+
+
+def normalize_mirror_src_port(config_db, src_port):
+    """Return canonical source-port list for ConfigDB storage."""
+    if not src_port:
+        return None
+
+    normalized_ports = []
+    for port in split_mirror_ports(src_port):
+        if clicommon.get_interface_naming_mode() == "alias":
+            port = interface_alias_to_name(config_db, port)
+        normalized_ports.append(port)
+
+    return ",".join(normalized_ports)
+
+
+def mirror_entry_has_port(entry, port_name):
+    """Check whether a mirror session entry contains a specific source port."""
+    return port_name in split_mirror_ports(entry.get('src_port', ''))
+
+
 def interface_has_mirror_config(ctx, mirror_table, dst_port, src_port, direction):
     """ Check if dst/src port is already configured with mirroring in same direction """
     for _, v in mirror_table.items():
         if src_port:
-            for port in src_port.split(","):
+            for port in split_mirror_ports(src_port):
                 if 'dst_port' in v and v['dst_port'] == port:
                     ctx.fail("Error: Source Interface {} already has mirror config".format(port))
-                if 'src_port' in v and re.search(port,v['src_port']):
+                if mirror_entry_has_port(v, port):
                     if check_mirror_direction_config(v, direction):
                         ctx.fail("Error: Source Interface {} already has mirror config in same direction".format(port))
         if dst_port:
-            if ('dst_port' in v and v['dst_port'] == dst_port) or ('src_port' in v and re.search(dst_port,v['src_port'])):
+            if ('dst_port' in v and v['dst_port'] == dst_port) or mirror_entry_has_port(v, dst_port):
                 ctx.fail("Error: Destination Interface {} already has mirror config".format(dst_port))
 
     return False
@@ -1202,16 +1239,30 @@ def is_port_mirror_capability_supported(direction, namespace=None):
     return True
 
 
-def validate_mirror_session_config(config_db, session_name, dst_port, src_port, direction):
+def mirror_session_exists(config_db, session_name):
+    """Check whether a mirror session name already exists in the given ConfigDB."""
+    return bool(config_db.get_entry('MIRROR_SESSION', session_name))
+
+
+def validate_mirror_session_config(config_db, session_name, dst_port, src_port, direction,
+                                   namespace=None, front_asic_configdbs=None):
     """ Check if SPAN mirror-session config is valid """
     ctx = click.get_current_context()
-    if len(config_db.get_entry('MIRROR_SESSION', session_name)) != 0:
+    if mirror_session_exists(config_db, session_name):
         click.echo("Error: {} already exists".format(session_name))
         return False
+    if front_asic_configdbs:
+        for front_asic_configdb in front_asic_configdbs.values():
+            if front_asic_configdb is config_db:
+                continue
+            if mirror_session_exists(front_asic_configdb, session_name):
+                click.echo("Error: {} already exists".format(session_name))
+                return False
 
     vlan_member_table = config_db.get_table('VLAN_MEMBER')
     mirror_table = config_db.get_table('MIRROR_SESSION')
     portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+    normalized_src_port = src_port
 
     # Determine namespaces to validate: always include None (single-ASIC/back-compat),
     # and for multi-ASIC include namespaces for dst/src ports if present.
@@ -1236,15 +1287,17 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
         namespace_set.add(get_port_namespace(dst_port))
 
     if src_port:
-        for port in src_port.split(","):
+        for port in split_mirror_ports(src_port):
             if not interface_name_is_valid(config_db, port):
                 ctx.fail("Error: Source Interface {} is invalid".format(port))
+        normalized_src_port = normalize_mirror_src_port(config_db, src_port)
+        for port in split_mirror_ports(normalized_src_port):
             if dst_port and dst_port == port:
                 ctx.fail("Error: Destination Interface can't be same as Source Interface")
 
             namespace_set.add(get_port_namespace(port))
 
-    if interface_has_mirror_config(ctx, mirror_table, dst_port, src_port, direction):
+    if interface_has_mirror_config(ctx, mirror_table, dst_port, normalized_src_port, direction):
         return False
 
     if direction:
@@ -3283,9 +3336,10 @@ def erspan(ctx):
 @click.argument('src_port', metavar='[src_port]', required=False)
 @click.argument('direction', metavar='[direction]', required=False)
 @click.option('--policer')
-def add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction):
+def erspan_add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction):
     """ Add ERSPAN mirror session """
     add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction)
+
 
 def gather_session_info(session_info, policer, queue, src_port, direction):
     if policer:
@@ -3295,13 +3349,7 @@ def gather_session_info(session_info, policer, queue, src_port, direction):
         session_info['queue'] = queue
 
     if src_port:
-        if clicommon.get_interface_naming_mode() == "alias":
-            src_port_list = []
-            for port in src_port.split(","):
-                src_port_list.append(interface_alias_to_name(None, port))
-            src_port=",".join(src_port_list)
-
-        session_info['src_port'] = src_port
+        session_info['src_port'] = ",".join(split_mirror_ports(src_port))
         if not direction:
             direction = "both"
         session_info['direction'] = direction.upper()
@@ -3321,6 +3369,7 @@ def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer
         session_info['gre_type'] = gre_type
 
     session_info = gather_session_info(session_info, policer, queue, src_port, direction)
+    raw_src_port = session_info.get('src_port')
     ctx = click.get_current_context()
 
     """
@@ -3331,23 +3380,84 @@ def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer
         config_db = ValidatedConfigDBConnector(ConfigDBConnector())
         config_db.connect()
         if ADHOC_VALIDATION:
-            if validate_mirror_session_config(config_db, session_name, None, src_port, direction) is False:
+            if validate_mirror_session_config(config_db, session_name, None, raw_src_port, direction) is False:
                 return
+        if raw_src_port:
+            session_info['src_port'] = normalize_mirror_src_port(config_db, raw_src_port)
         try:
             config_db.set_entry("MIRROR_SESSION", session_name, session_info)
         except ValueError as e:
             ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
     else:
+        # Validate and write src_port only in the matching namespace
+        # so ERSPAN is still available for ACL-based mirroring everywhere.
+        ns_src_ports = {}
+        if raw_src_port:
+            front_ns_set = set(namespaces['front_ns'])
+            for orig in split_mirror_ports(raw_src_port):
+                if not interface_name_is_valid(None, orig):
+                    ctx.fail("Error: Source Interface {} is invalid".format(orig))
+                port_ns = get_port_namespace(orig)
+                if port_ns not in front_ns_set:
+                    ctx.fail("Error: Source Interface {} is not a front-panel port".format(orig))
+                ns_src_ports.setdefault(port_ns, []).append(orig)
+
+        base_session_info = {k: v for k, v in session_info.items()
+                             if k not in ('src_port', 'direction')}
+
         per_npu_configdb = {}
         for front_asic_namespaces in namespaces['front_ns']:
-            per_npu_configdb[front_asic_namespaces] = ValidatedConfigDBConnector(ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespaces))
+            per_npu_configdb[front_asic_namespaces] = ValidatedConfigDBConnector(
+                ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespaces)
+            )
             per_npu_configdb[front_asic_namespaces].connect()
-            if ADHOC_VALIDATION:
-                if validate_mirror_session_config(per_npu_configdb[front_asic_namespaces], session_name, None, src_port, direction) is False:
-                    return
+
+        ns_session_infos = {}
+        for front_asic_namespaces in namespaces['front_ns']:
+            ns_ports = ns_src_ports.get(front_asic_namespaces)
+            if ns_ports:
+                ns_src_port = ",".join(ns_ports)
+                if ADHOC_VALIDATION:
+                    if validate_mirror_session_config(
+                        per_npu_configdb[front_asic_namespaces],
+                        session_name,
+                        None,
+                        ns_src_port,
+                        direction,
+                        front_asic_namespaces,
+                        front_asic_configdbs=per_npu_configdb
+                    ) is False:
+                        return
+                ns_session_info = dict(base_session_info)
+                ns_session_info['src_port'] = normalize_mirror_src_port(
+                    per_npu_configdb[front_asic_namespaces], ns_src_port
+                )
+                ns_session_info['direction'] = session_info.get('direction', 'BOTH')
+            else:
+                ns_src_port = None
+                if ADHOC_VALIDATION:
+                    if validate_mirror_session_config(
+                        per_npu_configdb[front_asic_namespaces],
+                        session_name,
+                        None,
+                        ns_src_port,
+                        direction,
+                        front_asic_namespaces,
+                        front_asic_configdbs=per_npu_configdb
+                    ) is False:
+                        return
+                ns_session_info = dict(base_session_info)
+
+            ns_session_infos[front_asic_namespaces] = ns_session_info
+
+        for front_asic_namespaces in namespaces['front_ns']:
             try:
-                per_npu_configdb[front_asic_namespaces].set_entry("MIRROR_SESSION", session_name, session_info)
+                per_npu_configdb[front_asic_namespaces].set_entry(
+                    "MIRROR_SESSION",
+                    session_name,
+                    ns_session_infos[front_asic_namespaces]
+                )
             except ValueError as e:
                 ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
@@ -3357,6 +3467,7 @@ def span(ctx):
     """ SPAN mirror session """
     pass
 
+
 @span.command('add')
 @click.argument('session_name', metavar='<session_name>', required=True)
 @click.argument('dst_port', metavar='<dst_port>', required=True)
@@ -3364,15 +3475,18 @@ def span(ctx):
 @click.argument('direction', metavar='[direction]', required=False)
 @click.argument('queue', metavar='[queue]', type=QUEUE_RANGE, required=False)
 @click.option('--policer')
-def add(session_name, dst_port, src_port, direction, queue, policer):
+def span_add(session_name, dst_port, src_port, direction, queue, policer):
     """ Add SPAN mirror session """
     add_span(session_name, dst_port, src_port, direction, queue, policer)
 
 def add_span(session_name, dst_port, src_port, direction, queue, policer):
+    # Save original dst_port for namespace detection (before alias conversion)
+    original_dst_port = dst_port
+
     if clicommon.get_interface_naming_mode() == "alias":
         dst_port = interface_alias_to_name(None, dst_port)
         if dst_port is None:
-            click.echo("Error: Destination Interface {} is invalid".format(dst_port))
+            click.echo("Error: Destination Interface {} is invalid".format(original_dst_port))
             return False
 
     session_info = {
@@ -3381,6 +3495,7 @@ def add_span(session_name, dst_port, src_port, direction, queue, policer):
             }
 
     session_info = gather_session_info(session_info, policer, queue, src_port, direction)
+    raw_src_port = session_info.get('src_port')
     ctx = click.get_current_context()
 
     """
@@ -3391,24 +3506,59 @@ def add_span(session_name, dst_port, src_port, direction, queue, policer):
         config_db = ValidatedConfigDBConnector(ConfigDBConnector())
         config_db.connect()
         if ADHOC_VALIDATION:
-            if validate_mirror_session_config(config_db, session_name, dst_port, src_port, direction) is False:
+            if validate_mirror_session_config(config_db, session_name, dst_port, raw_src_port, direction) is False:
                 return
+        if raw_src_port:
+            session_info['src_port'] = normalize_mirror_src_port(config_db, raw_src_port)
         try:
             config_db.set_entry("MIRROR_SESSION", session_name, session_info)
         except ValueError as e:
             ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
+        # Auto-detect namespace from destination port
+        dst_port_namespace = get_port_namespace(original_dst_port)
+        if dst_port_namespace is None:
+            ctx.fail("Error: Destination Interface {} is invalid".format(original_dst_port))
+        if dst_port_namespace not in namespaces['front_ns']:
+            ctx.fail("Error: Destination Interface {} is not a front-panel port".format(original_dst_port))
+
+        # Verify all source ports are in the same namespace as destination port.
+        if src_port:
+            for port in split_mirror_ports(src_port):
+                port_ns = get_port_namespace(port)
+                if port_ns is None:
+                    ctx.fail("Error: Source Interface {} is invalid".format(port))
+                if port_ns != dst_port_namespace:
+                    ctx.fail(
+                        ("Error: Source Interface {} is not on the same ASIC as "
+                         "Destination Interface {}").format(port, dst_port)
+                    )
+
         per_npu_configdb = {}
         for front_asic_namespaces in namespaces['front_ns']:
-            per_npu_configdb[front_asic_namespaces] = ValidatedConfigDBConnector(ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespaces))
+            per_npu_configdb[front_asic_namespaces] = ValidatedConfigDBConnector(
+                ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespaces)
+            )
             per_npu_configdb[front_asic_namespaces].connect()
-            if ADHOC_VALIDATION:
-                if validate_mirror_session_config(per_npu_configdb[front_asic_namespaces], session_name, dst_port, src_port, direction) is False:
-                    return
-            try:
-                per_npu_configdb[front_asic_namespaces].set_entry("MIRROR_SESSION", session_name, session_info)
-            except ValueError as e:
-                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+
+        config_db = per_npu_configdb[dst_port_namespace]
+        if ADHOC_VALIDATION:
+            if validate_mirror_session_config(
+                config_db,
+                session_name,
+                dst_port,
+                raw_src_port,
+                direction,
+                dst_port_namespace,
+                front_asic_configdbs=per_npu_configdb
+            ) is False:
+                return
+        if raw_src_port:
+            session_info['src_port'] = normalize_mirror_src_port(config_db, raw_src_port)
+        try:
+            config_db.set_entry("MIRROR_SESSION", session_name, session_info)
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 @mirror_session.command()
@@ -3433,10 +3583,11 @@ def remove(session_name):
         for front_asic_namespaces in namespaces['front_ns']:
             per_npu_configdb[front_asic_namespaces] = ValidatedConfigDBConnector(ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespaces))
             per_npu_configdb[front_asic_namespaces].connect()
-            try:
-                per_npu_configdb[front_asic_namespaces].set_entry("MIRROR_SESSION", session_name, None)
-            except JsonPatchConflict as e:
-                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+            if per_npu_configdb[front_asic_namespaces].get_entry("MIRROR_SESSION", session_name):
+                try:
+                    per_npu_configdb[front_asic_namespaces].set_entry("MIRROR_SESSION", session_name, None)
+                except JsonPatchConflict as e:
+                    ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 #
 # 'pfcwd' group ('config pfcwd ...')

--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -1,4 +1,5 @@
 import pytest
+import click
 import config.main as config
 import jsonpatch
 from unittest import mock
@@ -189,7 +190,7 @@ def test_mirror_session_erspan_add_invalid_yang_validation():
 
 
 @patch("config.main.ConfigDBConnector", spec=True, connect=mock.Mock())
-@patch("config.main.multi_asic.get_all_namespaces", mock.Mock(return_value={'front_ns': 'sample_ns'}))
+@patch("config.main.multi_asic.get_all_namespaces", mock.Mock(return_value={'front_ns': ['sample_ns']}))
 @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
 @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
 def test_mirror_session_erspan_add_multi_asic_invalid_yang_validation(mock_db_connector):
@@ -306,7 +307,8 @@ def test_mirror_session_span_add():
 
 
 @patch("config.main.ConfigDBConnector", spec=True, connect=mock.Mock())
-@patch("config.main.multi_asic.get_all_namespaces", mock.Mock(return_value={'front_ns': 'sample_ns'}))
+@patch("config.main.multi_asic.get_all_namespaces", mock.Mock(return_value={'front_ns': ['sample_ns']}))
+@patch("config.main.get_port_namespace", mock.Mock(return_value='sample_ns'))
 @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
 @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))
 def test_mirror_session_span_add_multi_asic_invalid_yang_validation(mock_db_connector):
@@ -331,10 +333,12 @@ def test_mirror_session_span_add_invalid_yang_validation():
     assert "Invalid ConfigDB. Error" in result.output
 
 
-@patch("config.main.multi_asic.get_all_namespaces", mock.Mock(return_value={'front_ns': 'sample_ns'}))
+@patch("config.main.multi_asic.get_all_namespaces", mock.Mock(return_value={'front_ns': ['sample_ns']}))
 @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
 @patch("config.main.ConfigDBConnector", spec=True, connect=mock.Mock())
 @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))
+@patch("config.main.ValidatedConfigDBConnector.get_entry",
+       mock.Mock(return_value={'type': 'SPAN', 'dst_port': 'Ethernet0'}), create=True)
 def test_mirror_session_remove_multi_asic_invalid_yang_validation(mock_db_connector):
     config.ADHOC_VALIDATION = False
     runner = CliRunner()
@@ -355,6 +359,300 @@ def test_mirror_session_remove_invalid_yang_validation():
             ["mrr_sample"])
     print(result.output)
     assert "Invalid ConfigDB. Error" in result.output
+
+
+def test_interface_has_mirror_config_matches_exact_port_tokens():
+    ctx = mock.Mock()
+    mirror_table = {
+        "test_session": {
+            "src_port": "Ethernet40,Ethernet48",
+            "direction": "RX"
+        }
+    }
+
+    assert config.interface_has_mirror_config(ctx, mirror_table, None, "Ethernet4", "rx") is False
+    ctx.fail.assert_not_called()
+
+
+def test_add_span_validates_before_src_port_alias_conversion():
+    config.ADHOC_VALIDATION = True
+    db = mock.MagicMock()
+
+    with click.Context(click.Command("test")):
+        with mock.patch("config.main.multi_asic.get_all_namespaces", return_value={"front_ns": []}), \
+             mock.patch("config.main.ConfigDBConnector", return_value=mock.Mock()), \
+             mock.patch("config.main.ValidatedConfigDBConnector", return_value=db), \
+             mock.patch("config.main.validate_mirror_session_config", return_value=True) as mock_validate, \
+             mock.patch("config.main.clicommon.get_interface_naming_mode", return_value="alias"), \
+             mock.patch("config.main.interface_alias_to_name",
+                        side_effect=lambda _db, name: {"Eth0": "Ethernet0", "Eth4": "Ethernet4"}.get(name, name)):
+            config.add_span("test_session", "Eth0", "Eth4", "rx", 0, None)
+
+    assert mock_validate.call_args[0][3] == "Eth4"
+    assert db.set_entry.call_args[0][2]["src_port"] == "Ethernet4"
+
+
+def test_add_erspan_validates_before_src_port_alias_conversion():
+    config.ADHOC_VALIDATION = True
+    db = mock.MagicMock()
+
+    with click.Context(click.Command("test")):
+        with mock.patch("config.main.multi_asic.get_all_namespaces", return_value={"front_ns": []}), \
+             mock.patch("config.main.ConfigDBConnector", return_value=mock.Mock()), \
+             mock.patch("config.main.ValidatedConfigDBConnector", return_value=db), \
+             mock.patch("config.main.validate_mirror_session_config", return_value=True) as mock_validate, \
+             mock.patch("config.main.clicommon.get_interface_naming_mode", return_value="alias"), \
+             mock.patch("config.main.interface_alias_to_name",
+                        side_effect=lambda _db, name: {"Eth4": "Ethernet4"}.get(name, name)):
+            config.add_erspan("test_session", "1.1.1.1", "2.2.2.2", 8, 63, 10, 0, None, "Eth4", "rx")
+
+    assert mock_validate.call_args[0][3] == "Eth4"
+    assert db.set_entry.call_args[0][2]["src_port"] == "Ethernet4"
+
+
+def test_mirror_session_span_add_multi_asic_writes_only_destination_namespace():
+    config.ADHOC_VALIDATION = True
+    dbs = {"asic0": mock.MagicMock(), "asic1": mock.MagicMock()}
+
+    with click.Context(click.Command("test")):
+        with mock.patch('config.main.multi_asic.get_all_namespaces', return_value={'front_ns': ['asic0', 'asic1']}), \
+             mock.patch('config.main.get_port_namespace',
+                        side_effect=lambda port: {'Ethernet0': 'asic1', 'Ethernet4': 'asic1'}[port]), \
+             mock.patch('config.main.ConfigDBConnector',
+                        side_effect=lambda **kwargs: mock.MagicMock(namespace=kwargs.get('namespace'))), \
+             mock.patch('config.main.ValidatedConfigDBConnector', side_effect=lambda conn: dbs[conn.namespace]), \
+             mock.patch('config.main.validate_mirror_session_config', return_value=True) as mock_validate:
+            config.add_span("test_session", "Ethernet0", "Ethernet4", "rx", 0, None)
+
+    # asic0 should not have any writes
+    dbs["asic0"].set_entry.assert_not_called()
+    # asic1 should have exactly one write
+    dbs["asic1"].set_entry.assert_called_once()
+    _, _, value = dbs["asic1"].set_entry.call_args[0]
+    assert value["dst_port"] == "Ethernet0"
+    assert value["src_port"] == "Ethernet4"
+    assert value["direction"] == "RX"
+    assert value["queue"] == 0
+    # Validation targeted the destination port's namespace
+    assert mock_validate.call_args[0][5] == "asic1"
+
+
+def test_mirror_session_span_add_multi_asic_rejects_cross_asic_source_port():
+    config.ADHOC_VALIDATION = True
+    dbs = {"asic0": mock.MagicMock(), "asic1": mock.MagicMock()}
+
+    with click.Context(click.Command("test")):
+        with mock.patch('config.main.multi_asic.get_all_namespaces', return_value={'front_ns': ['asic0', 'asic1']}), \
+             mock.patch('config.main.get_port_namespace',
+                        side_effect=lambda port: {'Ethernet0': 'asic0', 'Ethernet64': 'asic1'}[port]), \
+             mock.patch('config.main.ConfigDBConnector',
+                        side_effect=lambda **kwargs: mock.MagicMock(namespace=kwargs.get('namespace'))), \
+             mock.patch('config.main.ValidatedConfigDBConnector', side_effect=lambda conn: dbs[conn.namespace]):
+            with pytest.raises(click.UsageError):
+                config.add_span("test_session", "Ethernet0", "Ethernet64", "rx", 0, None)
+
+    # No writes to any namespace
+    dbs["asic0"].set_entry.assert_not_called()
+    dbs["asic1"].set_entry.assert_not_called()
+
+
+def test_mirror_session_erspan_add_multi_asic_splits_source_ports_by_namespace():
+    config.ADHOC_VALIDATION = True
+    dbs = {"asic0": mock.MagicMock(), "asic1": mock.MagicMock(), "asic2": mock.MagicMock()}
+
+    with click.Context(click.Command("test")):
+        with mock.patch('config.main.multi_asic.get_all_namespaces',
+                        return_value={'front_ns': ['asic0', 'asic1', 'asic2']}), \
+             mock.patch('config.main.get_port_namespace',
+                        side_effect=lambda port: {'Ethernet0': 'asic0', 'Ethernet8': 'asic1'}[port]), \
+             mock.patch('config.main.ConfigDBConnector',
+                        side_effect=lambda **kwargs: mock.MagicMock(namespace=kwargs.get('namespace'))), \
+             mock.patch('config.main.ValidatedConfigDBConnector', side_effect=lambda conn: dbs[conn.namespace]), \
+             mock.patch('config.main.validate_mirror_session_config', return_value=True), \
+             mock.patch('config.main.interface_name_is_valid', return_value=True):
+            config.add_erspan(
+                "test_session", "1.1.1.1", "2.2.2.2", 8, 63, 10, 0, None,
+                "Ethernet0,Ethernet8", "rx"
+            )
+
+    # Each namespace should get exactly one write
+    for ns in ["asic0", "asic1", "asic2"]:
+        dbs[ns].set_entry.assert_called_once()
+
+    asic0_value = dbs["asic0"].set_entry.call_args[0][2]
+    asic1_value = dbs["asic1"].set_entry.call_args[0][2]
+    asic2_value = dbs["asic2"].set_entry.call_args[0][2]
+
+    # asic0 gets Ethernet0's src_port
+    assert asic0_value["src_port"] == "Ethernet0"
+    assert asic0_value["direction"] == "RX"
+    # asic1 gets Ethernet8's src_port
+    assert asic1_value["src_port"] == "Ethernet8"
+    assert asic1_value["direction"] == "RX"
+    # asic2 gets the base ERSPAN session without src_port
+    assert "src_port" not in asic2_value
+    assert "direction" not in asic2_value
+
+
+def test_mirror_session_remove_multi_asic_skips_missing_sessions():
+    config.ADHOC_VALIDATION = False
+    asic0_db = mock.MagicMock()
+    asic0_db.get_entry.return_value = {"type": "SPAN", "dst_port": "Ethernet0"}
+    asic1_db = mock.MagicMock()
+    asic1_db.get_entry.return_value = {}
+    dbs = {"asic0": asic0_db, "asic1": asic1_db}
+
+    runner = CliRunner()
+    with mock.patch('config.main.multi_asic.get_all_namespaces', return_value={'front_ns': ['asic0', 'asic1']}), \
+         mock.patch('config.main.ConfigDBConnector',
+                    side_effect=lambda **kwargs: mock.MagicMock(namespace=kwargs.get('namespace'))), \
+         mock.patch('config.main.ValidatedConfigDBConnector', side_effect=lambda conn: dbs[conn.namespace]):
+        result = runner.invoke(
+            config.config.commands["mirror_session"].commands["remove"],
+            ["sess1"]
+        )
+        assert result.exit_code == 0
+
+    # asic0 has the session, so it should be deleted
+    dbs["asic0"].set_entry.assert_called_once_with("MIRROR_SESSION", "sess1", None)
+    # asic1 does not have the session, so set_entry should not be called
+    dbs["asic1"].set_entry.assert_not_called()
+
+
+def test_split_mirror_ports():
+    assert config.split_mirror_ports("Ethernet0,Ethernet4") == ["Ethernet0", "Ethernet4"]
+    assert config.split_mirror_ports("Ethernet0 , Ethernet4") == ["Ethernet0", "Ethernet4"]
+    assert config.split_mirror_ports("Ethernet0") == ["Ethernet0"]
+    assert config.split_mirror_ports("") == []
+    assert config.split_mirror_ports(None) == []
+
+
+def test_normalize_mirror_src_port_alias_mode():
+    db = mock.MagicMock()
+    alias_map = {"Eth0": "Ethernet0", "Eth4": "Ethernet4"}
+    with mock.patch("config.main.clicommon.get_interface_naming_mode",
+                    return_value="alias"), \
+         mock.patch("config.main.interface_alias_to_name",
+                    side_effect=lambda _db, name: alias_map.get(
+                        name, name)):
+        result = config.normalize_mirror_src_port(db, "Eth0,Eth4")
+    assert result == "Ethernet0,Ethernet4"
+
+
+def test_normalize_mirror_src_port_returns_none_for_empty():
+    assert config.normalize_mirror_src_port(mock.MagicMock(), None) is None
+    assert config.normalize_mirror_src_port(mock.MagicMock(), "") is None
+
+
+def test_validate_mirror_session_config_cross_asic_duplicate():
+    """validate_mirror_session_config should fail when session exists on another ASIC."""
+    config.ADHOC_VALIDATION = True
+    local_db = mock.MagicMock()
+    local_db.get_entry.return_value = {}  # no session locally
+    local_db.get_table.return_value = {}
+
+    other_db = mock.MagicMock()
+    other_db.get_entry.return_value = {"type": "ERSPAN"}  # session exists on other ASIC
+
+    with click.Context(click.Command("test")):
+        result = config.validate_mirror_session_config(
+            local_db, "dup_session", None, None, None,
+            namespace="asic0",
+            front_asic_configdbs={"asic0": local_db, "asic1": other_db}
+        )
+    assert result is False
+
+
+def test_erspan_multi_asic_validation_failure_prevents_all_writes():
+    """Validation failure on one ASIC prevents writes to all ASICs."""
+    config.ADHOC_VALIDATION = True
+    dbs = {"asic0": mock.MagicMock(), "asic1": mock.MagicMock()}
+    ns_map = {'Ethernet0': 'asic0', 'Ethernet8': 'asic1'}
+    call_count = [0]
+
+    def validate_side_effect(*args, **kwargs):
+        call_count[0] += 1
+        return call_count[0] < 2
+
+    def make_conn(**kwargs):
+        return mock.MagicMock(namespace=kwargs.get('namespace'))
+
+    with click.Context(click.Command("test")):
+        with mock.patch('config.main.multi_asic.get_all_namespaces',
+                        return_value={
+                            'front_ns': ['asic0', 'asic1']}), \
+             mock.patch('config.main.get_port_namespace',
+                        side_effect=lambda p: ns_map[p]), \
+             mock.patch('config.main.ConfigDBConnector',
+                        side_effect=make_conn), \
+             mock.patch('config.main.ValidatedConfigDBConnector',
+                        side_effect=lambda c: dbs[c.namespace]), \
+             mock.patch('config.main.validate_mirror_session_config',
+                        side_effect=validate_side_effect), \
+             mock.patch('config.main.interface_name_is_valid',
+                        return_value=True):
+            config.add_erspan(
+                "test_session", "1.1.1.1", "2.2.2.2",
+                8, 63, 10, 0, None,
+                "Ethernet0,Ethernet8", "rx"
+            )
+
+    dbs["asic0"].set_entry.assert_not_called()
+    dbs["asic1"].set_entry.assert_not_called()
+
+
+def test_erspan_multi_asic_rejects_non_front_panel_source_port():
+    """ERSPAN multi-ASIC rejects source ports not in front_ns."""
+    config.ADHOC_VALIDATION = True
+
+    with click.Context(click.Command("test")):
+        with mock.patch('config.main.multi_asic.get_all_namespaces',
+                        return_value={'front_ns': ['asic0']}), \
+             mock.patch('config.main.get_port_namespace',
+                        return_value='back_ns0'), \
+             mock.patch('config.main.interface_name_is_valid',
+                        return_value=True):
+            with pytest.raises(click.UsageError,
+                               match="not a front-panel port"):
+                config.add_erspan(
+                    "test_session", "1.1.1.1", "2.2.2.2",
+                    8, 63, 10, 0, None, "Ethernet128", "rx"
+                )
+
+
+def test_erspan_multi_asic_rejects_invalid_source_port():
+    """ERSPAN multi-ASIC rejects invalid source ports."""
+    config.ADHOC_VALIDATION = True
+
+    with click.Context(click.Command("test")):
+        with mock.patch('config.main.multi_asic.get_all_namespaces',
+                        return_value={'front_ns': ['asic0']}), \
+             mock.patch('config.main.interface_name_is_valid',
+                        return_value=False):
+            with pytest.raises(click.UsageError,
+                               match="Source Interface.*invalid"):
+                config.add_erspan(
+                    "test_session", "1.1.1.1", "2.2.2.2",
+                    8, 63, 10, 0, None, "InvalidPort", "rx"
+                )
+
+
+def test_span_multi_asic_rejects_invalid_source_port():
+    """SPAN multi-ASIC rejects source ports with no namespace."""
+    config.ADHOC_VALIDATION = True
+    ns_map = {'Ethernet0': 'asic0'}
+
+    with click.Context(click.Command("test")):
+        with mock.patch('config.main.multi_asic.get_all_namespaces',
+                        return_value={'front_ns': ['asic0']}), \
+             mock.patch('config.main.get_port_namespace',
+                        side_effect=lambda p: ns_map.get(p)):
+            with pytest.raises(click.UsageError,
+                               match="Source Interface.*invalid"):
+                config.add_span(
+                    "test_session", "Ethernet0",
+                    "BadPort", "rx", 0, None
+                )
 
 
 def test_mirror_session_capability_checking():


### PR DESCRIPTION
#### What I did

Fixed `config mirror_session` and `show mirror_session` commands for multi-ASIC platforms. The previous implementation wrote SPAN/ERSPAN sessions to all front-panel ASIC namespaces, which caused failures when port-based arguments (dst_port, src_port) were only valid in one namespace — the loop would succeed on the port's own ASIC but fail on others, leaving partial writes in ConfigDB. This PR changes the storage model so that SPAN sessions are written only to the destination port's namespace, and ERSPAN src_port fields are distributed only to the namespace that owns each port. The `show mirror_session` (acl_loader) is updated accordingly to read and merge from all namespaces. Additionally, several robustness improvements were made: two-phase validate-then-write to prevent partial writes, exact port-token matching to avoid substring false positives, alias-aware port resolution, and cross-namespace duplicate session name detection.

#### How I did it

**`config/main.py`:**

- **SPAN (`add_span`)**: Instead of looping through all front-panel ASIC namespaces (which fails because the destination port only exists in one namespace), the new code auto-detects the destination port's namespace via `get_port_namespace()` and writes the session only to that single namespace. It also validates that all source ports are on the same ASIC as the destination port before writing. All namespace ConfigDBs are connected upfront so that `validate_mirror_session_config` can perform cross-namespace duplicate session name checks.
- **ERSPAN (`add_erspan`)**: Source ports are distributed per-namespace — only the namespace that owns a given source port gets the `src_port`/`direction` fields. All other namespaces still receive the base ERSPAN session (without `src_port`) so ACL-based mirroring remains available everywhere. A two-phase approach (validate all namespaces first, then write) prevents partial writes when validation fails on any namespace.
- **`remove`**: Added a `get_entry` check before `set_entry(None)` so that only namespaces that actually contain the session attempt to delete it, avoiding unnecessary `JsonPatchConflict` errors.
- **`validate_mirror_session_config`**: Added `front_asic_configdbs` parameter to check for duplicate session names across all namespaces (not just the current one). Validation now uses `split_mirror_ports()` for exact port-token matching and `normalize_mirror_src_port()` for alias-to-canonical-name conversion.
- **`get_port_namespace`**: Improved to resolve physical ports by both canonical name and alias regardless of CLI naming mode, and to fall back to scanning PORT aliases when the port name does not match a known table prefix.
- **New helper functions**: `split_mirror_ports()` (exact comma-separated token parsing), `normalize_mirror_src_port()` (alias-to-canonical conversion for ConfigDB storage), `mirror_entry_has_port()` (exact port match replacing `re.search` substring matching), `mirror_session_exists()` (extracted for reuse).
- **`interface_has_mirror_config`**: Replaced `re.search` substring matching with exact token matching via `mirror_entry_has_port()` to prevent false positives (e.g., `Ethernet4` incorrectly matching `Ethernet40`).
- **`gather_session_info`**: Removed inline alias conversion for src_port; alias handling is now deferred to `normalize_mirror_src_port()` which runs after validation, ensuring validation sees the original user-supplied port names.

**`acl_loader/main.py`:**

- Since this PR changes SPAN sessions to be stored in only the destination port's namespace (instead of all namespaces), `show session` must now read from all front-panel ASIC namespace ConfigDBs and merge results (de-duplicated by session key), instead of reading from only the first namespace. Without this change, SPAN sessions could be invisible if the first namespace happens not to be the one containing the session.
- Tracks which namespaces each session belongs to (`session_namespaces`), so state_db queries only target relevant namespaces — eliminating false `error` status for SPAN sessions on ASICs where they don't exist.

**`tests/config_mirror_session_test.py`:**

- Fixed `front_ns` mock values from `'sample_ns'` (string) to `['sample_ns']` (list) to match the actual `get_all_namespaces()` return format.
- Added `get_port_namespace` mock for SPAN multi-ASIC test.
- Added `get_entry` mock for `remove` multi-ASIC test.
- New unit tests:
  - `test_interface_has_mirror_config_matches_exact_port_tokens`: verifies `Ethernet4` does not false-match `Ethernet40,Ethernet48`.
  - `test_add_span_validates_before_src_port_alias_conversion`: verifies validation sees original alias names, ConfigDB gets canonical names.
  - `test_add_erspan_validates_before_src_port_alias_conversion`: same for ERSPAN path.
  - `test_mirror_session_span_add_multi_asic_writes_only_destination_namespace`: verifies SPAN writes only to dst_port's ASIC namespace.
  - `test_mirror_session_span_add_multi_asic_rejects_cross_asic_source_port`: verifies cross-ASIC src_port is rejected with no writes.
  - `test_mirror_session_erspan_add_multi_asic_splits_source_ports_by_namespace`: verifies ERSPAN distributes src_ports per-namespace correctly.
  - `test_mirror_session_remove_multi_asic_skips_missing_sessions`: verifies remove only deletes from namespaces that have the session.

#### How to verify it

**On multi-ASIC platform:**

1. ERSPAN with src_port — previously caused partial-write:
```bash
# Old behavior: fails with "Source Interface Ethernet0 is invalid", but asic0 already has data
# New behavior: succeeds, asic0 gets src_port, asic1-3 get base ERSPAN session
sudo config mirror_session erspan add TEST_ERSPAN 192.0.2.31 198.51.100.31 23 34 35006 9 Ethernet0
show mirror_session TEST_ERSPAN
# Verify: all 4 ASICs show 'inactive' (not 'error')
sudo sonic-db-cli -n asic0 CONFIG_DB hgetall "MIRROR_SESSION|TEST_ERSPAN"
# Should have src_port=Ethernet0, direction=BOTH
sudo sonic-db-cli -n asic1 CONFIG_DB hgetall "MIRROR_SESSION|TEST_ERSPAN"
# Should have base ERSPAN fields only (no src_port)
sudo config mirror_session remove TEST_ERSPAN
```

2. SPAN with src/dst port — previously caused partial-write:
```bash
# Old behavior: fails with "Destination Interface Ethernet0 is invalid", but asic0 already has data
# New behavior: succeeds, only asic0 has the session
sudo config mirror_session span add TEST_SPAN Ethernet0 Ethernet1 both 10
show mirror_session TEST_SPAN
# Verify: only shows {'asic0': 'active'}, no error for other ASICs
sudo sonic-db-cli -n asic0 CONFIG_DB hgetall "MIRROR_SESSION|TEST_SPAN"
# Should have dst_port, src_port, direction, queue
sudo sonic-db-cli -n asic1 CONFIG_DB hgetall "MIRROR_SESSION|TEST_SPAN"
# Should be empty {}
sudo config mirror_session remove TEST_SPAN
```

3. ERSPAN cross-ASIC src_ports with conflict — verify no partial-write:
```bash
# Create a pre-existing session using Ethernet513 on asic1
sudo config mirror_session span add PRE_EXIST Ethernet512 Ethernet513 rx
# Attempt ERSPAN with src_ports spanning asic0 and asic1 (Ethernet513 conflicts)
sudo config mirror_session erspan add TEST_PARTIAL 192.0.2.1 198.51.100.1 8 64 0x6558 0 Ethernet0,Ethernet513 rx
# Should fail with "Source Interface Ethernet513 already has mirror config in same direction"
# Verify NO partial writes on any ASIC:
sudo sonic-db-cli -n asic0 CONFIG_DB hgetall "MIRROR_SESSION|TEST_PARTIAL"
# Should be empty {}
sudo sonic-db-cli -n asic1 CONFIG_DB hgetall "MIRROR_SESSION|TEST_PARTIAL"
# Should be empty {}
sudo config mirror_session remove PRE_EXIST
```

4. SPAN cross-ASIC src_port rejection:
```bash
sudo config mirror_session span add TEST_CROSS Ethernet0 Ethernet512 rx
# Should fail with "Source Interface Ethernet512 is not on the same ASIC as Destination Interface Ethernet0"
```

**On single-ASIC platform:**

```bash
# All commands should behave identically to before the change
sudo config mirror_session span add TEST1 Ethernet4 Ethernet8 rx
sudo config mirror_session erspan add TEST2 10.0.0.1 10.0.0.2 8 64 0x6558 3 Ethernet8 rx
sudo config mirror_session add TEST3 10.0.0.3 10.0.0.4 16 128
show mirror_session
sudo config mirror_session remove TEST1
sudo config mirror_session remove TEST2
sudo config mirror_session remove TEST3
```

#### Previous command output (if the output of a command-line utility has changed)

On multi-ASIC, `show mirror_session` for a SPAN session showed false errors:
```
SPAN Sessions
Name        Status                                                                     DST Port    SRC Port    Direction      Queue  Policer
----------  -------------------------------------------------------------------------  ----------  ----------  -----------  -------  ---------
TSPAN_FULL  {'asic0': 'active', 'asic1': 'error', 'asic2': 'error', 'asic3': 'error'}  Ethernet0   Ethernet1   both              10
```

#### New command output (if the output of a command-line utility has changed)

On multi-ASIC, `show mirror_session` now only shows relevant ASICs:
```
SPAN Sessions
Name        Status               DST Port    SRC Port    Direction      Queue  Policer
----------  -------------------  ----------  ----------  -----------  -------  ---------
TSPAN_FULL  {'asic0': 'active'}  Ethernet0   Ethernet1   both              10
```

On multi-ASIC, ERSPAN with src_port now shows all ASICs healthy:
```
ERSPAN Sessions
Name         Status                                                                                SRC IP      DST IP           GRE    DSCP    TTL    Queue  Policer    Monitor Port                                          SRC Port    Direction
-----------  ------------------------------------------------------------------------------------  ----------  -------------  -----  ------  -----  -------  ---------  ----------------------------------------------------  ----------  -----------
TERSPAN_DEF  {'asic0': 'inactive', 'asic1': 'inactive', 'asic2': 'inactive', 'asic3': 'inactive'}  192.0.2.31  198.51.100.31  35006      23     34        9             {'asic0': '', 'asic1': '', 'asic2': '', 'asic3': ''}  Ethernet0   both
```
