### PR TITLE
Fix multi-ASIC package feature management

### DIFF
--- a/config/feature.py
+++ b/config/feature.py
@@ -16,12 +16,17 @@ def set_feature_state(cfgdb_clients, name, state, block):
         entry_data = cfgdb.get_entry('FEATURE', name)
         if not entry_data:
             raise Exception("Feature '{}' doesn't exist".format(name))
-        entry_data_set.add(entry_data['state'])
+        entry_state = entry_data.get('state')
+        if entry_state is not None:
+            entry_data_set.add(entry_state)
+
+    if not entry_data_set:
+        raise Exception("Feature '{}' state is not available in any namespace".format(name))
 
     if len(entry_data_set) > 1:
         raise Exception("Feature '{}' state is not consistent across namespaces".format(name))
 
-    if entry_data['state'] == "always_enabled":
+    if entry_data_set.pop() == "always_enabled":
         raise Exception("Feature '{}' state is always enabled and can not be modified".format(name))
 
     for ns, cfgdb in cfgdb_clients.items():
@@ -137,13 +142,19 @@ def feature_autorestart(db, name, autorestart):
         if not entry_data:
             click.echo("Feature '{}' doesn't exist".format(name))
             sys.exit(1)
-        entry_data_set.add(entry_data['auto_restart'])
+        entry_auto_restart = entry_data.get('auto_restart')
+        if entry_auto_restart is not None:
+            entry_data_set.add(entry_auto_restart)
+
+    if not entry_data_set:
+        click.echo("Feature '{}' auto-restart is not available in any namespace".format(name))
+        sys.exit(1)
 
     if len(entry_data_set) > 1:
         click.echo("Feature '{}' auto-restart is not consistent across namespaces".format(name))
         sys.exit(1)
 
-    if entry_data['auto_restart'] == "always_enabled":
+    if entry_data_set.pop() == "always_enabled":
         click.echo("Feature '{}' auto-restart is always enabled and can not be modified".format(name))
         return
 

--- a/config/feature.py
+++ b/config/feature.py
@@ -16,6 +16,8 @@ def set_feature_state(cfgdb_clients, name, state, block):
         entry_data = cfgdb.get_entry('FEATURE', name)
         if not entry_data:
             raise Exception("Feature '{}' doesn't exist".format(name))
+        # Entries missing 'state' are deliberately excluded from the
+        # consistency check; they are backfilled by the write below.
         entry_state = entry_data.get('state')
         if entry_state is not None:
             entry_data_set.add(entry_state)
@@ -142,6 +144,8 @@ def feature_autorestart(db, name, autorestart):
         if not entry_data:
             click.echo("Feature '{}' doesn't exist".format(name))
             sys.exit(1)
+        # Entries missing 'auto_restart' are deliberately excluded from the
+        # consistency check; they are backfilled by the write below.
         entry_auto_restart = entry_data.get('auto_restart')
         if entry_auto_restart is not None:
             entry_data_set.add(entry_auto_restart)

--- a/sonic_package_manager/service_creator/sonic_db.py
+++ b/sonic_package_manager/service_creator/sonic_db.py
@@ -7,6 +7,7 @@ import os
 from swsscommon import swsscommon
 
 from config.config_mgmt import sonic_cfggen
+from sonic_py_common import device_info
 
 from sonic_package_manager.service_creator import ETC_SONIC_PATH
 from sonic_package_manager.service_creator.utils import in_chroot
