### PR TITLE
Validate config_db.json in reload path.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2164,8 +2164,8 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
-    if not force:
-        if filename is None and file_format == 'config_db':
+    if filename is None and file_format == 'config_db':
+        if not force:
             cfg_files_to_validate = [DEFAULT_CONFIG_DB_FILE]
             if multi_asic.is_multi_asic():
                 default_cfg_file_root, default_cfg_file_ext = os.path.splitext(
@@ -2207,13 +2207,13 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
                         )
                     )
                     raise click.Abort()
-        elif filename is not None and filename != "/dev/stdin":
-            if multi_asic.is_multi_asic():
-                for cfg_file in cfg_files:
-                    if cfg_file is not None:
-                        config_file_yang_validation(cfg_file)
-            else:
-                config_file_yang_validation(filename)
+    elif filename is not None and filename != "/dev/stdin":
+        if multi_asic.is_multi_asic():
+            for cfg_file in cfg_files:
+                if cfg_file is not None:
+                    config_file_yang_validation(cfg_file)
+        else:
+            config_file_yang_validation(filename)
 
     #Stop services before config push
     if not no_service_restart:

--- a/config/main.py
+++ b/config/main.py
@@ -1677,7 +1677,10 @@ def config_file_yang_validation(filename):
     if multi_asic.is_multi_asic():
         asic_list.extend(multi_asic.get_namespace_list())
     for scope in asic_list:
-        config_to_check = config.get(scope) if multi_asic.is_multi_asic() else config
+        if multi_asic.is_multi_asic() and HOST_NAMESPACE in config:
+            config_to_check = config.get(scope)
+        else:
+            config_to_check = config if scope == HOST_NAMESPACE else None
         if config_to_check:
             try:
                 sy.loadData(configdbJson=config_to_check)
@@ -2162,8 +2165,30 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             return
 
     if filename is None and file_format == 'config_db':
-        # Validate the default config before stopping services and flushing CONFIG_DB.
-        config_file_yang_validation(DEFAULT_CONFIG_DB_FILE)
+        cfg_files_to_validate = [DEFAULT_CONFIG_DB_FILE]
+        if multi_asic.is_multi_asic():
+            default_cfg_file_root, default_cfg_file_ext = os.path.splitext(DEFAULT_CONFIG_DB_FILE)
+            cfg_files_to_validate.extend([
+                "{}{}{}".format(default_cfg_file_root, inst, default_cfg_file_ext)
+                for inst in range(num_asic)
+            ])
+
+        for cfg_file in cfg_files_to_validate:
+            if not os.path.exists(cfg_file):
+                click.echo("The config file {} doesn't exist".format(cfg_file))
+                raise click.Abort()
+            if not os.access(cfg_file, os.R_OK):
+                click.echo("The config file {} is not readable".format(cfg_file))
+                raise click.Abort()
+            try:
+                if not config_file_yang_validation(cfg_file):
+                    click.secho("Invalid config file:'{}'!".format(cfg_file), fg='magenta')
+                    raise click.Abort()
+            except click.Abort:
+                raise
+            except Exception as e:
+                click.echo("Failed to read config file {}: {}".format(cfg_file, str(e)))
+                raise click.Abort()
     elif filename is not None and filename != "/dev/stdin":
         if multi_asic.is_multi_asic():
             for cfg_file in cfg_files:

--- a/config/main.py
+++ b/config/main.py
@@ -2161,7 +2161,10 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
-    if filename is not None and filename != "/dev/stdin":
+    if filename is None and file_format == 'config_db':
+        # Validate the default config before stopping services and flushing CONFIG_DB.
+        config_file_yang_validation(DEFAULT_CONFIG_DB_FILE)
+    elif filename is not None and filename != "/dev/stdin":
         if multi_asic.is_multi_asic():
             for cfg_file in cfg_files:
                 if cfg_file is not None:

--- a/config/main.py
+++ b/config/main.py
@@ -2167,27 +2167,44 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
     if filename is None and file_format == 'config_db':
         cfg_files_to_validate = [DEFAULT_CONFIG_DB_FILE]
         if multi_asic.is_multi_asic():
