### PR TITLE
[tempershow]: Read SFP temperature from xcvrd-managed tables

### DIFF
--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -5,10 +5,21 @@
 """
 import argparse
 import json
+from datetime import datetime
 
 from tabulate import tabulate
 from swsscommon.swsscommon import SonicV2Connector
 from natsort import natsorted
+
+try:
+    from sonic_py_common import multi_asic
+except ImportError:
+    multi_asic = None
+
+try:
+    from utilities_common import platform_sfputil_helper
+except ImportError:
+    platform_sfputil_helper = None
 
 
 header = ['Sensor', 'Temperature', 'High TH', 'Low TH', 'Crit High TH', 'Crit Low TH', 'Warning', 'Timestamp']
@@ -22,59 +33,227 @@ CRIT_HIGH_THRESH_FIELD_NAME = 'critical_high_threshold'
 CRIT_LOW_THRESH_FIELD_NAME = 'critical_low_threshold'
 WARNING_STATUS_FIELD_NAME = 'warning_status'
 
+# SFP/transceiver temperature is published by xcvrd into the dedicated
+# TRANSCEIVER_DOM_TEMPERATURE table; thresholds come from
+# TRANSCEIVER_DOM_THRESHOLD; per-flag warning/alarm state comes from
+# TRANSCEIVER_DOM_FLAG. Field names are defined by xcvrd.
+SFP_TEMPER_TABLE_NAME = 'TRANSCEIVER_DOM_TEMPERATURE'
+SFP_THRESHOLD_TABLE_NAME = 'TRANSCEIVER_DOM_THRESHOLD'
+SFP_FLAG_TABLE_NAME = 'TRANSCEIVER_DOM_FLAG'
+SFP_DISPLAY_TIME_FORMAT = '%Y%m%d %H:%M:%S'
+SFP_TEMPER_FIELD_NAME = 'temperature'
+# Threshold field names (TRANSCEIVER_DOM_THRESHOLD) are snake_case as
+# defined by the SFP API (e.g. CMIS get_transceiver_threshold_info).
+SFP_TEMP_HIGH_WARN_FIELD = 'temphighwarning'
+SFP_TEMP_LOW_WARN_FIELD = 'templowwarning'
+SFP_TEMP_HIGH_ALARM_FIELD = 'temphighalarm'
+SFP_TEMP_LOW_ALARM_FIELD = 'templowalarm'
+# Flag field names (TRANSCEIVER_DOM_FLAG) are camelCase as defined by the
+# SFP API (e.g. CMIS get_transceiver_dom_flags) and do not match the
+# threshold field names.
+SFP_TEMP_FLAG_HIGH_ALARM_FIELD = 'tempHAlarm'
+SFP_TEMP_FLAG_LOW_ALARM_FIELD = 'tempLAlarm'
+SFP_TEMP_FLAG_HIGH_WARN_FIELD = 'tempHWarn'
+SFP_TEMP_FLAG_LOW_WARN_FIELD = 'tempLWarn'
+SFP_TEMP_FLAG_FIELDS = (
+    SFP_TEMP_FLAG_HIGH_WARN_FIELD,
+    SFP_TEMP_FLAG_LOW_WARN_FIELD,
+    SFP_TEMP_FLAG_HIGH_ALARM_FIELD,
+    SFP_TEMP_FLAG_LOW_ALARM_FIELD,
+)
+
+NA = 'N/A'
+
 
 class TemperShow(object):
     def __init__(self):
         self.db = SonicV2Connector(host="127.0.0.1")
         self.db.connect(self.db.STATE_DB)
+        self._sfp_helper_ready = self._init_sfp_util_helper()
+
+    @staticmethod
+    def _init_sfp_util_helper():
+        """Initialize the shared SfpUtilHelper for port-name mapping.
+
+        Uses utilities_common.platform_sfputil_helper so multi-ASIC
+        port-config handling stays consistent with other CLIs (sfpshow,
+        sfputil). Returns False if the helper is unavailable; SFP rows
+        will then fall back to displaying the logical port name.
+        """
+        if platform_sfputil_helper is None:
+            return False
+        try:
+            platform_sfputil_helper.load_platform_sfputil()
+            platform_sfputil_helper.platform_sfputil_read_porttab_mappings()
+            return True
+        except Exception:
+            return False
+
+    def _sfp_display_name(self, port_name):
+        """Map a logical port name (e.g. 'Ethernet0') to 'xSFP module <N> Temp'.
+
+        Falls back to the logical port name if the mapping is unavailable.
+        This matches the legacy thermalctld naming convention so existing
+        consumers/operators see the same sensor labels.
+        """
+        if not self._sfp_helper_ready:
+            return port_name
+        try:
+            physical = platform_sfputil_helper.logical_port_name_to_physical_port_list(port_name)
+            if physical and len(physical) > 0 and physical[0] is not None:
+                # physical port index from SfpUtilHelper is already 1-based
+                return 'xSFP module {} Temp'.format(physical[0])
+        except Exception:
+            pass
+        return port_name
+
+    @staticmethod
+    def _get_sfp_db_connections():
+        """Return a list of STATE_DB connections, one per ASIC namespace.
+
+        On single-ASIC platforms this is a single connection to the host
+        STATE_DB. On multi-ASIC platforms each per-ASIC namespace is
+        included so SFP rows from every namespace are collected.
+        """
+        connections = []
+        if multi_asic is not None and multi_asic.is_multi_asic():
+            try:
+                for ns in multi_asic.get_front_end_namespaces():
+                    db = multi_asic.connect_to_all_dbs_for_ns(ns)
+                    connections.append(db)
+            except Exception:
+                connections = []
+        if not connections:
+            db = SonicV2Connector(host="127.0.0.1")
+            db.connect(db.STATE_DB)
+            connections.append(db)
+        return connections
+
+    def _collect_platform_sensors(self):
+        """Collect chassis/PSU/fan thermal sensors from TEMPERATURE_INFO."""
+        rows = []
+        keys = self.db.keys(self.db.STATE_DB, TEMPER_TABLE_NAME + '|*')
+        if not keys:
+            return rows
+        for key in natsorted(keys):
+            key_list = key.split('|')
+            if len(key_list) != 2:
+                print('Warn: Invalid key in table {}: {}'.format(TEMPER_TABLE_NAME, key))
+                continue
+            name = key_list[1]
+            data_dict = self.db.get_all(self.db.STATE_DB, key) or {}
+            rows.append({
+                'name': name,
+                'temperature': data_dict.get(TEMPER_FIELD_NAME, NA),
+                'high_th': data_dict.get(HIGH_THRESH_FIELD_NAME, NA),
+                'low_th': data_dict.get(LOW_THRESH_FIELD_NAME, NA),
+                'crit_high_th': data_dict.get(CRIT_HIGH_THRESH_FIELD_NAME, NA),
+                'crit_low_th': data_dict.get(CRIT_LOW_THRESH_FIELD_NAME, NA),
+                'warning': data_dict.get(WARNING_STATUS_FIELD_NAME, NA),
+                'timestamp': data_dict.get(TIMESTAMP_FIELD_NAME, NA),
+            })
+        return rows
+
+    def _collect_sfp_sensors(self):
+        """Collect SFP/transceiver temperatures from xcvrd-managed tables.
+
+        Map xcvrd threshold fields onto tempershow's columns:
+          high_th       <- temphighwarning
+          low_th        <- templowwarning
+          crit_high_th  <- temphighalarm
+          crit_low_th   <- templowalarm
+
+        Warning column is True if any of the temperature high/low
+        warning/alarm flags in TRANSCEIVER_DOM_FLAG are asserted.
+
+        On multi-ASIC platforms, transceiver tables are namespace-scoped,
+        so this iterates every front-end ASIC namespace's STATE_DB and
+        merges the results.
+        """
+        rows = []
+        timestamp = datetime.now().strftime(SFP_DISPLAY_TIME_FORMAT)
+        seen_ports = set()
+        for db in self._get_sfp_db_connections():
+            try:
+                keys = db.keys(db.STATE_DB, SFP_TEMPER_TABLE_NAME + '|*')
+            except Exception:
+                continue
+            if not keys:
+                continue
+            for key in natsorted(keys):
+                key_list = key.split('|')
+                if len(key_list) != 2:
+                    print('Warn: Invalid key in table {}: {}'.format(SFP_TEMPER_TABLE_NAME, key))
+                    continue
+                port = key_list[1]
+                if port in seen_ports:
+                    continue
+                seen_ports.add(port)
+                temp_dict = db.get_all(db.STATE_DB, key) or {}
+                thr_dict = db.get_all(
+                    db.STATE_DB,
+                    '{}|{}'.format(SFP_THRESHOLD_TABLE_NAME, port)) or {}
+                flag_dict = db.get_all(
+                    db.STATE_DB,
+                    '{}|{}'.format(SFP_FLAG_TABLE_NAME, port)) or {}
+                rows.append({
+                    'name': self._sfp_display_name(port),
+                    'temperature': temp_dict.get(SFP_TEMPER_FIELD_NAME, NA),
+                    'high_th': thr_dict.get(SFP_TEMP_HIGH_WARN_FIELD, NA),
+                    'low_th': thr_dict.get(SFP_TEMP_LOW_WARN_FIELD, NA),
+                    'crit_high_th': thr_dict.get(SFP_TEMP_HIGH_ALARM_FIELD, NA),
+                    'crit_low_th': thr_dict.get(SFP_TEMP_LOW_ALARM_FIELD, NA),
+                    'warning': self._derive_sfp_warning(flag_dict),
+                    'timestamp': timestamp,
+                })
+        return rows
+
+    @staticmethod
+    def _derive_sfp_warning(flag_dict):
+        """Return True/False/N/A based on temp flags in TRANSCEIVER_DOM_FLAG.
+
+        True  - any of temphigh/lowwarning/alarm is asserted
+        False - all four flags are present and de-asserted
+        N/A   - none of the four flags are present
+        """
+        if not flag_dict:
+            return NA
+        seen = False
+        for field in SFP_TEMP_FLAG_FIELDS:
+            value = flag_dict.get(field)
+            if value is None:
+                continue
+            seen = True
+            if str(value).strip().lower() == 'true':
+                return True
+        return False if seen else NA
 
     def show(self, output_json):
-        keys = self.db.keys(self.db.STATE_DB, TEMPER_TABLE_NAME + '*')
-        if not keys:
+        rows = self._collect_platform_sensors() + self._collect_sfp_sensors()
+        if not rows:
             print('Thermal Not detected\n')
             return
 
-        table = []
-        json_output = []
-        for key in natsorted(keys):
-            key_list = key.split('|')
-            if len(key_list) != 2: # error data in DB, log it and ignore
-                print('Warn: Invalid key in table {}: {}'.format(TEMPER_TABLE_NAME, key))
-                continue
-
-            name = key_list[1]
-            data_dict = self.db.get_all(self.db.STATE_DB, key)
-            if output_json:
-                json_output.append({
-                    "Sensor": name,
-                    "Temperature": data_dict[TEMPER_FIELD_NAME],
-                    "High_TH": data_dict[HIGH_THRESH_FIELD_NAME],
-                    "Low_TH": data_dict[LOW_THRESH_FIELD_NAME],
-                    "Crit_High_TH": data_dict[CRIT_HIGH_THRESH_FIELD_NAME],
-                    "Crit_Low_TH": data_dict[CRIT_LOW_THRESH_FIELD_NAME],
-                    "Warning": data_dict[WARNING_STATUS_FIELD_NAME],
-                    "Timestamp": data_dict[TIMESTAMP_FIELD_NAME]
-                })
-
-            else:
-                table.append((name, 
-                              data_dict[TEMPER_FIELD_NAME], 
-                              data_dict[HIGH_THRESH_FIELD_NAME],
-                              data_dict[LOW_THRESH_FIELD_NAME],
-                              data_dict[CRIT_HIGH_THRESH_FIELD_NAME],
-                              data_dict[CRIT_LOW_THRESH_FIELD_NAME],
-                              data_dict[WARNING_STATUS_FIELD_NAME],
-                              data_dict[TIMESTAMP_FIELD_NAME]
-                              ))
-        
         if output_json:
+            json_output = [{
+                "Sensor": r['name'],
+                "Temperature": r['temperature'],
+                "High_TH": r['high_th'],
+                "Low_TH": r['low_th'],
+                "Crit_High_TH": r['crit_high_th'],
+                "Crit_Low_TH": r['crit_low_th'],
+                "Warning": r['warning'],
+                "Timestamp": r['timestamp'],
+            } for r in rows]
             print(json.dumps(json_output, indent=2))
-        elif table:
-            print(tabulate(table, header, tablefmt='simple', stralign='right'))
-        else:
-            print('No temperature data available\n')
+            return
 
-            
+        table = [(r['name'], r['temperature'], r['high_th'], r['low_th'],
+                  r['crit_high_th'], r['crit_low_th'], r['warning'],
+                  r['timestamp']) for r in rows]
+        print(tabulate(table, header, tablefmt='simple', stralign='right'))
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Display the temperature Sensor information',
                                      formatter_class=argparse.RawTextHelpFormatter,

--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -8,7 +8,7 @@ import json
 from datetime import datetime
 
 from tabulate import tabulate
-from swsscommon.swsscommon import SonicV2Connector
+from swsscommon.swsscommon import SonicDBConfig, SonicV2Connector
 from natsort import natsorted
 
 try:
@@ -67,6 +67,8 @@ NA = 'N/A'
 
 class TemperShow(object):
     def __init__(self):
+        if not SonicDBConfig.isGlobalInit():
+            SonicDBConfig.load_sonic_global_db_config()
         self.db = SonicV2Connector(host="127.0.0.1")
         self.db.connect(self.db.STATE_DB)
         self._sfp_helper_ready = self._init_sfp_util_helper()

--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -86,7 +86,7 @@ class TemperShow(object):
             platform_sfputil_helper.load_platform_sfputil()
             platform_sfputil_helper.platform_sfputil_read_porttab_mappings()
             return True
-        except Exception:
+        except (Exception, SystemExit):
             return False
 
     def _sfp_display_name(self, port_name):
@@ -118,11 +118,16 @@ class TemperShow(object):
         connections = []
         if multi_asic is not None and multi_asic.is_multi_asic():
             try:
-                for ns in multi_asic.get_front_end_namespaces():
-                    db = multi_asic.connect_to_all_dbs_for_ns(ns)
-                    connections.append(db)
+                namespaces = multi_asic.get_front_end_namespaces()
             except Exception:
-                connections = []
+                namespaces = []
+            # Connect per-namespace so a single failing namespace does not
+            # silently drop SFP rows from the other namespaces.
+            for ns in namespaces:
+                try:
+                    connections.append(multi_asic.connect_to_all_dbs_for_ns(ns))
+                except Exception:
+                    continue
         if not connections:
             db = SonicV2Connector(host="127.0.0.1")
             db.connect(db.STATE_DB)
@@ -180,6 +185,8 @@ class TemperShow(object):
                 continue
             if not keys:
                 continue
+            thr_map = self._prefetch_table(db, SFP_THRESHOLD_TABLE_NAME)
+            flag_map = self._prefetch_table(db, SFP_FLAG_TABLE_NAME)
             for key in natsorted(keys):
                 key_list = key.split('|')
                 if len(key_list) != 2:
@@ -190,12 +197,8 @@ class TemperShow(object):
                     continue
                 seen_ports.add(port)
                 temp_dict = db.get_all(db.STATE_DB, key) or {}
-                thr_dict = db.get_all(
-                    db.STATE_DB,
-                    '{}|{}'.format(SFP_THRESHOLD_TABLE_NAME, port)) or {}
-                flag_dict = db.get_all(
-                    db.STATE_DB,
-                    '{}|{}'.format(SFP_FLAG_TABLE_NAME, port)) or {}
+                thr_dict = thr_map.get(port, {})
+                flag_dict = flag_map.get(port, {})
                 rows.append({
                     'name': self._sfp_display_name(port),
                     'temperature': temp_dict.get(SFP_TEMPER_FIELD_NAME, NA),
@@ -209,12 +212,40 @@ class TemperShow(object):
         return rows
 
     @staticmethod
-    def _derive_sfp_warning(flag_dict):
-        """Return True/False/N/A based on temp flags in TRANSCEIVER_DOM_FLAG.
+    def _prefetch_table(db, table_name):
+        """Build a {port: {field: value}} map for an entire STATE_DB table.
 
-        True  - any of temphigh/lowwarning/alarm is asserted
-        False - all four flags are present and de-asserted
-        N/A   - none of the four flags are present
+        Used to avoid per-port hgetall round trips when populating SFP rows.
+        Returns an empty dict on any DB error.
+        """
+        result = {}
+        try:
+            keys = db.keys(db.STATE_DB, table_name + '|*')
+        except Exception:
+            return result
+        if not keys:
+            return result
+        for key in keys:
+            parts = key.split('|')
+            if len(parts) != 2:
+                continue
+            try:
+                result[parts[1]] = db.get_all(db.STATE_DB, key) or {}
+            except Exception:
+                continue
+        return result
+
+    @staticmethod
+    def _derive_sfp_warning(flag_dict):
+        """Return 'True'/'False'/'N/A' based on temp flags in TRANSCEIVER_DOM_FLAG.
+
+        Returns string values to stay consistent with the platform sensor
+        warning column (which is read as a string from TEMPERATURE_INFO),
+        keeping the JSON output's 'Warning' field type stable across rows.
+
+        'True'  - any of temphigh/lowwarning/alarm is asserted
+        'False' - all four flags are present and de-asserted
+        'N/A'   - none of the four flags are present
         """
         if not flag_dict:
             return NA
