### PR TITLE
Fix show ntp VRF selection when NTP|global.vrf=default

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2191,9 +2191,14 @@ def ntp(ctx, verbose):
     chronyc_tracking_cmd = ["chronyc", "-n", "tracking"]
     chronyc_sources_cmd = ["chronyc", "-n", "sources"]
     if is_mgmt_vrf_enabled(ctx) is True:
-        # ManagementVRF is enabled. Call chronyc using "ip vrf exec" based on linux version
-        chronyc_tracking_cmd = ["sudo", "ip", "vrf", "exec", "mgmt"] + chronyc_tracking_cmd
-        chronyc_sources_cmd = ["sudo", "ip", "vrf", "exec", "mgmt"] + chronyc_sources_cmd
+        # Check if NTP is explicitly configured for default VRF
+        try:
+            _ntp_vrf = subprocess.check_output(["sonic-db-cli", "CONFIG_DB", "HGET", "NTP|global", "vrf"], text=True, stderr=subprocess.DEVNULL).strip()
+        except Exception:
+            _ntp_vrf = ""
+        if _ntp_vrf != "default":
+            chronyc_tracking_cmd = ["sudo", "ip", "vrf", "exec", "mgmt"] + chronyc_tracking_cmd
+            chronyc_sources_cmd = ["sudo", "ip", "vrf", "exec", "mgmt"] + chronyc_sources_cmd
 
     run_command(chronyc_tracking_cmd, display_cmd=verbose)
     run_command(chronyc_sources_cmd, display_cmd=verbose)

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -1325,6 +1325,7 @@ class TestShow(object):
                           call(['chronyc', '-n', 'sources'], display_cmd=False)]
         mock_run_command.assert_has_calls(expected_calls)
 
+    @patch('show.main.subprocess.check_output', MagicMock(return_value='mgmt\n'))
     @patch('show.main.is_mgmt_vrf_enabled', MagicMock(return_value=True))
     @patch('show.main.run_command')
     def test_show_ntp_mgmt_vrf(self, mock_run_command):
@@ -1334,6 +1335,31 @@ class TestShow(object):
         expected_calls = [call(['sudo', 'ip', 'vrf', 'exec', 'mgmt', 'chronyc', '-n', 'tracking'], display_cmd=False),
                           call(['sudo', 'ip', 'vrf', 'exec', 'mgmt', 'chronyc', '-n', 'sources'], display_cmd=False)]
         mock_run_command.assert_has_calls(expected_calls)
+        assert mock_run_command.call_count == 2
+
+    @patch('show.main.subprocess.check_output', MagicMock(return_value='default\n'))
+    @patch('show.main.is_mgmt_vrf_enabled', MagicMock(return_value=True))
+    @patch('show.main.run_command')
+    def test_show_ntp_mgmt_vrf_ntp_default(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands['ntp'])
+        assert result.exit_code == 0
+        expected_calls = [call(['chronyc', '-n', 'tracking'], display_cmd=False),
+                          call(['chronyc', '-n', 'sources'], display_cmd=False)]
+        mock_run_command.assert_has_calls(expected_calls)
+        assert mock_run_command.call_count == 2
+
+    @patch('show.main.subprocess.check_output', MagicMock(side_effect=Exception('db read failed')))
+    @patch('show.main.is_mgmt_vrf_enabled', MagicMock(return_value=True))
+    @patch('show.main.run_command')
+    def test_show_ntp_mgmt_vrf_db_failure(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands['ntp'])
+        assert result.exit_code == 0
+        expected_calls = [call(['sudo', 'ip', 'vrf', 'exec', 'mgmt', 'chronyc', '-n', 'tracking'], display_cmd=False),
+                          call(['sudo', 'ip', 'vrf', 'exec', 'mgmt', 'chronyc', '-n', 'sources'], display_cmd=False)]
+        mock_run_command.assert_has_calls(expected_calls)
+        assert mock_run_command.call_count == 2
 
     def teardown_method(self):
         print('TEAR DOWN')


### PR DESCRIPTION
#### What I did
Fixes #4400

Fixed `show ntp` to respect `NTP|global.vrf` config when management VRF is enabled.

Previously, `show ntp` unconditionally routed `chronyc` through the mgmt VRF whenever
management VRF was enabled, ignoring the `NTP|global.vrf` setting. This caused `Invalid VRF name`
or incorrect output when NTP was configured with `vrf: default` — because `chronyd` runs in the
default VRF (per `chronyd-starter.sh`) but `show ntp` queried `chronyc` in the mgmt VRF.

This was introduced by the chrony migration in #3574, which ported the ntpd-era VRF logic
without accounting for the `NTP|global.vrf` override that `chronyd-starter.sh` supports.

#### How I did it

Added a CONFIG_DB lookup for `NTP|global.vrf` in the `ntp()` function in `show/main.py`,
mirroring the two-level VRF check already used by `chronyd-starter.sh`:

1. Check if management VRF is enabled
2. If yes, read `NTP|global.vrf` from CONFIG_DB via `sonic-db-cli`
3. Only route through mgmt VRF if the value is NOT `default`
4. Fall back to mgmt VRF on DB read failure (safe default)

Added/updated three unit tests with `call_count` assertions:
- `test_show_ntp_mgmt_vrf` — mgmt VRF enabled, NTP vrf=mgmt (updated with explicit DB mock)
- `test_show_ntp_mgmt_vrf_ntp_default` — mgmt VRF enabled, NTP vrf=default (bug-fix case)
- `test_show_ntp_mgmt_vrf_db_failure` — mgmt VRF enabled, DB read fails (fallback)

#### How to verify it

1. Enable management VRF: `config vrf add mgmt`
2. Configure NTP with default VRF: `sonic-db-cli CONFIG_DB HSET "NTP|global" "vrf" "default"`
3. Run `show ntp` — should display chronyc tracking and sources output

Unit tests:
```
pytest tests/show_test.py -k "show_ntp" -v
```

#### Previous command output (if the output of a command-line utility has changed)

```
admin@switch:~$ show ntp
Invalid VRF name
```

#### New command output (if the output of a command-line utility has changed)

```
admin@switch:~$ show ntp
Reference ID    : ...
Stratum         : 4
...
MS Name/IP address         Stratum Poll Reach LastRx Last sample
===============================================================================
^* <ntp-server>                  3  10   377   816   -141us[ -181us] +/-   13ms
```
