### PR TITLE
generate_dump: exclude credentials directory from techsupport dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2710,7 +2710,8 @@ main() {
     $TARDIR/etc/ssh* $TARDIR/etc/mlnx $TARDIR/etc/mft \
     $TARDIR/etc/ssl/certs/* $TARDIR/etc/ssl/private/*
     rm_list=$(find -L $TARDIR -type f \( -iname \*.cer -o -iname \*.crt -o \
-        -iname \*.pem -o -iname \*.key -o -iname \*snmpd.conf\* -o -iname \*get_creds\* \))
+        -iname \*.pem -o -iname \*.key -o -iname \*snmpd.conf\* -o -iname \*get_creds\* \
+        -o -path \*/credentials/\* \))
     if [ ! -z "$rm_list" ]
     then
         rm $rm_list

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2710,7 +2710,7 @@ main() {
     $TARDIR/etc/ssh* $TARDIR/etc/mlnx $TARDIR/etc/mft \
     $TARDIR/etc/ssl/certs/* $TARDIR/etc/ssl/private/*
     rm_list=$(find -L $TARDIR -type f \( -iname \*.cer -o -iname \*.crt -o \
-        -iname \*.pem -o -iname \*.key -o -iname \*snmpd.conf\* -o -iname \*get_creds\* \
+        -iname \*.pem -o -iname \*.key -o -iname \*.pfx -o -iname \*snmpd.conf\* -o -iname \*get_creds\* \
         -o -path \*/credentials/\* \))
     if [ ! -z "$rm_list" ]
     then


### PR DESCRIPTION
#### What I did

Files under `/etc/sonic/credentials/` and `/etc/sonic/old_config/credentials/` contain private keys. These were being included verbatim in techsupport bundles.

Added `-path */credentials/*` to the existing `rm_list` find expression so all files in those directories are deleted from the dump.

#### How I did it

Extended the existing `find` command in `main()` that already removes `*.key`, `*.pem`, `*.cer`, `*.crt`, and `etc/ssh*` files. One extra `-o -path \*/credentials/\*` term covers all files under any `credentials/` directory recursively, regardless of filename or extension.

#### How to verify it

Create dummy credential files in a staging dir and run the find expression manually:

```bash
tmpdir=/tmp/tmp.kxFluBt64t
mkdir -p /etc/sonic/credentials/subdir
touch /etc/sonic/credentials/restapiserver.key
touch /etc/sonic/credentials/restapiserver.key.1
touch /etc/sonic/credentials/subdir/nested.key
mkdir -p /etc/sonic/old_config/credentials
touch /etc/sonic/old_config/credentials/restapiserver.key

find -L  -type f \( -iname \*.cer -o -iname \*.crt -o     -iname \*.pem -o -iname \*.key -o -iname \*snmpd.conf\* -o -iname \*get_creds\*     -o -path \*/credentials/\* \)
```

All 5 files should appear in the output and be removed. Tested on KVM VS.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A