### PR TITLE
Sfputil: add loopback-capability and loopback-status flags to sfputil debug loopback

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3896,34 +3896,6 @@ This command displays the current loopback enablement state for each loopback mo
     ...
   ```
 
-- Usage:
-  ```
-  sfputil debug loopback-status [PORT_NAME]
-  ```
-
-- Example (single port):
-  ```
-  admin@sonic:~$ sfputil debug loopback-status Ethernet88
-  Ethernet88: loopback status:
-    host-side-input:   False
-    host-side-output:  False
-    media-side-input:  True
-    media-side-output: False
-  ```
-
-- Example (all ports):
-  ```
-  admin@sonic:~$ sfputil debug loopback-status
-  Ethernet0: loopback status:
-    host-side-input:   False
-    host-side-output:  False
-    media-side-input:  False
-    media-side-output: False
-  Ethernet8: loopback status:
-    host-side-input:   True
-    ...
-  ```
-
 ### CMIS debug rx-output
 
 The command disables RX input by muting the optical receiver on the module, preventing it from detecting incoming signals.

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -56,6 +56,8 @@
   * [CMIS firmware target mode commands](#cmis-firmware-target-mode-commands)
 * [CMIS debug](#cmis-debug)
 * [CMIS debug loopback](#cmis-debug-loopback)
+* [CMIS debug loopback-capability](#cmis-debug-loopback-capability)
+* [CMIS debug loopback-status](#cmis-debug-loopback-status)
 * [CMIS debug rx-output](#cmis-debug-rx-output)
 * [CMIS debug tx-output](#cmis-debug-tx-output)
 * [DHCP Relay](#dhcp-relay)
@@ -3834,41 +3836,65 @@ This command is the standard CMIS diagnostic control used for troubleshooting li
   admin@sonic:~$ sfputil debug loopback Ethernet88 media-side-output disable
   ```
 
-**sfputil debug loopback-capability**
+### CMIS debug loopback-capability
 
-This command reads the loopback modes advertised as supported by the transceiver module. If `PORT_NAME` is omitted, the command iterates over all logical ports and prints the loopback capability of every port whose module advertises one.
+This command displays the loopback modes advertised as supported by the CMIS module. If no port is specified, it prints capability for all ports that support loopback.
+
+**sfputil debug loopback-capability**
 
 - Usage:
   ```
   sfputil debug loopback-capability [PORT_NAME]
   ```
 
-- Example (single port):
+- Example:
   ```
   admin@sonic:~$ sfputil debug loopback-capability Ethernet88
   Ethernet88: loopback capability:
-    simultaneous_host_media_loopback_supported: True
-    per_lane_media_loopback_supported: True
-    per_lane_host_loopback_supported: True
     host_side_input_loopback_supported: True
     host_side_output_loopback_supported: True
-    media_side_input_loopback_supported: True
-    media_side_output_loopback_supported: True
-  ```
+    media_side_input_loopback_supported: False
+    media_side_output_loopback_supported: False
 
-- Example (all ports):
-  ```
   admin@sonic:~$ sfputil debug loopback-capability
   Ethernet0: loopback capability:
-    simultaneous_host_media_loopback_supported: True
+    host_side_input_loopback_supported: True
+    host_side_output_loopback_supported: True
+    media_side_input_loopback_supported: False
+    media_side_output_loopback_supported: False
+  Ethernet4: loopback capability:
     ...
-  Ethernet8: The module does not advertise any loopback capability
-  ...
   ```
+
+### CMIS debug loopback-status
+
+This command displays the current loopback enablement state for each loopback mode on the CMIS module. If no port is specified, it prints status for all ports that support loopback. For host-side it prints per lane.
 
 **sfputil debug loopback-status**
 
-This command reads which loopback modes are currently enabled on the transceiver module. If `PORT_NAME` is omitted, the command iterates over all logical ports and prints the loopback status of every port whose module supports loopback.
+- Usage:
+  ```
+  sfputil debug loopback-status [PORT_NAME]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sfputil debug loopback-status Ethernet88
+  Ethernet88: loopback status:
+    host-side-input:   [True, False, False, False, False, False, False, False]
+    host-side-output:  [False, False, False, False, False, False, False, False]
+    media-side-input:  False
+    media-side-output: False
+
+  admin@sonic:~$ sfputil debug loopback-status
+  Ethernet0: loopback status:
+    host-side-input:   [False, False, False, False, False, False, False, False]
+    host-side-output:  [False, False, False, False, False, False, False, False]
+    media-side-input:  False
+    media-side-output: False
+  Ethernet4: loopback status:
+    ...
+  ```
 
 - Usage:
   ```

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -3834,6 +3834,70 @@ This command is the standard CMIS diagnostic control used for troubleshooting li
   admin@sonic:~$ sfputil debug loopback Ethernet88 media-side-output disable
   ```
 
+**sfputil debug loopback-capability**
+
+This command reads the loopback modes advertised as supported by the transceiver module. If `PORT_NAME` is omitted, the command iterates over all logical ports and prints the loopback capability of every port whose module advertises one.
+
+- Usage:
+  ```
+  sfputil debug loopback-capability [PORT_NAME]
+  ```
+
+- Example (single port):
+  ```
+  admin@sonic:~$ sfputil debug loopback-capability Ethernet88
+  Ethernet88: loopback capability:
+    simultaneous_host_media_loopback_supported: True
+    per_lane_media_loopback_supported: True
+    per_lane_host_loopback_supported: True
+    host_side_input_loopback_supported: True
+    host_side_output_loopback_supported: True
+    media_side_input_loopback_supported: True
+    media_side_output_loopback_supported: True
+  ```
+
+- Example (all ports):
+  ```
+  admin@sonic:~$ sfputil debug loopback-capability
+  Ethernet0: loopback capability:
+    simultaneous_host_media_loopback_supported: True
+    ...
+  Ethernet8: The module does not advertise any loopback capability
+  ...
+  ```
+
+**sfputil debug loopback-status**
+
+This command reads which loopback modes are currently enabled on the transceiver module. If `PORT_NAME` is omitted, the command iterates over all logical ports and prints the loopback status of every port whose module supports loopback.
+
+- Usage:
+  ```
+  sfputil debug loopback-status [PORT_NAME]
+  ```
+
+- Example (single port):
+  ```
+  admin@sonic:~$ sfputil debug loopback-status Ethernet88
+  Ethernet88: loopback status:
+    host-side-input:   False
+    host-side-output:  False
+    media-side-input:  True
+    media-side-output: False
+  ```
+
+- Example (all ports):
+  ```
+  admin@sonic:~$ sfputil debug loopback-status
+  Ethernet0: loopback status:
+    host-side-input:   False
+    host-side-output:  False
+    media-side-input:  False
+    media-side-output: False
+  Ethernet8: loopback status:
+    host-side-input:   True
+    ...
+  ```
+
 ### CMIS debug rx-output
 
 The command disables RX input by muting the optical receiver on the module, preventing it from detecting incoming signals.

