### PR TITLE
Support new pdb object and remove redundancy error message

### DIFF
--- a/scripts/psushow
+++ b/scripts/psushow
@@ -11,25 +11,23 @@ from tabulate import tabulate
 VERSION = '1.0'
 
 def get_psu_status_list():
+    """
+    Build list of PSU/PDB status from STATE_DB PSU_INFO table.
+    Keys may be "PSU 1", "PSU 2" (PSU platform) or "PDB 1", "PDB 2" (PDB platform).
+    Returns empty list when no entries exist (no error; HLD: output is simply no rows).
+    """
     psu_status_list = []
-
     db = SonicV2Connector(host="127.0.0.1")
     db.connect(db.STATE_DB)
 
-    # Currently set chassis_num to 1, need to improve it once new platform API is implemented
-    chassis_num = 1
-    chassis_name = "chassis {}".format(chassis_num)
-    num_psus = db.get(db.STATE_DB, 'CHASSIS_INFO|{}'.format(chassis_name), 'psu_num')
-    if not num_psus:
-        return None
+    keys = db.keys(db.STATE_DB, "PSU_INFO|*")
+    if not keys:
+        return psu_status_list
 
-    for psu_idx, psu_key in enumerate(natsorted(db.keys(db.STATE_DB, "PSU_INFO|*")), start = 1):
-        psu_key = psu_key.replace("PSU_INFO|", "")
+    for psu_idx, psu_key in enumerate(natsorted(keys), start=1):
+        psu_name = psu_key.replace("PSU_INFO|", "")
         psu_status = {}
-
         psu_status['index'] = str(psu_idx)
-
-        psu_name = psu_key
         psu_status['name'] = psu_name
 
         presence = db.get(db.STATE_DB, 'PSU_INFO|{}'.format(psu_name), 'presence')
@@ -61,20 +59,21 @@ def get_psu_status_list():
 
 
 def psu_status_show_table(index):
+    """
+    Show PSU/PDB status table. Columns stay the same for consistent experience (HLD).
+    When no PSU/PDB present, output is simply header and no rows (no error message).
+    """
     psu_status_list = get_psu_status_list()
-
-    if not psu_status_list:
-        return None
-
-    header = ['PSU',  'Model', 'Serial', 'HW Rev', 'Voltage (V)', 'Current (A)', 'Power (W)', 'Status', 'LED']
+    header = ['PSU', 'Model', 'Serial', 'HW Rev', 'Voltage (V)', 'Current (A)', 'Power (W)', 'Status', 'LED']
     status_table = []
 
     if index > 0:
+        if not psu_status_list:
+            print("Error: PSU {} is not available. Number of supported PSUs: 0".format(index))
+            return -1
         if index > len(psu_status_list):
             print("Error: PSU {} is not available. Number of supported PSUs: {}".format(index, len(psu_status_list)))
             return -1
-
-        # Trim the list down to contain only the requested PSU
         psu_status_list = [psu_status_list[index-1]]
 
     for psu_status in psu_status_list:
@@ -88,24 +87,23 @@ def psu_status_show_table(index):
                              psu_status['status'],
                              psu_status['led_status']])
 
-    if status_table:
-        print(tabulate(status_table, header, tablefmt="simple", floatfmt='.2f'))
-
+    print(tabulate(status_table, header, tablefmt="simple", floatfmt='.2f'))
     return 0
 
 
 def psu_status_show_json(index):
+    """
+    Show PSU/PDB status in JSON. When no PSU/PDB present, output [] (no error message).
+    """
     psu_status_list = get_psu_status_list()
 
-    if not psu_status_list:
-        return None
-
     if index > 0:
+        if not psu_status_list:
+            print("Error: PSU {} is not available. Number of supported PSUs: 0".format(index))
+            return -1
         if index > len(psu_status_list):
             print("Error: PSU {} is not available. Number of supported PSUs: {}".format(index, len(psu_status_list)))
             return -1
-
-        # Trim the list down to contain only the requested PSU
         psu_status_list = [psu_status_list[index-1]]
 
     print(json.dumps(psu_status_list, indent=4))
@@ -138,10 +136,10 @@ Examples:
         else:
             ret = psu_status_show_table(psu_index)
 
-        if ret != 0:
-            print("PSU not detected")
+        if ret == -1:
             return 1
-
+        # ret == 0: success (including empty list: header + no rows, or JSON [])
+        # No "PSU not detected" when list is empty (HLD: output is simply no rows)
     return 0
 
 

--- a/tests/psushow_test.py
+++ b/tests/psushow_test.py
@@ -57,6 +57,14 @@ class TestPsushow(object):
         psu_status_list = psushow.get_psu_status_list()
         assert psu_status_list == expected_psu_status_list
 
+    def test_get_psu_status_list_no_psu_keys(self):
+        """STATE_DB has no PSU_INFO keys: early return with empty list."""
+        mock_db = mock.MagicMock()
+        mock_db.STATE_DB = 6
+        mock_db.keys.return_value = []
+        with mock.patch.object(psushow, 'SonicV2Connector', return_value=mock_db):
+            assert psushow.get_psu_status_list() == []
+
     def test_status_table(self, capsys):
         expected_output = '''\
 PSU    Model    Serial                        HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
@@ -95,10 +103,9 @@ PSU 2  0J6J4K   CN-0J6J4K-17972-5AF-008M-A00  A                 12.18          1
             captured = capsys.readouterr()
             assert captured.out == expected_output
 
-        # Test trying to display a non-existent PSU
+        # Test trying to display a non-existent PSU (no "PSU not detected" per HLD)
         expected_output = '''\
 Error: PSU 3 is not available. Number of supported PSUs: 2