-            default_cfg_file_root, default_cfg_file_ext = os.path.splitext(DEFAULT_CONFIG_DB_FILE)
+            default_cfg_file_root, default_cfg_file_ext = os.path.splitext(
+                DEFAULT_CONFIG_DB_FILE
+            )
             cfg_files_to_validate.extend([
-                "{}{}{}".format(default_cfg_file_root, inst, default_cfg_file_ext)
+                "{}{}{}".format(
+                    default_cfg_file_root,
+                    inst,
+                    default_cfg_file_ext,
+                )
                 for inst in range(num_asic)
             ])
 
         for cfg_file in cfg_files_to_validate:
             if not os.path.exists(cfg_file):
-                click.echo("The config file {} doesn't exist".format(cfg_file))
+                click.echo(
+                    "The config file {} doesn't exist".format(cfg_file)
+                )
                 raise click.Abort()
             if not os.access(cfg_file, os.R_OK):
-                click.echo("The config file {} is not readable".format(cfg_file))
+                click.echo(
+                    "The config file {} is not readable".format(cfg_file)
+                )
                 raise click.Abort()
             try:
                 if not config_file_yang_validation(cfg_file):
-                    click.secho("Invalid config file:'{}'!".format(cfg_file), fg='magenta')
+                    click.secho(
+                        "Invalid config file:'{}'!".format(cfg_file),
+                        fg='magenta'
+                    )
                     raise click.Abort()
             except click.Abort:
                 raise
             except Exception as e:
-                click.echo("Failed to read config file {}: {}".format(cfg_file, str(e)))
+                click.echo(
+                    "Failed to read config file {}: {}".format(
+                        cfg_file, str(e)
+                    )
+                )
                 raise click.Abort()
     elif filename is not None and filename != "/dev/stdin":
         if multi_asic.is_multi_asic():

--- a/config/main.py
+++ b/config/main.py
@@ -2164,55 +2164,56 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
             click.echo("Input {} config file(s) separated by comma for multiple files ".format(num_cfg_file))
             return
 
