### PR TITLE
Allow `show techsupport` to save with a custom filename

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -14772,8 +14772,10 @@ Resulting archive file is saved as `/var/dump/<DEVICE_HOST_NAME>_YYYYMMDD_HHMMSS
 
 - Example:
   ```
-  admin@sonic:~$ show techsupport [--since=<time_specifier>]
+  admin@sonic:~$ show techsupport [--since=<time_specifier>] [--filename=<file_name>]
   ```
+
+With the `--filename` option, files will be saved under `/var/dump/<file_name>`. Passing in filenames with path components will be rejected. 
 
 If the SONiC system was running for quite some time `show techsupport` will produce a large dump file. To reduce the amount of syslog and core files gathered during system dump use `--since` option:
 
@@ -14783,6 +14785,9 @@ If the SONiC system was running for quite some time `show techsupport` will prod
   ```
   ```
   admin@sonic:~$ show techsupport --since='hour ago' # Will collect syslog and core files for the last one hour
+  ```
+  ```
+  admin@sonic:~$ show techsupport --filename=custom_name # saved under /var/dump/custom_name.tar.gz
   ```
 
 ### Debug Dumps

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2904,30 +2904,15 @@ OPTIONS
         Redirect any intermediate errors to STDERR
     -d
         Collect the output of debug dump cli
-<<<<<<< HEAD
-=======
-    -T
-        Enable tcpdump capture during techsupport collection
-    -P PERIOD
-        Duration in seconds for tcpdump capture (default: 60). Requires -T
-    -L LIMIT
-        Maximum number of packets to capture (default: 10000). Requires -T
-    -F FILTER
-        BPF filter expression for tcpdump (e.g., 'port 179', 'udp port 3784'). Requires -T
     -f FILENAME
         Base name for the output dump file (default: sonic_dump_<hostname>_<timestamp>).
         The file will be created as $DUMPDIR/<FILENAME>.tar[.gz].
         WARN: if the file already exists, this command will fail and exit.
->>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
 EOF
 }
 
 
-<<<<<<< HEAD
-while getopts ":xnvhzas:t:r:d" opt; do
-=======
-while getopts ":xnvhzas:t:r:dTP:L:F:f:" opt; do
->>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
+while getopts ":xnvhzas:t:r:d:f:" opt; do
     case $opt in
         x)
             # enable bash debugging
@@ -2978,32 +2963,6 @@ while getopts ":xnvhzas:t:r:dTP:L:F:f:" opt; do
         d)
             DEBUG_DUMP=true
             ;;
