### PR TITLE
[ACL] Add CTRLPLANE table services support

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -7833,7 +7833,7 @@ def parse_acl_table_info(table_name, table_type, description, ports, stage, name
         if services:
             raise ValueError("--services is only valid for CTRLPLANE ACL tables")
 
-        if not ports and ports != None:
+        if not ports and ports is not None:
             raise ValueError("Cannot bind empty list of ports")
 
         port_list = []

--- a/config/main.py
+++ b/config/main.py
@@ -7803,7 +7803,11 @@ def expand_vlan_ports(port_name, namespace=None):
     return members
 
 
-def parse_acl_table_info(table_name, table_type, description, ports, stage, namespace=None):
+# Valid services for CTRLPLANE ACL tables, as handled by caclmgrd
+ACL_CTRLPLANE_VALID_SERVICES = {"NTP", "SNMP", "SSH", "EXTERNAL_CLIENT", "ANY"}
+
+
+def parse_acl_table_info(table_name, table_type, description, ports, stage, namespace=None, services=None):
     table_info = {"type": table_type}
 
     if description:
@@ -7811,23 +7815,41 @@ def parse_acl_table_info(table_name, table_type, description, ports, stage, name
     else:
         table_info["policy_desc"] = table_name
 
-    if not ports and ports != None:
-        raise ValueError("Cannot bind empty list of ports")
-
-    port_list = []
-    valid_acl_ports = get_acl_bound_ports(namespace)
-    if ports:
-        for port in ports.split(","):
-            port_list += expand_vlan_ports(port, namespace)
-        port_list = list(set(port_list))  # convert to set first to remove duplicate ifaces
+    if table_type.upper() == "CTRLPLANE":
+        if not services:
+            raise ValueError("CTRLPLANE ACL table requires at least one service via -S/--services (e.g. SNMP,SSH,NTP)")
+        if ports:
+            raise ValueError("CTRLPLANE ACL table cannot bind to ports, use -S/--services instead")
+        service_list = [s.strip().upper() for s in services.split(",")]
+        invalid = [s for s in service_list if s not in ACL_CTRLPLANE_VALID_SERVICES]
+        if invalid:
+            raise ValueError(
+                "Invalid service(s): {}. Valid services are: {}".format(
+                    ", ".join(invalid), ", ".join(sorted(ACL_CTRLPLANE_VALID_SERVICES))
+                )
+            )
+        table_info["services"] = service_list
     else:
-        port_list = valid_acl_ports
+        if services:
+            raise ValueError("--services is only valid for CTRLPLANE ACL tables")
 
-    for port in port_list:
-        if port not in valid_acl_ports:
-            raise ValueError("Cannot bind ACL to specified port {}".format(port))
+        if not ports and ports != None:
+            raise ValueError("Cannot bind empty list of ports")
 
-    table_info["ports"] = port_list
+        port_list = []
+        valid_acl_ports = get_acl_bound_ports(namespace)
+        if ports:
+            for port in ports.split(","):
+                port_list += expand_vlan_ports(port, namespace)
+            port_list = list(set(port_list))  # convert to set first to remove duplicate ifaces
+        else:
+            port_list = valid_acl_ports
+
+        for port in port_list:
+            if port not in valid_acl_ports:
+                raise ValueError("Cannot bind ACL to specified port {}".format(port))
+
+        table_info["ports"] = port_list
 
     table_info["stage"] = stage
 
@@ -7845,8 +7867,9 @@ def parse_acl_table_info(table_name, table_type, description, ports, stage, name
 @click.option("-p", "--ports")
 @click.option("-s", "--stage", type=click.Choice(["ingress", "egress"]), default="ingress")
 @click.option('-n', '--namespace', help='Namespace name', type=click.Choice(multi_asic.get_namespace_list()))
+@click.option('-S', '--services', help='Comma-separated list of services for CTRLPLANE ACL tables (e.g. SNMP,SSH,NTP)')
 @click.pass_context
-def add_table(ctx, table_name, table_type, description, ports, stage, namespace):
+def add_table(ctx, table_name, table_type, description, ports, stage, namespace, services):
     """
     Add ACL table
     """
@@ -7854,7 +7877,7 @@ def add_table(ctx, table_name, table_type, description, ports, stage, namespace)
     config_db.connect()
 
     try:
-        table_info = parse_acl_table_info(table_name, table_type, description, ports, stage, namespace)
+        table_info = parse_acl_table_info(table_name, table_type, description, ports, stage, namespace, services)
     except ValueError as e:
         ctx.fail("Failed to parse ACL table config: exception={}".format(e))
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2200,19 +2200,20 @@ This command is used to create new ACL tables.
 
 - Usage:
   ```
-  config acl add table [OPTIONS] <table_name> <table_type> [-d <description>] [-p <ports>] [-s (ingress | egress)] [-n <namespace>]
+  config acl add table [OPTIONS] <table_name> <table_type> [-d <description>] [-p <ports>] [-s (ingress | egress)] [-n <namespace>] [-S <services>]
   ```
 
 - Parameters:
   - table_name: The name of the ACL table to create.
-  - table_type: The type of ACL table to create (e.g. "L3", "L3V6", "L3V4V6", "MIRROR")
+  - table_type: The type of ACL table to create (e.g. "L3", "L3V6", "L3V4V6", "MIRROR", "CTRLPLANE")
   - description: A description of the table for the user. (default is the table_name)
-  - ports: A comma-separated list of ports/interfaces to add to the table. The behavior is as follows:
+  - ports: A comma-separated list of ports/interfaces to add to the table. Not valid for CTRLPLANE tables. The behavior is as follows:
     - Physical ports will be bound as physical ports
     - Portchannels will be bound as portchannels - passing a portchannel member is invalid
     - VLANs will be expanded into their members (e.g. "Vlan1000" will become "Ethernet0,Ethernet2,Ethernet4...")
   - stage: The stage this ACL table will be applied to, either ingress or egress. (default is ingress)
   - namespace: Namespace name for multi-ASIC platforms. When specified, the table is created in that ASIC's config DB.
+  - services: A comma-separated list of services for CTRLPLANE ACL tables. Required when table_type is CTRLPLANE. Valid values: ANY, EXTERNAL_CLIENT, NTP, SNMP, SSH. Not valid for non-CTRLPLANE tables.
 
 - Examples:
   ```
@@ -2223,6 +2224,12 @@ This command is used to create new ACL tables.
   ```
   ```
   admin@sonic:~$ sudo config acl add table EXAMPLE_ASIC0 L3 -p Ethernet0 -n asic0
+  ```
+  ```
+  admin@sonic:~$ sudo config acl add table SNMP_ACL CTRLPLANE -S SNMP
+  ```
+  ```
+  admin@sonic:~$ sudo config acl add table ROUTER_ACL CTRLPLANE -S SNMP,SSH,NTP
   ```
 
 **config acl remove table**

--- a/tests/acl_config_test.py
+++ b/tests/acl_config_test.py
@@ -139,3 +139,76 @@ class TestConfigAcl(object):
 
         mock_cfg_connector.assert_called_once_with(namespace="asic0")
         mock_instance.set_entry.assert_called_once_with("ACL_TABLE", "DATAACL", None)
+
+    def test_parse_ctrlplane_table_with_services(self):
+        table_info = parse_acl_table_info("SNMP_ACL", "CTRLPLANE", None, None, "ingress", services="SNMP")
+        assert table_info["type"] == "CTRLPLANE"
+        assert table_info["policy_desc"] == "SNMP_ACL"
+        assert table_info["services"] == ["SNMP"]
+        assert "ports" not in table_info
+
+    def test_parse_ctrlplane_table_with_multiple_services(self):
+        table_info = parse_acl_table_info("ROUTER_ACL", "CTRLPLANE", None, None, "ingress", services="SNMP,SSH")
+        assert table_info["services"] == ["SNMP", "SSH"]
+        assert "ports" not in table_info
+
+    def test_parse_ctrlplane_table_without_services_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            parse_acl_table_info("SNMP_ACL", "CTRLPLANE", None, None, "ingress")
+        assert "requires at least one service" in str(exc_info.value)
+
+    def test_parse_ctrlplane_table_with_invalid_service_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            parse_acl_table_info("TEST_ACL", "CTRLPLANE", None, None, "ingress", services="INVALID_SVC")
+        assert "Invalid service(s)" in str(exc_info.value)
+        assert "INVALID_SVC" in str(exc_info.value)
+
+    def test_parse_ctrlplane_table_with_partial_invalid_services_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            parse_acl_table_info("TEST_ACL", "CTRLPLANE", None, None, "ingress", services="SNMP,BADSERVICE")
+        assert "Invalid service(s)" in str(exc_info.value)
+        assert "BADSERVICE" in str(exc_info.value)
+
+    def test_parse_ctrlplane_table_with_ports_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            parse_acl_table_info("SNMP_ACL", "CTRLPLANE", None, "Ethernet0", "ingress", services="SNMP")
+        assert "cannot bind to ports" in str(exc_info.value)
+
+    def test_parse_non_ctrlplane_table_with_services_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            parse_acl_table_info("TEST", "L3", None, None, "ingress", services="SNMP")
+        assert "--services is only valid for CTRLPLANE" in str(exc_info.value)
+
+    def test_acl_add_ctrlplane_table_without_services(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["acl"].commands["add"].commands["table"],
+            ["SNMP_ACL", "CTRLPLANE"])
+        assert result.exit_code != 0
+        assert "requires at least one service" in result.output
+
+    @patch("config.main.ConfigDBConnector")
+    def test_acl_add_ctrlplane_table_with_services(self, mock_cfg_connector):
+        mock_instance = mock.Mock()
+        mock_cfg_connector.return_value = mock_instance
+        mock_instance.connect.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["acl"].commands["add"].commands["table"],
+            ["SNMP_ACL", "CTRLPLANE", "-S", "SNMP"])
+        assert result.exit_code == 0
+
+        mock_instance.set_entry.assert_called_once()
+        table_info = mock_instance.set_entry.call_args[0][2]
+        assert table_info["type"] == "CTRLPLANE"
+        assert table_info["services"] == ["SNMP"]
+        assert "ports" not in table_info
+
+    def test_acl_add_ctrlplane_table_with_ports_fails(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["acl"].commands["add"].commands["table"],
+            ["SNMP_ACL", "CTRLPLANE", "-S", "SNMP", "-p", "Ethernet0"])
+        assert result.exit_code != 0
+        assert "cannot bind to ports" in result.output


### PR DESCRIPTION
fixes https://github.com/sonic-net/sonic-buildimage/issues/4970

**What I did**

Added --services / -S option to the config acl add table command to support CTRLPLANE ACL table type. Previously, CTRLPLANE tables could not be properly configured.

**How I did it**

- Added ACL_CTRLPLANE_VALID_SERVICES = {"NTP", "SNMP", "SSH", "EXTERNAL_CLIENT", "ANY"} in config/main.py
- Updated parse_acl_table_info() to accept an optional services parameter
- For CTRLPLANE tables: validates that at least one service is provided, rejects port bindings, and validates service names against the allowed set
- For non-CTRLPLANE tables: raises an error if --services is passed
- Added -S / --services CLI option to the add table command
- Added 10 new unit tests covering all new code paths in tests/acl_config_test.py

**How to verify it**

#Should succeed
config acl add table SNMP_ACL CTRLPLANE -S SNMP.     
config acl add table ROUTER_ACL CTRLPLANE -S SNMP,SSH,NTP

#Should fail - no service provided
config acl add table SNMP_ACL CTRLPLANE

#Should fail - CTRLPLANE cannot bind ports
config acl add table SNMP_ACL CTRLPLANE -S SNMP -p Ethernet0

#Should fail - invalid service
config acl add table SNMP_ACL CTRLPLANE -S INVALID_SVC

**Previous command output (if the output of a command-line utility has changed)**

$ config acl add table SNMP_ACL CTRLPLANE
#(no error — silently created table without services field)
#show acl table then crashes with KeyError:

**New command output (if the output of a command-line utility has changed)**

$ config acl add table SNMP_ACL CTRLPLANE
Failed to parse ACL table config: exception=CTRLPLANE ACL table requires at least one service via -S/--services (e.g. SNMP,SSH,NTP)

$ config acl add table SNMP_ACL CTRLPLANE -S SNMP
#(succeeds, table created with services=["SNMP"])

