### PR TITLE
fix(gcu): initialize SonicDBConfig in gcu-standalone for multi-ASIC support

### DIFF
--- a/generic_config_updater/main.py
+++ b/generic_config_updater/main.py
@@ -38,6 +38,7 @@ from generic_config_updater.gu_common import (
     GenericConfigUpdaterError,
 )
 from sonic_py_common import multi_asic
+from utilities_common.general import load_db_config
 
 logger = logging.getLogger(__name__)
 
@@ -782,6 +783,8 @@ Examples:
 
 def main():
     """Main entry point for the gcu-standalone console script."""
+    load_db_config()
+
     parser = build_parser()
     args = parser.parse_args()
 


### PR DESCRIPTION
## Description

The `gcu-standalone` entry point (`main()`) does not call `load_db_config()`, causing `ConfigDBConnector(namespace='asicN')` to fail with:

```
swsscommon.SonicDBException: validateNamespace: Initialize global DB config
```

on multi-ASIC platforms (e.g., Nokia 7250 IXR chassis).

## Root Cause

When `config apply-patch` runs, the `config` Click group callback in `config/main.py` calls `load_db_config()` before dispatching — so the DB config is already initialized. However, `gcu-standalone` invokes `generic_config_updater/main.py:main()` directly, bypassing that initialization entirely.

## Fix

Add `load_db_config()` as the first call in `main()`. This matches the established pattern used by every other standalone entry point in sonic-utilities (`config/main.py`, `show/main.py`, `scripts/port2alias`, `scripts/portconfig`, `acl_loader/main.py`, etc.).

`load_db_config()` is idempotent (guarded by `isGlobalInit()`/`isInit()` checks) and a no-op on single-ASIC devices where DB is already initialized.

## Testing

- Verified on Nokia 7250 IXR multi-ASIC chassis (2 ASICs: asic0, asic1)
- `gcu-standalone apply-patch` with asic0-scoped patch proceeds past DB init (previously crashed)
- Single-ASIC regression: no behavior change (idempotent no-op)
