### PR TITLE
[config]: Fix SNMP service restart failure for consecutive snmptrap/a…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4186,8 +4186,12 @@ def add_snmp_agent_address(ctx, agentip, port, vrf):
     config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', key, {})
 
     #Restarting the SNMP service will regenerate snmpd.conf and rerun snmpd
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+    try:
+        clicommon.run_command(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        clicommon.run_command(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 @snmpagentaddress.command('del')
 @click.argument('agentip', metavar='<SNMP AGENT LISTENING IP Address>', required=True)
@@ -4205,8 +4209,12 @@ def del_snmp_agent_address(ctx, agentip, port, vrf):
         key = key+vrf
     config_db = ctx.obj['db']
     config_db.set_entry('SNMP_AGENT_ADDRESS_CONFIG', key, None)
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+    try:
+        clicommon.run_command(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        clicommon.run_command(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 @config.group(cls=clicommon.AbbreviationGroup)
 @click.pass_context
@@ -4236,8 +4244,12 @@ def modify_snmptrap_server(ctx, ver, serverip, port, vrf, comm):
     else:
         config_db.mod_entry('SNMP_TRAP_CONFIG', "v3TrapDest", {"DestIp": serverip, "DestPort": port, "vrf": vrf, "Community": comm})
 
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+    try:
+        clicommon.run_command(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        clicommon.run_command(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 @snmptrap.command('del')
 @click.argument('ver', metavar='<SNMP Version>', type=click.Choice(['1', '2', '3']), required=True)
@@ -4252,8 +4264,12 @@ def delete_snmptrap_server(ctx, ver):
         config_db.mod_entry('SNMP_TRAP_CONFIG', "v2TrapDest", None)
     else:
         config_db.mod_entry('SNMP_TRAP_CONFIG', "v3TrapDest", None)
-    cmd="systemctl restart snmp"
-    os.system (cmd)
+    try:
+        clicommon.run_command(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        clicommon.run_command(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+    except SystemExit as e:
+        click.echo("Restart service snmp failed with error {}".format(e))
+        raise click.Abort()
 
 
 

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -845,28 +845,105 @@ class TestSNMPConfigCommands(object):
                                               [{'addr': '10.1.0.32', 'netmask': '255.255.255.0',
                                                 'broadcast': '10.1.0.255'}],
                                                 10: [{'addr': 'fe80::1%eth0', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
-    @patch('os.system', mock.Mock(return_value=0))
     def test_config_snmpagentaddress_add_linklocal(self):
         db = Db()
         obj = {'db': db.cfgdb}
         runner = CliRunner()
-        runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1%eth0"], obj=obj)
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["fe80::1%eth0"], obj=obj)
         assert ('fe80::1%eth0', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
         assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "fe80::1%eth0||") == {}
+        assert mock_run_command.call_count == 2
+        mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        mock_run_command.assert_any_call(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
 
     @patch('netifaces.interfaces', mock.Mock(return_value=['eth0']))
     @patch('netifaces.ifaddresses', mock.Mock(return_value={2:
                                               [{'addr': '10.1.0.32', 'netmask': '255.255.255.0',
                                                 'broadcast': '10.1.0.255'}],
                                                 10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
-    @patch('os.system', mock.Mock(return_value=0))
     def test_config_snmpagentaddress_add_ipv4(self):
         db = Db()
         obj = {'db': db.cfgdb}
         runner = CliRunner()
-        runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["10.1.0.32"], obj=obj)
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["10.1.0.32"], obj=obj)
         assert ('10.1.0.32', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
         assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "10.1.0.32||") == {}
+        assert mock_run_command.call_count == 2
+        mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        mock_run_command.assert_any_call(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+
+    @patch('netifaces.interfaces', mock.Mock(return_value=['eth0']))
+    @patch('netifaces.ifaddresses', mock.Mock(return_value={2:
+                                              [{'addr': '10.1.0.32', 'netmask': '255.255.255.0',
+                                                'broadcast': '10.1.0.255'}],
+                                                10: [{'addr': 'fe80::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]}))
+    def test_config_snmpagentaddress_add_restart_failure(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command', side_effect=SystemExit(1)):
+            result = runner.invoke(config.config.commands["snmpagentaddress"].commands["add"], ["10.1.0.32"], obj=obj)
+        assert 'Restart service snmp failed with error' in result.output
+
+    def test_config_snmpagentaddress_del(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            runner.invoke(config.config.commands["snmpagentaddress"].commands["del"], ["10.1.0.32"], obj=obj)
+        assert mock_run_command.call_count == 2
+        mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        mock_run_command.assert_any_call(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+
+    def test_config_snmpagentaddress_del_restart_failure(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command', side_effect=SystemExit(1)):
+            result = runner.invoke(config.config.commands["snmpagentaddress"].commands["del"], ["10.1.0.32"], obj=obj)
+        assert 'Restart service snmp failed with error' in result.output
+
+    def test_config_snmptrap_modify(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["snmptrap"].commands["modify"],
+                                   ["1", "10.1.0.32", "-p", "162", "-v", "mgmt", "-c", "public"], obj=obj)
+        assert result.exit_code == 0
+        assert mock_run_command.call_count == 2
+        mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        mock_run_command.assert_any_call(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+
+    def test_config_snmptrap_modify_restart_failure(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command', side_effect=SystemExit(1)):
+            result = runner.invoke(config.config.commands["snmptrap"].commands["modify"],
+                                   ["1", "10.1.0.32", "-p", "162", "-v", "mgmt", "-c", "public"], obj=obj)
+        assert 'Restart service snmp failed with error' in result.output
+
+    def test_config_snmptrap_del(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["snmptrap"].commands["del"], ["1"], obj=obj)
+        assert result.exit_code == 0
+        assert mock_run_command.call_count == 2
+        mock_run_command.assert_any_call(['systemctl', 'reset-failed', 'snmp.service'], display_cmd=False)
+        mock_run_command.assert_any_call(['systemctl', 'restart', 'snmp.service'], display_cmd=False)
+
+    def test_config_snmptrap_del_restart_failure(self):
+        db = Db()
+        obj = {'db': db.cfgdb}
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command', side_effect=SystemExit(1)):
+            result = runner.invoke(config.config.commands["snmptrap"].commands["del"], ["1"], obj=obj)
+        assert 'Restart service snmp failed with error' in result.output
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
### What I did
Fixed SNMP service restart failure when `config snmptrap del/modify` or `config snmpagentaddress add/del` commands are executed consecutively.

Closes #4514 

### How I did it
Replaced `os.system('systemctl restart snmp')` with `clicommon.run_command()` using `systemctl reset-failed snmp.service` before `systemctl restart snmp.service` in the following functions:
- `add_snmp_agent_address`
- `del_snmp_agent_address`
- `modify_snmptrap_server`
- `delete_snmptrap_server`

This is consistent with the pattern already used by `config snmp community add/del`.

### How to verify it
```bash
# Run consecutive snmptrap config changes
sudo config snmptrap modify 1 -p 1162 -v mgmt -c trap_community1 10.221.64.23
sudo config snmptrap del 1
sudo config snmptrap modify 1 -p 1162 -v mgmt -c trap_community1 10.221.64.23
sudo config snmptrap del 1

# Verify SNMP docker is still running (should show "Up", not "Exited")
docker ps -a | grep snmp

# Verify service is active
systemctl status snmp.service
