### PR TITLE
Align firmware download with new CDB API signature

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1543,7 +1543,7 @@ def download_firmware(port_name, filepath):
     try:
         fwinfo = api.get_module_fw_mgmt_feature()
         if fwinfo['status'] == True:
-            startLPLsize, maxblocksize, lplonly_flag, autopaging_flag, writelength = fwinfo['feature']
+            startLPLsize, maxblocksize, lplonly_flag, _, _ = fwinfo['feature']
         else:
             click.echo("Failed to fetch CDB Firmware management features")
             sys.exit(EXIT_FAIL)
@@ -1552,11 +1552,11 @@ def download_firmware(port_name, filepath):
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
     click.echo('CDB: Starting firmware download')
-    startdata = fd.read(startLPLsize)
-    status = api.cdb_start_firmware_download(startLPLsize, startdata, file_size)
+    status = api.cdb_start_firmware_download(filepath)
     if status != 1:
         click.echo('CDB: Start firmware download failed - status {}'.format(status))
         sys.exit(EXIT_FAIL)
+    fd.seek(startLPLsize)
 
     # Increase the optoe driver's write max to speed up firmware download
     try:
@@ -1581,7 +1581,7 @@ def download_firmware(port_name, filepath):
             if lplonly_flag:
                 status = api.cdb_lpl_block_write(address, data)
             else:
-                status = api.cdb_epl_block_write(address, data, autopaging_flag, writelength)
+                status = api.cdb_epl_block_write(address, data)
             if (status != 1):
                 click.echo("CDB: firmware download failed! - status {}".format(status))
                 sys.exit(EXIT_FAIL)

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1467,36 +1467,32 @@ def is_fw_switch_done(port_name):
         sys.exit(ERROR_NOT_IMPLEMENTED)
 
     try:
-        MAX_WAIT = 60 # 60s timeout.
-        is_busy = 1 # Initial to 1 for entering while loop at least one time.
+        MAX_WAIT = 60
         timeout_time = time.time() + MAX_WAIT
-        while is_busy and (time.time() < timeout_time):
+        while time.time() < timeout_time:
             fw_info = api.get_module_fw_info()
-            is_busy = 1 if (fw_info['status'] == False) and (fw_info['result'] is not None) else 0
+            if fw_info['status'] is True and fw_info['result'] is not None:
+                (ImageA, ImageARunning, ImageACommitted, ImageAInvalid,
+                 ImageB, ImageBRunning, ImageBCommitted, ImageBInvalid, _, _) = fw_info['result']
+
+                if (ImageARunning == 1) and (ImageAInvalid == 1):
+                    click.echo("FW info error : ImageA shows running, but also shows invalid!")
+                    return -1
+                elif (ImageBRunning == 1) and (ImageBInvalid == 1):
+                    click.echo("FW info error : ImageB shows running, but also shows invalid!")
+                    return -1
+                elif (ImageARunning == 1) and (ImageACommitted == 0):
+                    click.echo("FW images switch successful : ImageA is running")
+                    return 1
+                elif (ImageBRunning == 1) and (ImageBCommitted == 0):
+                    click.echo("FW images switch successful : ImageB is running")
+                    return 1
+                # Switch not done yet — module may have returned stale pre-reset data, keep polling
+
             time.sleep(2)
 
-        if fw_info['status'] == True:
-            (ImageA, ImageARunning, ImageACommitted, ImageAInvalid,
-             ImageB, ImageBRunning, ImageBCommitted, ImageBInvalid, _, _) = fw_info['result']
-
-            if (ImageARunning == 1) and (ImageAInvalid == 1):       # ImageA is running, but also invalid.
-                click.echo("FW info error : ImageA shows running, but also shows invalid!")
-                status = -1 # Abnormal status.
-            elif (ImageBRunning == 1) and (ImageBInvalid == 1):     # ImageB is running, but also invalid.
-                click.echo("FW info error : ImageB shows running, but also shows invalid!")
-                status = -1 # Abnormal status.
-            elif (ImageARunning == 1) and (ImageACommitted == 0):   # ImageA is running, but not committed.
-                click.echo("FW images switch successful : ImageA is running")
-                status = 1  # run_firmware is done. 
-            elif (ImageBRunning == 1) and (ImageBCommitted == 0):   # ImageB is running, but not committed.
-                click.echo("FW images switch successful : ImageB is running")
-                status = 1  # run_firmware is done. 
-            else:                                                   # No image is running, or running and committed image is same.
-                click.echo("FW info error : Failed to switch into uncommitted image!")
-                status = -1 # Failure for Switching images.
-        else:
-            click.echo("FW switch : Timeout!")
-            status = -1     # Timeout or check code error or CDB not supported.
+        click.echo("FW switch : Timeout!")
+        status = -1
 
     except NotImplementedError:
         click.echo("This functionality is not applicable for this transceiver")

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1303,9 +1303,34 @@ EEPROM hexdump for port Ethernet4
         mock_sfp.set_optoe_write_max = MagicMock(side_effect=NotImplementedError)
         status = sfputil.download_firmware("Ethernet0", "test.bin")
         assert status == 1
