### PR TITLE
dualtor_neighbor_check: suppress alerts for neighbors mid-mux-move

### DIFF
--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -17,6 +17,7 @@ import sys
 import syslog
 import subprocess
 import tabulate
+import time
 
 from natsort import natsorted
 
@@ -210,6 +211,8 @@ NEIGHBOR_ATTRIBUTES_HOST_ROUTE = ["NEIGHBOR", "MAC", "PORT", "MUX_STATE", "IN_MU
 NEIGHBOR_ATTRIBUTES_PREFIX_ROUTE = ["NEIGHBOR", "MAC", "PORT", "MUX_STATE", "IN_MUX_TOGGLE", "NEIGHBOR_IN_ASIC",
                                     "PREFIX_ROUTE", "NEXTHOP_TYPE", "HWSTATUS"]
 NOT_AVAILABLE = "N/A"
+BOUNCING = "bouncing"
+DEFAULT_RECHECK_DELAY_MS = 300
 
 
 class LogOutput(enum.Enum):
@@ -265,6 +268,14 @@ def parse_args():
         default=None,
         help="stdout log level"
     )
+    parser.add_argument(
+        "--recheck-delay-ms",
+        type=int,
+        default=DEFAULT_RECHECK_DELAY_MS,
+        help=("Milliseconds to wait before re-reading APPL_DB/ASIC_DB to filter out "
+              "transient FDB/NEIGH races on suspect inconsistent neighbors. "
+              "Set to 0 to disable. Default: %d." % DEFAULT_RECHECK_DELAY_MS),
+    )
     args = parser.parse_args()
 
     if args.log_output == LogOutput.STDOUT:
@@ -283,6 +294,9 @@ def parse_args():
 
         if args.log_level is not None:
             parser.error("Received stdout log level with log output to syslog.")
+
+    if args.recheck_delay_ms < 0:
+        parser.error("--recheck-delay-ms must be non-negative.")
 
     return args
 
