### PR TITLE
Clarify in the help string how negative values can be specified when configuring transceiver tx-power

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6179,17 +6179,19 @@ def frequency(ctx, interface_name, frequency):
     clicommon.run_command(command)
 
 
-#
-# 'tx_power' subcommand ('config interface transceiver tx_power ...')
-# For negative float use:-
-# config interface transceiver tx_power Ethernet0 -- -27.4"
-#
 @transceiver.command('tx_power')
 @click.pass_context
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument('tx-power', metavar='<tx-power>', required=True, type=float)
 def tx_power(ctx, interface_name, tx_power):
-    """Set transceiver (only for 400G-ZR) Tx laser power"""
+    """Set transciever (only for 400G-ZR) Tx laser power.
+
+    For negative values, you must insert ``--`` before the value so that
+    Click treats it as a positional argument instead of an option. For example:
+
+      config interface transceiver tx_power Ethernet0 -- -11
+    """
+
     # Get the config_db connector
     config_db = ctx.obj['config_db']
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The config interface transceiver tx_power command is built using click, and tx_power is a argument instead of an option. This means this command does not accept a value, and so a negative number being passed in after this variable gets parsed as a flag which leads to the user not being able to set negative numbers. There is a comment explaining how to pass in neg numbers, but is not part of the docstring, and so is omitted from the help message. I moved the text to be part of the docstring

#### How I did it

Changed the comment to be part of the docstring. 

#### How to verify it
```
sudo config interface transceiver tx_power --help
Usage: config interface transceiver tx_power [OPTIONS] <interface_name> <tx-
                                             power>

  Set transciever (only for 400G-ZR) Tx laser power.

  For negative values, you must insert ``--`` before the value so that Click
  treats it as a positional argument instead of an option. For example:

    config interface transceiver tx_power Ethernet0 -- -11

Options:
  -?, -h, --help  Show this message and exit.
```
#### Previous command output (if the output of a command-line utility has changed)
```
sudo config interface transceiver tx_power --help
Usage: config interface transceiver tx_power [OPTIONS] <interface_name> <tx-
                                             power>

  Set transciever (only for 400G-ZR) Tx laser power

Options:
  -?, -h, --help  Show this message and exit.
```

#### New command output (if the output of a command-line utility has changed)
```
sudo config interface transceiver tx_power --help
Usage: config interface transceiver tx_power [OPTIONS] <interface_name> <tx-
                                             power>

  Set transciever (only for 400G-ZR) Tx laser power.

  For negative values, you must insert ``--`` before the value so that Click
  treats it as a positional argument instead of an option. For example:

    config interface transceiver tx_power Ethernet0 -- -11

Options:
  -?, -h, --help  Show this message and exit.
```
