### PR TITLE
[pfcwd] fix interval crash on PFC_WD entries missing detection_time/restoration_time

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -345,43 +345,47 @@ class PfcwdCli(object):
     def interval(self, poll_interval):
         if os.geteuid() != 0:
             sys.exit("Root privileges are required for this operation")
-        pfcwd_info = {}
-        if poll_interval is not None:
-            pfcwd_table = self.config_db.get_table(CONFIG_DB_PFC_WD_TABLE_NAME)
-            entry_min = MAX_POLL_INTERVAL_TIME
-            for entry in pfcwd_table:
-                if("Ethernet" not in entry):
-                    continue
-                detection_time_entry_value = int(self.config_db.get_entry(
-                    CONFIG_DB_PFC_WD_TABLE_NAME, entry
-                ).get('detection_time'))
-                restoration_time_entry_value = int(self.config_db.get_entry(
-                    CONFIG_DB_PFC_WD_TABLE_NAME, entry
-                ).get('restoration_time'))
-                if ((detection_time_entry_value is not None) and
-                    (detection_time_entry_value < entry_min)
-                ):
-                    entry_min = detection_time_entry_value
-                    entry_min_str = "detection time"
-                if ((restoration_time_entry_value is not None) and
-                    (restoration_time_entry_value < entry_min)
-                ):
-                    entry_min = restoration_time_entry_value
-                    entry_min_str = "restoration time"
-            if entry_min < poll_interval:
-                click.echo(
-                   "unable to use polling interval = {}ms, value is "
-                   "bigger than one of the configured {} values, "
-                   "please choose a smaller polling_interval".format(
-                        poll_interval, entry_min_str
-                    ), err=True
-                )
-                sys.exit(1)
+        if poll_interval is None:
+            return
 
-            pfcwd_info['POLL_INTERVAL'] = poll_interval
-            self.config_db.mod_entry(
-                CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL", pfcwd_info
+        # An Ethernet entry in PFC_WD may legitimately omit detection_time or
+        # restoration_time (e.g. created by `pfcwd pfc_stat_history` on a port
+        # with no prior PFC_WD config — that path uses mod_entry, which merges
+        # rather than replaces). Skip the field when absent rather than calling
+        # int() on None.
+        pfcwd_table = self.config_db.get_table(CONFIG_DB_PFC_WD_TABLE_NAME)
+        entry_min = MAX_POLL_INTERVAL_TIME
+        entry_min_str = None
+        for entry, fields in pfcwd_table.items():
+            if "Ethernet" not in entry:
+                continue
+            detection_time = fields.get('detection_time')
+            if detection_time is not None:
+                detection_time = int(detection_time)
+                if detection_time < entry_min:
+                    entry_min = detection_time
+                    entry_min_str = "detection time"
+            restoration_time = fields.get('restoration_time')
+            if restoration_time is not None:
+                restoration_time = int(restoration_time)
+                if restoration_time < entry_min:
+                    entry_min = restoration_time
+                    entry_min_str = "restoration time"
+
+        if entry_min < poll_interval:
+            click.echo(
+               "unable to use polling interval = {}ms, value is "
+               "bigger than one of the configured {} values, "
+               "please choose a smaller polling_interval".format(
+                    poll_interval, entry_min_str
+                ), err=True
             )
+            sys.exit(1)
+
+        self.config_db.mod_entry(
+            CONFIG_DB_PFC_WD_TABLE_NAME, "GLOBAL",
+            {'POLL_INTERVAL': poll_interval}
+        )
 
     @multi_asic_util.run_on_multi_asic
     def stop(self, ports):

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -575,6 +575,84 @@ class TestPfcwd(object):
             assert len(result.output) > 0
             assert "QUEUE" in result.output  # Should contain table headers
 
+    @patch('pfcwd.main.os')
+    def test_pfcwd_interval_valid(self, mock_os):
+        # mock has Ethernet0/4/8 with detection_time=600, restoration_time=600;
+        # 100 < 600, so the interval write must succeed.
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        mock_os.geteuid.return_value = 0
+        result = runner.invoke(
+            pfcwd.cli.commands["interval"], ["100"], obj=db
+        )
+        print(result.output)
+        assert result.exit_code == 0, result.output
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == "100"
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_interval_rejects_value_above_detection_time(self, mock_os):
+        # mock has detection_time=600 on every port; 700 must be rejected and
+        # the GLOBAL POLL_INTERVAL must remain at its pre-existing value (600).
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        mock_os.geteuid.return_value = 0
+        result = runner.invoke(
+            pfcwd.cli.commands["interval"], ["700"], obj=db
+        )
+        print(result.output)
+        assert result.exit_code == 1
+        assert "detection time" in result.output
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == "600"
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_interval_partial_entry_no_crash(self, mock_os):
+        # Regression test for NOS-7575. A PFC_WD entry can legitimately exist
+        # without detection_time/restoration_time (e.g. created by
+        # `pfcwd pfc_stat_history` on a port with no prior PFC_WD config —
+        # mod_entry merges, leaving a partial entry). Previously the interval
+        # command crashed with `TypeError: int() argument must be ... not NoneType`
+        # on such entries.
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        # Inject a partial entry containing only pfc_stat_history.
+        db.cfgdb.set_entry("PFC_WD", "Ethernet12", {"pfc_stat_history": "disable"})
+
+        mock_os.geteuid.return_value = 0
+        result = runner.invoke(
+            pfcwd.cli.commands["interval"], ["100"], obj=db
+        )
+        print(result.output)
+        assert result.exit_code == 0, \
+            "interval command crashed on partial PFC_WD entry: {}".format(result.output)
+        assert "Traceback" not in result.output
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == "100"
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_interval_only_partial_entries(self, mock_os):
+        # If every Ethernet entry is partial (no detection/restoration), there
+        # is no constraint to compare against and the write must still succeed.
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        # Strip detection/restoration from every existing PFC_WD|Ethernet* entry.
+        for port in ("Ethernet0", "Ethernet4", "Ethernet8"):
+            db.cfgdb.set_entry("PFC_WD", port, {"pfc_stat_history": "disable"})
+
+        mock_os.geteuid.return_value = 0
+        result = runner.invoke(
+            pfcwd.cli.commands["interval"], ["500"], obj=db
+        )
+        print(result.output)
+        assert result.exit_code == 0, result.output
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == "500"
+
     @classmethod
     def teardown_class(cls):
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])