@@ -590,11 +604,91 @@ def check_neighbor_consistency(neighbors, mux_states, hw_mux_states, mac_to_port
     return check_results
 
 
-def parse_check_results(check_results):
+def identify_suspect_neighbors(check_results):
+    """Return list of (neighbor_ip, mac, port) tuples for rows that would currently be
+    flagged as inconsistent and are eligible for a recheck.
+
+    Eligibility: non-zero MAC, port resolved (not N/A), mux not mid-toggle, HWSTATUS False.
+    Zero-MAC and in-toggle rows are intentionally excluded — they are handled (or
+    suppressed) by existing logic and rechecking them adds no signal.
+    """
+    suspects = []
+    for r in check_results:
+        if r.get("MAC") == ZERO_MAC:
+            continue
+        if r.get("PORT", NOT_AVAILABLE) == NOT_AVAILABLE:
+            continue
+        if r.get("IN_MUX_TOGGLE") is True:
+            continue
+        if r.get("HWSTATUS") is False:
+            suspects.append((r["NEIGHBOR"], r["MAC"], r["PORT"]))
+    return suspects
+
+
+def detect_bouncing(suspects, first_neighbors, first_mac_to_port,
+                    second_neighbors, second_mac_to_port):
+    """Return the set of neighbor IPs whose IP->MAC binding or MAC->port binding
+    changed between two reads of APPL_DB:NEIGH_TABLE / ASIC_DB FDB.
+
+    These are transient FDB / NEIGH races (a MAC moving between ports while
+    orchagent / dualtor_neighbor_check is reading) — the inconsistency is not a
+    real failure of mux/neighbor programming, just a snapshot caught mid-move.
+    """
+    bouncing = set()
+    for ip, mac, _port in suspects:
+        new_mac = second_neighbors.get(ip)
+        if new_mac is None or new_mac != mac:
+            # IP disappeared from NEIGH_TABLE or its MAC changed -> bouncing.
+            bouncing.add(ip)
+            continue
+
+        first_port = first_mac_to_port.get(mac)
+        new_port = second_mac_to_port.get(mac)
+        if new_port != first_port:
+            # MAC moved (or disappeared from) FDB between reads -> bouncing.
+            bouncing.add(ip)
+            continue
+    return bouncing
+
+
+def recheck_bouncing_neighbors(check_results, first_neighbors, first_mac_to_port,
+                               appl_db, if_oid_to_port_name_map, delay_ms):
+    """Re-read APPL_DB / ASIC_DB after `delay_ms` and identify suspect inconsistent
+    neighbors that are actually mid-bounce (transient FDB / NEIGH race).
+
+    Returns the set of bouncing neighbor IPs (subset of the suspect IPs). Empty
+    when delay_ms <= 0, when there are no suspects, or when none of the suspects
+    changed binding between reads.
+    """
+    if delay_ms <= 0:
+        return set()
+
+    suspects = identify_suspect_neighbors(check_results)
+    if not suspects:
+        return set()
+
+    WRITE_LOG_INFO("Found %d suspect inconsistent neighbor(s); re-reading after %d ms "
+                   "to filter transient FDB/NEIGH races.", len(suspects), delay_ms)
+    time.sleep(delay_ms / 1000.0)
+
+    second_neighbors, _, _, _, second_asic_fdb, _, _, _ = read_tables_from_db(appl_db)
+    second_mac_to_port = get_mac_to_port_name_map(second_asic_fdb, if_oid_to_port_name_map)
+
+    bouncing_ips = detect_bouncing(suspects, first_neighbors, first_mac_to_port,
+                                   second_neighbors, second_mac_to_port)
+    if bouncing_ips:
+        WRITE_LOG_WARN("Detected %d transient (bouncing) neighbor(s); these will be "
+                       "logged but not reported as inconsistent: %s",
+                       len(bouncing_ips), sorted(bouncing_ips))
+    return bouncing_ips
+
+
+def parse_check_results(check_results, bouncing_ips=None):
     """Parse the check results to see if there are neighbors that are inconsistent with mux state."""
     failed_neighbors = []
     bool_to_yes_no = ("no", "yes")
     bool_to_consistency = ("inconsistent", "consistent")
+    bouncing_ips = bouncing_ips or set()
 
     # Group check results by neighbor_mode
     prefix_route_results = []
@@ -604,6 +698,7 @@ def parse_check_results(check_results):
         port = check_result["PORT"]
         is_zero_mac = check_result["MAC"] == ZERO_MAC
         neighbor_mode = check_result.get("_NEIGHBOR_MODE", "host-route")
+        is_bouncing = (not is_zero_mac) and (check_result["NEIGHBOR"] in bouncing_ips)
 
         if port == NOT_AVAILABLE and not is_zero_mac:
             host_route_results.append(check_result)
@@ -622,11 +717,14 @@ def parse_check_results(check_results):
             check_result["TUNNEL_IN_ASIC"] = bool_to_yes_no[check_result["TUNNEL_IN_ASIC"]]
             host_route_results.append(check_result)
 
-        check_result["HWSTATUS"] = bool_to_consistency[hwstatus]
+        if is_bouncing and not hwstatus:
+            check_result["HWSTATUS"] = BOUNCING
+        else:
+            check_result["HWSTATUS"] = bool_to_consistency[hwstatus]
         if (not hwstatus):
             if is_zero_mac:
                 failed_neighbors.append(check_result)
-            elif not in_toggle:
+            elif not in_toggle and not is_bouncing:
                 failed_neighbors.append(check_result)
 
     # Display prefix-route neighbors if any
@@ -718,5 +816,15 @@ if __name__ == "__main__":
         mux_server_to_port_map,
         port_neighbor_modes
     )
-    res = parse_check_results(check_results)
+
+    bouncing_ips = recheck_bouncing_neighbors(
+        check_results,
+        neighbors,
+        mac_to_port_name_map,
+        appl_db,
+        if_oid_to_port_name_map,
+        args.recheck_delay_ms,
+    )
+
+    res = parse_check_results(check_results, bouncing_ips=bouncing_ips)
     sys.exit(0 if res else 1)

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -971,3 +971,162 @@ class TestDualtorNeighborCheck(object):
         assert res is False
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
         mock_log_error.assert_has_calls(expected_log_error_calls)
