### PR TITLE
[config/syslog]: Resolve per-ASIC-only features to their container on single-ASIC platforms

### DIFF
--- a/config/syslog.py
+++ b/config/syslog.py
@@ -537,14 +537,25 @@ def get_feature_names_to_proceed(db, service_name, namespace):
         else:
             feature_config = features[service_name]
             feature_list = []
-            if feature_config[syslog_common.FEATURE_HAS_GLOBAL_SCOPE].lower() == 'true':
-                feature_list.append(service_name)
-            
+            has_global_scope = feature_config.get(syslog_common.FEATURE_HAS_GLOBAL_SCOPE, '').lower() == 'true'
+            has_per_asic_scope = feature_config.get(syslog_common.FEATURE_HAS_PER_ASIC_SCOPE, '').lower() == 'true'
+
             if multi_asic.is_multi_asic():
-                if feature_config[syslog_common.FEATURE_HAS_PER_ASIC_SCOPE].lower() == 'true':
+                if has_global_scope:
+                    feature_list.append(service_name)
+                if has_per_asic_scope:
                     asic_count = multi_asic.get_num_asics()
                     for i in range(asic_count):
                         feature_list.append(multi_asic.get_container_name_from_asic_id(service_name, i))
+            else:
+                # On a single-ASIC platform a feature has exactly one running container
+                # whose name equals the service name, regardless of whether it is tagged
+                # with has_global_scope, has_per_asic_scope, or both. Treating the two
+                # flags symmetrically here keeps this helper consistent with
+                # syslog_util.common.extract_feature_data, which also collapses both
+                # scopes onto the single-ASIC namespace.
+                if has_global_scope or has_per_asic_scope:
+                    feature_list.append(service_name)
     elif namespace == 'default':
         if not service_name:
             feature_list = [feature_name for feature_name in global_feature_data.keys()]
@@ -570,6 +581,9 @@ def get_feature_names_to_proceed(db, service_name, namespace):
 def enable_rate_limit_feature(db, service_name, namespace):
     """ Enable syslog rate limit feature """
     feature_list = get_feature_names_to_proceed(db, service_name, namespace)
+    if not feature_list:
+        click.echo(f'No container resolved for service {service_name!r} in namespace {namespace!r}, nothing to enable')
+        return
     for feature_name in feature_list:
         click.echo(f'Enabling syslog rate limit feature for {feature_name}')
         shell_cmd = f'docker ps -f status=running --format "{{{{.Names}}}}" | grep -E "^{feature_name}$"'
@@ -612,6 +626,9 @@ def enable_rate_limit_feature(db, service_name, namespace):
 def disable_rate_limit_feature(db, service_name, namespace):
     """ Disable syslog rate limit feature """
     feature_list = get_feature_names_to_proceed(db, service_name, namespace)
+    if not feature_list:
+        click.echo(f'No container resolved for service {service_name!r} in namespace {namespace!r}, nothing to disable')
+        return
     for feature_name in feature_list:
         click.echo(f'Disabling syslog rate limit feature for {feature_name}')
         shell_cmd = f'docker ps -f status=running --format "{{{{.Names}}}}" | grep -E "^{feature_name}$"'

--- a/tests/syslog_test.py
+++ b/tests/syslog_test.py
@@ -20,7 +20,9 @@ from syslog_util.common import FEATURE_TABLE, \
                                SYSLOG_CONFIG_FEATURE_TABLE, \
                                SYSLOG_RATE_LIMIT_INTERVAL, \
                                SYSLOG_RATE_LIMIT_BURST, \
-                               SUPPORT_RATE_LIMIT
+                               SUPPORT_RATE_LIMIT, \
+                               FEATURE_HAS_GLOBAL_SCOPE, \
+                               FEATURE_HAS_PER_ASIC_SCOPE
 
 from .mock_tables import dbconnector
 from .syslog_input import config_mock
@@ -481,6 +483,95 @@ class TestSyslog:
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"], obj=db
         )
         assert result.exit_code == SUCCESS
