### PR TITLE
Allow batch flapping of interfaces on multi-asic systems via CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -36,7 +36,7 @@ from swsscommon import swsscommon
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, ConfigDBPipeConnector, \
                                 isInterfaceNameValid, IFACE_NAME_MAX_LEN
 from utilities_common.db import Db
-from utilities_common.intf_filter import parse_interface_in_filter
+from utilities_common.intf_filter import expand_single_intf_filter
 from utilities_common import bgp_util
 import utilities_common.cli as clicommon
 from utilities_common.helper import get_port_pbh_binding, get_port_acl_binding, update_config
@@ -588,6 +588,109 @@ def get_port_namespace(port):
                 return namespace
 
     return None
+
+
+def _load_other_namespace_ports(namespace):
+    """Build a port-to-namespace map for all namespaces other than provided namespace."""
+    other_ns_ports = {}
+    if not multi_asic.is_multi_asic():
+        return other_ns_ports
+    ns_list = multi_asic.get_all_namespaces()
+    for ns in ns_list['front_ns'] + ns_list['back_ns']:
+        if ns == namespace:
+            continue
+        ns_db = ConfigDBConnector(use_unix_socket_path=True, namespace=ns)
+        ns_db.connect()
+        for port in ns_db.get_table('PORT'):
+            other_ns_ports[port] = ns
+        for pc in ns_db.get_table('PORTCHANNEL'):
+            other_ns_ports[pc] = ns
+    return other_ns_ports
+
+
+def get_interface_names_in_namespace(ctx, interface_name):
+    """Return existing interfaces selected by filter in the provided namespace."""
+    config_db = ctx.obj.get('config_db')
+    namespace = ctx.obj.get('namespace', DEFAULT_NAMESPACE)
+    cross_ns_intfs = []
+    invalid_intfs = []
+    valid_intfs = []
+    seen_intfs = set()
+    other_ns_ports = None
+
+    # Expand all possible comma seperated input interface(s).
+    for intf_filter in interface_name.split(','):
+        intf_filter = intf_filter.strip()
+        try:
+            intf_fs, is_range = expand_single_intf_filter(intf_filter)
+        except ValueError as e:
+            log.log_warning("Invalid interface filter '{}' in namespace '{}': {}".format(
+                intf_filter, namespace, str(e)))
+            ctx.fail(str(e))
+
+        missing_intfs = []
+        valid_in_filter = []
+        cross_ns_in_filter = []
+        for intf in intf_fs:
+            if intf in seen_intfs:
+                continue
+            seen_intfs.add(intf)
+            # Check if interface is in target namespace.
+            if interface_name_is_valid(config_db, intf):
+                valid_in_filter.append(intf)
+            else:
+                if other_ns_ports is None:
+                    # Lazy init on first miss to skip uneccessary config_db connections
+                    # when all input interfaces are valid.
+                    other_ns_ports = _load_other_namespace_ports(namespace)
+                # Case when interface is present in other namespace.
+                if intf in other_ns_ports:
+                    cross_ns_in_filter.append((intf, other_ns_ports[intf]))
+                # Sparse gap in range which is not present in any namespace.
+                # This interfaces are tolerated if range has other valid hits.
+                elif is_range:
+                    missing_intfs.append(intf)
+                else:
+                    invalid_intfs.append(intf)
+
+        cross_ns_intfs.extend(cross_ns_in_filter)
+
+        # Range that matched nothing — promote missing to invalid for proper error reporting.
+        if is_range and not valid_in_filter and not cross_ns_in_filter:
+            invalid_intfs.extend(missing_intfs)
+            missing_intfs = []
+
+        valid_intfs.extend(valid_in_filter)
+
+        if missing_intfs:
+            log.log_info("Interface range '{}' in namespace '{}' skipped missing interface(s): {}".format(
+                intf_filter, namespace, ', '.join(missing_intfs)))
+
+        if valid_in_filter:
+            log.log_info("Interface filter '{}' in namespace '{}' resolved to existing interface(s): {}".format(
+                intf_filter, namespace, ', '.join(valid_in_filter)))
+
+    # Fail with clear error if valid interfaces existed on different namespace.
+    if cross_ns_intfs:
+        by_ns = {}
+        for intf, ns in cross_ns_intfs:
+            by_ns.setdefault(ns, []).append(intf)
+        parts = []
+        for ns, intfs in by_ns.items():
+            parts.append("Interface(s) {} exist(s) on namespace '{}'".format(', '.join(intfs), ns))
+        msg = "Interface(s) not in provided namespace '{}'. {}".format(namespace, '. '.join(parts))
+        log.log_warning(msg)
+        ctx.fail(msg)
+
+    # Fail when input includes interface(s) that don't exist on any namespace.
+    if invalid_intfs:
+        log.log_warning("Invalid interface(s) in namespace '{}': {}".format(
+            namespace, ', '.join(invalid_intfs)))
+        ctx.fail("Provided interface(s) : '{}' are invalid in namespace '{}'".format(
+            ', '.join(invalid_intfs), namespace))
+
+    return valid_intfs
+
 
 def del_interface_bind_to_vrf(config_db, vrf_name):
     """del interface bind to vrf
@@ -5337,6 +5440,8 @@ def fast_linkup(ctx, interface_name, mode, verbose):
     if verbose:
         command += ['-vv']
     clicommon.run_command(command, display_cmd=verbose)
+
+
 #
 # 'startup' subcommand
 #
@@ -5354,37 +5459,13 @@ def startup(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    try:
-        intf_fs = parse_interface_in_filter(interface_name)
-    except ValueError as e:
-        ctx.fail(str(e))
-
-    if len(intf_fs) > 1 and multi_asic.is_multi_asic():
-        ctx.fail("Interface range not supported in multi-asic platforms !!")
-
-    if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
-        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
-
+    intf_fs = get_interface_names_in_namespace(ctx, interface_name)
     log.log_info("'interface startup {}' executing...".format(interface_name))
-    port_dict = config_db.get_table('PORT')
-    for port_name in port_dict:
-        if port_name in intf_fs:
-            config_db.mod_entry("PORT", port_name, {"admin_status": "up"})
-
-    portchannel_list = config_db.get_table("PORTCHANNEL")
-    for po_name in portchannel_list:
-        if po_name in intf_fs:
-            config_db.mod_entry("PORTCHANNEL", po_name, {"admin_status": "up"})
-
-    subport_list = config_db.get_table("VLAN_SUB_INTERFACE")
-    for sp_name in subport_list:
-        if sp_name in intf_fs:
-            config_db.mod_entry("VLAN_SUB_INTERFACE", sp_name, {"admin_status": "up"})
-
-    lo_list = config_db.get_table("LOOPBACK_INTERFACE")
-    for lo in lo_list:
-        if lo in intf_fs:
-            config_db.mod_entry("LOOPBACK_INTERFACE", lo, {"admin_status": "up"})
+    for intf in intf_fs:
+        table_name = get_port_table_name(intf)
+        if not table_name:
+            continue
+        config_db.mod_entry(table_name, intf, {"admin_status": "up"})
 
 #
 # 'shutdown' subcommand
@@ -5395,7 +5476,6 @@ def startup(ctx, interface_name):
 @click.pass_context
 def shutdown(ctx, interface_name):
     """Shut down interface"""
-    log.log_info("'interface shutdown {}' executing...".format(interface_name))
     # Get the config_db connector
     config_db = ctx.obj['config_db']
 
@@ -5404,36 +5484,13 @@ def shutdown(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    try:
-        intf_fs = parse_interface_in_filter(interface_name)
-    except ValueError as e:
-        ctx.fail(str(e))
-
-    if len(intf_fs) > 1 and multi_asic.is_multi_asic():
-        ctx.fail("Interface range not supported in multi-asic platforms !!")
-
-    if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
-        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
-
-    port_dict = config_db.get_table('PORT')
-    for port_name in port_dict:
-        if port_name in intf_fs:
-            config_db.mod_entry("PORT", port_name, {"admin_status": "down"})
-
-    portchannel_list = config_db.get_table("PORTCHANNEL")
-    for po_name in portchannel_list:
-        if po_name in intf_fs:
-            config_db.mod_entry("PORTCHANNEL", po_name, {"admin_status": "down"})
-
-    subport_list = config_db.get_table("VLAN_SUB_INTERFACE")
-    for sp_name in subport_list:
-        if sp_name in intf_fs:
-            config_db.mod_entry("VLAN_SUB_INTERFACE", sp_name, {"admin_status": "down"})
-
-    lo_list = config_db.get_table("LOOPBACK_INTERFACE")
-    for lo in lo_list:
-        if lo in intf_fs:
-            config_db.mod_entry("LOOPBACK_INTERFACE", lo, {"admin_status": "down"})
+    intf_fs = get_interface_names_in_namespace(ctx, interface_name)
+    log.log_info("'interface shutdown {}' executing...".format(interface_name))
+    for intf in intf_fs:
+        table_name = get_port_table_name(intf)
+        if not table_name:
+            continue
+        config_db.mod_entry(table_name, intf, {"admin_status": "down"})
 
 #
 # 'sys-mac' group ('config interface sys-mac ...')

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4462,6 +4462,98 @@ class TestConfigInterface(object):
         assert result.exit_code == 0
         assert db.cfgdb.get_table('LOOPBACK_INTERFACE')['Loopback0']['admin_status'] == 'up'
 
+    def test_expand_single_intf_filter_is_range(self):
+        from utilities_common.intf_filter import expand_single_intf_filter
+        intfs, is_range = expand_single_intf_filter('Ethernet0-4')
+        assert intfs == ['Ethernet0', 'Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
+        assert is_range is True
+        intfs, is_range = expand_single_intf_filter('PortChannel1-4')
+        assert intfs == ['PortChannel1', 'PortChannel2', 'PortChannel3', 'PortChannel4']
+        assert is_range is True
+        intfs, is_range = expand_single_intf_filter('Ethernet-BP0-3')
+        assert intfs == ['Ethernet-BP0', 'Ethernet-BP1', 'Ethernet-BP2', 'Ethernet-BP3']
+        assert is_range is True
+        intfs, is_range = expand_single_intf_filter('Ethernet0')
+        assert intfs == ['Ethernet0']
+        assert is_range is False
+        intfs, is_range = expand_single_intf_filter('Ethernet-BP0')
+        assert intfs == ['Ethernet-BP0']
+        assert is_range is False
+        intfs, is_range = expand_single_intf_filter('Ethernet-Rec0')
+        assert intfs == []
+        assert is_range is False
+        intfs, is_range = expand_single_intf_filter('Ethernet-IB0')
+        assert intfs == []
+        assert is_range is False
+
+    def test_startup_shutdown_sparse_port_range(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb, 'namespace': ''}
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               ['Ethernet0-4'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = db.cfgdb.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'down'
+        assert port_table['Ethernet4']['admin_status'] == 'down'
+        assert 'Ethernet1' not in port_table
+
+        result = runner.invoke(config.config.commands['interface'].commands['startup'],
+                               ['Ethernet0-4'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = db.cfgdb.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'up'
+        assert port_table['Ethernet4']['admin_status'] == 'up'
+
+    def test_startup_shutdown_mixed_interface_filter(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb, 'namespace': ''}
+        interface_filter = 'Ethernet8,Ethernet16-20,Ethernet32'
+        expected_interfaces = ['Ethernet8', 'Ethernet16', 'Ethernet20', 'Ethernet32']
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               [interface_filter], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = db.cfgdb.get_table('PORT')
+        for interface_name in expected_interfaces:
+            assert port_table[interface_name]['admin_status'] == 'down'
+        assert 'Ethernet17' not in port_table
+        assert 'Ethernet18' not in port_table
+        assert 'Ethernet19' not in port_table
+
+        result = runner.invoke(config.config.commands['interface'].commands['startup'],
+                               [interface_filter], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = db.cfgdb.get_table('PORT')
+        for interface_name in expected_interfaces:
+            assert port_table[interface_name]['admin_status'] == 'up'
+
+    def test_single_asic_explicit_invalid_interface_fails(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb, 'namespace': ''}
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               ['Ethernet0,Ethernet999'], obj=obj)
+        assert result.exit_code != 0
+        assert "Ethernet999" in result.output
+
+    def test_sparse_port_range_with_no_valid_interfaces_fails(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb, 'namespace': ''}
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               ['Ethernet1-3'], obj=obj)
+        assert result.exit_code != 0
+        assert "Ethernet1, Ethernet2, Ethernet3" in result.output
+
     @pytest.mark.parametrize("interface_name", [
         "Ethernet320-Ethernet376",  # range bounds not numeric
         "Ethernet0-",               # missing end of range
@@ -4497,6 +4589,157 @@ class TestConfigInterface(object):
         assert "Invalid interface range" in result.output
 
     def teardown_method(self):
+        print("TEARDOWN")
+
+
+class TestConfigInterfaceMasic(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        cls.original_topology = os.environ.get("UTILITIES_UNIT_TESTING_TOPOLOGY")
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        import config.main
+        importlib.reload(config.main)
+        from .mock_tables import dbconnector
+        from .mock_tables import mock_multi_asic
+        importlib.reload(mock_multi_asic)
+        dbconnector.load_namespace_config()
+
+    def test_startup_shutdown_single_port(self, get_cmd_module, setup_multi_broadcom_masic):
+        (config, _) = get_cmd_module
+        config_db = config.ConfigDBConnector(use_unix_socket_path=True, namespace='asic0')
+        config_db.connect()
+        runner = CliRunner()
+        obj = {'config_db': config_db, 'namespace': 'asic0'}
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               ['Ethernet0'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = config_db.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'down'
+
+        result = runner.invoke(config.config.commands['interface'].commands['startup'],
+                               ['Ethernet0'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = config_db.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'up'
+
+    def test_startup_shutdown_comma_separated_ports(self, get_cmd_module, setup_multi_broadcom_masic):
+        (config, _) = get_cmd_module
+        config_db = config.ConfigDBConnector(use_unix_socket_path=True, namespace='asic0')
+        config_db.connect()
+        runner = CliRunner()
+        obj = {'config_db': config_db, 'namespace': 'asic0'}
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               ['Ethernet0,Ethernet4'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = config_db.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'down'
+        assert port_table['Ethernet4']['admin_status'] == 'down'
+
+        result = runner.invoke(config.config.commands['interface'].commands['startup'],
+                               ['Ethernet0,Ethernet4'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = config_db.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'up'
+        assert port_table['Ethernet4']['admin_status'] == 'up'
+
+    def test_startup_shutdown_sparse_port_range(self, get_cmd_module, setup_multi_broadcom_masic):
+        (config, _) = get_cmd_module
+        config_db = config.ConfigDBConnector(use_unix_socket_path=True, namespace='asic0')
+        config_db.connect()
+        runner = CliRunner()
+        obj = {'config_db': config_db, 'namespace': 'asic0'}
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               ['Ethernet0-4'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = config_db.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'down'
+        assert port_table['Ethernet4']['admin_status'] == 'down'
+        assert 'Ethernet1' not in port_table
+
+        result = runner.invoke(config.config.commands['interface'].commands['startup'],
+                               ['Ethernet0-4'], obj=obj)
+        assert result.exit_code == 0
+
+        port_table = config_db.get_table('PORT')
+        assert port_table['Ethernet0']['admin_status'] == 'up'
+        assert port_table['Ethernet4']['admin_status'] == 'up'
+
+    @pytest.mark.parametrize("command_name,initial_status", [
+        ("shutdown", "up"),
+        ("startup", "down"),
+    ])
+    def test_startup_shutdown_mixed_filter_with_interface_in_other_namespace_fails(
+            self, get_cmd_module, setup_multi_broadcom_masic, command_name, initial_status
+    ):
+        (config, _) = get_cmd_module
+        config_db = config.ConfigDBConnector(use_unix_socket_path=True, namespace='asic0')
+        config_db.connect()
+        runner = CliRunner()
+        obj = {'config_db': config_db, 'namespace': 'asic0'}
+
+        # The explicit Ethernet0/Ethernet4 members and the generated
+        # Ethernet16/Ethernet20 members belong to asic0. Ethernet64 is also
+        # generated by the range filter but belongs to asic1
+        local_interfaces = ['Ethernet0', 'Ethernet4', 'Ethernet16', 'Ethernet20']
+        for interface_name in local_interfaces:
+            config_db.mod_entry('PORT', interface_name, {'admin_status': initial_status})
+        try:
+            result = runner.invoke(config.config.commands['interface'].commands[command_name],
+                                   ['Ethernet0,Ethernet16-64,Ethernet4'], obj=obj)
+            assert result.exit_code != 0
+            assert ("Interface(s) not in provided namespace 'asic0'. "
+                    "Interface(s) Ethernet64 exist(s) on namespace 'asic1'") in result.output
+
+            port_table = config_db.get_table('PORT')
+            for interface_name in local_interfaces:
+                assert port_table[interface_name]['admin_status'] == initial_status
+        finally:
+            for interface_name in local_interfaces:
+                config_db.mod_entry('PORT', interface_name, {'admin_status': 'up'})
+
+    @pytest.mark.parametrize("command_name,initial_status", [
+        ("shutdown", "up"),
+        ("startup", "down"),
+    ])
+    def test_startup_shutdown_explicit_invalid_interface_fails(
+            self, get_cmd_module, setup_multi_broadcom_masic, command_name, initial_status
+    ):
+        (config, _) = get_cmd_module
+        config_db = config.ConfigDBConnector(use_unix_socket_path=True, namespace='asic0')
+        config_db.connect()
+        runner = CliRunner()
+        obj = {'config_db': config_db, 'namespace': 'asic0'}
+
+        config_db.mod_entry('PORT', 'Ethernet0', {'admin_status': initial_status})
+        try:
+            result = runner.invoke(config.config.commands['interface'].commands[command_name],
+                                   ['Ethernet0,Ethernet272'], obj=obj)
+            assert result.exit_code != 0
+            assert ("Provided interface(s) : 'Ethernet272' are invalid "
+                    "in namespace 'asic0'") in result.output
+
+            port_table = config_db.get_table('PORT')
+            assert port_table['Ethernet0']['admin_status'] == initial_status
+        finally:
+            config_db.mod_entry('PORT', 'Ethernet0', {'admin_status': 'up'})
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        if cls.original_topology is None:
+            os.environ.pop("UTILITIES_UNIT_TESTING_TOPOLOGY", None)
+        else:
+            os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = cls.original_topology
         print("TEARDOWN")
 
 

--- a/utilities_common/intf_filter.py
+++ b/utilities_common/intf_filter.py
@@ -4,6 +4,61 @@ SONIC_PORT_NAME_PREFIX = "Ethernet"
 SONIC_LAG_NAME_PREFIX = "PortChannel"
 SONIC_BACK_PORT_NAME_PREFIX = "Ethernet-BP"
 
+
+def expand_range(intf_filter, prefix):
+    """Try to expand a prefixed interface filter as a numeric range.
+
+    If the suffix after the prefix starts with a digit and contains '-',
+    it is treated as a range (e.g. Ethernet0-3). If the range is malformed
+    (e.g. Ethernet0-ff), a ValueError is raised.
+
+    Returns (interfaces, is_range).
+    """
+    suffix = intf_filter[len(prefix):]
+    if not suffix or not suffix[0].isdigit():
+        return ([intf_filter], False)
+    if '-' not in suffix:
+        return ([intf_filter], False)
+    range_start, range_end = suffix.split('-', 1)
+    if not range_start.isdigit() or not range_end.isdigit():
+        raise ValueError(
+            "Invalid interface range '{}'. Expected a range like "
+            "'{}0-3'.".format(intf_filter, prefix))
+    start, end = int(range_start), int(range_end)
+    if start > end:
+        raise ValueError(
+            "Invalid interface range '{}'. The start of the range "
+            "must not be greater than the end.".format(intf_filter))
+    return ([prefix + str(i) for i in range(start, end + 1)], True)
+
+
+def expand_single_intf_filter(intf_filter):
+    """Expand a single interface filter segment (no commas) into interface names.
+
+    Returns (interfaces, is_range) where is_range indicates whether the filter
+    used range syntax (e.g. Ethernet0-4) vs an explicit name (e.g. Ethernet0).
+    """
+    if intf_filter.startswith(SONIC_BACK_PORT_NAME_PREFIX):
+        return expand_range(intf_filter, SONIC_BACK_PORT_NAME_PREFIX)
+
+    if '-' in intf_filter:
+        if intf_filter.startswith(SONIC_PORT_NAME_PREFIX):
+            suffix = intf_filter[len(SONIC_PORT_NAME_PREFIX):]
+            # Range expansion is not applicable to recirculation ports (e.g., Ethernet-Rec0)
+            # or in-band ports (e.g., Ethernet-IB0), so return an empty list.
+            if suffix.startswith(("-Rec", "-IB")):
+                return ([], False)
+            return expand_range(intf_filter, SONIC_PORT_NAME_PREFIX)
+        elif intf_filter.startswith(SONIC_LAG_NAME_PREFIX):
+            return expand_range(intf_filter, SONIC_LAG_NAME_PREFIX)
+        else:
+            raise ValueError(
+                "Invalid interface range '{}'. A range must start with "
+                "'{}' or '{}'.".format(intf_filter, SONIC_PORT_NAME_PREFIX, SONIC_LAG_NAME_PREFIX))
+
+    return ([intf_filter], False)
+
+
 def parse_interface_in_filter(intf_filter):
     intf_fs = []
 
@@ -12,51 +67,11 @@ def parse_interface_in_filter(intf_filter):
 
     fs = intf_filter.split(',')
     for x in fs:
-        if x.startswith(SONIC_BACK_PORT_NAME_PREFIX):
-            intf = SONIC_BACK_PORT_NAME_PREFIX
-            x = x.split(intf)[1]
-            if '-' in x:
-                start = x.split('-')[0]
-                end = x.split('-')[1]
-                if not start.isdigit() or not end.isdigit():
-                    raise ValueError(
-                        "Invalid interface range '{}{}'. Expected a range like "
-                        "'{}0-3'.".format(intf, x, intf))
-                if int(start) > int(end):
-                    raise ValueError(
-                        "Invalid interface range '{}{}'. The start of the range "
-                        "must not be greater than the end.".format(intf, x))
-                for i in range(int(start), int(end)+1):
-                    intf_fs.append(intf+str(i))
-            else:
-                intf_fs.append(intf+x)
-        elif '-' in x:
-            # handle range
-            if x.startswith(SONIC_PORT_NAME_PREFIX):
-                intf = SONIC_PORT_NAME_PREFIX
-            elif x.startswith(SONIC_LAG_NAME_PREFIX):
-                intf = SONIC_LAG_NAME_PREFIX
-            else:
-                raise ValueError(
-                    "Invalid interface range '{}'. A range must start with "
-                    "'{}' or '{}'.".format(x, SONIC_PORT_NAME_PREFIX, SONIC_LAG_NAME_PREFIX))
-            start = x.split('-')[0].split(intf,1)[1]
-            end = x.split('-')[1]
-
-            if not start.isdigit() or not end.isdigit():
-                raise ValueError(
-                    "Invalid interface range '{}'. Expected a range like "
-                    "'{}0-3'.".format(x, intf))
-            if int(start) > int(end):
-                raise ValueError(
-                    "Invalid interface range '{}'. The start of the range "
-                    "must not be greater than the end.".format(x))
-            for i in range(int(start), int(end)+1):
-                intf_fs.append(intf+str(i))
-        else:
-            intf_fs.append(x)
+        names, _ = expand_single_intf_filter(x)
+        intf_fs.extend(names)
 
     return intf_fs
+
 
 def interface_in_filter(intf, filter):
     if filter is None:


### PR DESCRIPTION
Context : currently, shutdown and startup of a batch of interfaces is not allowed multi asic. We have checks to return error saying it is not allowed. 

#### What I did

Enabled batch interface flapping (startup/shutdown) on multi-ASIC platforms by removing the blanket restriction and adding proper namespace validation instead.

Fixes: #4781 

### Backport request 

Requesting backport of same to 202511 and 202605 branch

#### How I did it

1. Created a new helper function `validate_interface_names_in_namespace()` that validates:
     - Interface names are valid and exist in config_db
     - On multi-ASIC systems, all interfaces belong to the correct namespace

  2. Refactored `startup()` and `shutdown()` commands to:
     - Replace the blanket multi-ASIC batch rejection with targeted namespace validation
     - Use a generic loop with `get_port_table_name()` helper to handle all interface types
  (PORT, PORTCHANNEL, VLAN_SUB_INTERFACE, LOOPBACK_INTERFACE) instead of duplicate
  table-by-table checks
     - Reduce code duplication across both functions

#### How to verify it

Verified command functions as expected on multi-asic

#### Previous command output (if the output of a command-line utility has changed)

Previously the command errors out as follows : 
```
$ config interface startup Ethernet0,Ethernet4
Error: Interface range not supported in multi-asic platforms !!
```
#### New command output (if the output of a command-line utility has changed)

Multi-asic behavior

Only success case : provided input interfaces ( single interface, comma-seperated list or range-based list ) that exist on provided namespace ( -n arg ) will successfully complete

```
admin@qzd554:~$ sudo config interface -n asic0 shutdown Ethernet0-16,Ethernet40
admin@qzd554:~$ show interfaces status Ethernet0-16,Ethernet40
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Medium     Type           Vendor            Model    Asym PFC    Flaps
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  --------  -------  ---------------  ---------------  ----------  -------
  Ethernet0          72,73,74,75,76,77,78,79     400G   9100     rs     etp1  routed    down     down    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        4
  Ethernet8          80,81,82,83,84,85,86,87     400G   9100     rs     etp2  routed    down     down    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        4
 Ethernet16          88,89,90,91,92,93,94,95     400G   9100     rs     etp3  routed    down     down    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        4
 Ethernet40  112,113,114,115,116,117,118,119     400G   9100     rs     etp6  routed    down     down    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        4

admin@qzd554:~$ sudo config interface -n asic0 startup Ethernet0-16,Ethernet40
admin@qzd554:~$ show interfaces status Ethernet0-16,Ethernet40
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Medium     Type           Vendor            Model    Asym PFC    Flaps
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  --------  -------  ---------------  ---------------  ----------  -------
  Ethernet0          72,73,74,75,76,77,78,79     400G   9100     rs     etp1  routed      up       up    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        3
  Ethernet8          80,81,82,83,84,85,86,87     400G   9100     rs     etp2  routed      up       up    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        3
 Ethernet16          88,89,90,91,92,93,94,95     400G   9100     rs     etp3  routed      up       up    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        3
 Ethernet40  112,113,114,115,116,117,118,119     400G   9100     rs     etp6  routed      up       up    Copper  QSFP-DD  Arista Networks  CAB-D-D-400G-1M
    off        3
```

Failure cases:

When resolved valid interfaces from input interfaces does not exists on provided namespace

```
admin@qzd554:~$ sudo config interface -n asic0 shutdown Ethernet0,Ethernet40,Ethernet128-152
Usage: config interface shutdown [OPTIONS] <interface_name>
Try 'config interface shutdown -h' for help.

Error: Interface(s) not in provided namespace 'asic0'. Interface(s) Ethernet144, Ethernet152 exist(s) on namespace 'asic1'

admin@qzd554:~$ sudo config interface -n asic0 shutdown Ethernet128-152
Usage: config interface shutdown [OPTIONS] <interface_name>
Try 'config interface shutdown -h' for help.

Error: Interface(s) not in provided namespace 'asic0'. Interface(s) Ethernet144, Ethernet152 exist(s) on namespace 'asic1'

sudo config interface -n asic0 shutdown Ethernet0,Ethernet8,Ethernet200
Usage: config interface shutdown [OPTIONS] <interface_name>
Try 'config interface shutdown -h' for help.

Error: Interface(s) not in provided namespace 'asic0'. Interface(s) Ethernet200 exist(s) on namespace 'asic1'
```

When resolved interfaces from input interfaces does not have any valid interfaces

```
admin@qzd554:~$ sudo config interface -n asic0 shutdown Ethernet1-7
Usage: config interface shutdown [OPTIONS] <interface_name>
Try 'config interface shutdown -h' for help.

Error: Provided interface(s) : 'Ethernet1, Ethernet2, Ethernet3, Ethernet4, Ethernet5, Ethernet6, Ethernet7' are invalid in namespace 'asic0'

admin@qzd554:~$ sudo config interface -n asic0 shutdown Ethernet137-143
Usage: config interface shutdown [OPTIONS] <interface_name>
Try 'config interface shutdown -h' for help.

Error: Provided interface(s) : 'Ethernet137, Ethernet138, Ethernet139, Ethernet140, Ethernet141, Ethernet142, Ethernet143' are invalid in namespace 'asic0'
```