@@ -92,6 +93,7 @@ class SonicDB:
     configs. """
 
     _running_db_conn = None
+    _namespace_db_conns = None
 
     @classmethod
     def get_connectors(cls):
@@ -103,6 +105,35 @@ class SonicDB:
         yield initial_db_conn
         if running_db_conn is not None:
             yield running_db_conn
+            for ns_conn in cls.get_namespace_db_connectors():
+                yield ns_conn
+
+    @classmethod
+    def get_namespace_db_connectors(cls):
+        """ Returns namespace CONFIG_DB connectors for multi-ASIC platforms.
+
+        On multi-ASIC systems each ASIC namespace has its own CONFIG_DB.
+        This method returns connectors for all namespace CONFIG_DBs so that
+        callers of get_connectors() write to every CONFIG_DB instance.
+        """
+
+        if in_chroot():
+            return []
+
+        if cls._namespace_db_conns is None:
+            cls._namespace_db_conns = []
+            if device_info.is_multi_npu():
+                from swsscommon.swsscommon import SonicDBConfig
+                SonicDBConfig.initializeGlobalConfig()
+                for ns in device_info.get_namespaces():
+                    try:
+                        conn = swsscommon.ConfigDBConnector(namespace=ns)
+                        conn.connect()
+                        cls._namespace_db_conns.append(conn)
+                    except RuntimeError:
+                        pass
+
+        return cls._namespace_db_conns
 
     @classmethod
     def get_running_db_connector(cls):

--- a/sonic_package_manager/service_creator/sonic_db.py
+++ b/sonic_package_manager/service_creator/sonic_db.py
@@ -110,28 +110,26 @@ class SonicDB:
 
     @classmethod
     def get_namespace_db_connectors(cls):
-        """ Returns namespace CONFIG_DB connectors for multi-ASIC platforms.
+        """ Returns per-ASIC namespace CONFIG_DB connectors (empty on single-ASIC).
 
-        On multi-ASIC systems each ASIC namespace has its own CONFIG_DB.
-        This method returns connectors for all namespace CONFIG_DBs so that
-        callers of get_connectors() write to every CONFIG_DB instance.
+        Resolved once and cached. A namespace that fails to connect raises
+        rather than being skipped, and the cache is populated only once all
+        namespaces connect, so a failed run is retried on the next call.
         """
 
         if in_chroot():
             return []
 
         if cls._namespace_db_conns is None:
-            cls._namespace_db_conns = []
+            conns = []
             if device_info.is_multi_npu():
-                from swsscommon.swsscommon import SonicDBConfig
-                SonicDBConfig.initializeGlobalConfig()
+                if not swsscommon.SonicDBConfig.isGlobalInit():
+                    swsscommon.SonicDBConfig.initializeGlobalConfig()
                 for ns in device_info.get_namespaces():
-                    try:
-                        conn = swsscommon.ConfigDBConnector(namespace=ns)
-                        conn.connect()
-                        cls._namespace_db_conns.append(conn)
-                    except RuntimeError:
-                        pass
+                    conn = swsscommon.ConfigDBConnector(namespace=ns)
+                    conn.connect()
+                    conns.append(conn)
+            cls._namespace_db_conns = conns
 
         return cls._namespace_db_conns
 

--- a/sonic_package_manager/service_creator/sonic_db.py
+++ b/sonic_package_manager/service_creator/sonic_db.py
@@ -112,9 +112,11 @@ class SonicDB:
     def get_namespace_db_connectors(cls):
         """ Returns per-ASIC namespace CONFIG_DB connectors (empty on single-ASIC).
 
-        Resolved once and cached. A namespace that fails to connect raises
-        rather than being skipped, and the cache is populated only once all
-        namespaces connect, so a failed run is retried on the next call.
+        In chroot this is a fast-path that always returns an empty list
+        without caching. Otherwise the result is resolved once and cached:
+        a namespace that fails to connect raises rather than being skipped,
+        and the cache is populated only once all namespaces connect, so a
+        failed run is retried on the next call.
         """
 
         if in_chroot():

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -187,6 +187,52 @@ config_feature_bgp_inconsistent_autorestart_output="""\
 Feature 'bgp' auto-restart is not consistent across namespaces
 """
 
