### PR TITLE
pfcwd: fix TypeError crash in interval() on partial PFC_WD entries

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -350,24 +350,27 @@ class PfcwdCli(object):
             pfcwd_table = self.config_db.get_table(CONFIG_DB_PFC_WD_TABLE_NAME)
             entry_min = MAX_POLL_INTERVAL_TIME
             for entry in pfcwd_table:
-                if("Ethernet" not in entry):
+                if "Ethernet" not in entry:
                     continue
-                detection_time_entry_value = int(self.config_db.get_entry(
+                entry_data = self.config_db.get_entry(
                     CONFIG_DB_PFC_WD_TABLE_NAME, entry
-                ).get('detection_time'))
-                restoration_time_entry_value = int(self.config_db.get_entry(
-                    CONFIG_DB_PFC_WD_TABLE_NAME, entry
-                ).get('restoration_time'))
-                if ((detection_time_entry_value is not None) and
-                    (detection_time_entry_value < entry_min)
-                ):
-                    entry_min = detection_time_entry_value
-                    entry_min_str = "detection time"
-                if ((restoration_time_entry_value is not None) and
-                    (restoration_time_entry_value < entry_min)
-                ):
-                    entry_min = restoration_time_entry_value
-                    entry_min_str = "restoration time"
+                )
+                detection_time_raw = entry_data.get('detection_time')
+                restoration_time_raw = entry_data.get('restoration_time')
+                # Skip entries missing both timing fields (e.g. partial entries
+                # created by pfc_stat_history_cmd on unconfigured ports).
+                if detection_time_raw is None and restoration_time_raw is None:
+                    continue
+                if detection_time_raw is not None:
+                    detection_time_entry_value = int(detection_time_raw)
+                    if detection_time_entry_value < entry_min:
+                        entry_min = detection_time_entry_value
+                        entry_min_str = "detection time"
+                if restoration_time_raw is not None:
+                    restoration_time_entry_value = int(restoration_time_raw)
+                    if restoration_time_entry_value < entry_min:
+                        entry_min = restoration_time_entry_value
+                        entry_min_str = "restoration time"
             if entry_min < poll_interval:
                 click.echo(
                    "unable to use polling interval = {}ms, value is "

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -187,7 +187,7 @@ class TestPfcwd(object):
 
         # Verify the poll interval was actually written
         global_entry = db.cfgdb.get_entry("PFC_WD", "GLOBAL")
-        assert global_entry.get("POLL_INTERVAL") == 200
+        assert str(global_entry.get("POLL_INTERVAL")) == "200"
 
     @patch('pfcwd.main.os')
     def test_pfcwd_start_actions(self, mock_os):

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -152,6 +152,44 @@ class TestPfcwd(object):
         assert result.output == test_vectors.pfcwd_show_enable_history_config_output_pass
 
     @patch('pfcwd.main.os')
+    def test_pfcwd_interval_skips_partial_entry(self, mock_os):
+        """
+        Regression test for GitHub issue #4535.
+
+        pfc_stat_history_cmd writes only pfc_stat_history via mod_entry() on a
+        port that has no prior PFC_WD configuration, creating a PFC_WD entry
+        that is missing detection_time and restoration_time.  The original
+        interval() code called int(...get('detection_time')) unconditionally,
+        causing a TypeError: int() argument must be ... not 'NoneType'.
+
+        After the fix, interval() must skip such partial entries and succeed.
+        """
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        mock_os.geteuid.return_value = 0
+
+        # Simulate a partial PFC_WD entry with only pfc_stat_history set
+        # (no detection_time / restoration_time), as created by pfc_stat_history_cmd
+        # on a port with no prior PFC_WD config.
+        db.cfgdb.mod_entry("PFC_WD", "Ethernet12", {"pfc_stat_history": "disable"})
+
+        # config pfcwd interval must not crash with TypeError
+        result = runner.invoke(
+            pfcwd.cli.commands["interval"],
+            ["200"],
+            obj=db
+        )
+        assert result.exit_code == 0, (
+            "interval() crashed on partial PFC_WD entry: {}".format(result.output)
+        )
+
+        # Verify the poll interval was actually written
+        global_entry = db.cfgdb.get_entry("PFC_WD", "GLOBAL")
+        assert global_entry.get("POLL_INTERVAL") == 200
+
+    @patch('pfcwd.main.os')
     def test_pfcwd_start_actions(self, mock_os):
         # pfcwd start --action forward --restoration-time 200 Ethernet0 200
         import pfcwd.main as pfcwd


### PR DESCRIPTION
## Description

Fixes #4535.

`pfc_stat_history_cmd` writes only `pfc_stat_history` via `mod_entry()` on a port that has
no prior `PFC_WD` configuration, creating a table entry that is missing `detection_time`
and `restoration_time`. When `config pfcwd interval <N>` is subsequently called,
`interval()` calls `int(...get('detection_time'))` unconditionally:

```python
# before (broken)
detection_time_entry_value = int(self.config_db.get_entry(
    CONFIG_DB_PFC_WD_TABLE_NAME, entry
).get('detection_time'))   # .get() returns None → int(None) raises TypeError
```

The `is not None` guards two lines below are dead code because the conversion happens
before them. Once in this state, every retry crashes the same way and the polling interval
cannot be updated without `redis-cli` surgery.

## Root Cause

`pfc_stat_history_cmd` uses `mod_entry()` (merge) which creates a partial entry on a port
with no prior `PFC_WD` config. This is valid behaviour for that command. `interval()` did
not account for entries that legitimately lack timing fields.

## Fix

- Read raw field values first via a single `get_entry()` call per entry (previously two).
- Skip entries where **both** `detection_time` and `restoration_time` are absent.
- Perform `int()` conversion only after the `None` check, eliminating the dead guard code.

## Testing

Added `test_pfcwd_interval_skips_partial_entry` in `tests/pfcwd_test.py`:

1. Inserts a partial `PFC_WD|Ethernet12` entry containing only `pfc_stat_history`
   (no `detection_time` / `restoration_time`), replicating the crash scenario.
2. Invokes `config pfcwd interval 200`.
3. Asserts exit code 0 and that `POLL_INTERVAL` is written to `PFC_WD|GLOBAL`.

## Checklist
- [x] Added regression test covering the reported crash scenario
- [x] Existing `pfcwd_test.py` tests unaffected
- [x] Single `get_entry()` call per loop iteration (was two)