### PR TITLE
snmp: allow any string for sysContact, remove email format enforcement

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4468,16 +4468,12 @@ def contact(db):
     pass
 
 
-def is_valid_email(email):
-    return bool(re.search(r"^[\w\.\+\-]+\@[\w]+\.[a-z]{2,3}$", email))
-
-
 @contact.command('add')
 @click.argument('contact', metavar='<contact_name>', required=True)
-@click.argument('contact_email', metavar='<contact_email>', required=True)
+@click.argument('contact_email', metavar='<contact_info>', required=True)
 @clicommon.pass_db
 def add_contact(db, contact, contact_email):
-    """ Add snmp contact name and email """
+    """ Add snmp contact name and contact info """
     snmp = db.cfgdb.get_table("SNMP")
     try:
         if snmp['CONTACT']:
@@ -4485,7 +4481,7 @@ def add_contact(db, contact, contact_email):
             sys.exit(1)
         else:
             db.cfgdb.set_entry('SNMP', 'CONTACT', {contact: contact_email}) # TODO: ERROR IN YANG MODEL. Contact name is not defined as key
-            click.echo("Contact name {} and contact email {} have been added to "
+            click.echo("Contact name {} and contact info {} have been added to "
                        "configuration".format(contact, contact_email))
             try:
                 click.echo("Restarting SNMP service...")
@@ -4496,11 +4492,8 @@ def add_contact(db, contact, contact_email):
                 raise click.Abort()
     except KeyError:
         if "CONTACT" not in snmp.keys():
-            if not is_valid_email(contact_email):
-                click.echo("Contact email {} is not valid".format(contact_email))
-                sys.exit(2)
             db.cfgdb.set_entry('SNMP', 'CONTACT', {contact: contact_email})
-            click.echo("Contact name {} and contact email {} have been added to "
+            click.echo("Contact name {} and contact info {} have been added to "
                        "configuration".format(contact, contact_email))
             try:
                 click.echo("Restarting SNMP service...")
@@ -4539,7 +4532,7 @@ def del_contact(db, contact):
 
 @contact.command('modify')
 @click.argument('contact', metavar='<contact>', required=True)
-@click.argument('contact_email', metavar='<contact email>', required=True)
+@click.argument('contact_email', metavar='<contact_info>', required=True)
 @clicommon.pass_db
 def modify_contact(db, contact, contact_email):
     """ Modify snmp contact"""
@@ -4554,11 +4547,8 @@ def modify_contact(db, contact, contact_email):
             click.echo("SNMP contact {} {} already exists".format(contact, contact_email))
             sys.exit(1)
         elif contact == current_snmp_contact_name and contact_email != current_snmp_contact_email:
-            if not is_valid_email(contact_email):
-                click.echo("Contact email {} is not valid".format(contact_email))
-                sys.exit(2)
             db.cfgdb.mod_entry('SNMP', 'CONTACT', {contact: contact_email})
-            click.echo("SNMP contact {} email updated to {}".format(contact, contact_email))
+            click.echo("SNMP contact {} info updated to {}".format(contact, contact_email))
             try:
                 click.echo("Restarting SNMP service...")
                 clicommon.run_command(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
@@ -4567,12 +4557,9 @@ def modify_contact(db, contact, contact_email):
                 click.echo("Restart service snmp failed with error {}".format(e))
                 raise click.Abort()
         else:
-            if not is_valid_email(contact_email):
-                click.echo("Contact email {} is not valid".format(contact_email))
-                sys.exit(2)
             db.cfgdb.set_entry('SNMP', 'CONTACT', None)
             db.cfgdb.set_entry('SNMP', 'CONTACT', {contact: contact_email})
-            click.echo("SNMP contact {} and contact email {} updated".format(contact, contact_email))
+            click.echo("SNMP contact {} and contact info {} updated".format(contact, contact_email))
             try:
                 click.echo("Restarting SNMP service...")
                 clicommon.run_command(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -370,7 +370,6 @@ class TestSNMPConfigCommands(object):
             assert result.exit_code == 1
             assert 'SNMP contact testuser testuser@contoso.com already exists' in result.output
 
-
     def test_config_snmp_contact_modify_contact_new_name(self):
         db = Db()
         runner = CliRunner()
@@ -379,8 +378,8 @@ class TestSNMPConfigCommands(object):
                                     ["testuser", "testuser@contoso.com"], obj=db)
             assert result.exit_code == 0
 
-            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["modify"],
-                                    ["newuser", "newuser@contoso.com"], obj=db)
+            modify_cmd = config.config.commands["snmp"].commands["contact"].commands["modify"]
+            result = runner.invoke(modify_cmd, ["newuser", "newuser@contoso.com"], obj=db)
             print(result.exit_code)
             print(result.output)
             assert result.exit_code == 0

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -370,6 +370,22 @@ class TestSNMPConfigCommands(object):
             assert result.exit_code == 1
             assert 'SNMP contact testuser testuser@contoso.com already exists' in result.output
 
+
+    def test_config_snmp_contact_modify_contact_new_name(self):
+        db = Db()
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["add"],
+                                    ["testuser", "testuser@contoso.com"], obj=db)
+            assert result.exit_code == 0
+
+            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["modify"],
+                                    ["newuser", "newuser@contoso.com"], obj=db)
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert "SNMP contact newuser and contact info newuser@contoso.com updated" in result.output
+
     # Add snmp location tests
     def test_config_snmp_location_add_exiting_location_with_same_location_already_existing(self):
         db = Db()

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -23,7 +23,7 @@ json_data_show_run_snmp_contact_expected = """\
 """
 
 config_snmp_contact_add_del_new_contact ="""\
-Contact name testuser and contact email testuser@contoso.com have been added to configuration
+Contact name testuser and contact info testuser@contoso.com have been added to configuration
 Restarting SNMP service...
 """ 
 
