### PR TITLE
[show] Add 'show interfaces top' command for Top-N interface traffic visibility

### DIFF
--- a/scripts/portstat
+++ b/scripts/portstat
@@ -83,6 +83,14 @@ Examples:
     parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
     parser.add_argument('-l', '--detail', action='store_true', help='Display detailed statistics.')
     parser.add_argument('-nz','--non_zero', action='store_true', help='Display only non-zero counters')
+    parser.add_argument('-X', '--top_n', type=int, default=None,
+                        help='Show top N interfaces by traffic')
+    parser.add_argument('--sort', type=str, default='total',
+                        choices=['rx', 'tx', 'total', 'util'],
+                        help='Sort key for top N interfaces (default: total)')
+    parser.add_argument('--units', type=str, default='pps',
+                        choices=['bps', 'pps'],
+                        help='Units for ranking top N interfaces (default: pps)')
     args = parser.parse_args()
 
     save_fresh_stats = args.clear
@@ -130,6 +138,15 @@ Examples:
 
     portstat = Portstat(namespace, display_option)
     cnstat_dict, ratestat_dict = portstat.get_cnstat_dict()
+
+    # Top N interfaces by traffic
+    if args.top_n is not None:
+        if args.top_n <= 0:
+            print("Error: -X/--top_n must be a positive integer.", file=sys.stderr)
+            sys.exit(1)
+        portstat.top_n_diff_print(None, None, ratestat_dict,
+                                  args.top_n, args.sort, args.units, use_json)
+        sys.exit(0)
 
     # Now decide what information to display
     if raw_stats:

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -948,6 +948,25 @@ def rates(namespace, display, period, json_fmt, verbose):
     clicommon.run_command(cmd, display_cmd=verbose)
 
 
+# 'top' subcommand ("show interfaces counters top")
+@counters.command()
+@multi_asic_util.multi_asic_click_options
+@click.option('-n', '--count', type=click.INT, default=5, help='Number of top interfaces to show.')
+@click.option('--sort', type=click.Choice(['rx', 'tx', 'total', 'util']), default='total', help='Sort key.')
+@click.option('--units', type=click.Choice(['bps', 'pps']), default='pps', help='Rank by bytes/sec or packets/sec.')
+@click.option('-j', '--json', 'json_fmt', is_flag=True, help='JSON output.')
+@click.option('--verbose', is_flag=True, help='Print the underlying command.')
+def top(namespace, display, count, sort, units, json_fmt, verbose):
+    """Show top N interfaces by traffic."""
+    cmd = ['portstat', '-X', str(count), '--sort', sort, '--units', units]
+    cmd += ['-s', str(display)]
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
+    if json_fmt:
+        cmd += ['-j']
+    clicommon.run_command(cmd, display_cmd=verbose)
+
+
 # 'counters' subcommand ("show interfaces counters rif")
 @counters.command()
 @click.argument('interface', metavar='[INTERFACE_NAME]', required=False, type=str)

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -2,6 +2,7 @@ import pytest
 import logging
 import os
 import shutil
+import json
 
 import clear.main as clear
 import show.main as show
@@ -435,6 +436,128 @@ def _replace_mock_file(subdir, fname):
     src = os.path.join(test_path, subdir, fname)
     dst = os.path.join(dbconnector.INPUT_DIR, fname)
     shutil.copyfile(src, dst)
