### PR TITLE
allow per-interface filtering for "show interfaces counters errors"

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6047,12 +6047,12 @@ Optional argument "-p" specify a period (in seconds) with which to gather counte
 
 - Usage:
   ```
-  show interfaces counters [-a|--printall] [-p|--period <period>]
-  show interfaces counters errors
-  show interfaces counters rates
-  show interfaces counters rif [-p|--period <period>] [-i <interface_name>]
-  show interfaces counters fec-histogram [-i <interface_name>]
-  show interfaces counters fec-stats
+  show interfaces counters [<interface_name>] [-a|--printall] [-p|--period <period>]
+  show interfaces counters errors [<interface_name>]
+  show interfaces counters rates [<interface_name>]
+  show interfaces counters rif [-p|--period <period>] [<interface_name>]
+  show interfaces counters fec-histogram [<interface_name>]
+  show interfaces counters fec-stats [<interface_name>]
   show interfaces counters detailed <interface_name>
   show interfaces counters trim [interface_name] [-p|--period <sec>] [-j|--json]
   ```
@@ -6070,7 +6070,7 @@ Optional argument "-p" specify a period (in seconds) with which to gather counte
    Ethernet20        U   47,983,339,172   35.89 MB/s      0.70%         0     2,174         0   58,986,354,359   51.83 MB/s      1.01%         0         0         0
    Ethernet24        U   33,543,533,441   36.59 MB/s      0.71%         0     1,613         0   43,066,076,370   49.92 MB/s      0.97%         0         0         0
 
-  admin@sonic:~$ show interfaces counters -i Ethernet4,Ethernet12-16
+  admin@sonic:~$ show interfaces counters Ethernet4,Ethernet12-16
         IFACE    STATE            RX_OK       RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR            TX_OK       TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
   -----------  -------  ---------------  -----------  ---------  --------  --------  --------  ---------------  -----------  ---------  --------  --------  --------
     Ethernet4        U  453,838,006,636  632.97 MB/s     12.36%         0     1,636         0  388,299,875,056  529.34 MB/s     10.34%         0         0         0
@@ -6089,6 +6089,11 @@ The "errors" subcommand is used to display the interface errors.
     Ethernet4        U         0         0         0         0         0         0
     Ethernet8        U         0         1         0         0         0         0
    Ethernet12        U         0         0         0         0         0         0
+
+  admin@str-s6000-acs-11:~$ show interface counters errors Ethernet0
+      IFACE    STATE    RX_ERR    RX_DRP    RX_OVR    TX_ERR    TX_DRP    TX_OVR
+  -----------  -------  --------  --------  --------  --------  --------  --------
+    Ethernet0        U         0         4         0         0         0         0
    ```
 
 The "rates" subcommand is used to disply only the interface rates.
@@ -6102,6 +6107,11 @@ The "rates" subcommand is used to disply only the interface rates.
     Ethernet4        U   469679       N/A       N/A        N/A   469245       N/A       N/A        N/A
     Ethernet8        U   466660       N/A       N/A        N/A   465982       N/A       N/A        N/A
    Ethernet12        U   466579       N/A       N/A        N/A   466318       N/A       N/A        N/A
+
+  admin@str-s6000-acs-11:/usr/bin$ show int counters rates Ethernet4
+      IFACE    STATE    RX_OK    RX_BPS    RX_PPS    RX_UTIL    TX_OK    TX_BPS    TX_PPS    TX_UTIL
+  -----------  -------  -------  --------  --------  ---------  -------  --------  --------  ---------
+    Ethernet4        U   469679       N/A       N/A        N/A   469245       N/A       N/A        N/A
    ```
 
 
@@ -6263,6 +6273,11 @@ The "fec-stats" subcommand is used to disply the interface fec related statistic
   -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------  --------  -------------------  -----------
    Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16  4.31e-10       7.81e-10 (89%)      2.34e-05
    Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14         0       4.81e-10 (84%)      1.87e-05
