### PR TITLE
GCU: silence transient YANG leafref ERR during patch-sort search

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -137,7 +137,7 @@ class ConfigWrapper:
         except sonic_yang.SonicYangException as ex:
             return False, ex
 
-    def validate_config_db_config(self, config_db_as_json):
+    def validate_config_db_config(self, config_db_as_json, quiet=False):
         sy = self.create_sonic_yang_with_loaded_models()
 
         # TODO: Move these validators to YANG models
@@ -146,7 +146,7 @@ class ConfigWrapper:
 
         try:
             # Loading data automatically does full validation
-            sy.loadData(config_db_as_json)
+            sy.loadData(config_db_as_json, quiet=quiet)
             for supplemental_yang_validator in supplemental_yang_validators:
                 success, error = supplemental_yang_validator(config_db_as_json)
                 if not success:

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -849,7 +849,12 @@ class FullConfigMoveValidator:
         self.config_wrapper = config_wrapper
 
     def validate(self, move, diff, simulated_config) -> Tuple[bool, Optional[str]]:
-        is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
+        # Speculative validation during patch-sort search. Transient YANG
+        # leafref failures are expected here and are handled by the sorter
+        # as a signal to prune the search branch. Pass quiet=True so
+        # sonic_yang.loadData does not leak a LOG_ERR line to syslog for
+        # every transient failure during the search.
+        is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config, quiet=True)
         return is_valid, error
 
 class CreateOnlyMoveValidator:

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -946,6 +946,21 @@ class TestFullConfigMoveValidator(unittest.TestCase):
         self.assertTrue(
                 validator.validate(JsonMoveGroup("", self.any_move), self.any_diff, self.any_simulated_config)[0])
 
+    def test_validate__passes_quiet_true_to_config_wrapper(self):
+        # Regression guard: FullConfigMoveValidator MUST invoke the config
+        # wrapper with quiet=True so the speculative patch-sort search does
+        # not spam syslog with transient YANG leafref LOG_ERR lines (the
+        # sorter already handles those via the returned tuple).
+        config_wrapper = Mock()
+        config_wrapper.validate_config_db_config.return_value = (True, None)
+        validator = ps.FullConfigMoveValidator(config_wrapper)
+
+        validator.validate(JsonMoveGroup("", self.any_move), self.any_diff, self.any_simulated_config)
+
+        config_wrapper.validate_config_db_config.assert_called_once_with(
+            self.any_simulated_config, quiet=True)
+
+
 class TestCreateOnlyMoveValidator(unittest.TestCase):
     def setUp(self):
         self.validator = ps.CreateOnlyMoveValidator(ps.PathAddressing())


### PR DESCRIPTION
FullConfigMoveValidator is invoked speculatively during the patch-sort search to check whether a candidate move results in a YANG-valid config. Forward leafref references produce expected transient validation failures; the sorter already handles these as a prune signal via the returned (False, error) tuple.

However, sonic_yang.loadData logs a LOG_ERR "Data Loading Failed" line to syslog on every exception (log-and-throw antipattern) before raising, so each speculative probe leaks an ERR to syslog. In practice a single config apply-patch during the GCU test suite can emit 100+ such lines, which trips loganalyzer and makes real errors hard to find.

This change threads a quiet= kwarg through:
  ConfigWrapper.validate_config_db_config(..., quiet=False)
      -> sonic_yang.loadData(..., quiet=quiet)

and makes FullConfigMoveValidator.validate pass quiet=True. Non- speculative callers (e.g. final target-config validation) keep the existing default (quiet=False) and continue to log on real errors.

Depends on sonic-net/sonic-buildimage: quiet= kwarg added to sonic_yang_ext.SonicYangExtMixin.loadData.

Validated on DUT with sonic-mgmt generic_config_updater subset (dhcp_relay, eth_interface, vlan_interface, portchannel_interface, cacl, lo_interface, bgp_prefix, syslog):
  BEFORE: 31P/1F/3S/3E, 231 apply-patch,  115 Data Loading Failed ERR
  AFTER:  31P/1F/3S/2E, 231 apply-patch,   34 Data Loading Failed ERR
Remaining ERR lines are from legitimate non-speculative callers.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

 Silenced the `Data Loading Failed` LOG_ERR spam that the GCU patch sorter emits during its speculative search, without altering the sorter's control flow or changing behavior for any non-speculative caller.
 
 Two files in `generic_config_updater/`:
 
 - **`gu_common.py`** — `ConfigWrapper.validate_config_db_config` gains a `quiet=False` kwarg, forwarded to `sy.loadData(..., quiet=quiet)`.
 - **`patch_sorter.py`** — `FullConfigMoveValidator.validate` passes `quiet=True`, since every failure there is an expected search-prune signal.
 
 No other caller is changed. `FullConfigMoveValidator`'s return semantics (`is_valid, error`) are unchanged, so real failures still surface through the returned tuple as before.
 
 Work item tracking (Microsoft ADO): **36655183** (`[SONiC_Baseline][Failed_Case][dhcp_relay.test_dhcpv4_relay][test_dhcp_relay_with_non_default_vrf]`) and **36656583** (`[SONiC_Baseline][Failed_Case][dhcp_relay.test_dhcpv4_relay][test_dhcp_relay_with_different_non_default_vrf]`).
 
 Depends on sonic-net/sonic-buildimage#<NNNNN> (adds the `quiet=` kwarg to `SonicYangExtMixin.loadData` in `sonic-yang-mgmt`). Must merge after that PR.

#### How I did it

 ```python
 # generic_config_updater/gu_common.py
 -def validate_config_db_config(self, config_db_as_json):
 +def validate_config_db_config(self, config_db_as_json, quiet=False):
      ...
 -    sy.loadData(config_db_as_json)
 +    sy.loadData(config_db_as_json, quiet=quiet)

 # generic_config_updater/patch_sorter.py — FullConfigMoveValidator.validate
 -    is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
 +    # Speculative validation during patch-sort search. Transient leafref
 +    # failures are expected; sorter handles them via returned (False, err).
 +    is_valid, error = self.config_wrapper.validate_config_db_config(
 +        simulated_config, quiet=True)
      return is_valid, error

#### How to verify it

 Run the sonic-mgmt `generic_config_updater` test subset against a T0 DUT and count `"Data Loading Failed"` lines in `/var/log/syslog` during the run.
 
 Validated on a T0 (20251110.19) with 8 test files (`dhcp_relay`, `eth_interface`, `vlan_interface`, `portchannel_interface`, `cacl`, `lo_interface`, `bgp_prefix`, `syslog`):
 
 BEFORE (stock):
 - 31 passed, 1 failed, 3 skipped, 3 pytest errors
 - 231 `apply-patch` events during the run
 - 115 `Data Loading Failed` lines in syslog
 - Duration 1:30:33
 
 AFTER (fix):
 - 31 passed, 1 failed, 3 skipped, 2 pytest errors
 - 231 `apply-patch` events during the run
 - 34 `Data Loading Failed` lines in syslog
 - Duration 1:27:42
 
 The remaining 34 ERR lines are from legitimate non-speculative callers (final target-config validation) — preserved behavior, not a bug.
 
 Also ran `dhcp_server/test_dhcp_server_port_based_customize_options` with the fix: 2/2 passed, 8 `apply-patch` events, 0 `Data Loading Failed` ERR, 0 leaked `sonic_yang` ERR.
 
 Default behavior (`quiet=False`) is exercised by every existing GCU unit test; no unit tests needed modification.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