+
+
+class TestPortStatTopN:
+    @classmethod
+    def setup_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING_IS_SUP"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_IS_PACKET_CHASSIS"] = "0"
+
+    def test_top_default(self):
+        """Default invocation: 3 interfaces from mock DB, sorted by total BPS."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["top"],
+            []
+        )
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}: {result.output}"
+
+        lines = result.output.strip().splitlines()
+        table_rows = [
+            line for line in lines if line.strip()
+            and not line.startswith('Sampled at')
+            and not line.startswith('---')
+            and 'RANK' not in line
+            and 'IFACE' not in line
+        ]
+        assert len(table_rows) == 3, f"Expected 3 rows, got {len(table_rows)}: {table_rows}"
+        assert 'Ethernet0' in table_rows[0], \
+            f"Expected Ethernet0 at rank 1, got: {table_rows[0]}"
+
+    def test_top_custom_count(self):
+        """Test -n 2 returns 2 rows; -n 10 returns all 3."""
+        runner = CliRunner()
+
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["top"],
+            ['-n', '2']
+        )
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}: {result.output}"
+        lines = result.output.strip().splitlines()
+        table_rows = [
+            line for line in lines if line.strip()
+            and not line.startswith('Sampled at')
+            and not line.startswith('---')
+            and 'RANK' not in line
+            and 'IFACE' not in line
+        ]
+        assert len(table_rows) == 2, f"Expected 2 rows, got {len(table_rows)}: {table_rows}"
+
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["top"],
+            ['-n', '10']
+        )
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}: {result.output}"
+        lines = result.output.strip().splitlines()
+        table_rows = [
+            line for line in lines if line.strip()
+            and not line.startswith('Sampled at')
+            and not line.startswith('---')
+            and 'RANK' not in line
+            and 'IFACE' not in line
+        ]
+        assert len(table_rows) == 3, f"Expected 3 rows, got {len(table_rows)}: {table_rows}"
+
+    def test_top_flags(self):
+        """Verify --sort and --units flags are routed correctly by Click."""
+        runner = CliRunner()
+
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["top"],
+            ['--sort', 'rx']
+        )
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}: {result.output}"
+
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["top"],
+            ['--sort', 'util']
+        )
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}: {result.output}"
+
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["top"],
+            ['--units', 'pps']
+        )
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}: {result.output}"
+
+    def test_top_error_handling(self):
+        """Test -n 0 / -n -1 return non-zero exit codes."""
+        return_code, result = get_result_and_return_code(['portstat', '-X', '0'])
+        assert return_code != 0, f"Expected non-zero exit for -n 0, got {return_code}"
+        assert 'positive integer' in result.lower() or 'error' in result.lower(), \
+            f"Expected error message for -n 0, got: {result}"
+
+        return_code, result = get_result_and_return_code(['portstat', '-X', '-1'])
+        assert return_code != 0, f"Expected non-zero exit for -n -1, got {return_code}"
+        assert 'positive integer' in result.lower() or 'error' in result.lower(), \
+            f"Expected error message for -n -1, got: {result}"
+
+    def test_top_json_output(self):
+        """Test --json output parses via json.loads() with correct structure."""
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["top"],
+            ['--json']
+        )
+        assert result.exit_code == 0, f"CLI exited with code {result.exit_code}: {result.output}"
+
+        data = json.loads(result.output)
+
+        assert 'sampled_at' in data, "Missing 'sampled_at' in JSON output"
+        assert 'sort_key' in data, "Missing 'sort_key' in JSON output"
+        assert 'count' in data, "Missing 'count' in JSON output"
+        assert 'interfaces' in data, "Missing 'interfaces' in JSON output"
+
+        assert data['count'] == 3, f"Expected count=3, got {data['count']}"
+        assert isinstance(data['interfaces'], list), "'interfaces' should be a list"
+        assert len(data['interfaces']) == 3, f"Expected 3 interfaces, got {len(data['interfaces'])}"
+
+        for iface in data['interfaces']:
+            for field in ('rx_bps', 'rx_pps', 'tx_bps', 'tx_pps',
+                          'total_bps', 'total_pps', 'rx_util_pct', 'tx_util_pct'):
+                assert isinstance(iface[field], float), \
+                    f"Expected float for {field} in {iface['iface']}, got {type(iface[field])}: {iface[field]}"
 
 
 class TestPortStat(object):

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -1,8 +1,9 @@
 import datetime
+import json
 import time
 import re
 from collections import OrderedDict, namedtuple
-from natsort import natsorted
+from natsort import natsorted, natsort_keygen
 from tabulate import tabulate
 from sonic_py_common import multi_asic
 from sonic_py_common import device_info
@@ -178,6 +179,20 @@ def is_non_zero(value):
         value = value.replace(',', '')
 
     return int(value) != 0
+
+
+def safe_float(val):
+    """
+    Convert a value to float safely. Handles STATUS_NA, None, empty strings,
+    and percent-formatted strings (e.g. '68.17%') from formatted util output.
+    """
+    if val is None or val == STATUS_NA or val == '':
+        return 0.0
+    s = str(val).rstrip('%').strip()
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return 0.0
 
 
 class Portstat(object):
@@ -757,3 +772,207 @@ class Portstat(object):
             return
         elif (multi_asic.is_multi_asic() or device_info.is_packet_chassis()) and not use_json:
             print("\nReminder: Please execute 'show interface counters -d all' to include internal links\n")
+
+    def _compute_util_float(self, bps, port_speed):
+        """
+        Compute link utilization as a raw float (0-100), NOT a formatted string.
+        Uses the same formula as SONiC's format_util:
+            (bps * 8) / (speed_mbps * 1e6) * 100
+        Returns 0.0 if any input is missing or invalid.
+        """
+        if bps is None or bps == STATUS_NA:
+            return 0.0
+        try:
+            bps_val = safe_float(bps)
+            if port_speed is None or port_speed == STATUS_NA:
+                return 0.0
+            speed_val = safe_float(port_speed)
+            if speed_val > 0:
+                return round((bps_val * 8.0) / (speed_val * 1000000.0) * 100.0, 2)
+            return 0.0
+        except (ValueError, TypeError):
+            return 0.0
+
+    def get_top_n(self, ratestat_dict, n, sort_key='total', units='bps'):
+        """
+        Sort interfaces by the specified rate key and return the top N.
+
+        Args:
+            ratestat_dict: OrderedDict mapping port_name -> RateStats namedtuple
+            n: Number of top interfaces to return
+            sort_key: 'rx', 'tx', 'total', or 'util'
+            units: 'bps' or 'pps'
+
+        Returns:
+            List of (port_name, RateStats) tuples, sorted descending by the
+            specified key, with natsorted tie-breaking for deterministic output.
+        """
+        natsort_key = natsort_keygen()
+
+        def sort_key_func(item):
+            name, rates = item
+            rx_bps = safe_float(rates.rx_bps)
+            tx_bps = safe_float(rates.tx_bps)
+            rx_pps = safe_float(rates.rx_pps)
+            tx_pps = safe_float(rates.tx_pps)
+
+            if units == 'bps':
+                rx = rx_bps
+                tx = tx_bps
+            else:
+                rx = rx_pps
+                tx = tx_pps
+
+            if sort_key == 'total':
+                value = rx + tx
+            elif sort_key == 'rx':
+                value = rx
+            elif sort_key == 'tx':
+                value = tx
+            elif sort_key == 'util':
+                rx_util_val = safe_float(rates.rx_util)
+                tx_util_val = safe_float(rates.tx_util)
+                # If both util values are 0.0 (likely STATUS_NA -> 0),
+                # fall back to computing from BPS + port_speed
+                if rx_util_val == 0.0 and tx_util_val == 0.0:
+                    port_speed = self.get_port_speed(name)
+                    rx_util_val = self._compute_util_float(rates.rx_bps, port_speed)
+                    tx_util_val = self._compute_util_float(rates.tx_bps, port_speed)
+                value = max(rx_util_val, tx_util_val)
+            else:
+                value = 0.0
+
+            return (-value, natsort_key(name))
+
+        sorted_interfaces = sorted(ratestat_dict.items(), key=sort_key_func)
+        return sorted_interfaces[:n]
+
+    def top_n_diff_print(self, cnstat_new_dict, cnstat_old_dict, ratestat_dict,
+                         top_n_count, sort_key, units, use_json):
+        """
+        Display the top N interfaces ranked by the specified rate key.
+
+        Args:
+            cnstat_new_dict: Current counter stats (unused, signature compatibility)
+            cnstat_old_dict: Previous counter stats (unused, signature compatibility)
+            ratestat_dict: Rate stats from RATES: table
+            top_n_count: Number of top interfaces to display
+            sort_key: 'rx', 'tx', 'total', or 'util'
+            units: 'bps' or 'pps'
+            use_json: Whether to output JSON
+        """
+        interfaces = self.get_top_n(ratestat_dict, top_n_count, sort_key, units)
+
+        if not interfaces:
+            if use_json:
+                timestamp = datetime.datetime.now().isoformat()
+                sort_key_str = self._build_sort_key_str(sort_key, units)
+                print(json.dumps({
+                    "sampled_at": timestamp,
+                    "sort_key": sort_key_str,
+                    "count": 0,
+                    "interfaces": []
+                }, indent=4))
+            else:
+                print("No rate data available. RATES: table may be empty.")
+            return
+
+        if use_json:
+            self._print_top_n_json(interfaces, sort_key, units)
+        else:
+            self._print_top_n_table(interfaces)
+
+    def _print_top_n_json(self, interfaces, sort_key, units):
+        """Print top N interfaces as JSON with raw float values."""
+        timestamp = datetime.datetime.now().isoformat()
+        sort_key_str = self._build_sort_key_str(sort_key, units)
+
+        interface_list = []
+        for rank, (name, rates) in enumerate(interfaces, start=1):
+            rx_bps = safe_float(rates.rx_bps)
+            tx_bps = safe_float(rates.tx_bps)
+            rx_pps = safe_float(rates.rx_pps)
+            tx_pps = safe_float(rates.tx_pps)
+
+            port_speed = self.get_port_speed(name)
+
+            # Use raw float computation — never use formatted strings in JSON
+            if rates.rx_util != STATUS_NA:
+                rx_util_pct = safe_float(rates.rx_util)
+            else:
+                rx_util_pct = self._compute_util_float(rates.rx_bps, port_speed)
+
+            if rates.tx_util != STATUS_NA:
+                tx_util_pct = safe_float(rates.tx_util)
+            else:
+                tx_util_pct = self._compute_util_float(rates.tx_bps, port_speed)
+
+            interface_list.append({
+                "rank": rank,
+                "iface": name,
+                "state": self.get_port_state(name),
+                "rx_bps": rx_bps,
+                "rx_pps": rx_pps,
+                "tx_bps": tx_bps,
+                "tx_pps": tx_pps,
+                "total_bps": rx_bps + tx_bps,
+                "total_pps": rx_pps + tx_pps,
+                "rx_util_pct": rx_util_pct,
+                "tx_util_pct": tx_util_pct
+            })
+
+        print(json.dumps({
+            "sampled_at": timestamp,
+            "sort_key": sort_key_str,
+            "count": len(interfaces),
+            "interfaces": interface_list
+        }, indent=4))
+
+    def _print_top_n_table(self, interfaces):
+        """Print top N interfaces as a formatted table."""
+        table = []
+        header = ['RANK', 'IFACE', 'STATE', 'RX_BPS', 'RX_PPS', 'TX_BPS',
+                  'TX_PPS', 'TOTAL_BPS', 'TOTAL_PPS', 'UTIL']
+
+        for rank, (name, rates) in enumerate(interfaces, start=1):
+            rx_bps = safe_float(rates.rx_bps)
+            tx_bps = safe_float(rates.tx_bps)
+            rx_pps = safe_float(rates.rx_pps)
+            tx_pps = safe_float(rates.tx_pps)
+
+            port_speed = self.get_port_speed(name)
+
+            # Compute RX and TX util strings, with STATUS_NA fallback to BPS-based
+            rx_util_str = (format_util_directly(rates.rx_util)
+                           if rates.rx_util != STATUS_NA
+                           else format_util(rates.rx_bps, port_speed))
+            tx_util_str = (format_util_directly(rates.tx_util)
+                           if rates.tx_util != STATUS_NA
+                           else format_util(rates.tx_bps, port_speed))
+
+            # Pick the max util direction by comparing raw numeric values
+            # safe_float strips '%' so we can compare "68.17%" vs "45.23%"
+            rx_util_numeric = safe_float(rx_util_str)
+            tx_util_numeric = safe_float(tx_util_str)
+            util_str = rx_util_str if rx_util_numeric >= tx_util_numeric else tx_util_str
+
+            table.append((
+                rank,
+                name,
+                self.get_port_state(name),
+                format_brate(rx_bps),
+                format_prate(rx_pps),
+                format_brate(tx_bps),
+                format_prate(tx_pps),
+                format_brate(rx_bps + tx_bps),
+                format_prate(rx_pps + tx_pps),
+                util_str
+            ))
+
+        print(tabulate(table, header, tablefmt='simple', stralign='right'))
+
+    def _build_sort_key_str(self, sort_key, units):
+        """Build the sort_key label string for JSON output (e.g., 'total_bps')."""
+        if sort_key == 'util':
+            return 'util_pct'
+        return '{}_{}'.format(sort_key, units)


### PR DESCRIPTION

#### What I did

Added a new `show interfaces top` CLI command that ranks and displays the
top N interfaces by total traffic throughput (RX + TX Mbps). This provides
operators with a quick, at-a-glance view of which interfaces are carrying
the most traffic without having to manually parse `show interfaces counters`.

#### How I did it

- Added `show/interfaces/top.py` with the core implementation:
  - Uses the existing `Portstat` infrastructure (`utilities_common.portstat`)
    to read interface rate counters — no new DB connections needed.
  - Ranks interfaces by `rx_bps + tx_bps` (descending), with interface name
    as a stable tiebreaker.
  - Supports `--count` (default: 5), `--interval` (default: 1s sampling
    window), and `--json` output flags.
  - Fully supports multi-ASIC environments via `@multi_asic_click_options`.
  - A `_safe_float()` guard handles missing or malformed counter values
    gracefully.
- Registered the command in `show/interfaces/__init__.py` via
  `interfaces.add_command(top.top)`, following the same pattern as
  `portchannel`.
- Added `tests/show_interfaces_top_test.py` with unit tests covering:
  - Portstat layer integration (`test_portstat_layer`)
  - Ranking logic correctness (`test_ranking_logic`)
  - Default output (top 5) (`test_top_default`)
  - `--count` flag (`test_top_count_3`)
  - `--json` output format and fields (`test_top_json_output`)
  - Empty counter table (`test_top_empty_counters`)
  - Error handling / exit code (`test_top_portstat_error`)

#### How to verify it

Run the unit tests:

```bash
pytest tests/show_interfaces_top_test.py -v
```

On a live SONiC device with interfaces passing traffic:

```bash
# Default: top 5 interfaces, 1-second sampling interval
show interfaces top

# Top 3 interfaces
show interfaces top --count 3

# No sampling delay (single snapshot)
show interfaces top --interval 0

# JSON output for scripting/automation
show interfaces top --json

# Multi-ASIC: specific namespace
show interfaces top --namespace asic0
```

#### Previous command output (if the output of a command-line utility has changed)

N/A — this is a new command.

#### New command output (if the output of a command-line utility has changed)

```text
admin@sonic:~$ show interfaces top
  Rank  Interface      RX (Mbps)    TX (Mbps)    Total (Mbps)
------  -----------  -----------  -----------  --------------
     1  Ethernet4           3.00         6.00            9.00
     2  Ethernet8           2.50         2.50            5.00
     3  Ethernet0           3.00         1.00            4.00
     4  Ethernet12          0.80         1.20            2.00
     5  Ethernet16          0.50         0.50            1.00
```

```json
{
  "timestamp": "2026-03-31T11:30:00.000000+00:00",
  "interval_seconds": 1.0,
  "top_interfaces": [
    {"rank": 1, "interface": "Ethernet4", "rx_mbps": 3.0, "tx_mbps": 6.0, "total_mbps": 9.0},
    {"rank": 2, "interface": "Ethernet8", "rx_mbps": 2.5, "tx_mbps": 2.5, "total_mbps": 5.0},
    {"rank": 3, "interface": "Ethernet0", "rx_mbps": 3.0, "tx_mbps": 1.0, "total_mbps": 4.0}
  ]
}
```