+
+class TestSetFeatureStateUnit(object):
+
+    def test_set_feature_state_missing_state_key(self):
+        from config.feature import set_feature_state
+
+        mock_cfgdb = mock.MagicMock()
+        mock_cfgdb.get_entry.return_value = {'auto_restart': 'enabled'}
+        cfgdb_clients = {'': mock_cfgdb, 'asic0': mock_cfgdb}
+
+        with pytest.raises(Exception, match="state is not available in any namespace"):
+            set_feature_state(cfgdb_clients, 'bgp', 'disabled', False)
+
+    def test_set_feature_state_partial_missing_state_key(self):
+        from config.feature import set_feature_state
+
+        mock_cfgdb_with_state = mock.MagicMock()
+        mock_cfgdb_with_state.get_entry.return_value = {'state': 'enabled'}
+        mock_cfgdb_with_state.mod_entry = mock.MagicMock()
+
+        mock_cfgdb_no_state = mock.MagicMock()
+        mock_cfgdb_no_state.get_entry.return_value = {'auto_restart': 'enabled'}
+        mock_cfgdb_no_state.mod_entry = mock.MagicMock()
+
+        cfgdb_clients = {'': mock_cfgdb_with_state, 'asic0': mock_cfgdb_no_state}
+
+        set_feature_state(cfgdb_clients, 'bgp', 'disabled', False)
+
+    def test_feature_autorestart_missing_auto_restart_key(self, get_cmd_module):
+        from unittest.mock import MagicMock
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        db.cfgdb.set_entry("FEATURE", "test_feat", {"state": "enabled"})
+
+        mock_cfgdb = MagicMock()
+        mock_cfgdb.get_entry.return_value = {"state": "enabled"}
+        with mock.patch.object(db, 'cfgdb_clients', {'': mock_cfgdb}):
+            result = runner.invoke(
+                config.config.commands["feature"].commands["autorestart"],
+                ["test_feat", "disabled"], obj=db)
+        assert result.exit_code == 1
+        assert "auto-restart is not available in any namespace" in result.output
+
+
 class TestFeature(object):
     @classmethod
     def setup_class(cls):

--- a/tests/feature_test.py
+++ b/tests/feature_test.py
@@ -205,15 +205,21 @@ class TestSetFeatureStateUnit(object):
 
         mock_cfgdb_with_state = mock.MagicMock()
         mock_cfgdb_with_state.get_entry.return_value = {'state': 'enabled'}
-        mock_cfgdb_with_state.mod_entry = mock.MagicMock()
 
         mock_cfgdb_no_state = mock.MagicMock()
         mock_cfgdb_no_state.get_entry.return_value = {'auto_restart': 'enabled'}
-        mock_cfgdb_no_state.mod_entry = mock.MagicMock()
 
         cfgdb_clients = {'': mock_cfgdb_with_state, 'asic0': mock_cfgdb_no_state}
 
-        set_feature_state(cfgdb_clients, 'bgp', 'disabled', False)
+        # Bypass YANG validation so the test does not depend on a Click
+        # context; ValidatedConfigDBConnector(conn) just returns the connector.
+        with mock.patch('config.feature.ValidatedConfigDBConnector', side_effect=lambda conn: conn):
+            set_feature_state(cfgdb_clients, 'bgp', 'disabled', False)
+
+        # Both namespaces are written, so the namespace that was missing
+        # 'state' gets backfilled to the requested value.
+        mock_cfgdb_with_state.mod_entry.assert_called_once_with('FEATURE', 'bgp', {'state': 'disabled'})
+        mock_cfgdb_no_state.mod_entry.assert_called_once_with('FEATURE', 'bgp', {'state': 'disabled'})
 
     def test_feature_autorestart_missing_auto_restart_key(self, get_cmd_module):
         from unittest.mock import MagicMock

--- a/tests/sonic_package_manager/test_sonic_db.py
+++ b/tests/sonic_package_manager/test_sonic_db.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from sonic_package_manager.service_creator.sonic_db import SonicDB
 
@@ -44,14 +44,21 @@ class TestGetNamespaceDbConnectors:
         mock_device_info.get_namespaces.return_value = ['asic0', 'asic1']
         mock_swsscommon.SonicDBConfig.isGlobalInit.return_value = False
 
-        mock_conn = MagicMock()
-        mock_swsscommon.ConfigDBConnector.return_value = mock_conn
+        # Distinct connectors per namespace, so the test fails if both
+        # namespaces collapse onto a single shared connector instance.
+        conn0 = MagicMock()
+        conn1 = MagicMock()
+        mock_swsscommon.ConfigDBConnector.side_effect = [conn0, conn1]
 
         result = SonicDB.get_namespace_db_connectors()
 
-        assert result == [mock_conn, mock_conn]
-        assert mock_swsscommon.ConfigDBConnector.call_count == 2
-        assert mock_conn.connect.call_count == 2
+        assert result == [conn0, conn1]
+        assert mock_swsscommon.ConfigDBConnector.call_args_list == [
+            call(namespace='asic0'),
+            call(namespace='asic1'),
+        ]
+        conn0.connect.assert_called_once_with()
+        conn1.connect.assert_called_once_with()
         mock_swsscommon.SonicDBConfig.initializeGlobalConfig.assert_called_once()
 
     @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)