+
+    @mock.patch('config.syslog.clicommon.run_command')
+    def test_enable_rate_limit_feature_single_asic_per_asic_scope(self, mock_run):
+        """
+        On a single-ASIC platform a feature that is marked with
+        has_global_scope=False and has_per_asic_scope=True (e.g. syncd) still
+        runs as a single container whose name equals the service name. The
+        enable/disable CLIs must operate on that container rather than
+        silently resolving to an empty list.
+        """
+        db = Db()
+        db.cfgdb.set_entry(FEATURE_TABLE, 'syncd', {
+            SUPPORT_RATE_LIMIT: 'true',
+            'state': 'enabled',
+            FEATURE_HAS_GLOBAL_SCOPE: 'False',
+            FEATURE_HAS_PER_ASIC_SCOPE: 'True',
+        })
+
+        runner = CliRunner()
+
+        mock_run.return_value = ('no such process', 0)
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands["enable"],
+            ['syncd'], obj=db
+        )
+        assert result.exit_code == SUCCESS, result.output
+        assert 'Enabling syslog rate limit feature for syncd' in result.output
+        assert 'Enabled syslog rate limit feature for syncd' in result.output
+        assert 'nothing to enable' not in result.output
+
+        commands_run = []
+        for call in mock_run.call_args_list:
+            args, kwargs = call
+            if not args:
+                continue
+            arg = args[0]
+            if isinstance(arg, list):
+                commands_run.append(arg)
+        assert ['docker', 'cp', '/usr/share/sonic/templates/containercfgd.conf',
+                'syncd:/etc/supervisor/conf.d/'] in commands_run
+        assert ['docker', 'exec', '-i', 'syncd', 'supervisorctl',
+                'start', 'containercfgd'] in commands_run
+
+        mock_run.reset_mock()
+        mock_run.return_value = ('something', 0)
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"],
+            ['syncd'], obj=db
+        )
+        assert result.exit_code == SUCCESS, result.output
+        assert 'Disabling syslog rate limit feature for syncd' in result.output
+        assert 'Disabled syslog rate limit feature for syncd' in result.output
+        assert 'nothing to disable' not in result.output
+
+        commands_run = []
+        for call in mock_run.call_args_list:
+            args, kwargs = call
+            if not args:
+                continue
+            arg = args[0]
+            if isinstance(arg, list):
+                commands_run.append(arg)
+        assert ['docker', 'exec', '-i', 'syncd', 'supervisorctl',
+                'stop', 'containercfgd'] in commands_run
+        assert ['docker', 'exec', '-i', 'syncd', 'rm', '-f',
+                '/etc/supervisor/conf.d/containercfgd.conf'] in commands_run
+
+    @mock.patch('config.syslog.clicommon.run_command')
+    def test_enable_rate_limit_feature_empty_feature_list(self, mock_run):
+        """
+        A feature that is neither globally- nor per-ASIC-scoped should not
+        silently no-op. It must return a clear message and touch nothing.
+        """
+        db = Db()
+        db.cfgdb.set_entry(FEATURE_TABLE, 'ghost', {
+            SUPPORT_RATE_LIMIT: 'true',
+            'state': 'enabled',
+            FEATURE_HAS_GLOBAL_SCOPE: 'False',
+            FEATURE_HAS_PER_ASIC_SCOPE: 'False',
+        })
+
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands["enable"],
+            ['ghost'], obj=db
+        )
+        assert result.exit_code == SUCCESS, result.output
+        assert 'nothing to enable' in result.output
+        mock_run.assert_not_called()
 
     @mock.patch('config.syslog.clicommon.run_command')
     def test_config_log_level(self, mock_run):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **
-->

#### What I did

Fix `config syslog rate-limit-feature enable/disable <svc>` being a silent no-op on single-ASIC platforms for features whose `FEATURE` entry has `has_global_scope=False` and `has_per_asic_scope=True` (e.g. `syncd`, `gbsyncd`, and `swss` on some platforms).

#### How I did it

