### PR TITLE
[Dualtor] Preserve mux neighbor_mode and prober_type

### DIFF
--- a/config/muxcable.py
+++ b/config/muxcable.py
@@ -255,22 +255,29 @@ def lookup_statedb_and_update_configdb(db, per_npu_statedb, config_db, port, sta
     if str(state_cfg_val) == str(configdb_state):
         port_status_dict[port_name] = 'OK'
     else:
-        if cable_type is not None or soc_ipv4_value is not None:
-            try:
-                config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                        "server_ipv4": ipv4_value,
-                                                        "server_ipv6": ipv6_value, 
-                                                        "soc_ipv4":soc_ipv4_value, 
-                                                        "cable_type": cable_type})
-            except ValueError as e:
-                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
-        else:
-            try:
-                config_db.set_entry("MUX_CABLE", port, {"state": state_cfg_val,
-                                                        "server_ipv4": ipv4_value,
-                                                        "server_ipv6": ipv6_value}) 
-            except ValueError as e:
-                ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+        fvs = {"state": state_cfg_val,
+               "server_ipv4": ipv4_value,
+               "server_ipv6": ipv6_value}
+        if soc_ipv4_value is not None:
+            fvs["soc_ipv4"] = soc_ipv4_value
+        if cable_type is not None:
+            fvs["cable_type"] = cable_type
+        soc_ipv6_value = get_optional_value_for_key_in_config_tbl(config_db, port, "soc_ipv6", "MUX_CABLE")
+        if soc_ipv6_value is not None:
+            fvs["soc_ipv6"] = soc_ipv6_value
+        prober_type_val = get_optional_value_for_key_in_config_tbl(config_db, port, "prober_type", "MUX_CABLE")
+        if prober_type_val is not None:
+            fvs["prober_type"] = prober_type_val
+        neighbor_mode_val = get_optional_value_for_key_in_config_tbl(config_db, port, "neighbor_mode", "MUX_CABLE")
+        if neighbor_mode_val is not None:
+            fvs["neighbor_mode"] = neighbor_mode_val
+        pck_loss_data = get_optional_value_for_key_in_config_tbl(config_db, port, "pck_loss_data_reset", "MUX_CABLE")
+        if pck_loss_data is not None:
+            fvs["pck_loss_data_reset"] = pck_loss_data
+        try:
+            config_db.set_entry("MUX_CABLE", port, fvs)
+        except ValueError as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
         if (str(state_cfg_val) == 'active' and str(state) != 'active') or (str(state_cfg_val) == 'standby' and str(state) != 'standby'):
             port_status_dict[port_name] = 'INPROGRESS'
         else:
@@ -290,9 +297,15 @@ def update_configdb_pck_loss_data(config_db, port, val):
     cable_type = get_optional_value_for_key_in_config_tbl(config_db, port, "cable_type", "MUX_CABLE")
     if cable_type is not None:
         fvs["cable_type"] = cable_type
+    soc_ipv6_value = get_optional_value_for_key_in_config_tbl(config_db, port, "soc_ipv6", "MUX_CABLE")
+    if soc_ipv6_value is not None:
+        fvs["soc_ipv6"] = soc_ipv6_value
     prober_type_val = get_optional_value_for_key_in_config_tbl(config_db, port, "prober_type", "MUX_CABLE")
     if prober_type_val is not None:
         fvs["prober_type"] = prober_type_val
+    neighbor_mode_val = get_optional_value_for_key_in_config_tbl(config_db, port, "neighbor_mode", "MUX_CABLE")
+    if neighbor_mode_val is not None:
+        fvs["neighbor_mode"] = neighbor_mode_val
 
     fvs["pck_loss_data_reset"] = val
     try:
@@ -316,9 +329,15 @@ def update_configdb_prober_type(config_db, port, val):
     cable_type = get_optional_value_for_key_in_config_tbl(config_db, port, "cable_type", "MUX_CABLE")
     if cable_type is not None:
         fvs["cable_type"] = cable_type
+    soc_ipv6_value = get_optional_value_for_key_in_config_tbl(config_db, port, "soc_ipv6", "MUX_CABLE")
+    if soc_ipv6_value is not None:
+        fvs["soc_ipv6"] = soc_ipv6_value
     pck_loss_data = get_optional_value_for_key_in_config_tbl(config_db, port, "pck_loss_data_reset", "MUX_CABLE")
     if pck_loss_data is not None:
         fvs["pck_loss_data_reset"] = pck_loss_data
+    neighbor_mode_val = get_optional_value_for_key_in_config_tbl(config_db, port, "neighbor_mode", "MUX_CABLE")
+    if neighbor_mode_val is not None:
+        fvs["neighbor_mode"] = neighbor_mode_val
 
     fvs["prober_type"] = val
     try:

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1944,6 +1944,7 @@
         "cable_type": "active-active",
         "soc_ipv4": "10.1.1.2",
         "soc_ipv6": "fc00::76",
