### PR TITLE
static_route: prevent duplicate next hops by adding a missing guard

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -7664,6 +7664,21 @@ def add_route(ctx, command_str):
         # If exist update current entry
         current_entry = config_db.get_entry('STATIC_ROUTE', key)
 
+        # Check for duplicate nexthop: build existing (nexthop, nexthop-vrf, ifname) tuples
+        # and reject the add if the incoming tuple is already present.
+        existing_nh = current_entry.get('nexthop', '').split(',')
+        existing_nhvrf = current_entry.get('nexthop-vrf', '').split(',')
+        existing_ifname = current_entry.get('ifname', '').split(',')
+        existing_zip = list(itertools.zip_longest(existing_nh, existing_nhvrf, existing_ifname, fillvalue=''))
+
+        incoming_tuple = (
+            route.get('nexthop', ''),
+            route.get('nexthop-vrf', vrf),
+            route.get('ifname', ''),
+        )
+        if incoming_tuple in existing_zip:
+            ctx.fail('Nexthop {} already exists for route {}'.format(incoming_tuple, key))
+
         for item in ['nexthop', 'nexthop-vrf', 'ifname', 'distance', 'blackhole']:
             if item not in current_entry:
                 current_entry[item] = ''

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -44,6 +44,7 @@ Error: interface {} does not exist.
 ERROR_STR_NO_DEL_MULTI_NH = '''
 Error: Only one nexthop can be deleted at a time
 '''
+ERROR_STR_DUPLICATE_NEXTHOP = "already exists for route"
 
 
 class TestStaticRoutes(object):
@@ -702,6 +703,74 @@ class TestStaticRoutes(object):
         assert result.exit_code == 0
         mock_config_db_connector.assert_called_once_with(use_unix_socket_path=True, namespace='')
         assert ('default', '1.2.3.4/32') in cfgdb.get_table('STATIC_ROUTE')
