### PR TITLE
Added gcu support for replacing xon and xon_offset

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -137,7 +137,9 @@
                     },
                     "PG headroom modification": {
                         "fields": [
-                            "xoff"
+                            "xoff",
+                            "xon",
+                            "xon_offset"
                         ],
                         "operations": [
                             "replace"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added GCU support for modifying xon and xon_offset for lossless buffer profiles. 
#### How I did it
Added xon/xon_offset to PG headroom modification fields in gcu_field_operation_validators.conf.json
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
`localhost: Modification of BUFFER_PROFILE table is illegal- validating function generic_config_updater.field_operation_validators.buffer_profile_config_update_validator returned False`
#### New command output (if the output of a command-line utility has changed)
Operation will now succeed.