--- a/sfputil/debug.py
+++ b/sfputil/debug.py
@@ -176,6 +176,39 @@ def set_output(port_name, enable, direction):
         sys.exit(EXIT_FAIL)
 
 
+def _get_loopback_api_and_capability(port_name, single_port):
+    """Get xcvr API and loopback capability dict for a port.
+
+    Returns (api, cap) when the module exposes the loopback API; cap may be an empty/None
+    dict if the module does not advertise any capability. Returns (None, None) when the
+    module lacks diagnostic page support or the get_loopback_capability method.
+    """
+    sfp = get_sfp_object(port_name)
+
+    try:
+        api = sfp.get_xcvr_api()
+    except NotImplementedError:
+        click.echo(f"{port_name}: This functionality is not implemented")
+        sys.exit(ERROR_NOT_IMPLEMENTED)
+
+    try:
+        if not api.get_diag_page_support():
+            if single_port:
+                click.echo(f"{port_name}: The module does not support diagnostic pages required for loopback")
+            return None, None
+    except AttributeError:
+        pass  # Older sonic-platform-common does not have get_diag_page_support
+
+    try:
+        cap = api.get_loopback_capability()
+    except AttributeError:
+        if single_port:
+            click.echo(f"{port_name}: Loopback capability is not applicable for this module")
+        return None, None
+
+    return api, cap
+
+
 @debug.command(name='loopback-capability')
 @click.argument('port_name', required=False, default=None)
 def loopback_capability(port_name):
@@ -191,31 +224,8 @@ def loopback_capability(port_name):
         if not single_port and (is_rj45_port(port) or not is_sfp_present(port)):
             continue
 
-        sfp = get_sfp_object(port)
-
-        try:
-            api = sfp.get_xcvr_api()
-        except NotImplementedError:
-            if single_port:
-                click.echo(f"{port}: This functionality is not implemented")
-                sys.exit(ERROR_NOT_IMPLEMENTED)
-            continue
-
-        try:
-            if not api.get_diag_page_support():
-                if single_port:
-                    click.echo(f"{port}: The module does not support diagnostic pages required for loopback")
-                    sys.exit(EXIT_FAIL)
-                continue
-        except AttributeError:
-            pass  # Older sonic-platform-common does not have diag page method
-
-        try:
-            cap = api.get_loopback_capability()
-        except AttributeError:
-            if single_port:
-                click.echo(f"{port}: Loopback capability is not applicable for this module")
-                sys.exit(ERROR_NOT_IMPLEMENTED)
+        api, cap = _get_loopback_api_and_capability(port, single_port)
+        if api is None:
             continue
 
         found = True
@@ -246,24 +256,14 @@ def loopback_status(port_name):
         if not single_port and (is_rj45_port(port) or not is_sfp_present(port)):
             continue
 
-        sfp = get_sfp_object(port)
-
-        try:
-            api = sfp.get_xcvr_api()
-        except NotImplementedError:
-            if single_port:
-                click.echo(f"{port}: This functionality is not implemented")
-                sys.exit(ERROR_NOT_IMPLEMENTED)
+        api, cap = _get_loopback_api_and_capability(port, single_port)
+        if api is None:
             continue
 
-        try:
-            if not api.get_diag_page_support():
-                if single_port:
-                    click.echo(f"{port}: The module does not support diagnostic pages required for loopback")
-                    sys.exit(EXIT_FAIL)
-                continue
-        except AttributeError:
-            pass  # Older sonic-platform-common does not have diag_page_support function
+        if not cap:
+            if single_port:
+                click.echo(f"{port}: The module does not advertise any loopback capability")
+            continue
 
         try:
             host_input = api.get_host_input_loopback()
@@ -273,7 +273,6 @@ def loopback_status(port_name):
         except AttributeError:
             if single_port:
                 click.echo(f"{port}: Loopback status is not applicable for this module")
-                sys.exit(ERROR_NOT_IMPLEMENTED)
             continue
 
         found = True

--- a/sfputil/debug.py
+++ b/sfputil/debug.py
@@ -181,15 +181,17 @@ def _get_loopback_api_and_capability(port_name, single_port):
 
     Returns (api, cap) when the module exposes the loopback API; cap may be an empty/None
     dict if the module does not advertise any capability. Returns (None, None) when the
-    module lacks diagnostic page support or the get_loopback_capability method.
+    module lacks the xcvr API, diagnostic page support, or the get_loopback_capability
+    method.
     """
     sfp = get_sfp_object(port_name)
 
     try:
         api = sfp.get_xcvr_api()
     except NotImplementedError:
-        click.echo(f"{port_name}: This functionality is not implemented")
-        sys.exit(ERROR_NOT_IMPLEMENTED)
+        if single_port:
+            click.echo(f"{port_name}: This functionality is not implemented")
+        return None, None
 
     try:
         if not api.get_diag_page_support():

--- a/sfputil/debug.py
+++ b/sfputil/debug.py
@@ -8,8 +8,6 @@ from utilities_common.platform_sfputil_helper import (
     get_subport,
     get_sfp_object,
     get_logical_list,
-    is_rj45_port,
-    is_sfp_present,
     get_subport_lane_mask,
     get_media_lane_count,
     get_host_lane_count,
@@ -176,27 +174,29 @@ def set_output(port_name, enable, direction):
         sys.exit(EXIT_FAIL)
 
 
-def _get_loopback_api_and_capability(port_name, single_port):
+def _get_loopback_api_and_capability(port_name):
     """Get xcvr API and loopback capability dict for a port.
 
     Returns (api, cap) when the module exposes the loopback API; cap may be an empty/None
     dict if the module does not advertise any capability. Returns (None, None) when the