-    if filename is None and file_format == 'config_db':
-        cfg_files_to_validate = [DEFAULT_CONFIG_DB_FILE]
-        if multi_asic.is_multi_asic():
-            default_cfg_file_root, default_cfg_file_ext = os.path.splitext(
-                DEFAULT_CONFIG_DB_FILE
-            )
-            cfg_files_to_validate.extend([
-                "{}{}{}".format(
-                    default_cfg_file_root,
-                    inst,
-                    default_cfg_file_ext,
+    if not force:
+        if filename is None and file_format == 'config_db':
+            cfg_files_to_validate = [DEFAULT_CONFIG_DB_FILE]
+            if multi_asic.is_multi_asic():
+                default_cfg_file_root, default_cfg_file_ext = os.path.splitext(
+                    DEFAULT_CONFIG_DB_FILE
                 )
-                for inst in range(num_asic)
-            ])
+                cfg_files_to_validate.extend([
+                    "{}{}{}".format(
+                        default_cfg_file_root,
+                        inst,
+                        default_cfg_file_ext,
+                    )
+                    for inst in range(num_asic)
+                ])
 
-        for cfg_file in cfg_files_to_validate:
-            if not os.path.exists(cfg_file):
-                click.echo(
-                    "The config file {} doesn't exist".format(cfg_file)
-                )
-                raise click.Abort()
-            if not os.access(cfg_file, os.R_OK):
-                click.echo(
-                    "The config file {} is not readable".format(cfg_file)
-                )
-                raise click.Abort()
-            try:
-                if not config_file_yang_validation(cfg_file):
-                    click.secho(
-                        "Invalid config file:'{}'!".format(cfg_file),
-                        fg='magenta'
+            for cfg_file in cfg_files_to_validate:
+                if not os.path.exists(cfg_file):
+                    click.echo(
+                        "The config file {} doesn't exist".format(cfg_file)
                     )
                     raise click.Abort()
-            except click.Abort:
-                raise
-            except Exception as e:
-                click.echo(
-                    "Failed to read config file {}: {}".format(
-                        cfg_file, str(e)
+                if not os.access(cfg_file, os.R_OK):
+                    click.echo(
+                        "The config file {} is not readable".format(cfg_file)
                     )
-                )
-                raise click.Abort()
-    elif filename is not None and filename != "/dev/stdin":
-        if multi_asic.is_multi_asic():
-            for cfg_file in cfg_files:
-                if cfg_file is not None:
-                    config_file_yang_validation(cfg_file)
-        else:
-            config_file_yang_validation(filename)
+                    raise click.Abort()
+                try:
+                    if not config_file_yang_validation(cfg_file):
+                        click.secho(
+                            "Invalid config file:'{}'!".format(cfg_file),
+                            fg='magenta'
+                        )
+                        raise click.Abort()
+                except click.Abort:
+                    raise
+                except Exception as e:
+                    click.echo(
+                        "Failed to read config file {}: {}".format(
+                            cfg_file, str(e)
+                        )
+                    )
+                    raise click.Abort()
+        elif filename is not None and filename != "/dev/stdin":
+            if multi_asic.is_multi_asic():
+                for cfg_file in cfg_files:
+                    if cfg_file is not None:
+                        config_file_yang_validation(cfg_file)
+            else:
+                config_file_yang_validation(filename)
 
     #Stop services before config push
     if not no_service_restart:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -728,8 +728,10 @@ class TestConfigReload(object):
         open(cls.dummy_cfg_file, 'w').close()
 
     def test_config_reload(self, get_cmd_module, setup_single_broadcom_asic):
-        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command:
-            (config, show) = get_cmd_module
+        (config, show) = get_cmd_module
+
+        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
+                mock.patch.object(config, "config_file_yang_validation") as mock_validate_config:
 
             jsonfile_config = os.path.join(mock_db_path, "config_db.json")
             jsonfile_init_cfg = os.path.join(mock_db_path, "init_cfg.json")
@@ -753,6 +755,22 @@ class TestConfigReload(object):
 
             assert "\n".join([line.rstrip() for line in result.output.split('\n')][:2]) == \
                 reload_config_with_sys_info_command_output.format(config.SYSTEM_RELOAD_LOCK)
+            mock_validate_config.assert_called_once_with(jsonfile_config)
+
+    def test_config_reload_default_config_validation_failure(self, get_cmd_module, setup_single_broadcom_asic):
+        (config, show) = get_cmd_module
+
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+        config.DEFAULT_CONFIG_DB_FILE = jsonfile_config
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command, \
+                mock.patch.object(config, "config_file_yang_validation", side_effect=click.Abort) as mock_validate_config:
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+
+            assert result.exit_code != 0
+            mock_validate_config.assert_called_once_with(jsonfile_config)
+            mock_run_command.assert_not_called()
 
     def test_config_reload_stdin(self, get_cmd_module, setup_single_broadcom_asic):
         def mock_json_load(f):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -775,6 +775,54 @@ class TestConfigReload(object):
             mock_validate_config.assert_called_once_with(jsonfile_config)
             mock_run_command.assert_not_called()
 
+    def test_config_reload_default_config_missing_file(self, get_cmd_module, setup_single_broadcom_asic):
+        (config, show) = get_cmd_module
+
+        config.DEFAULT_CONFIG_DB_FILE = os.path.join(mock_db_path, 'missing_config_db.json')
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+
+            assert result.exit_code != 0
+            assert "The config file {} doesn't exist".format(config.DEFAULT_CONFIG_DB_FILE) in result.output
+            assert "Traceback" not in result.output
+            mock_run_command.assert_not_called()
+
+    def test_config_reload_default_config_invalid_json(self, get_cmd_module, setup_single_broadcom_asic):
+        (config, show) = get_cmd_module
+
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+        config.DEFAULT_CONFIG_DB_FILE = jsonfile_config
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command, \
+                mock.patch('config.main.os.access', return_value=True), \
+                mock.patch.object(config, "config_file_yang_validation", side_effect=Exception("bad json")):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+
+            assert result.exit_code != 0
+            assert "Failed to read config file {}: bad json".format(jsonfile_config) in result.output
+            assert "Traceback" not in result.output
+            mock_run_command.assert_not_called()
+
+    def test_config_reload_default_config_invalid_root(self, get_cmd_module, setup_single_broadcom_asic):
+        (config, show) = get_cmd_module
+
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+        config.DEFAULT_CONFIG_DB_FILE = jsonfile_config
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command, \
+                mock.patch('config.main.os.access', return_value=True), \
+                mock.patch.object(config, "config_file_yang_validation", return_value=False) as mock_validate_config:
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+
+            assert result.exit_code != 0
+            assert "Invalid config file:'{}'!".format(jsonfile_config) in result.output
+            mock_validate_config.assert_called_once_with(jsonfile_config)
+            mock_run_command.assert_not_called()
+
     def test_config_reload_stdin(self, get_cmd_module, setup_single_broadcom_asic):
         def mock_json_load(f):
             device_metadata = {
@@ -957,9 +1005,9 @@ class TestConfigReloadMasic(object):
             }
 
         with mock.patch("utilities_common.cli.run_command",
-                        mock.MagicMock(side_effect=mock_run_command_side_effect)),\
+                mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                       mock.MagicMock(side_effect=read_json_file_side_effect)):
+                   mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -1032,9 +1080,9 @@ class TestConfigReloadMasic(object):
             }
 
         with mock.patch("utilities_common.cli.run_command",
-                        mock.MagicMock(side_effect=mock_run_command_side_effect)),\
+                mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                       mock.MagicMock(side_effect=read_json_file_side_effect)):
+                   mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -1057,9 +1105,9 @@ class TestConfigReloadMasic(object):
             }
 
         with mock.patch("utilities_common.cli.run_command",
-                        mock.MagicMock(side_effect=mock_run_command_side_effect)),\
+                mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                       mock.MagicMock(side_effect=read_json_file_side_effect)):
+                   mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -1131,6 +1179,34 @@ class TestConfigReloadMasic(object):
             assert result.exit_code == 0
             assert "\n".join([li.rstrip() for li in result.output.split('\n')]) == \
                 RELOAD_MASIC_CONFIG_DB_OUTPUT.format(config.SYSTEM_RELOAD_LOCK)