@@ -225,8 +256,8 @@ class TemperShow(object):
                 continue
             seen = True
             if str(value).strip().lower() == 'true':
-                return True
-        return False if seen else NA
+                return 'True'
+        return 'False' if seen else NA
 
     def show(self, output_json):
         rows = self._collect_platform_sensors() + self._collect_sfp_sensors()


### PR DESCRIPTION
#### What I did

Update `tempershow` (`show platform temperature`) to read SFP/transceiver temperatures from xcvrd-managed STATE_DB tables (`TRANSCEIVER_DOM_TEMPERATURE` for the value, `TRANSCEIVER_DOM_THRESHOLD` for thresholds, `TRANSCEIVER_DOM_FLAG` for the warning state), instead of relying on `TEMPERATURE_INFO` entries published by `thermalctld`.

This is the CLI-side companion to the `thermalctld` change that stops polling and publishing per-SFP temperature data into `TEMPERATURE_INFO` (sonic-platform-daemons). After that change, SFP rows would silently disappear from `show platform temperature` unless the CLI sources them directly from xcvrd's tables.

Field mapping from xcvrd tables to tempershow columns:

| tempershow column | xcvrd table                  | xcvrd field        |
| ----------------- | ---------------------------- | ------------------ |
| Temperature       | `TRANSCEIVER_DOM_TEMPERATURE` | `temperature`      |
| High TH           | `TRANSCEIVER_DOM_THRESHOLD`   | `temphighwarning`  |
| Low TH            | `TRANSCEIVER_DOM_THRESHOLD`   | `templowwarning`   |
| Crit High TH      | `TRANSCEIVER_DOM_THRESHOLD`   | `temphighalarm`    |
| Crit Low TH       | `TRANSCEIVER_DOM_THRESHOLD`   | `templowalarm`     |
| Warning           | `TRANSCEIVER_DOM_FLAG`        | `tempHWarn` / `tempLWarn` / `tempHAlarm` / `tempLAlarm` |

