### PR TITLE
Added neighbor_mode in show muxcable config

### DIFF
--- a/show/muxcable.py
+++ b/show/muxcable.py
@@ -913,7 +913,8 @@ def config(db, port, json_output):
                     peer_tor_data.append(peer_switch_value)
                     print_peer_tor.append(peer_tor_data)
                     click.echo(tabulate(print_peer_tor, headers=headers))
-                    headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6', 'prober_type', 'neighbor_mode']
+                    headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6', 'prober_type',
+                               'neighbor_mode']
                     click.echo(tabulate(print_data, headers=headers))
 
                     sys.exit(CONFIG_SUCCESSFUL)
@@ -961,7 +962,8 @@ def config(db, port, json_output):
             peer_tor_data.append(peer_switch_value)
             print_peer_tor.append(peer_tor_data)
             click.echo(tabulate(print_peer_tor, headers=headers))
-            headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6', 'prober_type', 'neighbor_mode']
+            headers = ['port', 'state', 'ipv4', 'ipv6', 'cable_type', 'soc_ipv4', 'soc_ipv6', 'prober_type',
+                       'neighbor_mode']
             click.echo(tabulate(print_data, headers=headers))
 
         sys.exit(CONFIG_SUCCESSFUL)

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1944,6 +1944,7 @@
         "cable_type": "active-active",
         "soc_ipv4": "10.1.1.2",
         "soc_ipv6": "fc00::76",
+        "neighbor_mode": "prefix-route",
         "server_ipv6": "fc00::75"
     },
     "MUX_CABLE|Ethernet16": {
@@ -1965,6 +1966,7 @@
     "MUX_CABLE|Ethernet4": {
         "state": "auto",
 	"prober_type": "software",
+	"neighbor_mode": "host-route",
         "server_ipv4": "10.3.1.1",
         "server_ipv6": "e801::46",
         "soc_ipv6": "e801::47"

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -143,30 +143,30 @@ tabular_data_config_output_expected = """\
 SWITCH_NAME    PEER_TOR
 -------------  ----------
 sonic-switch   10.2.2.2
-port        state    ipv4      ipv6      cable_type      soc_ipv4    soc_ipv6    prober_type
-----------  -------  --------  --------  --------------  ----------  ----------  -------------
-Ethernet0   active   10.2.1.1  e800::46                                          software
-Ethernet4   auto     10.3.1.1  e801::46                              e801::47    software
-Ethernet8   active   10.4.1.1  e802::46                                          hardware
-Ethernet12  active   10.4.1.1  e802::46                                          software
-Ethernet16  standby  10.1.1.1  fc00::75  active-standby                          software
-Ethernet28  manual   10.1.1.1  fc00::75                                          software
-Ethernet32  auto     10.1.1.1  fc00::75  active-active   10.1.1.2    fc00::76    software
+port        state    ipv4      ipv6      cable_type      soc_ipv4    soc_ipv6    prober_type    neighbor_mode
+----------  -------  --------  --------  --------------  ----------  ----------  -------------  ---------------
+Ethernet0   active   10.2.1.1  e800::46                                          software       host-route
+Ethernet4   auto     10.3.1.1  e801::46                              e801::47    software       host-route
+Ethernet8   active   10.4.1.1  e802::46                                          hardware       host-route
+Ethernet12  active   10.4.1.1  e802::46                                          software       host-route
+Ethernet16  standby  10.1.1.1  fc00::75  active-standby                          software       host-route
+Ethernet28  manual   10.1.1.1  fc00::75                                          software       host-route
+Ethernet32  auto     10.1.1.1  fc00::75  active-active   10.1.1.2    fc00::76    software       prefix-route
 """
 
 tabular_data_config_output_expected_alias = """\
 SWITCH_NAME    PEER_TOR
 -------------  ----------
 sonic-switch   10.2.2.2
-port    state    ipv4      ipv6      cable_type      soc_ipv4    soc_ipv6    prober_type
-------  -------  --------  --------  --------------  ----------  ----------  -------------
-etp1    active   10.2.1.1  e800::46                                          software
-etp2    auto     10.3.1.1  e801::46                              e801::47    software
-etp3    active   10.4.1.1  e802::46                                          hardware
-etp4    active   10.4.1.1  e802::46                                          software
-etp5    standby  10.1.1.1  fc00::75  active-standby                          software
-etp8    manual   10.1.1.1  fc00::75                                          software
-etp9    auto     10.1.1.1  fc00::75  active-active   10.1.1.2    fc00::76    software
+port    state    ipv4      ipv6      cable_type      soc_ipv4    soc_ipv6    prober_type    neighbor_mode
+------  -------  --------  --------  --------------  ----------  ----------  -------------  ---------------
+etp1    active   10.2.1.1  e800::46                                          software       host-route
+etp2    auto     10.3.1.1  e801::46                              e801::47    software       host-route
+etp3    active   10.4.1.1  e802::46                                          hardware       host-route
+etp4    active   10.4.1.1  e802::46                                          software       host-route
+etp5    standby  10.1.1.1  fc00::75  active-standby                          software       host-route
+etp8    manual   10.1.1.1  fc00::75                                          software       host-route
+etp9    auto     10.1.1.1  fc00::75  active-active   10.1.1.2    fc00::76    software       prefix-route
 """
 
 json_data_status_config_output_expected = """\
@@ -187,7 +187,8 @@ json_data_status_config_output_expected = """\
                     "IPv4": "10.3.1.1",
                     "IPv6": "e801::46",
                     "soc_ipv6": "e801::47",
-                    "prober_type": "software"
+                    "prober_type": "software",
+                    "neighbor_mode": "host-route"
                 }
             },
             "Ethernet8": {
@@ -227,7 +228,8 @@ json_data_status_config_output_expected = """\
                     "IPv6": "fc00::75",
                     "cable_type": "active-active",
                     "soc_ipv4": "10.1.1.2",
-                    "soc_ipv6": "fc00::76"
+                    "soc_ipv6": "fc00::76",
+                    "neighbor_mode": "prefix-route"
                 }
             }
         }
@@ -253,7 +255,8 @@ json_data_status_config_output_expected_alias = """\
                     "IPv4": "10.3.1.1",
                     "IPv6": "e801::46",
                     "soc_ipv6": "e801::47",
-                    "prober_type": "software"
+                    "prober_type": "software",
+                    "neighbor_mode": "host-route"
                 }
             },
             "etp3": {
@@ -293,7 +296,8 @@ json_data_status_config_output_expected_alias = """\
                     "IPv6": "fc00::75",
                     "cable_type": "active-active",
                     "soc_ipv4": "10.1.1.2",
-                    "soc_ipv6": "fc00::76"
+                    "soc_ipv6": "fc00::76",
+                    "neighbor_mode": "prefix-route"
                 }
             }
         }
@@ -310,7 +314,8 @@ json_port_data_status_config_output_expected = """\
                 "STATE": "auto",
                 "SERVER": {
                     "IPv4": "10.1.1.1",
-                    "IPv6": "fc00::75"
+                    "IPv6": "fc00::75",
+                    "neighbor_mode": "prefix-route"
                 }
             }
         }
