### PR TITLE
Added Sonic CLI commands to configure VxLAN ports

### DIFF
--- a/config/vxlan.py
+++ b/config/vxlan.py
@@ -5,9 +5,19 @@ from utilities_common.constants import DEFAULT_NAMESPACE
 
 from jsonpatch import JsonPatchConflict
 from .validated_config_db_connector import ValidatedConfigDBConnector
-from swsscommon.swsscommon import isInterfaceNameValid, IFACE_NAME_MAX_LEN
+from swsscommon.swsscommon import isInterfaceNameValid, IFACE_NAME_MAX_LEN, ConfigDBConnector, SonicV2Connector, ProducerStateTable
 
 ADHOC_VALIDATION = True
+
+
+def _write_switch_table_to_appl_db(field, value):
+    """Write a field to APP_DB SWITCH_TABLE via ProducerStateTable so orchagent is notified."""
+    app_db = SonicV2Connector()
+    app_db.connect(app_db.APPL_DB)
+    tbl = ProducerStateTable(app_db.get_redis_client(app_db.APPL_DB), 'SWITCH_TABLE')
+    tbl.set('switch', [(field, value)])
+
+
 #
 # 'vxlan' group ('config vxlan ...')
 #
@@ -94,6 +104,81 @@ def del_vxlan(db, vxlan_name):
         config_db.set_entry('VXLAN_TUNNEL', vxlan_name, None)
     except JsonPatchConflict as e:
         ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+
+@vxlan.command('destination-port')
+@click.argument('port', metavar='<port>', required=True, type=int)
+@clicommon.pass_db
+def set_destination_port(db, port):
+    """Set VXLAN destination UDP port"""
+    ctx = click.get_current_context()
+
+    # Validate port range (1-65535)
+    if port < 1 or port > 65535:
+        ctx.fail("Invalid port number {}. Valid range is 1-65535".format(port))
+
+    # Persist vxlan_port in CONFIG_DB under DEVICE_METADATA|localhost
+    try:
+        db.cfgdb.mod_entry('DEVICE_METADATA', 'localhost', {'vxlan_port': str(port)})
+    except Exception as e:
+        ctx.fail("Failed to update CONFIG_DB. Error: {}".format(e))
+
+    # Write vxlan_port to APP_DB SWITCH_TABLE via ProducerStateTable for orchagent notification
+    try:
+        _write_switch_table_to_appl_db('vxlan_port', str(port))
+    except Exception as e:
+        ctx.fail("Failed to update APP_DB. Error: {}".format(e))
+
+    click.echo("VXLAN destination port set to {}".format(port))
+
+@vxlan.command('source-port')
+@click.argument('port', metavar='<port>', required=True, type=int)
+@clicommon.pass_db
+def set_source_port(db, port):
+    """Set VXLAN source UDP port"""
+    ctx = click.get_current_context()
+
+    # Validate port range (1-65535)
+    if port < 1 or port > 65535:
+        ctx.fail("Invalid port number {}. Valid range is 1-65535".format(port))
+
+    # Persist vxlan_sport in CONFIG_DB under DEVICE_METADATA|localhost
+    try:
+        db.cfgdb.mod_entry('DEVICE_METADATA', 'localhost', {'vxlan_sport': str(port)})
+    except Exception as e:
+        ctx.fail("Failed to update CONFIG_DB. Error: {}".format(e))
+
+    # Write vxlan_sport to APP_DB SWITCH_TABLE via ProducerStateTable for orchagent notification
+    try:
+        _write_switch_table_to_appl_db('vxlan_sport', str(port))
+    except Exception as e:
+        ctx.fail("Failed to update APP_DB. Error: {}".format(e))
+
+    click.echo("VXLAN source port set to {}".format(port))
+
+@vxlan.command('source-port-mask')
+@click.argument('mask', metavar='<mask>', required=True, type=int)
+@clicommon.pass_db
+def set_source_port_mask(db, mask):
+    """Set VXLAN source UDP port mask"""
+    ctx = click.get_current_context()
+
+    # Validate mask range (0-255)
+    if mask < 0 or mask > 255:
+        ctx.fail("Invalid mask {}. Valid range is 0-255".format(mask))
+
+    # Persist vxlan_mask in CONFIG_DB under DEVICE_METADATA|localhost
+    try:
+        db.cfgdb.mod_entry('DEVICE_METADATA', 'localhost', {'vxlan_mask': str(mask)})
+    except Exception as e:
+        ctx.fail("Failed to update CONFIG_DB. Error: {}".format(e))
+
+    # Write vxlan_mask to APP_DB SWITCH_TABLE via ProducerStateTable for orchagent notification
+    try:
+        _write_switch_table_to_appl_db('vxlan_mask', str(mask))
+    except Exception as e:
+        ctx.fail("Failed to update APP_DB. Error: {}".format(e))
+
+    click.echo("VXLAN source port mask set to {}".format(mask))
 
 @vxlan.group('evpn_nvo')
 def vxlan_evpn_nvo():

--- a/tests/vxlan_test.py
+++ b/tests/vxlan_test.py
@@ -406,6 +406,122 @@ Error: 'vxlan_name' length should not exceed 15 characters
         assert result.exit_code != 0
         assert "Please delete all VNET configuration referencing the tunnel" in result.output
 
