### PR TITLE
Add show command for tech support

### DIFF
--- a/scripts/gpins_techsupport
+++ b/scripts/gpins_techsupport
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import sys
+import dbus
+
+
+def main():
+    bus = dbus.SystemBus()
+    dbus_object = bus.get_object(
+        "org.SONiC.HostService.debug_info", "/org/SONiC/HostService/debug_info")
+    rc, artifact = dbus_object.collect(
+        ['{"component": "all", "level": "all"}'])
+    if rc != 0:
+        print("Failed to collect debug artifact: {}".format(artifact))
+    else:
+        artifact = "/tmp/dump{}".format(artifact[9:])
+        print("Debug artifact saved in {}".format(artifact))
+
+    return rc
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ setup(
         'scripts/gearboxutil',
         'scripts/generate_dump',
         'scripts/generate_shutdown_order.py',
+        'scripts/gpins_techsupport',
         'scripts/intfutil',
         'scripts/intfstat',
         'scripts/ipintutil',

--- a/show/main.py
+++ b/show/main.py
@@ -1809,6 +1809,18 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
 
 
 #
+# 'gpins-techsupport' command ("show gpins-techsupport")
+#
+
+@cli.command()
+@click.option("--verbose", is_flag=True, help="Enable verbose output")
+def gpins_techsupport(verbose):
+    """Gather debug information for troubleshooting"""
+    cmd = "gpins_techsupport"
+    run_command(cmd, display_cmd=verbose)
+
+
+#
 # 'runningconfiguration' group ("show runningconfiguration")
 #
 

--- a/tests/gpins_techsupport_test.py
+++ b/tests/gpins_techsupport_test.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+import os
+import sys
+import dbus
+
+from utilities_common.general import load_module_from_source
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, 'scripts')
+sys.path.insert(0, modules_path)
+
+# Load the file under test
+scripts_path = os.path.join(scripts_path, 'gpins_techsupport')
+techsupport = load_module_from_source('gpins_techsupport', scripts_path)
+
+
+class TestGpinsTechSupport(object):
+    @mock.patch.object(dbus, 'SystemBus', autospec=True)
+    @mock.patch('builtins.print', autospec=True)
+    def test_host_service_success(self, mock_print, mock_system_bus):
+        mock_object = mock.Mock()
+        mock_object.collect.return_value = (0, '/var/dump/foo')
+        mock_dbus = mock.Mock()
+        mock_dbus.get_object.return_value = mock_object
+        mock_system_bus.return_value = mock_dbus
+        assert techsupport.main() == 0
+        mock_system_bus.assert_called_once_with()
+        mock_dbus.get_object.assert_called_once_with(
+            "org.SONiC.HostService.debug_info", "/org/SONiC/HostService/debug_info")
+        mock_object.collect.assert_called_once_with(
+            ['{"component": "all", "level": "all"}'])
+        mock_print.assert_called_once_with(
+            'Debug artifact saved in /tmp/dump/foo')
+
+    @mock.patch.object(dbus, 'SystemBus', autospec=True)
+    @mock.patch('builtins.print', autospec=True)
+    def test_host_service_fail(self, mock_print, mock_system_bus):
+        mock_object = mock.Mock()
+        mock_object.collect.return_value = (1, 'fail reason')
+        mock_dbus = mock.Mock()
+        mock_dbus.get_object.return_value = mock_object
+        mock_system_bus.return_value = mock_dbus
+        assert techsupport.main() == 1
+        mock_system_bus.assert_called_once_with()
+        mock_dbus.get_object.assert_called_once_with(
+            "org.SONiC.HostService.debug_info", "/org/SONiC/HostService/debug_info")
+        mock_object.collect.assert_called_once_with(
+            ['{"component": "all", "level": "all"}'])
+        mock_print.assert_called_once_with(
+            'Failed to collect debug artifact: fail reason')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added show command support for tech support 

#### How I did it
Adding files in show and tests folder

#### How to verify it
Execute below command for Unit test
python3 -m pytest tests/gpins_techsupport_test.py

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

