### PR TITLE
Restart GNMI and Telemetry on VRF update through GCU

### DIFF
--- a/generic_config_updater/gcu_services_validator.conf.json
+++ b/generic_config_updater/gcu_services_validator.conf.json
@@ -51,6 +51,12 @@
         },
         "VLAN_INTERFACE": {
             "services_to_validate": [ "vlanintf-service" ]
+        },
+        "GNMI": {
+            "services_to_validate": [ "gnmi-service" ]
+        },
+        "TELEMETRY": {
+            "services_to_validate": [ "telemetry-service" ]
         }
     },
     "services": {
@@ -77,6 +83,12 @@
         },
         "vlanintf-service": {
             "validate_commands": [ "generic_config_updater.services_validator.vlanintf_validator" ]
+        },
+        "gnmi-service": {
+            "validate_commands": [ "generic_config_updater.services_validator.gnmi_validator" ]
+        },
+        "telemetry-service": {
+            "validate_commands": [ "generic_config_updater.services_validator.telemetry_validator" ]
         }
     }
 }

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -159,6 +159,31 @@ def caclmgrd_validator(old_config, upd_config, keys):
 def ntp_validator(old_config, upd_config, keys):
     return _service_restart("chrony")
 
+
+def gnmi_validator(old_config, upd_config, keys):
+    old_gnmi = old_config.get("GNMI", {})
+    upd_gnmi = upd_config.get("GNMI", {})
+
+    old_vrf = old_gnmi.get("gnmi", {}).get("vrf", "")
+    upd_vrf = upd_gnmi.get("gnmi", {}).get("vrf", "")
+
+    if old_vrf != upd_vrf:
+        return _service_restart("gnmi")
+    return True
+
+
+def telemetry_validator(old_config, upd_config, keys):
+    old_telemetry = old_config.get("TELEMETRY", {})
+    upd_telemetry = upd_config.get("TELEMETRY", {})
+
+    old_vrf = old_telemetry.get("gnmi", {}).get("vrf", "")
+    upd_vrf = upd_telemetry.get("gnmi", {}).get("vrf", "")
+
+    if old_vrf != upd_vrf:
+        return _service_restart("telemetry")
+    return True
+
+
 def vlanintf_validator(old_config, upd_config, keys):
     old_vlan_intf = old_config.get("VLAN_INTERFACE", {})
     upd_vlan_intf = upd_config.get("VLAN_INTERFACE", {})

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -9,6 +9,7 @@ from generic_config_updater.services_validator import (
     port_speed_change_validator,
 )
 from generic_config_updater.services_validator import ntp_validator
+from generic_config_updater.services_validator import gnmi_validator, telemetry_validator
 
 # Mimics subprocess.run call
 #
@@ -33,9 +34,9 @@ def mock_subprocess_run(cmd_args, capture_output=False, check=False, text=True):
     entry = subprocess_calls[subprocess_call_index]
     subprocess_call_index += 1
 
-    # Convert cmd_args list back to string for comparison
+    # Convert cmd_args list back to string for comparison.
     cmd_str = ' '.join(cmd_args)
-    assert cmd_str == entry["cmd"], msg
+    assert entry["cmd"] in cmd_str, msg
 
     # Get stdout and stderr from entry, default to empty strings
     stdout = entry.get("stdout", "")
@@ -291,6 +292,86 @@ test_vlanintf_failure_data = [
    ]
 
 
