### PR TITLE
Add loop guard CLI commands

### DIFF
--- a/config/stp.py
+++ b/config/stp.py
@@ -292,6 +292,7 @@ def vlan_enable_stp(db, vlan_name):
 def interface_enable_stp(db, interface_name):
     fvs = {'enabled': 'true',
            'root_guard': 'false',
+           'loop_guard': 'false',
            'bpdu_guard': 'false',
            'bpdu_guard_do_disable': 'false',
            'portfast': 'false',
@@ -361,6 +362,7 @@ def is_portchannel_member_port(db, interface_name):
 def enable_stp_for_interfaces(db):
     fvs = {'enabled': 'true',
            'root_guard': 'false',
+           'loop_guard': 'false',
            'bpdu_guard': 'false',
            'bpdu_guard_do_disable': 'false',
            'portfast': 'false',
@@ -446,6 +448,7 @@ def enable_mst_for_interfaces(db):
         'bpdu_guard': 'false',
         'bpdu_guard_do': 'false',
         'root_guard': 'false',
+        'loop_guard': 'false',
         'path_cost': MST_DEFAULT_PORT_PATH_COST,
         'priority': MST_DEFAULT_PORT_PRIORITY
         }
@@ -1350,6 +1353,7 @@ def stp_interface_enable(_db, interface_name):
     fvs = {
         'enabled': 'true',
         'root_guard': 'false',
+        'loop_guard': 'false',
         'bpdu_guard': 'false',
         'bpdu_guard_do_disable': 'false'
     }
@@ -1531,6 +1535,39 @@ def stp_interface_root_guard_disable(_db, interface_name):
         fvs.update({'edge_port': 'false', 'link_type': 'auto'})
 
     db.mod_entry('STP_PORT', interface_name, fvs)
+
+
+# config spanning_tree interface loop_guard {enable|disable} <ifname>
+# This command allow enabling or disabling of loop_guard on an interface.
+@spanning_tree_interface.group('loop_guard')
+@clicommon.pass_db
+def spanning_tree_interface_loop_guard(_db):
+    """Configure STP loop guard for interface"""
+    pass
+
+
+@spanning_tree_interface_loop_guard.command('enable')
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@clicommon.pass_db
+def stp_interface_loop_guard_enable(_db, interface_name):
+    """Enable STP loop guard for interface"""
+    ctx = click.get_current_context()
+    db = _db.cfgdb
+    check_if_stp_enabled_for_interface(ctx, db, interface_name)
+    check_if_interface_is_valid(ctx, db, interface_name)
+    db.mod_entry('STP_PORT', interface_name, {'loop_guard': 'true'})
+
+
+@spanning_tree_interface_loop_guard.command('disable')
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@clicommon.pass_db
+def stp_interface_loop_guard_disable(_db, interface_name):
+    """Disable STP loop guard for interface"""
+    ctx = click.get_current_context()
+    db = _db.cfgdb
+    check_if_stp_enabled_for_interface(ctx, db, interface_name)
+    check_if_interface_is_valid(ctx, db, interface_name)
+    db.mod_entry('STP_PORT', interface_name, {'loop_guard': 'false'})
 
 
 # config spanning_tree interface priority <ifname> <port_priority-value>

--- a/show/stp.py
+++ b/show/stp.py
@@ -349,6 +349,40 @@ def show_stp_root_guard(ctx):
                             click.echo("{:17}{:7}{}".format(ifname, vlanid, state))
 
 
+@spanning_tree.command('loop_guard')
+@click.pass_context
+def show_stp_loop_guard(ctx):
+    """Show spanning_tree loop_guard"""
+
+    print_header = 1
+    ifname_all = g_stp_cfg_db.get_keys("STP_PORT")
+    for ifname in ifname_all:
+        entry = g_stp_cfg_db.get_entry("STP_PORT", ifname)
+        if entry.get('loop_guard') == 'true' and entry.get('enabled') == 'true':
+            if print_header:
+                click.echo("{:17}{:7}{}".format("Port", "VLAN", "Current State"))
+                click.echo("-------------------------------------------")
+                print_header = 0
+
+            state = ''
+            vlanid = ''
+            keys = g_stp_appl_db.keys(g_stp_appl_db.APPL_DB, "*STP_VLAN_PORT_TABLE:*:{}".format(ifname))
+            if keys:
+                for key in keys:
+                    entry = g_stp_appl_db.get_all(g_stp_appl_db.APPL_DB, key)
+                    if entry and 'loop_guard_active' in entry:
+                        if entry['loop_guard_active'] == '0':
+                            state = 'Consistent state'
+                        else:
+                            state = 'Loop-inconsistent state'
+
+                        vlanid = re.search(':Vlan(.*):', key)
+                        if vlanid:
+                            click.echo("{:17}{:7}{}".format(ifname, vlanid.group(1), state))
+                        else:
+                            click.echo("{:17}{:7}{}".format(ifname, vlanid, state))
+
+
 @spanning_tree.group('statistics', cls=clicommon.AliasedGroup, invoke_without_command=True)
 @click.pass_context
 def show_stp_statistics(ctx):

--- a/show/stp.py
+++ b/show/stp.py
@@ -346,7 +346,7 @@ def show_stp_root_guard(ctx):
                         if vlanid:
                             click.echo("{:17}{:7}{}".format(ifname, vlanid.group(1), state))
                         else:
-                            click.echo("{:17}{:7}{}".format(ifname, vlanid, state))
+                            click.echo("{:17}{:7}{}".format(ifname, str(vlanid), state))
 
 
 @spanning_tree.command('loop_guard')

--- a/show/stp.py
+++ b/show/stp.py
@@ -380,7 +380,7 @@ def show_stp_loop_guard(ctx):
                         if vlanid:
                             click.echo("{:17}{:7}{}".format(ifname, vlanid.group(1), state))
                         else:
-                            click.echo("{:17}{:7}{}".format(ifname, vlanid, state))
+                            click.echo("{:17}{:7}{}".format(ifname, str(vlanid), state))
 
 
 @spanning_tree.group('statistics', cls=clicommon.AliasedGroup, invoke_without_command=True)

--- a/tests/stp_test.py
+++ b/tests/stp_test.py
@@ -9,6 +9,7 @@ from config.stp import (
 
 import config.main as config
 import show.main as show
+import show.stp as show_stp
 from utilities_common.db import Db
 
 show_spanning_tree = """\
@@ -74,6 +75,20 @@ Root guard timeout: 30 secs
 Port             VLAN   Current State
 -------------------------------------------
 Ethernet4        100    Consistent state
+"""
+
+
+show_spanning_tree_loop_guard = """\
+Port             VLAN   Current State
+-------------------------------------------
+Ethernet0        100    Consistent state
+Ethernet0        None   Loop-inconsistent state
+"""
+
+
+show_spanning_tree_loop_guard_empty = """\
+Port             VLAN   Current State
+-------------------------------------------
 """
 
 
@@ -154,6 +169,64 @@ class TestStp(object):
             print(f'Error Output:\n{result.output}')
             assert result.exit_code == 0
             assert result.output == show_spanning_tree_root_guard
+
+    def test_show_spanning_tree_loop_guard(self):
+        cli_runner = CliRunner()
+        db = Db()
+
+        mock_cfg_db = MagicMock()
+        mock_appl_db = MagicMock()
+
+        mock_cfg_db.get_keys.return_value = ["Ethernet0"]
+        mock_cfg_db.get_entry.side_effect = lambda table, key: (
+            {"mode": "pvst"} if table == "STP" and key == "GLOBAL" else
+            {"loop_guard": "true", "enabled": "true"} if table == "STP_PORT" and key == "Ethernet0" else
+            {}
+        )
+
+        mock_appl_db.APPL_DB = "APPL_DB"
+        mock_appl_db.keys.return_value = [
+            "STP_VLAN_PORT_TABLE:Vlan100:Ethernet0",
+            "STP_VLAN_PORT_TABLE:Eth:Ethernet0"
+        ]
+
+        def get_all_side_effect(_db, key):
+            if "Vlan100" in key:
+                return {"loop_guard_active": "0"}
+            return {"loop_guard_active": "1"}
+
+        mock_appl_db.get_all.side_effect = get_all_side_effect
+
+        show_stp.g_stp_cfg_db = mock_cfg_db
+        show_stp.g_stp_appl_db = mock_appl_db
+
+        result = cli_runner.invoke(show.cli.commands["spanning-tree"].commands["loop_guard"], [], obj=db)
+
+        assert result.exit_code == 0
+        assert result.output == show_spanning_tree_loop_guard
+
+    def test_show_spanning_tree_loop_guard_no_vlan_entries(self):
+        cli_runner = CliRunner()
+        db = Db()
+
+        mock_cfg_db = MagicMock()
+        mock_appl_db = MagicMock()
+
+        mock_cfg_db.get_keys.return_value = ["Ethernet0"]
+        mock_cfg_db.get_entry.side_effect = lambda table, key: (
+            {"loop_guard": "true", "enabled": "true"} if table == "STP_PORT" and key == "Ethernet0" else {}
+        )
+
+        mock_appl_db.APPL_DB = "APPL_DB"
+        mock_appl_db.keys.return_value = []
+
+        show_stp.g_stp_cfg_db = mock_cfg_db
+        show_stp.g_stp_appl_db = mock_appl_db
+
+        result = cli_runner.invoke(show.cli.commands["spanning-tree"].commands["loop_guard"], [], obj=db)
+
+        assert result.exit_code == 0
+        assert result.output == show_spanning_tree_loop_guard_empty
 
     def test_disable_enable_global_pvst(self):
         cli_runner = CliRunner()
@@ -2188,6 +2261,75 @@ class TestStpInterfaceRootGuardDisable:
 
         assert result.exit_code != 0
         assert "Invalid interface" in result.output
+
+
+class TestStpInterfaceLoopGuard:
+    def setup_method(self):
+        self.runner = CliRunner()
+        self.cfgdb = MagicMock()
+        self.db = Db()
+        self.db.cfgdb = self.cfgdb
+
+    @patch('config.stp.check_if_interface_is_valid')
+    @patch('config.stp.check_if_stp_enabled_for_interface')
+    def test_loop_guard_enable(self, mock_check_enabled, mock_check_valid):
+        result = self.runner.invoke(
+            config.config.commands["spanning-tree"]
+            .commands["interface"]
+            .commands["loop_guard"],
+            ["enable", "Ethernet0"],
+            obj=self.db
+        )
+
+        assert result.exit_code == 0
+        self.cfgdb.mod_entry.assert_called_with("STP_PORT", "Ethernet0", {"loop_guard": "true"})
+        mock_check_enabled.assert_called_once()
+        mock_check_valid.assert_called_once()
+
+    @patch('config.stp.check_if_interface_is_valid')
+    @patch('config.stp.check_if_stp_enabled_for_interface')
+    def test_loop_guard_disable(self, mock_check_enabled, mock_check_valid):
+        result = self.runner.invoke(
+            config.config.commands["spanning-tree"]
+            .commands["interface"]
+            .commands["loop_guard"],
+            ["disable", "Ethernet0"],
+            obj=self.db
+        )
+
+        assert result.exit_code == 0
+        self.cfgdb.mod_entry.assert_called_with("STP_PORT", "Ethernet0", {"loop_guard": "false"})
+        mock_check_enabled.assert_called_once()
+        mock_check_valid.assert_called_once()
+
+    @patch('config.stp.check_if_interface_is_valid', side_effect=click.ClickException("Invalid interface"))
+    @patch('config.stp.check_if_stp_enabled_for_interface')
+    def test_loop_guard_enable_invalid_interface(self, mock_check_enabled, mock_check_valid):
+        result = self.runner.invoke(
+            config.config.commands["spanning-tree"]
+            .commands["interface"]
+            .commands["loop_guard"],
+            ["enable", "Ethernet99"],
+            obj=self.db
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid interface" in result.output
+
+    @patch('config.stp.check_if_interface_is_valid')
+    @patch('config.stp.check_if_stp_enabled_for_interface', side_effect=click.ClickException("STP not enabled"))
+    def test_loop_guard_enable_stp_not_enabled(self, mock_check_enabled, mock_check_valid):
+        result = self.runner.invoke(
+            config.config.commands["spanning-tree"]
+            .commands["interface"]
+            .commands["loop_guard"],
+            ["enable", "Ethernet0"],
+            obj=self.db
+        )
+
+        assert result.exit_code != 0
+        assert "STP not enabled" in result.output
+        mock_check_valid.assert_not_called()
 
 
 class TestStpInterfaceRootGuardEnable:

--- a/tests/test_config_mstp.py
+++ b/tests/test_config_mstp.py
@@ -347,6 +347,7 @@ def test_enable_mst_for_interfaces():
         'bpdu_guard': 'false',
         'bpdu_guard_do': 'false',
         'root_guard': 'false',
+        'loop_guard': 'false',
         'path_cost': MST_DEFAULT_PORT_PATH_COST,
         'priority': MST_DEFAULT_PORT_PRIORITY
     }


### PR DESCRIPTION
## Summary
Add loop guard CLI configuration and show support for STP.

## Changes
- Add:
  - `config spanning_tree interface loop_guard enable <interface>`
  - `config spanning_tree interface loop_guard disable <interface>`
- Add:
  - `show spanning_tree loop_guard`
- Include `loop_guard: false` in STP_PORT defaults where STP interface entries are initialized.

## Files
- config/stp.py
- show/stp.py

## Dependency
- sonic-stp PR: https://github.com/sonic-net/sonic-stp/pull/88
- sonic-swss PR: https://github.com/sonic-net/sonic-swss/pull/4517