### PR TITLE
GCU sort: cache find_ref_paths() results to eliminate redundant loadData calls

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import jsonpatch
 import importlib
@@ -472,6 +473,7 @@ class PathAddressing:
 
     def __init__(self, config_wrapper=None):
         self.config_wrapper = config_wrapper
+        self._ref_paths_cache = {}
 
     @staticmethod
     def get_path_tokens(path):
@@ -534,6 +536,18 @@ class PathAddressing:
             /ACL_TABLE/EVERFLOW6/ports/0
             /ACL_TABLE/EVERFLOW6/ports/1
         """
+        # Only cache when reload_config=True. When reload_config=False the caller
+        # has already loaded sy externally; the config argument may not accurately
+        # represent what is in sy, so caching by config hash would be incorrect.
+        if reload_config:
+            paths_key = tuple(sorted(paths)) if isinstance(paths, list) else (paths,)
+            config_hash = hashlib.md5(
+                json.dumps(config, sort_keys=True).encode()
+            ).hexdigest()
+            cache_key = (paths_key, config_hash)
+            if cache_key in self._ref_paths_cache:
+                return self._ref_paths_cache[cache_key]
+
         # TODO: Also fetch references by must statement (check similar statements)
         sy = self._create_sonic_yang_with_loaded_models()
 
@@ -564,6 +578,10 @@ class PathAddressing:
                 ref_paths_set.add(ref_path)
 
         ref_paths.sort()
+
+        if reload_config:
+            self._ref_paths_cache[cache_key] = ref_paths
+
         return ref_paths
 
     def _get_inner_leaf_xpaths(self, xpath, sy):

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -894,6 +894,109 @@ class TestPathAddressing(unittest.TestCase):
               xpath="/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4']/ports[.='Ethernet0']")
         check(path="/VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode",
              xpath="/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/tagging_mode")
+
+
+class TestPathAddressingRefPathsCache(unittest.TestCase):
+    """Tests for the _ref_paths_cache optimization on PathAddressing.find_ref_paths()."""
+
+    def _create_path_addressing_with_mock_sy(self):
+        """Helper: creates a PathAddressing with a mocked sonic_yang object."""
+        config_wrapper = gu_common.ConfigWrapper()
+
+        mock_sy = MagicMock()
+        # loadData succeeds silently
+        mock_sy.loadData = MagicMock()
+        # find_data_dependencies returns empty (no refs)
+        mock_sy.find_data_dependencies = MagicMock(return_value=[])
+        # root.find_path(...).data() yields nothing
+        mock_node_iter = MagicMock()
+        mock_node_iter.data = MagicMock(return_value=iter([]))
+        mock_sy.root.find_path = MagicMock(return_value=mock_node_iter)
+        # configdb_path_to_xpath returns a dummy xpath
+        mock_sy.configdb_path_to_xpath = MagicMock(return_value="/dummy:xpath")
+
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        pa = gu_common.PathAddressing(config_wrapper)
+        return pa, mock_sy
+
+    def test_find_ref_paths__same_paths_same_config__loadData_called_once(self):
+        pa, mock_sy = self._create_path_addressing_with_mock_sy()
+        config = {"PORT": {"Ethernet0": {"lanes": "0"}}}
+
+        pa.find_ref_paths("/PORT", config)
+        pa.find_ref_paths("/PORT", config)
+
+        self.assertEqual(mock_sy.loadData.call_count, 1)
+
+    def test_find_ref_paths__same_paths_different_config__loadData_called_twice(self):
+        pa, mock_sy = self._create_path_addressing_with_mock_sy()
+        config_a = {"PORT": {"Ethernet0": {"lanes": "0"}}}
+        config_b = {"PORT": {"Ethernet0": {"lanes": "1"}}}
+
+        pa.find_ref_paths("/PORT", config_a)
+        pa.find_ref_paths("/PORT", config_b)
+
+        self.assertEqual(mock_sy.loadData.call_count, 2)
+
+    def test_find_ref_paths__different_paths_same_config__loadData_called_twice(self):
+        pa, mock_sy = self._create_path_addressing_with_mock_sy()
+        config = {"PORT": {"Ethernet0": {"lanes": "0"}}, "VLAN": {}}
+
+        pa.find_ref_paths("/PORT", config)
+        pa.find_ref_paths("/VLAN", config)
+
+        self.assertEqual(mock_sy.loadData.call_count, 2)
+
+    def test_find_ref_paths__cache_returns_same_result_object(self):
+        pa, _ = self._create_path_addressing_with_mock_sy()
+        config = {"PORT": {"Ethernet0": {"lanes": "0"}}}
+
+        result1 = pa.find_ref_paths("/PORT", config)
+        result2 = pa.find_ref_paths("/PORT", config)
+
+        self.assertIs(result1, result2)
+
+    def test_find_ref_paths__reload_config_false__result_not_cached(self):
+        pa, mock_sy = self._create_path_addressing_with_mock_sy()
+        config = {"PORT": {"Ethernet0": {"lanes": "0"}}}
+
+        # First call with reload_config=False — should NOT cache
+        pa.find_ref_paths("/PORT", config, reload_config=False)
+        # Second call with reload_config=True — should miss cache and call loadData
+        pa.find_ref_paths("/PORT", config, reload_config=True)
+
+        # loadData is NOT called when reload_config=False, but IS called when True
+        self.assertEqual(mock_sy.loadData.call_count, 1)
+        # The cache should have exactly 1 entry (from the reload_config=True call)
+        self.assertEqual(len(pa._ref_paths_cache), 1)
+
+    def test_find_ref_paths__cache_independent_of_validate_config_cache(self):
+        config_wrapper = gu_common.ConfigWrapper()
+
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        mock_sy.find_data_dependencies = MagicMock(return_value=[])
+        mock_node_iter = MagicMock()
+        mock_node_iter.data = MagicMock(return_value=iter([]))
+        mock_sy.root.find_path = MagicMock(return_value=mock_node_iter)
+        mock_sy.configdb_path_to_xpath = MagicMock(return_value="/dummy:xpath")
+
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        config = {"PORT": {"Ethernet0": {"lanes": "0"}}}
+
+        # Call validate_config_db_config (uses config_wrapper directly)
+        config_wrapper.validate_config_db_config(config)
+
+        # Call find_ref_paths via PathAddressing
+        pa = gu_common.PathAddressing(config_wrapper)
+        pa.find_ref_paths("/PORT", config)
+
+        # _ref_paths_cache on PathAddressing should have exactly 1 entry
+        self.assertEqual(len(pa._ref_paths_cache), 1)
+        # PathAddressing and ConfigWrapper caches are separate objects
+        self.assertFalse(hasattr(config_wrapper, '_ref_paths_cache'))
         check(path="/VLAN_MEMBER/Vlan1000|Ethernet8",
               xpath="/sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']")
         check(path="/DEVICE_METADATA/localhost/hwsku",


### PR DESCRIPTION
## Root cause

The shared `sy` (SonicYang) object is overwritten by `FullConfigMoveValidator`'s `sy.loadData(simulated_config)` between REMOVE moves. This forces a re-load of the unchanged `diff.current_config` on every subsequent move -- even though it never changes during the DFS traversal. For a 512-port ACL removal this means ~512 redundant `loadData` calls at ~1.3s each (~11 min wasted).

## What this PR does

Adds a `(paths, config_hash) -> result_list` cache on `PathAddressing` so that `find_ref_paths()` returns instantly on repeat queries without touching `sy` at all. The cache is keyed by a tuple of sorted path strings and the MD5 hex-digest of the JSON-serialized config, so identical queries on the same config are served from memory.

The cache is only used when `reload_config=True`. When `reload_config=False` the caller has loaded `sy` externally, so the config argument may not reflect what is actually in `sy` -- caching by config hash would be incorrect in that case.

## How it layers on #4476

#4476 skips `sy.loadData()` when the last-loaded hash matches the requested config. This PR caches the **full result list** so that even after `sy` is overwritten by a `simulated_config` load, the answer is returned instantly -- no `loadData`, no `find_data_dependencies` traversal.

## How it layers on #4478

#4478 reduces REMOVE move count from N to 1 via `BulkLeafListMoveGenerator` (fewer DFS steps). This PR reduces the per-move cost, so both optimizations stack multiplicatively.

## Expected gain

512-port ACL REMOVE: from ~512 `loadData` calls on `current_config` to 1 miss + 511 cache hits = effectively 1 `loadData` call total.

## Test coverage added (`TestPathAddressingRefPathsCache`)

- `test_find_ref_paths__same_paths_same_config__loadData_called_once`
- `test_find_ref_paths__same_paths_different_config__loadData_called_twice`
- `test_find_ref_paths__different_paths_same_config__loadData_called_twice`
- `test_find_ref_paths__cache_returns_same_result_object`
- `test_find_ref_paths__reload_config_false__result_not_cached`
- `test_find_ref_paths__cache_independent_of_validate_config_cache`
