### PR TITLE
[CLI] [show] Added CLI to show label-port interfaces mapping and status

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5964,6 +5964,7 @@ Subsequent pages explain each of these commands in detail.
   switchport   Show Interface switchport information
   tpid         Show Interface tpid information
   transceiver  Show SFP Transceiver information
+  label-port   Show label-port mapping information
   ```
 
 **show interfaces autoneg**
@@ -6844,6 +6845,91 @@ is command.
 **show interfaces transceiver**
 
 This command is already explained [here](#Transceivers)
+
+**show interfaces label-port status**
+
+This command displays a standardized mapping of front-panel label ports to SONiC interface names, their lanes, and operational status under the current breakout configuration. Each table cell shows the mapped interface name and status for the corresponding lane (for example, `Ethernet0(UP)`). On multi-ASIC systems, the interface name also includes the ASIC namespace (for example, `Ethernet0|asic0(UP)`).
+
+- Usage:
+  ```
+  show interfaces label-port status
+  ```
+
+- Example (single-ASIC, 2 x 4x breakout):
+  ```
+  admin@sonic:~$ show interfaces label-port status
+  +--------------+-----------------+-----------------+-----------------+-----------------+
+  |   Label Port | Lane 1          | Lane 2          | Lane 3          | Lane 4          |
+  +==============+=================+=================+=================+=================+
+  |            1 | Ethernet0(UP)   | Ethernet0(UP)   | Ethernet0(UP)   | Ethernet0(UP)   |
+  |            2 | Ethernet4(UP)   | Ethernet4(UP)   | Ethernet4(UP)   | Ethernet4(UP)   |
+  |            3 | Ethernet8(UP)   | Ethernet8(UP)   | Ethernet8(UP)   | Ethernet8(UP)   |
+  |          ... | ...             | ...             | ...             | ...             |
+  |          128 | Ethernet508(UP) | Ethernet508(UP) | Ethernet508(DOWN) | Ethernet508(UP) |
+  +--------------+-----------------+-----------------+-----------------+-----------------+
+  ```
+
+- Example (single-ASIC, 4 x 2x breakout):
+  ```
+  admin@sonic:~$ show interfaces label-port status
+  +--------------+-----------------+-----------------+------------------+------------------+
+  |   Label Port | Lane 1          | Lane 2          | Lane 3           | Lane 4           |
+  +==============+=================+=================+==================+==================+
+  |            1 | Ethernet0(UP)   | Ethernet0(UP)   | Ethernet2(UP)    | Ethernet2(UP)    |
+  |            2 | Ethernet4(UP)   | Ethernet4(UP)   | Ethernet6(UP)    | Ethernet6(UP)    |
+  |            3 | Ethernet8(UP)   | Ethernet8(UP)   | Ethernet10(UP)   | Ethernet10(UP)   |
+  |          ... | ...             | ...             | ...              | ...              |
+  |          128 | Ethernet508(UP) | Ethernet508(UP) | Ethernet510(DOWN) | Ethernet510(UP)   |
+  +--------------+-----------------+-----------------+------------------+------------------+
+  ```
+
+- Example (multi-ASIC):
+  ```
+  admin@sonic:~$ show interfaces label-port status
+  +--------------+---------------------+-----------------------+------------------------+------------------------+
+  |   Label Port | Lane 1              | Lane 2                | Lane 3                 | Lane 4                 |
+  +==============+=====================+=======================+========================+========================+
+  |            1 | Ethernet0|asic0(UP) | Ethernet512|asic1(UP) | Ethernet1024|asic2(UP) | Ethernet1536|asic3(UP) |
+  |            2 | Ethernet1|asic0(UP) | Ethernet513|asic1(UP) | Ethernet1025|asic2(UP) | Ethernet1537|asic3(UP) |
+  |            3 | Ethernet2|asic0(UP) | Ethernet514|asic1(UP) | Ethernet1026|asic2(UP) | Ethernet1538|asic3(UP) |
+  |          ... | ...                 | ...                   | ...                    | ...                    |
+  |          512 | Ethernet511|asic0(UP) | Ethernet1023|asic1(UP) | Ethernet1535|asic2(DOWN) | Ethernet2047|asic3(UP) |
+  +--------------+---------------------+-----------------------+------------------------+------------------------+
+  ```
+
+- Platform requirements (`platform.json`):
+
+  All supported platforms must define `label_port_lanes_mapping`:
+
+  - **Key**: label-port identifier (string), for example `"1"`, `"2"`.
+  - **Value**: list of global lane numbers (strings), for example `["0", "1", "2", "3"]`.
+
+  Multi-ASIC platforms must also define `number_of_lanes_per_asic`. This value is used to compute global lane offsets:
+
+  `global_lane = local_lane + (asic_index x number_of_lanes_per_asic)`
+
+  Single-ASIC example:
+  ```json
+  "label_port_lanes_mapping": {
+     "1": ["0", "1", "2", "3"],
+     "2": ["4", "5", "6", "7"],
+     ...
+     "127": ["504", "505", "506", "507"],
+     "128": ["508", "509", "510", "511"]
+  }
+  ```
+
+  Multi-ASIC example:
+  ```json
+  "number_of_lanes_per_asic": "512",
+  "label_port_lanes_mapping": {
+     "1": ["0", "512", "1024", "1536"],
+     "2": ["1", "513", "1025", "1537"],
+     ...
+     "511": ["510", "1022", "1534", "2046"],
+     "512": ["511", "1023", "1535", "2047"]
+  }
+  ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#interfaces)
 

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -1531,11 +1531,9 @@ def get_ports_data():
         db = multi_asic.connect_to_all_dbs_for_ns(namespace=namespace)
         port_table = multi_asic.get_port_table(namespace=namespace)
         for port_name, port_info in port_table.items():
