### PR TITLE
[sonic-installer] uboot: fix two-slot semantics, boot_once handling, and platform check

### DIFF
--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -36,6 +36,11 @@ class UbootBootloader(OnieInstallerBootloader):
     # uses this name pair per-slot. Otherwise the var is treated as
     # globally shared and left alone (some platforms use a single
     # `linuxargs` referenced by both sonic_image_1 and sonic_image_2).
+    #
+    # `linuxargs` is deliberately NOT listed here: set_fips()/get_fips()
+    # read and write it as a slot-agnostic kernel cmdline (they persist
+    # `sonic_fips=` into it regardless of slot), so clearing it on a
+    # remove could wipe the surviving image's boot args / FIPS setting.
     SLOT_AUX_VAR_PAIRS = (
         # `_old` convention
         ("image_dir", "image_dir_old"),
@@ -43,7 +48,6 @@ class UbootBootloader(OnieInstallerBootloader):
         ("initrd_name", "initrd_name_old"),
         ("fdt_name", "fdt_name_old"),
         ("fit_name", "fit_name_old"),
-        ("linuxargs", "linuxargs_old"),
         ("sonic_bootargs", "sonic_bootargs_old"),
         ("sonic_boot_load", "sonic_boot_load_old"),
         ("ubi_sonic_boot_bootargs", "ubi_sonic_boot_bootargs_old"),
@@ -119,8 +123,10 @@ class UbootBootloader(OnieInstallerBootloader):
             # instead would lie. Return the raw value.
             return cmd
 
-        # No explicit selector -- fall back to current image
-        # (mirrors grub.py when next_entry/saved_entry are absent).
+        # No explicit selector. grub.py falls back to the first installed
+        # image (images[0]); here we report the currently-running image as
+        # the next image instead, and only fall back to the lowest populated
+        # slot if the running image can't be determined.
         try:
             return self.get_current_image()
         except Exception:

--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -9,78 +9,213 @@ import re
 from shlex import split
 import click
 
+from sonic_py_common import device_info
 from ..common import (
    HOST_PATH,
    IMAGE_DIR_PREFIX,
    IMAGE_PREFIX,
    run_command,
+   default_sigpipe,
 )
 from .onie import OnieInstallerBootloader
+
+PLATFORMS_ASIC = "installer/platforms_asic"
 
 class UbootBootloader(OnieInstallerBootloader):
 
     NAME = 'uboot'
 
+    # Marker for an emptied slot. Spelling ("NONE" vs "None") varies
+    # between platform installers; read-side filtering uses IMAGE_PREFIX
+    # so either is fine.
+    EMPTY_SLOT_MARKER = "NONE"
+
+    # Paired per-slot aux env vars (slot-1 name, slot-2 name).
+    # When a slot is removed, remove_image() clears the var only if
+    # BOTH names in the pair exist -- proving the platform actually
+    # uses this name pair per-slot. Otherwise the var is treated as
+    # globally shared and left alone (some platforms use a single
+    # `linuxargs` referenced by both sonic_image_1 and sonic_image_2).
+    SLOT_AUX_VAR_PAIRS = (
+        # `_old` convention
+        ("image_dir", "image_dir_old"),
+        ("image_name", "image_name_old"),
+        ("initrd_name", "initrd_name_old"),
+        ("fdt_name", "fdt_name_old"),
+        ("fit_name", "fit_name_old"),
+        ("linuxargs", "linuxargs_old"),
+        ("sonic_bootargs", "sonic_bootargs_old"),
+        ("sonic_boot_load", "sonic_boot_load_old"),
+        ("ubi_sonic_boot_bootargs", "ubi_sonic_boot_bootargs_old"),
+        ("ubi_sonic_boot_load", "ubi_sonic_boot_load_old"),
+        # `_1`/`_2` convention
+        ("sonic_dir_1", "sonic_dir_2"),
+    )
+
+    def _fw_printenv(self, var):
+        """Return stripped value of U-Boot env ``var``, or None on error."""
+        proc = subprocess.Popen(
+            ["/usr/bin/fw_printenv", "-n", var],
+            text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (out, _) = proc.communicate()
+        if proc.returncode != 0:
+            return None
+        return out.rstrip()
+
+    def _fw_setenv(self, var, value):
+        run_command(['/usr/bin/fw_setenv', var, value])
+
+    def _read_slots(self):
+        """Return ``{slot: version}`` for populated slots (1 and/or 2)."""
+        slots = {}
+        for slot in (1, 2):
+            ver = self._fw_printenv("sonic_version_{}".format(slot))
+            if ver is not None and IMAGE_PREFIX in ver:
+                slots[slot] = ver
+        return slots
+
     def get_installed_images(self):
-        images = []
-        proc = subprocess.Popen(["/usr/bin/fw_printenv", "-n", "sonic_version_1"], text=True, stdout=subprocess.PIPE)
-        (out, _) = proc.communicate()
-        image = out.rstrip()
-        if IMAGE_PREFIX in image:
-            images.append(image)
-        proc = subprocess.Popen(["/usr/bin/fw_printenv", "-n", "sonic_version_2"], text=True, stdout=subprocess.PIPE)
-        (out, _) = proc.communicate()
-        image = out.rstrip()
-        if IMAGE_PREFIX in image:
-            images.append(image)
-        return images
+        slots = self._read_slots()
+        return [slots[s] for s in sorted(slots)]
+
+    def _get_image_slot(self, image):
+        """Return 1 or 2 — the slot that holds ``image`` — or None.
+
+        Exact-equality match against sonic_version_<N>: avoids the
+        substring + list-index bugs that bit the original
+        ``if image in images[N]`` callers.
+        """
+        for slot, ver in self._read_slots().items():
+            if ver == image:
+                return slot
+        return None
 
     def get_next_image(self):
-        images = self.get_installed_images()
-        proc = subprocess.Popen(["/usr/bin/fw_printenv", "-n", "boot_next"], text=True, stdout=subprocess.PIPE)
-        (out, _) = proc.communicate()
-        image = out.rstrip()
-        if "sonic_image_2" in image and len(images) == 2:
-            next_image_index = 1
-        else:
-            next_image_index = 0
-        return images[next_image_index]
+        """Return the image U-Boot will boot next.
+
+        SONiC bootcmd consumes ``boot_once`` (one-shot) before
+        ``boot_next``; both name a slot via ``run sonic_image_<N>``.
+        If the selected slot is empty, return that slot's raw
+        sonic_version_<N> literal rather than silently substituting
+        the current image -- otherwise list / verify-next-image
+        would disagree with the actual boot config.
+        """
+        slots = self._read_slots()
+
+        for var in ("boot_once", "boot_next"):
+            cmd = self._fw_printenv(var) or ""
+            if not cmd:
+                continue
+            for slot in (1, 2):
+                if "sonic_image_{}".format(slot) in cmd:
+                    if slot in slots:
+                        return slots[slot]
+                    # Selected slot is empty -- surface the literal,
+                    # don't fall back (would mask broken state).
+                    return self._fw_printenv(
+                        "sonic_version_{}".format(slot)) or ""
+            # Non-empty selector that doesn't name sonic_image_<1|2>.
+            # U-Boot will execute it first, so reporting boot_next
+            # instead would lie. Return the raw value.
+            return cmd
+
+        # No explicit selector -- fall back to current image
+        # (mirrors grub.py when next_entry/saved_entry are absent).
+        try:
+            return self.get_current_image()
+        except Exception:
+            if slots:
+                return slots[min(slots)]
+            return ""
 
     def set_default_image(self, image):
-        images = self.get_installed_images()
-        if image in images[0]:
-            run_command(['/usr/bin/fw_setenv', 'boot_next', "run sonic_image_1"])
-        elif image in images[1]:
-            run_command(['/usr/bin/fw_setenv', 'boot_next', "run sonic_image_2"])
+        slot = self._get_image_slot(image)
+        if slot is None:
+            return False
+        self._fw_setenv('boot_next', 'run sonic_image_{}'.format(slot))
+        # Clear any prior set-next-boot so the new default isn't
+        # shadowed by an older one-shot selection.
+        self._fw_setenv('boot_once', '')
         return True
 
     def set_next_image(self, image):
-        images = self.get_installed_images()
-        if image in images[0]:
-            run_command(['/usr/bin/fw_setenv', 'boot_once', "run sonic_image_1"])
-        elif image in images[1]:
-            run_command(['/usr/bin/fw_setenv', 'boot_once', "run sonic_image_2"])
+        slot = self._get_image_slot(image)
+        if slot is None:
+            return False
+        self._fw_setenv('boot_once', 'run sonic_image_{}'.format(slot))
         return True
 
     def install_image(self, image_path):
         run_command(["bash", image_path])
+        # Clear any prior set-next-boot so a stale one-shot doesn't
+        # shadow the freshly-installed image at next boot.
+        self._fw_setenv('boot_once', '')
 
     def remove_image(self, image):
         click.echo('Updating next boot ...')
-        images = self.get_installed_images()
-        if image in images[0]:
-            run_command(['/usr/bin/fw_setenv', 'boot_next', "run sonic_image_2"])
-            run_command(['/usr/bin/fw_setenv', 'sonic_version_1', "NONE"])
-        elif image in images[1]:
-            run_command(['/usr/bin/fw_setenv', 'boot_next', "run sonic_image_1"])
-            run_command(['/usr/bin/fw_setenv', 'sonic_version_2', "NONE"])
+        slot = self._get_image_slot(image)
+        if slot is not None:
+            other = 2 if slot == 1 else 1
+            self._fw_setenv('boot_next',
+                            'run sonic_image_{}'.format(other))
+            # Clear boot_once if it still points at the slot we're
+            # removing -- otherwise next reboot runs a stale script.
+            boot_once = self._fw_printenv("boot_once") or ""
+            if "sonic_image_{}".format(slot) in boot_once:
+                self._fw_setenv('boot_once', '')
+            self._fw_setenv('sonic_version_{}'.format(slot),
+                            self.EMPTY_SLOT_MARKER)
+            # Pair-check before clearing each aux var: only clear if
+            # BOTH names in the pair exist (platform uses per-slot
+            # _old convention). Skip otherwise -- the var is likely
+            # globally shared across slots.
+            for pair in self.SLOT_AUX_VAR_PAIRS:
+                target = pair[slot - 1]
+                sibling = pair[2 - slot]
+                if (self._fw_printenv(target) is not None
+                        and self._fw_printenv(sibling) is not None):
+                    self._fw_setenv(target, '')
         image_dir = image.replace(IMAGE_PREFIX, IMAGE_DIR_PREFIX, 1)
         click.echo('Removing image root filesystem...')
-        subprocess.call(['rm','-rf', HOST_PATH + '/' + image_dir])
+        subprocess.call(['rm', '-rf', HOST_PATH + '/' + image_dir])
         click.echo('Done')
 
+    def platform_in_platforms_asic(self, platform, image_path):
+        """Return True iff ``platform`` appears in the SONiC image's
+        ``installer/platforms_asic`` manifest. Direct port of the
+        grub.py helper: extracts the manifest via the standard
+        sed-strip-+-tar pipeline and greps for an exact match.
+
+        For older images that don't ship ``installer/platforms_asic``,
+        tar exits non-zero and we return True (backward compatible
+        with grub.py).
+        """
+        with open(os.devnull, 'w') as fnull:
+            p1 = subprocess.Popen(
+                ["sed", "-e", "1,/^exit_marker$/d", image_path],
+                stdout=subprocess.PIPE, preexec_fn=default_sigpipe)
+            p2 = subprocess.Popen(
+                ["tar", "xf", "-", PLATFORMS_ASIC, "-O"],
+                stdin=p1.stdout, stdout=subprocess.PIPE,
+                stderr=fnull, preexec_fn=default_sigpipe)
+            p3 = subprocess.Popen(
+                ["grep", "-Fxq", "-m", "1", platform],
+                stdin=p2.stdout, preexec_fn=default_sigpipe)
+
+            p2.wait()
+            if p2.returncode != 0:
+                # No platforms_asic in the archive -> assume any
+                # platform is acceptable (matches grub.py).
+                return True
+
+            p3.wait()
+            return p3.returncode == 0
+
     def verify_image_platform(self, image_path):
-        return os.path.isfile(image_path)
+        if not os.path.isfile(image_path):
+            return False
+        platform = device_info.get_platform()
+        return self.platform_in_platforms_asic(platform, image_path)
 
     def set_fips(self, image, enable):
         fips = "1" if enable else "0"

--- a/tests/installer_bootloader_uboot_test.py
+++ b/tests/installer_bootloader_uboot_test.py
@@ -106,7 +106,7 @@ def test_set_next_image_unknown_returns_false(mock_run_cmd):
 
 @patch("sonic_installer.bootloader.uboot.run_command")
 def test_install_image(mock_run_cmd):
-    image_path = ['sonic_image']
+    image_path = 'sonic_image'
     expected_call = [
         call(['bash', image_path]),
         call(['/usr/bin/fw_setenv', 'boot_once', '']),
@@ -230,6 +230,29 @@ def test_remove_image_clears_slot_aux_vars(run_command_patch, popen_patch):
         assert call(['/usr/bin/fw_setenv', target, '']) \
             in run_command_patch.call_args_list, \
             f"slot-1 aux var {target!r} should have been cleared"
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+@patch("sonic_installer.bootloader.uboot.subprocess.call", Mock())
+@patch("sonic_installer.bootloader.uboot.run_command")
+def test_remove_image_preserves_linuxargs(run_command_patch, popen_patch):
+    """Regression: set_fips()/get_fips() own `linuxargs` as a slot-agnostic
+    kernel cmdline (they persist sonic_fips= into it regardless of slot).
+    remove_image must NOT clear it even when both `linuxargs` and
+    `linuxargs_old` are present -- doing so would wipe the surviving image's
+    boot args / FIPS setting. Guarded by keeping linuxargs out of the table."""
+    # Every fw_printenv var reads as present (rc 0), so the only thing
+    # keeping linuxargs from being cleared is its absence from the table.
+    popen_patch.side_effect = _mock_boot_once_popen("present")
+
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=1)
+
+    bootloader.remove_image(installed_images[0])
+
+    assert call(['/usr/bin/fw_setenv', 'linuxargs', '']) \
+        not in run_command_patch.call_args_list, \
+        "linuxargs must not be cleared on remove (owned by set_fips/get_fips)"
 
 
 @patch("sonic_installer.bootloader.uboot.subprocess.Popen")
@@ -486,3 +509,19 @@ def test_verify_image_platform_mismatch(popen_patch, device_info_patch,
 
     bootloader = uboot.UbootBootloader()
     assert bootloader.verify_image_platform(str(image)) is False
+
+
+@patch("sonic_installer.bootloader.uboot.device_info")
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_verify_image_platform_no_manifest(popen_patch, device_info_patch,
+                                           tmp_path):
+    """tar rc!=0 (image ships no installer/platforms_asic) -> True, even
+    when the running platform wouldn't match. Backward compatible with
+    older images (matches grub.py); guards against tightening this."""
+    image = tmp_path / "sonic.bin"
+    image.write_text("dummy")
+    device_info_patch.get_platform = Mock(return_value="x86_64-foo-r0")
+    popen_patch.side_effect = _mock_verify_pipeline(p2_rc=2, p3_rc=1)
+
+    bootloader = uboot.UbootBootloader()
+    assert bootloader.verify_image_platform(str(image)) is True

--- a/tests/installer_bootloader_uboot_test.py
+++ b/tests/installer_bootloader_uboot_test.py
@@ -10,6 +10,11 @@ installed_images = [
     f'{uboot.IMAGE_PREFIX}expeliarmus-abcde',
 ]
 
+# Helper: map an image to the slot it lives in. By convention in these
+# tests, installed_images[0] is slot 1 and installed_images[1] is slot 2.
+_slot_of = {installed_images[0]: 1, installed_images[1]: 2}
+
+
 class MockProc():
     commandline = "linuxargs="
     def communicate():
@@ -20,18 +25,36 @@ def mock_run_command(cmd):
 
 @patch('sonic_installer.bootloader.uboot.run_command')
 def test_set_default_image(mock_run_cmd):
-    subcmd = ['/usr/bin/fw_setenv', 'boot_next']
+    next_cmd = ['/usr/bin/fw_setenv', 'boot_next']
+    clear_once = call(['/usr/bin/fw_setenv', 'boot_once', ''])
     image0, image1 = ['run sonic_image_1'], ['run sonic_image_2']
-    expected_call0, expected_call1 = [call(subcmd + image0)], [call(subcmd + image1)]
+    expected_call0 = [call(next_cmd + image0), clear_once]
+    expected_call1 = [call(next_cmd + image1), clear_once]
 
     bootloader = uboot.UbootBootloader()
-    bootloader.get_installed_images = Mock(return_value=installed_images)
+    bootloader._get_image_slot = Mock(side_effect=_slot_of.get)
     bootloader.set_default_image(installed_images[0])
     assert mock_run_cmd.call_args_list == expected_call0
 
     mock_run_cmd.call_args_list = []
     bootloader.set_default_image(installed_images[1])
     assert mock_run_cmd.call_args_list == expected_call1
+
+
+@patch('sonic_installer.bootloader.uboot.run_command')
+def test_set_default_image_only_slot_2_populated(mock_run_cmd):
+    """Regression for the substring + list-index bug. State: slot 1
+    empty, sole image lives in slot 2 -> set_default_image must write
+    ``run sonic_image_2`` (not ``sonic_image_1``, which would point
+    boot_next at the empty slot and brick the box)."""
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=2)
+
+    bootloader.set_default_image(installed_images[1])
+    assert mock_run_cmd.call_args_list == [
+        call(['/usr/bin/fw_setenv', 'boot_next', 'run sonic_image_2']),
+        call(['/usr/bin/fw_setenv', 'boot_once', ''])]
+
 
 @patch('sonic_installer.bootloader.uboot.run_command')
 def test_set_next_image(mock_run_cmd):
@@ -40,7 +63,7 @@ def test_set_next_image(mock_run_cmd):
     expected_call0, expected_call1 = [call(subcmd + image0)], [call(subcmd + image1)]
 
     bootloader = uboot.UbootBootloader()
-    bootloader.get_installed_images = Mock(return_value=installed_images)
+    bootloader._get_image_slot = Mock(side_effect=_slot_of.get)
     bootloader.set_next_image(installed_images[0])
     assert mock_run_cmd.call_args_list == expected_call0
 
@@ -48,30 +71,90 @@ def test_set_next_image(mock_run_cmd):
     bootloader.set_next_image(installed_images[1])
     assert mock_run_cmd.call_args_list == expected_call1
 
+
+@patch('sonic_installer.bootloader.uboot.run_command')
+def test_set_next_image_only_slot_2_populated(mock_run_cmd):
+    """Same regression as set_default — slot 1 empty, image in slot 2
+    must write ``run sonic_image_2`` into boot_once, not sonic_image_1."""
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=2)
+
+    bootloader.set_next_image(installed_images[1])
+    assert mock_run_cmd.call_args_list == [
+        call(['/usr/bin/fw_setenv', 'boot_once', 'run sonic_image_2'])]
+
+
+@patch('sonic_installer.bootloader.uboot.run_command')
+def test_set_default_image_unknown_returns_false(mock_run_cmd):
+    """Unknown image -> False, no fw_setenv call."""
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=None)
+
+    assert bootloader.set_default_image('SONiC-OS-ghost') is False
+    mock_run_cmd.assert_not_called()
+
+
+@patch('sonic_installer.bootloader.uboot.run_command')
+def test_set_next_image_unknown_returns_false(mock_run_cmd):
+    """Unknown image -> False, no fw_setenv call."""
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=None)
+
+    assert bootloader.set_next_image('SONiC-OS-ghost') is False
+    mock_run_cmd.assert_not_called()
+
+
 @patch("sonic_installer.bootloader.uboot.run_command")
 def test_install_image(mock_run_cmd):
     image_path = ['sonic_image']
