### PR TITLE
[python tests] Fix pytest issues related to import sonic_platform and watchdogutil_test

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,13 +1,20 @@
 import sys
 import pytest
 from unittest import mock
-from utilities_common.util_base import UtilHelper
 from utilities_common.module import ModuleHelper, INVALID_MODULE_INDEX
 
-sys.modules['sonic_platform'] = mock.MagicMock()
+# Populated by _mock_sonic_platform_module before any test in this module runs.
+module_helper = None
 
-util = UtilHelper()
-module_helper = ModuleHelper()
+
+@pytest.fixture(scope="module", autouse=True)
+def _mock_sonic_platform_module():
+    """Install a fake sonic_platform module."""
+    global module_helper
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setitem(sys.modules, "sonic_platform", mock.MagicMock())
+        module_helper = ModuleHelper()
+        yield
 
 
 class TestModuleHelper:

--- a/tests/watchdogutil_test.py
+++ b/tests/watchdogutil_test.py
@@ -1,3 +1,5 @@
+import builtins
+
 from click.testing import CliRunner
 import watchdogutil.main as watchdogutil
 from unittest.mock import patch, MagicMock
@@ -13,10 +15,24 @@ class TestWatchdog(object):
 
     @patch('os.geteuid', MagicMock(return_value=0))
     def test_import_fails(self):
-        runner = CliRunner()
-        result = runner.invoke(watchdogutil.watchdogutil, ["version"])
+        real_import = builtins.__import__
+
+        def mock_import_impl(name, globals=None, locals=None, fromlist=(), level=0):
+            """Mock the import of the sonic_platform module."""
+            if level == 0 and name == "sonic_platform":
+                raise ImportError("No module named 'sonic_platform'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        mock_import = MagicMock(side_effect=mock_import_impl)
+        with patch("builtins.__import__", mock_import):
+            runner = CliRunner()
+            result = runner.invoke(watchdogutil.watchdogutil, ["version"])
         assert result.exit_code != 0
         assert result.exception
+        assert any(
+            call_record[0] and call_record[0][0] == "sonic_platform"
+            for call_record in mock_import.call_args_list
+        ), "expected \"import sonic_platform\" to be called"
 
     def test_version(self):
         runner = CliRunner()


### PR DESCRIPTION

#### What I did

Fix issues in pytests related to `import sonic_platform`. That module may or may not be available on the python search path when the tests are run, and generally tests are written in a way to work when it is not present (or incorrectly assume it isn't present), using different approaches. This change fixes the way this is handled in two cases.

* test_module.py: Fix the way sonic_platform module is substituted with MagicMock, such that it now cleans up / doesn't leak to the test cases after.

* watchdogutil_test.py: The test case `TestWatchdog.test_import_fails` assumes the module is not present. However, it is possible that it is present. This also interacts in weird ways with the `test_module.py` leaking import (bullet point above), to cause failures. This change fixes that issue by mocking the `import` statement to simulate the module not being found, whether it exists or not, and adds an assertion that `import sonic_platform` actually gets called. 

Without these changes, its possible that if the `sonic_platform` module is available on the search path, the following test failure can occur:

```
FAILED tests/watchdogutil_test.py::TestWatchdog::test_import_fails -
assert 0 != 0
```

With these details:

```
_____________________ TestWatchdog.test_import_fails
_____________________

self = <tests.watchdogutil_test.TestWatchdog object at 0x7f73a36a42d0>

    @patch('os.geteuid', MagicMock(return_value=0))
    def test_import_fails(self):
        runner = CliRunner()
        result = runner.invoke(watchdogutil.watchdogutil, ["version"])
>       assert result.exit_code != 0
E       assert 0 != 0
E        +  where 0 = <Result okay>.exit_code

tests/watchdogutil_test.py:18: AssertionError
```

#### How I did it

Using monkeypatches to enforce and clean up the special-case behaviors for `sonic_platform`.

#### How to verify it

Without these changes, you can reproduce by ensuring that module sonic_platform is available.

 You can do this in `sonic-buildimage` when building with
`PLATFORM=mellanox` by manually installing the wheel `mlnx_platform_api-1.0-py3-none-any.whl` in the slave container, or altering the `sonic-utilities.mk` file to add
`$(SONIC_PLATFORM_API_PY3)` to the `$(SONIC_UTILITIES_PY3)_DEPENDS` list so it builds and installs before the test cases run:

``` diff
 $(SONIC_UTILITIES_PY3)_DEPENDS += $(SONIC_PY_COMMON_PY3) \                                                                                                                                                                
                                   $(SONIC_CONFIG_ENGINE_PY3) \                                                                                                                                                                             
                                   $(SONIC_PLATFORM_COMMON_PY3) \                                                                                                                                                                           
                                   $(SONIC_YANG_MGMT_PY3) \                                                                                                                                                                                 
-                                  $(SONIC_YANG_MODELS_PY3)                                                                                                                                                                                 
+                                  $(SONIC_YANG_MODELS_PY3) \                                                                                                                                                                               
+                                  $(SONIC_PLATFORM_API_PY3) 
```

and then building sonic_utilities, which will run the test case:

```
rm  target/python-wheels/trixie/sonic_utilities-1.2-py3-none-any.whl   

NOBOOKWORM=1 KEEP_SLAVE_ON=yes SONIC_BUILD_JOBS=64 \
 DOCKER_EXTRA_OPTS="--registry-mirror=https://dockerhub.nvidia.com" \
 make target/python-wheels/trixie/sonic_utilities-1.2-py3-none-any.whl                                                 
```

If you want a **much quicker reproduction**, you can add `BUILD_SKIP_TEST=y` to skip the many long tests that normally run, and then manually run the two tests in the slave container after the wheels are built. You must run both of these tests in one go to trigger the failure:
* `tests/test_module.py`
* `tests/watchdogutil_test.py`

by running:

```
cd src/sonic-utilities

python -m pytest tests/test_module.py tests/watchdogutil_test.py
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

Signed-off-by: Judson Wilson <judsonw@nvidia.com>