@@ -327,7 +332,8 @@ json_port_data_status_config_output_expected_alias = """\
                 "STATE": "auto",
                 "SERVER": {
                     "IPv4": "10.1.1.1",
-                    "IPv6": "fc00::75"
+                    "IPv6": "fc00::75",
+                    "neighbor_mode": "prefix-route"
                 }
             }
         }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added neighbor_mode in the output of 'show muxcable config' 
#### How I did it
Modified the show/muxcable.py
#### How to verify it
Verified output in hardware device.
#### Previous command output (if the output of a command-line utility has changed)
```
# show muxcable config
SWITCH_NAME    PEER_TOR
-------------  ----------
tor40-1        10.1.0.32
port         state    ipv4             ipv6               cable_type     soc_ipv4         soc_ipv6    prober_type
-----------  -------  ---------------  -----------------  -------------  ---------------  ----------  -------------
Ethernet0    auto     192.168.0.2/32   fc02:1000::2/128   active-active  192.168.0.3/32               software
Ethernet8    auto     192.168.0.4/32   fc02:1000::4/128   active-active  192.168.0.5/32               software
Ethernet16   auto     192.168.0.6/32   fc02:1000::6/128   active-active  192.168.0.7/32               software
```
#### New command output (if the output of a command-line utility has changed)
```
# show muxcable config
SWITCH_NAME    PEER_TOR
-------------  ----------
tor40-1        10.1.0.32
port         state    ipv4             ipv6               cable_type     soc_ipv4         soc_ipv6    prober_type    neighbor_mode
-----------  -------  ---------------  -----------------  -------------  ---------------  ----------  -------------  ---------------
Ethernet0    auto     192.168.0.2/32   fc02:1000::2/128   active-active  192.168.0.3/32               software       host-route
Ethernet8    auto     192.168.0.4/32   fc02:1000::4/128   active-active  192.168.0.5/32               software       host-route
Ethernet16   auto     192.168.0.6/32   fc02:1000::6/128   active-active  192.168.0.7/32               software       prefix-route
```