Note: xcvrd's `TRANSCEIVER_DOM_FLAG` table uses **camelCase** field names (per the SFP API `get_transceiver_dom_flags()`), while `TRANSCEIVER_DOM_THRESHOLD` uses **snake_case** field names (per `get_transceiver_threshold_info()`). Both naming conventions are handled correctly.

Additional behavior:

- Sensor name parity with the legacy thermalctld output: SFP rows are labelled `xSFP module <N> Temp`, mapped via the shared `utilities_common.platform_sfputil_helper` (used by `sfpshow` / `sfputil`), so multi-ASIC port-config handling stays consistent across CLIs. Falls back to the logical port name if the helper is unavailable.
- `Warning` column is `True` when any of the four temperature flags (`tempHWarn`, `tempLWarn`, `tempHAlarm`, `tempLAlarm`) in `TRANSCEIVER_DOM_FLAG` is asserted; `False` when all four are present and de-asserted; `N/A` when the flag table has no temperature flags for the port. This matches the legacy thermalctld semantics.
- `Timestamp` column uses the current wall-clock time formatted as `YYYYMMDD HH:MM:SS`, matching the legacy thermalctld behavior of stamping every poll with the current time.
- Multi-ASIC support: Calls `SonicDBConfig.load_sonic_global_db_config()` to initialize global DB config before creating namespace-scoped connections. SFP rows are collected by iterating every front-end ASIC namespace's `STATE_DB` (via `multi_asic.get_front_end_namespaces()` and `multi_asic.connect_to_all_dbs_for_ns()`) and merging the results, so transceiver rows from per-namespace tables are not missed on multi-ASIC platforms.
- Existing platform thermal sensors (chassis/PSU/fan/CPU/SODIMM) continue to be displayed from `TEMPERATURE_INFO`.
- Missing fields default to `N/A` instead of raising `KeyError`.
- Tightened the table-key glob to `<table>|*` so unrelated keys are not accidentally matched.

