### PR TITLE
Optimize GCU sort: content-hash cache to skip redundant loadData

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -81,6 +81,8 @@ class ConfigWrapper:
         self.scope = scope
         self.yang_dir = YANG_DIR
         self.sonic_yang_with_loaded_models = None
+        self._loaded_data_config_id = None
+        self._loaded_data_config_hash = None
 
     def get_config_db_as_json(self):
         return get_config_db_as_json(self.scope)
@@ -131,11 +133,39 @@ class ConfigWrapper:
         sy = self.create_sonic_yang_with_loaded_models()
 
         try:
-            # Loading data automatically does full validation
             sy.loadData(config_db_as_json)
+            self._mark_data_loaded(config_db_as_json)
             return True, None
         except sonic_yang.SonicYangException as ex:
+            self._clear_data_loaded()
             return False, ex
+
+    def _compute_config_hash(self, config):
+        """Compute a content hash for a config dict."""
+        import hashlib
+        return hashlib.md5(json.dumps(config, sort_keys=True).encode()).hexdigest()
+
+    def _is_data_loaded_for(self, config):
+        """
+        Check if the shared SonicYang instance already has data loaded for
+        the given config. Uses fast id() check first, falls back to content
+        hash comparison on id() miss.
+        """
+        if self._loaded_data_config_id is not None and self._loaded_data_config_id == id(config):
+            return True
+        if self._loaded_data_config_hash is not None and self._loaded_data_config_hash == self._compute_config_hash(config):
+            return True
+        return False
+
+    def _mark_data_loaded(self, config):
+        """Record that SonicYang currently has data loaded for this config."""
+        self._loaded_data_config_id = id(config)
+        self._loaded_data_config_hash = self._compute_config_hash(config)
+
+    def _clear_data_loaded(self):
+        """Clear the loaded-data cache (e.g. after an exception)."""
+        self._loaded_data_config_id = None
+        self._loaded_data_config_hash = None
 
     def validate_config_db_config(self, config_db_as_json):
         sy = self.create_sonic_yang_with_loaded_models()
@@ -145,13 +175,15 @@ class ConfigWrapper:
                                         self.validate_lanes]
 
         try:
-            # Loading data automatically does full validation
-            sy.loadData(config_db_as_json)
+            if not self._is_data_loaded_for(config_db_as_json):
+                sy.loadData(config_db_as_json)
+                self._mark_data_loaded(config_db_as_json)
             for supplemental_yang_validator in supplemental_yang_validators:
                 success, error = supplemental_yang_validator(config_db_as_json)
                 if not success:
                     return success, error
         except sonic_yang.SonicYangException as ex:
+            self._clear_data_loaded()
             return False, str(ex)
 
         return True, None
@@ -533,7 +565,14 @@ class PathAddressing:
         sy = self._create_sonic_yang_with_loaded_models()
 
         if reload_config:
-            sy.loadData(config)
+            # Skip loadData if the shared SonicYang instance already has this
+            # config loaded (e.g. by a prior validate_config_db_config call
+            # or a previous find_ref_paths call with the same config).
+            # This avoids redundant O(N^2) leafref resolution in libyang v1.
+            if self.config_wrapper is None or not self.config_wrapper._is_data_loaded_for(config):
+                sy.loadData(config)
+                if self.config_wrapper is not None:
+                    self.config_wrapper._mark_data_loaded(config)
 
         # Force to be a list
         if not isinstance(paths, list):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1026,14 +1026,15 @@ class NoDependencyMoveValidator:
         deleted_paths, added_paths = self._get_paths(diff.current_config, simulated_config, [])
 
         # Note: on replace operations we are loading both current and simulated configs so we have to
-        #       load twice :(
-
-        # For deleted paths, we check the current config has no dependencies between nodes under the removed path
-        if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
-            return False
+        #       load twice. Check simulated first so it can reuse data already loaded by
+        #       FullConfigMoveValidator.validate_config_db_config() (same simulated_config).
 
         # For added paths, we check the simulated config has no dependencies between nodes under the added path
         if not self._validate_paths_config(added_paths, simulated_config, reload_config=True):
+            return False
+
+        # For deleted paths, we check the current config has no dependencies between nodes under the removed path
+        if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
             return False
 
         return True


### PR DESCRIPTION
## Description

During the `config apply-patch` sort step, multiple validators call `SonicYang.loadData()` on the same config repeatedly via a shared singleton. Each `loadData()` triggers libyang v1's **O(N²) leafref resolution**.

## Changes

### Commit 1: Content-hash cache (`gu_common.py`)
Tracks which config is currently loaded via `id()` + MD5 hash. Skips `loadData()` when same content is already loaded.

### Commit 2: Reorder REPLACE validation (`patch_sorter.py`)
Swaps the two `find_ref_paths` calls in `_validate_replace()`: checks `simulated_config` before `current_config`. This lets the cache hit on simulated (already loaded by FullConfigMoveValidator). The two checks are independent — order does not affect correctness.

## Benchmark Results

Shared SonicYang singleton, exact real code path. At 512 ports, 10 moves:

| Op Type | Before | After | Loads | Speedup |
|---------|--------|-------|-------|---------|
| ADD     | 14.3s  | 5.1s  | 10/30 | **2.8x** |
| REPLACE | 14.0s  | 10.2s | 20/30 | **1.4x** |
| REMOVE  | 14.1s  | 14.1s | 30/30 | 1.0x |

**Projected for 100 moves at 512 ports:**
- ADD: 156s → 52s
- REPLACE: 162s → 109s
- REMOVE: no improvement

## Known Limitations

**REMOVE moves see no benefit.** Validators alternate between `simulated_config` and `current_config`, evicting the single-entry cache each time. A more comprehensive fix (restructuring the validator chain to load data once per move) is planned as a follow-up.

## Correctness
- Cache only set after successful `loadData` (cleared on exception)
- `validate_config_db_config` always runs first with new `simulated_config`
- The REPLACE reorder swaps two independent validation checks

## Reproducer
https://github.com/rookie-who/sonic-gcu-issues
