### PR TITLE
[tempershow] guard global DB config load behind multi-asic check

### DIFF
--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -8,6 +8,7 @@ import json
 from datetime import datetime
 
 from tabulate import tabulate
+from sonic_py_common import multi_asic
 from swsscommon.swsscommon import SonicDBConfig, SonicV2Connector
 from natsort import natsorted
 
@@ -67,8 +68,12 @@ NA = 'N/A'
 
 class TemperShow(object):
     def __init__(self):
-        if not SonicDBConfig.isGlobalInit():
-            SonicDBConfig.load_sonic_global_db_config()
+        if multi_asic.is_multi_asic():
+            if not SonicDBConfig.isGlobalInit():
+                SonicDBConfig.load_sonic_global_db_config()
+         else:
+            if not SonicDBConfig.isInit():
+                SonicDBConfig.load_sonic_db_config()
         self.db = SonicV2Connector(host="127.0.0.1")
         self.db.connect(self.db.STATE_DB)
         self._sfp_helper_ready = self._init_sfp_util_helper()

--- a/scripts/tempershow
+++ b/scripts/tempershow
@@ -8,7 +8,6 @@ import json
 from datetime import datetime
 
 from tabulate import tabulate
-from sonic_py_common import multi_asic
 from swsscommon.swsscommon import SonicDBConfig, SonicV2Connector
 from natsort import natsorted
 
@@ -71,7 +70,7 @@ class TemperShow(object):
         if multi_asic.is_multi_asic():
             if not SonicDBConfig.isGlobalInit():
                 SonicDBConfig.load_sonic_global_db_config()
-         else:
+        else:
             if not SonicDBConfig.isInit():
                 SonicDBConfig.load_sonic_db_config()
         self.db = SonicV2Connector(host="127.0.0.1")


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed `scripts/tempershow` so it no longer unconditionally calls `SonicDBConfig.load_sonic_global_db_config()`. On single-ASIC platforms the global DB config file `/var/run/redis/sonic-db/database_global.json` does not exist, and the swss-common C++ layer logs an ERR every time `tempershow` runs:
```
ERR python3: :- initializeGlobalConfig: Sonic database config global file
doesn't exist at /var/run/redis/sonic-db/database_global.json
```
Because `show techsupport` invokes `tempershow`, this ERR is captured by LogAnalyzer and fails sonic-mgmt test `show_techsupport/test_auto_techsupport.py::TestAutoTechSupport::test_sanity` on every single-ASIC run (e.g. KVM t0 PR checks).
 
#### How I did it
- Detect multi-ASIC via `sonic_py_common.multi_asic.is_multi_asic()`.
- On multi-ASIC: call `SonicDBConfig.load_sonic_global_db_config()` only if `isGlobalInit()` is False (unchanged behavior).
- On single-ASIC: call `SonicDBConfig.load_sonic_db_config()` only if `isInit()` is False — matches the pattern used by other utilities (e.g. `psushow`, `show` CLI helpers).
#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

