### PR TITLE
[config] Add YANG validation to config load command (issue 3502)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1879,6 +1879,38 @@ def load(filename, yes):
             click.echo("The config_db file {} doesn't exist".format(file))
             return
 
+        # Validate the config file before loading
+        try:
+            with open(file, 'r') as f:
+                config_input = json.load(f)
+
+            # Get config DB connection for the namespace
+            config_db = ConfigDBConnector(use_unix_socket_path=False, namespace=namespace)
+            config_db.connect()
+
+            # Enable YANG validation if configured
+            yang_enabled = device_info.is_yang_config_validation_enabled(config_db)
+            if yang_enabled:
+                # Validate the input config using YANG
+                try:
+                    cm = ConfigMgmt(configdb=config_db)
+                    cm.validateConfigData()
+
+                    # Validate input config
+                    tmp_config = copy.deepcopy(config_input)
+                    cm.loadData(tmp_config)
+                    cm.validateConfigData()
+                except Exception as ex:
+                    click.secho("Failed to validate config file {}. Error: {}".format(file, ex), fg="red")
+                    sys.exit(1)
+
+        except json.JSONDecodeError as ex:
+            click.secho("Failed to parse JSON config file {}. Error: {}".format(file, ex), fg="red")
+            sys.exit(1)
+        except Exception as ex:
+            click.secho("Error validating config file {}. Error: {}".format(file, ex), fg="red")
+            sys.exit(1)
+
         if namespace is None:
             command = [str(SONIC_CFGGEN_PATH), '-j', file, '--write-to-db']
         else:


### PR DESCRIPTION
Fixes issue #3502: config load command now validates YANG schema constraints before loading configuration into CONFIG_DB. This prevents invalid configurations from being loaded, especially for features like CACL or CoPP that don't have sonic-cli configuration support.

The validation is performed when YANG config validation is enabled and will report leafref violations and other schema errors early, preventing downstream issues during config replace or rollback operations.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

- Modified the [load()](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) command in [config/main.py](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to add YANG schema validation before writing configuration to CONFIG_DB
- Added validation logic that checks if YANG config validation is enabled on the DUT
- Integrated existing [ConfigMgmt](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) class validation methods to validate input config
- Added proper error handling and user-friendly error messages
- Ensured validation works for both single-ASIC and multi-ASIC systems

#### How I did it
1. Enhanced the config load command ([config/main.py](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):

- Added JSON parsing for the config file before loading
- Initialized ConfigDBConnector for the target namespace
- Checked if YANG validation is enabled via [device_info.is_yang_config_validation_enabled()](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Used [ConfigMgmt](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) class to validate:
- Running config in the current state
- Input config from the JSON file
- Reports YANG validation errors with clear messages before writing to DB

2. Integration with existing infrastructure:
- Leveraged existing [ConfigMgmt](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) validation methods
- Used same validation pattern as [config replace](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) command
- Maintained backward compatibility when YANG validation is disabled

#### How to verify it
Test Case 1: Invalid CACL Rule (issue reproduction)
# Create invalid CACL rule without CACL table
cat > /tmp/acl.json <<EOF
{
    "ACL_RULE": {
        "control-plane-v4|30-SNMP": {
            "IP_PROTOCOL": "17",
            "SRC_IP": "172.168.158.0/24",
            "PACKET_ACTION": "ACCEPT",
            "L4_DST_PORT_RANGE": "161-162",
            "PRIORITY": "9999"
        }
    }
}
EOF

# Try to load config
sudo config load /tmp/acl.json

Expected Output (Before Fix):
# Config loads without validation error
# Error only appears later during config replace/rollback

Expected Output (After Fix):
Failed to validate config file /tmp/acl.json. Error: Leafref "/sonic-acl:sonic-acl/sonic-acl:ACL_TABLE/sonic-acl:ACL_TABLE_LIST/sonic-acl:ACL_TABLE_NAME" of value "control-plane-v4" points to a non-existing leaf.

Test Case 2: Valid configuration (should still work)
# Save current valid config
sudo config save /tmp/valid_config.json

# Load it back
sudo config load /tmp/valid_config.json -y

Expected Output:
Load config from the file(s) /tmp/valid_config.json ?
'load' executing...
[Command output showing successful config load]

#### Previous command output (if the output of a command-line utility has changed)
Before this fix, [config load](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) did not validate YANG schema constraints:

$ sudo config load /tmp/invalid_acl.json -y
'load' executing...
[Loads successfully without validation]

$ sudo config replace /tmp/config_with_invalid_acl.json -d
Config Replacer: Config replacement starting.
...
Error: Given patch will produce invalid config. Error: Data Loading Failed
Leafref "/sonic-acl:sonic-acl/sonic-acl:ACL_TABLE/sonic-acl:ACL_TABLE_LIST/sonic-acl:ACL_TABLE_NAME" of value "control-plane-v4" points to a non-existing leaf.

#### New command output (if the output of a command-line utility has changed)
After this fix, [config load](vscode-file://vscode-app/c:/Users/sumalatha.g/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) validates schema constraints immediately:

$ sudo config load /tmp/invalid_acl.json -y
Failed to validate config file /tmp/invalid_acl.json. Error: Leafref "/sonic-acl:sonic-acl/sonic-acl:ACL_TABLE/sonic-acl:ACL_TABLE_LIST/sonic-acl:ACL_TABLE_NAME" of value "control-plane-v4" points to a non-existing leaf.

Type of change

- [x]  Bug fix
- [x]  New feature
- [x]  Breaking change

Supported testbed topology

- All topologies (this is a CLI validation enhancement)

Testing considerations

- Tested with YANG validation enabled
- Tested with YANG validation disabled (should skip validation gracefully)
- Tested on both single-ASIC and multi-ASIC systems
- Tested with valid and invalid configurations

