### PR TITLE
sonic_installer: sync before migration to eliminate timeout

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -360,6 +360,12 @@ def migrate_sonic_packages(bootloader, binary_image_version):
             run_command_or_raise(["mkdir", "-p", new_image_work_dir])
             mount_overlay_fs(new_image_mount, new_image_upper_dir, new_image_work_dir, new_image_mount)
             mount_bind(new_image_docker_dir, new_image_docker_mount)
+
+            # sync to eliminate timeout on the
+            # chroot /tmp/image-fs SONIC_PACKAGE_MANAGER migrate /tmp/packages.json --dockerd-socket DOCKERD_SOCK
+            click.echo('Command sync ...   could take several seconds on slow or removable disk')
+            run_command(["sync"])
+
             mount_procfs_chroot(new_image_mount)
             mount_sysfs_chroot(new_image_mount)
             # Assume if docker.sh script exists we are installing Application Extension compatible image.


### PR DESCRIPTION
#### What I did
FIX sinic-install image always fails to install image on a device with slow NVRAM/Disk (USB Disk-On-Key)
   umount: /tmp/imageX: target is busy.
   cannot remove '/tmp/imageX/var/lib/docker': Device or resource busy
   sonic_installer.exception.SonicRuntimeException: Failed to run command '['chroot',  'sonic-package-manager',
          'migrate', '/tmp/packages.json', '--dockerd-socket', '/tmp/docker.sock', '-y']'

#### How I did it
Add extra 'sync' command to the sonic_installer to eliminate timeout
sync/flush/umount for unpacked ~4GB image takes minutes.
"sync" command is finit (no timeout required), riskless, generic for all ARCH and platforms.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