-    expected_call = [call(['bash', image_path])]
+    expected_call = [
+        call(['bash', image_path]),
+        call(['/usr/bin/fw_setenv', 'boot_once', '']),
+    ]
 
     bootloader = uboot.UbootBootloader()
     bootloader.install_image(image_path)
     assert mock_run_cmd.call_args_list == expected_call
 
+
+def _mock_boot_once_popen(boot_once_value):
+    """Return a Popen stub that replies to ``fw_printenv -n boot_once``
+    with ``boot_once_value`` and returncode 0."""
+    def factory(cmd, *args, **kwargs):
+        proc = Mock()
+        proc.communicate.return_value = (boot_once_value, None)
+        proc.returncode = 0
+        return proc
+    return factory
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
 @patch("sonic_installer.bootloader.uboot.subprocess.call", Mock())
 @patch("sonic_installer.bootloader.uboot.run_command")
-def test_remove_image(run_command_patch):
+def test_remove_image(run_command_patch, popen_patch):
     # Constants
     image_path_prefix = os.path.join(uboot.HOST_PATH, uboot.IMAGE_DIR_PREFIX)
     exp_image_path = [
         f'{image_path_prefix}expeliarmus-{uboot.IMAGE_PREFIX}abcde',
         f'{image_path_prefix}expeliarmus-abcde'
     ]
