### PR TITLE
Make show int stat on supervisor trigger rexec

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -152,7 +152,7 @@ def status(interfacename, namespace, display, verbose):
     if device_info.is_supervisor():
         # the command will be executed directly by rexec
         click.echo("Since the current device is a chassis supervisor, "
-                    "this command will be executed remotely on all linecards")
+                   "this command will be executed remotely on all linecards")
         proc = subprocess.run(["rexec", "all"] + ["-c", " ".join(sys.argv)])
         sys.exit(proc.returncode)
 

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 import subprocess
 import click
@@ -147,6 +148,13 @@ def naming_mode(verbose):
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def status(interfacename, namespace, display, verbose):
     """Show Interface status information"""
+
+    if device_info.is_supervisor():
+        # the command will be executed directly by rexec
+        click.echo("Since the current device is a chassis supervisor, "
+                    "this command will be executed remotely on all linecards")
+        proc = subprocess.run(["rexec", "all"] + ["-c", " ".join(sys.argv)])
+        sys.exit(proc.returncode)
 
     ctx = click.get_current_context()
 

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -25,6 +25,40 @@ Error
 '''
 
 
+class TestRexecInterfacesStatus(object):
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    @mock.patch("show.interfaces.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "interfaces", "status"])
+    def test_show_interfaces_status_rexec(self):
+        import show.main as show
+        runner = CliRunner()
+
+        _old_subprocess_run = subprocess.run
+        subprocess.run = mock_rexec_command
+        result = runner.invoke(show.cli.commands["interfaces"].commands["status"])
+        print(result.output)
+        subprocess.run = _old_subprocess_run
+        assert result.exit_code == 0
+        assert MULTI_LC_REXEC_OUTPUT == result.output
+
+    @mock.patch("show.interfaces.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "interfaces", "status"])
+    def test_show_interfaces_status_error_rexec(self):
+        import show.main as show
+        runner = CliRunner()
+
+        _old_subprocess_run = subprocess.run
+        subprocess.run = mock_rexec_error_cmd
+        result = runner.invoke(show.cli.commands["interfaces"].commands["status"])
+        print(result.output)
+        subprocess.run = _old_subprocess_run
+        assert result.exit_code == 1
+        assert MULTI_LC_ERR_OUTPUT == result.output
+
+
 class TestRexecBgp(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

Fixes https://github.com/sonic-net/sonic-buildimage/issues/27222

#### What I did
Change `show int stat` on chassis supervisor to trigger `rexec`, to return `show int stat` output from LCs (as happens when running `show ip bgp ...` on supervisors)
#### How I did it
Add the same functionality under `status` as is under `bgp` functions
#### How to verify it
Edited python file on device, to ensure it works
#### Previous command output (if the output of a command-line utility has changed)
```
admin@t2_supervisor:~$ show int stat
  Interface    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  -------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
```
#### New command output (if the output of a command-line utility has changed)
```
admin@t2_supervisor:~$ show int stat
Since the current device is a chassis supervisor, this command will be executed remotely on all linecards
Password for username 'admin':
======== LINE-CARD0|None output: ========
     Interface            Lanes    Speed    MTU    FEC         Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  ------------  --------------  ------  -------  ---------------  ----------
     Ethernet0      72,73,74,75     100G   9100     rs   Ethernet1/1  PortChannel102      up       up  QSFP28 or later         off
     Ethernet8      80,81,82,83     100G   9100     rs   Ethernet2/1  PortChannel102      up       up  QSFP28 or later         off
    Ethernet16      88,89,90,91     100G   9100     rs   Ethernet3/1  PortChannel104      up       up  QSFP28 or later         off
... 

======== LINE-CARD1|None output: ========
     Interface            Lanes    Speed    MTU    FEC         Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  ------------  --------------  ------  -------  ---------------  ----------
     Ethernet0      72,73,74,75     100G   9100     rs   Ethernet1/1  PortChannel101      up       up  QSFP28 or later         off
     Ethernet8      80,81,82,83     100G   9100     rs   Ethernet2/1  PortChannel101      up       up  QSFP28 or later         off
    Ethernet16      88,89,90,91     100G   9100     rs   Ethernet3/1  PortChannel103      up       up  QSFP28 or later         off
...

======== LINE-CARD2|None output: ========
     Interface            Lanes    Speed    MTU    FEC         Alias            Vlan    Oper    Admin             Type    Asym PFC
--------------  ---------------  -------  -----  -----  ------------  --------------  ------  -------  ---------------  ----------
     Ethernet0      72,73,74,75     100G   9100     rs   Ethernet1/1  PortChannel149      up       up  QSFP28 or later         off
     Ethernet8      80,81,82,83     100G   9100     rs   Ethernet2/1  PortChannel149      up       up  QSFP28 or later         off
    Ethernet16      88,89,90,91     100G   9100     rs   Ethernet3/1  PortChannel150      up       up  QSFP28 or later         off
...
```
