### PR TITLE
Add lpmode show and firmware show commands as aliases for show

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3704,9 +3704,18 @@ The sfputil command shows the current major and minor versions of active/inactiv
   Inactive Firmware: 0.3.5
   ```
 
+**sfputil firmware show**
+
+Alias of `sfputil show fwversion`. Usage and output are identical to `sfputil show fwversion` above.
+
+- Usage:
+  ```
+  sfputil firmware show PORT_NAME
+  ```
+
 ### CMIS firmware upgrade commands
 
-The sfputil commands are used to download/upgrade firmware on transciver modules. The download/upgrade actually happens using set of CMIS CDB commands. The module may replace the exisiting image or copy into the inactive bank of the module. The host issues a download complete CDB command when the entire firmware image has been written to LPL or EPL pages. Each steps can be verified using the 'sfputil show fwversion PORT_NAME'
+The sfputil commands are used to download/upgrade firmware on transciver modules. The download/upgrade actually happens using set of CMIS CDB commands. The module may replace the exisiting image or copy into the inactive bank of the module. The host issues a download complete CDB command when the entire firmware image has been written to LPL or EPL pages. Each steps can be verified using `sfputil show fwversion PORT_NAME` (or its alias `sfputil firmware show PORT_NAME`).
 
 **sfputil firmware download**
 
@@ -15996,6 +16005,27 @@ Enabling low-power mode for port Ethernet0 ... OK
 admin@sonic:~$ sudo sfputil lpmode off Ethernet0 --use-lpmode-pin
 Disabling low-power mode for port Ethernet0 ... OK
 ```
+
+# SFP Utilities lpmode commands
+
+These commands control and inspect the low-power mode of SFP transceivers.
+
+**sfputil lpmode show**
+
+Display the low-power mode status of one or all SFP transceivers. Equivalent to `sfputil show lpmode`.
+
+- Usage:
+  ```
+  sfputil lpmode show [-p <port_name>]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sfputil lpmode show -p Ethernet0
+  Port       Low-power Mode
+  ---------  ----------------
+  Ethernet0  On
+  ```
 
 # SFP Utilities read command
 

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -1291,6 +1291,9 @@ def set_lpmode(logical_port, enable, use_lpmode_pin=False):
         i += 1
 
 
+# 'show' subcommand — alias of `sfputil show lpmode`
+lpmode.add_command(show.commands['lpmode'], name='show')
+
 # 'off' subcommand
 @lpmode.command()
 @click.argument('port_name', metavar='<port_name>')
@@ -1431,6 +1434,10 @@ def update_firmware_info_to_state_db(port_name):
 def firmware():
     """Download/Upgrade firmware on the transceiver"""
     pass