+
+    def test_config_reload_default_files_validate_all_namespaces(self):
+        device_metadata = {
+            "DEVICE_METADATA": {
+                "localhost": {
+                    "platform": "some_platform",
+                    "mac": "02:42:f0:7f:01:05"
+                }
+            }
+        }
+
+        with mock.patch("utilities_common.cli.run_command",
+                        mock.MagicMock(side_effect=mock_run_command_side_effect)), \
+                mock.patch('config.main.os.path.exists', return_value=True), \
+                mock.patch('config.main.os.access', return_value=True), \
+                mock.patch.object(config, 'read_json_file', return_value=device_metadata), \
+                mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model, \
+                mock.patch('config.main.sonic_yang.SonicYang.loadData') as mock_load_data, \
+                mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree') as mock_validate_data_tree:
+            runner = CliRunner()
+            config.DEFAULT_CONFIG_DB_FILE = os.path.join(mock_db_path, 'config_db.json')
+
+            result = runner.invoke(config.config.commands["reload"], ['-y', '-f', '-n'])
+
+            assert result.exit_code == 0
+            assert mock_load_yang_model.call_count == 3
+            assert mock_load_data.call_count == 3
+            assert mock_validate_data_tree.call_count == 3
 
     @classmethod
     def teardown_class(cls):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -775,53 +775,95 @@ class TestConfigReload(object):
             mock_validate_config.assert_called_once_with(jsonfile_config)
             mock_run_command.assert_not_called()
 
-    def test_config_reload_default_config_missing_file(self, get_cmd_module, setup_single_broadcom_asic):
+    def test_config_reload_default_config_missing_file(
+        self, get_cmd_module, setup_single_broadcom_asic
+    ):
         (config, show) = get_cmd_module
 
-        config.DEFAULT_CONFIG_DB_FILE = os.path.join(mock_db_path, 'missing_config_db.json')
+        config.DEFAULT_CONFIG_DB_FILE = os.path.join(
+            mock_db_path, 'missing_config_db.json'
+        )
 
-        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+        with mock.patch(
+            "utilities_common.cli.run_command"
+        ) as mock_run_command:
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+            result = runner.invoke(
+                config.config.commands["reload"], ["-y", "-f"]
+            )
 
             assert result.exit_code != 0
