### PR TITLE
[doc] fix malformed markdown in vlan member examples

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -13455,23 +13455,18 @@ This command is to add or delete a member port into multiple already created vla
   ```
   admin@sonic:~$ sudo config vlan member add -m 100-103 Ethernet0
   This command will add Ethernet0 as member of the vlan 100, vlan 101, vlan 102, vlan 103
-   ```
-   ```
+
   admin@sonic:~$ sudo config vlan member add -m 100,101,102 Ethernet4
   This command will add Ethernet4 as member of the vlan 100, vlan 101, vlan 102
-   ```
-   ```
+
   admin@sonic:~$ sudo config vlan member add -e -m 104,105 Ethernet8
-  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet8 as member of  vlan 100, vlan 101, vlan 102, vlan 103
-  ```
-  ```
+  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are existing vlans. This command will add Ethernet8 as member of  vlan 100, vlan 101, vlan 102, vlan 103
+
   admin@sonic:~$ sudo config vlan member add -e 100 Ethernet12
-  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet12 as member of vlan 101, vlan 102, vlan 103, vlan 104, vlan 105
-  ```
-   ```
+  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are existing vlans. This command will add Ethernet12 as member of vlan 101, vlan 102, vlan 103, vlan 104, vlan 105
+
   admin@sonic:~$ sudo config vlan member add all Ethernet20
-  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are exisiting vlans. This command will add Ethernet20 as member of vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 1
-05
+  Suppose vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105 are existing vlans. This command will add Ethernet20 as member of vlan 100, vlan 101, vlan 102, vlan 103, vlan 104, vlan 105
   ```
 
 **config proxy_arp enabled/disabled**


### PR DESCRIPTION
#### What I did
Fixed malformed Markdown in doc/Command-Reference.md for the config vlan member add/del examples.
Stray fenced-code markers between sub-examples, a hard line break that split vlan 105 across two lines, and the typo exisiting to existing in those example lines.

#### How I did it
Merged the multiple broken ``` open/close pairs into one fenced code block under - Example:, matching the style used for the earlier vlan member examples. Joined the wrapped line so the last example ends with vlan 105 on a single line.

#### How to verify it
Open doc/Command-Reference.md and jump to the config vlan member add/del section.
Confirm there is a single opening ``` after - Example: and a single closing ``` before config proxy_arp enabled/disabled, and that the add all Ethernet20 paragraph reads correctly on one line through vlan 105. 
Optionally preview the file in a Markdown viewer or GitHub and confirm the example renders as one continuous code block and next titles are shown correctly for example - **config proxy_arp enabled/disabled**.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
