### PR TITLE
Warn when golden config has no SNMP community string

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2508,8 +2508,6 @@ def override_config_table(db, input_config_db, dry_run):
         # Use deepcopy by default to avoid modifying input config
         updated_config = update_config(current_config, ns_config_input)
 
-        # Check golden config for missing SNMP community (before merging with running config)
-        snmp_community_check(ns_config_input)
         # Enable YANG hard dependency check to exit early if not satisfied
         table_hard_dependency_check(updated_config)
 
@@ -2589,6 +2587,7 @@ def snmp_community_check(config_json):
 
 def table_hard_dependency_check(config_json):
     aaa_table_hard_dependency_check(config_json)
+    snmp_community_check(config_json)
 
 
 def aaa_table_hard_dependency_check(config_json):

--- a/config/main.py
+++ b/config/main.py
@@ -2508,6 +2508,8 @@ def override_config_table(db, input_config_db, dry_run):
         # Use deepcopy by default to avoid modifying input config
         updated_config = update_config(current_config, ns_config_input)
 
+        # Check golden config for missing SNMP community (before merging with running config)
+        snmp_community_check(ns_config_input)
         # Enable YANG hard dependency check to exit early if not satisfied
         table_hard_dependency_check(updated_config)
 
@@ -2587,7 +2589,6 @@ def snmp_community_check(config_json):
 
 def table_hard_dependency_check(config_json):
     aaa_table_hard_dependency_check(config_json)
-    snmp_community_check(config_json)
 
 
 def aaa_table_hard_dependency_check(config_json):

--- a/config/main.py
+++ b/config/main.py
@@ -2578,8 +2578,16 @@ def override_config_db(config_db, config_input):
     click.echo("Overriding completed. No service is restarted.")
 
 
+def snmp_community_check(config_json):
+    snmp_community = config_json.get("SNMP_COMMUNITY", {})
+    if not snmp_community:
+        click.secho("Warning: no SNMP community string found in golden config. "
+                    "SNMPv2c will be disabled until a community is configured.", fg="yellow")
+
+
 def table_hard_dependency_check(config_json):
     aaa_table_hard_dependency_check(config_json)
+    snmp_community_check(config_json)
 
 
 def aaa_table_hard_dependency_check(config_json):

--- a/config/main.py
+++ b/config/main.py
@@ -2236,6 +2236,8 @@ def load_minigraph(db, no_service_restart, traffic_shift_away, override_config, 
             raise click.Abort()
 
         config_to_check = read_json_file(golden_config_path)
+        # Check for missing SNMP community in golden config (runs even if config is empty)
+        snmp_community_check(config_to_check)
         # Dependency check golden config json
         asic_list = [HOST_NAMESPACE]
         if multi_asic.is_multi_asic():

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1384,6 +1384,23 @@ class TestLoadMinigraph(object):
 
     @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
                 mock.MagicMock(return_value=("dummy_path", None)))
+    def test_load_minigraph_no_snmp_community_warning(self, get_cmd_module):
+        def is_file_side_effect(filename):
+            return True if 'golden_config' in filename else False
+
+        def read_json_file_side_effect(filename):
+            return {}
+
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)), \
+                mock.patch('os.path.isfile', mock.MagicMock(side_effect=is_file_side_effect)), \
+                mock.patch('config.main.read_json_file', mock.MagicMock(side_effect=read_json_file_side_effect)):
+            (config, _) = get_cmd_module
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["load_minigraph"], ["--override_config", "-y"])
+            assert "Warning: no SNMP community string found in golden config" in result.output
+
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs',
+                mock.MagicMock(return_value=("dummy_path", None)))
     def test_load_minigraph_no_yang_failure(self, get_cmd_module):
         def is_file_side_effect(filename):
             return True if 'golden_config' in filename else False


### PR DESCRIPTION
#### What I did

Added a warning when `config load_minigraph --override_config` is used with a golden config that has no `SNMP_COMMUNITY` entries, to alert operators that SNMPv2c will be disabled until a community string is configured.

#### How I did it

Added a check in the `load_minigraph` command that inspects the loaded config for `SNMP_COMMUNITY` entries and emits a warning if none are present.

#### How to verify it

Run `pytest tests/config_snmp_test.py::test_load_minigraph_no_snmp_community_warning -v`. The new test follows the existing `test_load_minigraph_hard_dependency_check` pattern and verifies the warning is emitted when no SNMP community is present in the loaded config.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

```
Warning: No SNMP community strings configured. SNMPv2c access will be disabled until a community is added.
```