+
+    def test_identify_suspect_neighbors_filters_correctly(self, mock_log_functions):
+        """Only non-zero-MAC, non-in-toggle, failing rows with a resolved port should be suspects."""
+        zero = dualtor_neighbor_check.ZERO_MAC
+        na = dualtor_neighbor_check.NOT_AVAILABLE
+        check_results = [
+            {"NEIGHBOR": "10.0.0.1", "MAC": "aa:bb:cc:dd:ee:01", "PORT": "Ethernet4",
+             "IN_MUX_TOGGLE": False, "HWSTATUS": False},
+            {"NEIGHBOR": "10.0.0.2", "MAC": "aa:bb:cc:dd:ee:02", "PORT": "Ethernet8",
+             "IN_MUX_TOGGLE": False, "HWSTATUS": True},
+            {"NEIGHBOR": "10.0.0.3", "MAC": "aa:bb:cc:dd:ee:03", "PORT": "Ethernet12",
+             "IN_MUX_TOGGLE": True,  "HWSTATUS": False},
+            {"NEIGHBOR": "10.0.0.4", "MAC": zero,                "PORT": "Ethernet16",
+             "IN_MUX_TOGGLE": False, "HWSTATUS": False},
+            {"NEIGHBOR": "10.0.0.5", "MAC": "aa:bb:cc:dd:ee:05", "PORT": na,
+             "IN_MUX_TOGGLE": False, "HWSTATUS": False},
+        ]
+        suspects = dualtor_neighbor_check.identify_suspect_neighbors(check_results)
+        assert suspects == [("10.0.0.1", "aa:bb:cc:dd:ee:01", "Ethernet4")]
+
+    def test_detect_bouncing_detects_mac_move_and_neigh_change(self, mock_log_functions):
+        """detect_bouncing should flag IPs whose IP->MAC or MAC->port mapping changed."""
+        suspects = [
+            ("10.0.0.1", "aa:bb:cc:dd:ee:01", "Ethernet4"),
+            ("10.0.0.2", "aa:bb:cc:dd:ee:02", "Ethernet8"),
+            ("10.0.0.3", "aa:bb:cc:dd:ee:03", "Ethernet12"),
+            ("10.0.0.4", "aa:bb:cc:dd:ee:04", "Ethernet16"),
+            ("10.0.0.5", "aa:bb:cc:dd:ee:05", "Ethernet20"),
+        ]
+        first_neighbors = {
+            "10.0.0.1": "aa:bb:cc:dd:ee:01", "10.0.0.2": "aa:bb:cc:dd:ee:02",
+            "10.0.0.3": "aa:bb:cc:dd:ee:03", "10.0.0.4": "aa:bb:cc:dd:ee:04",
+            "10.0.0.5": "aa:bb:cc:dd:ee:05",
+        }
+        first_mac_to_port = {
+            "aa:bb:cc:dd:ee:01": "Ethernet4",  "aa:bb:cc:dd:ee:02": "Ethernet8",
+            "aa:bb:cc:dd:ee:03": "Ethernet12", "aa:bb:cc:dd:ee:04": "Ethernet16",
+            "aa:bb:cc:dd:ee:05": "Ethernet20",
+        }
+        second_neighbors = {
+            "10.0.0.1": "aa:bb:cc:dd:ee:01",
+            "10.0.0.2": "aa:bb:cc:dd:ee:02",
+            "10.0.0.3": "aa:bb:cc:dd:ee:99",
+            "10.0.0.5": "aa:bb:cc:dd:ee:05",
+        }
+        second_mac_to_port = {
+            "aa:bb:cc:dd:ee:01": "Ethernet4",
+            "aa:bb:cc:dd:ee:02": "Ethernet36",
+            "aa:bb:cc:dd:ee:03": "Ethernet12",
+            "aa:bb:cc:dd:ee:99": "Ethernet12",
+        }
+        bouncing = dualtor_neighbor_check.detect_bouncing(
+            suspects, first_neighbors, first_mac_to_port, second_neighbors, second_mac_to_port)
+        assert bouncing == {"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"}
+
+    def test_detect_bouncing_no_change_returns_empty(self, mock_log_functions):
+        suspects = [("10.0.0.1", "aa:bb:cc:dd:ee:01", "Ethernet4")]
+        first_neighbors = {"10.0.0.1": "aa:bb:cc:dd:ee:01"}
+        first_mac_to_port = {"aa:bb:cc:dd:ee:01": "Ethernet4"}
+        bouncing = dualtor_neighbor_check.detect_bouncing(
+            suspects, first_neighbors, first_mac_to_port,
+            dict(first_neighbors), dict(first_mac_to_port))
+        assert bouncing == set()
+
+    def test_parse_check_results_bouncing_demoted_to_non_failure(self, mock_log_functions):
+        """A row whose IP is in bouncing_ips must not be reported as a failure;
+        its HWSTATUS column is rendered as 'bouncing' for operator visibility."""
+        mock_log_error, _, _, _ = mock_log_functions
+        check_results = [{
+            "NEIGHBOR": "10.0.0.2", "MAC": "aa:bb:cc:dd:ee:02", "PORT": "Ethernet8",
+            "MUX_STATE": "standby", "IN_MUX_TOGGLE": False,
+            "NEIGHBOR_IN_ASIC": True, "TUNNEL_IN_ASIC": False, "HWSTATUS": False,
+            "_NEIGHBOR_MODE": "host-route",
+        }]
+        res = dualtor_neighbor_check.parse_check_results(check_results, bouncing_ips={"10.0.0.2"})
+        assert res is True
+        assert check_results[0]["HWSTATUS"] == dualtor_neighbor_check.BOUNCING
+        mock_log_error.assert_not_called()
+
+    def test_parse_check_results_without_bouncing_still_fails(self, mock_log_functions):
+        """Sanity: same inconsistent row, no bouncing_ips -> still a failure."""
+        check_results = [{
+            "NEIGHBOR": "10.0.0.2", "MAC": "aa:bb:cc:dd:ee:02", "PORT": "Ethernet8",
+            "MUX_STATE": "standby", "IN_MUX_TOGGLE": False,
+            "NEIGHBOR_IN_ASIC": True, "TUNNEL_IN_ASIC": False, "HWSTATUS": False,
+            "_NEIGHBOR_MODE": "host-route",
+        }]
+        res = dualtor_neighbor_check.parse_check_results(check_results)
+        assert res is False
+        assert check_results[0]["HWSTATUS"] == "inconsistent"
+
+    def test_recheck_bouncing_neighbors_disabled_when_delay_zero(self, mock_log_functions):
+        """delay_ms=0 must short-circuit: no sleep, no re-read, empty set."""
+        check_results = [{
+            "NEIGHBOR": "10.0.0.1", "MAC": "aa:bb:cc:dd:ee:01", "PORT": "Ethernet4",
+            "IN_MUX_TOGGLE": False, "HWSTATUS": False,
+        }]
+        with patch("dualtor_neighbor_check.time.sleep") as mock_sleep, \
+                patch("dualtor_neighbor_check.read_tables_from_db") as mock_read:
+            bouncing = dualtor_neighbor_check.recheck_bouncing_neighbors(
+                check_results, {}, {}, MagicMock(), {}, delay_ms=0)
+        assert bouncing == set()
+        mock_sleep.assert_not_called()
+        mock_read.assert_not_called()
+
+    def test_recheck_bouncing_neighbors_no_suspects_skips_reread(self, mock_log_functions):
+        """No failing rows -> no sleep, no re-read."""
+        check_results = [{
+            "NEIGHBOR": "10.0.0.1", "MAC": "aa:bb:cc:dd:ee:01", "PORT": "Ethernet4",
+            "IN_MUX_TOGGLE": False, "HWSTATUS": True,
+        }]
+        with patch("dualtor_neighbor_check.time.sleep") as mock_sleep, \
+                patch("dualtor_neighbor_check.read_tables_from_db") as mock_read:
+            bouncing = dualtor_neighbor_check.recheck_bouncing_neighbors(
+                check_results, {}, {}, MagicMock(), {}, delay_ms=300)
+        assert bouncing == set()
+        mock_sleep.assert_not_called()
+        mock_read.assert_not_called()
+
+    def test_recheck_bouncing_neighbors_detects_mac_move(self, mock_log_functions):
+        """A failing row whose MAC moves ports between the two reads is bouncing."""
+        check_results = [{
+            "NEIGHBOR": "10.0.0.2", "MAC": "aa:bb:cc:dd:ee:02", "PORT": "Ethernet8",
+            "IN_MUX_TOGGLE": False, "HWSTATUS": False,
+        }]
+        first_neighbors = {"10.0.0.2": "aa:bb:cc:dd:ee:02"}
+        first_mac_to_port = {"aa:bb:cc:dd:ee:02": "Ethernet8"}
+
+        second_neighbors = {"10.0.0.2": "aa:bb:cc:dd:ee:02"}
+        second_asic_fdb = {"aa:bb:cc:dd:ee:02": "oid:0xbridgeport_eth36"}
+        if_oid_to_port_name_map = {"oid:0xbridgeport_eth36": "Ethernet36"}
+
+        with patch("dualtor_neighbor_check.time.sleep"), \
+                patch("dualtor_neighbor_check.read_tables_from_db",
+                      return_value=(second_neighbors, {}, {}, {}, second_asic_fdb, [], [], {})):
+            bouncing = dualtor_neighbor_check.recheck_bouncing_neighbors(
+                check_results, first_neighbors, first_mac_to_port,
+                MagicMock(), if_oid_to_port_name_map, delay_ms=300)
+        assert bouncing == {"10.0.0.2"}
+
+    def test_recheck_bouncing_neighbors_stable_returns_empty(self, mock_log_functions):
+        """A failing row whose bindings are stable across reads is NOT bouncing
+        (this is the RC2-persistent path we still want to fail loudly)."""
+        check_results = [{
+            "NEIGHBOR": "10.0.0.2", "MAC": "aa:bb:cc:dd:ee:02", "PORT": "Ethernet8",
+            "IN_MUX_TOGGLE": False, "HWSTATUS": False,
+        }]
+        first_neighbors = {"10.0.0.2": "aa:bb:cc:dd:ee:02"}
+        first_mac_to_port = {"aa:bb:cc:dd:ee:02": "Ethernet8"}
+        second_asic_fdb = {"aa:bb:cc:dd:ee:02": "oid:0xbridgeport_eth8"}
+        if_oid_to_port_name_map = {"oid:0xbridgeport_eth8": "Ethernet8"}
+
+        with patch("dualtor_neighbor_check.time.sleep"), \
+                patch("dualtor_neighbor_check.read_tables_from_db",
+                      return_value=(dict(first_neighbors), {}, {}, {}, second_asic_fdb, [], [], {})):
+            bouncing = dualtor_neighbor_check.recheck_bouncing_neighbors(
+                check_results, first_neighbors, first_mac_to_port,
+                MagicMock(), if_oid_to_port_name_map, delay_ms=300)
+        assert bouncing == set()


