### PR TITLE
Fix Pensando DPU reboot handling in smartswitch operations

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -98,7 +98,7 @@ function stop_sonic_services()
         systemctl stop mux
     fi
 
-    if [[ x"$ASIC_TYPE" != x"mellanox" ]]; then
+    if [[ x"$ASIC_TYPE" != x"mellanox" && x"$ASIC_TYPE" != x"pensando" ]]; then
         ASIC_CONF=${DEVPATH}/$PLATFORM/asic.conf
         if [ -f "$ASIC_CONF" ]; then
             source $ASIC_CONF
@@ -122,7 +122,9 @@ function stop_sonic_services()
 function stop_services_asan()
 {
     debug "Stopping swss for ASAN"
-    systemctl stop swss
+    if [[ x"$ASIC_TYPE" != x"pensando" ]]; then
+        systemctl stop swss
+    fi
 }
 
 function clear_warm_boot()


### PR DESCRIPTION
Modified reboot scripts to properly handle Pensando ASIC type during smartswitch reboot operations to prevent unnecessary service disruptions.

Changes:
scripts/reboot:
   - Exclude Pensando from ASIC shutdown sequence (similar to Mellanox)
   - Skip stopping swss service for Pensando during ASAN cleanup

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