#### How I did it

- Added `_collect_platform_sensors()` (existing TEMPERATURE_INFO data path) and a new `_collect_sfp_sensors()` that reads `TRANSCEIVER_DOM_TEMPERATURE|*` plus the matching `TRANSCEIVER_DOM_THRESHOLD|<port>` and `TRANSCEIVER_DOM_FLAG|<port>` rows.
- Added `_init_sfp_util_helper()` / `_sfp_display_name()` that delegate to `utilities_common.platform_sfputil_helper` for logical -> physical port mapping, reusing the shared multi-ASIC-aware helper instead of re-implementing the porttab init logic.
- Added `_get_sfp_db_connections()` to return one `STATE_DB` connection per front-end ASIC namespace on multi-ASIC platforms (and a single host connection on single-ASIC), so transceiver tables are read from every namespace.
- Added `_derive_sfp_warning()` to translate the four temperature flags in `TRANSCEIVER_DOM_FLAG` into the `True` / `False` / `N/A` warning state.
- Added `SonicDBConfig.load_sonic_global_db_config()` call (guarded by `isGlobalInit()`) in `__init__` to initialize global DB config for multi-ASIC namespace resolution. Without this, `connect_to_all_dbs_for_ns()` fails with `validateNamespace: Initialize global DB config`.
- Compute the `Timestamp` once per `show` invocation using `datetime.now().strftime('%Y%m%d %H:%M:%S')` so the format matches the legacy `TEMPERATURE_INFO.timestamp` column written by thermalctld.
- `show()` merges platform + SFP rows; both tabular and JSON (`-j`) outputs are supported with the same column set as before.