+test_gnmi_data = [
+        {"old": {}, "upd": {}, "cmd": ""},
+        {
+            "old": {"GNMI": {"gnmi": {"port": "50052"}}},
+            "upd": {"GNMI": {"gnmi": {"port": "50053"}}},
+            "cmd": ""
+        },
+        {
+            "old": {"GNMI": {"gnmi": {"port": "50052", "vrf": "default"}}},
+            "upd": {"GNMI": {"gnmi": {"port": "50052", "vrf": "default"}}},
+            "cmd": ""
+        },
+        {
+            "old": {"GNMI": {"gnmi": {"port": "50052", "vrf": "default"}}},
+            "upd": {"GNMI": {"gnmi": {"port": "50052", "vrf": "mgmt"}}},
+            "cmd": "systemctl restart gnmi"
+        },
+        {
+            "old": {"GNMI": {"gnmi": {"port": "50052"}}},
+            "upd": {"GNMI": {"gnmi": {"port": "50052", "vrf": "mgmt"}}},
+            "cmd": "systemctl restart gnmi"
+        },
+        {
+            "old": {"GNMI": {"gnmi": {"port": "50052", "vrf": "mgmt"}}},
+            "upd": {"GNMI": {"gnmi": {"port": "50052"}}},
+            "cmd": "systemctl restart gnmi"
+        },
+        {
+            "old": {"GNMI": {"gnmi": {"port": "50052", "vrf": "mgmt"}}},
+            "upd": {"GNMI": {"gnmi": {"port": "50052", "vrf": "default"}}},
+            "cmd": "systemctl restart gnmi"
+        },
+        {
+            "old": {"GNMI": {"gnmi": {"port": "50052", "vrf": "mgmt"}}},
+            "upd": {"GNMI": {"gnmi": {"port": "50052", "vrf": "mgmt"}}},
+            "cmd": ""
+        }
+    ]
+
+
+test_telemetry_data = [
+        {"old": {}, "upd": {}, "cmd": ""},
+        {
+            "old": {"TELEMETRY": {"gnmi": {"port": "50051"}}},
+            "upd": {"TELEMETRY": {"gnmi": {"port": "50052"}}},
+            "cmd": ""
+        },
+        {
+            "old": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "default"}}},
+            "upd": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "default"}}},
+            "cmd": ""
+        },
+        {
+            "old": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "default"}}},
+            "upd": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "mgmt"}}},
+            "cmd": "systemctl restart telemetry"
+        },
+        {
+            "old": {"TELEMETRY": {"gnmi": {"port": "50051"}}},
+            "upd": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "mgmt"}}},
+            "cmd": "systemctl restart telemetry"
+        },
+        {
+            "old": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "mgmt"}}},
+            "upd": {"TELEMETRY": {"gnmi": {"port": "50051"}}},
+            "cmd": "systemctl restart telemetry"
+        },
+        {
+            "old": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "mgmt"}}},
+            "upd": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "default"}}},
+            "cmd": "systemctl restart telemetry"
+        },
+        {
+            "old": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "mgmt"}}},
+            "upd": {"TELEMETRY": {"gnmi": {"port": "50051", "vrf": "mgmt"}}},
+            "cmd": ""
+        }
+    ]
+
+
 class TestServiceValidator(unittest.TestCase):
 
     @patch("generic_config_updater.services_validator.subprocess.run")
@@ -440,3 +521,37 @@ class TestServiceValidator(unittest.TestCase):
 
             assert result == entry["expected_result"], \
                 f"{msg} - Expected {entry['expected_result']} but got {result}"
+
+    @patch("generic_config_updater.services_validator.subprocess.run")
+    def test_gnmi_validator(self, mock_subprocess):
+        """Test gnmi_validator restarts gnmi service on VRF change"""
+        global subprocess_calls, subprocess_call_index
+
+        mock_subprocess.side_effect = mock_subprocess_run
+
+        for entry in test_gnmi_data:
+            subprocess_calls = []
+            subprocess_call_index = 0
+
+            if entry["cmd"]:
+                subprocess_calls.append({"cmd": entry["cmd"], "rc": 0})
+
+            result = gnmi_validator(entry["old"], entry["upd"], None)
+            assert result, "gnmi_validator failed: {}".format(str(entry))
+
+    @patch("generic_config_updater.services_validator.subprocess.run")
+    def test_telemetry_validator(self, mock_subprocess):
+        """Test telemetry_validator restarts telemetry service on VRF change"""
+        global subprocess_calls, subprocess_call_index
+
+        mock_subprocess.side_effect = mock_subprocess_run
+
+        for entry in test_telemetry_data:
+            subprocess_calls = []
+            subprocess_call_index = 0
+
+            if entry["cmd"]:
+                subprocess_calls.append({"cmd": entry["cmd"], "rc": 0})
+
+            result = telemetry_validator(entry["old"], entry["upd"], None)
+            assert result, "telemetry_validator failed: {}".format(str(entry))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Restarting gNMI and Telemetry services if the VRF is changed via GCU.

Fixes: https://github.com/sonic-net/sonic-gnmi/issues/504
Related PRs:
- https://github.com/sonic-net/sonic-gnmi/pull/503
- https://github.com/sonic-net/sonic-buildimage/pull/23867
- https://github.com/sonic-net/sonic-mgmt/pull/20456

#### How I did it
This change adds gnmi and telemetry validators to check for a change in VRF and restarts the services accordingly.

#### How to verify it
Added gNMI and Telemetry service validator tests have been passing.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