--- a/tests/sonic_package_manager/test_sonic_db.py
+++ b/tests/sonic_package_manager/test_sonic_db.py
@@ -1,0 +1,119 @@
+from unittest.mock import MagicMock, patch
+
+from sonic_package_manager.service_creator.sonic_db import SonicDB
+
+
+class TestGetNamespaceDbConnectors:
+
+    def setup_method(self):
+        SonicDB._namespace_db_conns = None
+        SonicDB._running_db_conn = None
+
+    def teardown_method(self):
+        SonicDB._namespace_db_conns = None
+        SonicDB._running_db_conn = None
+
+    @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=True)
+    def test_returns_empty_in_chroot(self, mock_in_chroot):
+        result = SonicDB.get_namespace_db_connectors()
+        assert result == []
+
+    @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
+    @patch('sonic_package_manager.service_creator.sonic_db.device_info')
+    def test_returns_empty_on_single_asic(self, mock_device_info, mock_in_chroot):
+        mock_device_info.is_multi_npu.return_value = False
+        result = SonicDB.get_namespace_db_connectors()
+        assert result == []
+
+    @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
+    @patch('sonic_package_manager.service_creator.sonic_db.device_info')
+    @patch('sonic_package_manager.service_creator.sonic_db.swsscommon')
+    def test_returns_connectors_on_multi_asic(self, mock_swsscommon, mock_device_info, mock_in_chroot):
+        mock_device_info.is_multi_npu.return_value = True
+        mock_device_info.get_namespaces.return_value = ['asic0', 'asic1']
+
+        mock_conn = MagicMock()
+        mock_swsscommon.ConfigDBConnector.return_value = mock_conn
+
+        with patch('swsscommon.swsscommon.SonicDBConfig.initializeGlobalConfig'):
+            result = SonicDB.get_namespace_db_connectors()
+
+        assert len(result) == 2
+        assert mock_swsscommon.ConfigDBConnector.call_count == 2
+        assert mock_conn.connect.call_count == 2
+
+    @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
+    @patch('sonic_package_manager.service_creator.sonic_db.device_info')
+    @patch('sonic_package_manager.service_creator.sonic_db.swsscommon')
+    def test_partial_connection_failure(self, mock_swsscommon, mock_device_info, mock_in_chroot):
+        mock_device_info.is_multi_npu.return_value = True
+        mock_device_info.get_namespaces.return_value = ['asic0', 'asic1']
+
+        good_conn = MagicMock()
+        bad_conn = MagicMock()
+        bad_conn.connect.side_effect = RuntimeError("connection failed")
+
+        mock_swsscommon.ConfigDBConnector.side_effect = [good_conn, bad_conn]
+
+        with patch('swsscommon.swsscommon.SonicDBConfig.initializeGlobalConfig'):
+            result = SonicDB.get_namespace_db_connectors()
+
+        assert len(result) == 1
+        assert result[0] is good_conn
+
+    @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
+    @patch('sonic_package_manager.service_creator.sonic_db.device_info')
+    @patch('sonic_package_manager.service_creator.sonic_db.swsscommon')
+    def test_caching_behavior(self, mock_swsscommon, mock_device_info, mock_in_chroot):
+        mock_device_info.is_multi_npu.return_value = True
+        mock_device_info.get_namespaces.return_value = ['asic0']
+
+        mock_conn = MagicMock()
+        mock_swsscommon.ConfigDBConnector.return_value = mock_conn
+
+        with patch('swsscommon.swsscommon.SonicDBConfig.initializeGlobalConfig'):
+            result1 = SonicDB.get_namespace_db_connectors()
+            result2 = SonicDB.get_namespace_db_connectors()
+
+        assert result1 is result2
+        assert mock_swsscommon.ConfigDBConnector.call_count == 1
+
+
+class TestGetConnectorsWithNamespaces:
+
+    def setup_method(self):
+        SonicDB._namespace_db_conns = None
+        SonicDB._running_db_conn = None
+
+    def teardown_method(self):
+        SonicDB._namespace_db_conns = None
+        SonicDB._running_db_conn = None
+
+    @patch.object(SonicDB, 'get_namespace_db_connectors')
+    @patch.object(SonicDB, 'get_running_db_connector')
+    @patch.object(SonicDB, 'get_initial_db_connector')
+    def test_yields_namespace_connectors_when_running_db_exists(
+            self, mock_initial, mock_running, mock_ns):
+        mock_init_conn = MagicMock()
+        mock_run_conn = MagicMock()
+        mock_ns_conn = MagicMock()
+
+        mock_initial.return_value = mock_init_conn
+        mock_running.return_value = mock_run_conn
+        mock_ns.return_value = [mock_ns_conn]
+
+        connectors = list(SonicDB.get_connectors())
+        assert connectors == [mock_init_conn, mock_run_conn, mock_ns_conn]
+
+    @patch.object(SonicDB, 'get_namespace_db_connectors')
+    @patch.object(SonicDB, 'get_running_db_connector')
+    @patch.object(SonicDB, 'get_initial_db_connector')
+    def test_no_namespace_connectors_when_no_running_db(
+            self, mock_initial, mock_running, mock_ns):
+        mock_init_conn = MagicMock()
+        mock_initial.return_value = mock_init_conn
+        mock_running.return_value = None
+
+        connectors = list(SonicDB.get_connectors())
+        assert connectors == [mock_init_conn]
+        mock_ns.assert_not_called()

