### PR TITLE
[DPU] Add flow dump collection to techsupport

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -53,6 +53,8 @@ DEBUG_DUMP=false
 ROUTE_TAB_LIMIT_DIRECT_ITERATION=24000
 IS_SUPERVISOR=false
 
+ENABLE_FLOW_DUMP=false
+
 # lock dirs/files
 LOCKDIR="/tmp/techsupport-lock"
 PIDFILE="${LOCKDIR}/PID"
@@ -2468,6 +2470,62 @@ save_container_files() {
 }
 
 ###############################################################################
+# Save DPU Flow Dump for better debugging
+###############################################################################
+start_dpu_flow_dump() {
+    trap 'handle_error $? $LINENO' ERR
+    if [[ "${ENABLE_FLOW_DUMP}" != true ]]; then
+        return
+    fi
+
+    if $NOOP; then
+        return
+    fi
+
+    if [[ ! -f /usr/local/bin/sonic-dpu-flow-dump.py ]]; then
+        echo "INFO: sonic-dpu-flow-dump.py not found, skipping DPU flow dump collection." >&2
+        return
+    fi
+
+    local is_dpu
+    is_dpu=$(python3 -c "from sonic_py_common import device_info; print(device_info.is_dpu())" 2>/dev/null) || is_dpu="False"
+    if [[ "$is_dpu" != "True" ]]; then
+        return
+    fi
+
+    if [ ! -d $LOGDIR ]; then
+        $MKDIR $V -p $LOGDIR
+    fi
+
+    echo "Started DPU flow dump collection (pid ${BASHPID})."
+
+    local start_t=$(date +%s%3N)
+    local path_file stderr_file
+    path_file=$(mktemp /tmp/ts_dpu_flow_dump_path.XXXXXX)
+    stderr_file=$(mktemp /tmp/ts_dpu_flow_dump_err.XXXXXX)
+    sonic-dpu-flow-dump.py --no-flow-state --file-only > "$path_file" 2>"$stderr_file"
+    local rc=$?
+    if [[ "$rc" -eq 0 ]] && [[ -f "$path_file" ]]; then
+        echo "DPU flow dump collection successful (rc=${rc})."
+        local src
+        src=$(tr -d '\n\r' < "$path_file")
+        if [[ -n "$src" && -f "$src" ]]; then
+            $MV "$src" $LOGDIR
+            echo "DPU flow dump saved: $LOGDIR/$(basename "$src")"
+        fi
+    else
+        if [[ -f "$stderr_file" ]]; then
+            echo "DPU flow dump collection failed (rc=${rc}). Stderr: $stderr_file"
+        else
+            echo "DPU flow dump collection failed or skipped (rc=${rc})."
+        fi
+    fi
+    $RM -f "$path_file" "$stderr_file"
+    local end_t=$(date +%s%3N)
+    echo "[ dpu_flow_dump ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
+}
+
+###############################################################################
 # Main generate_dump routine
 # Globals:
 #  All of them.
@@ -2689,6 +2747,7 @@ main() {
         collect_pensando
     fi
 
+    start_dpu_flow_dump &
 
     # 2nd counter snapshot late. Need 2 snapshots to make sense of counters trend.
     save_counter_snapshot $asic 2
@@ -2874,7 +2933,7 @@ abort() {
 ###############################################################################
 usage() {
     cat <<EOF
-$0 [-xnvh]
+$0 [-xnvhf]
 
 Create a SONiC system dump for support/debugging. Requires root privileges.
 
@@ -2903,11 +2962,12 @@ OPTIONS
         Redirect any intermediate errors to STDERR
     -d
         Collect the output of debug dump cli
+    -f
+        On DPU platforms, also collect a DPU flow dump
 EOF
 }
 
-
-while getopts ":xnvhzas:t:r:d" opt; do
+while getopts ":xnvhzas:t:r:df" opt; do
     case $opt in
         x)
             # enable bash debugging
@@ -2957,6 +3017,9 @@ while getopts ":xnvhzas:t:r:d" opt; do
             ;;
         d)
             DEBUG_DUMP=true
+            ;;
+        f)
+            ENABLE_FLOW_DUMP=true
             ;;
         /?)
             echo "Invalid option: -$OPTARG" >&2