+
+    def test_add_duplicate_nexthop_static_route(self):
+        """Adding the same nexthop twice for the same prefix must be rejected (default and named VRF)."""
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        # --- default VRF ---
+        result = runner.invoke(config.config.commands["route"].commands["add"],
+                               ["prefix", "20.0.0.0/24", "nexthop", "10.10.10.2"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert ('default', '20.0.0.0/24') in db.cfgdb.get_table('STATIC_ROUTE')
+
+        # Add with identical nexthop - must be rejected
+        result = runner.invoke(config.config.commands["route"].commands["add"],
+                               ["prefix", "20.0.0.0/24", "nexthop", "10.10.10.2"], obj=obj)
+        print(result.exit_code, result.output)
+        assert ERROR_STR_DUPLICATE_NEXTHOP in result.output
+
+        # DB must still contain exactly one nexthop entry
+        entry = db.cfgdb.get_entry('STATIC_ROUTE', 'default|20.0.0.0/24')
+        assert entry['nexthop'] == '10.10.10.2'
+        assert entry['blackhole'] == 'false'
+        assert entry['nexthop-vrf'] == 'default'
+
+        # --- VRF ---
+        result = runner.invoke(config.config.commands["vrf"].commands["add"], ["Vrf-RED"], obj=obj)
+        print(result.exit_code, result.output)
+
+        # First add
+        result = runner.invoke(config.config.commands["route"].commands["add"],
+                               ["prefix", "vrf", "Vrf-RED", "30.30.30.0/24", "nexthop", "10.10.10.2"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert ('Vrf-RED', '30.30.30.0/24') in db.cfgdb.get_table('STATIC_ROUTE')
+
+        # Second add with the same nexthop - must be rejected
+        result = runner.invoke(config.config.commands["route"].commands["add"],
+                               ["prefix", "vrf", "Vrf-RED", "30.30.30.0/24", "nexthop", "10.10.10.2"], obj=obj)
+        print(result.exit_code, result.output)
+        assert ERROR_STR_DUPLICATE_NEXTHOP in result.output
+
+        # DB must still contain exactly one nexthop entry in the VRF
+        entry = db.cfgdb.get_entry('STATIC_ROUTE', 'Vrf-RED|30.30.30.0/24')
+        assert entry['nexthop'] == '10.10.10.2'
+        assert ',' not in entry['nexthop']
+        assert ',' not in entry['blackhole']
+
+        # --- IPv6 ---
+        # First add — should succeed
+        result = runner.invoke(config.config.commands["route"].commands["add"],
+                               ["prefix", "2001:db8::/32", "nexthop", "fc00::1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert ('default', '2001:db8::/32') in db.cfgdb.get_table('STATIC_ROUTE')
+
+        # Second add with identical IPv6 nexthop - must be rejected
+        result = runner.invoke(config.config.commands["route"].commands["add"],
+                               ["prefix", "2001:db8::/32", "nexthop", "fc00::1"], obj=obj)
+        print(result.exit_code, result.output)
+        assert ERROR_STR_DUPLICATE_NEXTHOP in result.output
+
+        # DB must still contain exactly one nexthop entry
+        entry = db.cfgdb.get_entry('STATIC_ROUTE', 'default|2001:db8::/32')
+        assert entry['nexthop'] == 'fc00::1'
+        assert ',' not in entry['nexthop']
+        assert ',' not in entry['blackhole']
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
#### What I did
Added a duplicate nexthop guard to `config route add`. Previously, running the same `config route add` command multiple times for the same prefix and nexthop silently appended duplicate comma-separated entries to every field in `STATIC_ROUTE`, corrupting the route entry. 
The command now rejects the add with a clear error if the identical `(nexthop, nexthop-vrf, ifname)` tuple already exists for that prefix.

#### How I did it
before appending a new nexthop to an existing `STATIC_ROUTE` entry, the existing nexthop tuples (nexthop, nexthop-vrf, ifname) are search for duplication. Similar check is already there in `del_route` path.

A new test  was added to `tests/static_routes_test.py` covering both the default VRF and a named VRF case.

#### How to verify it
Add identical nexthops multiple times.

```bash
 "STATIC_ROUTE|Vrf_test|30.30.30.0/24": {
    "type": "hash",
    "value": {
      "blackhole": "false,false,false",
      "distance": "0,0,0",
      "ifname": ",",
      "nexthop": "10.10.10.2,10.10.10.2,10.10.10.2",
      "nexthop-vrf": "Vrf_test,Vrf_test,Vrf_test"
    }
```

#### Previous command output (if the output of a command-line utility has changed)
```bash
$config route add prefix vrf Vrf_test 30.30.30.0/24 nexthop 10.10.10.2
$config route add prefix vrf Vrf_test 30.30.30.0/24 nexthop 10.10.10.2
$config route add prefix vrf Vrf_test 30.30.30.0/24 nexthop 10.10.10.2
```

#### New command output (if the output of a command-line utility has changed)
```bash
config route add prefix vrf Vrf_test 30.30.30.0/24 nexthop 10.10.10.2
Usage: config route add [OPTIONS] prefix [vrf <vrf_name>] <A.B.C.D/M> nexthop
                        [vrf <vrf_name>]                 <A.B.C.D>|<dev
                        <dev_name>>|<A.B.C.D dev <dev_name>>
Try 'config route add -h' for help.

Error: Nexthop ('10.10.10.2', 'Vrf_test', '') already exists for route Vrf_test|30.30.30.0/24

config route add prefix vrf Vrf_test 2001::0/64 nexthop 2001::1
config route add prefix vrf Vrf_test 2001::0/64 nexthop 2001::1
Usage: config route add [OPTIONS] prefix [vrf <vrf_name>] <A.B.C.D/M> nexthop
                        [vrf <vrf_name>]                 <A.B.C.D>|<dev
                        <dev_name>>|<A.B.C.D dev <dev_name>>
Try 'config route add -h' for help.

Error: Nexthop ('2001::1', 'Vrf_test', '') already exists for route Vrf_test|2001::0/64

```