### PR TITLE
Add platform-level fallback for buffer and QoS templates to support Generic HWSKU

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3675,7 +3675,7 @@ def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports, verbose)
     if not dry_run:
         status = _clear_qos(delay=not no_delay, verbose=verbose)
 
-    _, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
+    platform_path, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
     sonic_version_file = device_info.get_sonic_version_file()
     from_db = ['-d']
     if dry_run:
@@ -3711,16 +3711,22 @@ def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports, verbose)
 
         if not no_dynamic_buffer and asic_type in vendors_supporting_dynamic_buffer:
             buffer_template_file = os.path.join(hwsku_path, asic_id_suffix, "buffers_dynamic.json.j2")
+            if not os.path.isfile(buffer_template_file):
+                buffer_template_file = os.path.join(platform_path, asic_id_suffix, "buffers_dynamic.json.j2")
             buffer_model_updated |= _update_buffer_calculation_model(config_db, "dynamic")
         else:
             buffer_template_file = os.path.join(hwsku_path, asic_id_suffix, "buffers.json.j2")
+            if not os.path.isfile(buffer_template_file):
+                buffer_template_file = os.path.join(platform_path, asic_id_suffix, "buffers.json.j2")
             if asic_type in vendors_supporting_dynamic_buffer:
                 buffer_model_updated |= _update_buffer_calculation_model(config_db, "traditional")
 
         if os.path.isfile(buffer_template_file):
-            qos_template_file = os.path.join(
-                hwsku_path, asic_id_suffix, "qos.json.j2"
-            )
+            qos_template_file = os.path.join(hwsku_path, asic_id_suffix, "qos.json.j2")
+            if not os.path.isfile(qos_template_file):
+                qos_template_file = os.path.join(platform_path, asic_id_suffix, "qos.json.j2")
+                if not os.path.isfile(qos_template_file):
+                    qos_template_file = "/usr/share/sonic/templates/qos_config.j2"
             if os.path.isfile(qos_template_file):
                 cmd_ns = [] if ns is DEFAULT_NAMESPACE else ['-n', str(ns)]
                 buffer_fname = "/tmp/cfg_buffer{}.json".format(asic_id_suffix)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Fixes [#25747](https://github.com/sonic-net/sonic-buildimage/issues/25747)

#### What I did
Add platform-level fallback for buffer and QoS template files during `config qos reload` to support the Generic HWSKU initiative (HLD [#2309](https://github.com/sonic-net/SONiC/pull/2309)).  
Previously these files (`buffers_dynamic.json.j2`, `buffers.json.j2`, `qos.json.j2`) were required to exist in each HWSKU directory, causing duplication.  
Now they are looked up in the following order:
1. HWSKU directory (per‑HWSKU override)
2. Platform directory (shared for all HWSKUs on that platform)
3. (For `qos.json.j2` only) a global template: `/usr/share/sonic/templates/qos_config.j2`

#### How I did it
- In `config/main.py`, inside the `reload` function (which implements `config qos reload`):
  - Changed `_, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()` to `platform_path, hwsku_path` so both directories are available.
  - For dynamic buffer template: check `hwsku_path/.../buffers_dynamic.json.j2`; if missing, try `platform_path/.../buffers_dynamic.json.j2`.
  - For traditional buffer template (`buffers.json.j2`): same fallback logic.
  - For QoS template (`qos.json.j2`): check HWSKU, then platform, then the hardcoded global template path.
- Added `os.path.isfile` checks before each fallback attempt.
- Ensured existing HWSKUs with their own templates continue to work unchanged.

#### How to verify it
- Remove `buffers_dynamic.json.j2`, `buffers.json.j2`, or `qos.json.j2` from a HWSKU directory.
- Run `config qos reload` (e.g., `sudo config qos reload`).
- Verify that the command succeeds and uses the platform‑level file (or the global template for `qos.json.j2` when platform file also missing).
- Verify that HWSKUs that still have their own custom templates load the per‑HWSKU file (no regression).

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

