### PR TITLE
[show/vnet]: Fix missing status column in short-endpoint tunnel routes

### DIFF
--- a/show/vnet.py
+++ b/show/vnet.py
@@ -651,8 +651,8 @@ def _show_tunnel_helper(vnet_name=None, appl_db=None, state_db=None):
             r.append(val.get('mac_address'))
             r.append(val.get('vni'))
             r.append(val.get('metric'))
-            if val_state:
-                r.append(val_state.get('state'))
+            state = val_state.get('state') if val_state else ""
+            r.append(state)
             table.append(r)
             continue
         state = val_state.get('state') if val_state else ""

--- a/tests/multi_asic_vnet_test.py
+++ b/tests/multi_asic_vnet_test.py
@@ -162,8 +162,8 @@ vnet name    prefix       nexthop       interface
 -----------  -----------  ------------  -----------
 Vnet_2000    10.0.0.0/24  10.10.10.100  Ethernet16
 
-vnet name    prefix       endpoint       mac address          vni  metric
------------  -----------  -------------  -----------------  -----  --------
+vnet name    prefix       endpoint       mac address          vni  metric    status
+-----------  -----------  -------------  -----------------  -----  --------  --------
 Vnet_2000    20.0.0.0/24  192.168.1.200  00:aa:bb:cc:dd:01   5000
 Vnet_3000    30.0.0.0/24  192.168.1.201                      6000
 
@@ -172,8 +172,8 @@ vnet name    prefix       nexthop       interface
 -----------  -----------  ------------  -----------
 Vnet_4000    40.0.0.0/24  10.10.10.200  Ethernet64
 
-vnet name    prefix       endpoint       mac address          vni  metric
------------  -----------  -------------  -----------------  -----  --------
+vnet name    prefix       endpoint       mac address          vni  metric    status
+-----------  -----------  -------------  -----------------  -----  --------  --------
 Vnet_4000    50.0.0.0/24  192.168.2.200  00:aa:bb:cc:dd:02   4000
 """
 
@@ -182,8 +182,8 @@ vnet name    prefix       nexthop       interface
 -----------  -----------  ------------  -----------
 Vnet_2000    10.0.0.0/24  10.10.10.100  Ethernet16
 
-vnet name    prefix       endpoint       mac address          vni  metric
------------  -----------  -------------  -----------------  -----  --------
+vnet name    prefix       endpoint       mac address          vni  metric    status
+-----------  -----------  -------------  -----------------  -----  --------  --------
 Vnet_2000    20.0.0.0/24  192.168.1.200  00:aa:bb:cc:dd:01   5000
 Vnet_3000    30.0.0.0/24  192.168.1.201                      6000
 """
@@ -191,20 +191,20 @@ Vnet_3000    30.0.0.0/24  192.168.1.201                      6000
 show_vnet_routes_tunnel_multi_asic_output = """\
 
 Namespace: asic0
-vnet name    prefix       endpoint       mac address          vni  metric
------------  -----------  -------------  -----------------  -----  --------
+vnet name    prefix       endpoint       mac address          vni  metric    status
+-----------  -----------  -------------  -----------------  -----  --------  --------
 Vnet_2000    20.0.0.0/24  192.168.1.200  00:aa:bb:cc:dd:01   5000
 Vnet_3000    30.0.0.0/24  192.168.1.201                      6000
 
 Namespace: asic1
-vnet name    prefix       endpoint       mac address          vni  metric
------------  -----------  -------------  -----------------  -----  --------
+vnet name    prefix       endpoint       mac address          vni  metric    status
+-----------  -----------  -------------  -----------------  -----  --------  --------
 Vnet_4000    50.0.0.0/24  192.168.2.200  00:aa:bb:cc:dd:02   4000
 """
 
 show_vnet_routes_tunnel_asic1_output = """\
-vnet name    prefix       endpoint       mac address          vni  metric
------------  -----------  -------------  -----------------  -----  --------
+vnet name    prefix       endpoint       mac address          vni  metric    status
+-----------  -----------  -------------  -----------------  -----  --------  --------
 Vnet_4000    50.0.0.0/24  192.168.2.200  00:aa:bb:cc:dd:02   4000
 """
 


### PR DESCRIPTION
#### Why I did it
In `_show_tunnel_helper`, the short-endpoint code path only appends the route state when `val_state` is truthy. When `val_state` is missing the row gets 6 columns instead of 7.

Fix #4480
Fix https://github.com/sonic-net/sonic-buildimage/issues/27148

#### How I did it
* Always append a state value in the short-endpoint path using the same ternary pattern as the long-endpoint path (`val_state.get('state') if val_state else ""`)
* Updated multi-ASIC test expected output to include the `status` column header

#### How to verify it
1. Populate APPL_DB with a tunnel route entry while leaving STATE_DB empty for that key
2. Run `show vnet routes tunnel` and verify `status` column exist

#### Description for the changelog
Fix missing status column in short-endpoint vnet tunnel route display when state_db entry is absent

#### Previous command output (if the output of a command-line utility has changed)
When `val_state` is missing from all entries the column is dropped:
```
vnet name    prefix       endpoint       mac address          vni  metric
-----------  -----------  -------------  -----------------  -----  --------
Vnet_2000    20.0.0.0/24  192.168.1.200  00:aa:bb:cc:dd:01   5000
```
#### New command output (if the output of a command-line utility has changed)
```
vnet name    prefix       endpoint       mac address          vni  metric    status
-----------  -----------  -------------  -----------------  -----  --------  --------
Vnet_2000    20.0.0.0/24  192.168.1.200  00:aa:bb:cc:dd:01   5000
```