#### How to verify it

1. Install the updated `tempershow` and the companion `thermalctld` (which no longer publishes SFP entries to `TEMPERATURE_INFO`).
2. Run `show platform temperature`.
3. Confirm:
   - SFP rows are present and labelled `xSFP module <N> Temp`.
   - SFP temperature values match `sonic-db-cli -n asic0 STATE_DB hget 'TRANSCEIVER_DOM_TEMPERATURE|<port>' temperature` (on multi-ASIC) or `redis-cli -n 6 hget 'TRANSCEIVER_DOM_TEMPERATURE|<port>' temperature` (on single-ASIC).
   - SFP thresholds match the corresponding `TRANSCEIVER_DOM_THRESHOLD|<port>` fields.
   - `Warning` reflects the temperature flag state in `TRANSCEIVER_DOM_FLAG|<port>` (`False` when all four temp flags are de-asserted, `True` if any is asserted, `N/A` if the flags are not yet populated).
   - `Timestamp` is in the same `YYYYMMDD HH:MM:SS` format as the platform sensor rows and reflects the time the command was run.
   - Chassis / PSU / fan / CPU / SODIMM rows still appear and remain sourced from `TEMPERATURE_INFO`.
   - `show platform temperature -j` still produces well-formed JSON with `Sensor` / `Temperature` keys.