--- a/scripts/sonic-dpu-flow-dump.py
+++ b/scripts/sonic-dpu-flow-dump.py
@@ -6,13 +6,14 @@ This script triggers a flow dump session, waits for completion, and extracts/pri
 It automatically creates the configuration file in /etc/sonic/ha/flow_dump.json.
 
 Usage:
-    sonic-dpu-flow-dump.py [-f FLOW_STATE] [-t TIMEOUT] [-m MAX_FLOWS] [-v]
+    sonic-dpu-flow-dump.py [--no-flow-state] [-f] [-t TIMEOUT] [-m MAX_FLOWS] [-v]
 
 Options:
-    -f, --flow-state    Flow state (true/false), default: true
-    -t, --timeout       Timeout in seconds, default: 60
-    -m, --max-flows     Maximum number of flows to dump, default: 1000
-    -v, --verbose       Enable verbose output
+    --no-flow-state     Omit flow state from the dump (default: include flow state)
+    -f, --file-only     Print only the output file path (for automation, e.g. techsupport)
+    -t, --timeout       Wait timeout in seconds (default: 60)
+    -m, --max-flows     Maximum flows to dump (default: 1000)
+    -v, --verbose       Verbose logging
 """
 
 import json

--- a/show/main.py
+++ b/show/main.py
@@ -1780,7 +1780,8 @@ def users(verbose):
 @click.option('--silent', is_flag=True, help="Run techsupport in silent mode")
 @click.option('--debug-dump', is_flag=True, help="Collect Debug Dump Output")
 @click.option('--redirect-stderr', '-r', is_flag=True, help="Redirect an intermediate errors to STDERR")
-def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent, debug_dump, redirect_stderr):
+@click.option('--flow-dump', is_flag=True, help="Collect DPU flow dump (Only valid on DPU platforms)")
+def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent, debug_dump, redirect_stderr, flow_dump):
     """Gather information for troubleshooting"""
     cmd = ["sudo"]
 
@@ -1801,6 +1802,9 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
 
     if debug_dump:
         cmd += ["-d"]
+
+    if flow_dump:
+        cmd += ["-f"]
 
     cmd += ['-t', str(cmd_timeout)]
     if redirect_stderr:

--- a/tests/techsupport_test.py
+++ b/tests/techsupport_test.py
@@ -15,6 +15,8 @@ EXPECTED_BASE_COMMAND = ['sudo']
             (['--allow-process-stop'], ['generate_dump', '-v', '-a', '-t', '5']),
             (['--silent'], ['generate_dump', '-t', '5']),
             (['--debug-dump', '--redirect-stderr'], ['generate_dump', '-v', '-d', '-t', '5', '-r']),
+            (['--flow-dump'], ['generate_dump', '-v', '-f', '-t', '5']),
+            (['--debug-dump', '--flow-dump'], ['generate_dump', '-v', '-d', '-f', '-t', '5']),
         ]
 )
 def test_techsupport(run_command, cli_arguments, expected):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add Flow Dump Collection on DPU Platform during techsupport collection

#### How I did it

Provide an optional argument `--flow-dump` to show techsupport CLI 

#### How to verify it

```
root@smartswitch-dpu-0:/show techsupport --flow-dump
/var/dump/sonic_dump_smartswitch-dpu-0_20260414_203635.tar.gz


root@smartswitch-dpu-0:/sonic_dump_smartswitch-dpu-0_20260414_203635/dump# ls -l | grep flow
-rw-r--r--  1 root root     172 Apr 14 20:37 flow_dump_0x0018008000000048.jsonl.gz

root@smartswitch-dpu-0:/sonic_dump_smartswitch-dpu-0_20260414_203635/dump# gzip -d flow_dump_0x0018008000000048.jsonl.gz

root@smartswitch-dpu-0:/sonic_dump_smartswitch-dpu-0_20260414_203635/dump# cat flow_dump_0x0018008000000048.jsonl
{"di":"10.2.0.100","dp":55057,"em":"F4:93:9F:EF:C4:7E","epoch":1776199074,"pr":17,"si":"10.0.0.11","sp":34074,"vn":0}
{"di":"fd41:108:20:d107:64:ff71:a00:b","dp":34074,"em":"F4:93:9F:EF:C4:7E","epoch":1776199074,"pr":17,"si":"2603:10e1:100:2::3401:203","sp":55057,"vn":0}
```



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