-            assert "The config file {} doesn't exist".format(config.DEFAULT_CONFIG_DB_FILE) in result.output
+            assert (
+                "The config file {} doesn't exist".format(
+                    config.DEFAULT_CONFIG_DB_FILE
+                ) in result.output
+            )
             assert "Traceback" not in result.output
             mock_run_command.assert_not_called()
 
-    def test_config_reload_default_config_invalid_json(self, get_cmd_module, setup_single_broadcom_asic):
+    def test_config_reload_default_config_invalid_json(
+        self, get_cmd_module, setup_single_broadcom_asic
+    ):
         (config, show) = get_cmd_module
 
         jsonfile_config = os.path.join(mock_db_path, "config_db.json")
         config.DEFAULT_CONFIG_DB_FILE = jsonfile_config
 
-        with mock.patch("utilities_common.cli.run_command") as mock_run_command, \
-                mock.patch('config.main.os.access', return_value=True), \
-                mock.patch.object(config, "config_file_yang_validation", side_effect=Exception("bad json")):
-            runner = CliRunner()
-            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+        with mock.patch(
+            "utilities_common.cli.run_command"
+        ) as mock_run_command:
+            with mock.patch('config.main.os.access', return_value=True):
+                with mock.patch.object(
+                    config,
+                    "config_file_yang_validation",
+                    side_effect=Exception("bad json"),
+                ):
+                    runner = CliRunner()
+                    result = runner.invoke(
+                        config.config.commands["reload"], ["-y", "-f"]
+                    )
 
-            assert result.exit_code != 0
-            assert "Failed to read config file {}: bad json".format(jsonfile_config) in result.output
-            assert "Traceback" not in result.output
-            mock_run_command.assert_not_called()
+                    assert result.exit_code != 0
+                    assert (
+                        "Failed to read config file {}: bad json".format(
+                            jsonfile_config
+                        ) in result.output
+                    )
+                    assert "Traceback" not in result.output
+                    mock_run_command.assert_not_called()
 
-    def test_config_reload_default_config_invalid_root(self, get_cmd_module, setup_single_broadcom_asic):
+    def test_config_reload_default_config_invalid_root(
+        self, get_cmd_module, setup_single_broadcom_asic
+    ):
         (config, show) = get_cmd_module
 
         jsonfile_config = os.path.join(mock_db_path, "config_db.json")
         config.DEFAULT_CONFIG_DB_FILE = jsonfile_config
 
-        with mock.patch("utilities_common.cli.run_command") as mock_run_command, \
-                mock.patch('config.main.os.access', return_value=True), \
-                mock.patch.object(config, "config_file_yang_validation", return_value=False) as mock_validate_config:
-            runner = CliRunner()
-            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+        with mock.patch(
+            "utilities_common.cli.run_command"
+        ) as mock_run_command:
+            with mock.patch('config.main.os.access', return_value=True):
+                with mock.patch.object(
+                    config,
+                    "config_file_yang_validation",
+                    return_value=False,
+                ) as mock_validate_config:
+                    runner = CliRunner()
+                    result = runner.invoke(
+                        config.config.commands["reload"], ["-y", "-f"]
+                    )
 
-            assert result.exit_code != 0
-            assert "Invalid config file:'{}'!".format(jsonfile_config) in result.output
-            mock_validate_config.assert_called_once_with(jsonfile_config)
-            mock_run_command.assert_not_called()
+                    assert result.exit_code != 0
+                    assert (
+                        "Invalid config file:'{}'!".format(
+                            jsonfile_config
+                        ) in result.output
+                    )
+                    mock_validate_config.assert_called_once_with(
+                        jsonfile_config
+                    )
+                    mock_run_command.assert_not_called()
 
     def test_config_reload_stdin(self, get_cmd_module, setup_single_broadcom_asic):
         def mock_json_load(f):