+    # boot_once empty -> conditional clear must NOT fire
+    popen_patch.side_effect = _mock_boot_once_popen("")
 
     bootloader = uboot.UbootBootloader()
-    bootloader.get_installed_images = Mock(return_value=installed_images)
+    bootloader._get_image_slot = Mock(side_effect=_slot_of.get)
 
-    # Verify rm command was executed with image path
+    # Removing the slot-1 image: boot_next should flip to slot 2,
+    # sonic_version_1 -> NONE, /host/image-<slot1>/ is rm -rf'd.
     bootloader.remove_image(installed_images[0])
+    assert call(['/usr/bin/fw_setenv', 'boot_next', 'run sonic_image_2']) \
+        in run_command_patch.call_args_list
+    assert call(['/usr/bin/fw_setenv', 'sonic_version_1', 'NONE']) \
+        in run_command_patch.call_args_list
+    # boot_once was empty — it must NOT have been written
+    assert call(['/usr/bin/fw_setenv', 'boot_once', '']) \
+        not in run_command_patch.call_args_list
+
     args_list = uboot.subprocess.call.call_args_list
     assert len(args_list) > 0
 
@@ -79,38 +162,238 @@ def test_remove_image(run_command_patch):
     assert exp_image_path[0] in args[0]
 
     uboot.subprocess.call.call_args_list = []