@@ -294,16 +294,6 @@ class TestSNMPConfigCommands(object):
             assert result.exit_code == 1
             assert 'Contact already exists.  Use sudo config snmp contact modify instead' in result.output
 
-    def test_config_snmp_contact_add_invalid_email(self):
-        db = Db()
-        runner = CliRunner()
-        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
-            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["add"],
-                              ["testuser", "testusercontoso.com"], obj=db)
-            print(result.exit_code)
-            assert result.exit_code == 2
-            assert "Contact email testusercontoso.com is not valid" in result.output
-
 
     # Delete snmp contact tests
     def test_config_snmp_contact_del_new_contact_when_contact_exists(self):
@@ -359,7 +349,7 @@ class TestSNMPConfigCommands(object):
                                                          ["testuser", "testuser@test.com"], obj=db)
             print(result.exit_code)
             assert result.exit_code == 0
-            assert 'SNMP contact testuser email updated to testuser@test.com' in result.output
+            assert 'SNMP contact testuser info updated to testuser@test.com' in result.output
             assert db.cfgdb.get_entry("SNMP", "CONTACT") == {"testuser": "testuser@test.com"}
 
     def test_config_snmp_contact_modify_contact_and_email_with_existing_entry(self):
@@ -379,43 +369,6 @@ class TestSNMPConfigCommands(object):
             print(result.exit_code)
             assert result.exit_code == 1
             assert 'SNMP contact testuser testuser@contoso.com already exists' in result.output
-
-    def test_config_snmp_contact_modify_existing_contact_with_invalid_email(self):
-        db = Db()
-        runner = CliRunner()
-        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
-            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["add"],
-                                    ["testuser", "testuser@contoso.com"], obj=db)
-            print(result.exit_code)
-            print(result.output)
-            assert result.exit_code == 0
-            assert result.output == config_snmp_contact_add_del_new_contact
-            assert db.cfgdb.get_entry("SNMP", "CONTACT") == {"testuser": "testuser@contoso.com"}
-
-            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["modify"],
-                                                     ["testuser", "testuser@contosocom"], obj=db)
-            print(result.exit_code)
-            assert result.exit_code == 2
-            assert 'Contact email testuser@contosocom is not valid' in result.output
-
-
-    def test_config_snmp_contact_modify_new_contact_with_invalid_email(self):
-        db = Db()
-        runner = CliRunner()
-        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
-            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["add"],
-                                    ["testuser", "testuser@contoso.com"], obj=db)
-            print(result.exit_code)
-            print(result.output)
-            assert result.exit_code == 0
-            assert result.output == config_snmp_contact_add_del_new_contact
-            assert db.cfgdb.get_entry("SNMP", "CONTACT") == {"testuser": "testuser@contoso.com"}
-
-            result = runner.invoke(config.config.commands["snmp"].commands["contact"].commands["modify"],
-                                                     ["blah", "blah@contoso@com"], obj=db)
-            print(result.exit_code)
-            assert result.exit_code == 2
-            assert 'Contact email blah@contoso@com is not valid' in result.output
 
     # Add snmp location tests
     def test_config_snmp_location_add_exiting_location_with_same_location_already_existing(self):
@@ -861,11 +814,6 @@ class TestSNMPConfigCommands(object):
         assert result.exit_code == 1
         assert 'SNMP user test_nopriv_RO_2 is not configured' in result.output
 
-    @pytest.mark.parametrize("invalid_email", ['test@contoso', 'test.contoso.com', 'testcontoso@com', 
-                                               '123_%contoso.com', 'mytest@contoso.comm'])
-    def test_is_valid_email(self, invalid_email):
-        output = config.is_valid_email(invalid_email)
-        assert output == False
 
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=ValueError))

--- a/tests/show_snmp_test.py
+++ b/tests/show_snmp_test.py
@@ -27,7 +27,7 @@ Restarting SNMP service...
 """
 
 config_snmp_contact_add_del_new_contact ="""\
-Contact name testuser and contact email testuser@contoso.com have been added to configuration
+Contact name testuser and contact info testuser@contoso.com have been added to configuration
 Restarting SNMP service...
 """ 
 


### PR DESCRIPTION
#### Why I did it

RFC 1213 defines sysContact as a free-form string (0-255 chars). The current CLI enforces email format on the contact value, which prevents operators from setting contact strings required by their management platforms.

Companion PR: sonic-net/sonic-buildimage#26991

##### Work item tracking
- Microsoft ADO:

#### How I did it

- Removed `is_valid_email()` check from `add` and `modify` contact commands
- Renamed CLI argument metavar from `contact_email` to `contact_info` to reflect the broader accepted format
- Updated output strings accordingly
- Removed tests that validated email rejection (no longer applicable)

#### How to verify it

- `config snmp contact add "NOC Team" "noc-team+monitoring"` — should succeed
- `config snmp contact modify "NOC Team" "ops@example.com"` — email format still works
- `show snmp contact` — displays correctly

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

snmp: allow any string for sysContact per RFC 1213, remove email format enforcement

#### Link to config_db schema for YANG module changes

N/A
