### PR TITLE
GCU: silence transient YANG leafref ERR during patch-sort search (#4482)

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -147,7 +147,13 @@ class ConfigWrapper:
         try:
             tmp_config_db_as_json = copy.deepcopy(config_db_as_json)
 
-            sy.loadData(tmp_config_db_as_json)
+            # Loading data automatically does full validation.
+            # quiet=True suppresses sonic_yang.loadData's LOG_ERR
+            # "Data Loading Failed" line on every exception (log-and-throw
+            # antipattern). Real failures still surface via the returned
+            # tuple / SonicYangException, so callers retain full error
+            # signal -- only the duplicate syslog spam is silenced.
+            sy.loadData(tmp_config_db_as_json, quiet=True)
 
             sy.validate_data_tree()
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -933,6 +933,23 @@ class TestFullConfigMoveValidator(unittest.TestCase):
         # Act and assert
         self.assertTrue(validator.validate(self.any_move, self.any_diff))
 
+    def test_validate__passes_quiet_true_to_config_wrapper(self):
+        # Regression guard: gu_common.ConfigWrapper.validate_config_db_config
+        # MUST call sonic_yang.loadData with quiet=True so the speculative
+        # patch-sort search does not spam syslog with transient YANG
+        # leafref LOG_ERR lines (the sorter already handles those via the
+        # returned tuple). This is enforced inside ConfigWrapper itself,
+        # so all callers benefit; FullConfigMoveValidator simply delegates.
+        config_wrapper = Mock()
+        config_wrapper.validate_config_db_config.return_value = (True, None)
+        validator = ps.FullConfigMoveValidator(config_wrapper)
+
+        validator.validate(self.any_move, self.any_diff)
+
+        config_wrapper.validate_config_db_config.assert_called_once_with(
+            self.any_simulated_config)
+
+
 class TestCreateOnlyMoveValidator(unittest.TestCase):
     def setUp(self):
         self.validator = ps.CreateOnlyMoveValidator(ps.PathAddressing())


### PR DESCRIPTION

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->


Cherry-pick of #4482 to 202511.

 Original PR: sonic-net/sonic-utilities#4482 Original commit: e04fdbbf24dd4bfbdbbd23ca110b0b3ffbdce06c

#### What I did

Silenced the Data Loading Failed LOG_ERR spam emitted by sonic_yang.loadData during GCU's speculative patch-sort search. FullConfigMoveValidator already handles validation failures via the returned (False, error) tuple, so the syslog line is duplicate noise that trips loganalyzer.

Conflict resolution

generic_config_updater/gu_common.py: 202511 still carries the original tmp_config_db_as_json = copy.deepcopy(config_db_as_json) step in validate_config_db_config (removed on master by Brad House in fc9ae89f / PR #3831 "optimization: prevent unneeded deep copies that show up in profiling", not cherry-picked to 202511). Resolution: keep the deepcopy, apply 
quiet=True to the sy.loadData(tmp_config_db_as_json, ...) call.

tests/generic_config_updater/patch_sorter_test.py: clean auto-merge.

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