+    @mock.patch('config.vxlan.ProducerStateTable')
+    @mock.patch('config.vxlan.SonicV2Connector')
+    def test_config_vxlan_destination_port(self, mock_sonic_v2_connector, mock_producer_state_table):
+        """Test setting valid VXLAN destination port writes to both CONFIG_DB and APP_DB,
+        and invalid port values are rejected"""
+        runner = CliRunner()
+        db = Db()
+
+        # Test invalid port - too low
+        result = runner.invoke(config.config.commands["vxlan"].commands["destination-port"], ["0"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid port number 0. Valid range is 1-65535" in result.output
+
+        # Test invalid port - too high
+        result = runner.invoke(config.config.commands["vxlan"].commands["destination-port"], ["65536"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid port number 65536. Valid range is 1-65535" in result.output
+
+        # Test valid port - mock APP_DB
+        mock_app_db = mock.Mock()
+        mock_sonic_v2_connector.return_value = mock_app_db
+        mock_tbl = mock.Mock()
+        mock_producer_state_table.return_value = mock_tbl
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["destination-port"], ["4789"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "VXLAN destination port set to 4789" in result.output
+
+        # Verify CONFIG_DB was updated
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost').get('vxlan_port') == '4789'
+
+        # Verify ProducerStateTable was used to notify orchagent
+        mock_producer_state_table.assert_called_once_with(mock_app_db.get_redis_client.return_value, 'SWITCH_TABLE')
+        mock_tbl.set.assert_called_once_with('switch', [('vxlan_port', '4789')])
+
+    @mock.patch('config.vxlan.ProducerStateTable')
+    @mock.patch('config.vxlan.SonicV2Connector')
+    def test_config_vxlan_source_port(self, mock_sonic_v2_connector, mock_producer_state_table):
+        """Test setting valid VXLAN source port writes to both CONFIG_DB and APP_DB,
+        and invalid port values are rejected"""
+        runner = CliRunner()
+        db = Db()
+
+        # Test invalid port - too low
+        result = runner.invoke(config.config.commands["vxlan"].commands["source-port"], ["0"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid port number 0. Valid range is 1-65535" in result.output
+
+        # Test invalid port - too high
+        result = runner.invoke(config.config.commands["vxlan"].commands["source-port"], ["65536"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid port number 65536. Valid range is 1-65535" in result.output
+
+        # Test valid port - mock APP_DB
+        mock_app_db = mock.Mock()
+        mock_sonic_v2_connector.return_value = mock_app_db
+        mock_tbl = mock.Mock()
+        mock_producer_state_table.return_value = mock_tbl
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["source-port"], ["1024"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "VXLAN source port set to 1024" in result.output
+
+        # Verify CONFIG_DB was updated
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost').get('vxlan_sport') == '1024'
+
+        # Verify ProducerStateTable was used to notify orchagent
+        mock_producer_state_table.assert_called_once_with(mock_app_db.get_redis_client.return_value, 'SWITCH_TABLE')
+        mock_tbl.set.assert_called_once_with('switch', [('vxlan_sport', '1024')])
+
+    @mock.patch('config.vxlan.ProducerStateTable')
+    @mock.patch('config.vxlan.SonicV2Connector')
+    def test_config_vxlan_source_port_mask(self, mock_sonic_v2_connector, mock_producer_state_table):
+        """Test setting valid VXLAN source port mask writes to both CONFIG_DB and APP_DB,
+        and invalid mask values are rejected"""
+        runner = CliRunner()
+        db = Db()
+
+        # Test invalid mask - too high (> 255, mask is 8-bit)
+        result = runner.invoke(config.config.commands["vxlan"].commands["source-port-mask"], ["256"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Invalid mask 256. Valid range is 0-255" in result.output
+
+        # Test valid mask - mock APP_DB
+        mock_app_db = mock.Mock()
+        mock_sonic_v2_connector.return_value = mock_app_db
+        mock_tbl = mock.Mock()
+        mock_producer_state_table.return_value = mock_tbl
+
+        result = runner.invoke(config.config.commands["vxlan"].commands["source-port-mask"], ["255"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "VXLAN source port mask set to 255" in result.output
+
+        # Verify CONFIG_DB was updated
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'localhost').get('vxlan_mask') == '255'
+
+        # Verify ProducerStateTable was used to notify orchagent
+        mock_producer_state_table.assert_called_once_with(mock_app_db.get_redis_client.return_value, 'SWITCH_TABLE')
+        mock_tbl.set.assert_called_once_with('switch', [('vxlan_mask', '255')])
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added three new Sonic CLI commands to configure VxLAN ports:
1. configure vxlan destination-port
2. configure vxlan source-port
3. configure vxlan source-port-mask

After configuring these commands, SWITCH_TABLE in APP_DB will be updated dynamically so that the VxLAN port values are active for installed VxLAN tunnels. 

Also, after configuring these commands, the port values will be stored in DEVICE_METADATA, so that in case of config reload or reboot, the same values are replayed using vxlanmgrd. Refer to:
https://github.com/sonic-net/sonic-swss/pull/4492 

Please note: After configuring these commands, config save is necessary for the port settings saved under DEVICE_METADATA to persist.

#### How I did it

#### How to verify it
Added 3 new tests.
tests/vxlan_test.py::TestVxlan::test_config_vxlan_destination_port PASSED                                                                                                                                                                                               [ 91%] 
tests/vxlan_test.py::TestVxlan::test_config_vxlan_source_port PASSED                                                                                                                                                                                                    [ 95%] 
tests/vxlan_test.py::TestVxlan::test_config_vxlan_source_port_mask PASSED                                                                                                                                                                                               [100%] 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

root@sonic:/home/admin# config vxlan destination-port 51234                                                                                                                     
VXLAN destination port set to 51234
root@sonic:/home/admin# config vxlan source-port 1234                                                                                  
VXLAN source port set to 1234                                      
root@sonic:/home/admin# config vxlan source-port-mask 7                                                                                                                                                        
VXLAN source port mask set to 7    
