### PR TITLE
Add stop-time option to App Extension, to stop container after wanted number of seconds

### DIFF
--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -204,6 +204,7 @@ class ManifestSchema:
             ManifestField('delayed', DefaultMarshaller(bool), False),
             ManifestField('check_up_status', DefaultMarshaller(bool), False),
             ManifestField('type', DefaultMarshaller(str), ''),
+            ManifestField('stop-time', DefaultMarshaller(str), ''),
             ManifestRoot('warm-shutdown', [
                 ManifestArray('after', DefaultMarshaller(str)),
                 ManifestArray('before', DefaultMarshaller(str)),

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -252,6 +252,7 @@ class ServiceCreator:
 
         image_id = package.image_id
         name = package.manifest['service']['name']
+        stop_time = package.manifest['service']['stop-time']
         container_spec = package.manifest['container']
         script_path = os.path.join(DOCKER_CTL_SCRIPT_LOCATION, f'{name}.sh')
         script_template = get_tmpl_path(DOCKER_CTL_SCRIPT_TEMPLATE)
@@ -285,7 +286,8 @@ class ServiceCreator:
             'docker_image_name': package.entry.repository,
             'docker_image_reference': package.entry.docker_image_reference,
             'docker_image_run_opt': run_opt,
-            'sonic_asic_platform': sonic_asic_platform
+            'sonic_asic_platform': sonic_asic_platform,
+            'stop_time': stop_time
         }
         render_template(script_template, script_path, render_ctx, executable=True)
         log.info(f'generated {script_path}')


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add stop-time to manifest options, and pass the stop-time to docker_image_ctl.j2. 
+ 
sonic-buildimage PR - https://github.com/sonic-net/sonic-buildimage/pull/26366
#### How to verify it
Run Application extension with stop-time in manifest and make sure it is stopping after the wanted stop-time.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