4. Verify there are no `TEMPERATURE_INFO|*SFP*` keys remaining: `redis-cli -n 6 keys 'TEMPERATURE_INFO|*SFP*'`.

#### Tested on

- **Single-ASIC**: Mellanox SN2700 (SONiC master) — SFP rows displayed correctly
- **Multi-ASIC**: Arista 7280DR3AM-36 (ASIC Count: 2, Broadcom DNX) — SFP rows from both `asic0` and `asic1` namespaces displayed correctly after `SonicDBConfig.load_sonic_global_db_config()` fix

#### Previous command output (if the output of a command-line utility has changed)

```
$ show platform temperature
                Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
                  ASIC           71.0        105       N/A             120            N/A      False  20260506 18:28:08
 Ambient Fan Side Temp         32.562        N/A       N/A             N/A            N/A      False  20260506 18:28:08
Ambient Port Side Temp         32.562        N/A       N/A             N/A            N/A      False  20260506 18:28:08
         CPU Pack Temp         34.375       95.0       N/A           100.0            N/A      False  20260506 18:28:08
            PSU-1 Temp            N/A        N/A       N/A             N/A            N/A      False  20260506 18:28:08
            PSU-2 Temp           24.5       63.0       N/A             N/A            N/A      False  20260506 18:28:08
            PSU-3 Temp            N/A        N/A       N/A             N/A            N/A      False  20260506 18:28:08
            PSU-4 Temp           24.5       63.0       N/A             N/A            N/A      False  20260506 18:28:08
         SODIMM 2 Temp           35.5       85.0       N/A            95.0            N/A      False  20260506 18:28:08
    xSFP module 1 Temp         46.715       75.0      -5.0            80.0          -10.0      False  20260506 18:28:08
    xSFP module 2 Temp         53.297       75.0      -5.0            80.0          -10.0      False  20260506 18:28:08
    ... (SFP modules 3..64, populated transceivers)
   xSFP module 65 Temp            0.0       70.0       0.0            75.0           -5.0      False  20260506 18:28:08
   xSFP module 66 Temp            0.0       70.0       0.0            75.0           -5.0      False  20260506 18:28:08
```

