### PR TITLE
Fix route_check.py ijson performance regression

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -47,14 +47,13 @@ import signal
 import traceback
 import subprocess
 import concurrent.futures
-os.environ.setdefault('IJSON_BACKEND', 'python')
-import ijson  # noqa: E402
+import ijson
 
-from ipaddress import ip_network  # noqa: E402
-from swsscommon import swsscommon  # noqa: E402
-from utilities_common import chassis  # noqa: E402
-from sonic_py_common import multi_asic, device_info  # noqa: E402
-from utilities_common.general import load_db_config  # noqa: E402
+from ipaddress import ip_network
+from swsscommon import swsscommon
+from utilities_common import chassis
+from sonic_py_common import multi_asic, device_info
+from utilities_common.general import load_db_config
 
 APPL_DB_NAME = 'APPL_DB'
 ASIC_DB_NAME = 'ASIC_DB'


### PR DESCRIPTION
#### What I did

Remove the forced `IJSON_BACKEND=python` override in `route_check.py`. The pure-Python
ijson backend is slow, causing route_check to take 21 minutes on chassis platforms with
100K+ routes (reported in sonic-net/sonic-buildimage#23442).

The companion sonic-buildimage PR installs `python3-ijson` from Debian repos, which
provides the fast `yajl2_c` C extension backend. With this backend available, ijson
auto-detects it — delivering 24× better performance while remaining safe under monit's
`MemoryDenyWriteExecute=true`.

Fixes sonic-net/sonic-buildimage#23442

#### How I did it

Removed `os.environ.setdefault('IJSON_BACKEND', 'python')` from `scripts/route_check.py`
(line 50).

#### How to verify it

1. Build a VS image with the companion sonic-buildimage PR
2. On the DUT, verify: `python3 -c "import ijson; print(ijson.backend)"` → `yajl2_c`
3. Run `sudo route_check.py` — completes in seconds instead of minutes
4. Check `sudo monit summary` — `routeCheck` shows OK (no crash)

**Unit test results (37/37 passed):**
```
tests/route_check_test.py::TestRouteCheck::test_route_check_default_namespace PASSED
tests/route_check_test.py::TestRouteCheck::test_route_check_multi_asic PASSED
... (all 37 tests passed in 85.38s)
```

**On-box validation (KVM VS testbed):**
- `ijson.backend` = `yajl2_c` ✅
- `MemoryDenyWriteExecute=true` active, no crash ✅
- `routeCheck` monit status: OK ✅
- `route_check.py` manual run: 4.3s ✅

**Nokia on-box validation (reported by @saksarav-nokia on issue #23442):**
- Route check time: 21 min → 1 min 12 sec

#### Previous command output (if the output of a command-line utility has changed)

N/A — no CLI output changes.

#### New command output (if the output of a command-line utility has changed)

N/A