### PR TITLE
[202511 Cherry-pick][GCU][MGGMT_INTERFACE] Fix the remove forced_mgmt_route unexpected value (cherry-pick PR4423)

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1302,7 +1302,7 @@ class SingleRunLowLevelMoveGenerator:
             yield move
 
     def _traverse_current_list(self, ptr, current_tokens):
-        if len(ptr) == 0:
+        if len(ptr) <= 1:
             yield JsonMove(self.diff, OperationType.REMOVE, current_tokens)
             return
 


### PR DESCRIPTION
(cherry picked from commit 239f38cc18f77b75c4c56ba05de363c3a3196926)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Cherry-pick PR https://github.com/sonic-net/sonic-utilities/pull/4423

#### How I did it
Cherry-pick PR https://github.com/sonic-net/sonic-utilities/pull/4423 to fix the GCU remove forced_mgmt_route 

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