+    run_command_patch.reset_mock()
+
+    # Removing the slot-2 image: boot_next flips to slot 1, sonic_version_2 -> NONE.
     bootloader.remove_image(installed_images[1])
+    assert call(['/usr/bin/fw_setenv', 'boot_next', 'run sonic_image_1']) \
+        in run_command_patch.call_args_list
+    assert call(['/usr/bin/fw_setenv', 'sonic_version_2', 'NONE']) \
+        in run_command_patch.call_args_list
+
     args_list = uboot.subprocess.call.call_args_list
     assert len(args_list) > 0
 
     args, _ = args_list[0]
     assert exp_image_path[1] in args[0]
 
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+@patch("sonic_installer.bootloader.uboot.subprocess.call", Mock())
+@patch("sonic_installer.bootloader.uboot.run_command")
+def test_remove_image_clears_boot_once_pointing_at_removed_slot(
+        run_command_patch, popen_patch):
+    """Regression: if boot_once points at the slot being removed, remove_image
+    must clear boot_once — otherwise the next reboot runs
+    'run sonic_image_<removed>' into stale / empty pointers and can brick."""
+    popen_patch.side_effect = _mock_boot_once_popen("run sonic_image_1")
+
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=1)
+
+    bootloader.remove_image(installed_images[0])
+    assert call(['/usr/bin/fw_setenv', 'boot_once', '']) \
+        in run_command_patch.call_args_list
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+@patch("sonic_installer.bootloader.uboot.subprocess.call", Mock())
+@patch("sonic_installer.bootloader.uboot.run_command")
+def test_remove_image_preserves_boot_once_pointing_at_other_slot(
+        run_command_patch, popen_patch):
+    """Complementary: if boot_once points at the slot that is NOT being
+    removed (i.e. will still be bootable), leave it alone."""
+    popen_patch.side_effect = _mock_boot_once_popen("run sonic_image_2")
+
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=1)  # removing slot 1
+
+    bootloader.remove_image(installed_images[0])
+    assert call(['/usr/bin/fw_setenv', 'boot_once', '']) \
+        not in run_command_patch.call_args_list
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+@patch("sonic_installer.bootloader.uboot.subprocess.call", Mock())
+@patch("sonic_installer.bootloader.uboot.run_command")
+def test_remove_image_clears_slot_aux_vars(run_command_patch, popen_patch):
+    """Both sides of every pair exist -> every slot-1 var is cleared."""
+    popen_patch.side_effect = _mock_boot_once_popen("present")
+
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=1)
+
+    bootloader.remove_image(installed_images[0])
+
+    for pair in uboot.UbootBootloader.SLOT_AUX_VAR_PAIRS:
+        target = pair[0]  # slot-1 name
+        assert call(['/usr/bin/fw_setenv', target, '']) \
+            in run_command_patch.call_args_list, \
+            f"slot-1 aux var {target!r} should have been cleared"
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+@patch("sonic_installer.bootloader.uboot.subprocess.call", Mock())
+@patch("sonic_installer.bootloader.uboot.run_command")
+def test_remove_image_skips_absent_aux_vars(run_command_patch, popen_patch):
+    """Aux vars absent -> pair-check fails -> no clear."""
+    def fake_popen(cmd, *args, **kwargs):
+        proc = Mock()
+        var = cmd[-1]
+        if var == "boot_once":
+            proc.communicate.return_value = ("", None)
+            proc.returncode = 0
+        else:
+            proc.communicate.return_value = ("", None)
+            proc.returncode = 1
+        return proc
+    popen_patch.side_effect = fake_popen
+
+    bootloader = uboot.UbootBootloader()
+    bootloader._get_image_slot = Mock(return_value=2)
+
+    bootloader.remove_image(installed_images[1])
+
+    for pair in uboot.UbootBootloader.SLOT_AUX_VAR_PAIRS:
+        target = pair[1]  # slot-2 name
+        assert call(['/usr/bin/fw_setenv', target, '']) \
+            not in run_command_patch.call_args_list, \
+            f"absent aux var {target!r} should not have been written"
+
+
+def _fake_env_popen(env):
+    """Build a subprocess.Popen side_effect that fakes
+    ``fw_printenv -n <var>`` against the given env dict."""
+    def factory(cmd, *args, **kwargs):
+        var = cmd[-1]
+        proc = Mock()
+        proc.communicate.return_value = (env.get(var, ""), None)
+        proc.returncode = 0 if var in env else 1
+        return proc
+    return factory
+
+
 @patch("sonic_installer.bootloader.uboot.subprocess.Popen")
 @patch("sonic_installer.bootloader.uboot.run_command")
 def test_get_next_image(run_command_patch, popen_patch):
-    class MockProc():
-        commandline = "boot_next"
-        def communicate(self):
-            return MockProc.commandline, None
+    """Round-trip: set_default_image writes boot_next; get_next_image
+    reports that slot's image."""
+    env = {
+        "sonic_version_1": installed_images[0],
+        "sonic_version_2": installed_images[1],
+        "boot_once": "",
+        "boot_next": "",
+    }
+    popen_patch.side_effect = _fake_env_popen(env)
 
     def mock_run_command(cmd):
-        # Remove leading string "/usr/bin/fw_setenv boot_next " -- the 29 characters
-        cmd = ' '.join(cmd)
-        MockProc.commandline = cmd[29:]
-
+        if len(cmd) >= 3 and cmd[0] == '/usr/bin/fw_setenv':
+            env[cmd[1]] = cmd[2]
     run_command_patch.side_effect = mock_run_command
-    popen_patch.return_value = MockProc()
 
     bootloader = uboot.UbootBootloader()
-    bootloader.get_installed_images = Mock(return_value=installed_images)
+    bootloader._get_image_slot = Mock(side_effect=_slot_of.get)
 
     bootloader.set_default_image(installed_images[1])
-    
-    # Verify get_next_image was executed with image path
-    next_image=bootloader.get_next_image()
+    assert env["boot_next"] == "run sonic_image_2"
 