+  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13  1.24e-10       6.03e-09 (79%)      3.12e-05
+
+  admin@ctd615:~$ show interfaces counters fec-stats Ethernet16
+        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
+  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------  --------  -------------------  -----------
   Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13  1.24e-10       6.03e-09 (79%)      3.12e-05
   ```
 

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -40,8 +40,12 @@ def readJsonFile(fileName):
     return result
 
 
-def try_convert_interfacename_from_alias(ctx, interfacename):
-    """try to convert interface name from alias"""
+def try_convert_interfacename_from_alias(ctx, interfacename, check_db=False):
+    """
+    Try to convert interface name from alias
+
+    If `check_db` is true, this function will check if `interfacename` exists in CONFIG_DB
+    """
 
     if clicommon.get_interface_naming_mode() == "alias":
         alias = interfacename
@@ -50,6 +54,10 @@ def try_convert_interfacename_from_alias(ctx, interfacename):
         # the port name for the alias
         if interfacename == alias:
             ctx.fail("cannot find interface name for alias {}".format(alias))
+    elif check_db:
+        port_dict = multi_asic.get_port_table(namespace=None)
+        if not port_dict or interfacename not in port_dict:
+            ctx.fail("interface {} does not exist".format(interfacename))
 
     return interfacename
 
@@ -775,9 +783,8 @@ def error_status(db, interfacename, fetch_from_hardware, namespace, verbose):
 # counters group ("show interfaces counters ...")
 #
 
-@interfaces.group(invoke_without_command=True)
+@interfaces.group(cls=clicommon.CountersGroup, invoke_without_command=True)
 @multi_asic_util.multi_asic_click_options
-@click.option('-i', '--interface', help="Filter by interface name")
 @click.option('-a', '--printall', is_flag=True, help="Show all counters")
 @click.option('-p', '--period', type=click.INT, help="Display statistics over a specified period (in seconds)")
 @click.option('-j', '--json', 'json_fmt', is_flag=True, help="Print in JSON format")
@@ -795,7 +802,7 @@ def counters(ctx, namespace, display, interface, printall, period, json_fmt, ver
         if period is not None:
             cmd += ['-p', str(period)]
         if interface is not None:
-            interface = try_convert_interfacename_from_alias(ctx, interface)
+            interface = try_convert_interfacename_from_alias(ctx, interface, check_db=True)
             cmd += ['-i', str(interface)]
             if multi_asic.is_multi_asic():
                 cmd += ['-s', str(display)]
@@ -814,10 +821,12 @@ def counters(ctx, namespace, display, interface, printall, period, json_fmt, ver
 # 'errors' subcommand ("show interfaces counters errors")
 @counters.command()
 @multi_asic_util.multi_asic_click_options
+@click.argument('interface', required=False)
 @click.option('-p', '--period', type=click.INT, help="Display statistics over a specified period (in seconds)")
 @click.option('-j', '--json', 'json_fmt', is_flag=True, help="Print in JSON format")
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def errors(namespace, display, period, json_fmt, verbose):  # noqa: F811
+@click.pass_context
+def errors(ctx, namespace, display, interface, period, json_fmt, verbose):  # noqa: F811
     """Show interface counters errors"""
 
     cmd = ['portstat', '-e']
@@ -825,7 +834,14 @@ def errors(namespace, display, period, json_fmt, verbose):  # noqa: F811
     if period is not None:
         cmd += ['-p', str(period)]
 
-    cmd += ['-s', str(display)]
+    if interface is not None:
+        interface = try_convert_interfacename_from_alias(ctx, interface, check_db=True)
+        cmd += ['-i', str(interface)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-s', str(display)]
+    else:
+        cmd += ['-s', str(display)]
+
     if namespace is not None:
         cmd += ['-n', str(namespace)]
 
@@ -838,19 +854,28 @@ def errors(namespace, display, period, json_fmt, verbose):  # noqa: F811
 # 'fec-stats' subcommand ("show interfaces counters errors")
 @counters.command('fec-stats')
 @multi_asic_util.multi_asic_click_options
+@click.argument('interface', required=False)
 @click.option('-p', '--period', type=click.INT, help="Display statistics over a specified period (in seconds)")
 @click.option('-j', '--json', 'json_fmt', is_flag=True, help="Print in JSON format")
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 @click.option('--nonzero', is_flag=True, help="Only display non zero counters")
-def fec_stats(namespace, display, period, json_fmt, verbose, nonzero):
+@click.pass_context
+def fec_stats(ctx, namespace, display, interface, period, json_fmt, verbose, nonzero):
     """Show interface counters fec-stats"""
 
     cmd = ['portstat', '-f']
 
+    if interface is not None:
+        interface = try_convert_interfacename_from_alias(ctx, interface, check_db=True)
+        cmd += ['-i', str(interface)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-s', str(display)]
+    else:
+        cmd += ['-s', str(display)]
+
     if period is not None:
         cmd += ['-p', str(period)]
 
-    cmd += ['-s', str(display)]
     if namespace is not None:
         cmd += ['-n', str(namespace)]
 
@@ -921,17 +946,26 @@ def fec_histogram(db, interfacename, namespace, display):
 # 'rates' subcommand ("show interfaces counters rates")
 @counters.command()
 @multi_asic_util.multi_asic_click_options
+@click.argument('interface', required=False)
 @click.option('-p', '--period', type=click.INT, help="Display statistics over a specified period (in seconds)")
 @click.option('-j', '--json', 'json_fmt', is_flag=True, help="Print in JSON format")
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
-def rates(namespace, display, period, json_fmt, verbose):
+@click.pass_context
+def rates(ctx, namespace, display, interface, period, json_fmt, verbose):
     """Show interface counters rates"""
 
     cmd = ['portstat', '-R']
 
+    if interface is not None:
+        interface = try_convert_interfacename_from_alias(ctx, interface, check_db=True)
+        cmd += ['-i', str(interface)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-s', str(display)]
+    else:
+        cmd += ['-s', str(display)]
+
     if period is not None:
         cmd += ['-p', str(period)]
-    cmd += ['-s', str(display)]
     if namespace is not None:
         cmd += ['-n', str(namespace)]
     if json_fmt:

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -465,7 +465,7 @@ class TestPortStat(object):
     def test_show_intf_counters_ethernet4(self):
         runner = CliRunner()
         result = runner.invoke(
-            show.cli.commands["interfaces"].commands["counters"], ["-i", "Ethernet4"])
+            show.cli.commands["interfaces"].commands["counters"], ["Ethernet4"])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
@@ -507,6 +507,33 @@ class TestPortStat(object):
         print("result = {}".format(result))
         assert return_code == 0
         assert result == intf_fec_counters
+
+    def test_show_intf_fec_counters_interface_filter(self):
+        remove_tmp_cnstat_file()
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["fec-stats"], ["Ethernet4"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Ethernet4" in result.output
+        assert "Ethernet0" not in result.output
+        assert "Ethernet8" not in result.output
+
+        return_code, portstat_result = get_result_and_return_code(['portstat', '-f', '-i', 'Ethernet4'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(portstat_result))
+        assert return_code == 0
+        assert portstat_result == result.output
+
+    def test_show_intf_fec_counters_invalid_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["fec-stats"], ["InvalidEth"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "interface InvalidEth does not exist" in result.output
 
     def test_show_intf_counters_fec_histogram(self):
         runner = CliRunner()
@@ -804,6 +831,59 @@ class TestPortStat(object):
         print("result = {}".format(result))
         assert return_code == 0
         assert result == intf_rates_nonzero
+
+    def test_show_intf_rates_interface_filter(self):
+        remove_tmp_cnstat_file()
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["rates"], ["Ethernet4"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Ethernet4" in result.output
+        assert "Ethernet0" not in result.output
+        assert "Ethernet8" not in result.output
+
+        return_code, portstat_result = get_result_and_return_code(['portstat', '-R', '-i', 'Ethernet4'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(portstat_result))
+        assert return_code == 0
+        assert portstat_result == result.output
+
+    def test_show_intf_rates_invalid_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["rates"], ["InvalidEth"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "interface InvalidEth does not exist" in result.output
+
+    def test_show_intf_errors_interface_filter(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["errors"], ["Ethernet4"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Ethernet4" in result.output
+        assert "Ethernet0" not in result.output
+        assert "Ethernet8" not in result.output
+
+        return_code, portstat_result = get_result_and_return_code(['portstat', '-e', '-i', 'Ethernet4'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(portstat_result))
+        assert return_code == 0
+        assert portstat_result == result.output
+
+    def test_show_intf_errors_invalid_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["interfaces"].commands["counters"].commands["errors"], ["InvalidEth"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "interface InvalidEth does not exist" in result.output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -570,12 +570,16 @@ class TestShowInterfaces(object):
     @patch.object(click.Choice, 'convert', MagicMock(return_value='asic0'))
     def test_counters(self, mock_run_command):
         runner = CliRunner()
-        result = runner.invoke(show.cli.commands['interfaces'].commands['counters'], ['-i', 'Ethernet0', '-p', '3', '-a', '-n', 'asic0', '--verbose'])
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'],
+            ['Ethernet0', '-p', '3', '-a', '-n', 'asic0', '--verbose'],
+        )
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['portstat', '-a', '-p', '3', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=True)
 
+    @patch('show.interfaces.try_convert_interfacename_from_alias', lambda ctx, intfname, check_db=False: intfname)
     @patch('utilities_common.cli.run_command')
     @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
     @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
@@ -583,7 +587,7 @@ class TestShowInterfaces(object):
         runner = CliRunner()
         result = runner.invoke(
             show.cli.commands['interfaces'].commands['counters'],
-            ['-i', 'Ethernet-BP0', '-p', '3', '-a', '-d', 'all', '--verbose'],
+            ['Ethernet-BP0', '-p', '3', '-a', '-d', 'all', '--verbose'],
         )
 
         print(result.exit_code)
@@ -603,6 +607,41 @@ class TestShowInterfaces(object):
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['portstat', '-e', '-p', '3', '-s', 'all'], display_cmd=True)
 
+    @patch('show.interfaces.try_convert_interfacename_from_alias', lambda ctx, intfname, check_db=False: intfname)
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_counters_error(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'].commands['errors'],
+            ['-p', '3', 'Ethernet-BP0', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['portstat', '-e', '-p', '3', '-i', 'Ethernet-BP0', '-s', 'all'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
+    def test_counters_error_interface_filter(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'].commands['errors'],
+            ['Ethernet0', '-p', '3', '--verbose'],
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['portstat', '-e', '-p', '3', '-i', 'Ethernet0'],
+            display_cmd=True,
+        )
+
+    @patch('show.interfaces.try_convert_interfacename_from_alias', lambda ctx, intfname, check_db=False: intfname)
     @patch('utilities_common.cli.run_command')
     def test_counters_rates(self, mock_run_command):
         runner = CliRunner()
@@ -610,7 +649,86 @@ class TestShowInterfaces(object):
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        mock_run_command.assert_called_once_with(['portstat', '-R', '-p', '3', '-s', 'all'], display_cmd=True)
+        mock_run_command.assert_called_once_with(['portstat', '-R', '-s', 'all', '-p', '3'], display_cmd=True)
+
+    @patch('show.interfaces.try_convert_interfacename_from_alias', lambda ctx, intfname, check_db=False: intfname)
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_counters_rates(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'].commands['rates'],
+            ['-p', '3', 'Ethernet-BP0', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['portstat', '-R', '-i', 'Ethernet-BP0', '-s', 'all', '-p', '3'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
+    def test_counters_rates_interface_filter(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'].commands['rates'],
+            ['Ethernet0', '-p', '3', '--verbose'],
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['portstat', '-R', '-i', 'Ethernet0', '-p', '3'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
+    def test_counters_fec_stats(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'].commands['fec-stats'],
+            ['-p', '3', '--verbose'],
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(['portstat', '-f', '-s', 'all', '-p', '3'], display_cmd=True)
+
+    @patch('show.interfaces.try_convert_interfacename_from_alias', lambda ctx, intfname, check_db=False: intfname)
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_counters_fec_stats(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'].commands['fec-stats'],
+            ['Ethernet-BP0', '-p', '3', '--verbose'],
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['portstat', '-f', '-i', 'Ethernet-BP0', '-s', 'all', '-p', '3'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
+    def test_counters_fec_stats_interface_filter(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'].commands['fec-stats'],
+            ['Ethernet0', '-p', '3', '--verbose'],
+        )
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['portstat', '-f', '-i', 'Ethernet0', '-p', '3'],
+            display_cmd=True,
+        )
 
     @patch('utilities_common.cli.run_command')
     def test_counters_detailed(self, mock_run_command):

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -126,6 +126,45 @@ class AliasedGroup(click.Group):
         ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 
+class CountersGroup(click.Group):
+    """
+    This subclass of click.Group supports `show interfaces counters` commands
+    with interface name as a positional argument
+    """
+    def format_usage(self, ctx, formatter):
+        formatter.write_usage(ctx.command_path, "[OPTIONS] [INTERFACE]")
+        formatter.write_usage(ctx.command_path, "[OPTIONS] COMMAND [ARGS]...")
+
+    def parse_args(self, ctx, args):
+        args = list(args)
+
+        value_opts = []
+        for param in self.params:
+            if isinstance(param, click.Option) and not param.is_flag:
+                value_opts += param.opts
+        # set of options that take in a value, unlike boolean flags
+        value_opts = set(value_opts)
+
+        interface = None
+        i = 0
+        while i < len(args):
+            arg = args[i]
+            if arg.startswith('-'):
+                i += 2 if arg in value_opts else 1
+                continue
+
+            # if a valid command, delegate rest of args to that sub-command
+            if arg in self.commands:
+                break
+            interface = arg
+            i += 1
+
+        if interface is not None:
+            args.remove(interface)
+        ctx.params['interface'] = interface
+        return super().parse_args(ctx, args)
+
+
 class InterfaceAliasConverter(object):
     """Class which handles conversion between interface name and alias"""
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

fixes #4501 

Added per-interface filtering for the `show interface counters` suite of commands (for ones that didn't already have this feature)

#### How I did it

in `interfaces/__init__.py`, I updated `counters` sub-commands that didn't support per-interface filtering to take in an optional `INTERFACE` positional argument.

I added per-interface filtering support for the following commands:
- `show interfaces counters errors`
- `show interfaces counters fec-stats`
- `show interfaces counters rates`
- `show interfaces counters` was also updated to use a positional argument instead of the `-i` flag

This filtering functionality already existed for the other sub-commands. After discussions it was decided that it'd be best to keep the CLI consistent (with other CLI commands that provide per-interface filtering) by providing filtering capabilities via positional arguments rather than a flag. 

#### How to verify it

on a DUT:
```sh
# display single-row table for Ethernet0
show interfaces counters Ethernet0