@@ -1005,9 +1047,9 @@ class TestConfigReloadMasic(object):
             }
 
         with mock.patch("utilities_common.cli.run_command",
-                mock.MagicMock(side_effect=mock_run_command_side_effect)),\
+                        mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                   mock.MagicMock(side_effect=read_json_file_side_effect)):
+                       mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -1080,9 +1122,9 @@ class TestConfigReloadMasic(object):
             }
 
         with mock.patch("utilities_common.cli.run_command",
-                mock.MagicMock(side_effect=mock_run_command_side_effect)),\
+                        mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                   mock.MagicMock(side_effect=read_json_file_side_effect)):
+                       mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -1105,9 +1147,9 @@ class TestConfigReloadMasic(object):
             }
 
         with mock.patch("utilities_common.cli.run_command",
-                mock.MagicMock(side_effect=mock_run_command_side_effect)),\
+                        mock.MagicMock(side_effect=mock_run_command_side_effect)),\
             mock.patch('config.main.read_json_file',
-                   mock.MagicMock(side_effect=read_json_file_side_effect)):
+                       mock.MagicMock(side_effect=read_json_file_side_effect)):
 
             runner = CliRunner()
 
@@ -1191,17 +1233,31 @@ class TestConfigReloadMasic(object):
         }
 
         with mock.patch("utilities_common.cli.run_command",
-                        mock.MagicMock(side_effect=mock_run_command_side_effect)), \
+                        mock.MagicMock(
+                            side_effect=mock_run_command_side_effect
+                        )), \
                 mock.patch('config.main.os.path.exists', return_value=True), \
                 mock.patch('config.main.os.access', return_value=True), \
-                mock.patch.object(config, 'read_json_file', return_value=device_metadata), \
-                mock.patch('config.main.sonic_yang.SonicYang.loadYangModel') as mock_load_yang_model, \
-                mock.patch('config.main.sonic_yang.SonicYang.loadData') as mock_load_data, \
-                mock.patch('config.main.sonic_yang.SonicYang.validate_data_tree') as mock_validate_data_tree:
+                mock.patch.object(
+                    config, 'read_json_file', return_value=device_metadata
+                ), \
+                mock.patch(
+                    'config.main.sonic_yang.SonicYang.loadYangModel'
+                ) as mock_load_yang_model, \
+                mock.patch(
+                    'config.main.sonic_yang.SonicYang.loadData'
+                ) as mock_load_data, \
+                mock.patch(
+                    'config.main.sonic_yang.SonicYang.validate_data_tree'
+                ) as mock_validate_data_tree:
             runner = CliRunner()
-            config.DEFAULT_CONFIG_DB_FILE = os.path.join(mock_db_path, 'config_db.json')
+            config.DEFAULT_CONFIG_DB_FILE = os.path.join(
+                mock_db_path, 'config_db.json'
+            )
 
-            result = runner.invoke(config.config.commands["reload"], ['-y', '-f', '-n'])
+            result = runner.invoke(
+                config.config.commands["reload"], ['-y', '-f', '-n']
+            )
 
             assert result.exit_code == 0
             assert mock_load_yang_model.call_count == 3

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -730,7 +730,9 @@ class TestConfigReload(object):
     def test_config_reload(self, get_cmd_module, setup_single_broadcom_asic):
         (config, show) = get_cmd_module
 
-        with mock.patch("utilities_common.cli.run_command", mock.MagicMock(side_effect=mock_run_command_side_effect)) as mock_run_command, \
+        with mock.patch(
+                "utilities_common.cli.run_command",
+                mock.MagicMock(side_effect=mock_run_command_side_effect)), \
                 mock.patch.object(config, "config_file_yang_validation") as mock_validate_config:
 
             jsonfile_config = os.path.join(mock_db_path, "config_db.json")
@@ -764,7 +766,8 @@ class TestConfigReload(object):
         config.DEFAULT_CONFIG_DB_FILE = jsonfile_config
 
         with mock.patch("utilities_common.cli.run_command") as mock_run_command, \
-                mock.patch.object(config, "config_file_yang_validation", side_effect=click.Abort) as mock_validate_config:
+                mock.patch.object(
+                    config, "config_file_yang_validation", side_effect=click.Abort) as mock_validate_config:
             runner = CliRunner()
             result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -769,11 +769,30 @@ class TestConfigReload(object):
                 mock.patch.object(
                     config, "config_file_yang_validation", side_effect=click.Abort) as mock_validate_config:
             runner = CliRunner()