--- a/tests/sonic_package_manager/test_sonic_db.py
+++ b/tests/sonic_package_manager/test_sonic_db.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import MagicMock, patch
 
 from sonic_package_manager.service_creator.sonic_db import SonicDB
@@ -15,15 +16,25 @@ class TestGetNamespaceDbConnectors:
 
     @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=True)
     def test_returns_empty_in_chroot(self, mock_in_chroot):
-        result = SonicDB.get_namespace_db_connectors()
-        assert result == []
+        assert SonicDB.get_namespace_db_connectors() == []
 
     @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
     @patch('sonic_package_manager.service_creator.sonic_db.device_info')
     def test_returns_empty_on_single_asic(self, mock_device_info, mock_in_chroot):
         mock_device_info.is_multi_npu.return_value = False
-        result = SonicDB.get_namespace_db_connectors()
-        assert result == []
+        assert SonicDB.get_namespace_db_connectors() == []
+        mock_device_info.get_namespaces.assert_not_called()
+
+    @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
+    @patch('sonic_package_manager.service_creator.sonic_db.device_info')
+    def test_single_asic_result_is_cached(self, mock_device_info, mock_in_chroot):
+        # Single-ASIC result is cached: the platform check runs only once.
+        mock_device_info.is_multi_npu.return_value = False
+
+        assert SonicDB.get_namespace_db_connectors() == []
+        assert SonicDB.get_namespace_db_connectors() == []
+
+        assert mock_device_info.is_multi_npu.call_count == 1
 
     @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
     @patch('sonic_package_manager.service_creator.sonic_db.device_info')
@@ -31,51 +42,67 @@ class TestGetNamespaceDbConnectors:
     def test_returns_connectors_on_multi_asic(self, mock_swsscommon, mock_device_info, mock_in_chroot):
         mock_device_info.is_multi_npu.return_value = True
         mock_device_info.get_namespaces.return_value = ['asic0', 'asic1']
+        mock_swsscommon.SonicDBConfig.isGlobalInit.return_value = False
 
         mock_conn = MagicMock()
         mock_swsscommon.ConfigDBConnector.return_value = mock_conn
 
-        with patch('swsscommon.swsscommon.SonicDBConfig.initializeGlobalConfig'):
-            result = SonicDB.get_namespace_db_connectors()
+        result = SonicDB.get_namespace_db_connectors()
 
-        assert len(result) == 2
+        assert result == [mock_conn, mock_conn]
         assert mock_swsscommon.ConfigDBConnector.call_count == 2
         assert mock_conn.connect.call_count == 2
+        mock_swsscommon.SonicDBConfig.initializeGlobalConfig.assert_called_once()
 
     @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
     @patch('sonic_package_manager.service_creator.sonic_db.device_info')
     @patch('sonic_package_manager.service_creator.sonic_db.swsscommon')
