### PR TITLE
[GCU] Fix GCU MGMT_INTERFACE/interface_key/forced_mgmt_routes removal  ERR log

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1811,7 +1811,7 @@ class LowLevelMoveGenerator:
             yield move
 
     def _traverse_current_list(self, ptr, current_tokens):
-        if len(ptr) == 0:
+        if len(ptr) <= 1:
             yield JsonMoveGroup(self.__class__.__name__, JsonMove(self.diff, OperationType.REMOVE, current_tokens))
             return
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
 When GCU Patching tries to remove MGMT_INTERFACE/forced_mgmt_routes, it constructs the forced_mgmt_routes with empty list instead of deleting the 'forced_mgmt_routes' data field from the config Json data.  When self.ctx.parse_data_mem(dumps(self.xlateJson) parses the json file which contains a empty list, it returns a failure.  This PR modifies function _traverse_current_list() to remove the data field from entry when its value is an empty list.  Fixes  https://github.com/sonic-net/sonic-buildimage/issues/23872

#### How I did it
MGMT_INTERFACE/eth0|<ipv4_address|ipv6_address>/forced_mgmt_routes attribute is a list in configuration entry.  When the last element of this list is removed, the configuration key "forced_mgmt_routes" should be deleted from the entry. But the current GCU 'generator' constructs an empty list instead of deleting this configuration key and value from the configuration entry.  An empty list value in the json file causes _yang.Context_parse_data_mem() returns error due to Yang model validation.  This PR modifies the _traverse_current_list() check "if  len(prt) <= 1" insteaf of "if len(ptr) == 0"  to constructs a configuration path ([{"op": "remove", "path": "/MGMT_INTERFACE/eth0|FC00:2::32~164/forced_mgmt_routes"}] without index when the last element is removed.  This change will generate the config DB without an empty list value in the configuration.  And this will pass the Yang model validation when  _yang.Context_parse_data_mem() parse the config json file. 

#### How to verify it
1. Add a forced_mgmt_route :  

```
Patch Content: [
    {
        "path": "/localhost/MGMT_INTERFACE/eth0|FC00:2::32~164/forced_mgmt_routes",
        "value": [
            "1::2:3:4/64"
        ],
        "op": "add"
    }
]
```

2. Remove forced_mgmt_route :
```
Patch Content: [
    {
        "path": "/localhost/MGMT_INTERFACE/eth0|FC00:2::32~164/forced_mgmt_routes",
        "op": "remove"
    }
]
```
3) Apply both patch files. No error shown
'''
admin@line-card25:~$ sudo config apply-patch eth0-add.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"path": "/MGMT_INTERFACE/eth0|FC00:2::32~164/forced_mgmt_routes", "value": ["1::2:3:4/64"], "op": "add"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 0 changes.
Patch Applier: localhost: applying 0 changes in order.
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
admin@line-card25:~$ sudo config apply-patch eth0-del.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"path": "/MGMT_INTERFACE/eth0|FC00:2::32~164/forced_mgmt_routes", "op": "remove"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier: localhost: applying 1 change in order:
Patch Applier:   * [{"op": "remove", "path": "/MGMT_INTERFACE/eth0|FC00:2::32~164/forced_mgmt_routes"}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
admin@line-card25:~$ 
'''
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202601
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511
- [x] 202601 private image 
- [x] 202605, docker-sonic-vs `0b2faef94`

#### Test result

202605: PASS. Tested by @rimunagala, because 202605 needs this change as a prerequisite for #4731. Everything in this section is my own run on 202605; the 202511 and 202601 entries above are @mlok-nokia's.

Image: 202605 `docker-sonic-vs`, `branch: '202605'`, `commit_id: '0b2faef94'`.

Unit tests, `tests/generic_config_updater/`:

| 202605 tree | result |
| --- | --- |
| baseline, nothing picked | 549 passed |
| this PR only | 549 passed, no regression |
| #4731 only | 552 passed, 1 failed |
| this PR + #4731 | 553 passed, 0 failed |

The failure without this PR is `test_patch_sorter__remove_last_bgp_allowed_prefix__removes_field_instead_of_emptying_it`, which asserts the single change form that `len(ptr) <= 1` produces. So this PR has to reach 202605 before #4731, otherwise the cherry-pick of #4731 fails its own unit test in CI.

Functional check on 202605 using the removal from **How to verify it** above:

```
202605 without this PR:
Patch Applier: The localhost patch was converted into 2 changes:
Patch Applier:   * [{"op": "remove", "path": ".../forced_mgmt_routes/0"}]
Patch Applier:   * [{"op": "remove", "path": ".../forced_mgmt_routes"}]

202605 with this PR:
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier:   * [{"op": "remove", "path": ".../forced_mgmt_routes"}]
```

`forced_mgmt_routes` ends up absent from CONFIG_DB either way, so on this image the difference is the change count, and with this PR 202605 matches master. The cherry-pick applies cleanly on 202605.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)