-<<<<<<< HEAD
-        /?)
-=======
-        T)
-            WITH_TCPDUMP=true
-            ;;
-        P)
-            if ! [[ ${OPTARG} =~ ^[0-9]+$ ]]; then
-                echo "Invalid tcpdump duration value: ${OPTARG}, Please enter a numeric value."
-                exit $EXT_GENERAL
-            fi
-            TCPDUMP_DURATION="${OPTARG}"
-            TCPDUMP_DURATION_SET=true
-            ;;
-        L)
-            if ! [[ ${OPTARG} =~ ^[0-9]+$ ]]; then
-                echo "Invalid tcpdump packet limit value: ${OPTARG}, Please enter a numeric value."
-                exit $EXT_GENERAL
-            fi
-            TCPDUMP_PACKET_LIMIT="${OPTARG}"
-            TCPDUMP_PACKET_LIMIT_SET=true
-            ;;
-        F)
-            TCPDUMP_FILTER="${OPTARG}"
-            TCPDUMP_FILTER_SET=true
-            ;;
         f)
             BASE="${OPTARG}"
             if [[ "$BASE" == */* ]]; then
@@ -3025,15 +2984,12 @@ while getopts ":xnvhzas:t:r:dTP:L:F:f:" opt; do
             fi
             ;;
         \?)
->>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
             echo "Invalid option: -$OPTARG" >&2
             exit $EXT_GENERAL
             ;;
     esac
 done
 
-<<<<<<< HEAD
-=======
 if $CUSTOM_FILENAME_SET; then
     if $DO_COMPRESS && [[ -f ${TARFILE}.gz ]]; then
         echo "WARNING: ${TARFILE}.gz already exists, aborting without dumping." >&2
@@ -3044,23 +3000,6 @@ if $CUSTOM_FILENAME_SET; then
     fi
 fi
 
-# Validate that tcpdump options (-P, -L, -F) require -T to be specified
-if ! $WITH_TCPDUMP; then
-    if $TCPDUMP_DURATION_SET; then
-        echo "Error: -P (tcpdump duration) requires -T (enable tcpdump) to be specified" >&2
-        exit $EXT_INVALID_ARGUMENT
-    fi
-    if $TCPDUMP_PACKET_LIMIT_SET; then
-        echo "Error: -L (tcpdump packet limit) requires -T (enable tcpdump) to be specified" >&2
-        exit $EXT_INVALID_ARGUMENT
-    fi
-    if $TCPDUMP_FILTER_SET; then
-        echo "Error: -F (tcpdump filter) requires -T (enable tcpdump) to be specified" >&2
-        exit $EXT_INVALID_ARGUMENT
-    fi
-fi
-
->>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
 # Check permissions before proceeding further
 if [ `whoami` != root ] && ! $NOOP;
 then

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -49,6 +49,7 @@ TIMEOUT_MIN="5"
 SKIP_BCMCMD=0
 SAVE_STDERR=true
 RETURN_CODE=$EXT_SUCCESS
+CUSTOM_FILENAME_SET=false
 DEBUG_DUMP=false
 ROUTE_TAB_LIMIT_DIRECT_ITERATION=24000
 IS_SUPERVISOR=false
@@ -2903,11 +2904,30 @@ OPTIONS
         Redirect any intermediate errors to STDERR
     -d
         Collect the output of debug dump cli
+<<<<<<< HEAD
+=======
+    -T
+        Enable tcpdump capture during techsupport collection
+    -P PERIOD
+        Duration in seconds for tcpdump capture (default: 60). Requires -T
+    -L LIMIT
+        Maximum number of packets to capture (default: 10000). Requires -T
+    -F FILTER
+        BPF filter expression for tcpdump (e.g., 'port 179', 'udp port 3784'). Requires -T
+    -f FILENAME
+        Base name for the output dump file (default: sonic_dump_<hostname>_<timestamp>).
+        The file will be created as $DUMPDIR/<FILENAME>.tar[.gz].
+        WARN: if the file already exists, this command will fail and exit.
+>>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
 EOF
 }
 
 
+<<<<<<< HEAD
 while getopts ":xnvhzas:t:r:d" opt; do
+=======
+while getopts ":xnvhzas:t:r:dTP:L:F:f:" opt; do
+>>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
     case $opt in
         x)
             # enable bash debugging
@@ -2958,13 +2978,89 @@ while getopts ":xnvhzas:t:r:d" opt; do
         d)
             DEBUG_DUMP=true
             ;;
+<<<<<<< HEAD
         /?)
+=======
+        T)
+            WITH_TCPDUMP=true
+            ;;
+        P)
+            if ! [[ ${OPTARG} =~ ^[0-9]+$ ]]; then
+                echo "Invalid tcpdump duration value: ${OPTARG}, Please enter a numeric value."
+                exit $EXT_GENERAL
+            fi
+            TCPDUMP_DURATION="${OPTARG}"
+            TCPDUMP_DURATION_SET=true
+            ;;
+        L)
+            if ! [[ ${OPTARG} =~ ^[0-9]+$ ]]; then
+                echo "Invalid tcpdump packet limit value: ${OPTARG}, Please enter a numeric value."
+                exit $EXT_GENERAL
+            fi
+            TCPDUMP_PACKET_LIMIT="${OPTARG}"
+            TCPDUMP_PACKET_LIMIT_SET=true
+            ;;
+        F)
+            TCPDUMP_FILTER="${OPTARG}"
+            TCPDUMP_FILTER_SET=true
+            ;;
+        f)
+            BASE="${OPTARG}"
+            if [[ "$BASE" == */* ]]; then
+                echo "ERROR: Invalid filename ${BASE}, filename must be a plain name with no path component." >&2
+                exit $EXT_GENERAL
+            fi
+            TARDIR=$DUMPDIR/$BASE
+            TARFILE=$DUMPDIR/$BASE.tar
+            LOGDIR=$DUMPDIR/$BASE/dump
+            CUSTOM_FILENAME_SET=true
+
+            # avoid dumps with redundant file extensions like "customname.tar.gz.tar.gz"
+            if [[ "$BASE" == *.tar.gz ]]; then
+                BASE="${BASE%.tar.gz}".
+                echo "INFO: Pruning redundant file extension '.tar.gz' from filename; dump will be saved under '${TARFILE}.gz'" >&2
+            elif [[ "$BASE" == *.tar ]]; then
+                BASE="${BASE%.tar}"
+                echo "INFO: Pruning redundant file extension '.tar' from filename; dump will be saved under '${TARFILE}'" >&2
+            fi
+            ;;
+        \?)
+>>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
             echo "Invalid option: -$OPTARG" >&2
             exit $EXT_GENERAL
             ;;
     esac
 done
 