+        "neighbor_mode": "prefix-route",
         "server_ipv6": "fc00::75"
     },
     "MUX_CABLE|Ethernet16": {
@@ -1965,6 +1966,7 @@
     "MUX_CABLE|Ethernet4": {
         "state": "auto",
 	"prober_type": "software",
+	"neighbor_mode": "host-route",
         "server_ipv4": "10.3.1.1",
         "server_ipv6": "e801::46",
         "soc_ipv6": "e801::47"

--- a/tests/muxcable_test.py
+++ b/tests/muxcable_test.py
@@ -1020,6 +1020,87 @@ class TestMuxcable(object):
 
         assert result.exit_code == 0
 
+    def test_config_muxcable_mode_Ethernet4_preserves_neighbor_mode(self):
+        runner = CliRunner()
+        db = Db()
+
+        from swsscommon.swsscommon import ConfigDBConnector
+        original_set_entry = ConfigDBConnector.set_entry
+        set_entry_calls = []
+
+        def recording_set_entry(self_inner, table, key, data):
+            if table == "MUX_CABLE":
+                set_entry_calls.append((table, key, dict(data) if data else {}))
+            return original_set_entry(self_inner, table, key, data)
+
+        with mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper') as patched_util:
+            patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
+            with mock.patch.object(ConfigDBConnector, 'set_entry', recording_set_entry):
+                result = runner.invoke(config.config.commands["muxcable"].commands["mode"],
+                                       ["active", "Ethernet4"], obj=db)
+
+        assert result.exit_code == 0
+        assert len(set_entry_calls) == 1
+        fvs = set_entry_calls[0][2]
+        assert fvs.get("neighbor_mode") == "host-route"
+        assert fvs.get("prober_type") == "software"
+        assert fvs.get("soc_ipv6") == "e801::47"
+        assert fvs.get("state") == "active"
+
+    def test_config_muxcable_mode_Ethernet32_preserves_neighbor_mode(self):
+        runner = CliRunner()
+        db = Db()
+
+        from swsscommon.swsscommon import ConfigDBConnector
+        original_set_entry = ConfigDBConnector.set_entry
+        set_entry_calls = []
+
+        def recording_set_entry(self_inner, table, key, data):
+            if table == "MUX_CABLE":
+                set_entry_calls.append((table, key, dict(data) if data else {}))
+            return original_set_entry(self_inner, table, key, data)
+
+        with mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper') as patched_util:
+            patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
+            with mock.patch.object(ConfigDBConnector, 'set_entry', recording_set_entry):
+                result = runner.invoke(config.config.commands["muxcable"].commands["mode"],
+                                       ["active", "Ethernet32"], obj=db)
+
+        assert result.exit_code == 0
+        assert len(set_entry_calls) == 1
+        fvs = set_entry_calls[0][2]
+        assert fvs.get("neighbor_mode") == "prefix-route"
+        assert fvs.get("cable_type") == "active-active"
+        assert fvs.get("soc_ipv4") == "10.1.1.2"
+        assert fvs.get("soc_ipv6") == "fc00::76"
+        assert fvs.get("state") == "active"
+
+    def test_config_muxcable_probertype_Ethernet4_preserves_neighbor_mode(self):
+        runner = CliRunner()
+        db = Db()
+
+        from swsscommon.swsscommon import ConfigDBConnector
+        original_set_entry = ConfigDBConnector.set_entry
+        set_entry_calls = []
+
+        def recording_set_entry(self_inner, table, key, data):
+            if table == "MUX_CABLE":
+                set_entry_calls.append((table, key, dict(data) if data else {}))
+            return original_set_entry(self_inner, table, key, data)
+
+        with mock.patch('sonic_platform_base.sonic_sfp.sfputilhelper') as patched_util:
+            patched_util.SfpUtilHelper.return_value.get_asic_id_for_logical_port.return_value = 0
+            with mock.patch.object(ConfigDBConnector, 'set_entry', recording_set_entry):
+                result = runner.invoke(config.config.commands["muxcable"].commands["probertype"],
+                                       ["hardware", "Ethernet4"], obj=db)
+
+        assert result.exit_code == 0
+        assert len(set_entry_calls) == 1
+        fvs = set_entry_calls[0][2]
+        assert fvs.get("neighbor_mode") == "host-route"
+        assert fvs.get("prober_type") == "hardware"
+        assert fvs.get("soc_ipv6") == "e801::47"
+
     def test_config_muxcable_tabular_port_with_incorrect_index(self):
         runner = CliRunner()
         db = Db()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Mux neighbor_mode and prober_type config is preserved when muxcable.py configures mode, etc.

#### How I did it
Retrieve the optional config and set them back in config_db along with changed parameters of mux cable.

#### How to verify it
Verified on hardware by changing mux mode.
Verified using muxcable tests.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
No change
