### PR TITLE
[showtech] Add dmidecode -t memory to generate_dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2584,6 +2584,7 @@ main() {
     save_cmd "lspci -vvv -xx" "lspci" &
     save_cmd "lsusb -v" "lsusb" &
     save_cmd "sysctl -a" "sysctl" &
+    save_cmd "dmidecode -t memory" "dmidecode.mem" &
     wait
 
     save_ip_info &


### PR DESCRIPTION
Added "dmidecode -t memory" to generate_dump script.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add `dmidecode -t memory` to `show tech support` CLI

#### How I did it
Add `dmidecode -t memory` to generate_dump script

#### How to verify it
Run `show tech support` CLI

#### Previous command output (if the output of a command-line utility has changed)
No dmidecode output

#### New command output (if the output of a command-line utility has changed)
dmidecode memory dump in `/var/dump/...`