(SFP rows sourced from `TEMPERATURE_INFO` populated by `thermalctld`.)

#### New command output (if the output of a command-line utility has changed)

```
$ show platform temperature
                Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
                  ASIC           72.0        105       N/A             120            N/A      False  20260506 22:06:16
 Ambient Fan Side Temp         33.812        N/A       N/A             N/A            N/A      False  20260506 22:05:58
Ambient Port Side Temp         33.562        N/A       N/A             N/A            N/A      False  20260506 22:05:58
         CPU Pack Temp          34.75       95.0       N/A           100.0            N/A      False  20260506 22:05:58
            PSU-1 Temp            N/A        N/A       N/A             N/A            N/A      False  20260506 22:05:58
            PSU-2 Temp           25.0       63.0       N/A             N/A            N/A      False  20260506 22:05:58
            PSU-3 Temp            N/A        N/A       N/A             N/A            N/A      False  20260506 22:05:58
            PSU-4 Temp           25.0       63.0       N/A             N/A            N/A      False  20260506 22:05:58
         SODIMM 2 Temp           36.0       85.0       N/A            95.0            N/A      False  20260506 22:05:58
    xSFP module 1 Temp         48.617       75.0      -5.0            80.0          -10.0      False  20260506 22:06:19
    xSFP module 2 Temp         54.832       75.0      -5.0            80.0          -10.0      False  20260506 22:06:19
   ... (SFP modules 3..64, populated transceivers)
   xSFP module 65 Temp            0.0       70.0       0.0            75.0           -5.0        N/A  20260506 22:06:19
   xSFP module 66 Temp            0.0       70.0       0.0            75.0           -5.0        N/A  20260506 22:06:19
```

Notes:

- SFP rows now come from `TRANSCEIVER_DOM_TEMPERATURE` / `TRANSCEIVER_DOM_THRESHOLD` (values + thresholds) and `TRANSCEIVER_DOM_FLAG` (warning state) instead of `TEMPERATURE_INFO`.
- Sensor labels are unchanged (`xSFP module <N> Temp`), so dashboards and parsers depending on the legacy naming continue to work.
- `Warning` and `Timestamp` columns are populated for SFP rows with the same semantics and format as the legacy thermalctld output. Modules 65 and 66 show `N/A` for `Warning` because their `TRANSCEIVER_DOM_FLAG` table is not populated (no transceiver inserted on this device for those ports).