-            lanes = port_info.get(LANES, []).split(',')
+            lanes = [lane for lane in port_info.get(LANES, "").split(',') if lane]
             oper = db.get(db.APPL_DB, f"{APPL_PORT_TABLE}:{port_name}", OPER_STATUS)
             status = (oper or DOWN).upper()
-            if namespace not in ports_dict:
-                ports_dict[namespace] = {}
             ports_dict[port_name] = {
                 LANES: [int(lane) for lane in lanes],
                 STATUS: status,
@@ -1565,7 +1563,7 @@ def get_labelport_to_ports_map(ports_dict, labelport_map, lanes_per_asic):
             except (KeyError, ValueError):
                 log.log_debug("Lane {} not found in labelport {}".format(lane, labelport_num))
                 continue
-            port_name = f"{port}/{info.get(ASIC)}" if info.get(ASIC) != "" else port
+            port_name = f"{port}|{info.get(ASIC)}" if info.get(ASIC) != "" else port
             if labelport_num not in labelport_to_ports_map:
                 labelport_to_ports_map[int(labelport_num)] = ['-'] * labelport_lanes_number
             labelport_to_ports_map[int(labelport_num)][position] = f"{port_name}({info.get(STATUS, DOWN)})"
@@ -1573,8 +1571,7 @@ def get_labelport_to_ports_map(ports_dict, labelport_map, lanes_per_asic):
 
 
 @labelport.command(name='status')
-@clicommon.pass_db
-def labelport_status(db):
+def labelport_status():
     """
     Show a mapping and status of label-ports -> ports
     """
@@ -1603,5 +1600,10 @@ def labelport_status(db):
 
     # Build the table
     header = ['Label Port'] + [f'Lane {i+1}' for i in range(labelport_lanes_number)]
-    body = [[int(labelport)] + labelport_to_ports_map[labelport] for labelport in sorted(labelport_to_ports_map.keys())]
+    body = [
+        [int(labelport)] + labelport_to_ports_map.get(
+            int(labelport), ['-'] * labelport_lanes_number
+        )
+        for labelport in sorted(labelport_map.keys(), key=int)
+    ]
     click.echo(tabulate(body, header, tablefmt="outline"))

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -1532,7 +1532,8 @@ def get_ports_data():
         port_table = multi_asic.get_port_table(namespace=namespace)
         for port_name, port_info in port_table.items():
             lanes = port_info.get(LANES, []).split(',')
-            status = db.get(db.APPL_DB, f"{APPL_PORT_TABLE}:{port_name}", OPER_STATUS).upper()
+            oper = db.get(db.APPL_DB, f"{APPL_PORT_TABLE}:{port_name}", OPER_STATUS)
+            status = (oper or DOWN).upper()
             if namespace not in ports_dict:
                 ports_dict[namespace] = {}
             ports_dict[port_name] = {
@@ -1545,7 +1546,8 @@ def get_ports_data():
 
 def get_labelport_to_ports_map(ports_dict, labelport_map, lanes_per_asic):
     """
-    This function returns a dictionary of LabelPorts -> ports: key = labelport_num, value = list of ports connected to this LabelPort
+    This function returns a dictionary of LabelPorts -> ports
+    key = labelport_num, value = list of ports connected to this LabelPort
     """
     lanes_to_labelport = {}
     for k, values in labelport_map.items():
@@ -1560,7 +1562,7 @@ def get_labelport_to_ports_map(ports_dict, labelport_map, lanes_per_asic):
             labelport_num = lanes_to_labelport.get(lane)
             try:
                 position = labelport_map[str(labelport_num)].index(str(lane))
-            except KeyError:
+            except (KeyError, ValueError):
                 log.log_debug("Lane {} not found in labelport {}".format(lane, labelport_num))
                 continue
             port_name = f"{port}/{info.get(ASIC)}" if info.get(ASIC) != "" else port
@@ -1582,20 +1584,24 @@ def labelport_status(db):
         click.echo("No platform data found", err=True)
         raise click.Abort()
     labelport_map = platform_data.get('label_port_lanes_mapping')
-    lanes_per_asic = int(platform_data.get('number_of_lanes_per_asic', 0))
     if labelport_map is None:
-        click.echo("No Label-ports mapping found in platform data", err=True)
+        click.echo("No Label-port mapping found in platform data", err=True)
         raise click.Abort()
+    lanes_per_asic = 0
+    if multi_asic.is_multi_asic():
+        try:
+            lanes_per_asic = int(platform_data.get('number_of_lanes_per_asic'))
+        except (TypeError, ValueError):
+            click.echo("No number of lanes per ASIC found in platform data", err=True)
+            raise click.Abort()
     labelport_lanes_number = len(labelport_map[list(labelport_map.keys())[0]])
-
     # Get all ports data
     ports_dict = get_ports_data()
 
     # Create a dictionary of labelports -> ports: key = labelport_num, value = list of ports connected to this labelport
     labelport_to_ports_map = get_labelport_to_ports_map(ports_dict, labelport_map, lanes_per_asic)
-    
+
     # Build the table
     header = ['Label Port'] + [f'Lane {i+1}' for i in range(labelport_lanes_number)]
     body = [[int(labelport)] + labelport_to_ports_map[labelport] for labelport in sorted(labelport_to_ports_map.keys())]
     click.echo(tabulate(body, header, tablefmt="outline"))
-    

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -10,6 +10,7 @@ from natsort import natsorted
 from tabulate import tabulate
 from sonic_py_common import multi_asic
 from sonic_py_common import device_info
+from sonic_py_common import syslogger
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from portconfig import get_child_ports
 import sonic_platform_base.sonic_sfp.sfputilhelper
@@ -21,6 +22,15 @@ from datetime import datetime
 HWSKU_JSON = 'hwsku.json'
 
 REDIS_HOSTIP = "127.0.0.1"
+LANES = "lanes"
+ASIC = "asic"
+STATUS = "status"
+DOWN = "DOWN"
+UP = "UP"
+APPL_PORT_TABLE = "PORT_TABLE"
+OPER_STATUS = "oper_status"
+
+log = syslogger.SysLogger("show_interfaces")
 
 # Read given JSON file
 def readJsonFile(fileName):
@@ -1503,3 +1513,89 @@ def phy_serdes(db, ctx, interfacename, namespace, display, snr, rxvga, txfir):
     if txfir:
         attr_data = port_phy_data.get('tx_fir_taps_list')
         display_phy_taps_attribute('TX FIR Taps', attr_data)
+
+
+@interfaces.group(name='label-port', cls=clicommon.AliasedGroup)
+def labelport():
+    """Show label-port information"""
+    pass
+
+
+def get_ports_data():
+    """
+    This function returns a dictionary of ports, their lanes and status
+    """
+    ports_dict = {}
+    namespaces = multi_asic.get_namespace_list()
+    for namespace in namespaces:
+        db = multi_asic.connect_to_all_dbs_for_ns(namespace=namespace)
+        port_table = multi_asic.get_port_table(namespace=namespace)
+        for port_name, port_info in port_table.items():
+            lanes = port_info.get(LANES, []).split(',')
+            status = db.get(db.APPL_DB, f"{APPL_PORT_TABLE}:{port_name}", OPER_STATUS).upper()
+            if namespace not in ports_dict:
+                ports_dict[namespace] = {}
+            ports_dict[port_name] = {
+                LANES: [int(lane) for lane in lanes],
+                STATUS: status,
+                ASIC: namespace
+            }
+    return ports_dict
+
+
+def get_labelport_to_ports_map(ports_dict, labelport_map, lanes_per_asic):
+    """
+    This function returns a dictionary of LabelPorts -> ports: key = labelport_num, value = list of ports connected to this LabelPort
+    """
+    lanes_to_labelport = {}
+    for k, values in labelport_map.items():
+        for v in values:
+            lanes_to_labelport[int(v)] = int(k)
+    labelport_lanes_number = len(labelport_map[list(labelport_map.keys())[0]])
+    labelport_to_ports_map = {}
+    for port, info in ports_dict.items():
+        for lane in info.get(LANES, []):
+            asic_number = multi_asic.get_asic_index_from_namespace(info.get(ASIC))
+            lane += asic_number * lanes_per_asic
+            labelport_num = lanes_to_labelport.get(lane)
+            try:
+                position = labelport_map[str(labelport_num)].index(str(lane))
+            except KeyError:
+                log.log_debug("Lane {} not found in labelport {}".format(lane, labelport_num))
+                continue
+            port_name = f"{port}/{info.get(ASIC)}" if info.get(ASIC) != "" else port
+            if labelport_num not in labelport_to_ports_map:
+                labelport_to_ports_map[int(labelport_num)] = ['-'] * labelport_lanes_number
+            labelport_to_ports_map[int(labelport_num)][position] = f"{port_name}({info.get(STATUS, DOWN)})"
+    return labelport_to_ports_map
+
+
+@labelport.command(name='status')
+@clicommon.pass_db
+def labelport_status(db):
+    """
+    Show a mapping and status of label-ports -> ports
+    """
+    # Get the labelport -> lanes mapping from platform.json
+    platform_data = device_info.get_platform_json_data()
+    if platform_data is None:
+        click.echo("No platform data found", err=True)
+        raise click.Abort()
+    labelport_map = platform_data.get('label_port_lanes_mapping')
+    lanes_per_asic = int(platform_data.get('number_of_lanes_per_asic', 0))
+    if labelport_map is None:
+        click.echo("No Label-ports mapping found in platform data", err=True)
+        raise click.Abort()
+    labelport_lanes_number = len(labelport_map[list(labelport_map.keys())[0]])
+
+    # Get all ports data
+    ports_dict = get_ports_data()
+
+    # Create a dictionary of labelports -> ports: key = labelport_num, value = list of ports connected to this labelport
+    labelport_to_ports_map = get_labelport_to_ports_map(ports_dict, labelport_map, lanes_per_asic)
+    
+    # Build the table
+    header = ['Label Port'] + [f'Lane {i+1}' for i in range(labelport_lanes_number)]
+    body = [[int(labelport)] + labelport_to_ports_map[labelport] for labelport in sorted(labelport_to_ports_map.keys())]
+    click.echo(tabulate(body, header, tablefmt="outline"))
+    

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -2,11 +2,13 @@ import os
 import traceback
 
 from click.testing import CliRunner
+from tabulate import tabulate
 from unittest import mock
 from utilities_common.intf_filter import parse_interface_in_filter
 
 import config.main as config
 import show.main as show
+from show import interfaces as interfaces_mod
 from utilities_common.db import Db
 
 show_interfaces_alias_output = """\
@@ -936,3 +938,228 @@ class TestInterfaces(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
+
+
+class MockLabelPortDb:
+    APPL_DB = 0
+
+    def __init__(self, oper_status):
+        self._oper_status = oper_status
+
+    def get(self, dbid, key, field):
+        if dbid == self.APPL_DB and field == 'oper_status':
+            return self._oper_status.get(key)
+        return None
+
+
+def setup_labelport_status_test(monkeypatch, platform_data, port_tables_by_ns,
+                                oper_status_by_ns=None, multi_asic=False):
+    namespaces = list(port_tables_by_ns.keys())
+    oper_status_by_ns = oper_status_by_ns or {}
+    asic_indexes = {'': 0}
+    asic_indexes.update({namespace: index for index, namespace in enumerate(namespaces)})
+
+    monkeypatch.setattr(interfaces_mod.device_info, 'get_platform_json_data', lambda: platform_data)
+    monkeypatch.setattr(interfaces_mod.multi_asic, 'is_multi_asic', lambda: multi_asic)
+    monkeypatch.setattr(interfaces_mod.multi_asic, 'get_namespace_list', lambda: namespaces)
+    monkeypatch.setattr(interfaces_mod.multi_asic, 'get_asic_index_from_namespace',
+                        lambda namespace: asic_indexes[namespace])
+    monkeypatch.setattr(interfaces_mod.multi_asic, 'get_port_table',
+                        lambda namespace=None: port_tables_by_ns[namespace])
+    monkeypatch.setattr(interfaces_mod.multi_asic, 'connect_to_all_dbs_for_ns',
+                        lambda namespace=None: MockLabelPortDb(oper_status_by_ns.get(namespace, {})))
+
+
+def invoke_labelport_status():
+    runner = CliRunner()
+    return runner.invoke(
+        show.cli.commands["interfaces"].commands["label-port"].commands["status"],
+        [],
+        obj=object.__new__(Db)
+    )
+
+
+def expected_labelport_output(rows, lane_count=4):
+    header = ['Label Port'] + [f'Lane {index + 1}' for index in range(lane_count)]
+    return tabulate(rows, header, tablefmt="outline") + "\n"
+
+
+class TestInterfacesLabelPortStatus(object):
+    def test_basic_single_asic(self, monkeypatch):
+        platform_data = {
+            'label_port_lanes_mapping': {
+                '1': ['0', '1', '2', '3'],
+                '2': ['4', '5', '6', '7'],
+            }
+        }
+        port_tables_by_ns = {
+            '': {
+                'Ethernet0': {'lanes': '0,1,2,3'},
+                'Ethernet4': {'lanes': '4,5,6,7'},
+            }
+        }
+        oper_status_by_ns = {
+            '': {
+                'PORT_TABLE:Ethernet0': 'up',
+                'PORT_TABLE:Ethernet4': 'down',
+            }
+        }
+        setup_labelport_status_test(monkeypatch, platform_data, port_tables_by_ns, oper_status_by_ns)
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code == 0
+        assert result.output == expected_labelport_output([
+            [1, 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)'],
+            [2, 'Ethernet4(DOWN)', 'Ethernet4(DOWN)', 'Ethernet4(DOWN)', 'Ethernet4(DOWN)'],
+        ])
+
+    def test_basic_multi_asic(self, monkeypatch):
+        platform_data = {
+            'number_of_lanes_per_asic': 4,
+            'label_port_lanes_mapping': {
+                '1': ['0', '4', '8', '12'],
+                '2': ['1', '5', '9', '13'],
+            }
+        }
+        port_tables_by_ns = {
+            'asic0': {'Ethernet0': {'lanes': '0'}, 'Ethernet1': {'lanes': '1'}},
+            'asic1': {'Ethernet512': {'lanes': '0'}, 'Ethernet513': {'lanes': '1'}},
+            'asic2': {'Ethernet1024': {'lanes': '0'}, 'Ethernet1025': {'lanes': '1'}},
+            'asic3': {'Ethernet1536': {'lanes': '0'}, 'Ethernet1537': {'lanes': '1'}},
+        }
+        oper_status_by_ns = {
+            namespace: {f'PORT_TABLE:{port}': 'up' for port in port_table}
+            for namespace, port_table in port_tables_by_ns.items()
+        }
+        setup_labelport_status_test(monkeypatch, platform_data, port_tables_by_ns,
+                                    oper_status_by_ns, multi_asic=True)
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code == 0
+        assert result.output == expected_labelport_output([
+            [1, 'Ethernet0/asic0(UP)', 'Ethernet512/asic1(UP)', 'Ethernet1024/asic2(UP)',
+             'Ethernet1536/asic3(UP)'],
+            [2, 'Ethernet1/asic0(UP)', 'Ethernet513/asic1(UP)', 'Ethernet1025/asic2(UP)',
+             'Ethernet1537/asic3(UP)'],
+        ])
+
+    def test_mixed_splits_lane_positions_and_fanout(self, monkeypatch):
+        platform_data = {
+            'label_port_lanes_mapping': {
+                '1': ['0', '1', '2', '3'],
+                '2': ['4', '5', '6', '7'],
+            }
+        }
+        port_tables_by_ns = {
+            '': {
+                'Ethernet0': {'lanes': '0,1,2,3'},
+                'Ethernet4': {'lanes': '4,5'},
+                'Ethernet6': {'lanes': '6'},
+                'Ethernet7': {'lanes': '7'},
+            }
+        }
+        oper_status_by_ns = {
+            '': {
+                'PORT_TABLE:Ethernet0': 'up',
+                'PORT_TABLE:Ethernet4': 'down',
+                'PORT_TABLE:Ethernet6': 'up',
+                'PORT_TABLE:Ethernet7': 'up',
+            }
+        }
+        setup_labelport_status_test(monkeypatch, platform_data, port_tables_by_ns, oper_status_by_ns)
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code == 0
+        assert result.output == expected_labelport_output([
+            [1, 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)', 'Ethernet0(UP)'],
+            [2, 'Ethernet4(DOWN)', 'Ethernet4(DOWN)', 'Ethernet6(UP)', 'Ethernet7(UP)'],
+        ])
+        assert result.output.count('Ethernet0(UP)') == 4
+        assert result.output.count('Ethernet4(DOWN)') == 2
+        assert result.output.count('Ethernet6(UP)') == 1
+        assert result.output.count('Ethernet7(UP)') == 1
+
+    def test_platform_json_read_error(self, monkeypatch):
+        setup_labelport_status_test(monkeypatch, None, {'': {}})
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code != 0
+        assert "No platform data found" in result.output
+
+    def test_missing_labelport_lanes_mapping(self, monkeypatch):
+        setup_labelport_status_test(monkeypatch, {}, {'': {}})
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code != 0
+        assert "No Label-port  mapping found in platform data" in result.output
+
+    def test_multi_asic_missing_number_of_lanes_per_asic(self, monkeypatch):
+        platform_data = {
+            'label_port_lanes_mapping': {
+                '1': ['0', '4', '8', '12'],
+            }
+        }
+        port_tables_by_ns = {
+            'asic0': {'Ethernet0': {'lanes': '0'}},
+            'asic1': {'Ethernet512': {'lanes': '0'}},
+        }
+        setup_labelport_status_test(monkeypatch, platform_data, port_tables_by_ns, multi_asic=True)
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code != 0
+        assert "No number of lanes per ASIC found in platform data" in result.output
+
+    def test_multi_asic_one_asic_down(self, monkeypatch):
+        platform_data = {
+            'number_of_lanes_per_asic': 4,
+            'label_port_lanes_mapping': {
+                '1': ['0', '4', '8', '12'],
+                '2': ['1', '5', '9', '13'],
+            }
+        }
+        port_tables_by_ns = {
+            'asic0': {'Ethernet0': {'lanes': '0'}, 'Ethernet1': {'lanes': '1'}},
+            'asic1': {},
+            'asic2': {'Ethernet1024': {'lanes': '0'}, 'Ethernet1025': {'lanes': '1'}},
+            'asic3': {'Ethernet1536': {'lanes': '0'}, 'Ethernet1537': {'lanes': '1'}},
+        }
+        oper_status_by_ns = {
+            namespace: {f'PORT_TABLE:{port}': 'up' for port in port_table}
+            for namespace, port_table in port_tables_by_ns.items()
+        }
+        setup_labelport_status_test(monkeypatch, platform_data, port_tables_by_ns,
+                                    oper_status_by_ns, multi_asic=True)
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code == 0
+        assert result.output == expected_labelport_output([
+            [1, 'Ethernet0/asic0(UP)', '-', 'Ethernet1024/asic2(UP)', 'Ethernet1536/asic3(UP)'],
+            [2, 'Ethernet1/asic0(UP)', '-', 'Ethernet1025/asic2(UP)', 'Ethernet1537/asic3(UP)'],
+        ])
+
+    def test_missing_oper_status_displays_down(self, monkeypatch):
+        platform_data = {
+            'label_port_lanes_mapping': {
+                '1': ['0', '1', '2', '3'],
+            }
+        }
+        port_tables_by_ns = {
+            '': {
+                'Ethernet0': {'lanes': '0,1,2,3'},
+            }
+        }
+        setup_labelport_status_test(monkeypatch, platform_data, port_tables_by_ns)
+
+        result = invoke_labelport_status()
+
+        assert result.exit_code == 0
+        assert result.output == expected_labelport_output([
+            [1, 'Ethernet0(DOWN)', 'Ethernet0(DOWN)', 'Ethernet0(DOWN)', 'Ethernet0(DOWN)'],
+        ])

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -974,8 +974,7 @@ def invoke_labelport_status():
     runner = CliRunner()
     return runner.invoke(
         show.cli.commands["interfaces"].commands["label-port"].commands["status"],
-        [],
-        obj=object.__new__(Db)
+        []
     )
 
 
@@ -1039,10 +1038,10 @@ class TestInterfacesLabelPortStatus(object):
 
         assert result.exit_code == 0
         assert result.output == expected_labelport_output([
-            [1, 'Ethernet0/asic0(UP)', 'Ethernet512/asic1(UP)', 'Ethernet1024/asic2(UP)',
-             'Ethernet1536/asic3(UP)'],
-            [2, 'Ethernet1/asic0(UP)', 'Ethernet513/asic1(UP)', 'Ethernet1025/asic2(UP)',
-             'Ethernet1537/asic3(UP)'],
+            [1, 'Ethernet0|asic0(UP)', 'Ethernet512|asic1(UP)', 'Ethernet1024|asic2(UP)',
+             'Ethernet1536|asic3(UP)'],
+            [2, 'Ethernet1|asic0(UP)', 'Ethernet513|asic1(UP)', 'Ethernet1025|asic2(UP)',
+             'Ethernet1537|asic3(UP)'],
         ])
 
     def test_mixed_splits_lane_positions_and_fanout(self, monkeypatch):
@@ -1140,8 +1139,8 @@ class TestInterfacesLabelPortStatus(object):
 
         assert result.exit_code == 0
         assert result.output == expected_labelport_output([
-            [1, 'Ethernet0/asic0(UP)', '-', 'Ethernet1024/asic2(UP)', 'Ethernet1536/asic3(UP)'],
-            [2, 'Ethernet1/asic0(UP)', '-', 'Ethernet1025/asic2(UP)', 'Ethernet1537/asic3(UP)'],
+            [1, 'Ethernet0|asic0(UP)', '-', 'Ethernet1024|asic2(UP)', 'Ethernet1536|asic3(UP)'],
+            [2, 'Ethernet1|asic0(UP)', '-', 'Ethernet1025|asic2(UP)', 'Ethernet1537|asic3(UP)'],
         ])
 
     def test_missing_oper_status_displays_down(self, monkeypatch):

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -1096,7 +1096,7 @@ class TestInterfacesLabelPortStatus(object):
         result = invoke_labelport_status()
 
         assert result.exit_code != 0
-        assert "No Label-port  mapping found in platform data" in result.output
+        assert "No Label-port mapping found in platform data" in result.output
 
     def test_multi_asic_missing_number_of_lanes_per_asic(self, monkeypatch):
         platform_data = {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
A CLI that displays for each front-panel label port, how it maps to lanes and SONiC interfaces under the current split mode.

For all supported platforms, platform.json should be extended with:

1. label_port_lanes_mapping (object):
   a. Key: Label-port identifiers (strings, e.g., "1", "2").
   b. Values: list of lane numbers (strings, e.g., ["1", "2", "3", "4"] ).
2. For multi-ASIC platforms only - number_of_lanes_per_asic (stringified integer) - Used to compute global lane offsets on multi-ASIC systems: global_lane = local_lane + (asic_index × number_of_lanes_per_asic).

Example:

platform.json

```json
// Single-ASIC

"label_port_lanes_mapping": {
   "1": ["0", "1", "2", "3"],
   "2": ["4", "5", "6", "7"],
   ...
   "127": ["504", "505", "506", "507"],
   "128": ["508", "509", "510", "511"]
}
```

```json
// Multi-ASIC

"number_of_lanes_per_asic": "512",
"label_port_lanes_mapping": {
   "1": ["0", "512", "1024", "1536"],
   "2": ["1", "513", "1025", "1537"],
   ...
   "511": ["510", "1022", "1534", "2046"],
   "512": ["511", "1023", "1535", "2047"]
}
```

#### How I did it
1. Get Label-port → lanes mapping from platform.json.
2. Get the running ports configuration and lane splits from CONFIG_DB.
3. Get ports status from APPL_DB .
4. Create and print a table that shows the current Label-ports → ports mapping (based on the current configuration and platform lanes map).

#### How to verify it

Run the following command: show interfaces label-port status

Example output:

Single-ASIC ( 2 x 4x)

```text
>> show interfaces label-port status
Label-port | Lane 1        | Lane 2        | Lane 3        | Lane 4
-----------|---------------|---------------|---------------|---------------
1          | Ethernet0(UP) | Ethernet0(UP) | Ethernet0(UP) | Ethernet0(UP)
2          | Ethernet4(UP) | Ethernet4(UP) | Ethernet4(UP) | Ethernet4(UP)
3          | Ethernet8(UP) | Ethernet8(UP) | Ethernet8(UP) | Ethernet8(UP)
...
128        | Ethernet508(UP) | Ethernet508(UP) | Ethernet508(DN) | Ethernet508(UP)
```

Single-ASIC ( 4 x 2x)

```text
>> show interfaces label-port status
Label-port | Lane 1        | Lane 2        | Lane 3        | Lane 4
-----------|---------------|---------------|---------------|---------------
1          | Ethernet0(UP) | Ethernet0(UP) | Ethernet2(UP) | Ethernet2(UP)
2          | Ethernet4(UP) | Ethernet4(UP) | Ethernet6(UP) | Ethernet6(UP)
3          | Ethernet8(UP) | Ethernet8(UP) | Ethernet10(UP) | Ethernet10(UP)
...
128        | Ethernet508(UP) | Ethernet508(UP) | Ethernet510(DN) | Ethernet510(UP)
```

Multi-ASIC

```text
>> show interfaces label-port status
Label-port | Lane 1              | Lane 2              | Lane 3              | Lane 4
-----------|---------------------|---------------------|---------------------|---------------------
1          | Ethernet0/asic0(UP) | Ethernet512/asic1(UP) | Ethernet1024/asic2(UP) | Ethernet1536/asic3(UP)
2          | Ethernet1/asic0(UP) | Ethernet513/asic1(UP) | Ethernet1025/asic2(UP) | Ethernet1537/asic3(UP)
3          | Ethernet2/asic0(UP) | Ethernet514/asic1(UP) | Ethernet1026/asic2(UP) | Ethernet1538/asic3(UP)
...
512        | Ethernet511/asic0(UP) | Ethernet1023/asic1(UP) | Ethernet1535/asic2(DN) | Ethernet2047/asic3(UP)
```


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

