### PR TITLE
[Mellanox][HFT] Add HFT support for all supported systems

### DIFF
--- a/utilities_common/hft.py
+++ b/utilities_common/hft.py
@@ -3,6 +3,13 @@
 from sonic_py_common import device_info
 
 SUPPORTED_PLATFORMS = (
+    'x86_64-nvidia_sn5600-r0',
+    'x86_64-nvidia_sn5600_simx-r0',
+    'x86_64-nvidia_sn5640-r0',
+    'x86_64-nvidia_sn5640_simx-r0',
+    'x86_64-nvidia_sn6600-r0',
+    'x86_64-nvidia_sn6600_ld_simx-r0',
+    'x86_64-nvidia_sn6600_simx-r0',
     'x86_64-nvidia_sn5640-r0',
     'x86_64-kvm_x86_64-r0',
     'x86_64-arista_7060x6_64pe_b',

--- a/utilities_common/hft.py
+++ b/utilities_common/hft.py
@@ -7,7 +7,7 @@ SUPPORTED_PLATFORMS = (
     'x86_64-nvidia_sn5600_simx-r0',
     'x86_64-nvidia_sn5640-r0',
     'x86_64-nvidia_sn5640_simx-r0',
-    'x86_64-nvidia_sn6600-r0',
+    'x86_64-nvidia_sn6600_ld-r0',
     'x86_64-nvidia_sn6600_ld_simx-r0',
     'x86_64-nvidia_sn6600_simx-r0',
     'x86_64-nvidia_sn5640-r0',


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add devices that supports HFT to supported list

#### How I did it
Add all Mellanox systems to the SUPPORTED_PLATFORMS list in utilities_common/hft.py

#### How to verify it
Run HFT commands on supported device.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

