### PR TITLE
route_check error messages during MACSec testcases run

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -82,6 +82,11 @@ FRR_WAIT_TIME = 15
 
 REDIS_TIMEOUT_MSECS = 0
 
+# Retry constants for transient route mismatch recovery.
+# BGP reconvergence after session disruption can take up to 2 minutes,
+# so retries use full DB re-reads with a sleep aligned to FRR_WAIT_TIME.
+ROUTE_CHECK_RETRIES = 8
+ROUTE_CHECK_WAIT_TIME = 15
 
 class Level(Enum):
     ERR = 'ERR'
@@ -921,11 +926,6 @@ def check_routes_for_namespace(namespace):
         # Look for subscribe updates for a second
         adds, deletes = get_subscribe_updates(selector, subs)
 
-    # Release the subscriber. If we keep the subscriber open then route updates will accumulate in the subscriber queue
-    # causing high client memory usage in redis.
-    del subs
-    del selector
-
     # Drop all those for which SET received
     rt_appl_miss, _ = diff_sorted_lists(rt_appl_miss, adds)
 
@@ -935,6 +935,63 @@ def check_routes_for_namespace(namespace):
     # Filter local p2p IPs if any that are reported as missing in APPL_DB
     if rt_appl_miss:
         rt_appl_miss = filter_out_local_p2p_ips(namespace, rt_appl_miss)
+
+    # Retry logic: if an initial mismatch is found, wait for route convergence before
+    # declaring failure. Routes can take up to 2 minutes to appear in ASIC_DB after a
+    # BGP session disruption.
+    #
+    # For rt_appl_miss: reuse the existing ASIC_DB subscriber (selector/subs). Events
+    # that arrive while we sleep are buffered in the subscriber; draining them via
+    # get_subscribe_updates is O(new events) with no full table scan or new connection.
+    #
+    # For rt_asic_miss: re-read only APPL_DB (lightweight getKeys()), and only when
+    # rt_asic_miss is still non-empty.
+    if rt_appl_miss or rt_asic_miss:
+        for retry_attempt in range(ROUTE_CHECK_RETRIES):
+            print_message(syslog.LOG_INFO,
+                          "Route mismatch in namespace {} (attempt {}/{}). Waiting {}s for "
+                          "convergence...".format(namespace, retry_attempt + 1,
+                                                  ROUTE_CHECK_RETRIES, ROUTE_CHECK_WAIT_TIME))
+            print_message(syslog.LOG_DEBUG, "Mismatches: appl_miss={}, asic_miss={}".format(
+                len(rt_appl_miss), len(rt_asic_miss)))
+
+            time.sleep(ROUTE_CHECK_WAIT_TIME)
+
+            # Drain ASIC_DB events buffered during the sleep.
+            # SET events resolve rt_appl_miss; DEL events resolve rt_asic_miss.
+            # No new DB connection or full table scan — only incremental events are processed.
+            new_adds, new_deletes = get_subscribe_updates(selector, subs)
+
+            if rt_appl_miss:
+                rt_appl_miss, _ = diff_sorted_lists(rt_appl_miss, new_adds)
+
+            if rt_asic_miss:
+                # First try DEL events from ASIC_DB (route removed from ASIC).
+                rt_asic_miss, _ = diff_sorted_lists(rt_asic_miss, new_deletes)
+                # Then re-read APPL_DB (getKeys only) for routes that appeared there.
+                if rt_asic_miss:
+                    rt_appl_retry_set = set(get_appdb_routes(namespace))
+                    rt_asic_miss = [r for r in rt_asic_miss if r not in rt_appl_retry_set]
+
+            print_message(syslog.LOG_DEBUG,
+                          "After retry {}: appl_miss={}, asic_miss={}".format(
+                              retry_attempt + 1, len(rt_appl_miss), len(rt_asic_miss)))
+
+            # Early exit if resolved
+            if not rt_appl_miss and not rt_asic_miss:
+                print_message(syslog.LOG_INFO, "Route check passed for namespace {} after {} retries".format(
+                    namespace, retry_attempt + 1))
+                break
+        else:
+            # Retries exhausted - likely a genuine issue
+            print_message(syslog.LOG_WARNING,
+                          "Route mismatch persists in namespace {} after {} retries".format(
+                              namespace, ROUTE_CHECK_RETRIES))
+
+    # Release the subscriber. If we keep the subscriber open then route updates will accumulate in the subscriber queue
+    # causing high client memory usage in redis.
+    del subs
+    del selector
 
     if rt_appl_miss:
         results["missed_ROUTE_TABLE_routes"] = rt_appl_miss

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -10,7 +10,8 @@ from unittest.mock import MagicMock, patch
 from tests.route_check_test_data import (
     APPL_DB, MULTI_ASIC, NAMESPACE, DEFAULTNS, ARGS, ASIC_DB, CONFIG_DB,
     DEFAULT_CONFIG_DB, APPL_STATE_DB, OP_DEL, OP_SET, PRE, RESULT, RET, TEST_DATA,
-    UPD, FRR_ROUTES
+    UPD, FRR_ROUTES, ROUTE_TABLE, RT_ENTRY_TABLE, INTF_TABLE,
+    ASIC_RT_ENTRY_KEY_PREFIX, ASIC_RT_ENTRY_KEY_SUFFIX
 )
 
 import pytest
@@ -222,6 +223,8 @@ class TestRouteCheck(object):
     def init(self):
         route_check.UNIT_TESTING = 1
         route_check.FRR_WAIT_TIME = 0
