### PR TITLE
[tests] Fix flaky test_is_rj45_port and test_load_pcie_module_warning under xdist

### DIFF
--- a/tests/pcieutil_test.py
+++ b/tests/pcieutil_test.py
@@ -209,7 +209,11 @@ class TestPcieUtil(object):
         sys.stdout = result = StringIO()
         try:
             pcieutil.load_platform_pcieutil()
-        except ImportError:
+        except (ImportError, SystemExit):
+            # On platforms that ship sonic_platform.pcie (e.g. Mellanox), the
+            # import succeeds but Pcie("dummy_path") sys.exit()s when the yaml
+            # config isn't found. The warning we're checking for is only emitted
+            # on the ImportError branch, so SystemExit is fine to swallow here.
             pass
         sys.stdout = stdout
         assert pcieutil_load_module_warning_msg not in result.getvalue()

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -1224,8 +1224,12 @@ Ethernet200  Not present
     def test_is_rj45_port(self):
         import utilities_common.platform_sfputil_helper as platform_sfputil_helper
         platform_sfputil_helper.platform_chassis = None
+        # Force `import sonic_platform` to raise ImportError regardless of whether
+        # the package is installed (it is, in per-platform sonic-buildimage CI) and
+        # regardless of whether other tests in this xdist worker pre-loaded it.
         mods_to_hide = {k: None for k in list(sys.modules)
                         if k == 'sonic_platform' or k.startswith('sonic_platform.')}
+        mods_to_hide.setdefault('sonic_platform', None)
         with patch.dict(sys.modules, mods_to_hide):
             assert platform_sfputil_helper.is_rj45_port("Ethernet0") is False
 


### PR DESCRIPTION
#### What I did

Fix two latent bugs in `tests/sfp_test.py::Test_multiAsic_SFP::test_is_rj45_port` and `tests/pcieutil_test.py::TestPcieUtil::test_load_pcie_module_warning` that surface as flaky failures when sonic-utilities is built inside sonic-buildimage CI for a real platform (e.g. Mellanox, nvidia-bluefield).

Failures observed in the sonic-buildimage submodule-update PR [sonic-net/sonic-buildimage#27221](https://github.com/sonic-net/sonic-buildimage/pull/27221), reported on [PR #4516](https://github.com/sonic-net/sonic-utilities/pull/4516#issuecomment-4401925356):

- `test_is_rj45_port` — `TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'` (Mellanox + nvidia-bluefield trixie wheel builds)
- `test_load_pcie_module_warning` — `SystemExit` (Mellanox trixie wheel build)

These follow up on the parallelization work in #4439, #4519, and #4516. Parallelization didn't introduce the bugs (the tests have been wrong since they were written), but `--dist loadfile` removed the incidental sequential test ordering that was masking them on standalone sonic-utilities CI.

#### How I did it

**`test_is_rj45_port`** — the test built `mods_to_hide` solely from currently-loaded `sys.modules` entries:

```python
mods_to_hide = {k: None for k in list(sys.modules)
                if k == 'sonic_platform' or k.startswith('sonic_platform.')}
with patch.dict(sys.modules, mods_to_hide):
    assert platform_sfputil_helper.is_rj45_port("Ethernet0") is False
```

If no test in the worker's queue had already imported `sonic_platform`, the dict was empty and `patch.dict` was a no-op. In sonic-buildimage CI the platform's `sonic_platform` package _is_ installed, so the real import succeeded and ran into `device_info.get_path_to_platform_dir()` returning `None`, triggering `TypeError` in `os.path.join` — which the production `except (ModuleNotFoundError, FileNotFoundError)` clause doesn't catch. (The pre-#4439 `sys.modules.pop('sonic_platform')` had the same flaw and would fail under the same conditions; only sequential test ordering hid it.)

Fix: unconditionally force `sonic_platform` to `None` in `sys.modules` so the import always raises `ModuleNotFoundError`, regardless of prior worker state.

```python
mods_to_hide = {k: None for k in list(sys.modules)
                if k == 'sonic_platform' or k.startswith('sonic_platform.')}
mods_to_hide.setdefault('sonic_platform', None)
with patch.dict(sys.modules, mods_to_hide):
    assert platform_sfputil_helper.is_rj45_port("Ethernet0") is False
```

Verified locally that `sys.modules['sonic_platform'] = None` causes `import sonic_platform` to raise `ModuleNotFoundError`, which the production code's `except` clause does catch.

**`test_load_pcie_module_warning`** — the test only caught `ImportError`:

```python
try:
    pcieutil.load_platform_pcieutil()
except ImportError:
    pass
```

On Mellanox the `from sonic_platform.pcie import Pcie` import succeeds, so `Pcie("dummy_path")` runs and calls `load_config_file()`, which on `FileNotFoundError` does `sys.exit()` → `SystemExit` propagates and fails the test. The stdout-warning assertion (`pcieutil_load_module_warning_msg not in result.getvalue()`) would still hold either way because `log.log_warning` writes to syslog rather than stdout.

Fix: also catch `SystemExit`.

```python
try:
    pcieutil.load_platform_pcieutil()
except (ImportError, SystemExit):
    pass
```

#### How to verify it

- Standalone sonic-utilities CI (Azure.sonic-utilities) — both tests continue to pass via the `ModuleNotFoundError` path since `sonic_platform` isn't installed there.
- sonic-buildimage submodule update CI (Mellanox + nvidia-bluefield trixie wheel builds) — both tests should now pass deterministically; previously they failed in 4/4 retries on Mellanox and 4/4 retries on nvidia-bluefield (rj45 only).
- Reproduced the fix logic locally with a synthetic Python script confirming `sys.modules['sonic_platform'] = None` raises `ModuleNotFoundError` whether or not the module was previously loaded.

#### Previous command output (if the output of a command-line utility has changed)

N/A — test-only changes.

#### New command output (if the output of a command-line utility has changed)

N/A — test-only changes.