+<<<<<<< HEAD
+=======
+if $CUSTOM_FILENAME_SET; then
+    if $DO_COMPRESS && [[ -f ${TARFILE}.gz ]]; then
+        echo "WARNING: ${TARFILE}.gz already exists, aborting without dumping." >&2
+        exit $EXT_GENERAL
+    elif ! $DO_COMPRESS && [[ -f $TARFILE ]]; then
+        echo "WARNING: $TARFILE already exists, aborting without dumping." >&2
+        exit $EXT_GENERAL
+    fi
+fi
+
+# Validate that tcpdump options (-P, -L, -F) require -T to be specified
+if ! $WITH_TCPDUMP; then
+    if $TCPDUMP_DURATION_SET; then
+        echo "Error: -P (tcpdump duration) requires -T (enable tcpdump) to be specified" >&2
+        exit $EXT_INVALID_ARGUMENT
+    fi
+    if $TCPDUMP_PACKET_LIMIT_SET; then
+        echo "Error: -L (tcpdump packet limit) requires -T (enable tcpdump) to be specified" >&2
+        exit $EXT_INVALID_ARGUMENT
+    fi
+    if $TCPDUMP_FILTER_SET; then
+        echo "Error: -F (tcpdump filter) requires -T (enable tcpdump) to be specified" >&2
+        exit $EXT_INVALID_ARGUMENT
+    fi
+fi
+
+>>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
 # Check permissions before proceeding further
 if [ `whoami` != root ] && ! $NOOP;
 then

--- a/show/main.py
+++ b/show/main.py
@@ -1786,20 +1786,8 @@ def users(verbose):
 @click.option('--silent', is_flag=True, help="Run techsupport in silent mode")
 @click.option('--debug-dump', is_flag=True, help="Collect Debug Dump Output")
 @click.option('--redirect-stderr', '-r', is_flag=True, help="Redirect an intermediate errors to STDERR")
-<<<<<<< HEAD
-def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent, debug_dump, redirect_stderr):
-=======
-@click.option('--with-tcpdump', is_flag=True, help="Capture traffic with tcpdump during techsupport")
-@click.option('--tcpdump-duration', 'tcpdump_duration', type=click.IntRange(1, 300), default=None,
-              help="Duration in seconds for tcpdump capture (default: 60, range: 1-300). Requires --with-tcpdump")
-@click.option('--tcpdump-packet-limit', 'tcpdump_packet_limit', type=click.IntRange(1, 100000), default=None,
-              help="Maximum number of packets to capture (default: 10000, range: 1-100000). Requires --with-tcpdump")
-@click.option('--tcpdump-filter', 'tcpdump_filter', type=str, default=None,
-              help="BPF filter expression for tcpdump (e.g., 'port 179', 'udp port 3784'). Requires --with-tcpdump")
-def techsupport(since, filename, global_timeout, cmd_timeout, verbose,
-                allow_process_stop, silent, debug_dump, redirect_stderr,
-                with_tcpdump, tcpdump_duration, tcpdump_packet_limit, tcpdump_filter):
->>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
+def techsupport(since, filename, global_timeout, cmd_timeout, 
+                verbose, allow_process_stop, silent, debug_dump, redirect_stderr):
     """Gather information for troubleshooting"""
     cmd = ["sudo"]
 

--- a/show/main.py
+++ b/show/main.py
@@ -1786,7 +1786,7 @@ def users(verbose):
 @click.option('--silent', is_flag=True, help="Run techsupport in silent mode")
 @click.option('--debug-dump', is_flag=True, help="Collect Debug Dump Output")
 @click.option('--redirect-stderr', '-r', is_flag=True, help="Redirect an intermediate errors to STDERR")
-def techsupport(since, filename, global_timeout, cmd_timeout, 
+def techsupport(since, filename, global_timeout, cmd_timeout,
                 verbose, allow_process_stop, silent, debug_dump, redirect_stderr):
     """Gather information for troubleshooting"""
     cmd = ["sudo"]

--- a/show/main.py
+++ b/show/main.py
@@ -1777,6 +1777,8 @@ def users(verbose):
 
 @cli.command()
 @click.option('--since', required=False, help="Collect logs and core files since given date")
+@click.option('-f', '--filename', required=False,
+              help="Custom dump filename under /var/dump. WARN: if file already exists, this command will abort.")
 @click.option('-g', '--global-timeout', required=False, type=int, help="Global timeout in minutes. WARN: Dump might be incomplete if enforced")
 @click.option('-c', '--cmd-timeout', default=5, type=int, help="Individual command timeout in minutes. Default 5 mins")
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
@@ -1784,7 +1786,20 @@ def users(verbose):
 @click.option('--silent', is_flag=True, help="Run techsupport in silent mode")
 @click.option('--debug-dump', is_flag=True, help="Collect Debug Dump Output")
 @click.option('--redirect-stderr', '-r', is_flag=True, help="Redirect an intermediate errors to STDERR")
+<<<<<<< HEAD
 def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop, silent, debug_dump, redirect_stderr):