+
+
+# 'show' subcommand — alias of `sfputil show fwversion`
+firmware.add_command(show.commands['fwversion'], name='show')
 
 def run_firmware(port_name, mode):
     """

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -521,6 +521,19 @@ class TestSfputil(object):
 
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    def test_firmware_show(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        mock_api.get_module_fw_info.return_value = {'info': ""}
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['firmware'].commands['show'], ["Ethernet0"])
+        assert result.exit_code == 0
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
     @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
     def test_show_presence(self, mock_chassis):
@@ -667,6 +680,55 @@ Ethernet0  On
         assert result.exit_code == ERROR_NOT_IMPLEMENTED
         mock_sfp.get_lpmode_via_pin.assert_called_once_with()
         assert "This functionality is currently not implemented for this platform" in result.output
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
+    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
+    def test_lpmode_show(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_lpmode.return_value = True
+        mock_sfp.get_presence = MagicMock(return_value=True)
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['lpmode'].commands['show'], ["-p", "Ethernet0"])
+        assert result.exit_code == 0
+        expected_output = """Port       Low-power Mode
+---------  ----------------
+Ethernet0  On
+"""
+        assert result.output == expected_output
+
+        mock_sfp.get_lpmode.return_value = False
+        result = runner.invoke(sfputil.cli.commands['lpmode'].commands['show'], ["-p", "Ethernet0"])
+        assert result.exit_code == 0
+        expected_output = """Port       Low-power Mode
+---------  ----------------
+Ethernet0  Off
+"""
+        assert result.output == expected_output
+
+        mock_sfp.get_presence.return_value = False
+        result = runner.invoke(sfputil.cli.commands['lpmode'].commands['show'], ["-p", "Ethernet0"])
+        assert result.exit_code == 0
+        expected_output = """Port       Low-power Mode
+---------  ----------------
+Ethernet0  Not Present
+"""
+        assert result.output == expected_output
+
+        mock_sfp.get_presence.return_value = True
+        mock_sfp.get_lpmode.return_value = False
+        mock_sfp.get_transceiver_info = MagicMock(return_value={'type': sfputil.RJ45_PORT_TYPE})
+        mock_chassis.get_port_or_cage_type = MagicMock(return_value=sfputil.SfpBase.SFP_PORT_TYPE_BIT_RJ45)
+        result = runner.invoke(sfputil.cli.commands['lpmode'].commands['show'], ["-p", "Ethernet0"])
+        assert result.exit_code == 0
+        expected_output = """Port       Low-power Mode
+---------  ----------------
+Ethernet0  N/A
+"""
+        assert result.output == expected_output
 
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
@@ -1420,6 +1482,20 @@ EEPROM hexdump for port Ethernet4
         mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['show'].commands['fwversion'], ["Ethernet0"])
+        assert result.output == 'Show firmware version is not applicable for RJ45 port Ethernet0.\n'
+        assert result.exit_code == EXIT_FAIL
+
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=True))
+    def test_firmware_show_Rj45(self, mock_chassis):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api = MagicMock(return_value=mock_api)
+        mock_sfp.get_presence.return_value = True
+        mock_chassis.get_sfp = MagicMock(return_value=mock_sfp)
+        runner = CliRunner()
+        result = runner.invoke(sfputil.cli.commands['firmware'].commands['show'], ["Ethernet0"])
         assert result.output == 'Show firmware version is not applicable for RJ45 port Ethernet0.\n'
         assert result.exit_code == EXIT_FAIL
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
closes https://github.com/sonic-net/sonic-utilities/issues/4518

#### What I did

To view the LPMode state of a xcvr (or all xcvrs), the user has to run "sfputil show lpmode", all while "sfputil lpmode" is already existing as a subcommand. Same for firmware. This is very unintuitive.

This PR adds a new subcommand under both `lpmode` and `firmware` to view the respective fields. Internally, it just reroutes to `show lpmode/fwversion`. 

Note that the help commands are also updated. The `sfputil show` command will still be the single source of truth. If for whatever reason, a new flag/param is added to the `sfputil show lpmode/fwversion` command, it will be picked up automatically by `sfputil lpmode/firmware show`. 

#### How I did it

I added 2 new subcommands, linking them to the objects for `show fwversion` and `show lpmode`.

#### How to verify it
```
admin@sonic:~$ sudo sfputil firmware show Ethernet4
Image A Version: 61.23.32
Image B Version: 61.24.16
Factory Image Version: 0.0.0
Running Image: B
Committed Image: B
Active Firmware: 61.24.16
Inactive Firmware: 61.23.32
```

and

```
admin@sonic:~$ sudo sfputil lpmode show
Port         Low-power Mode
-----------  ----------------
Ethernet0    Off
Ethernet4    Off
Ethernet8    Off
Ethernet12   Off
Ethernet16   Off
Ethernet20   Off
Ethernet24   Off
Ethernet28   Off
```
#### Previous command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sudo sfputil firmware show Ethernet4
Usage: sfputil firmware [OPTIONS] COMMAND [ARGS]...
Try 'sfputil firmware --help' for help.

Error: No such command 'show'.
```

and 

```
admin@sonic:~$ sudo sfputil lpmode show Ethernet4
Usage: sfputil lpmode [OPTIONS] COMMAND [ARGS]...
Try 'sfputil lpmode --help' for help.

Error: No such command 'show'.
```

#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sudo sfputil firmware show Ethernet4
Image A Version: 61.23.32
Image B Version: 61.24.16
Factory Image Version: 0.0.0
Running Image: B
Committed Image: B
Active Firmware: 61.24.16
Inactive Firmware: 61.23.32
```

and

```
admin@sonic:~$ sudo sfputil lpmode show
Port         Low-power Mode
-----------  ----------------
Ethernet0    Off
Ethernet4    Off
Ethernet8    Off
Ethernet12   Off
Ethernet16   Off
Ethernet20   Off
Ethernet24   Off
Ethernet28   Off
```

Help command outputs:
```
admin@sonic:~$ sudo sfputil lpmode show --help
Usage: sfputil lpmode show [OPTIONS]

  Display low-power mode status of SFP transceiver(s)

Options:
  -p, --port <port_name>  Display SFP low-power mode status for port
                          <port_name> only
  --help                  Show this message and exit.
```
```
admin@sonic:~$ sudo sfputil lpmode --help
Usage: sfputil lpmode [OPTIONS] COMMAND [ARGS]...

  Enable or disable low-power mode for SFP transceiver

Options:
  --help  Show this message and exit.

Commands:
  off   Disable low-power mode for SFP transceiver
  on    Enable low-power mode for SFP transceiver
  show  Display low-power mode status of SFP transceiver(s)
```
```
admin@sonic:~$ sudo sfputil firmware show --help
Usage: sfputil firmware show [OPTIONS] <port_name>

  Show firmware version of the transceiver

Options:
  --help  Show this message and exit.
```
```
admin@sonic:~$ sudo sfputil firmware --help
Usage: sfputil firmware [OPTIONS] COMMAND [ARGS]...

  Download/Upgrade firmware on the transceiver

Options:
  --help  Show this message and exit.

Commands:
  commit    Commit the running firmware
  download  Download firmware on the transceiver
  run       Run the firmware with default mode=0
  show      Show firmware version of the transceiver
  target    Select target end for firmware download 0-(local)
  unlock    Unlock the firmware download feature via CDB host password
  upgrade   Upgrade firmware on the transceiver
```