-PSU not detected
 '''
         for arg in ['-s', '--status']:
             with mock.patch('sys.argv', ['psushow', arg, '-i', '3']):
@@ -193,10 +200,9 @@ PSU not detected
             captured = capsys.readouterr()
             assert captured.out == expected_output
 
-        # Test trying to display a non-existent PSU
+        # Test trying to display a non-existent PSU (no "PSU not detected" per HLD)
         expected_output = '''\
 Error: PSU 3 is not available. Number of supported PSUs: 2
-PSU not detected
 '''
         for arg in ['-j', '--json']:
             with mock.patch('sys.argv', ['psushow', '-s', '-i', '3', arg]):
@@ -204,6 +210,49 @@ PSU not detected
             assert ret == 1
             captured = capsys.readouterr()
             assert captured.out == expected_output
+
+    def test_status_table_empty_no_error(self, capsys):
+        """HLD: when no PSU/PDB, output is simply header and no rows (no 'PSU not detected' error)."""
+        with mock.patch.object(psushow, 'get_psu_status_list', return_value=[]):
+            with mock.patch('sys.argv', ['psushow', '-s']):
+                ret = psushow.main()
+        assert ret == 0
+        captured = capsys.readouterr()
+        # Header only, no data rows, no error message
+        assert 'PSU ' in captured.out and 'Model' in captured.out
+        assert 'PSU not detected' not in captured.out
+
+    def test_status_table_empty_with_index_errors(self, capsys):
+        """Explicit index with no PSUs: error path in psu_status_show_table."""
+        expected = (
+            'Error: PSU 1 is not available. Number of supported PSUs: 0\n'
+        )
+        with mock.patch.object(psushow, 'get_psu_status_list', return_value=[]):
+            with mock.patch('sys.argv', ['psushow', '-s', '-i', '1']):
+                ret = psushow.main()
+        assert ret == 1
+        assert capsys.readouterr().out == expected
+
+    def test_status_json_empty_no_error(self, capsys):
+        """When no PSU/PDB, JSON output is [] and no error."""
+        with mock.patch.object(psushow, 'get_psu_status_list', return_value=[]):
+            with mock.patch('sys.argv', ['psushow', '-s', '-j']):
+                ret = psushow.main()
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == '[]'
+        assert 'PSU not detected' not in captured.out
+
+    def test_status_json_empty_with_index_errors(self, capsys):
+        """Explicit index with no PSUs: error path in psu_status_show_json."""
+        expected = (
+            'Error: PSU 1 is not available. Number of supported PSUs: 0\n'
+        )
+        with mock.patch.object(psushow, 'get_psu_status_list', return_value=[]):
+            with mock.patch('sys.argv', ['psushow', '-s', '-j', '-i', '1']):
+                ret = psushow.main()
+        assert ret == 1
+        assert capsys.readouterr().out == expected
 
     def test_version(self, capsys):
         for arg in ['-v', '--version']:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This pr is part of the design [Support PDB flows](https://github.com/sonic-net/SONiC/pull/2219)
- Updated psushow data collection to read directly from STATE_DB PSU_INFO|* keys, so it works for both PSU entries (PSU n) and PDB entries (PDB n).
- Removed generic "PSU not detected" flow for empty inventory; now empty status output is non-error (table header only or JSON []), while invalid index requests still return explicit errors.
- Added/updated unit tests to verify removed error text behavior and new empty-inventory handling for both table and JSON outputs.

#### How I did it
extended current psushow script to collaborate the new pdb object, as well as remove the redundancy error message since no psu does not mean an error anymore in pdb based system.

#### How to verify it
manually test the command line on pdb installed system, as well as unit test.

#### Previous command output (if the output of a command-line utility has changed)
when psu is normally detected, the CLI will print out relevant information
```
PSU    Model          Serial        HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -------------  ------------  --------  -------------  -------------  -----------  --------  -----
PSU 1  XXXXXXXXXXXXX  XXXXXXXXXXXX  A4                12.00           4.50        52.00  OK        green
PSU 2  XXXXXXXXXXXXX  XXXXXXXXXXXX  A4                12.00           4.88        56.00  OK        green
```
in case no psu is detected, an info will print out to user
```
PSU not detected
```

#### New command output (if the output of a command-line utility has changed)
in pdb based system, pdb information will print out accordingly
```
PSU    Model        Serial       HW Rev  Voltage (V)   Current (A)   Power (W)   Status   LED
-----  ------------ ------------ ------- ------------  ------------  ----------  -------  -----
PDB1   XXXX         XXXX            XXXX      11.99         71.10         845.00   OK    green
```
and when no psu or pdb detected in correspond system, empty row will be shown without further indication.
```
PSU    Model        Serial       HW Rev  Voltage (V)   Current (A)   Power (W)   Status   LED
-----  ------------ ------------ ------- ------------  ------------  ----------  -------  -----
```