-    module lacks the xcvr API, diagnostic page support, or the get_loopback_capability
-    method.
+    port can't be read (RJ45 / EEPROM not detected / xcvr API not implemented / no diag
+    pages / no get_loopback_capability method).
     """
-    sfp = get_sfp_object(port_name)
+    try:
+        sfp = get_sfp_object(port_name)
+    except SystemExit:
+        # get_sfp_object already echoed the reason (RJ45 / EEPROM not detected).
+        return None, None
 
     try:
         api = sfp.get_xcvr_api()
     except NotImplementedError:
-        if single_port:
-            click.echo(f"{port_name}: This functionality is not implemented")
+        click.echo(f"{port_name}: This functionality is not implemented")
         return None, None
 
     try:
         if not api.get_diag_page_support():
-            if single_port:
-                click.echo(f"{port_name}: The module does not support diagnostic pages required for loopback")
+            click.echo(f"{port_name}: The module does not support diagnostic pages required for loopback")
             return None, None
     except AttributeError:
         pass  # Older sonic-platform-common does not have get_diag_page_support
@@ -204,8 +204,7 @@ def _get_loopback_api_and_capability(port_name, single_port):
     try:
         cap = api.get_loopback_capability()
     except AttributeError:
-        if single_port:
-            click.echo(f"{port_name}: Loopback capability is not applicable for this module")
+        click.echo(f"{port_name}: Loopback capability is not applicable for this module")
         return None, None
 
     return api, cap
@@ -223,10 +222,7 @@ def loopback_capability(port_name):
     found = False
 
     for port in port_list:
-        if not single_port and (is_rj45_port(port) or not is_sfp_present(port)):
-            continue
-
-        api, cap = _get_loopback_api_and_capability(port, single_port)
+        api, cap = _get_loopback_api_and_capability(port)
         if api is None:
             continue
 
@@ -255,16 +251,12 @@ def loopback_status(port_name):
     found = False
 
     for port in port_list:
-        if not single_port and (is_rj45_port(port) or not is_sfp_present(port)):
-            continue
-
-        api, cap = _get_loopback_api_and_capability(port, single_port)
+        api, cap = _get_loopback_api_and_capability(port)
         if api is None:
             continue
 
         if not cap:
-            if single_port:
-                click.echo(f"{port}: The module does not advertise any loopback capability")
+            click.echo(f"{port}: The module does not advertise any loopback capability")
             continue
 
         try:
@@ -273,8 +265,7 @@ def loopback_status(port_name):
             media_input = api.get_media_input_loopback()
             media_output = api.get_media_output_loopback()
         except AttributeError:
-            if single_port:
-                click.echo(f"{port}: Loopback status is not applicable for this module")
+            click.echo(f"{port}: Loopback status is not applicable for this module")
             continue
 
         found = True

--- a/sfputil/debug.py
+++ b/sfputil/debug.py
@@ -223,9 +223,9 @@ def loopback_capability(port_name):
             click.echo(f"{port}: The module does not advertise any loopback capability")
             continue
 
-        click.echo(f"{port}: loopback capability: ")
-        for key, value in cap.items():
-            click.echo(f"  {key}: {value}")
+        click.echo(f"{port}: loopback capability:")
+        for key in sorted(cap):
+            click.echo(f"  {key}: {cap[key]}")
 
     if not single_port and not found:
         click.echo("No ports found that support loopback capability")
@@ -277,7 +277,7 @@ def loopback_status(port_name):
             continue
 
         found = True
-        click.echo(f"{port}: loopback status: ")
+        click.echo(f"{port}: loopback status:")
         click.echo(f"  host-side-input:   {host_input}")
         click.echo(f"  host-side-output:  {host_output}")
         click.echo(f"  media-side-input:  {media_input}")

--- a/sfputil/debug.py
+++ b/sfputil/debug.py
@@ -1,11 +1,15 @@
 import sys
 import time
 import click
+from natsort import natsorted
 import utilities_common.cli as clicommon
 from utilities_common import platform_sfputil_helper
 from utilities_common.platform_sfputil_helper import (
     get_subport,
     get_sfp_object,
+    get_logical_list,
+    is_rj45_port,
+    is_sfp_present,
     get_subport_lane_mask,
     get_media_lane_count,
     get_host_lane_count,
@@ -170,6 +174,117 @@ def set_output(port_name, enable, direction):
     except Exception as e:
         click.echo(f"{port_name}: {direction.upper()} disable failed due to {str(e)}")
         sys.exit(EXIT_FAIL)
+
+
+@debug.command(name='loopback-capability')
+@click.argument('port_name', required=False, default=None)
+def loopback_capability(port_name):
+    """Show the loopback modes advertised as supported by the module.
+
+    If PORT_NAME is omitted, prints capability for all ports that support loopback.
+    """
+    port_list = [port_name] if port_name else natsorted(set(get_logical_list()))
+    single_port = port_name is not None
+    found = False
+
+    for port in port_list:
+        if not single_port and (is_rj45_port(port) or not is_sfp_present(port)):
+            continue
+
+        sfp = get_sfp_object(port)
+
+        try:
+            api = sfp.get_xcvr_api()
+        except NotImplementedError:
+            if single_port:
+                click.echo(f"{port}: This functionality is not implemented")
+                sys.exit(ERROR_NOT_IMPLEMENTED)
+            continue
+
+        try:
+            if not api.get_diag_page_support():
+                if single_port:
+                    click.echo(f"{port}: The module does not support diagnostic pages required for loopback")
+                    sys.exit(EXIT_FAIL)
+                continue
+        except AttributeError:
+            pass  # Older sonic-platform-common does not have diag page method
+
+        try:
+            cap = api.get_loopback_capability()
+        except AttributeError:
+            if single_port:
+                click.echo(f"{port}: Loopback capability is not applicable for this module")
+                sys.exit(ERROR_NOT_IMPLEMENTED)
+            continue
+
+        found = True
+        if not cap:
+            click.echo(f"{port}: The module does not advertise any loopback capability")
+            continue
+
+        click.echo(f"{port}: loopback capability: ")
+        for key, value in cap.items():
+            click.echo(f"  {key}: {value}")
+
+    if not single_port and not found:
+        click.echo("No ports found that support loopback capability")
+
+
+@debug.command(name='loopback-status')
+@click.argument('port_name', required=False, default=None)
+def loopback_status(port_name):
+    """Show which loopback modes are currently enabled on the module.
+
+    If PORT_NAME is omitted, prints status for all ports that support loopback.
+    """
+    port_list = [port_name] if port_name else natsorted(set(get_logical_list()))
+    single_port = port_name is not None
+    found = False
+
+    for port in port_list:
+        if not single_port and (is_rj45_port(port) or not is_sfp_present(port)):
+            continue
+
+        sfp = get_sfp_object(port)
+
+        try:
+            api = sfp.get_xcvr_api()
+        except NotImplementedError:
+            if single_port:
+                click.echo(f"{port}: This functionality is not implemented")
+                sys.exit(ERROR_NOT_IMPLEMENTED)
+            continue
+
+        try:
+            if not api.get_diag_page_support():
+                if single_port:
+                    click.echo(f"{port}: The module does not support diagnostic pages required for loopback")
+                    sys.exit(EXIT_FAIL)
+                continue
+        except AttributeError:
+            pass  # Older sonic-platform-common does not have diag_page_support function
+
+        try:
+            host_input = api.get_host_input_loopback()
+            host_output = api.get_host_output_loopback()
+            media_input = api.get_media_input_loopback()
+            media_output = api.get_media_output_loopback()
+        except AttributeError:
+            if single_port:
+                click.echo(f"{port}: Loopback status is not applicable for this module")
+                sys.exit(ERROR_NOT_IMPLEMENTED)
+            continue
+
+        found = True
+        click.echo(f"{port}: loopback status: ")
+        click.echo(f"  host-side-input:   {host_input}")
+        click.echo(f"  host-side-output:  {host_output}")
+        click.echo(f"  media-side-input:  {media_input}")
+        click.echo(f"  media-side-output: {media_output}")
+
+    if not single_port and not found:
+        click.echo("No ports found that support loopback status")
 
 
 @debug.command()

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -2010,15 +2010,10 @@ EEPROM hexdump for port Ethernet4
         assert 'media_side_output_loopback_supported: False' in result.output
         assert result.exit_code == 0
 
-    @patch('sfputil.debug.is_sfp_present')
-    @patch('sfputil.debug.is_rj45_port')
     @patch('sfputil.debug.get_logical_list')
     @patch('sfputil.debug.get_sfp_object')
-    def test_debug_loopback_capability_all_ports(self, mock_get_sfp_object, mock_get_logical_list,
-                                                 mock_is_rj45_port, mock_is_sfp_present):
+    def test_debug_loopback_capability_all_ports(self, mock_get_sfp_object, mock_get_logical_list):
         mock_get_logical_list.return_value = ['Ethernet0', 'Ethernet4', 'Ethernet8', 'Ethernet12']
-        mock_is_rj45_port.return_value = False
-        mock_is_sfp_present.return_value = True
         runner = CliRunner()
         cmd = sfputil.cli.commands['debug'].commands['loopback-capability']
 
@@ -2033,26 +2028,23 @@ EEPROM hexdump for port Ethernet4
                 api.get_loopback_capability.return_value = cap
             return sfp
 
-        # RJ45 and absent ports are skipped before get_sfp_object is called
-        mock_is_rj45_port.side_effect = lambda p: p == 'Ethernet0'
-        mock_is_sfp_present.side_effect = lambda p: p != 'Ethernet4'
+        # RJ45 and absent ports: get_sfp_object raises SystemExit (and prints diagnostic).
+        # The helper catches SystemExit so iteration continues past them.
         mock_get_sfp_object.side_effect = [
+            SystemExit(EXIT_FAIL),  # Ethernet0: simulated RJ45
+            SystemExit(EXIT_FAIL),  # Ethernet4: simulated no transceiver
             make_sfp(cap={'host_side_input_loopback_supported': True}),
             make_sfp(cap={'host_side_input_loopback_supported': False}),
         ]
         result = runner.invoke(cmd, [])
         assert result.exit_code == 0
-        assert 'Ethernet0' not in result.output
-        assert 'Ethernet4' not in result.output
         assert 'Ethernet8: loopback capability:' in result.output
         assert 'Ethernet12: loopback capability:' in result.output
-        assert mock_get_sfp_object.call_count == 2
+        # All four ports are visited; iteration is not aborted by the SystemExits.
+        assert mock_get_sfp_object.call_count == 4
 
-        # Mixed: CMIS with cap, no diag support, non-CMIS, no cap advertised
-        mock_is_rj45_port.side_effect = None
-        mock_is_rj45_port.return_value = False
-        mock_is_sfp_present.side_effect = None
-        mock_is_sfp_present.return_value = True
+        # Mixed: CMIS with cap, no diag support, non-CMIS, no cap advertised.
+        # Every skipped port emits a diagnostic message so the operator sees why.
         mock_get_sfp_object.reset_mock()
         mock_get_sfp_object.side_effect = [
             make_sfp(cap={'host_side_input_loopback_supported': True}),
@@ -2063,16 +2055,17 @@ EEPROM hexdump for port Ethernet4
         result = runner.invoke(cmd, [])
         assert result.exit_code == 0
         assert 'Ethernet0: loopback capability:' in result.output
-        assert 'Ethernet4' not in result.output
-        assert 'Ethernet8' not in result.output
-        assert 'does not advertise any loopback capability' in result.output
-        assert 'Ethernet12' in result.output
+        assert 'Ethernet4: The module does not support diagnostic pages required for loopback' in result.output
+        assert 'Ethernet8: Loopback capability is not applicable for this module' in result.output
+        assert 'Ethernet12: The module does not advertise any loopback capability' in result.output
 
-        # No ports support loopback (all non-CMIS)
+        # No ports support loopback (all non-CMIS): per-port diagnostics + the summary line.
         mock_get_sfp_object.reset_mock()
         mock_get_sfp_object.side_effect = [make_sfp(attr_error=True)] * 4
         result = runner.invoke(cmd, [])
         assert result.exit_code == 0
+        assert 'Ethernet0: Loopback capability is not applicable for this module' in result.output
+        assert 'Ethernet12: Loopback capability is not applicable for this module' in result.output
         assert 'No ports found that support loopback capability' in result.output
 
     @patch('sfputil.debug.get_sfp_object')
@@ -2141,15 +2134,10 @@ EEPROM hexdump for port Ethernet4
         assert 'media-side-output: True' in result.output
         assert result.exit_code == 0
 
-    @patch('sfputil.debug.is_sfp_present')
-    @patch('sfputil.debug.is_rj45_port')
     @patch('sfputil.debug.get_logical_list')
     @patch('sfputil.debug.get_sfp_object')
-    def test_debug_loopback_status_all_ports(self, mock_get_sfp_object, mock_get_logical_list,
-                                             mock_is_rj45_port, mock_is_sfp_present):
+    def test_debug_loopback_status_all_ports(self, mock_get_sfp_object, mock_get_logical_list):
         mock_get_logical_list.return_value = ['Ethernet0', 'Ethernet4', 'Ethernet8', 'Ethernet12']
-        mock_is_rj45_port.return_value = False
-        mock_is_sfp_present.return_value = True
         runner = CliRunner()
         cmd = sfputil.cli.commands['debug'].commands['loopback-status']
 
@@ -2159,33 +2147,35 @@ EEPROM hexdump for port Ethernet4
             sfp.get_xcvr_api.return_value = api
             if attr_error:
                 api.get_diag_page_support.return_value = True
+                api.get_loopback_capability.return_value = {'host_side_input_loopback_supported': True}
                 api.get_host_input_loopback.side_effect = AttributeError
             else:
                 api.get_diag_page_support.return_value = diag_support
+                api.get_loopback_capability.return_value = {'host_side_input_loopback_supported': True}
                 api.get_host_input_loopback.return_value = [False] * 8
                 api.get_host_output_loopback.return_value = [False] * 8
                 api.get_media_input_loopback.return_value = False
                 api.get_media_output_loopback.return_value = False
             return sfp
 
-        # RJ45 and absent ports are skipped before get_sfp_object is called
+        # RJ45 and absent ports: get_sfp_object raises SystemExit (and prints diagnostic).
+        # The helper catches SystemExit so iteration continues past them.
         # Ethernet0: RJ45, Ethernet4: no transceiver, Ethernet8: CMIS, Ethernet12: CMIS
-        mock_is_rj45_port.side_effect = lambda p: p == 'Ethernet0'
-        mock_is_sfp_present.side_effect = lambda p: p != 'Ethernet4'
-        mock_get_sfp_object.side_effect = [make_cmis_sfp(), make_cmis_sfp()]
+        mock_get_sfp_object.side_effect = [
+            SystemExit(EXIT_FAIL),
+            SystemExit(EXIT_FAIL),
+            make_cmis_sfp(),
+            make_cmis_sfp(),
+        ]
         result = runner.invoke(cmd, [])
         assert result.exit_code == 0
-        assert 'Ethernet0' not in result.output
-        assert 'Ethernet4' not in result.output
         assert 'Ethernet8: loopback status:' in result.output
         assert 'Ethernet12: loopback status:' in result.output
-        assert mock_get_sfp_object.call_count == 2  # only called for Ethernet8 and Ethernet12
+        # All four ports are visited; iteration is not aborted by the SystemExits.
+        assert mock_get_sfp_object.call_count == 4
 
-        # Mixed CMIS: diag support, no diag support, non-CMIS (AttributeError)
-        mock_is_rj45_port.side_effect = None
-        mock_is_rj45_port.return_value = False
-        mock_is_sfp_present.side_effect = None
-        mock_is_sfp_present.return_value = True
+        # Mixed CMIS: diag support, no diag support, non-CMIS (AttributeError).
+        # Skipped ports each emit a diagnostic.
         mock_get_sfp_object.reset_mock()
         mock_get_sfp_object.side_effect = [
             make_cmis_sfp(diag_support=True),
@@ -2196,15 +2186,17 @@ EEPROM hexdump for port Ethernet4
         result = runner.invoke(cmd, [])
         assert result.exit_code == 0
         assert 'Ethernet0: loopback status:' in result.output
-        assert 'Ethernet4' not in result.output
-        assert 'Ethernet8' not in result.output
+        assert 'Ethernet4: The module does not support diagnostic pages required for loopback' in result.output
+        assert 'Ethernet8: Loopback status is not applicable for this module' in result.output
         assert 'Ethernet12: loopback status:' in result.output
 
-        # No ports support loopback (all non-CMIS)
+        # No ports support loopback (all non-CMIS): per-port diagnostics + the summary line.
         mock_get_sfp_object.reset_mock()
         mock_get_sfp_object.side_effect = [make_cmis_sfp(attr_error=True)] * 4
         result = runner.invoke(cmd, [])
         assert result.exit_code == 0
+        assert 'Ethernet0: Loopback status is not applicable for this module' in result.output
+        assert 'Ethernet12: Loopback status is not applicable for this module' in result.output
         assert 'No ports found that support loopback status' in result.output
 
     @pytest.mark.parametrize(

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1945,6 +1945,261 @@ EEPROM hexdump for port Ethernet4
         assert result.output == 'Error: \nEthernet0: subport is not present in CONFIG_DB\n'
         assert result.exit_code == EXIT_FAIL
 
+    @patch('sfputil.debug.get_sfp_object')
+    def test_debug_loopback_capability(self, mock_get_sfp_object):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api.return_value = mock_api
+        mock_get_sfp_object.return_value = mock_sfp
+        runner = CliRunner()
+        cmd = sfputil.cli.commands['debug'].commands['loopback-capability']
+
+        # NotImplementedError from get_xcvr_api
+        mock_sfp.get_xcvr_api.side_effect = NotImplementedError
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert result.output == 'Ethernet0: This functionality is not implemented\n'
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+
+        mock_sfp.get_xcvr_api.side_effect = None
+        mock_sfp.get_xcvr_api.return_value = mock_api
+
+        # Diagnostic pages not supported
+        mock_api.get_diag_page_support.return_value = False
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'does not support diagnostic pages required for loopback' in result.output
+        assert result.exit_code == EXIT_FAIL
+
+        # SFF-8636 / non-CMIS module: AttributeError on get_loopback_capability
+        mock_api.get_diag_page_support.return_value = True
+        mock_api.get_loopback_capability.side_effect = AttributeError
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert result.output == 'Ethernet0: Loopback capability is not applicable for this module\n'
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+
+        # CCmisApi: get_diag_page_support absent but get_loopback_capability present
+        mock_api.get_diag_page_support.side_effect = AttributeError
+        mock_api.get_loopback_capability.side_effect = None
+        mock_api.get_loopback_capability.return_value = {'host_side_input_loopback_supported': True}
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'Ethernet0: loopback capability:' in result.output
+        assert result.exit_code == 0
+
+        mock_api.get_diag_page_support.side_effect = None
+        mock_api.get_diag_page_support.return_value = True
+
+        # No capability advertised
+        mock_api.get_loopback_capability.side_effect = None
+        mock_api.get_loopback_capability.return_value = None
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'does not advertise any loopback capability' in result.output
+        assert result.exit_code == 0
+
+        # Capability advertised
+        mock_api.get_loopback_capability.return_value = {
+            'simultaneous_host_media_loopback_supported': True,
+            'per_lane_media_loopback_supported': False,
+            'per_lane_host_loopback_supported': True,
+            'host_side_input_loopback_supported': True,
+            'host_side_output_loopback_supported': False,
+            'media_side_input_loopback_supported': True,
+            'media_side_output_loopback_supported': False,
+        }
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'Ethernet0: loopback capability:' in result.output
+        assert 'host_side_input_loopback_supported: True' in result.output
+        assert 'media_side_output_loopback_supported: False' in result.output
+        assert result.exit_code == 0
+
+    @patch('sfputil.debug.is_sfp_present')
+    @patch('sfputil.debug.is_rj45_port')
+    @patch('sfputil.debug.get_logical_list')
+    @patch('sfputil.debug.get_sfp_object')
+    def test_debug_loopback_capability_all_ports(self, mock_get_sfp_object, mock_get_logical_list,
+                                                 mock_is_rj45_port, mock_is_sfp_present):
+        mock_get_logical_list.return_value = ['Ethernet0', 'Ethernet4', 'Ethernet8', 'Ethernet12']
+        mock_is_rj45_port.return_value = False
+        mock_is_sfp_present.return_value = True
+        runner = CliRunner()
+        cmd = sfputil.cli.commands['debug'].commands['loopback-capability']
+
+        def make_sfp(diag_support=True, attr_error=False, cap=None):
+            sfp = MagicMock()
+            api = MagicMock()
+            sfp.get_xcvr_api.return_value = api
+            api.get_diag_page_support.return_value = diag_support
+            if attr_error:
+                api.get_loopback_capability.side_effect = AttributeError
+            else:
+                api.get_loopback_capability.return_value = cap
+            return sfp
+
+        # RJ45 and absent ports are skipped before get_sfp_object is called
+        mock_is_rj45_port.side_effect = lambda p: p == 'Ethernet0'
+        mock_is_sfp_present.side_effect = lambda p: p != 'Ethernet4'
+        mock_get_sfp_object.side_effect = [
+            make_sfp(cap={'host_side_input_loopback_supported': True}),
+            make_sfp(cap={'host_side_input_loopback_supported': False}),
+        ]
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert 'Ethernet0' not in result.output
+        assert 'Ethernet4' not in result.output
+        assert 'Ethernet8: loopback capability:' in result.output
+        assert 'Ethernet12: loopback capability:' in result.output
+        assert mock_get_sfp_object.call_count == 2
+
+        # Mixed: CMIS with cap, no diag support, non-CMIS, no cap advertised
+        mock_is_rj45_port.side_effect = None
+        mock_is_rj45_port.return_value = False
+        mock_is_sfp_present.side_effect = None
+        mock_is_sfp_present.return_value = True
+        mock_get_sfp_object.reset_mock()
+        mock_get_sfp_object.side_effect = [
+            make_sfp(cap={'host_side_input_loopback_supported': True}),
+            make_sfp(diag_support=False),
+            make_sfp(attr_error=True),
+            make_sfp(cap=None),
+        ]
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert 'Ethernet0: loopback capability:' in result.output
+        assert 'Ethernet4' not in result.output
+        assert 'Ethernet8' not in result.output
+        assert 'does not advertise any loopback capability' in result.output
+        assert 'Ethernet12' in result.output
+
+        # No ports support loopback (all non-CMIS)
+        mock_get_sfp_object.reset_mock()
+        mock_get_sfp_object.side_effect = [make_sfp(attr_error=True)] * 4
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert 'No ports found that support loopback capability' in result.output
+
+    @patch('sfputil.debug.get_sfp_object')
+    def test_debug_loopback_status(self, mock_get_sfp_object):
+        mock_sfp = MagicMock()
+        mock_api = MagicMock()
+        mock_sfp.get_xcvr_api.return_value = mock_api
+        mock_get_sfp_object.return_value = mock_sfp
+        runner = CliRunner()
+        cmd = sfputil.cli.commands['debug'].commands['loopback-status']
+
+        # NotImplementedError from get_xcvr_api
+        mock_sfp.get_xcvr_api.side_effect = NotImplementedError
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert result.output == 'Ethernet0: This functionality is not implemented\n'
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+
+        mock_sfp.get_xcvr_api.side_effect = None
+        mock_sfp.get_xcvr_api.return_value = mock_api
+
+        # Diagnostic pages not supported
+        mock_api.get_diag_page_support.return_value = False
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'does not support diagnostic pages required for loopback' in result.output
+        assert result.exit_code == EXIT_FAIL
+
+        # SFF-8636 / non-CMIS module: AttributeError on a getter
+        mock_api.get_diag_page_support.return_value = True
+        mock_api.get_host_input_loopback.side_effect = AttributeError
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert result.output == 'Ethernet0: Loopback status is not applicable for this module\n'
+        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+
+        # CCmisApi: get_diag_page_support absent but loopback getters present
+        mock_api.get_diag_page_support.side_effect = AttributeError
+        mock_api.get_host_input_loopback.side_effect = None
+        mock_api.get_host_input_loopback.return_value = [False] * 8
+        mock_api.get_host_output_loopback.return_value = [False] * 8
+        mock_api.get_media_input_loopback.return_value = False
+        mock_api.get_media_output_loopback.return_value = False
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'Ethernet0: loopback status:' in result.output
+        assert result.exit_code == 0
+
+        mock_api.get_diag_page_support.side_effect = None
+        mock_api.get_diag_page_support.return_value = True
+
+        # CMIS module: per-lane host lists, scalar media flags
+        mock_api.get_host_input_loopback.side_effect = None
+        mock_api.get_host_input_loopback.return_value = [True, False, False, False, False, False, False, False]
+        mock_api.get_host_output_loopback.return_value = [False] * 8
+        mock_api.get_media_input_loopback.return_value = False
+        mock_api.get_media_output_loopback.return_value = True
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'Ethernet0: loopback status:' in result.output
+        assert 'host-side-input:   [True, False, False, False, False, False, False, False]' in result.output
+        assert 'host-side-output:  [False, False, False, False, False, False, False, False]' in result.output
+        assert 'media-side-input:  False' in result.output
+        assert 'media-side-output: True' in result.output
+        assert result.exit_code == 0
+
+    @patch('sfputil.debug.is_sfp_present')
+    @patch('sfputil.debug.is_rj45_port')
+    @patch('sfputil.debug.get_logical_list')
+    @patch('sfputil.debug.get_sfp_object')
+    def test_debug_loopback_status_all_ports(self, mock_get_sfp_object, mock_get_logical_list,
+                                             mock_is_rj45_port, mock_is_sfp_present):
+        mock_get_logical_list.return_value = ['Ethernet0', 'Ethernet4', 'Ethernet8', 'Ethernet12']
+        mock_is_rj45_port.return_value = False
+        mock_is_sfp_present.return_value = True
+        runner = CliRunner()
+        cmd = sfputil.cli.commands['debug'].commands['loopback-status']
+
+        def make_cmis_sfp(diag_support=True, attr_error=False):
+            sfp = MagicMock()
+            api = MagicMock()
+            sfp.get_xcvr_api.return_value = api
+            if attr_error:
+                api.get_diag_page_support.return_value = True
+                api.get_host_input_loopback.side_effect = AttributeError
+            else:
+                api.get_diag_page_support.return_value = diag_support
+                api.get_host_input_loopback.return_value = [False] * 8
+                api.get_host_output_loopback.return_value = [False] * 8
+                api.get_media_input_loopback.return_value = False
+                api.get_media_output_loopback.return_value = False
+            return sfp
+
+        # RJ45 and absent ports are skipped before get_sfp_object is called
+        # Ethernet0: RJ45, Ethernet4: no transceiver, Ethernet8: CMIS, Ethernet12: CMIS
+        mock_is_rj45_port.side_effect = lambda p: p == 'Ethernet0'
+        mock_is_sfp_present.side_effect = lambda p: p != 'Ethernet4'
+        mock_get_sfp_object.side_effect = [make_cmis_sfp(), make_cmis_sfp()]
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert 'Ethernet0' not in result.output
+        assert 'Ethernet4' not in result.output
+        assert 'Ethernet8: loopback status:' in result.output
+        assert 'Ethernet12: loopback status:' in result.output
+        assert mock_get_sfp_object.call_count == 2  # only called for Ethernet8 and Ethernet12
+
+        # Mixed CMIS: diag support, no diag support, non-CMIS (AttributeError)
+        mock_is_rj45_port.side_effect = None
+        mock_is_rj45_port.return_value = False
+        mock_is_sfp_present.side_effect = None
+        mock_is_sfp_present.return_value = True
+        mock_get_sfp_object.reset_mock()
+        mock_get_sfp_object.side_effect = [
+            make_cmis_sfp(diag_support=True),
+            make_cmis_sfp(diag_support=False),
+            make_cmis_sfp(attr_error=True),
+            make_cmis_sfp(diag_support=True),
+        ]
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert 'Ethernet0: loopback status:' in result.output
+        assert 'Ethernet4' not in result.output
+        assert 'Ethernet8' not in result.output
+        assert 'Ethernet12: loopback status:' in result.output
+
+        # No ports support loopback (all non-CMIS)
+        mock_get_sfp_object.reset_mock()
+        mock_get_sfp_object.side_effect = [make_cmis_sfp(attr_error=True)] * 4
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert 'No ports found that support loopback status' in result.output
+
     @pytest.mark.parametrize(
         "direction, lane_count, enable, disable_func_result, cmis_version, output_dict, expected_echo, expected_exit",
         [

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1954,11 +1954,11 @@ EEPROM hexdump for port Ethernet4
         runner = CliRunner()
         cmd = sfputil.cli.commands['debug'].commands['loopback-capability']
 
-        # NotImplementedError from get_xcvr_api: platform-wide failure, exit with error code
+        # NotImplementedError from get_xcvr_api: print and continue so multi-port runs aren't aborted
         mock_sfp.get_xcvr_api.side_effect = NotImplementedError
         result = runner.invoke(cmd, ["Ethernet0"])
         assert result.output == 'Ethernet0: This functionality is not implemented\n'
-        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        assert result.exit_code == 0
 
         mock_sfp.get_xcvr_api.side_effect = None
         mock_sfp.get_xcvr_api.return_value = mock_api
@@ -2084,11 +2084,11 @@ EEPROM hexdump for port Ethernet4
         runner = CliRunner()
         cmd = sfputil.cli.commands['debug'].commands['loopback-status']
 
-        # NotImplementedError from get_xcvr_api: platform-wide failure, exit with error code
+        # NotImplementedError from get_xcvr_api: print and continue so multi-port runs aren't aborted
         mock_sfp.get_xcvr_api.side_effect = NotImplementedError
         result = runner.invoke(cmd, ["Ethernet0"])
         assert result.output == 'Ethernet0: This functionality is not implemented\n'
-        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        assert result.exit_code == 0
 
         mock_sfp.get_xcvr_api.side_effect = None
         mock_sfp.get_xcvr_api.return_value = mock_api

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1954,7 +1954,7 @@ EEPROM hexdump for port Ethernet4
         runner = CliRunner()
         cmd = sfputil.cli.commands['debug'].commands['loopback-capability']
 
-        # NotImplementedError from get_xcvr_api
+        # NotImplementedError from get_xcvr_api: platform-wide failure, exit with error code
         mock_sfp.get_xcvr_api.side_effect = NotImplementedError
         result = runner.invoke(cmd, ["Ethernet0"])
         assert result.output == 'Ethernet0: This functionality is not implemented\n'
@@ -1963,18 +1963,18 @@ EEPROM hexdump for port Ethernet4
         mock_sfp.get_xcvr_api.side_effect = None
         mock_sfp.get_xcvr_api.return_value = mock_api
 
-        # Diagnostic pages not supported
+        # Diagnostic pages not supported: per-module, no exit so other ports keep iterating
         mock_api.get_diag_page_support.return_value = False
         result = runner.invoke(cmd, ["Ethernet0"])
         assert 'does not support diagnostic pages required for loopback' in result.output
-        assert result.exit_code == EXIT_FAIL
+        assert result.exit_code == 0
 
         # SFF-8636 / non-CMIS module: AttributeError on get_loopback_capability
         mock_api.get_diag_page_support.return_value = True
         mock_api.get_loopback_capability.side_effect = AttributeError
         result = runner.invoke(cmd, ["Ethernet0"])
         assert result.output == 'Ethernet0: Loopback capability is not applicable for this module\n'
-        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        assert result.exit_code == 0
 
         # CCmisApi: get_diag_page_support absent but get_loopback_capability present
         mock_api.get_diag_page_support.side_effect = AttributeError
@@ -2084,7 +2084,7 @@ EEPROM hexdump for port Ethernet4
         runner = CliRunner()
         cmd = sfputil.cli.commands['debug'].commands['loopback-status']
 
-        # NotImplementedError from get_xcvr_api
+        # NotImplementedError from get_xcvr_api: platform-wide failure, exit with error code
         mock_sfp.get_xcvr_api.side_effect = NotImplementedError
         result = runner.invoke(cmd, ["Ethernet0"])
         assert result.output == 'Ethernet0: This functionality is not implemented\n'
@@ -2093,18 +2093,25 @@ EEPROM hexdump for port Ethernet4
         mock_sfp.get_xcvr_api.side_effect = None
         mock_sfp.get_xcvr_api.return_value = mock_api
 
-        # Diagnostic pages not supported
+        # Diagnostic pages not supported: per-module, no exit
         mock_api.get_diag_page_support.return_value = False
         result = runner.invoke(cmd, ["Ethernet0"])
         assert 'does not support diagnostic pages required for loopback' in result.output
-        assert result.exit_code == EXIT_FAIL
+        assert result.exit_code == 0
+
+        # Loopback capability not advertised: skip without reading status
+        mock_api.get_diag_page_support.return_value = True
+        mock_api.get_loopback_capability.return_value = None
+        result = runner.invoke(cmd, ["Ethernet0"])
+        assert 'does not advertise any loopback capability' in result.output
+        assert result.exit_code == 0
 
         # SFF-8636 / non-CMIS module: AttributeError on a getter
-        mock_api.get_diag_page_support.return_value = True
+        mock_api.get_loopback_capability.return_value = {'host_side_input_loopback_supported': True}
         mock_api.get_host_input_loopback.side_effect = AttributeError
         result = runner.invoke(cmd, ["Ethernet0"])
-        assert result.output == 'Ethernet0: Loopback status is not applicable for this module\n'
-        assert result.exit_code == ERROR_NOT_IMPLEMENTED
+        assert 'Ethernet0: Loopback status is not applicable for this module' in result.output
+        assert result.exit_code == 0
 
         # CCmisApi: get_diag_page_support absent but loopback getters present
         mock_api.get_diag_page_support.side_effect = AttributeError


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did


sfputil debug previously only supported writing loopback mode; this adds two read commands that surface the existing CMIS API readers in sonic-platform-common:

#### How I did it

sfputil debug loopback-capability <port> calls api.get_loopback_capability() and prints the advertised flags.
sfputil debug loopback-status <port> calls the four get_{host,media}_{input,output}_loopback() getters and prints current state (host returns per-lane lists, media returns scalars).
Both commands check first for api.get_diag_page_support()


It was done this way to comply with the existing platform apis:

Host-side: Per-lane. get_host_input_loopback() and get_host_output_loopback() return a list with one bool per lane (iterates NUM_CHANNELS bits). So you can enable loopback on individual host lanes.

Media-side: Depends on the module's per_lane_media_loopback_supported capability bit. The write API (set_media_input/output_loopback) accepts a lane_mask and does bitwise operations per-lane when that capability is set. But the read API (get_media_input/output_loopback) returns result == 1 — a single boolean regardless

See:  https://github.com/sonic-net/sonic-platform-common/blob/64beade8cddecdbc154531bc84bed2fa86581ea8/sonic_platform_base/sonic_xcvr/api/public/cmis.py#L1202


#### How to verify it

By setting and unsetting the loopback
```

$ sudo sfputil debug loopback-capability Ethernet32
Ethernet32: loopback capability:
  simultaneous_host_media_loopback_supported: True
  per_lane_media_loopback_supported: True
  per_lane_host_loopback_supported: True
  host_side_input_loopback_supported: True
  host_side_output_loopback_supported: True
  media_side_input_loopback_supported: True
  media_side_output_loopback_supported: True

$ sudo sfputil debug loopback-status Ethernet32
Ethernet32: loopback status:
  host-side-input:   [False, False, False, False, False, False, False, False]
  host-side-output:  [False, False, False, False, False, False, False, False]
  media-side-input:  False
  media-side-output: False

$ sudo sfputil debug loopback Ethernet32 host-side-input enable
Ethernet32: enable host-side-input loopback

$ sudo sfputil debug loopback-status Ethernet32
Ethernet32: loopback status:
  host-side-input:   [True, True, True, True, True, True, True, True]
  host-side-output:  [False, False, False, False, False, False, False, False]
  media-side-input:  False
  media-side-output: False

$ sudo sfputil debug loopback Ethernet32 host-side-input disable
Ethernet32: disable host-side-input loopback

$ sudo sfputil debug loopback-status Ethernet32
Ethernet32: loopback status:
  host-side-input:   [False, False, False, False, False, False, False, False]
  host-side-output:  [False, False, False, False, False, False, False, False]
  media-side-input:  False
  media-side-output: False
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

