### PR TITLE
[ecnconfig]: Fix races under pytest-xdist parallel execution

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -392,7 +392,7 @@ def main(command, show_config, profile, green_min,
          red_drop_prob, namespace, verbose, queue):
     test_filename = None
     if os.environ.get("UTILITIES_UNIT_TESTING", "0") == "2":
-        test_filename = '/tmp/ecnconfig'
+        test_filename = os.environ.get("ECNCONFIG_FILE", "/tmp/ecnconfig")
 
     try:
         load_db_config()

--- a/tests/ecn_test.py
+++ b/tests/ecn_test.py
@@ -23,9 +23,15 @@ sys.path.insert(0, modules_path)
 
 
 class TestEcnConfigBase(object):
+    # Per-worker file path to avoid race conditions in parallel test runs.
+    _ecnconfig_file = None
+
     @classmethod
     def setup_class(cls):
         print("SETUP")
+        worker_tmp = os.environ.get('WORKER_TMP', '/tmp')
+        cls._ecnconfig_file = os.path.join(worker_tmp, 'ecnconfig')
+        os.environ['ECNCONFIG_FILE'] = cls._ecnconfig_file
 
     def process_cmp_args(self, cmp_args):
         """
@@ -76,7 +82,7 @@ class TestEcnConfigBase(object):
             assert exit_code != 0
 
         if 'cmp_args' in input:
-            fd = open('/tmp/ecnconfig', 'r')
+            fd = open(self._ecnconfig_file, 'r')
             cmp_data = json.load(fd)
 
             # Verify queue assignments
@@ -114,8 +120,9 @@ class TestEcnConfigBase(object):
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
 
-        if os.path.isfile('/tmp/ecnconfig'):
-            os.remove('/tmp/ecnconfig')
+        if cls._ecnconfig_file and os.path.isfile(cls._ecnconfig_file):
+            os.remove(cls._ecnconfig_file)
+        os.environ.pop('ECNCONFIG_FILE', None)
         print("TEARDOWN")
 
 

--- a/tests/multi_asic_ecnconfig_test.py
+++ b/tests/multi_asic_ecnconfig_test.py
@@ -14,6 +14,7 @@ sys.path.insert(0, modules_path)
 class TestEcnConfigMultiAsic(TestEcnConfigBase):
     @classmethod
     def setup_class(cls):
+        super().setup_class()
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
         from .mock_tables import mock_multi_asic
         importlib.reload(mock_multi_asic)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When running tests multiple workers execute test files simultaneously in the same process tree. All workers were writing and reading the same hardcoded path /tmp/ecnconfig, causing three distinct failures:

tests/multi_asic_ecnconfig_test.py::TestEcnConfigMultiAsic::test_ecn_config_change_other_threshold_masic
- KeyError: 'asic1' FAILED tests/ecn_test.py::TestEcnConfig::test_ecn_queue_set_q_off - KeyError: ''
FAILED
tests/ecn_test.py::TestEcnConfig::test_ecn_queue_set_all_on_verbose - KeyError: ''
FAILED tests/ecn_test.py::TestEcnConfig::test_ecn_queue_set_lossy_q_on - fileNotFoundError: [Errno 2] No such file or directory: '/tmp/ecnconfig'

#### How I did it
Fix mirrors the pattern already applied to mmuconfig (commit 604df54c):

1. scripts/ecnconfig: read ECNCONFIG_FILE env var (falling back to /tmp/ecnconfig) instead of hardcoding the path.  This allows the subprocess spawned by get_result_and_return_code() to write to the same per-worker path that the parent test process expects to read.

2. tests/ecn_test.py (TestEcnConfigBase): in setup_class, derive the output path from the WORKER_TMP env var that conftest.py sets to a per-worker directory (/tmp/worker-gw0/, /tmp/worker-gw1/, ...). Export it as ECNCONFIG_FILE so the ecnconfig subprocess inherits it. teardown_class removes the per-worker file and clears the env var.

3. tests/multi_asic_ecnconfig_test.py (TestEcnConfigMultiAsic): add super().setup_class() so the base class initialises _ecnconfig_file before the subclass overrides the topology. Without this call _ecnconfig_file remained None, causing TypeError when the executor tried to open the file.


#### How to verify it
Build sonic_utilities-1.2-py3-none-any.whl or run the pytest

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