+=======
+@click.option('--with-tcpdump', is_flag=True, help="Capture traffic with tcpdump during techsupport")
+@click.option('--tcpdump-duration', 'tcpdump_duration', type=click.IntRange(1, 300), default=None,
+              help="Duration in seconds for tcpdump capture (default: 60, range: 1-300). Requires --with-tcpdump")
+@click.option('--tcpdump-packet-limit', 'tcpdump_packet_limit', type=click.IntRange(1, 100000), default=None,
+              help="Maximum number of packets to capture (default: 10000, range: 1-100000). Requires --with-tcpdump")
+@click.option('--tcpdump-filter', 'tcpdump_filter', type=str, default=None,
+              help="BPF filter expression for tcpdump (e.g., 'port 179', 'udp port 3784'). Requires --with-tcpdump")
+def techsupport(since, filename, global_timeout, cmd_timeout, verbose,
+                allow_process_stop, silent, debug_dump, redirect_stderr,
+                with_tcpdump, tcpdump_duration, tcpdump_packet_limit, tcpdump_filter):
+>>>>>>> 4d8fde59 (NOS-6386: Allow show techsupport to save with a custom filename (#417))
     """Gather information for troubleshooting"""
     cmd = ["sudo"]
 
@@ -1796,6 +1811,11 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
         click.echo("Techsupport is running with silent option. This command might take a long time.")
     else:
         cmd += ['generate_dump', '-v']
+
+    if filename:
+        if '/' in filename:
+            raise click.UsageError("-f/--filename requires a file name with no path components")
+        cmd += ["-f", filename]
 
     if allow_process_stop:
         cmd += ["-a"]

--- a/tests/techsupport_test.py
+++ b/tests/techsupport_test.py
@@ -1,6 +1,6 @@
 import pytest
 import show.main
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 from click.testing import CliRunner
 
 EXPECTED_BASE_COMMAND = ['sudo']
@@ -15,6 +15,7 @@ EXPECTED_BASE_COMMAND = ['sudo']
             (['--allow-process-stop'], ['generate_dump', '-v', '-a', '-t', '5']),
             (['--silent'], ['generate_dump', '-t', '5']),
             (['--debug-dump', '--redirect-stderr'], ['generate_dump', '-v', '-d', '-t', '5', '-r']),
+            (['-f', 'custom-filename'], ['generate_dump', '-v', '-f', 'custom-filename', '-t', '5'])
         ]
 )
 def test_techsupport(run_command, cli_arguments, expected):
@@ -22,3 +23,18 @@ def test_techsupport(run_command, cli_arguments, expected):
     result = runner.invoke(show.main.cli.commands['techsupport'], cli_arguments)
     run_command.assert_called_with(EXPECTED_BASE_COMMAND + expected, display_cmd=False)
 
+
+@patch("show.main.run_command")
+@pytest.mark.parametrize(
+    "cli_arguments,expected_msg",
+    [
+        (['-f', '/other/dir/custom-filename'], "no path components"),
+        (['-f', '../relative/filepath'], "no path components"),
+    ]
+)
+def test_techsupport_filepath(run_command, cli_arguments, expected_msg):
+    runner = CliRunner()
+    result = runner.invoke(show.main.cli.commands['techsupport'], cli_arguments)
+    assert result.exit_code != 0
+    assert expected_msg in result.output
+    run_command.assert_not_called()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

fixes #4503 
added the ability to specify custom techsupport dump filenames

#### How I did it

- Added support for an optional `-f/--filename` flag for `show techsupport`.
- updated `generate_dump` script to take in the same flag

In the event of filename collisions, `generate_dump` will log the warning to stdout, and exit with code 1 without overwriting.

#### How to verify it

on a DUT:
```sh
show techsupport -f testdump

# verify the dump appeared
ls -l /var/dump | grep testdump
```

#### Previous command output (if the output of a command-line utility has changed)

The `--filename` flag wasn't supported before this PR, so the command would error out.

#### New command output (if the output of a command-line utility has changed)

```sh
$ show techsupport -f testdump
Lock successfully acquired and installed signal handlers
mkdir: created directory '/var/dump/testdump'
'/var/dump/testdump/generate_dump' -> '/usr/local/bin/generate_dump'

...

Cleaning up working directory /var/dump/testdump
Removing lock. Exit: 0
removed '/tmp/techsupport-lock/PID'
removed directory '/tmp/techsupport-lock'
/var/dump/testdump.tar.gz
```