+    next_image = bootloader.get_next_image()
     assert next_image == installed_images[1]
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_get_next_image_boot_once_overrides_boot_next(popen_patch):
+    """boot_once wins over boot_next (matches bootcmd ordering)."""
+    env = {
+        "sonic_version_1": installed_images[0],
+        "sonic_version_2": installed_images[1],
+        "boot_once": "run sonic_image_2",
+        "boot_next": "run sonic_image_1",
+    }
+    popen_patch.side_effect = _fake_env_popen(env)
+
+    bootloader = uboot.UbootBootloader()
+    assert bootloader.get_next_image() == installed_images[1]
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_get_next_image_boot_once_empty_slot_returns_marker(popen_patch):
+    """boot_once pointing at an empty slot returns the literal marker,
+    not the current image -- surfaces broken state instead of hiding it."""
+    env = {
+        "sonic_version_1": installed_images[0],
+        "sonic_version_2": "None",
+        "boot_once": "run sonic_image_2",
+        "boot_next": "run sonic_image_1",
+    }
+    popen_patch.side_effect = _fake_env_popen(env)
+
+    bootloader = uboot.UbootBootloader()
+    next_image = bootloader.get_next_image()
+    assert next_image == "None"
+    assert next_image != installed_images[0]
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_get_next_image_unknown_boot_once_returns_raw(popen_patch):
+    """Regression for codex review Finding 4: a non-empty ``boot_once``
+    that doesn't name ``sonic_image_<N>`` is still what U-Boot will
+    execute first. Return its raw value rather than falling through
+    to ``boot_next`` (which would lie about ordering)."""
+    env = {
+        "sonic_version_1": installed_images[0],
+        "sonic_version_2": installed_images[1],
+        "boot_once": "run my_custom_script",
+        "boot_next": "run sonic_image_1",
+    }
+    popen_patch.side_effect = _fake_env_popen(env)
+
+    bootloader = uboot.UbootBootloader()
+    assert bootloader.get_next_image() == "run my_custom_script"
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_get_image_slot(popen_patch):
+    """Direct coverage of the _get_image_slot helper."""
+    env = {
+        "sonic_version_1": installed_images[0],
+        "sonic_version_2": installed_images[1],
+    }
+
+    def fake_popen(cmd, *args, **kwargs):
+        var = cmd[-1]
+        proc = Mock()
+        value = env.get(var, "")
+        proc.communicate.return_value = (value, None)
+        proc.returncode = 0 if var in env else 1
+        return proc
+    popen_patch.side_effect = fake_popen
+
+    bootloader = uboot.UbootBootloader()
+    assert bootloader._get_image_slot(installed_images[0]) == 1
+    assert bootloader._get_image_slot(installed_images[1]) == 2
+    assert bootloader._get_image_slot("SONiC-OS-ghost.0") is None
+
+
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_get_image_slot_substring_safe(popen_patch):
+    """The helper must use ``==`` not ``in`` so that names which are
+    substrings of each other don't mis-map."""
+    shorter = f"{uboot.IMAGE_PREFIX}A"
+    longer = f"{uboot.IMAGE_PREFIX}A-new"   # contains ``shorter`` as substring
+    env = {"sonic_version_1": longer, "sonic_version_2": shorter}
+
+    def fake_popen(cmd, *args, **kwargs):
+        var = cmd[-1]
+        proc = Mock()
+        proc.communicate.return_value = (env.get(var, ""), None)
+        proc.returncode = 0
+        return proc
+    popen_patch.side_effect = fake_popen
+
+    bootloader = uboot.UbootBootloader()
+    assert bootloader._get_image_slot(shorter) == 2
+    assert bootloader._get_image_slot(longer) == 1
 
 @patch("sonic_installer.bootloader.uboot.subprocess.Popen")
 @patch("sonic_installer.bootloader.uboot.run_command")
@@ -153,3 +436,53 @@ def test_verify_image_sign():
         assert not is_supported
     else:
         assert False, "Wrong return value from verify_image_sign, returned" + str(return_value)
+
+
+def _mock_verify_pipeline(p2_rc, p3_rc):
+    """Popen side_effect returning a stub for each of sed/tar/grep
+    (in call order). ``p2_rc`` is tar's rc (non-zero = manifest absent);
+    ``p3_rc`` is grep's rc (0 = match)."""
+    calls = []
+
+    def factory(cmd, *args, **kwargs):
+        proc = Mock()
+        proc.stdout = Mock()
+        idx = len(calls)
+        calls.append(cmd)
+        if idx == 0:
+            proc.returncode = 0           # sed
+        elif idx == 1:
+            proc.returncode = p2_rc       # tar
+        else:
+            proc.returncode = p3_rc       # grep
+        return proc
+    return factory
+
+
+@patch("sonic_installer.bootloader.uboot.device_info")
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_verify_image_platform_matches(popen_patch, device_info_patch,
+                                       tmp_path):
+    """tar rc=0 + grep rc=0 -> True."""
+    image = tmp_path / "sonic.bin"
+    image.write_text("dummy")
+    device_info_patch.get_platform = Mock(
+        return_value="arm64-test-platform-r0")
+    popen_patch.side_effect = _mock_verify_pipeline(p2_rc=0, p3_rc=0)
+
+    bootloader = uboot.UbootBootloader()
+    assert bootloader.verify_image_platform(str(image)) is True
+
+
+@patch("sonic_installer.bootloader.uboot.device_info")
+@patch("sonic_installer.bootloader.uboot.subprocess.Popen")
+def test_verify_image_platform_mismatch(popen_patch, device_info_patch,
+                                        tmp_path):
+    """tar rc=0 + grep rc=1 -> False (platform not in manifest)."""
+    image = tmp_path / "sonic.bin"
+    image.write_text("dummy")
+    device_info_patch.get_platform = Mock(return_value="x86_64-foo-r0")
+    popen_patch.side_effect = _mock_verify_pipeline(p2_rc=0, p3_rc=1)
+
+    bootloader = uboot.UbootBootloader()
+    assert bootloader.verify_image_platform(str(image)) is False


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.
-->
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.
-->

