### PR TITLE
# [show] Add 'show monitor-link' command

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2609,6 +2609,8 @@ main() {
     save_cmd "show spanning-tree bpdu_guard" "stp.bg"
     save_cmd "show spanning-tree root_guard" "stp.rg"
 
+    save_cmd "show monitor-link-group" "monitor_link_group.show"
+
     save_cmd "ps aux" "ps.aux" &
     save_cmd "top -b -n 1" "top" &
     save_cmd "free" "free" &

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -47,6 +47,21 @@ PORT_MTU_STATUS = "mtu"
 PORT_FEC = "fec"
 PORT_DESCRIPTION = "description"
 PORT_OPTICS_TYPE = "type"
+
+# monitor-link-group can hold a managed-link admin DOWN when its group's
+# monitored-link count falls below min-monitored-links. intfmgrd publishes
+# per-interface state in STATE_DB.MONITOR_LINK_GROUP_MEMBER:
+#   state == "allow_up"  -- group is healthy; admin_status reflects user intent.
+#   anything else (e.g. "force_down") -- MLG is holding the port down;
+#                                        down_due_to lists the group(s).
+# We surface that as "error-down (mlg)" in show interface status so operators
+# can distinguish a policy-driven down from a user-driven shutdown. The
+# "(mlg)" tag names the source: today MLG is the only feature that drives
+# admin-down via this path, but if a new feature is added it should use its
+# own tag rather than collapse to a generic "error-down" -- otherwise
+# operators cannot tell which feature drove the port down.
+MONITOR_LINK_GROUP_MEMBER_TABLE_PREFIX = "MONITOR_LINK_GROUP_MEMBER|"
+PORT_ADMIN_STATUS_ERROR_DOWN_MLG = "error-down (mlg)"
 PORT_PFC_ASYM_STATUS = "pfc_asym"
 PORT_AUTONEG = 'autoneg'
 PORT_ADV_SPEEDS = 'adv_speeds'
@@ -181,6 +196,14 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
     status = appl_db.get(appl_db.APPL_DB, full_table_id, status_type)
     if status is None:
         return "N/A"
+    # Distinguish monitor-link-group-driven admin-down from user-driven
+    # shutdown. The "(mlg)" tag in the rendered value names the source so a
+    # future cause does not collapse into the same string. Also affects
+    # every other view that reads admin_status through this getter --
+    # consistent rendering across those views is intentional.
+    if status_type == PORT_ADMIN_STATUS and status == "down":
+        if _is_held_down_by_monitor_link_group(appl_db, intf_name):
+            return PORT_ADMIN_STATUS_ERROR_DOWN_MLG
     if status_type == PORT_SPEED and status != "N/A":
         optics_type = port_optics_get(appl_db, intf_name, PORT_OPTICS_TYPE)
         status = port_speed_parse(status, optics_type)
@@ -192,6 +215,27 @@ def appl_db_port_status_get(appl_db, intf_name, status_type):
             new_speed_list.append(port_speed_parse(s, optics_type))
         status = ','.join(new_speed_list)
     return status
+
+
+def _is_held_down_by_monitor_link_group(db, intf_name):
+    """Return True if the interface is currently held DOWN by monitor-link-group
+    policy (per intfmgrd's STATE_DB.MONITOR_LINK_GROUP_MEMBER table), else
+    False.
+
+    `db` is the multi-DB SonicV2Connector handle that the surrounding readers
+    use (it exposes both APPL_DB and STATE_DB attributes); we read STATE_DB.
+
+    See cfgmgr/monitorlinkgroupmgr.cpp::writeMonitorLinkGroupMemberStateToDb
+    for the producer side -- single source of truth, so this stays consistent
+    with the daemon's view.
+    """
+    if db is None:
+        return False
+    full_table_id = MONITOR_LINK_GROUP_MEMBER_TABLE_PREFIX + intf_name
+    state = db.get(db.STATE_DB, full_table_id, "state")
+    # Missing key, missing field, or healthy group: not held down.
+    return bool(state) and state != "allow_up"
+
 
 def state_db_port_status_get(db, intf_name, field):
     """
@@ -425,9 +469,17 @@ def appl_db_portchannel_status_get(appl_db, config_db, po_name, status_type, por
     #print(status)
     if status is None:
         return "N/A"
+    # Same monitor-link-group treatment as physical ports: a PortChannel held
+    # down by MLG renders as "error-down (mlg)" so operators can distinguish
+    # it from a user-driven shutdown.
+    if status_type == PORT_ADMIN_STATUS and status == "down":
+        if _is_held_down_by_monitor_link_group(appl_db, po_name):
+            return PORT_ADMIN_STATUS_ERROR_DOWN_MLG
     return status
 
 def appl_db_sub_intf_status_get(appl_db, config_db, front_panel_ports_list, portchannel_speed_dict, sub_intf_name, status_type):
+    # Sub-interfaces are not tracked by monitor-link-group (intfmgrd only
+    # publishes PORT and PORTCHANNEL members); admin_status is passed through.
     sub_intf_sep_idx = sub_intf_name.find(VLAN_SUB_INTERFACE_SEPARATOR)
     if sub_intf_sep_idx != -1:
         parent_port_name = get_intf_longname(sub_intf_name[:sub_intf_sep_idx])

--- a/show/main.py
+++ b/show/main.py
@@ -73,6 +73,7 @@ from . import srv6
 from . import switch
 from . import icmp
 from . import copp
+from . import monitor_link
 
 # Global Variables
 PLATFORM_JSON = 'platform.json'
@@ -316,6 +317,7 @@ cli.add_command(kdump.kdump)
 cli.add_command(interfaces.interfaces)
 cli.add_command(kdump.kdump)
 cli.add_command(kube.kubernetes)
+cli.add_command(monitor_link.monitor_link)
 cli.add_command(muxcable.muxcable)
 cli.add_command(nat.nat)
 cli.add_command(platform.platform)

--- a/show/monitor_link.py
+++ b/show/monitor_link.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import time
+from datetime import datetime, timezone
+
 import click
 from tabulate import tabulate
 from natsort import natsorted
@@ -65,9 +68,79 @@ def get_monitor_link_groups(state_db):
                 'linkup_delay': linkup_delay,
                 'interfaces': interfaces,
                 'state': state_data.get('state', 'unknown'),
+                # PR-A fields (all optional; legacy groups render unchanged when absent)
+                'last_state_change_time': state_data.get('last_state_change_time', '').strip(),
+                'last_state_change_from': state_data.get('last_state_change_from', '').strip(),
+                'last_state_change_to': state_data.get('last_state_change_to', '').strip(),
+                'last_state_change_reason': state_data.get('last_state_change_reason', '').strip(),
+                'pending_start_time': state_data.get('pending_start_time', '').strip(),
+                'up_to_down_count': state_data.get('up_to_down_count', '0'),
+                'down_to_up_count': state_data.get('down_to_up_count', '0'),
             }
 
     return groups
+
+
+def format_last_change(group_data):
+    """Return 'YYYY-MM-DD HH:MM:SS UTC (FROM -> TO, reason: ...)' or None if no transition recorded."""
+    epoch_str = group_data.get('last_state_change_time', '')
+    if not epoch_str:
+        return None
+    try:
+        epoch = int(epoch_str)
+    except ValueError:
+        return None
+    ts = datetime.fromtimestamp(epoch, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+    from_state = group_data.get('last_state_change_from', '').upper() or '?'
+    to_state = group_data.get('last_state_change_to', '').upper() or '?'
+    reason = group_data.get('last_state_change_reason', '')
+    if reason:
+        return f"{ts} ({from_state} -> {to_state}, reason: {reason})"
+    return f"{ts} ({from_state} -> {to_state})"
+
+
+def format_linkup_delay(group_data):
+    """Return 'N seconds' baseline. When state is PENDING and pending_start_time is set:
+      - '(elapsed: Xs, remaining: Ys)' while inside the delay window
+      - '(elapsed: Xs, OVERDUE by Ys)' once raw elapsed > delay (surfaces a stuck timer
+        instead of silently clamping the display to 100%)
+    """
+    delay_str = group_data.get('linkup_delay', '0')
+    base = f"{delay_str} seconds"
+
+    if group_data.get('state', '').lower() != 'pending':
+        return base
+
+    try:
+        delay = int(delay_str)
+    except ValueError:
+        return base
+    if delay <= 0:
+        return base
+
+    pending_start_str = group_data.get('pending_start_time', '')
+    if not pending_start_str:
+        return base
+    try:
+        pending_start = int(pending_start_str)
+    except ValueError:
+        return base
+
+    now = int(time.time())
+    raw_elapsed = max(0, now - pending_start)
+    if raw_elapsed > delay:
+        overdue = raw_elapsed - delay
+        return f"{base} (elapsed: {raw_elapsed}s, OVERDUE by {overdue}s)"
+
+    remaining = delay - raw_elapsed
+    return f"{base} (elapsed: {raw_elapsed}s, remaining: {remaining}s)"
+
+
+def format_transitions(group_data):
+    """Return 'UP->DOWN=N, DOWN->UP=M' counter line."""
+    u_to_d = group_data.get('up_to_down_count', '0') or '0'
+    d_to_u = group_data.get('down_to_up_count', '0') or '0'
+    return f"UP->DOWN={u_to_d}, DOWN->UP={d_to_u}"
 
 
 def format_group_state(state):
@@ -126,7 +199,11 @@ def monitor_link(db, group_name):
         click.echo(f"State:                 {format_group_state(group_data.get('state', 'unknown'))}")
         click.echo(f"Monitored Up:          {monitored_up_count_display}/{monitored_count}")
         click.echo(f"Min-monitored-links:   {group_data['min_monitored_links']}")
-        click.echo(f"Link-up-delay:         {group_data['linkup_delay']} seconds")
+        click.echo(f"Link-up-delay:         {format_linkup_delay(group_data)}")
+        last_change = format_last_change(group_data)
+        if last_change:
+            click.echo(f"Last change:           {last_change}")
+        click.echo(f"Transitions:           {format_transitions(group_data)}")
         click.echo(f"Total Interfaces:      {len(group_data['interfaces'])} "
                    f"({monitored_count} monitored, {managed_count} managed)")
         click.echo()

--- a/show/monitor_link.py
+++ b/show/monitor_link.py
@@ -72,17 +72,15 @@ def get_monitor_link_groups(state_db):
                 'last_state_change_time': state_data.get('last_state_change_time', '').strip(),
                 'last_state_change_from': state_data.get('last_state_change_from', '').strip(),
                 'last_state_change_to': state_data.get('last_state_change_to', '').strip(),
-                'last_state_change_reason': state_data.get('last_state_change_reason', '').strip(),
                 'pending_start_time': state_data.get('pending_start_time', '').strip(),
-                'up_to_down_count': state_data.get('up_to_down_count', '0'),
-                'down_to_up_count': state_data.get('down_to_up_count', '0'),
+                'total_transitions': state_data.get('total_transitions', '0'),
             }
 
     return groups
 
 
 def format_last_change(group_data):
-    """Return 'YYYY-MM-DD HH:MM:SS UTC (FROM -> TO, reason: ...)' or None if no transition recorded."""
+    """Return 'YYYY-MM-DD HH:MM:SS UTC (FROM -> TO)' or None if no transition recorded."""
     epoch_str = group_data.get('last_state_change_time', '')
     if not epoch_str:
         return None
@@ -93,9 +91,6 @@ def format_last_change(group_data):
     ts = datetime.fromtimestamp(epoch, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
     from_state = group_data.get('last_state_change_from', '').upper() or '?'
     to_state = group_data.get('last_state_change_to', '').upper() or '?'
-    reason = group_data.get('last_state_change_reason', '')
-    if reason:
-        return f"{ts} ({from_state} -> {to_state}, reason: {reason})"
     return f"{ts} ({from_state} -> {to_state})"
 
 
@@ -137,10 +132,10 @@ def format_linkup_delay(group_data):
 
 
 def format_transitions(group_data):
-    """Return 'UP->DOWN=N, DOWN->UP=M' counter line."""
-    u_to_d = group_data.get('up_to_down_count', '0') or '0'
-    d_to_u = group_data.get('down_to_up_count', '0') or '0'
-    return f"UP->DOWN={u_to_d}, DOWN->UP={d_to_u}"
+    """Return 'N' (total transitions count); blank string forces show CLI to omit
+    the line cleanly. Total is the count of all observed state transitions; a full
+    UP/DOWN cycle bumps it by 2."""
+    return group_data.get('total_transitions', '0') or '0'
 
 
 def format_group_state(state):

--- a/show/monitor_link.py
+++ b/show/monitor_link.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+import click
+from tabulate import tabulate
+from natsort import natsorted
+import utilities_common.cli as clicommon
+
+
+def get_monitor_link_member_info(state_db, interface_name):
+    """Get monitor link member information from STATE_DB"""
+    member_key = f"MONITOR_LINK_GROUP_MEMBER|{interface_name}"
+    member_data = state_db.get_all(state_db.STATE_DB, member_key)
+
+    if not member_data:
+        return None
+
+    return {
+        'state': member_data.get('state', ''),
+        'down_due_to': member_data.get('down_due_to', '')
+    }
+
+
+def get_monitor_link_groups(state_db):
+    """Get all monitor link groups from STATE_DB"""
+    groups = {}
+
+    # Get all monitor link group states (which contain all the info we need)
+    state_keys = state_db.keys(state_db.STATE_DB, 'MONITOR_LINK_GROUP_STATE|*')
+    for key in state_keys or []:
+        group_name = key.split('|', 1)[1] if '|' in key else key
+        state_data = state_db.get_all(state_db.STATE_DB, key)
+        if state_data:
+            interfaces = []
+
+            # Parse uplinks from uplinks field (comma-separated list)
+            uplinks_str = state_data.get('uplinks', '')
+            if uplinks_str:
+                for uplink in uplinks_str.split(','):
+                    uplink = uplink.strip()
+                    if uplink:
+                        interfaces.append({
+                            'name': uplink,
+                            'link_type': 'uplink'
+                        })
+
+            # Parse downlinks from downlinks field (comma-separated list)
+            downlinks_str = state_data.get('downlinks', '')
+            if downlinks_str:
+                for downlink in downlinks_str.split(','):
+                    downlink = downlink.strip()
+                    if downlink:
+                        interfaces.append({
+                            'name': downlink,
+                            'link_type': 'downlink'
+                        })
+
+            # Handle empty values by providing defaults
+            description = state_data.get('description', '').strip()
+            min_uplinks = state_data.get('link_up_threshold', '').strip() or '1'
+            linkup_delay = state_data.get('link_up_delay', '').strip() or '0'
+
+            groups[group_name] = {
+                'description': description or 'No description',
+                'min_uplinks': min_uplinks,
+                'linkup_delay': linkup_delay,
+                'interfaces': interfaces,
+                'state': state_data.get('state', 'unknown'),
+            }
+
+    return groups
+
+
+def format_group_state(state):
+    """Format group state with colors"""
+    if state.lower() == 'up':
+        return click.style("UP", fg='green', bold=True)
+    elif state.lower() == 'down':
+        return click.style("DOWN", fg='red', bold=True)
+    else:
+        return click.style(state.upper(), fg='yellow', bold=True)
+
+
+@click.command(name='monitor-link-group')
+@click.argument('group_name', required=False)
+@clicommon.pass_db
+def monitor_link(db, group_name):
+    """Show monitor link information for all groups or a specific group"""
+
+    # Get monitor link groups from STATE_DB (contains all needed info)
+    groups = get_monitor_link_groups(db.db)
+
+    if not groups:
+        click.echo("No monitor link groups configured")
+        return
+
+    # Filter by specific group if provided
+    if group_name:
+        if group_name not in groups:
+            click.echo(f"Monitor link group '{group_name}' not found")
+            return
+        groups = {group_name: groups[group_name]}
+
+    # Display information for each group
+    for name in natsorted(groups.keys()):
+        group_data = groups[name]
+
+        # Count uplink interfaces
+        uplink_count = len([intf for intf in group_data['interfaces']
+                           if intf['link_type'] == 'uplink'])
+        downlink_count = len([intf for intf in group_data['interfaces']
+                             if intf['link_type'] == 'downlink'])
+
+        # Always calculate uplinks up for real-time accuracy
+        actual_uplinks_up = 0
+        for intf in group_data['interfaces']:
+            if intf['link_type'] == 'uplink':
+                status = clicommon.get_interface_operational_status(db.db, intf['name'])
+                if status == 'UP':
+                    actual_uplinks_up += 1
+        uplink_up_count_display = str(actual_uplinks_up)
+
+        # Display group header
+        click.echo(f"Monitor Link Group: {name}")
+        click.echo("=" * (len(name) + 20))
+        click.echo(f"Description:      {group_data['description']}")
+        click.echo(f"State:            {format_group_state(group_data.get('state', 'unknown'))}")
+        click.echo(f"Uplinks Up:       {uplink_up_count_display}/{uplink_count}")
+        click.echo(f"Min-uplinks:      {group_data['min_uplinks']}")
+        click.echo(f"Link-up-delay:    {group_data['linkup_delay']} seconds")
+        click.echo(f"Total Interfaces: {len(group_data['interfaces'])} "
+                   f"({uplink_count} uplinks, {downlink_count} downlinks)")
+        click.echo()
+
+        # Display interfaces table
+        if group_data['interfaces']:
+            click.echo("Interfaces:")
+            click.echo("-" * 50)
+
+            # Sort interfaces by link type (uplink first, then downlink) and then by name
+            def sort_key(interface):
+                link_type_priority = 0 if interface['link_type'] == 'uplink' else 1
+                return (link_type_priority, interface['name'])
+
+            sorted_interfaces = sorted(group_data['interfaces'], key=sort_key)
+
+            table_data = []
+            headers = ['Interface', 'Link Type', 'Status', 'Reason']
+
+            for interface in sorted_interfaces:
+                interface_status = clicommon.get_interface_operational_status(db.db, interface['name'])
+                reason = ""
+
+                # For downlink interfaces that are DOWN, get the reason
+                if interface['link_type'] == 'downlink' and interface_status == 'DOWN':
+                    member_info = get_monitor_link_member_info(db.db, interface['name'])
+                    if member_info and member_info['down_due_to']:
+                        reason = f"Down due to group {member_info['down_due_to']}"
+
+                table_data.append([
+                    interface['name'],
+                    interface['link_type'],
+                    interface_status,
+                    reason
+                ])
+
+            click.echo(tabulate(table_data, headers=headers, tablefmt='simple'))
+        else:
+            click.echo("No interfaces configured")
+
+        click.echo()  # Add spacing between groups

--- a/show/monitor_link.py
+++ b/show/monitor_link.py
@@ -32,36 +32,36 @@ def get_monitor_link_groups(state_db):
         if state_data:
             interfaces = []
 
-            # Parse uplinks from uplinks field (comma-separated list)
-            uplinks_str = state_data.get('uplinks', '')
-            if uplinks_str:
-                for uplink in uplinks_str.split(','):
-                    uplink = uplink.strip()
-                    if uplink:
+            # Parse monitored-links from monitored-links field (comma-separated list)
+            monitored_str = state_data.get('monitored-links', '')
+            if monitored_str:
+                for monitored in monitored_str.split(','):
+                    monitored = monitored.strip()
+                    if monitored:
                         interfaces.append({
-                            'name': uplink,
-                            'link_type': 'uplink'
+                            'name': monitored,
+                            'link_type': 'monitored'
                         })
 
-            # Parse downlinks from downlinks field (comma-separated list)
-            downlinks_str = state_data.get('downlinks', '')
-            if downlinks_str:
-                for downlink in downlinks_str.split(','):
-                    downlink = downlink.strip()
-                    if downlink:
+            # Parse managed-links from managed-links field (comma-separated list)
+            managed_str = state_data.get('managed-links', '')
+            if managed_str:
+                for managed in managed_str.split(','):
+                    managed = managed.strip()
+                    if managed:
                         interfaces.append({
-                            'name': downlink,
-                            'link_type': 'downlink'
+                            'name': managed,
+                            'link_type': 'managed'
                         })
 
             # Handle empty values by providing defaults
             description = state_data.get('description', '').strip()
-            min_uplinks = state_data.get('link_up_threshold', '').strip() or '1'
+            min_monitored_links = state_data.get('link_up_threshold', '').strip() or '1'
             linkup_delay = state_data.get('link_up_delay', '').strip() or '0'
 
             groups[group_name] = {
                 'description': description or 'No description',
-                'min_uplinks': min_uplinks,
+                'min_monitored_links': min_monitored_links,
                 'linkup_delay': linkup_delay,
                 'interfaces': interfaces,
                 'state': state_data.get('state', 'unknown'),
@@ -104,31 +104,31 @@ def monitor_link(db, group_name):
     for name in natsorted(groups.keys()):
         group_data = groups[name]
 
-        # Count uplink interfaces
-        uplink_count = len([intf for intf in group_data['interfaces']
-                           if intf['link_type'] == 'uplink'])
-        downlink_count = len([intf for intf in group_data['interfaces']
-                             if intf['link_type'] == 'downlink'])
+        # Count monitored / managed interfaces
+        monitored_count = len([intf for intf in group_data['interfaces']
+                              if intf['link_type'] == 'monitored'])
+        managed_count = len([intf for intf in group_data['interfaces']
+                            if intf['link_type'] == 'managed'])
 
-        # Always calculate uplinks up for real-time accuracy
-        actual_uplinks_up = 0
+        # Always calculate monitored-links up for real-time accuracy
+        actual_monitored_up = 0
         for intf in group_data['interfaces']:
-            if intf['link_type'] == 'uplink':
+            if intf['link_type'] == 'monitored':
                 status = clicommon.get_interface_operational_status(db.db, intf['name'])
                 if status == 'UP':
-                    actual_uplinks_up += 1
-        uplink_up_count_display = str(actual_uplinks_up)
+                    actual_monitored_up += 1
+        monitored_up_count_display = str(actual_monitored_up)
 
         # Display group header
         click.echo(f"Monitor Link Group: {name}")
         click.echo("=" * (len(name) + 20))
-        click.echo(f"Description:      {group_data['description']}")
-        click.echo(f"State:            {format_group_state(group_data.get('state', 'unknown'))}")
-        click.echo(f"Uplinks Up:       {uplink_up_count_display}/{uplink_count}")
-        click.echo(f"Min-uplinks:      {group_data['min_uplinks']}")
-        click.echo(f"Link-up-delay:    {group_data['linkup_delay']} seconds")
-        click.echo(f"Total Interfaces: {len(group_data['interfaces'])} "
-                   f"({uplink_count} uplinks, {downlink_count} downlinks)")
+        click.echo(f"Description:           {group_data['description']}")
+        click.echo(f"State:                 {format_group_state(group_data.get('state', 'unknown'))}")
+        click.echo(f"Monitored Up:          {monitored_up_count_display}/{monitored_count}")
+        click.echo(f"Min-monitored-links:   {group_data['min_monitored_links']}")
+        click.echo(f"Link-up-delay:         {group_data['linkup_delay']} seconds")
+        click.echo(f"Total Interfaces:      {len(group_data['interfaces'])} "
+                   f"({monitored_count} monitored, {managed_count} managed)")
         click.echo()
 
         # Display interfaces table
@@ -136,9 +136,9 @@ def monitor_link(db, group_name):
             click.echo("Interfaces:")
             click.echo("-" * 50)
 
-            # Sort interfaces by link type (uplink first, then downlink) and then by name
+            # Sort interfaces by link type (monitored first, then managed) and then by name
             def sort_key(interface):
-                link_type_priority = 0 if interface['link_type'] == 'uplink' else 1
+                link_type_priority = 0 if interface['link_type'] == 'monitored' else 1
                 return (link_type_priority, interface['name'])
 
             sorted_interfaces = sorted(group_data['interfaces'], key=sort_key)
@@ -150,8 +150,8 @@ def monitor_link(db, group_name):
                 interface_status = clicommon.get_interface_operational_status(db.db, interface['name'])
                 reason = ""
 
-                # For downlink interfaces that are DOWN, get the reason
-                if interface['link_type'] == 'downlink' and interface_status == 'DOWN':
+                # For managed interfaces that are DOWN, get the reason
+                if interface['link_type'] == 'managed' and interface_status == 'DOWN':
                     member_info = get_monitor_link_member_info(db.db, interface['name'])
                     if member_info and member_info['down_due_to']:
                         reason = f"Down due to group {member_info['down_due_to']}"

--- a/tests/intfutil_monitor_link_test.py
+++ b/tests/intfutil_monitor_link_test.py
@@ -1,0 +1,217 @@
+"""Unit tests for the monitor-link-group integration in scripts/intfutil.
+
+`scripts/intfutil` is a Click script with no .py extension and a heavy
+import surface. To keep these tests self-contained and runnable without
+the SONiC dev container, we slice just the helper, the two getters under
+test, and the constants they reference out of the script via regex and
+exec them into a fresh namespace. The functions are pure data
+transformations on a SonicV2Connector-like handle, so a small MockDb is
+sufficient.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import types
+
+INTFUTIL_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "scripts", "intfutil"
+)
+
+
+class _MockDb:
+    """Mimics swsscommon.SonicV2Connector for the surface scripts/intfutil
+    actually uses: db attributes (APPL_DB, STATE_DB, CONFIG_DB) and
+    `.get(db, table_id, field)`.
+    """
+
+    APPL_DB = "APPL_DB"
+    STATE_DB = "STATE_DB"
+    CONFIG_DB = "CONFIG_DB"
+    COUNTERS_DB = "COUNTERS_DB"
+
+    def __init__(self, data):
+        self._data = data  # {db: {table_id: {field: value}}}
+
+    def get(self, db, table_id, field):
+        return self._data.get(db, {}).get(table_id, {}).get(field)
+
+
+def _load_intfutil():
+    """Pull the constants, helper, and two modified getters out of the
+    intfutil script into a fresh namespace, without executing the heavy
+    import block at the top of the file (tabulate, swsssdk, click, etc.).
+    """
+    src = open(INTFUTIL_PATH).read()
+    ns: dict = {
+        "natsorted": sorted,
+        "RJ45_PORT_TYPE": "RJ45",
+        "is_rj45_port": lambda *a, **k: False,
+        "multi_asic": types.SimpleNamespace(PORT_ROLE="role", DPU_CONNECT_PORT="Dpc"),
+        # Stub helpers the modified getters call but we don't exercise here.
+        "port_speed_parse": lambda speed, optics: speed,
+        "port_optics_get": lambda *a, **k: "N/A",
+    }
+    # Pull every top-level constant assignment up to the first `def`.
+    first_def = src.find("\ndef ")
+    consts = src[:first_def] if first_def > 0 else src
+    for line in consts.splitlines():
+        line = line.rstrip()
+        if not line or line.startswith(("#", "from ", "import ", "try", "    ", "\t")):
+            continue
+        if re.match(r"^[A-Z_][A-Z0-9_]*\s*=\s*", line):
+            try:
+                exec(line, ns)
+            except Exception:
+                pass
+    # Pull the three function defs we care about.
+    for name in (
+        "_is_held_down_by_monitor_link_group",
+        "appl_db_port_status_get",
+        "appl_db_portchannel_status_get",
+    ):
+        m = re.search(rf"^def {name}\(.*?(?=^def |\Z)", src, re.M | re.S)
+        assert m, f"could not find def {name} in intfutil"
+        exec(m.group(0), ns)
+    return types.SimpleNamespace(**ns)
+
+
+_intfutil = _load_intfutil()
+
+
+# ---------------------------------------------------------------------------
+# _is_held_down_by_monitor_link_group
+# ---------------------------------------------------------------------------
+
+
+def test_held_down_returns_false_when_db_is_none():
+    assert _intfutil._is_held_down_by_monitor_link_group(None, "Ethernet0") is False
+
+
+def test_held_down_returns_false_when_no_entry():
+    db = _MockDb({"STATE_DB": {}})
+    assert _intfutil._is_held_down_by_monitor_link_group(db, "Ethernet0") is False
+
+
+def test_held_down_returns_false_when_state_field_missing():
+    db = _MockDb({"STATE_DB": {"MONITOR_LINK_GROUP_MEMBER|Ethernet0": {}}})
+    assert _intfutil._is_held_down_by_monitor_link_group(db, "Ethernet0") is False
+
+
+def test_held_down_returns_false_when_state_is_allow_up():
+    db = _MockDb(
+        {
+            "STATE_DB": {
+                "MONITOR_LINK_GROUP_MEMBER|Ethernet0": {"state": "allow_up"}
+            }
+        }
+    )
+    assert _intfutil._is_held_down_by_monitor_link_group(db, "Ethernet0") is False
+
+
+def test_held_down_returns_true_when_state_is_force_down():
+    db = _MockDb(
+        {
+            "STATE_DB": {
+                "MONITOR_LINK_GROUP_MEMBER|Ethernet0": {"state": "force_down"}
+            }
+        }
+    )
+    assert _intfutil._is_held_down_by_monitor_link_group(db, "Ethernet0") is True
+
+
+# ---------------------------------------------------------------------------
+# appl_db_port_status_get
+# ---------------------------------------------------------------------------
+
+
+def test_port_status_admin_up_passes_through():
+    """admin_status=up: helper is not consulted, value returned as-is."""
+    db = _MockDb({"APPL_DB": {"PORT_TABLE:Ethernet0": {"admin_status": "up"}}})
+    assert _intfutil.appl_db_port_status_get(db, "Ethernet0", "admin_status") == "up"
+
+
+def test_port_status_user_shutdown_without_mlg_entry_renders_down():
+    """admin_status=down with no MLG entry: plain 'down' (user shutdown)."""
+    db = _MockDb({"APPL_DB": {"PORT_TABLE:Ethernet0": {"admin_status": "down"}}})
+    assert _intfutil.appl_db_port_status_get(db, "Ethernet0", "admin_status") == "down"
+
+
+def test_port_status_user_shutdown_with_healthy_group_renders_down():
+    """admin_status=down with state=allow_up: plain 'down' (user shutdown)."""
+    db = _MockDb(
+        {
+            "APPL_DB": {"PORT_TABLE:Ethernet0": {"admin_status": "down"}},
+            "STATE_DB": {
+                "MONITOR_LINK_GROUP_MEMBER|Ethernet0": {"state": "allow_up"}
+            },
+        }
+    )
+    assert _intfutil.appl_db_port_status_get(db, "Ethernet0", "admin_status") == "down"
+
+
+def test_port_status_held_by_mlg_renders_error_down():
+    """admin_status=down with state=force_down: 'error-down (mlg)'."""
+    db = _MockDb(
+        {
+            "APPL_DB": {"PORT_TABLE:Ethernet0": {"admin_status": "down"}},
+            "STATE_DB": {
+                "MONITOR_LINK_GROUP_MEMBER|Ethernet0": {"state": "force_down"}
+            },
+        }
+    )
+    assert (
+        _intfutil.appl_db_port_status_get(db, "Ethernet0", "admin_status")
+        == "error-down (mlg)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# appl_db_portchannel_status_get
+# ---------------------------------------------------------------------------
+
+
+def test_portchannel_status_admin_up_passes_through():
+    db = _MockDb(
+        {
+            "APPL_DB": {"LAG_TABLE:PortChannel100": {"admin_status": "up"}},
+        }
+    )
+    assert (
+        _intfutil.appl_db_portchannel_status_get(
+            db, None, "PortChannel100", "admin_status", {}, None
+        )
+        == "up"
+    )
+
+
+def test_portchannel_status_user_shutdown_without_mlg_renders_down():
+    db = _MockDb(
+        {
+            "APPL_DB": {"LAG_TABLE:PortChannel100": {"admin_status": "down"}},
+        }
+    )
+    assert (
+        _intfutil.appl_db_portchannel_status_get(
+            db, None, "PortChannel100", "admin_status", {}, None
+        )
+        == "down"
+    )
+
+
+def test_portchannel_status_held_by_mlg_renders_error_down():
+    db = _MockDb(
+        {
+            "APPL_DB": {"LAG_TABLE:PortChannel100": {"admin_status": "down"}},
+            "STATE_DB": {
+                "MONITOR_LINK_GROUP_MEMBER|PortChannel100": {"state": "force_down"}
+            },
+        }
+    )
+    assert (
+        _intfutil.appl_db_portchannel_status_get(
+            db, None, "PortChannel100", "admin_status", {}, None
+        )
+        == "error-down (mlg)"
+    )

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1855,5 +1855,89 @@
     },
     "COPP_TRAP_TABLE|neighbor_miss": {
         "state": "ok"
+    },
+    "MONITOR_LINK_GROUP_STATE|critical_links": {
+        "state": "up",
+        "description": "Critical uplink and downlink monitoring group",
+        "uplinks": "Ethernet64,Ethernet72",
+        "downlinks": "Ethernet80",
+        "link_up_threshold": "2",
+        "link_up_delay": "10",
+        "uplink_up_count": "2"
+    },
+    "MONITOR_LINK_GROUP_STATE|test_group": {
+        "state": "down",
+        "description": "Test monitoring group",
+        "uplinks": "PortChannel101,PortChannel103",
+        "downlinks": "PortChannel102",
+        "link_up_threshold": "1",
+        "link_up_delay": "5",
+        "uplink_up_count": "0"
+    },
+    "MONITOR_LINK_GROUP_STATE|pending_group": {
+        "state": "pending",
+        "description": "Group in pending state",
+        "uplinks": "Ethernet96,Ethernet100",
+        "downlinks": "Ethernet104",
+        "link_up_threshold": "2",
+        "link_up_delay": "15",
+        "uplink_up_count": "2"
+    },
+    "PORT_TABLE|Ethernet64": {
+        "netdev_oper_status": "up",
+        "state": "ok",
+        "admin_status": "up"
+    },
+    "PORT_TABLE|Ethernet72": {
+        "netdev_oper_status": "up",
+        "state": "ok",
+        "admin_status": "up"
+    },
+    "PORT_TABLE|Ethernet80": {
+        "netdev_oper_status": "down",
+        "state": "down",
+        "admin_status": "down"
+    },
+    "PORT_TABLE|Ethernet96": {
+        "netdev_oper_status": "up",
+        "state": "ok",
+        "admin_status": "up"
+    },
+    "PORT_TABLE|Ethernet100": {
+        "netdev_oper_status": "up",
+        "state": "ok",
+        "admin_status": "up"
+    },
+    "PORT_TABLE|Ethernet104": {
+        "netdev_oper_status": "down",
+        "state": "down",
+        "admin_status": "down"
+    },
+    "LAG_TABLE|PortChannel101": {
+        "oper_status": "up",
+        "state": "ok",
+        "admin_status": "up"
+    },
+    "LAG_TABLE|PortChannel103": {
+        "oper_status": "down",
+        "state": "down",
+        "admin_status": "up"
+    },
+    "LAG_TABLE|PortChannel102": {
+        "oper_status": "down",
+        "state": "down",
+        "admin_status": "down"
+    },
+    "MONITOR_LINK_GROUP_MEMBER|Ethernet80": {
+        "state": "force_down",
+        "down_due_to": "critical_links"
+    },
+    "MONITOR_LINK_GROUP_MEMBER|PortChannel102": {
+        "state": "force_down",
+        "down_due_to": "test_group"
+    },
+    "MONITOR_LINK_GROUP_MEMBER|Ethernet104": {
+        "state": "force_down",
+        "down_due_to": "pending_group"
     }
 }

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1858,30 +1858,46 @@
     },
     "MONITOR_LINK_GROUP_STATE|critical_links": {
         "state": "up",
-        "description": "Critical uplink and downlink monitoring group",
-        "uplinks": "Ethernet64,Ethernet72",
-        "downlinks": "Ethernet80",
+        "description": "Critical monitored and managed link monitoring group",
+        "monitored-links": "Ethernet64,Ethernet72",
+        "managed-links": "Ethernet80",
         "link_up_threshold": "2",
         "link_up_delay": "10",
-        "uplink_up_count": "2"
+        "last_state_change_time": "1700000000",
+        "last_state_change_from": "down",
+        "last_state_change_to": "up",
+        "last_state_change_reason": "monitored 2/2 >= min-monitored-links 2",
+        "up_to_down_count": "1",
+        "down_to_up_count": "2"
     },
     "MONITOR_LINK_GROUP_STATE|test_group": {
         "state": "down",
         "description": "Test monitoring group",
-        "uplinks": "PortChannel101,PortChannel103",
-        "downlinks": "PortChannel102",
+        "monitored-links": "PortChannel101,PortChannel103",
+        "managed-links": "PortChannel102",
         "link_up_threshold": "1",
         "link_up_delay": "5",
-        "uplink_up_count": "0"
+        "last_state_change_time": "1700000100",
+        "last_state_change_from": "up",
+        "last_state_change_to": "down",
+        "last_state_change_reason": "monitored 0/2 < min-monitored-links 1",
+        "up_to_down_count": "3",
+        "down_to_up_count": "2"
     },
     "MONITOR_LINK_GROUP_STATE|pending_group": {
         "state": "pending",
         "description": "Group in pending state",
-        "uplinks": "Ethernet96,Ethernet100",
-        "downlinks": "Ethernet104",
+        "monitored-links": "Ethernet96,Ethernet100",
+        "managed-links": "Ethernet104",
         "link_up_threshold": "2",
         "link_up_delay": "15",
-        "uplink_up_count": "2"
+        "last_state_change_time": "1700000200",
+        "last_state_change_from": "down",
+        "last_state_change_to": "pending",
+        "last_state_change_reason": "monitored 2/2 >= min-monitored-links 2, starting link-up-delay",
+        "pending_start_time": "1700000200",
+        "up_to_down_count": "0",
+        "down_to_up_count": "0"
     },
     "PORT_TABLE|Ethernet64": {
         "netdev_oper_status": "up",

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1866,9 +1866,7 @@
         "last_state_change_time": "1700000000",
         "last_state_change_from": "down",
         "last_state_change_to": "up",
-        "last_state_change_reason": "monitored 2/2 >= min-monitored-links 2",
-        "up_to_down_count": "1",
-        "down_to_up_count": "2"
+        "total_transitions": "3"
     },
     "MONITOR_LINK_GROUP_STATE|test_group": {
         "state": "down",
@@ -1880,9 +1878,7 @@
         "last_state_change_time": "1700000100",
         "last_state_change_from": "up",
         "last_state_change_to": "down",
-        "last_state_change_reason": "monitored 0/2 < min-monitored-links 1",
-        "up_to_down_count": "3",
-        "down_to_up_count": "2"
+        "total_transitions": "5"
     },
     "MONITOR_LINK_GROUP_STATE|pending_group": {
         "state": "pending",
@@ -1894,10 +1890,8 @@
         "last_state_change_time": "1700000200",
         "last_state_change_from": "down",
         "last_state_change_to": "pending",
-        "last_state_change_reason": "monitored 2/2 >= min-monitored-links 2, starting link-up-delay",
         "pending_start_time": "1700000200",
-        "up_to_down_count": "0",
-        "down_to_up_count": "0"
+        "total_transitions": "1"
     },
     "PORT_TABLE|Ethernet64": {
         "netdev_oper_status": "up",

--- a/tests/monitor_link_test.py
+++ b/tests/monitor_link_test.py
@@ -28,7 +28,7 @@ MOCK_STATE_DB_DATA = {
         'managed-links': 'Ethernet80',
         'link_up_threshold': '2',
         'link_up_delay': '10',
-        'down_to_up_count': '1'
+        'total_transitions': '3'
     },
     'MONITOR_LINK_GROUP_STATE|test_group': {
         'state': 'down',
@@ -37,7 +37,7 @@ MOCK_STATE_DB_DATA = {
         'managed-links': 'PortChannel102',
         'link_up_threshold': '1',
         'link_up_delay': '5',
-        'up_to_down_count': '0'
+        'total_transitions': '5'
     },
     'PORT_TABLE|Ethernet64': {
         'netdev_oper_status': 'up',
@@ -520,18 +520,16 @@ class TestMonitorLinkTransitionTracking:
         # epoch 1700000000 == 2023-11-14 22:13:20 UTC
         assert "2023-11-14" in result.output
         assert "DOWN -> UP" in result.output
-        assert "monitored 2/2 >= min-monitored-links 2" in result.output
 
     def test_transitions_counter_line(self):
-        """The 'Transitions:' line is always present and shows counters."""
+        """The 'Transitions:' line is always present and shows a total count."""
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(show.cli.commands["monitor-link-group"], ["test_group"], obj=db)
         assert result.exit_code == 0
-        assert "Transitions:" in result.output
-        assert "UP->DOWN=3" in result.output
-        assert "DOWN->UP=2" in result.output
+        # test_group fixture has total_transitions=5
+        assert "Transitions:           5" in result.output
 
     def test_pending_linkup_delay_progress(self):
         """When state is PENDING, Link-up-delay shows elapsed/remaining."""
@@ -591,8 +589,8 @@ class TestMonitorLinkTransitionTracking:
             assert result.exit_code == 0
             assert "Monitor Link Group: legacy_group" in result.output
             assert "Last change:" not in result.output
-            # Counters fall back to 0 when fields missing
-            assert "Transitions:           UP->DOWN=0, DOWN->UP=0" in result.output
+            # Counter falls back to 0 when field missing
+            assert "Transitions:           0" in result.output
         finally:
             if 'STATE_DB' in dbconnector.dedicated_dbs:
                 del dbconnector.dedicated_dbs['STATE_DB']

--- a/tests/monitor_link_test.py
+++ b/tests/monitor_link_test.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from unittest import mock
+from click.testing import CliRunner
+
+# Add the parent directory to the path to import the modules
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+# Import after path setup to avoid E402
+import show.main as show  # noqa: E402
+from utilities_common.db import Db  # noqa: E402
+from .mock_tables import dbconnector  # noqa: E402
+
+# Set up mock database path
+test_path = os.path.dirname(os.path.abspath(__file__))
+mock_db_path = os.path.join(test_path, "mock_tables")
+
+# Mock data for testing
+MOCK_STATE_DB_DATA = {
+    'MONITOR_LINK_GROUP_STATE|critical_links': {
+        'state': 'up',
+        'description': 'Critical uplink and downlink monitoring group',
+        'uplinks': 'Ethernet64,Ethernet72',
+        'downlinks': 'Ethernet80',
+        'link_up_threshold': '2',
+        'link_up_delay': '10',
+        'uplink_up_count': '2'
+    },
+    'MONITOR_LINK_GROUP_STATE|test_group': {
+        'state': 'down',
+        'description': 'Test monitoring group',
+        'uplinks': 'PortChannel101,PortChannel103',
+        'downlinks': 'PortChannel102',
+        'link_up_threshold': '1',
+        'link_up_delay': '5',
+        'uplink_up_count': '0'
+    },
+    'PORT_TABLE|Ethernet64': {
+        'netdev_oper_status': 'up',
+        'state': 'ok'
+    },
+    'PORT_TABLE|Ethernet72': {
+        'netdev_oper_status': 'up',
+        'state': 'ok'
+    },
+    'PORT_TABLE|Ethernet80': {
+        'netdev_oper_status': 'down',
+        'state': 'down'
+    },
+    'LAG_TABLE|PortChannel101': {
+        'oper_status': 'up',
+        'state': 'ok'
+    },
+    'LAG_TABLE|PortChannel103': {
+        'oper_status': 'down',
+        'state': 'down'
+    },
+    'LAG_TABLE|PortChannel102': {
+        'oper_status': 'down',
+        'state': 'down'
+    },
+    'MONITOR_LINK_GROUP_MEMBER|Ethernet80': {
+        'state': 'force_down',
+        'down_due_to': 'critical_links'
+    },
+    'MONITOR_LINK_GROUP_MEMBER|PortChannel102': {
+        'state': 'force_down',
+        'down_due_to': 'test_group'
+    }
+}
+
+
+class TestMonitorLink:
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+    def setup_method(self):
+        # Use the default state_db.json file which contains our merged monitor link data
+        # No need to set dedicated_dbs since the data is already in state_db.json
+        pass
+
+    def test_show_monitor_link_all_groups(self):
+        """Test showing all monitor link groups"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], [], obj=db)
+        assert result.exit_code == 0
+        assert "Monitor Link Group: critical_links" in result.output
+        assert "Monitor Link Group: test_group" in result.output
+        assert "State:" in result.output
+        assert "Uplinks Up:" in result.output
+        assert "Min-uplinks:" in result.output
+        assert "Link-up-delay:" in result.output
+
+    def test_show_monitor_link_specific_group(self):
+        """Test showing a specific monitor link group"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["critical_links"], obj=db)
+        assert result.exit_code == 0
+        assert "Monitor Link Group: critical_links" in result.output
+        assert "Monitor Link Group: test_group" not in result.output
+        assert "Critical uplink and downlink monitoring group" in result.output
+
+    def test_show_monitor_link_nonexistent_group(self):
+        """Test showing a non-existent monitor link group"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["nonexistent"], obj=db)
+        assert result.exit_code == 0
+        assert "Monitor link group 'nonexistent' not found" in result.output
+
+    def test_show_monitor_link_no_groups(self):
+        """Test showing monitor link when no groups are configured"""
+        # Create a temporary empty state db file
+        import tempfile
+        import json
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({}, f)
+            empty_db_file = f.name
+
+        try:
+            dbconnector.dedicated_dbs['STATE_DB'] = empty_db_file
+
+            runner = CliRunner()
+            db = Db()
+
+            result = runner.invoke(show.cli.commands["monitor-link-group"], [], obj=db)
+
+            assert result.exit_code == 0
+            assert "No monitor link groups configured" in result.output
+        finally:
+            # Clean up
+            import os
+            os.unlink(empty_db_file)
+            if 'STATE_DB' in dbconnector.dedicated_dbs:
+                del dbconnector.dedicated_dbs['STATE_DB']
+
+    def test_interface_status_display(self):
+        """Test that interface statuses are displayed correctly"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["critical_links"], obj=db)
+
+        assert result.exit_code == 0
+        assert "Ethernet64" in result.output
+        assert "Ethernet72" in result.output
+        assert "Ethernet80" in result.output
+        assert "uplink" in result.output
+        assert "downlink" in result.output
+
+    def test_downlink_reason_display(self):
+        """Test that downlink down reasons are displayed"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["critical_links"], obj=db)
+
+        assert result.exit_code == 0
+        assert "Down due to group critical_links" in result.output
+
+    def test_uplink_count_calculation(self):
+        """Test that uplink counts are calculated correctly"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["critical_links"], obj=db)
+
+        assert result.exit_code == 0
+        # Should show 2/2 uplinks up (both Ethernet64 and Ethernet72 are up)
+        assert "Uplinks Up:       2/2" in result.output
+
+    def test_portchannel_interfaces(self):
+        """Test that PortChannel interfaces are handled correctly"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["test_group"], obj=db)
+
+        assert result.exit_code == 0
+        assert "PortChannel101" in result.output
+        assert "PortChannel103" in result.output
+        assert "PortChannel102" in result.output
+
+    def test_group_state_formatting(self):
+        """Test that group states are formatted with colors"""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], [], obj=db)
+
+        assert result.exit_code == 0
+        # The actual color codes won't be visible in test output, but the states should be there
+        assert "State:" in result.output
+
+    def test_empty_fields_handling(self):
+        """Test handling of empty or missing fields"""
+        # Create test data with missing fields
+        test_data = {
+            'MONITOR_LINK_GROUP_STATE|empty_group': {
+                'state': 'unknown',
+                'uplinks': '',
+                'downlinks': '',
+                'link_up_threshold': '',
+                'link_up_delay': ''
+            }
+        }
+        # Backup and modify the existing state_db.json file
+        import json
+        import shutil
+
+        state_db_file = os.path.join(mock_db_path, 'state_db.json')
+        backup_file = state_db_file + '.backup'
+
+        # Backup original file
+        shutil.copy2(state_db_file, backup_file)
+
+        try:
+            # Write test data to state_db.json
+            with open(state_db_file, 'w') as f:
+                json.dump(test_data, f)
+
+            runner = CliRunner()
+            db = Db()
+
+            result = runner.invoke(show.cli.commands["monitor-link-group"], ["empty_group"], obj=db)
+
+            assert result.exit_code == 0
+            assert "Monitor Link Group: empty_group" in result.output
+            assert "No description" in result.output
+            assert "Min-uplinks:      1" in result.output  # Default value
+            assert "Link-up-delay:    0 seconds" in result.output  # Default value
+        finally:
+            # Restore original file
+            shutil.move(backup_file, state_db_file)
+
+
+class TestMonitorLinkFunctions:
+    """Test individual functions from monitor_link module"""
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+    def setup_method(self):
+        # Use the default state_db.json file which contains our merged monitor link data
+        pass
+
+    def test_get_monitor_link_groups(self):
+        """Test get_monitor_link_groups function"""
+        from show.monitor_link import get_monitor_link_groups
+
+        # Create a mock database connection
+        db = Db()
+        groups = get_monitor_link_groups(db.db)
+
+        assert len(groups) == 3
+        assert 'critical_links' in groups
+        assert 'test_group' in groups
+
+        # Test critical_links group
+        critical_group = groups['critical_links']
+        assert critical_group['state'] == 'up'
+        assert critical_group['description'] == 'Critical uplink and downlink monitoring group'
+        assert critical_group['min_uplinks'] == '2'
+        assert critical_group['linkup_delay'] == '10'
+        assert len(critical_group['interfaces']) == 3
+
+        # Check interfaces
+        interface_names = [intf['name'] for intf in critical_group['interfaces']]
+        assert 'Ethernet64' in interface_names
+        assert 'Ethernet72' in interface_names
+        assert 'Ethernet80' in interface_names
+
+    def test_get_monitor_link_member_info(self):
+        """Test get_monitor_link_member_info function"""
+        from show.monitor_link import get_monitor_link_member_info
+
+        db = Db()
+
+        # Test existing member
+        member_info = get_monitor_link_member_info(db.db, 'Ethernet80')
+        assert member_info is not None
+        assert member_info['state'] == 'force_down'
+        assert member_info['down_due_to'] == 'critical_links'
+
+        # Test non-existing member
+        member_info = get_monitor_link_member_info(db.db, 'NonExistent')
+        assert member_info is None
+
+    def test_format_group_state(self):
+        """Test format_group_state function"""
+        from show.monitor_link import format_group_state
+
+        # Test different states (we can't test colors directly, but we can test the function runs)
+        up_state = format_group_state('up')
+        down_state = format_group_state('down')
+        pending_state = format_group_state('pending')
+        unknown_state = format_group_state('unknown')
+
+        # The function should return strings (with ANSI color codes)
+        assert isinstance(up_state, str)
+        assert isinstance(down_state, str)
+        assert isinstance(pending_state, str)
+        assert isinstance(unknown_state, str)
+
+    @mock.patch('utilities_common.cli.get_interface_operational_status')
+    def test_uplink_count_calculation_with_mock(self, mock_get_status):
+        """Test uplink count calculation with mocked interface status"""
+        from show.monitor_link import get_monitor_link_groups
+
+        # Mock interface status calls
+        def mock_status_side_effect(db, interface):  # noqa: ARG001
+            status_map = {
+                'Ethernet64': 'UP',
+                'Ethernet72': 'UP',
+                'PortChannel101': 'UP',
+                'PortChannel103': 'DOWN'
+            }
+            return status_map.get(interface, 'DOWN')
+
+        mock_get_status.side_effect = mock_status_side_effect
+
+        db = Db()
+        groups = get_monitor_link_groups(db.db)
+
+        # The function itself doesn't calculate uplink counts, but we can test the data structure
+        assert 'critical_links' in groups
+        assert 'test_group' in groups
+
+
+class TestMonitorLinkEdgeCases:
+    """Test edge cases and error conditions"""
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+    def test_malformed_interface_lists(self):
+        """Test handling of malformed interface lists"""
+        malformed_data = {
+            'MONITOR_LINK_GROUP_STATE|malformed_group': {
+                'state': 'up',
+                'description': 'Test group with malformed data',
+                'uplinks': 'Ethernet1,,Ethernet2,   ,Ethernet3',  # Extra commas and spaces
+                'downlinks': ',Ethernet4,',  # Leading and trailing commas
+                'link_up_threshold': '2',
+                'link_up_delay': '5'
+            }
+        }
+        # Backup and modify the existing state_db.json file
+        import json
+        import shutil
+
+        state_db_file = os.path.join(mock_db_path, 'state_db.json')
+        backup_file = state_db_file + '.backup'
+
+        # Backup original file
+        shutil.copy2(state_db_file, backup_file)
+
+        try:
+            # Write malformed test data to state_db.json
+            with open(state_db_file, 'w') as f:
+                json.dump(malformed_data, f)
+
+            runner = CliRunner()
+            db = Db()
+
+            result = runner.invoke(show.cli.commands["monitor-link-group"], ["malformed_group"], obj=db)
+
+            assert result.exit_code == 0
+            assert "Monitor Link Group: malformed_group" in result.output
+            # Should handle malformed data gracefully
+            assert "Ethernet1" in result.output
+            assert "Ethernet2" in result.output
+            assert "Ethernet3" in result.output
+            assert "Ethernet4" in result.output
+        finally:
+            # Restore original file
+            shutil.move(backup_file, state_db_file)
+
+    def test_missing_state_db_fields(self):
+        """Test handling of missing STATE_DB fields"""
+        minimal_data = {
+            'MONITOR_LINK_GROUP_STATE|minimal_group': {
+                'state': 'up'
+                # Missing other fields
+            }
+        }
+        # Backup and modify the existing state_db.json file
+        import json
+        import shutil
+
+        state_db_file = os.path.join(mock_db_path, 'state_db.json')
+        backup_file = state_db_file + '.backup'
+
+        # Backup original file
+        shutil.copy2(state_db_file, backup_file)
+
+        try:
+            # Write minimal test data to state_db.json
+            with open(state_db_file, 'w') as f:
+                json.dump(minimal_data, f)
+
+            runner = CliRunner()
+            db = Db()
+
+            result = runner.invoke(show.cli.commands["monitor-link-group"], ["minimal_group"], obj=db)
+
+            assert result.exit_code == 0
+            assert "Monitor Link Group: minimal_group" in result.output
+            assert "No description" in result.output
+        finally:
+            # Restore original file
+            shutil.move(backup_file, state_db_file)
+
+    def test_interface_sorting(self):
+        """Test that interfaces are sorted correctly (uplinks first, then by name)"""
+        runner = CliRunner()
+        db = Db()
+        # Use default state_db.json which contains our monitor link data
+        # No need to set dedicated_dbs
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["critical_links"], obj=db)
+
+        assert result.exit_code == 0
+        output_lines = result.output.split('\n')
+
+        # Find the interface table section
+        interface_section_started = False
+        interface_lines = []
+        for line in output_lines:
+            if "Interface" in line and "Link Type" in line and "Status" in line:
+                interface_section_started = True
+                continue
+            if interface_section_started and line.strip() and not line.startswith('-'):
+                if line.strip():
+                    interface_lines.append(line.strip())
+                if not line.strip() or line.startswith('Monitor Link Group:'):
+                    break
+
+        # Should have uplinks first, then downlinks
+        downlink_found = False
+        for line in interface_lines:
+            if 'uplink' in line:
+                assert not downlink_found, "Uplinks should come before downlinks"
+            elif 'downlink' in line:
+                downlink_found = True
+
+    def test_utilities_common_integration(self):
+        """Test integration with utilities_common.cli functions"""
+        from utilities_common.cli import get_interface_operational_status
+
+        db = Db()
+        # Use default state_db.json which contains our monitor link data
+        # No need to set dedicated_dbs
+
+        # Test Ethernet interface (should use netdev_oper_status)
+        status = get_interface_operational_status(db.db, 'Ethernet64')
+        assert status == 'UP'
+
+        status = get_interface_operational_status(db.db, 'Ethernet80')
+        assert status == 'DOWN'
+
+        # Test PortChannel interface (should use oper_status)
+        status = get_interface_operational_status(db.db, 'PortChannel101')
+        assert status == 'UP'
+
+        status = get_interface_operational_status(db.db, 'PortChannel103')
+        assert status == 'DOWN'
+
+        # Test non-existent interface
+        status = get_interface_operational_status(db.db, 'NonExistent')
+        assert status == 'N/A'

--- a/tests/monitor_link_test.py
+++ b/tests/monitor_link_test.py
@@ -23,21 +23,21 @@ mock_db_path = os.path.join(test_path, "mock_tables")
 MOCK_STATE_DB_DATA = {
     'MONITOR_LINK_GROUP_STATE|critical_links': {
         'state': 'up',
-        'description': 'Critical uplink and downlink monitoring group',
-        'uplinks': 'Ethernet64,Ethernet72',
-        'downlinks': 'Ethernet80',
+        'description': 'Critical monitored and managed link monitoring group',
+        'monitored-links': 'Ethernet64,Ethernet72',
+        'managed-links': 'Ethernet80',
         'link_up_threshold': '2',
         'link_up_delay': '10',
-        'uplink_up_count': '2'
+        'down_to_up_count': '1'
     },
     'MONITOR_LINK_GROUP_STATE|test_group': {
         'state': 'down',
         'description': 'Test monitoring group',
-        'uplinks': 'PortChannel101,PortChannel103',
-        'downlinks': 'PortChannel102',
+        'monitored-links': 'PortChannel101,PortChannel103',
+        'managed-links': 'PortChannel102',
         'link_up_threshold': '1',
         'link_up_delay': '5',
-        'uplink_up_count': '0'
+        'up_to_down_count': '0'
     },
     'PORT_TABLE|Ethernet64': {
         'netdev_oper_status': 'up',
@@ -100,8 +100,8 @@ class TestMonitorLink:
         assert "Monitor Link Group: critical_links" in result.output
         assert "Monitor Link Group: test_group" in result.output
         assert "State:" in result.output
-        assert "Uplinks Up:" in result.output
-        assert "Min-uplinks:" in result.output
+        assert "Monitored Up:" in result.output
+        assert "Min-monitored-links:" in result.output
         assert "Link-up-delay:" in result.output
 
     def test_show_monitor_link_specific_group(self):
@@ -113,7 +113,7 @@ class TestMonitorLink:
         assert result.exit_code == 0
         assert "Monitor Link Group: critical_links" in result.output
         assert "Monitor Link Group: test_group" not in result.output
-        assert "Critical uplink and downlink monitoring group" in result.output
+        assert "Critical monitored and managed link monitoring group" in result.output
 
     def test_show_monitor_link_nonexistent_group(self):
         """Test showing a non-existent monitor link group"""
@@ -162,11 +162,11 @@ class TestMonitorLink:
         assert "Ethernet64" in result.output
         assert "Ethernet72" in result.output
         assert "Ethernet80" in result.output
-        assert "uplink" in result.output
-        assert "downlink" in result.output
+        assert "monitored" in result.output
+        assert "managed" in result.output
 
-    def test_downlink_reason_display(self):
-        """Test that downlink down reasons are displayed"""
+    def test_managed_reason_display(self):
+        """Test that managed-link down reasons are displayed"""
         runner = CliRunner()
         db = Db()
 
@@ -175,16 +175,16 @@ class TestMonitorLink:
         assert result.exit_code == 0
         assert "Down due to group critical_links" in result.output
 
-    def test_uplink_count_calculation(self):
-        """Test that uplink counts are calculated correctly"""
+    def test_monitored_count_calculation(self):
+        """Test that monitored-link counts are calculated correctly"""
         runner = CliRunner()
         db = Db()
 
         result = runner.invoke(show.cli.commands["monitor-link-group"], ["critical_links"], obj=db)
 
         assert result.exit_code == 0
-        # Should show 2/2 uplinks up (both Ethernet64 and Ethernet72 are up)
-        assert "Uplinks Up:       2/2" in result.output
+        # Should show 2/2 monitored-links up (both Ethernet64 and Ethernet72 are up)
+        assert "Monitored Up:          2/2" in result.output
 
     def test_portchannel_interfaces(self):
         """Test that PortChannel interfaces are handled correctly"""
@@ -215,8 +215,8 @@ class TestMonitorLink:
         test_data = {
             'MONITOR_LINK_GROUP_STATE|empty_group': {
                 'state': 'unknown',
-                'uplinks': '',
-                'downlinks': '',
+                'monitored-links': '',
+                'managed-links': '',
                 'link_up_threshold': '',
                 'link_up_delay': ''
             }
@@ -244,7 +244,7 @@ class TestMonitorLink:
             assert result.exit_code == 0
             assert "Monitor Link Group: empty_group" in result.output
             assert "No description" in result.output
-            assert "Min-uplinks:      1" in result.output  # Default value
+            assert "Min-monitored-links:   1" in result.output  # Default value
             assert "Link-up-delay:    0 seconds" in result.output  # Default value
         finally:
             # Restore original file
@@ -281,8 +281,8 @@ class TestMonitorLinkFunctions:
         # Test critical_links group
         critical_group = groups['critical_links']
         assert critical_group['state'] == 'up'
-        assert critical_group['description'] == 'Critical uplink and downlink monitoring group'
-        assert critical_group['min_uplinks'] == '2'
+        assert critical_group['description'] == 'Critical monitored and managed link monitoring group'
+        assert critical_group['min_monitored_links'] == '2'
         assert critical_group['linkup_delay'] == '10'
         assert len(critical_group['interfaces']) == 3
 
@@ -325,8 +325,8 @@ class TestMonitorLinkFunctions:
         assert isinstance(unknown_state, str)
 
     @mock.patch('utilities_common.cli.get_interface_operational_status')
-    def test_uplink_count_calculation_with_mock(self, mock_get_status):
-        """Test uplink count calculation with mocked interface status"""
+    def test_monitored_count_calculation_with_mock(self, mock_get_status):
+        """Test monitored-link count calculation with mocked interface status"""
         from show.monitor_link import get_monitor_link_groups
 
         # Mock interface status calls
@@ -344,7 +344,7 @@ class TestMonitorLinkFunctions:
         db = Db()
         groups = get_monitor_link_groups(db.db)
 
-        # The function itself doesn't calculate uplink counts, but we can test the data structure
+        # The function itself doesn't calculate monitored-link counts, but we can test the data structure
         assert 'critical_links' in groups
         assert 'test_group' in groups
 
@@ -366,8 +366,8 @@ class TestMonitorLinkEdgeCases:
             'MONITOR_LINK_GROUP_STATE|malformed_group': {
                 'state': 'up',
                 'description': 'Test group with malformed data',
-                'uplinks': 'Ethernet1,,Ethernet2,   ,Ethernet3',  # Extra commas and spaces
-                'downlinks': ',Ethernet4,',  # Leading and trailing commas
+                'monitored-links': 'Ethernet1,,Ethernet2,   ,Ethernet3',  # Extra commas and spaces
+                'managed-links': ',Ethernet4,',  # Leading and trailing commas
                 'link_up_threshold': '2',
                 'link_up_delay': '5'
             }
@@ -439,7 +439,7 @@ class TestMonitorLinkEdgeCases:
             shutil.move(backup_file, state_db_file)
 
     def test_interface_sorting(self):
-        """Test that interfaces are sorted correctly (uplinks first, then by name)"""
+        """Test that interfaces are sorted correctly (monitored first, then by name)"""
         runner = CliRunner()
         db = Db()
         # Use default state_db.json which contains our monitor link data
@@ -463,13 +463,13 @@ class TestMonitorLinkEdgeCases:
                 if not line.strip() or line.startswith('Monitor Link Group:'):
                     break
 
-        # Should have uplinks first, then downlinks
-        downlink_found = False
+        # Should have monitored first, then managed
+        managed_found = False
         for line in interface_lines:
-            if 'uplink' in line:
-                assert not downlink_found, "Uplinks should come before downlinks"
-            elif 'downlink' in line:
-                downlink_found = True
+            if 'monitored' in line:
+                assert not managed_found, "Monitored should come before managed"
+            elif 'managed' in line:
+                managed_found = True
 
     def test_utilities_common_integration(self):
         """Test integration with utilities_common.cli functions"""
@@ -496,3 +496,104 @@ class TestMonitorLinkEdgeCases:
         # Test non-existent interface
         status = get_interface_operational_status(db.db, 'NonExistent')
         assert status == 'N/A'
+
+
+class TestMonitorLinkTransitionTracking:
+    """PR-B: rendering of last_state_change_*, PENDING elapsed/remaining, transition counters."""
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+    def test_last_change_line_shown(self):
+        """When transition fields are present, the 'Last change:' line is rendered."""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["critical_links"], obj=db)
+        assert result.exit_code == 0
+        assert "Last change:" in result.output
+        # epoch 1700000000 == 2023-11-14 22:13:20 UTC
+        assert "2023-11-14" in result.output
+        assert "DOWN -> UP" in result.output
+        assert "monitored 2/2 >= min-monitored-links 2" in result.output
+
+    def test_transitions_counter_line(self):
+        """The 'Transitions:' line is always present and shows counters."""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["monitor-link-group"], ["test_group"], obj=db)
+        assert result.exit_code == 0
+        assert "Transitions:" in result.output
+        assert "UP->DOWN=3" in result.output
+        assert "DOWN->UP=2" in result.output
+
+    def test_pending_linkup_delay_progress(self):
+        """When state is PENDING, Link-up-delay shows elapsed/remaining."""
+        # pending_start_time in mock is 1700000200, link_up_delay is 15.
+        # Mock time.time() to 1700000204 -> elapsed=4s, remaining=11s.
+        with mock.patch('show.monitor_link.time.time', return_value=1700000204):
+            runner = CliRunner()
+            db = Db()
+            result = runner.invoke(show.cli.commands["monitor-link-group"], ["pending_group"], obj=db)
+
+        assert result.exit_code == 0
+        assert "Link-up-delay:         15 seconds (elapsed: 4s, remaining: 11s)" in result.output
+
+    def test_pending_progress_overdue(self):
+        """When the timer has overshot (raw elapsed > delay), display is OVERDUE."""
+        # pending_start_time=1700000200, delay=15. Mock now = pending_start + 999.
+        with mock.patch('show.monitor_link.time.time', return_value=1700001199):
+            runner = CliRunner()
+            db = Db()
+            result = runner.invoke(show.cli.commands["monitor-link-group"], ["pending_group"], obj=db)
+
+        assert result.exit_code == 0
+        # 999s elapsed - 15s delay = OVERDUE by 984s
+        assert "elapsed: 999s, OVERDUE by 984s" in result.output
+        # Make sure the misleading "remaining: 0s" form is not shown
+        assert "remaining:" not in result.output
+
+    def test_no_last_change_when_fields_missing(self):
+        """Backward compat: when transition fields are absent, 'Last change:' is omitted."""
+        minimal_data = {
+            'MONITOR_LINK_GROUP_STATE|legacy_group': {
+                'state': 'up',
+                'description': 'Legacy group without transition fields',
+                'monitored-links': 'Ethernet1',
+                'managed-links': '',
+                'link_up_threshold': '1',
+                'link_up_delay': '0',
+            }
+        }
+        import json
+        import shutil
+        import tempfile
+
+        # Use a per-test tempdir so parallel runs don't collide and a killed test
+        # doesn't leave the workspace dirty.
+        tmpdir = tempfile.mkdtemp()
+        test_db_file = os.path.join(tmpdir, 'state_db.json')
+        with open(test_db_file, 'w') as f:
+            json.dump(minimal_data, f)
+
+        try:
+            dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(tmpdir, 'state_db')
+
+            runner = CliRunner()
+            db = Db()
+            result = runner.invoke(show.cli.commands["monitor-link-group"], ["legacy_group"], obj=db)
+            assert result.exit_code == 0
+            assert "Monitor Link Group: legacy_group" in result.output
+            assert "Last change:" not in result.output
+            # Counters fall back to 0 when fields missing
+            assert "Transitions:           UP->DOWN=0, DOWN->UP=0" in result.output
+        finally:
+            if 'STATE_DB' in dbconnector.dedicated_dbs:
+                del dbconnector.dedicated_dbs['STATE_DB']
+            shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/monitor_link_test.py
+++ b/tests/monitor_link_test.py
@@ -245,7 +245,7 @@ class TestMonitorLink:
             assert "Monitor Link Group: empty_group" in result.output
             assert "No description" in result.output
             assert "Min-monitored-links:   1" in result.output  # Default value
-            assert "Link-up-delay:    0 seconds" in result.output  # Default value
+            assert "Link-up-delay:         0 seconds" in result.output  # Default value
         finally:
             # Restore original file
             shutil.move(backup_file, state_db_file)

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -956,3 +956,26 @@ class UserCache:
     def remove_all(self):
         """ Remove the content of the cache for all users """
         shutil.rmtree(self.cache_directory_app)
+
+
+def get_interface_operational_status(state_db, interface_name):
+    """
+    Get interface operational status from STATE_DB.
+    Tries PORT_TABLE (physical ports) then LAG_TABLE (port channels).
+
+    Returns:
+        str: "UP", "DOWN", or "N/A"
+    """
+    port_data = state_db.get_all(state_db.STATE_DB, f"PORT_TABLE|{interface_name}")
+    if port_data:
+        status = port_data.get('netdev_oper_status', '')
+        if status:
+            return "UP" if status.lower() == "up" else "DOWN"
+
+    lag_data = state_db.get_all(state_db.STATE_DB, f"LAG_TABLE|{interface_name}")
+    if lag_data:
+        status = lag_data.get('oper_status', '')
+        if status:
+            return "UP" if status.lower() == "up" else "DOWN"
+
+    return "N/A"


### PR DESCRIPTION
## What I did

Add `show monitor-link` and `show monitor-link <group>` CLI commands for the Monitor Link Group feature. Also include `show monitor-link` output in techsupport dumps.

Files changed:

| File | Change |
|------|--------|
| `show/monitor_link.py` | New — CLI implementation |
| `show/main.py` | Register `monitor-link` subcommand group |
| `utilities_common/cli.py` | Helper for table formatting |
| `scripts/generate_dump` | Add `show monitor-link` to techsupport collection |
| `tests/monitor_link_test.py` | New — unit tests |
| `tests/mock_tables/state_db.json` | State DB fixtures for tests |

## Why I did it

Provides operational visibility into monitor link group state for troubleshooting and post-incident debugging. Without this, group state is only visible by querying STATE_DB directly with `redis-cli`.

## Design

`show monitor-link` reads three STATE_DB tables:

- `MONITOR_LINK_GROUP_STATE` — group config and current state (UP / DOWN / PENDING)
- `PORT_TABLE` / `LAG_TABLE` — to derive live operational uplink count
- `MONITOR_LINK_GROUP_MEMBER` — to show which groups are forcing each downlink down (`down_due_to`)

Output columns: Group Name, State, Uplinks Up/Total, Downlinks, Min-Uplinks, Link-Up-Delay, Description.

`show monitor-link <group>` shows per-interface detail for that group's downlinks, including the `down_due_to` reason when an interface is forced down by multiple groups.

`generate_dump` includes `show monitor-link` output alongside existing port and LAG state in techsupport.

## How I verified it

- `tests/monitor_link_test.py` covers: table output across UP, DOWN, and PENDING states; multi-group downlink attribution; mixed Ethernet / PortChannel interfaces; single-group detail view.

## Companion PRs

- sonic-swss-common: STATE_DB table name macros
- sonic-swss: MonitorLinkGroupMgr implementation
- sonic-yang-models: YANG model
- SONiC/SONiC: HLD

HLD: https://github.com/sonic-net/SONiC/pull/2308
Yang Changes: https://github.com/sonic-net/sonic-buildimage/pull/27004
swss: https://github.com/sonic-net/sonic-swss/pull/4523
swss-common: https://github.com/sonic-net/sonic-swss-common/pull/1181