+        mock_api.cdb_start_firmware_download.assert_called_once_with("test.bin")
+
+        mock_api.cdb_start_firmware_download.reset_mock()
         mock_api.get_module_fw_mgmt_feature.return_value = {'status': True, 'feature': (0, 64, True, False, 0)}
         status = sfputil.download_firmware("Ethernet0", "test.bin")
         assert status == 1
+        mock_api.cdb_start_firmware_download.assert_called_once_with("test.bin")
+        mock_api.reset_mock()
+        block_a = b'\xaa' * 64
+        block_b = b'\xbb' * 64
+        mock_file.return_value.tell.return_value = 128
+        mock_file.return_value.read.side_effect = [block_a, block_b]
+        mock_api.get_module_fw_mgmt_feature.return_value = {
+            'status': True, 'feature': (0, 64, False, False, 0)
+        }
+        mock_api.cdb_start_firmware_download.return_value = 1
+        mock_api.cdb_epl_block_write.return_value = 1
+        mock_api.cdb_firmware_download_complete.return_value = 1
+        status = sfputil.download_firmware("Ethernet0", "test_fw.bin")
+        assert status == 1
+        mock_api.cdb_start_firmware_download.assert_called_once_with("test_fw.bin")
+        assert mock_api.cdb_epl_block_write.call_count == 2
+        for call in mock_api.cdb_epl_block_write.call_args_list:
+            args, kwargs = call
+            assert len(args) == 2
+            assert kwargs == {}
+        mock_api.cdb_epl_block_write.assert_any_call(0, block_a)
+        mock_api.cdb_epl_block_write.assert_any_call(64, block_b)
 
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1344,6 +1344,8 @@ EEPROM hexdump for port Ethernet4
         status = sfputil.run_firmware("Ethernet0", 1)
         assert status == 1
 
+    @patch('sfputil.main.time.time')
+    @patch('sfputil.main.time.sleep', MagicMock())
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
     @pytest.mark.parametrize("mock_response, expected", [
@@ -1354,17 +1356,16 @@ EEPROM hexdump for port Ethernet4
         ({'status': True,  'result': ("1.0.1", 0, 1, 0, "1.0.2", 1, 0, 0, "1.0.2", "1.0.1")} ,  1),
         ({'status': True,  'result': ("1.0.1", 1, 0, 1, "1.0.2", 0, 1, 0, "1.0.1", "1.0.2")} , -1),
         ({'status': True,  'result': ("1.0.1", 0, 1, 0, "1.0.2", 1, 0, 1, "1.0.2", "1.0.1")} , -1),
-
-        # "is_fw_switch_done" function will waiting until timeout under below condition, so that this test will spend around 1min.
         ({'status': False, 'result': 0}                                    , -1),
     ])
-    def test_is_fw_switch_done(self, mock_chassis, mock_response, expected):
+    def test_is_fw_switch_done(self, mock_chassis, mock_time, mock_response, expected):
         mock_sfp = MagicMock()
         mock_api = MagicMock()
         mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
         mock_sfp.get_presence.return_value = True
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
         mock_api.get_module_fw_info.return_value = mock_response
+        mock_time.side_effect = [0, 0, 61]
         status = sfputil.is_fw_switch_done("Ethernet0")
         assert status == expected
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
**This PR should be merged along with https://github.com/sonic-net/sonic-platform-common/pull/658**
#### What I did
Updated sfputil firmware command to use the refactored CDB API. The new API uses `CdbFwHandler` which provides cleaner method signatures while maintaining the same CLI behavior and output.

#### How I did it
Updated the firmware download paths in `sfputil` to call the new CDB API method exposed through the refactored module. 

#### How to verify it
- Run unit tests: pytest tests/sfputil_test.py -v
- Verify firmware update workflow on a device:
```
  sfputil show fwversion EthernetXX
  sfputil firmware download EthernetXX /path/to/firmware_image.bin
  sfputil firmware run EthernetXX
  sfputil firmware commit EthernetXX
  sfputil firmware upgrade EthernetXX /path/to/firmware_image.bin
  sfputil firmware unlock EthernetXX --password wrong_pwd
```

#### Previous command output (if the output of a command-line utility has changed)


#### New command output (if the output of a command-line utility has changed)