-            result = runner.invoke(config.config.commands["reload"], ["-y", "-f"])
+            result = runner.invoke(config.config.commands["reload"], ["-y", "-n"])
 
             assert result.exit_code != 0
             mock_validate_config.assert_called_once_with(jsonfile_config)
             mock_run_command.assert_not_called()
+
+    def test_config_reload_force_skips_validation(self, get_cmd_module, setup_single_broadcom_asic):
+        (config, show) = get_cmd_module
+
+        config.DEFAULT_CONFIG_DB_FILE = os.path.join(
+            mock_db_path, 'missing_config_db.json'
+        )
+
+        with mock.patch(
+                "utilities_common.cli.run_command",
+                mock.MagicMock(side_effect=mock_run_command_side_effect)), \
+                mock.patch.object(config, "config_file_yang_validation") as mock_validate_config:
+            runner = CliRunner()
+            result = runner.invoke(
+                config.config.commands["reload"], ["-y", "-f", "-n"]
+            )
+
+            assert result.exit_code == 0
+            mock_validate_config.assert_not_called()
 
     def test_config_reload_default_config_missing_file(
         self, get_cmd_module, setup_single_broadcom_asic
@@ -789,7 +808,7 @@ class TestConfigReload(object):
         ) as mock_run_command:
             runner = CliRunner()
             result = runner.invoke(
-                config.config.commands["reload"], ["-y", "-f"]
+                config.config.commands["reload"], ["-y", "-n"]
             )
 
             assert result.exit_code != 0
@@ -820,7 +839,7 @@ class TestConfigReload(object):
                 ):
                     runner = CliRunner()
                     result = runner.invoke(
-                        config.config.commands["reload"], ["-y", "-f"]
+                        config.config.commands["reload"], ["-y", "-n"]
                     )
 
                     assert result.exit_code != 0
@@ -851,7 +870,7 @@ class TestConfigReload(object):
                 ) as mock_validate_config:
                     runner = CliRunner()
                     result = runner.invoke(
-                        config.config.commands["reload"], ["-y", "-f"]
+                        config.config.commands["reload"], ["-y", "-n"]
                     )
 
                     assert result.exit_code != 0
@@ -1258,7 +1277,7 @@ class TestConfigReloadMasic(object):
             runner = CliRunner()
 
             result = runner.invoke(
-                config.config.commands["reload"], ['-y', '-f', '-n']
+                config.config.commands["reload"], ['-y', '-n']
             )
 
             assert result.exit_code == 0

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1223,6 +1223,15 @@ class TestConfigReloadMasic(object):
                 RELOAD_MASIC_CONFIG_DB_OUTPUT.format(config.SYSTEM_RELOAD_LOCK)
 
     def test_config_reload_default_files_validate_all_namespaces(self):
+        dummy_cfg_file = os.path.join(
+            os.sep, "tmp", "reload_validate_config_db.json"
+        )
+        dummy_cfg_file_asic0 = os.path.join(
+            os.sep, "tmp", "reload_validate_config_db0.json"
+        )
+        dummy_cfg_file_asic1 = os.path.join(
+            os.sep, "tmp", "reload_validate_config_db1.json"
+        )
         device_metadata = {
             "DEVICE_METADATA": {
                 "localhost": {
@@ -1231,38 +1240,34 @@ class TestConfigReloadMasic(object):
                 }
             }
         }
+        self._create_dummy_config(dummy_cfg_file, device_metadata)
+        self._create_dummy_config(dummy_cfg_file_asic0, device_metadata)
+        self._create_dummy_config(dummy_cfg_file_asic1, device_metadata)
 
         with mock.patch("utilities_common.cli.run_command",
                         mock.MagicMock(
                             side_effect=mock_run_command_side_effect
                         )), \
-                mock.patch('config.main.os.path.exists', return_value=True), \
-                mock.patch('config.main.os.access', return_value=True), \
                 mock.patch.object(
-                    config, 'read_json_file', return_value=device_metadata
+                    config, 'DEFAULT_CONFIG_DB_FILE', dummy_cfg_file
                 ), \
                 mock.patch(
-                    'config.main.sonic_yang.SonicYang.loadYangModel'
-                ) as mock_load_yang_model, \
-                mock.patch(
-                    'config.main.sonic_yang.SonicYang.loadData'
-                ) as mock_load_data, \
-                mock.patch(
-                    'config.main.sonic_yang.SonicYang.validate_data_tree'
-                ) as mock_validate_data_tree:
+                    'config.main.config_file_yang_validation',
+                    return_value=True
+                ) as mock_validate_config:
             runner = CliRunner()
