### PR TITLE
[Mellanox] Add new SKUs for SPC5 and SN4280 to GCU

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -21,9 +21,9 @@
                           "ACS-MSN2700-A1", "Mellanox-SN2700-A1", "Mellanox-SN2700-A1-C28D8", "Mellanox-SN2700-A1-D40C8S8", "Mellanox-SN2700-A1-D44C10", "Mellanox-SN2700-A1-D48C8" ],
                 "spc2": [ "ACS-MSN3800", "Mellanox-SN3800-D112C8", "ACS-MSN3420", "ACS-MSN3700C", "ACS-MSN3700", "Mellanox-SN3800-C64", "Mellanox-SN3800-D100C12S2", "Mellanox-SN3800-D24C52", "Mellanox-SN3800-D28C49S1", "Mellanox-SN3800-D28C50" ],
                 "spc3": [ "ACS-MSN4700", "ACS-MSN4600", "ACS-MSN4600C", "ACS-MSN4410", "ACS-SN4280", "Mellanox-SN4600C-D112C8", "Mellanox-SN4600C-C64", "Mellanox-SN4700-O8C48", "Mellanox-SN4600C-D100C12S2", "Mellanox-SN4600C-D48C40","Mellanox-SN4700-O32","Mellanox-SN4700-V64",
-                          "Mellanox-SN4700-A96C8V8", "Mellanox-SN4700-C128", "Mellanox-SN4700-O28", "Mellanox-SN4700-O8V48", "Mellanox-SN4700-V48C32", "Mellanox-SN4280-O28", "Mellanox-SN4280-O8C80", "Mellanox-SN4280-C48", "Mellanox-SN4280-O8C40", "Mellanox-SN4280-O8V40"],
+                          "Mellanox-SN4700-A96C8V8", "Mellanox-SN4700-C128", "Mellanox-SN4700-O28", "Mellanox-SN4700-O8V48", "Mellanox-SN4700-V48C32", "Mellanox-SN4280-O28", "Mellanox-SN4280-O8C80", "Mellanox-SN4280-C48", "Mellanox-SN4280-O8C40", "Mellanox-SN4280-O8V40", "Mellanox-SN4280-O4X96"],
                 "spc4": [ "ACS-SN5600", "Mellanox-SN5600-O128", "Mellanox-SN5600-V256", "Mellanox-SN5600-C256S1", "ACS-SN5400", "Mellanox-SN5600-C224O8", "Mellanox-SN5610N-C256S2", "Mellanox-SN5610N-C224O8" ],
-                "spc5": ["ACS-SN5640", "Mellanox-SN5640-C512S2", "Mellanox-SN5640-C448O16" ],
+                "spc5": ["ACS-SN5640", "Mellanox-SN5640-C512S2", "Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512X2", "Mellanox-SN5640-C508O1X2", "Mellanox-SN5640-O128X2" ],
                 "spc6": ["ACS-SN6600_LD"]
             },
             "broadcom_asics": {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added SPC and SN4280 SKUs
#### How I did it
Updated gcu_field_operation_validators.conf.json file with these SKUs 
"Mellanox-SN5640-C512X2", "Mellanox-SN5640-C508O1X2", "Mellanox-SN5640-O128X2
 "Mellanox-SN4280-O4X96"
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