# display single-row errors table for Ethernet0
show interfaces counters errors Ethernet0

# display single-row table with tx/rx rates
show interfaces counters rates Ethernet0 

# display single-row table for FEC data
show interfaces counters fec-stats Ethernet0
```

#### Previous command output (if the output of a command-line utility has changed)

Running `show interfaces counters Ethernet0` would spit out a message saying something along the lines of "Ethernet0 is not a valid command".

Running `show interfaces counters errors Ethernet0` would ignore the interface argument, and print out the counters table for all admin-up interfaces

#### New command output (if the output of a command-line utility has changed)

```
$ show interfaces counters Ethernet0
    IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
---------  -------  -------  --------  ---------  --------  --------  --------  -------  --------  ---------  --------  --------  --------
Ethernet0        X        0  0.00 B/s      0.00%         0         0         0        0  0.00 B/s      0.00%         0         0         0

$ show interfaces counters errors Ethernet0
    IFACE    STATE    RX_ERR    RX_DRP    RX_OVR    TX_ERR    TX_DRP    TX_OVR
---------  -------  --------  --------  --------  --------  --------  --------
Ethernet0        X         0         0         0         0         0         0

$ show interfaces counters fec-stats Ethernet0
    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX    FLR(O)    FLR(P) (Accuracy)    FEC_MAX_T
---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------  --------  -------------------  -----------
Ethernet0        X         N/A           N/A               N/A            N/A             N/A                N/A       N/A                  N/A          N/A

$ show interfaces counters rates Ethernet0
    IFACE    STATE    RX_OK    RX_BPS    RX_PPS    RX_UTIL    TX_OK    TX_BPS    TX_PPS    TX_UTIL
---------  -------  -------  --------  --------  ---------  -------  --------  --------  ---------
Ethernet0        X        0  0.00 B/s    0.00/s      0.00%        0  0.00 B/s    0.00/s      0.00%
```