### PR DESCRIPTION
### What I did
Reduce false-positive alerts from `scripts/dualtor_neighbor_check.py` when a neighbor's MAC is moving between the active and standby ToR.

### Why I did it
`dualtor_neighbor_check` reads `NEIGH_TABLE`, the ASIC FDB, and the mux state tables as a sequence of independent DB calls. Those reads are not atomic, so when a MAC is moving between the two ToRs (mid-toggle, server NIC failover, transient FDB flush) we can observe the new `MUX_STATE` before the FDB has caught up, or read the FDB while it is being rewritten. The row looks inconsistent for a few hundred milliseconds and then settles — but in the meantime the script logs it at ERROR.

### How I did it
After the first scan flags any inconsistent rows, re-read `NEIGH` and the ASIC FDB once more (default 300 ms later, configurable via `--recheck-delay-ms`; pass `0` to disable). For each suspect IP, compare the IP→MAC and MAC→port mappings across the two reads:

- If either mapping changed, the binding was in flight → mark the row `HWSTATUS=bouncing`, keep it in the WARN table for visibility, but **do not** add it to `failed_neighbors` and **do not** emit an ERROR log.
- If both mappings are stable, the row fails exactly as before.

The recheck only runs when at least one suspect exists, so the steady-state cost is unchanged.

### How to verify it
- New unit tests cover: suspect filtering, bouncing detection (MAC move, IP→MAC change, IP/MAC disappearing), the disabled path (`delay_ms=0`), the no-suspects fast path, and the stable-inconsistent path (which must still fail).
- Existing `parse_check_results` callers remain backward-compatible (`bouncing_ips` defaults to `None`).
- Manual: run the script with `--recheck-delay-ms 0` to get exactly the previous behaviour.

### Description for the changelog
`dualtor_neighbor_check`: re-read NEIGH/FDB once after the initial scan and demote rows whose bindings change between reads to a non-failure `bouncing` status, so neighbors that are simply mid-mux-move no longer trigger false alerts. Configurable via `--recheck-delay-ms` (default 300 ms; 0 disables).

### A picture of a cute animal (not mandatory but encouraged)
🐋
