### PR TITLE
parallel test case execution fixes

### DIFF
--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -2,14 +2,28 @@ import sys
 import os
 from click.testing import CliRunner
 from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import pytest
 
 import show.main as show
 import config.main as config
 import tests.mock_tables.dbconnector
 from utilities_common.db import Db
 from .utils import get_result_and_return_code
-from unittest import mock
 sys.modules['clicommon'] = mock.Mock()
+
+
+@pytest.fixture(autouse=True)
+def _inject_sonic_platform():
+    # conftest._reset_between_files() clears sys.modules['sonic_platform']
+    # before the first test of each file. Re-inject before every test so that
+    # chassis command handlers that import sonic_platform at call time can find
+    # it. Module-level injection is not sufficient because it runs before the
+    # conftest hook that clears it.
+    sys.modules['sonic_platform'] = mock.MagicMock()
+    yield
+
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,14 @@ def _reset_between_files():
     _CppDBConfig.load_sonic_db_config(db_config_path)
     _CppDBConfig.load_sonic_global_db_config(global_db_config_path)
 
+    # Clear sonic_platform mocks injected by test files at module import time.
+    # With --dist loadfile, xdist workers are reused; mocks from one file
+    # (e.g. sfputil_test.py) can pollute subsequent files (e.g. watchdogutil_test.py).
+    # Tests that need the mock will re-inject it when their module is imported.
+    for k in list(sys.modules):
+        if k == 'sonic_platform' or k.startswith('sonic_platform.') or k.startswith('sonic_platform_base.'):
+            sys.modules.pop(k, None)
+
 
 generated_services_list = [
     'warmboot-finalizer.service',
@@ -268,6 +276,7 @@ generated_services_list = [
     'syncd.service',
     'snmp.timer',
     'telemetry.timer']
+
 
 @pytest.fixture(autouse=True)
 def setup_env():

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -17,6 +17,16 @@ sys.path.insert(0, modules_path)
 sys.modules['sonic_platform'] = mock.MagicMock()
 
 
+@pytest.fixture(autouse=True)
+def _inject_sonic_platform():
+    # conftest._reset_between_files() clears sys.modules['sonic_platform']
+    # before the first test of each file; re-inject before every test so that
+    # lazy imports inside scripts (e.g. instantiate_eeprom_object) still find
+    # the mock. Module-level injection runs before the conftest hook clears it.
+    sys.modules['sonic_platform'] = mock.MagicMock()
+    yield
+
+
 decode_syseeprom_path = os.path.join(scripts_path, 'decode-syseeprom')
 decode_syseeprom = load_module_from_source('decode_syseeprom', decode_syseeprom_path)
 


### PR DESCRIPTION
## Why I did it

Fix critical test isolation issues in the parallel test infrastructure introduced by #4439 (commit 604df54c). These issues only manifest when running tests in parallel with pytest-xdist and cause test failures due to cross-test pollution.

The issues are:
1. **Test isolation failures**: sonic_platform mocks from one test file polluted subsequent test files on the same xdist worker, causing import errors and test failures
2. **Mock lifecycle issues**: Module-level mock injection was cleared by conftest hooks before tests ran, causing import failures in chassis and syseeprom tests

## How I did it

**Commit 1: Fix test isolation - clear sonic_platform mocks between test files**
- Modified tests/conftest.py to clear sonic_platform modules from sys.modules in the _reset_between_files() hook
- Prevents cross-test pollution when xdist workers are reused with --dist loadfile

**Commit 2: Fix sonic_platform mock injection for chassis and syseeprom tests**
- Moved sonic_platform mock injection from module-level to per-test autouse fixtures in tests/chassis_modules_test.py and tests/decode_syseeprom_test.py
- Fixes import failures when conftest._reset_between_files() clears sys.modules before tests run
- Per-test fixtures re-inject the mock after the conftest hook runs, ensuring it's available for lazy imports

## How to verify it

Run the parallel test suite to verify all tests pass with zero failures:

python3 -m pytest tests/ -n auto --dist loadfile
python3 -m pytest tests/ -n 1 --dist loadfile
python3 -m pytest tests/ -p no:xdist

Run specific affected test files to verify fixes:

python3 -m pytest tests/chassis_modules_test.py -v
python3 -m pytest tests/decode_syseeprom_test.py -v

Expected: All tests pass in all three execution modes (parallel, single-worker xdist, pure serial).

## Which release branch to backport

Master only. These fixes are required for the parallel test infrastructure introduced in #4439 (commit 604df54c).