### PR TITLE
[acl-loader] Include `IP_TYPE=IP` in `IP_PROTOCOL` rules

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -600,6 +600,11 @@ class AclLoader(object):
                         rule.ip.config.protocol, table_name, rule_idx))
 
                 rule_props["IP_PROTOCOL"] = rule.ip.config.protocol
+            if "IP_PROTOCOL" in rule_props:
+                # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
+                # we could match on non-IP packets if the bits at the same offset match
+                # https://github.com/sonic-net/sonic-mgmt/issues/23960
+                rule_props["IP_TYPE"] = "IP"
 
         if rule.ip.config.source_ip_address:
             source_ip_address = rule.ip.config.source_ip_address

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -600,11 +600,6 @@ class AclLoader(object):
                         rule.ip.config.protocol, table_name, rule_idx))
 
                 rule_props["IP_PROTOCOL"] = rule.ip.config.protocol
-            if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props:
-                # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
-                # we could match on non-IP packets if the bits at the same offset match
-                # https://github.com/sonic-net/sonic-mgmt/issues/23960
-                rule_props["IP_TYPE"] = "IP"
 
         if rule.ip.config.source_ip_address:
             source_ip_address = rule.ip.config.source_ip_address
@@ -778,6 +773,12 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_icmp(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_transport(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
+
+        if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props:
+            # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
+            # we could match on non-IP packets if the bits at the same offset match
+            # https://github.com/sonic-net/sonic-mgmt/issues/23960
+            rule_props["IP_TYPE"] = "IP"
 
         self.validate_rule_fields(rule_props)
 

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -600,7 +600,7 @@ class AclLoader(object):
                         rule.ip.config.protocol, table_name, rule_idx))
 
                 rule_props["IP_PROTOCOL"] = rule.ip.config.protocol
-            if "IP_PROTOCOL" in rule_props:
+            if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props:
                 # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
                 # we could match on non-IP packets if the bits at the same offset match
                 # https://github.com/sonic-net/sonic-mgmt/issues/23960

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -76,6 +76,7 @@ class TestAclLoader(object):
                 "VLAN_ID": 369,
                 "ETHER_TYPE": "2048",
                 "IP_PROTOCOL": 6,
+                'IP_TYPE': 'IP',
                 "SRC_IP": "20.0.0.2/32",
                 "DST_IP": "30.0.0.3/32",
                 "PACKET_ACTION": "FORWARD",
@@ -94,6 +95,7 @@ class TestAclLoader(object):
             "VLAN_ID": 369,
             "ETHER_TYPE": "2048",
             "IP_PROTOCOL": 6,
+            'IP_TYPE': 'IP',
             "SRC_IP": "20.0.0.2/32",
             "DST_IP": "30.0.0.3/32",
             "PACKET_ACTION": "FORWARD",
@@ -134,6 +136,7 @@ class TestAclLoader(object):
             "VLAN_ID": 369,
             "ETHER_TYPE": 2048,
             "IP_PROTOCOL": 6,
+            'IP_TYPE': 'IP',
             "SRC_IP": "20.0.0.2/32",
             "DST_IP": "30.0.0.3/32",
             "PACKET_ACTION": "FORWARD",
@@ -147,6 +150,7 @@ class TestAclLoader(object):
         assert acl_loader.rules_info[("DATAACLV4V6", "RULE_2")] == {
             "ETHER_TYPE": 34525,
             "IP_PROTOCOL": 58,
+            'IP_TYPE': 'IP',
             "SRC_IPV6": "::1/128",
             "DST_IPV6": "::1/128",
             "PACKET_ACTION": "FORWARD",
@@ -170,6 +174,7 @@ class TestAclLoader(object):
             "ICMP_TYPE": 3,
             "ICMP_CODE": 0,
             "IP_PROTOCOL": 1,
+            'IP_TYPE': 'IP',
             "SRC_IP": "20.0.0.2/32",
             "DST_IP": "30.0.0.3/32",
             "ETHER_TYPE": "2048",
@@ -208,6 +213,7 @@ class TestAclLoader(object):
             "ICMP_TYPE": 136,
             "ICMP_CODE": 0,
             "IP_PROTOCOL": 1,
+            'IP_TYPE': 'IP',
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9998"
         }
@@ -220,6 +226,7 @@ class TestAclLoader(object):
             "ICMPV6_TYPE": 136,
             "ICMPV6_CODE": 0,
             "IP_PROTOCOL": 58,
+            'IP_TYPE': 'IP',
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9998"
         }


### PR DESCRIPTION
If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rules then we might end up matching non-IP packets with matching values in the IP_PROTOCOL offset (10-bytes after ETH header).

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/23960

#### What I did
In acl-loader include `IP_TYPE=IP` qualifier on any rules that use `IP_PROTOCOL` as a qualifier.

#### How I did it
Modify the openconfig->db_schema function `convert_ip` to add `IP_TYPE=IP` if the rule being converted has `IP_PROTOCOL` in it.

#### How to verify it
I configured an ACL with an IP_PROTOCOL qualifying rule and saw that the `IP_TYPE=IP` was added to it (See RULE_7):
```
> acl-loader update full /etc/sonic/acl-erspan.json --table_name EVERFLOW --session_name test_session_1

> show acl rule
Table     Rule     Priority    Action                          Match                         Status
--------  -------  ----------  ------------------------------  ----------------------------  --------
EVERFLOW  RULE_1   9999        MIRROR INGRESS: test_session_1  SRC_IP: 20.0.0.10/32          Active
EVERFLOW  RULE_2   9998        MIRROR INGRESS: test_session_1  DST_IP: 30.0.0.10/32          Active
EVERFLOW  RULE_3   9997        MIRROR INGRESS: test_session_1  DST_IP: 192.168.0.2/32        Active
EVERFLOW  RULE_4   9996        MIRROR INGRESS: test_session_1  L4_SRC_PORT: 4661             Active
EVERFLOW  RULE_5   9995        MIRROR INGRESS: test_session_1  L4_DST_PORT: 4661             Active
EVERFLOW  RULE_6   9994        MIRROR INGRESS: test_session_1  ETHER_TYPE: 4660              Active
EVERFLOW  RULE_7   9993        MIRROR INGRESS: test_session_1  IP_PROTOCOL: 126              Active
                                                               IP_TYPE: IP
EVERFLOW  RULE_8   9992        MIRROR INGRESS: test_session_1  L4_SRC_PORT_RANGE: 4672-4681  Active
EVERFLOW  RULE_9   9991        MIRROR INGRESS: test_session_1  L4_DST_PORT_RANGE: 4672-4681  Active
EVERFLOW  RULE_10  9990        MIRROR INGRESS: test_session_1  DSCP: 51                      Active
```

I also reran `test_everflow_fwd_recircle_port_queue_check` on a system that always failed due to packets matching RULE_7 and now the test passes.

#### Previous command output (if the output of a command-line utility has changed)
No change

#### New command output (if the output of a command-line utility has changed)
No change

