### PR TITLE
Add cli-server: 10x faster show commands with fast autocompletion

### DIFF
--- a/scripts/cli-client
+++ b/scripts/cli-client
@@ -1,0 +1,58 @@
+#!/bin/bash
+# cli-client — near-instant Python CLI via a pre-fork server.
+#
+# Usage: cli-client <cli-script> [args...]
+#
+# On first call the server is not yet running, so this client starts it
+# in the background and runs the CLI script directly (normal speed).  On all
+# subsequent calls the server is ready: we connect via TCP localhost,
+# send argv/cwd/env, and stream the output back — avoiding ~1 s of
+# Python interpreter startup and module imports.
+set -eEu -o pipefail
+
+[[ $# -ge 1 ]] || { echo "Usage: cli-client <cli-script> [args...]" >&2; exit 1; }
+script="$1"; shift
+
+# Resolve the path to the companion server script (same directory).
+server="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/cli-server"
+
+# fallback: start the server in the background and run the CLI script directly.
+# Used whenever the server is not yet available (first call, stale files, etc.).
+fallback() { "$server" "$script" & exec "$script" "$@"; }
+
+# ── Runtime dir (must match cli-server) ──────────────────────────
+dir="/tmp/cli-server"
+[[ -d "$dir" ]] || fallback "$@"
+
+# ── Find server port ─────────────────────────────────────────────
+[[ -f "$dir/$script.port" ]] || fallback "$@"
+port=$(<"$dir/$script.port")
+
+# Connect to the server via TCP; fall back to direct execution on failure.
+exec 3<>/dev/tcp/127.0.0.1/"$port" 2>/dev/null || fallback "$@"
+
+# Read the forked child's PID so we can forward signals.
+IFS= read -r line <&3; pid="${line:1}"
+for sig in INT TERM; do trap "kill -$sig $pid 2>/dev/null" "$sig"; done
+
+# ── Send argv, cwd, env (length-prefixed blocks) ────────────────
+
+if [[ $# -gt 0 ]]; then argv=$(printf ' %q' "$@"); argv="${argv:1}"; else argv=""; fi
+printf '%d\n%s' "${#argv}" "$argv" >&3
+printf '%d\n%s' "${#PWD}" "$PWD" >&3
+e=$(mktemp); env -0 > "$e" 2>/dev/null
+printf '%d\n' "$(stat -c %s "$e")" >&3; cat "$e" >&3; rm -f "$e"
+
+# ── Read tagged output from server ───────────────────────────────
+# O = stdout line, E = stderr line, X = exit code (terminates).
+# awk is much faster than bash `read` for large outputs.
+# -W interactive disables stdin/stdout block-buffering so streamed
+# output is not held back.
+
+awk -W interactive '{
+    tag = substr($0, 1, 1)
+    data = substr($0, 2)
+    if (tag == "O") print data
+    else if (tag == "E") print data > "/dev/stderr"
+    else if (tag == "X") exit (data + 0)
+}' <&3

--- a/scripts/cli-server
+++ b/scripts/cli-server
@@ -1,0 +1,269 @@
+#!/usr/bin/python3
+"""cli-server: pre-fork server for instant Python CLI startup.
+
+Started automatically by the cli-client bash wrapper.  Loads a CLI script's
+entry point once, then fork()s for each request — skipping ~1 s of
+Python startup and module imports every time.
+
+Architecture:
+  1. Server starts, imports the CLI script's code (e.g. show.main:cli).
+  2. Binds a TCP socket on 127.0.0.1 (random port), writes port to a file.
+  3. On each connection: fork() → child handles the request with
+     everything already imported; parent keeps listening.
+  4. After CLI_SERVER_TIMEOUT seconds of inactivity the server exits.
+
+Protocol  (server → client):
+  P<pid>\n    child PID  (for signal forwarding)
+  O<text>\n   stdout line
+  E<text>\n   stderr line
+  X<code>\n   exit code  (terminates session)
+
+Protocol  (client → server):
+  Three length-prefixed blocks: argv, cwd, env.
+  Each block: <byte_count>\n<raw_bytes>
+"""
+import importlib.metadata, io, os, shlex, shutil
+import signal, socket, sys, syslog, time
+from pathlib import Path
+
+IDLE_TIMEOUT = int(os.environ.get("CLI_SERVER_TIMEOUT", "14400"))
+RUNTIME_DIR = Path("/tmp/cli-server")
+
+
+def server_state_paths(script):
+    """Return (pid_path, port_path) for the given CLI script.
+
+    Uses the script name directly (e.g. show.pid, show.port).
+    """
+    if not shutil.which(script):
+        raise SystemExit(f"cli-server: CLI script not found: {script}")
+    RUNTIME_DIR.mkdir(exist_ok=True, mode=0o755)
+    base = RUNTIME_DIR / script
+    return base.with_suffix(".pid"), base.with_suffix(".port")
+
+
+def preload_entry_point(script):
+    """Find and import the console_scripts entry point for *script*.
+
+    Returns the callable that runs the CLI script (e.g. show.main:cli).
+    """
+    entry_points = list(importlib.metadata.entry_points(group="console_scripts", name=script))
+    if not entry_points:
+        raise SystemExit(f"cli-server: no entry point for '{script}'")
+    return entry_points[0].load()
+
+
+# ── Tagged I/O (server → bash client) ────────────────────────────
+#   O<text>\n  stdout    E<text>\n  stderr    X<code>\n  exit code
+
+class TaggedOutput(io.TextIOBase):
+    """Drop-in replacement for sys.stdout / sys.stderr that prefixes
+    every output line with a single-character tag ('O' or 'E') and
+    sends it over a socket to the cli-client.
+
+    Text accumulates in a string buffer.  Complete lines are tagged
+    and sent in one sendall() call when EITHER BLOCK_SIZE bytes have
+    accumulated OR MAX_DELAY has elapsed since the previous send —
+    batching many small writes into a handful of syscalls while still
+    keeping latency low for slow-producing commands.  Partial lines
+    (no trailing newline yet) are held back until more text arrives
+    or flush() forces them out.
+    """
+
+    BLOCK_SIZE = 8192
+    MAX_DELAY = 0.05   # 50 ms
+
+    def __init__(self, sock, tag):
+        self._sock = sock
+        self._tag = tag
+        self._buf = ""
+        self._last_send = 0.0
+
+    def _send(self, incomplete_line=False):
+        """Tag complete lines and send them.  If *incomplete_line*, also
+        send any trailing unterminated text (used by flush())."""
+        out = ""
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            out += self._tag + line + "\n"
+        if incomplete_line and self._buf:
+            out += self._tag + self._buf + "\n"
+            self._buf = ""
+        if out:
+            self._sock.sendall(out.encode())
+
+    def write(self, text):
+        """Append text and send when either BLOCK_SIZE bytes have
+        accumulated or MAX_DELAY has elapsed since the previous send."""
+        self._buf += text
+        now = time.monotonic()
+        if (len(self._buf) >= self.BLOCK_SIZE
+                or now - self._last_send >= self.MAX_DELAY):
+            self._send()
+            self._last_send = now
+        return len(text)
+
+    def flush(self):
+        self._send(incomplete_line=True)
+
+    @property
+    def encoding(self):
+        return "utf-8"
+
+    def writable(self):
+        return True
+
+
+def read_block(reader):
+    """Read a length-prefixed block from the client: <byte_count>\\n<data>."""
+    length = int(reader.readline())
+    return reader.read(length) if length > 0 else b""
+
+
+def handle(connection, script, runner):
+    """Handle a single client connection in a forked child process.
+
+    Reads argv/cwd/env from the client, redirects stdout/stderr through
+    the tagged socket protocol, invokes the pre-loaded CLI script runner, and
+    sends back the exit code.
+    """
+    try:
+        connection.sendall(f"P{os.getpid()}\n".encode())
+        reader = connection.makefile("rb", 0)
+
+        # Restore argv from client
+        raw_argv = read_block(reader).decode()
+        sys.argv = [script] + (shlex.split(raw_argv) if raw_argv else [])
+
+        # Restore working directory from client
+        cwd = read_block(reader).decode()
+        if cwd:
+            os.chdir(cwd)
+
+        # Restore environment from client (null-separated KEY=VALUE pairs)
+        env_data = read_block(reader)
+        if env_data:
+            os.environ.clear()
+            os.environ.update(
+                dict(pair.split("=", 1) for pair in env_data.decode().split("\0") if "=" in pair))
+            os.environ.pop("_", None)
+
+        # Wire stdout/stderr through tagged socket writers
+        sys.stdout = TaggedOutput(connection, "O")
+        sys.stderr = TaggedOutput(connection, "E")
+
+        exit_code = 0
+        try:
+            result = runner()
+            if isinstance(result, int):
+                exit_code = result
+        except SystemExit as exc:
+            exit_code = exc.code if isinstance(exc.code, int) else (1 if exc.code else 0)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            exit_code = 1
+
+        sys.stdout.flush()
+        sys.stderr.flush()
+        connection.sendall(f"X{exit_code}\n".encode())
+    except Exception:
+        try:
+            connection.sendall(b"X1\n")
+        except Exception:
+            pass
+    finally:
+        try:
+            connection.shutdown(socket.SHUT_WR)
+        except Exception:
+            pass
+        connection.close()
+
+
+def main():
+    """Entry point: detach into background, pre-load the CLI script, and serve requests.
+
+    If a server for this CLI script is already running (pid file exists and
+    process is alive), exits immediately.  Otherwise double-forks to
+    detach from the terminal, loads the CLI script's entry point, and
+    enters the accept/fork loop.  Lifecycle events go to syslog.
+    """
+    script = sys.argv[1]
+    pid_path, port_path = server_state_paths(script)
+
+    # Exit if a server is already running for this CLI script
+    if pid_path.exists():
+        try:
+            os.kill(int(pid_path.read_text().strip()), 0)
+            sys.exit(0)
+        except (ProcessLookupError, PermissionError, ValueError):
+            pid_path.unlink(missing_ok=True)
+            port_path.unlink(missing_ok=True)
+
+    # Double-fork to fully detach from the controlling terminal
+    if os.fork() > 0:
+        sys.exit(0)
+    os.setsid()
+    if os.fork() > 0:
+        os._exit(0)
+
+    # Close stdin; redirect stdout/stderr to /dev/null (logs go to syslog)
+    os.close(0)
+    devnull = os.open(os.devnull, os.O_RDWR)
+    os.dup2(devnull, 1)
+    os.dup2(devnull, 2)
+    os.close(devnull)
+
+    syslog.openlog(f"cli-server[{script}]", syslog.LOG_PID, syslog.LOG_DAEMON)
+    syslog.syslog(f"Loading '{script}' ...")
+    runner = preload_entry_point(script)
+
+    # Bind TCP on localhost with a kernel-assigned port
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(5)
+    listener.settimeout(IDLE_TIMEOUT)
+    server_port = listener.getsockname()[1]
+
+    # Publish pid and port so the bash client can find us
+    server_pid = os.getpid()
+    pid_path.write_text(str(server_pid))
+    port_path.write_text(str(server_port))
+    syslog.syslog(f"Ready 127.0.0.1:{server_port}  pid={server_pid}")
+
+    # Auto-reap child processes; clean exit on SIGTERM
+    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+    try:
+        while True:
+            try:
+                connection, _ = listener.accept()
+            except socket.timeout:
+                syslog.syslog("Idle timeout, exiting")
+                break
+            # Fork a child to handle the request — the child inherits
+            # the pre-loaded CLI script so there is no import overhead.
+            child_pid = os.fork()
+            if child_pid == 0:
+                listener.close()
+                handle(connection, script, runner)
+                os._exit(0)
+            connection.close()
+    except (SystemExit, KeyboardInterrupt):
+        pass
+    finally:
+        listener.close()
+        # Clean up pid/port files only if they still belong to us
+        try:
+            if pid_path.exists() and int(pid_path.read_text().strip()) == server_pid:
+                pid_path.unlink(missing_ok=True)
+                port_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        syslog.syslog("Stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,9 @@ setup(
         'scripts/wredstat',
         'scripts/sonic-error-report',
         'scripts/chassis_db_consistency_checker.py',
-        'scripts/sonic-dpu-flow-dump.py'
+        'scripts/sonic-dpu-flow-dump.py',
+        'scripts/cli-client',
+        'scripts/cli-server'
     ],
     entry_points={
         'console_scripts': [

--- a/sonic-utilities-data/generate_completions.py
+++ b/sonic-utilities-data/generate_completions.py
@@ -28,6 +28,7 @@ def generate_completions(output_dir):
                                  )
                         .source()
                         .replace("\r\n", "\n")
+                        .replace("$(env ", "$(")
                         )
                 with open(os.path.join(output_dir, prog), "w", newline="") as f:
                     f.write(content)


### PR DESCRIPTION
#### What I did
Added a pre-fork server (cli-server) and bash client (cli-client) that eliminates ~1 seconds of Python interpreter startup overhead for show CLI commands.

#### How I did it
Two new scripts in scripts/:

cli-server — a Python server that loads a CLI tool's console_scripts entry point once (e.g. show.main:cli), then fork()s for each incoming request. Since the forked child inherits the fully-imported module tree, it skips all Python startup and import overhead.

cli-client — a bash wrapper that connects to the server via TCP on localhost. On the first call (server not running), it starts the server in the background and runs the command directly at normal speed. On subsequent calls, it sends argv/cwd/env over the socket and streams tagged output back — completing in ~100ms instead of ~1 s.

The server auto-exits after 4 hours of inactivity (CLI_SERVER_TIMEOUT env var, default 14400s).

setup.py updated to install both scripts to PATH.

No external dependencies — uses only Python stdlib and bash builtins.


Integration with /etc/bash.bashrc ([separate PR against sonic-buildimage](https://github.com/sonic-net/sonic-buildimage/pull/26729)):

```
if command -v cli-client &>/dev/null; then
    show()   { cli-client show "$@"; }
fi
``` 

Additionally, sonic-utilities-data/generate_completions.py is patched to drop the env prefix from Click-generated bash completion scripts. Click's default template uses $(env ... show) which invokes /usr/bin/env — an external binary that resolves show via PATH, bypassing shell functions entirely. By removing env, bash resolves commands normally (functions first, then PATH), so tab completion also goes through the cli-client/server when the show() shell function above is defined. This makes tab completion near-instant instead of paying the ~1s Python startup cost on every Tab press.

#### How to verify it

- [X] Speed gain
First call starts server in background, runs at normal speed:
time show
 Wait for server to finish loading:
sleep 2
 Second call uses the server — should complete in ~100-150ms:
time show
 
- [X] Verify server is running:

cat /tmp/cli-server/show.pid
cat /tmp/cli-server/show.port

- [X]  Verify Ctrl+C works (signal forwarding):
cli-client show logging # press Ctrl+C

- [X]  Verify fallback works if server is killed:
kill $(cat /tmp/cli-server/show.pid)
time cli-client show version # runs directly, restarts server

- [X] Previous command output (if the output of a command-line utility has changed)
No change to command output. The show and config commands produce identical output — only startup latency is reduced.

root@sonic:~# time show
...
real    0m1.528s
New command output (if the output of a command-line utility has changed)
Same output, faster execution after server is warm:

root@sonic:~# time cli-client show
...
real    0m0.125s