### PR DESCRIPTION
#### What I did

`config pfcwd interval <N>` crashes with `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` when any Ethernet entry in the `PFC_WD` table is missing `detection_time` or `restoration_time`. After the crash, the polling interval is never written, so every retry reproduces the same failure.

```
Traceback (most recent call last):
  File "/usr/local/bin/pfcwd", line 8, in <module>
    sys.exit(cli())
  ...
  File "/usr/local/lib/python3.13/dist-packages/pfcwd/main.py", line 352, in interval
    detection_time_entry_value = int(self.config_db.get_entry(
        CONFIG_DB_PFC_WD_TABLE_NAME, entry
    ).get('detection_time'))
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

#### Root cause

`PfcwdCli.interval()` did `int(self.config_db.get_entry(...).get('detection_time'))`. When the field is absent, `.get()` returns `None` and `int(None)` raises before the `is not None` check two lines below. The check was meant as a guard but is dead code because of the ordering.

Partial PFC_WD entries are reachable in normal operation: `pfc_stat_history_cmd` writes only `pfc_stat_history` via `configure_ports(..., overwrite=False)` → `mod_entry()`, which merges. On a port with no prior PFC_WD config, that creates an entry with no detection/restoration fields. Subsequent `pfcwd interval` then crashes.

#### How I did it

In `pfcwd/main.py`:
- Read each entry's fields once and skip a field when it is absent, so partial entries no longer crash the command.
- Initialize `entry_min_str = None` to prevent a NameError if the error branch is ever reached without any entry having updated the marker.
- Iterate `pfcwd_table.items()` instead of issuing two extra `get_entry` Redis calls per Ethernet entry.
- Hoist the `if poll_interval is None: return` guard to flatten the function.

In `tests/pfcwd_test.py`, added four cases:
- regression: a partial entry (`{pfc_stat_history: disable}`) must not crash interval.
- all entries partial: no constraint, write must still succeed.
- happy path: interval below detection_time succeeds and `POLL_INTERVAL` is written.
- rejection path: interval above detection_time exits 1 with the expected error message and leaves `POLL_INTERVAL` untouched.

#### How to verify it

```
pytest tests/pfcwd_test.py -k interval -v
```

All four new tests should pass. Existing tests are unaffected.

For an integration test on real hardware: enable `pfc_stat_history` on a port that has no prior PFC_WD entry (this creates a partial entry via the merging `mod_entry` call), then run `sudo config pfcwd interval 100`. Before this change the command crashes with the TypeError above; after, it succeeds and `show pfcwd config` reflects the new polling interval.

#### Previous command output (if the output of a command-line utility has changed)

```
admin@switch:~$ sudo config pfcwd interval 100
Traceback (most recent call last):
  File "/usr/local/bin/pfcwd", line 8, in <module>
    sys.exit(cli())
  ...
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

#### New command output (if the output of a command-line utility has changed)

```
admin@switch:~$ sudo config pfcwd interval 100
admin@switch:~$
```

The existing rejection message for too-large intervals is preserved:

```
admin@switch:~$ sudo config pfcwd interval 700
unable to use polling interval = 700ms, value is bigger than one of the configured detection time values, please choose a smaller polling_interval
```