-            config.DEFAULT_CONFIG_DB_FILE = os.path.join(
-                mock_db_path, 'config_db.json'
-            )
 
             result = runner.invoke(
                 config.config.commands["reload"], ['-y', '-f', '-n']
             )
 
             assert result.exit_code == 0
-            assert mock_load_yang_model.call_count == 3
-            assert mock_load_data.call_count == 3
-            assert mock_validate_data_tree.call_count == 3
+            assert mock_validate_config.call_count == 3
+            assert mock_validate_config.call_args_list == [
+                mock.call(dummy_cfg_file),
+                mock.call(dummy_cfg_file_asic0),
+                mock.call(dummy_cfg_file_asic1),
+            ]
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix for https://github.com/sonic-net/sonic-buildimage/issues/27178 . /etc/sonic/config_db.json was not validated in the config reload path before loading. If a config that did not conform to schema was partially loaded, the system could end up in a bad unrecoverable state. 

#### How I did it
added a config_file_yang_validation check to config_db.json in config reload path.

#### How to verify it
'config reload -y' after copying an invalid config to /etc/sonic/config_db.json.

#### Previous command output
```
:~$ sudo config reload -y
Acquired lock on /etc/sonic/reload.lock
Disabling container and routeCheck monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 542, in <module>
    main()
    ~~~~^^
  File "/usr/local/bin/sonic-cfggen", line 531, in main
    configdb.mod_config(FormatConverter.output_to_db(data))
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2862, in mod_config
    raw_data = self.typed_to_raw(data)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2797, in typed_to_raw
    elif len(typed_data) == 0:
         ~~~^^^^^^^^^^^^
TypeError: object of type 'int' has no len()
Released lock on /etc/sonic/reload.lock

```
Config is partially loaded in this case, leaving system in state that needs to be recovered with
```
sudo cp config_db.json_working /etc/sonic/config_db.json
sudo sonic-db-cli CONFIG_DB SET CONFIG_DB_INITIALIZED 1
sudo config reload -y -f
```

#### New command output 
```
:~$ sudo config reload -y
Acquired lock on /etc/sonic/reload.lock
sonic_yang(3):All Keys are not parsed in DASH_HA_GLOBAL_CONFIG
dict_keys(['cp_data_channel_port', 'dp_channel_dst_port', 'dp_channel_src_port_min', 'dp_channel_src_port_max', 'dp_channel_probe_interval_ms', 'dp_channel_probe_fail_threshold', 'dpu_bfd_probe_interval_in_ms', 'dpu_bfd_probe_multiplier', 'dpu_vnet', 'dpu_vlan'])
sonic_yang(3):exceptionList:[]
sonic_yang(3):Data Loading Failed:All Keys are not parsed in DASH_HA_GLOBAL_CONFIG
dict_keys(['cp_data_channel_port', 'dp_channel_dst_port', 'dp_channel_src_port_min', 'dp_channel_src_port_max', 'dp_channel_probe_interval_ms', 'dp_channel_probe_fail_threshold', 'dpu_bfd_probe_interval_in_ms', 'dpu_bfd_probe_multiplier', 'dpu_vnet', 'dpu_vlan'])
exceptionList:[]
/etc/sonic/config_db.json fails YANG validation! Error: Data Loading Failed
All Keys are not parsed in DASH_HA_GLOBAL_CONFIG
dict_keys(['cp_data_channel_port', 'dp_channel_dst_port', 'dp_channel_src_port_min', 'dp_channel_src_port_max', 'dp_channel_probe_interval_ms', 'dp_channel_probe_fail_threshold', 'dpu_bfd_probe_interval_in_ms', 'dpu_bfd_probe_multiplier', 'dpu_vnet', 'dpu_vlan'])
exceptionList:[]
Released lock on /etc/sonic/reload.lock
Aborted!
```
The incorrect config is not loaded in this case and system stays up.