- Root cause: `config/syslog.py::get_feature_names_to_proceed` only enumerated per-ASIC container names inside an `if multi_asic.is_multi_asic():` guard. On a single-ASIC DUT that branch was skipped, the feature list came back empty, and the outer `for` loop in `enable_rate_limit_feature` / `disable_rate_limit_feature` printed nothing and did nothing.
- Fix: on a single-ASIC platform a feature has exactly one container whose name equals the service name regardless of which scope flag is set, so both scopes are now treated symmetrically in that branch. Multi-ASIC behavior is preserved byte-for-byte.
- Hardened the flag lookups with `.get('flag', '')` to avoid a `KeyError` when a flag is absent.
- Safety net: `enable`/`disable` now emit an explicit "No container resolved … nothing to enable/disable" message when the resolved list is empty, so a future similar misconfiguration cannot silently no-op again.

##### Behavior matrix after the fix

| FEATURE flags | Single-ASIC → containers | Multi-ASIC (N ASICs) → containers |
|---|---|---|
| `global=True, per_asic=False` | `[svc]` | `[svc]` |
| `global=False, per_asic=True` | **`[svc]`** (was `[]` — the bug) | `[svc0, …, svc{N-1}]` |
| `global=True, per_asic=True` | **`[svc]`** (was `[]` when looked up by name) | `[svc, svc0, …, svc{N-1}]` |
| `global=False, per_asic=False` | `[]` + \"nothing to enable\" message | `[]` + \"nothing to enable\" message |

#### How to verify it

Unit tests:

\`\`\`bash
python3 -m pytest tests/syslog_test.py tests/syslog_multi_asic_test.py -x -q
\`\`\`

- New \`tests/syslog_test.py::TestSyslog::test_enable_rate_limit_feature_single_asic_per_asic_scope\` asserts that \`docker cp .../containercfgd.conf\` and \`supervisorctl start containercfgd\` are invoked for a single-ASIC \`syncd\`-like feature (\`has_global_scope=False, has_per_asic_scope=True\`), and the symmetric \`stop\` + \`rm -f\` on disable. Would have failed against the pre-fix code.
- New \`tests/syslog_test.py::TestSyslog::test_enable_rate_limit_feature_empty_feature_list\` asserts the new \"nothing to enable\" message and that no shell commands run when the resolved list is empty.
- Existing \`test_enable_syslog_rate_limit_feature\`, \`test_disable_syslog_rate_limit_feature\`, and \`tests/syslog_multi_asic_test.py\` paths are unaffected.

On a single-ASIC DUT:
- \`sudo config syslog rate-limit-feature enable syncd\` prints \`Enabling syslog rate limit feature for syncd\` and \`Enabled syslog rate limit feature for syncd\`.
- \`docker exec -i syncd supervisorctl status containercfgd\` → \`RUNNING\`.
- \`sudo config syslog rate-limit-container syncd -i 10 -b 500\` → \`docker exec -i syncd grep SystemLogRateLimit /etc/rsyslog.conf\` shows \`10\` / \`500\`, and \`grep containercfgd /var/log/syslog\` shows the \`Configure syslog rate limit interval=10, burst=500\` notice.
- \`sudo config syslog rate-limit-feature disable syncd\` cleanly tears everything down.

On a multi-ASIC DUT: existing behavior is unchanged (\`syncd0\`, \`syncd1\`, … resolve as before; \`bgp\` global-only still resolves to \`bgp\`; \`teamd\` with both flags still resolves to \`teamd\` + per-ASIC names).

#### Previous command output (if the output of a command-line utility has changed)

On a single-ASIC DUT, before the fix:

\`\`\`
admin@sonic:~\$ sudo config syslog rate-limit-feature enable syncd
admin@sonic:~\$
\`\`\`

(Silent no-op — nothing printed, container untouched.)

#### New command output (if the output of a command-line utility has changed)

\`\`\`
admin@sonic:~\$ sudo config syslog rate-limit-feature enable syncd
Enabling syslog rate limit feature for syncd
Enabled syslog rate limit feature for syncd
\`\`\`

And for a feature with neither scope flag set:

\`\`\`
admin@sonic:~\$ sudo config syslog rate-limit-feature enable ghost
No container resolved for service 'ghost' in namespace None, nothing to enable
\`\`\`