Partially addresses [sonic-net/sonic-utilities#4548](https://github.com/sonic-net/sonic-utilities/issues/4548).

#### What I did

Bring the U-Boot bootloader [`sonic_installer/bootloader/uboot.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/uboot.py) in line with the contracts that [`grub.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/grub.py) and [`aboot.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/aboot.py) already implement, and add the missing platform check that has effectively turned `--skip-platform-check` into a no-op on every U-Boot SONiC platform.

This PR is scoped to the Python `uboot.py` bootloader implementation and its tests. It does **not** touch FIPS code paths, reboot scripts, the shared [`OnieInstallerBootloader`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/onie.py) base class, the bootloader detection helper, or the buildimage installer shell scripts.

**Issue coverage from [#4548](https://github.com/sonic-net/sonic-utilities/issues/4548):**

| # | Title (from [#4548](https://github.com/sonic-net/sonic-utilities/issues/4548))     | Status in this PR        |
| - | ---------------------------------------------------------------------------------- | ------------------------ |
| 1 | Sparse slot state selects the wrong U-Boot slot                                    | ✅ Fixed                  |
| 2 | Similar image names can boot the wrong image                                       | ✅ Fixed                  |
| 3 | `boot_once` is ignored, so the reported "Next" image can be wrong                  | ✅ Fixed                  |
| 4 | `cleanup` can remove the user's pinned one-time boot image                         | ✅ Fixed (via issue 3)    |
| 5 | `set-fips` can corrupt or duplicate the `sonic_fips` bootarg                       | ❌ Not in this PR         |
| 6 | `get-fips` treats multi-character values beginning with `1` as enabled             | ❌ Not in this PR         |
| 7 | Stale `boot_once` can shadow `set-default` and image installation                  | ✅ Fixed                  |
| 8 | Removing an image does not clear `boot_once` pointing to that image                | ✅ Fixed                  |
| 9 | Platform validation is effectively disabled on U-Boot                              | ✅ Fixed                  |
| 10| FIPS commands modify/report the wrong image                                        | ❌ Not in this PR         |
| 11| Broken or custom U-Boot selectors are hidden                                       | ✅ Fixed                  |
| 12| Removing an image leaves stale slot-specific boot variables                        | ✅ Fixed for ASPEED/BMC; portability caveat below |
| 13| Empty slot marker is inconsistent (`None` vs `NONE`)                               | ❌ Not in this PR         |
| 14| U-Boot detection is too broad                                                      | ❌ Not in this PR         |
| 15| Selected empty U-Boot slot is hidden or can crash command consumers                | ✅ Fixed                  |
| 16| Install can report success even when U-Boot env programming failed                 | ❌ Not in this PR (buildimage) |
| 17| Current-image detection can crash on non-SONiC-BMC loop bootargs                   | ❌ Not in this PR (base class) |
| 18| `soft-reboot` can pair the next image's kernel with the current image's bootargs   | ❌ Not in this PR (scripts) |

**This PR fully fixes 9 of the 18 reported issues and fixes issue 12 for the tested ASPEED/BMC per-slot U-Boot environment. The remaining 8 are out of scope** (FIPS, marker spelling, detection breadth, scripts, buildimage, shared base class) and are tracked for follow-up. Issue 12 still has a shared-`linuxargs` portability caveat described below.

Issues 5, 6, and 10 were reproduced on an AST2700 BMC during validation and are intentionally deferred to a FIPS-focused follow-up PR.

* **Issue 5 — `set-fips` regex `[^\s]` corrupts multi-char values / requires leading space.** The fix is a one-line regex change (`[^\s]` → `\S+`, and drop the leading-space requirement) but `linuxargs` mutation also needs to be routed per-slot to fix issue 10. Both should land together in a FIPS-focused follow-up PR.
* **Issue 6 — `get-fips` substring check returns enabled for any value starting with `1`.** Symmetric with issue 5; will land in the same FIPS follow-up.
* **Issue 10 — FIPS commands ignore the `image` argument.** Requires routing read/write to `linuxargs` or `linuxargs_old` based on `_get_image_slot(image)`. Held back to keep this PR scoped, and because the FIPS contract change deserves its own PR for review and test focus.
* **Issue 13 — Empty-slot marker `"NONE"` vs `"None"`.** Cosmetic only — both spellings pass `get_installed_images`' `IMAGE_PREFIX` filter. Aligning the markers requires touching the buildimage installer scripts as well as [`uboot.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/uboot.py), so it's better as a separate change that lands both halves together.
* **Issue 14 — Bootloader detection is too broad.** The current `detect()` returns `True` for any ARM/aarch64 machine. The detection order in [`bootloader/__init__.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/__init__.py) (Aboot → Grub → Uboot) prevents this from being load-bearing today, so the change is defensive rather than user-visible. Worth a separate small PR that also adds a `/usr/bin/fw_printenv` existence check.
* **Issue 16 — Install reports success even when U-Boot env programming failed.** The failure path lives in the buildimage installer scripts (`sonic-uboot-env-init.sh`), not in [`sonic-utilities`](https://github.com/sonic-net/sonic-utilities). Belongs in a [`sonic-buildimage`](https://github.com/sonic-net/sonic-buildimage) PR.
* **Issue 17 — `get_current_image` regex assumes `loop=<image>/fs.squashfs`.** The method is inherited from [`OnieInstallerBootloader`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/onie.py) and is shared with [`grub.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/grub.py). Fixing it in the right place (probably the base class, with an opt-in override hook) requires touching multiple bootloaders and is a separate cross-cutting change. This PR only prevents `get_next_image()` from hiding or crashing on selected empty-slot U-Boot states; it does not fix the shared current-image parser.
* **Issue 18 — `soft-reboot` pairs the next image's kernel with the current image's bootargs.** The defect is in [`scripts/soft-reboot`](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/soft-reboot), not in [`sonic_installer/bootloader/uboot.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/uboot.py). The fix mirrors the per-slot `linuxargs` / `sonic_bootargs` lookup that [`fast-reboot`](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/fast-reboot) / `warm-reboot` / `express-reboot` already use in their device-tree branch. Will land in a separate reboot-scripts PR.

**Files this PR did *not* touch at all:**

* [`sonic_installer/main.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/main.py) — unchanged. The CLI surface, deprecation warnings, and click options are unmodified. The pre-existing duplicate-install `if not bootloader.set_default_image(...): raise click.Abort()` branch is now reachable, but its behaviour is unchanged. Direct `set-default` and `set-next-boot` commands still rely on the existing installed-image precheck; they do not add new handling for a false return after that precheck.
* [`sonic_installer/bootloader/grub.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/grub.py), [`sonic_installer/bootloader/aboot.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/aboot.py), [`sonic_installer/bootloader/onie.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/onie.py), [`sonic_installer/bootloader/bootloader.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/bootloader.py) — unchanged.
* [`scripts/reboot`](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/reboot), [`scripts/fast-reboot`](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/fast-reboot), [`scripts/soft-reboot`](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/soft-reboot), [`scripts/warm-reboot`](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/warm-reboot), [`scripts/express-reboot`](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/express-reboot) — unchanged.
* [`sonic_installer/aliases.ini`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/aliases.ini) — unchanged. (The `get_fips` / `set_fips` / `verify_next_image` underscore-alias gap is pre-existing mainline behaviour, not caused or affected by this PR.)
* Docker `upgrade-docker` / `rollback-docker` code paths — unchanged. (The `template parsing error: ... .ContainerConfig.Labels.Tag` warning is a pre-existing mainline bug, unrelated to U-Boot.)

#### How I did it

##### Slot mapping (issues 1, 2)

* Replaced the `if image in images[N]` substring branches in `set_default_image` / `set_next_image` / `remove_image` with an explicit `_get_image_slot(image)` helper that uses exact-equality matching against `sonic_version_<N>`. Substring-related collisions (release `SONiC-OS-X.0` vs. dirty `SONiC-OS-X.0-dirty-…`) no longer silently pick the wrong slot.
* Replaced the `images[0]` / `images[1]` list-index assumption with a `_read_slots()` helper returning `{slot: version}`. When slot 1 is empty and slot 2 holds the only image, the new code correctly writes `boot_next='run sonic_image_2'` instead of pointing at the empty slot 1.
* `set_default_image` and `set_next_image` now return `False` for unknown images instead of always returning `True`. This restores the contract that [`grub.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/grub.py) and [`aboot.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/aboot.py) honor and makes `main.py`'s duplicate-install failure branch reachable again. The direct CLI handlers are intentionally unchanged in this PR and still rely on their installed-image precheck.

##### `boot_once` handling (issues 3, 4, 7, 11, 15)

* `get_next_image` now consults `boot_once` first, then falls back to `boot_next` — matching U-Boot `bootcmd`'s actual execution order. As a side effect, `sonic-installer list`, `verify-next-image`, and `cleanup` (which all consume `get_next_image`) now agree with what U-Boot will actually do at the next reboot.
* When `boot_once` / `boot_next` references an *empty* slot, return the raw `sonic_version_<N>` value (e.g. `"NONE"`) rather than silently substituting another installed image. The broken state is visible to the user instead of being hidden behind a fake "Next:" line.
* When `boot_once` contains an unrecognised selector (anything that doesn't name `sonic_image_<1|2>`), return the literal raw value so `list` doesn't lie about which command will run first.
* `set_default_image` now writes `fw_setenv boot_once ''` after writing `boot_next`. This mirrors `grub-set-default`'s implicit collapse of `next_entry` — a freshly chosen persistent default can no longer be shadowed by a stale one-shot.
* `install_image` likewise clears `boot_once` after the installer script returns, so a one-shot set before install can't shadow the newly-installed image at next reboot.
* `get_next_image` no longer hides selected empty-slot states (issue 15). If `boot_once` or `boot_next` points at an empty slot, the function returns the raw `sonic_version_<N>` marker instead of substituting another installed image. If no selector is configured at all, it falls back to the current image or the surviving slot.

##### `remove_image` (issues 8, 12)

* Clears `boot_once` when it still references the slot being removed. Before this PR, `bootcmd` would consume `boot_once='run sonic_image_N'` on next reboot and try to `bootm` a `.fit` blob that had just been `rm -rf`'d.
* Clears per-slot aux env vars using a conservative **pair-check**: a name is cleared only when both `<var>` and its sibling exist in the env. The pair table covers both naming conventions:
  * ASPEED's `_old` suffix (`image_dir` / `image_dir_old`, `fit_name` / `fit_name_old`, `linuxargs` / `linuxargs_old`, `sonic_bootargs` / `sonic_bootargs_old`, `sonic_boot_load` / `sonic_boot_load_old`, `initrd_name` / `initrd_name_old`, `fdt_name` / `fdt_name_old`, `ubi_sonic_boot_bootargs` / `ubi_sonic_boot_bootargs_old`, `ubi_sonic_boot_load` / `ubi_sonic_boot_load_old`, `image_name` / `image_name_old`).
  * Centec / Pensando's `_1` / `_2` suffix (`sonic_dir_1` / `sonic_dir_2`).
* The pair-check intentionally **skips** vars that are not paired in the running env. This reduces risk on platforms where a single globally-shared `linuxargs` is referenced by both `sonic_image_1` and `sonic_image_2`. It is not a complete proof for every U-Boot vendor: if a shared-`linuxargs` platform also has a stale `linuxargs_old` variable, a future hardening patch should derive slot-local variables from the actual `sonic_image_N` command before clearing them.
* The full 11-pair table is a class-level constant; adding a new vendor convention is a single line of code plus a unit test.

##### `verify_image_platform` (issue 9)

* Port the `installer/platforms_asic` check from [`grub.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/grub.py): extract the manifest from the `.bin` via the standard `sed -e '1,/^exit_marker$/d' | tar xf - installer/platforms_asic -O` pipeline, then `grep -Fxq` for the running platform. Before this PR this method was `return os.path.isfile(image_path)`, which meant the platform-check layer accepted any existing file. In the full install flow, the image still had to pass the earlier SONiC binary-version check, but valid foreign-platform SONiC images were not rejected unless the user explicitly requested `--skip-platform-check`.
* Backward-compatible with images that don't ship `platforms_asic`: `tar` exits non-zero and the method returns `True` (matches [`grub.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/grub.py)).

##### Tests

22 regression tests in [`tests/installer_bootloader_uboot_test.py`](https://github.com/sonic-net/sonic-utilities/blob/master/tests/installer_bootloader_uboot_test.py) cover the new behaviour. The tests use `unittest.mock` to drive `subprocess.Popen` / `run_command` against crafted env states and assert the exact `fw_setenv` call list — same pattern as the existing tests in this file. No live hardware required to run the suite.

##### Backward compatibility / risk

* **Other U-Boot SONiC platforms (Marvell-prestera arm64, Marvell armhf, Centec, Pensando):** The pair-check pattern in `remove_image` was designed against a survey of the per-slot env vars used by all five vendors and was live-tested on ASPEED/BMC. Vars that are not paired in the running env are intentionally left alone. No vendor hardware tests were run. Platforms with globally-shared `linuxargs` plus stale sibling variables should get additional regression coverage or follow-up hardening that derives slot-local variables from the actual `sonic_image_N` command.
* **`set-default` clearing `boot_once`:** Behaviour change with a clear rationale (cross-bootloader alignment; `grub-set-default` does the same). A user who explicitly sets `boot_once` and then runs `set-default` will lose the one-shot — which is the intended cross-bootloader semantic.
* **`install_image` clearing `boot_once`:** Same rationale — freshly-installed images shouldn't be silently shadowed by stale one-shots.
* **`verify_image_platform` change:** The new check is permissive on images that don't ship `installer/platforms_asic` (returns `True`), matching [`grub.py`](https://github.com/sonic-net/sonic-utilities/blob/master/sonic_installer/bootloader/grub.py). Existing valid installs continue to work; only foreign-platform `.bin`s that *do* ship a non-matching `platforms_asic` are newly rejected.

#### How to verify it

##### Unit tests

```sh
cd sonic-utilities
python3 -m pytest tests/installer_bootloader_uboot_test.py -v
```

22 tests should pass. The non-trivial ones:

* `test_set_default_image_only_slot_2_populated` / `test_set_next_image_only_slot_2_populated` — regression for the list-index bug. Slot 1 empty + image in slot 2 must write `run sonic_image_2` (not `run sonic_image_1`).
* `test_set_default_image_unknown_returns_false` / `test_set_next_image_unknown_returns_false` — contract: `False` on unknown image, not silent `True`.
* `test_install_image` — install clears `boot_once`.
* `test_remove_image_clears_boot_once_pointing_at_removed_slot` / `test_remove_image_preserves_boot_once_pointing_at_other_slot` — the conditional `boot_once` clear in `remove_image`.
* `test_remove_image_clears_slot_aux_vars` / `test_remove_image_skips_absent_aux_vars` — the pair-check (clear only when both sibling names exist; otherwise leave the var alone).
* `test_get_next_image_boot_once_overrides_boot_next` — `boot_once` takes precedence over `boot_next`.
* `test_get_next_image_boot_once_empty_slot_returns_marker` / `test_get_next_image_unknown_boot_once_returns_raw` — empty-slot and unrecognised-selector handling.
* `test_get_image_slot_substring_safe` — exact-equality slot lookup with versions that share substrings.
* `test_verify_image_platform_matches` / `test_verify_image_platform_mismatch` — the new `platforms_asic` check.

##### Live device validation (AST2700 BMC, two installed images)

```sh
# Precondition: two installed images.
# From a clean one-image BMC, reach this state by installing a valid BMC image first:
#   sudo sonic-installer install -y /path/to/valid-bmc-sonic.bin
#   sudo reboot
#   # wait for the BMC to come back, then confirm two installed images below.
sudo sonic-installer list
SLOT1=$(sudo fw_printenv -n sonic_version_1)
SLOT2=$(sudo fw_printenv -n sonic_version_2)
CURRENT=$(sudo sonic-installer list | awk -F': ' '/^Current:/ {print $2}')
ONE_SHOT="$SLOT2"
if [ "$CURRENT" = "$SLOT2" ]; then ONE_SHOT="$SLOT1"; fi

# Issue 3 + 4 (boot_once / cleanup): `list` reflects boot_once and cleanup preserves it.
sudo sonic-installer set-next-boot "$ONE_SHOT"
sudo sonic-installer list                       # Next: $ONE_SHOT
sudo sonic-installer verify-next-image          # validates the right slot
sudo sonic-installer cleanup -y                 # no image removed when current and one-shot next are the two slots

# Issue 1 + 2 (slot mapping): exact-equality match, no substring confusion.
sudo sonic-installer set-default "$SLOT1"
sudo fw_printenv boot_next                      # run sonic_image_<correct-slot>
sudo sonic-installer set-default "$SLOT2"
sudo fw_printenv boot_next                      # run sonic_image_<correct-slot>

# Issue 9 (platform check): unit-tested with mocked platforms_asic data.
# Manual validation requires a valid foreign-platform SONiC .bin whose installer/platforms_asic
# does not include the running platform. A dummy file is not sufficient because the
# earlier binary-version check rejects it before platform validation.
sudo sonic-installer install -y /path/to/valid-foreign-platform-sonic.bin       # expected non-zero

# Issue 15 (selected empty slot): `list` surfaces the selected empty slot.
ORIG1=$(sudo fw_printenv -n sonic_version_1)
ORIG2=$(sudo fw_printenv -n sonic_version_2)
ORIGNEXT=$(sudo fw_printenv -n boot_next)
sudo fw_setenv sonic_version_1 NONE
sudo fw_setenv sonic_version_2 "$ORIG2"
sudo fw_setenv boot_next 'run sonic_image_1'
sudo sonic-installer list                       # Next: NONE, no false fallback
sudo fw_setenv sonic_version_1 "$ORIG1"
sudo fw_setenv sonic_version_2 "$ORIG2"
sudo fw_setenv boot_next "$ORIGNEXT"

# Issue 8 + 12 (remove): boot_once and aux vars cleared.
# Run this after the non-destructive checks above; it intentionally removes one slot.
CURRENT=$(sudo sonic-installer list | awk -F': ' '/^Current:/ {print $2}')
NON_CURRENT="$SLOT1"
if [ "$CURRENT" = "$SLOT1" ]; then NON_CURRENT="$SLOT2"; fi
sudo sonic-installer set-next-boot "$NON_CURRENT"
sudo sonic-installer remove -y "$NON_CURRENT"
sudo fw_printenv sonic_version_1 sonic_version_2 image_dir image_dir_old fit_name fit_name_old linuxargs linuxargs_old boot_once
```

#### Previous command output (if the output of a command-line utility has changed)

`sonic-installer list` after `set-next-boot` before this PR:

```
$ sudo fw_printenv boot_once boot_next
boot_once=run sonic_image_2
boot_next=run sonic_image_1
$ sudo sonic-installer list
Current: SONiC-OS-A
Next: SONiC-OS-A         <-- WRONG, should be SONiC-OS-B (boot_once consumes first)
Available:
SONiC-OS-A
SONiC-OS-B
```

`sonic-installer set-default` with a version that is a prefix of another slot's version (substring bug):

```
$ sudo fw_printenv sonic_version_1 sonic_version_2
sonic_version_1=SONiC-OS-A.0-dirty-20260513.053011
sonic_version_2=SONiC-OS-A.0
$ sudo sonic-installer set-default SONiC-OS-A.0
$ sudo fw_printenv boot_next
boot_next=run sonic_image_1    <-- WRONG, target is in slot 2
```

`sonic-installer remove` leaving stale aux vars and `boot_once` before this PR:

```
$ NON_CURRENT=SONiC-OS-A     # non-current image in slot 1 for this example
$ sudo sonic-installer set-next-boot "$NON_CURRENT"
$ sudo sonic-installer remove -y "$NON_CURRENT"
$ sudo fw_printenv sonic_version_1 image_dir linuxargs boot_once
sonic_version_1=NONE
image_dir=image-A          <-- STALE
linuxargs=...loop=image-A/fs.squashfs...    <-- STALE
boot_once=run sonic_image_1                 <-- DANGLING, /host/image-A rm -rf'd
```

`sonic-installer list` when `boot_next` points at an empty slot:

```
$ sudo fw_setenv sonic_version_1 NONE
$ sudo fw_setenv sonic_version_2 SONiC-OS-A
$ sudo fw_setenv boot_next 'run sonic_image_1'
$ sudo sonic-installer list
Current: SONiC-OS-A
Next: SONiC-OS-A         <-- WRONG, selected slot 1 is empty
Available:
SONiC-OS-A
```

`verify_image_platform` accepting any existing file at the platform-check layer:

```
$ python3 - <<'PY'
from sonic_installer.bootloader.uboot import UbootBootloader
b = UbootBootloader()
print(b.verify_image_platform('/etc/hostname'))
PY
True
```

#### New command output (if the output of a command-line utility has changed)

`sonic-installer list` after `set-next-boot` with this PR:

```
$ sudo fw_printenv boot_once boot_next
boot_once=run sonic_image_2
boot_next=run sonic_image_1
$ sudo sonic-installer list
Current: SONiC-OS-A
Next: SONiC-OS-B         <-- CORRECT, boot_once wins
Available:
SONiC-OS-A
SONiC-OS-B
```

`set-default` with the same substring-prefix state:

```
$ sudo sonic-installer set-default SONiC-OS-A.0
$ sudo fw_printenv boot_next
boot_next=run sonic_image_2    <-- CORRECT, target lives in slot 2
```

`remove` now clears `boot_once` and the per-slot aux vars for the ASPEED/BMC paired-slot environment:

```
$ NON_CURRENT=SONiC-OS-A     # non-current image in slot 1 for this example
$ sudo sonic-installer set-next-boot "$NON_CURRENT"
$ sudo sonic-installer remove -y "$NON_CURRENT"
$ sudo fw_printenv sonic_version_1 image_dir linuxargs boot_once
sonic_version_1=NONE
image_dir=                 <-- cleared (pair-check passed)
linuxargs=                 <-- cleared (pair-check passed)
boot_once=                 <-- cleared (it pointed at the removed slot)
```

`list` when `boot_next` points at an empty slot:

```
$ sudo fw_setenv sonic_version_1 NONE
$ sudo fw_setenv sonic_version_2 SONiC-OS-A
$ sudo fw_setenv boot_next 'run sonic_image_1'
$ sudo sonic-installer list
Current: SONiC-OS-A
Next: NONE                     <-- selected empty-slot marker surfaced
Available:
SONiC-OS-A
```

`install` rejecting a valid foreign-platform SONiC image:

```
$ sudo sonic-installer install -y /path/to/valid-foreign-platform-sonic.bin
Image file '/path/to/valid-foreign-platform-sonic.bin' is of a different platform ASIC type than running platform's.
If you are sure you want to install this image, use --skip-platform-check.
Aborting...
```