-    def test_partial_connection_failure(self, mock_swsscommon, mock_device_info, mock_in_chroot):
+    def test_skips_global_init_when_already_initialized(self, mock_swsscommon, mock_device_info, mock_in_chroot):
+        mock_device_info.is_multi_npu.return_value = True
+        mock_device_info.get_namespaces.return_value = ['asic0']
+        mock_swsscommon.SonicDBConfig.isGlobalInit.return_value = True
+
+        SonicDB.get_namespace_db_connectors()
+
+        mock_swsscommon.SonicDBConfig.initializeGlobalConfig.assert_not_called()
+
+    @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
+    @patch('sonic_package_manager.service_creator.sonic_db.device_info')
+    @patch('sonic_package_manager.service_creator.sonic_db.swsscommon')
+    def test_connection_failure_propagates(self, mock_swsscommon, mock_device_info, mock_in_chroot):
+        # A failed namespace connect must raise, not yield a partial set.
         mock_device_info.is_multi_npu.return_value = True
         mock_device_info.get_namespaces.return_value = ['asic0', 'asic1']
+        mock_swsscommon.SonicDBConfig.isGlobalInit.return_value = False
 
         good_conn = MagicMock()
         bad_conn = MagicMock()
         bad_conn.connect.side_effect = RuntimeError("connection failed")
-
         mock_swsscommon.ConfigDBConnector.side_effect = [good_conn, bad_conn]
 
-        with patch('swsscommon.swsscommon.SonicDBConfig.initializeGlobalConfig'):
-            result = SonicDB.get_namespace_db_connectors()
+        with pytest.raises(RuntimeError, match="connection failed"):
+            SonicDB.get_namespace_db_connectors()
 
-        assert len(result) == 1
-        assert result[0] is good_conn
+        # Failed run is not cached, so the next call retries.
+        assert SonicDB._namespace_db_conns is None
 
     @patch('sonic_package_manager.service_creator.sonic_db.in_chroot', return_value=False)
     @patch('sonic_package_manager.service_creator.sonic_db.device_info')
     @patch('sonic_package_manager.service_creator.sonic_db.swsscommon')
-    def test_caching_behavior(self, mock_swsscommon, mock_device_info, mock_in_chroot):
+    def test_connected_namespaces_are_cached(self, mock_swsscommon, mock_device_info, mock_in_chroot):
         mock_device_info.is_multi_npu.return_value = True
         mock_device_info.get_namespaces.return_value = ['asic0']
+        mock_swsscommon.SonicDBConfig.isGlobalInit.return_value = False
 
         mock_conn = MagicMock()
         mock_swsscommon.ConfigDBConnector.return_value = mock_conn
 
-        with patch('swsscommon.swsscommon.SonicDBConfig.initializeGlobalConfig'):
-            result1 = SonicDB.get_namespace_db_connectors()
-            result2 = SonicDB.get_namespace_db_connectors()
+        result1 = SonicDB.get_namespace_db_connectors()
+        result2 = SonicDB.get_namespace_db_connectors()
 
         assert result1 is result2
+        assert result1 == [mock_conn]
+        # Cached: not reconnected on later calls.
         assert mock_swsscommon.ConfigDBConnector.call_count == 1
 
 


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed two issues with dynamically installed packages on multi-ASIC platforms:

1. `sonic-package-manager install` now writes complete FEATURE entries to all per-ASIC namespace CONFIG_DBs, not just the host CONFIG_DB.
2. `config feature state` and `config feature autorestart` no longer crash with `KeyError` when per-ASIC FEATURE entries are incomplete.

#### How I did it

`sonic_package_manager/service_creator/sonic_db.py`: Added `get_namespace_db_connectors()` to `SonicDB` that returns per-ASIC namespace CONFIG_DB connectors on multi-ASIC platforms. `get_connectors()` now yields these after the host connector, so `FeatureRegistry.register()` and `deregister()` write to all CONFIG_DBs.

`config/feature.py`: Changed `entry_data['state']` to `entry_data.get('state')` in `set_feature_state()`, and `entry_data['auto_restart']` to `entry_data.get('auto_restart')` in `feature_autorestart()`. Namespace entries missing the field are skipped during validation. Added a guard for the case where no namespace has the field at all. Fixed the `always_enabled` check to use the collected set instead of relying on the last loop variable.

#### How to verify it

On a multi-ASIC system:

```bash
sudo sonic-package-manager install xxx

# Verify per-ASIC entries are complete
sonic-db-cli CONFIG_DB HGETALL "FEATURE|xxx"
sonic-db-cli -n asic0 CONFIG_DB HGETALL "FEATURE|xxx"
# Both should show all fields 

# Verify CLI commands work
sudo config feature state xxx enabled
sudo config feature autorestart xxx disabled

# Clean up
sudo sonic-package-manager uninstall xxx -y
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

