### PR TITLE
Add lldp interfaces and configuration to dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -400,6 +400,26 @@ copy_from_masic_docker() {
 }
 
 ###############################################################################
+# Populates ASIC_SUFFIXES array for iterating over ASIC instances.
+# Multi-ASIC: ("0" "1" ... "N-1"), Single-ASIC: ("") so that
+# ${container}${sfx} resolves to the unsuffixed container name.
+# Globals:
+#  NUM_ASICS
+#  ASIC_SUFFIXES (set by this function)
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+get_asic_suffixes() {
+    if [[ ( "$NUM_ASICS" > 1 ) ]]; then
+        ASIC_SUFFIXES=( $(seq 0 $((NUM_ASICS - 1))) )
+    else
+        ASIC_SUFFIXES=( "" )
+    fi
+}
+
+###############################################################################
 # Returns namespace option to be used with vtysh command, based on the ASIC ID.
 # Returns empty string if no ASIC ID is provided
 # Globals:
@@ -2589,22 +2609,14 @@ main() {
     wait
 
     save_cmd "lldpctl" "lldpctl" &
-    if [[ ( "$NUM_ASICS" > 1 ) ]]; then
-        for (( i=0; i<$NUM_ASICS; i++ ))
-        do
-            save_cmd "docker exec lldp$i lldpcli show statistics" "lldp$i.statistics" &
-            save_cmd "docker exec lldp$i lldpcli show configuration" "lldp$i.config" &
-            save_cmd "docker exec lldp$i lldpcli show interfaces" "lldp$i.interfaces" &
-            save_cmd "docker logs bgp$i" "docker.bgp$i.log" &
-            save_cmd "docker logs swss$i" "docker.swss$i.log" &
-        done
-    else
-        save_cmd "docker exec lldp lldpcli show statistics" "lldp.statistics" &
-        save_cmd "docker exec lldp lldpcli show configuration" "lldp.config" &
-        save_cmd "docker exec lldp lldpcli show interfaces" "lldp.interfaces" &
-        save_cmd "docker logs bgp" "docker.bgp.log" &
-        save_cmd "docker logs swss" "docker.swss.log" &
-    fi
+    get_asic_suffixes
+    for sfx in "${ASIC_SUFFIXES[@]}"; do
+        save_cmd "docker exec lldp${sfx} lldpcli show statistics" "lldp${sfx}.statistics" &
+        save_cmd "docker exec lldp${sfx} lldpcli show configuration" "lldp${sfx}.config" &
+        save_cmd "docker exec lldp${sfx} lldpcli show interfaces" "lldp${sfx}.interfaces" &
+        save_cmd "docker logs bgp${sfx}" "docker.bgp${sfx}.log" &
+        save_cmd "docker logs swss${sfx}" "docker.swss${sfx}.log" &
+    done
     wait
 
  	save_cmd "stpctl all" "stp.log"

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -399,7 +399,6 @@ copy_from_masic_docker() {
     fi
 }
 
-
 ###############################################################################
 # Returns namespace option to be used with vtysh command, based on the ASIC ID.
 # Returns empty string if no ASIC ID is provided

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2501,6 +2501,7 @@ main() {
     local start_t=0
     local end_t=0
     NUM_ASICS=$(get_asic_count)
+    get_asic_suffixes
     ${CMD_PREFIX}renice +5 -p $$ >> /dev/null
     ${CMD_PREFIX}ionice -c 2 -n 5 -p $$ >> /dev/null
 
@@ -2609,7 +2610,6 @@ main() {
     wait
 
     save_cmd "lldpctl" "lldpctl" &
-    get_asic_suffixes
     for sfx in "${ASIC_SUFFIXES[@]}"; do
         save_cmd "docker exec lldp${sfx} lldpcli show statistics" "lldp${sfx}.statistics" &
         save_cmd "docker exec lldp${sfx} lldpcli show configuration" "lldp${sfx}.config" &

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -399,25 +399,6 @@ copy_from_masic_docker() {
     fi
 }
 
-###############################################################################
-# Populates ASIC_SUFFIXES array for iterating over ASIC instances.
-# Multi-ASIC: ("0" "1" ... "N-1"), Single-ASIC: ("") so that
-# ${container}${sfx} resolves to the unsuffixed container name.
-# Globals:
-#  NUM_ASICS
-#  ASIC_SUFFIXES (set by this function)
-# Arguments:
-#  None
-# Returns:
-#  None
-###############################################################################
-get_asic_suffixes() {
-    if [[ ( "$NUM_ASICS" > 1 ) ]]; then
-        ASIC_SUFFIXES=( $(seq 0 $((NUM_ASICS - 1))) )
-    else
-        ASIC_SUFFIXES=( "" )
-    fi
-}
 
 ###############################################################################
 # Returns namespace option to be used with vtysh command, based on the ASIC ID.
@@ -2501,7 +2482,11 @@ main() {
     local start_t=0
     local end_t=0
     NUM_ASICS=$(get_asic_count)
-    get_asic_suffixes
+    if [[ ( "$NUM_ASICS" > 1 ) ]]; then
+        ASIC_SUFFIXES=( $(seq 0 $((NUM_ASICS - 1))) )
+    else
+        ASIC_SUFFIXES=( "" )
+    fi
     ${CMD_PREFIX}renice +5 -p $$ >> /dev/null
     ${CMD_PREFIX}ionice -c 2 -n 5 -p $$ >> /dev/null
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2593,11 +2593,15 @@ main() {
         for (( i=0; i<$NUM_ASICS; i++ ))
         do
             save_cmd "docker exec lldp$i lldpcli show statistics" "lldp$i.statistics" &
+            save_cmd "docker exec lldp$i lldpcli show configuration" "lldp$i.config" &
+            save_cmd "docker exec lldp$i lldpcli show interfaces" "lldp$i.interfaces" &
             save_cmd "docker logs bgp$i" "docker.bgp$i.log" &
             save_cmd "docker logs swss$i" "docker.swss$i.log" &
         done
     else
         save_cmd "docker exec lldp lldpcli show statistics" "lldp.statistics" &
+        save_cmd "docker exec lldp lldpcli show configuration" "lldp.config" &
+        save_cmd "docker exec lldp lldpcli show interfaces" "lldp.interfaces" &
         save_cmd "docker logs bgp" "docker.bgp.log" &
         save_cmd "docker logs swss" "docker.swss.log" &
     fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did
When debugging LLDP issues—such as missing neighbors or incorrect Chassis IDs (e.g., lldpd falling back to the system hostname due to incomplete interface detection, as seen in sonic-buildimage PR #25436)—relying solely on syslogs and lldpctl neighbor outputs is often insufficient.

It is critical to know exactly what lldpd's active configuration is (e.g., Interface pattern for chassis ID) and which interfaces it has actually successfully discovered and mapped from the kernel. Without this information, it is difficult to quickly isolate whether an issue is a deliberate configuration change or a runtime interface discovery failure.

#### What I did
Updated the generate_dump script to automatically capture the runtime configuration and active interface states from the lldp container.
#### How I did it
Added the following lldpcli commands to the dump collection process for both single-ASIC and multi-ASIC scenarios:
```
docker exec lldp lldpcli show configuration (saved to lldp.config)
docker exec lldp lldpcli show interfaces (saved to lldp.interfaces)
```
#### How to verify it

- Run generate_dump on a SONiC device.
- Extract the resulting dump tarball.
- Navigate to the dump/ directory and verify that lldp.config and lldp.interfaces (or lldp$i.* for multi-ASIC) are successfully generated and contain the correct lldpcli outputs.

**NOTE:** When the lldp docker is not running we will have empty files but there will be no syslog error or no corruption to the dump tarball.