+        route_check.ROUTE_CHECK_RETRIES = 0
+        route_check.ROUTE_CHECK_WAIT_TIME = 0
 
     @pytest.fixture
     def force_hang(self):
@@ -349,3 +352,89 @@ class TestRouteCheck(object):
             route_check.mitigate_installed_not_offloaded_frr_routes(namespace, missed_frr_rt, rt_appl)
         # Verify that the stdout are suppressed in this function
         assert not mock_stdout.getvalue()
+
+    def test_retry_exhausted(self, mock_dbs):
+        """Retry loop runs but mismatches never resolve — for-else warning fires."""
+        ct_data = TEST_DATA['2']
+        set_test_case_data(ct_data)
+        route_check.ROUTE_CHECK_RETRIES = 1
+        route_check.ROUTE_CHECK_WAIT_TIME = 0
+        try:
+            self.run_test(ct_data)
+        finally:
+            route_check.ROUTE_CHECK_RETRIES = 0
+
+    def test_retry_resolves_appl_miss(self, mock_dbs):
+        """rt_appl_miss resolved in retry via ASIC subscriber SET event — early break."""
+        ct_data = {
+            MULTI_ASIC: False,
+            NAMESPACE: [''],
+            ARGS: "route_check",
+            PRE: {
+                DEFAULTNS: {
+                    APPL_DB: {
+                        ROUTE_TABLE: {
+                            "0.0.0.0/0": {"ifname": "portchannel0"},
+                            "10.10.196.12/31": {"ifname": "portchannel0"},
+                        },
+                        INTF_TABLE: {}
+                    },
+                    ASIC_DB: {
+                        RT_ENTRY_TABLE: {
+                            ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        }
+                    }
+                }
+            }
+        }
+        set_test_case_data(ct_data)
+        route_check.ROUTE_CHECK_RETRIES = 1
+        route_check.ROUTE_CHECK_WAIT_TIME = 0
+        # First get_subscribe_updates (before retry loop) finds no new events.
+        # Second call (inside retry) delivers the missing route as a SET event,
+        # clearing rt_appl_miss and triggering the early break.
+        try:
+            with patch('route_check.get_subscribe_updates',
+                       side_effect=[([], []), (["10.10.196.12/31"], [])]):
+                self.run_test(ct_data)
+        finally:
+            route_check.ROUTE_CHECK_RETRIES = 0
+
+    def test_retry_resolves_asic_miss(self, mock_dbs):
+        """rt_asic_miss resolved in retry via APPL_DB re-read — early break."""
+        ct_data = {
+            MULTI_ASIC: False,
+            NAMESPACE: [''],
+            ARGS: "route_check",
+            PRE: {
+                DEFAULTNS: {
+                    APPL_DB: {
+                        ROUTE_TABLE: {
+                            "0.0.0.0/0": {"ifname": "portchannel0"},
+                        },
+                        INTF_TABLE: {}
+                    },
+                    ASIC_DB: {
+                        RT_ENTRY_TABLE: {
+                            ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                            ASIC_RT_ENTRY_KEY_PREFIX + "10.10.10.10/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        }
+                    }
+                }
+            }
+        }
+        set_test_case_data(ct_data)
+        route_check.ROUTE_CHECK_RETRIES = 1
+        route_check.ROUTE_CHECK_WAIT_TIME = 0
+        # get_subscribe_updates returns no events on both calls (no DEL events).
+        # get_appdb_routes: first call reflects initial state (no 10.10.10.10/32);
+        # second call (inside retry) sees the route appeared in APPL_DB, filtering
+        # it out of rt_asic_miss and triggering the early break.
+        try:
+            with patch('route_check.get_subscribe_updates',
+                       side_effect=[([], []), ([], [])]), \
+                 patch('route_check.get_appdb_routes',
+                       side_effect=[["0.0.0.0/0"], ["0.0.0.0/0", "10.10.10.10/32"]]):
+                self.run_test(ct_data)
+        finally:
+            route_check.ROUTE_CHECK_RETRIES = 0


### PR DESCRIPTION
Description:
route_check.py was generating false-positive ERR monit: routeCheck syslog entries during test teardown, causing loganalyzer to fail tests that were otherwise correct. This affected tests that cause BGP session disruption (e.g. BGP peer shutdown, interface-level config changes that trigger BGP flaps).

Root cause:
When BGP sessions are disrupted and restored, routes can take up to 2 minutes to fully reconverge — the time needed for session re-establishment and route re-advertisement. route_check.py has no tolerance for this window and immediately reports missed_ROUTE_TABLE_routes (routes present in APPL_DB but not yet programmed into ASIC_DB) as a hard failure.

Resolution:
- Added ROUTE_CHECK_RETRIES = 8 and ROUTE_CHECK_WAIT_TIME = 15 (8 × 15s = 120s max wait, consistent with FRR_WAIT_TIME)
- For rt_appl_miss: reuse the existing ASIC_DB subscriber (selector/subs) opened at check start. Events buffered during the sleep are drained via get_subscribe_updates — O(new events only), no new DB connection or full table scan.
- For rt_asic_miss: re-read APPL_DB (lightweight getKeys()) only when rt_asic_miss is still non-empty, avoiding unnecessary scans in the common case where only rt_appl_miss is present.
- Genuine failures (routes never converging) are still reported after all retries are exhausted.

Resolves: https://github.com/sonic-net/sonic-utilities/issues/4487

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

