### PR TITLE
Dualtor neighbor flush inconsistent neighbors

### DIFF
--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -204,6 +204,8 @@ result['asic_nexthop_table'] = asic_nexthop_table
 return redis.status_reply(cjson.encode(result))
 """
 
+# Allow kernel ARP/ND and orchagent to converge before validating the
+# one-time automatic neighbor flush mitigation.
 POST_FLUSH_CHECK_DELAY_SEC = 10
 
 DB_READ_SCRIPT_CONFIG_DB_KEY = "_DUALTOR_NEIGHBOR_CHECK_SCRIPT_SHA1"
@@ -271,7 +273,7 @@ def parse_args():
     parser.add_argument(
         "--flush-inconsistent-neighbors",
         action="store_true",
-        help="flush inconsistent kernel neighbor entries and rerun the check"
+        help="deprecated: inconsistent kernel neighbor entries are flushed once by default"
     )
     args = parser.parse_args()
 
@@ -370,16 +372,22 @@ def flush_neighbor(neighbor_ip):
 
 def flush_inconsistent_neighbors(failed_neighbors):
     """Flush kernel neighbor entries for failed neighbors."""
+    attempted_neighbors = set()
     flushed_neighbors = set()
 
     for neighbor in failed_neighbors:
         # Inconsistency can affect both host-route and prefix-route neighbors.
         neighbor_ip = neighbor["NEIGHBOR"]
-        if neighbor_ip in flushed_neighbors:
+        if neighbor_ip in attempted_neighbors:
             continue
 
+        attempted_neighbors.add(neighbor_ip)
         WRITE_LOG_WARN("Flushing inconsistent neighbor entry: %s", neighbor_ip)
-        flush_neighbor(neighbor_ip)
+        try:
+            flush_neighbor(neighbor_ip)
+        except (RuntimeError, ValueError) as err:
+            WRITE_LOG_ERROR("Failed to flush inconsistent neighbor entry %s: %s", neighbor_ip, err)
+            continue
         flushed_neighbors.add(neighbor_ip)
 
     return len(flushed_neighbors)
@@ -759,7 +767,7 @@ def main():
     check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
     res, failed_neighbors = parse_check_results(check_results)
 
-    if not res and args.flush_inconsistent_neighbors:
+    if not res:
         flush_count = flush_inconsistent_neighbors(failed_neighbors)
         if flush_count:
             WRITE_LOG_WARN("Flushed %d inconsistent neighbor entries.", flush_count)
@@ -771,7 +779,9 @@ def main():
             check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
             res, _ = parse_check_results(check_results)
             if not res:
-                WRITE_LOG_WARN("Post-flush dualtor neighbor check still found inconsistent neighbors.")
+                WRITE_LOG_ERROR("ALERT: post-flush dualtor neighbor check still found inconsistent neighbors.")
+        else:
+            WRITE_LOG_ERROR("ALERT: no inconsistent neighbor entries were flushed.")
 
     return 0 if res else 1
 

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -265,6 +265,11 @@ def parse_args():
         default=None,
         help="stdout log level"
     )
+    parser.add_argument(
+        "--flush-inconsistent-neighbors",
+        action="store_true",
+        help="flush inconsistent kernel neighbor entries and rerun the check"
+    )
     args = parser.parse_args()
 
     if args.log_output == LogOutput.STDOUT:
@@ -351,6 +356,29 @@ def redis_cli(redis_cmd):
     if "error" in result or "ERR" in result:
         raise RuntimeError("Redis command '%s' failed: %s" % (redis_cmd, result))
     return result
+
+
+def flush_neighbor(neighbor_ip):
+    """Flush a kernel neighbor entry by IP address."""
+    ip = ipaddress.ip_address(neighbor_ip)
+    ip_version = "4" if ip.version == 4 else "6"
+    run_command("sudo ip -%s neigh flush to %s" % (ip_version, ip.compressed))
+
+
+def flush_inconsistent_neighbors(failed_neighbors):
+    """Flush the kernel neighbor entries for failed neighbors."""
+    flushed_neighbors = set()
+
+    for neighbor in failed_neighbors:
+        neighbor_ip = neighbor["NEIGHBOR"]
+        if neighbor_ip in flushed_neighbors:
+            continue
+
+        WRITE_LOG_WARN("Flushing inconsistent neighbor entry: %s", neighbor_ip)
+        flush_neighbor(neighbor_ip)
+        flushed_neighbors.add(neighbor_ip)
+
+    return len(flushed_neighbors)
 
 
 def read_tables_from_db(appl_db):
@@ -590,7 +618,7 @@ def check_neighbor_consistency(neighbors, mux_states, hw_mux_states, mac_to_port
     return check_results
 
 
-def parse_check_results(check_results):
+def parse_check_results(check_results, return_failed_neighbors=False):
     """Parse the check results to see if there are neighbors that are inconsistent with mux state."""
     failed_neighbors = []
     bool_to_yes_no = ("no", "yes")
@@ -683,8 +711,31 @@ def parse_check_results(check_results):
             )
             for output_line in err_output_lines.split("\n"):
                 WRITE_LOG_ERROR(output_line)
+        if return_failed_neighbors:
+            return False, failed_neighbors
         return False
+    if return_failed_neighbors:
+        return True, failed_neighbors
     return True
+
+
+def run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map):
+    """Run the dualtor neighbor consistency check once."""
+    neighbors, mux_states, hw_mux_states, port_neighbor_modes, asic_fdb, asic_route_table, asic_neigh_table, \
+        asic_nexthop_table = read_tables_from_db(appl_db)
+    mac_to_port_name_map = get_mac_to_port_name_map(asic_fdb, if_oid_to_port_name_map)
+
+    return check_neighbor_consistency(
+        neighbors,
+        mux_states,
+        hw_mux_states,
+        mac_to_port_name_map,
+        asic_route_table,
+        asic_neigh_table,
+        asic_nexthop_table,
+        mux_server_to_port_map,
+        port_neighbor_modes
+    )
 
 
 if __name__ == "__main__":
@@ -703,20 +754,14 @@ if __name__ == "__main__":
 
     mux_server_to_port_map = get_mux_server_to_port_map(mux_cables)
     if_oid_to_port_name_map = get_if_br_oid_to_port_name_map()
-    neighbors, mux_states, hw_mux_states, port_neighbor_modes, asic_fdb, asic_route_table, asic_neigh_table, \
-        asic_nexthop_table = read_tables_from_db(appl_db)
-    mac_to_port_name_map = get_mac_to_port_name_map(asic_fdb, if_oid_to_port_name_map)
 
-    check_results = check_neighbor_consistency(
-        neighbors,
-        mux_states,
-        hw_mux_states,
-        mac_to_port_name_map,
-        asic_route_table,
-        asic_neigh_table,
-        asic_nexthop_table,
-        mux_server_to_port_map,
-        port_neighbor_modes
-    )
-    res = parse_check_results(check_results)
+    check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
+    res, failed_neighbors = parse_check_results(check_results, return_failed_neighbors=True)
+
+    if not res and args.flush_inconsistent_neighbors:
+        flush_count = flush_inconsistent_neighbors(failed_neighbors)
+        WRITE_LOG_WARN("Flushed %d inconsistent neighbor entries. Rerunning dualtor neighbor check.", flush_count)
+        check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
+        res = parse_check_results(check_results)
+
     sys.exit(0 if res else 1)

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -270,11 +270,6 @@ def parse_args():
         default=None,
         help="stdout log level"
     )
-    parser.add_argument(
-        "--flush-inconsistent-neighbors",
-        action="store_true",
-        help="deprecated: inconsistent kernel neighbor entries are flushed once by default"
-    )
     args = parser.parse_args()
 
     if args.log_output == LogOutput.STDOUT:

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -666,6 +666,16 @@ def parse_check_results(check_results, return_failed_neighbors=False):
             elif not in_toggle:
                 failed_neighbors.append(check_result)
 
+    # Keep the original no-neighbor output behavior by printing an empty prefix-route table.
+    if not prefix_route_results and not host_route_results:
+        output_lines = tabulate.tabulate(
+            [],
+            headers=NEIGHBOR_ATTRIBUTES_PREFIX_ROUTE,
+            tablefmt="simple"
+        )
+        for output_line in output_lines.split("\n"):
+            WRITE_LOG_WARN(output_line)
+
     # Display prefix-route neighbors if any
     if prefix_route_results:
         WRITE_LOG_WARN("=" * 80)

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -760,7 +760,7 @@ def main():
 
     if not is_dualtor(config_db) or not mux_cables:
         WRITE_LOG_DEBUG("Not a valid dualtor setup, skip the check.")
-        sys.exit(0)
+        return 0
 
     mux_server_to_port_map = get_mux_server_to_port_map(mux_cables)
     if_oid_to_port_name_map = get_if_br_oid_to_port_name_map()

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -747,7 +747,8 @@ def run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
     )
 
 
-if __name__ == "__main__":
+def main():
+    """Main entry point for dualtor neighbor consistency check."""
     args = parse_args()
     config_logging(args)
 
@@ -774,4 +775,8 @@ if __name__ == "__main__":
             check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
             res = parse_check_results(check_results)
 
-    sys.exit(0 if res else 1)
+    return 0 if res else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -17,6 +17,7 @@ import sys
 import syslog
 import subprocess
 import tabulate
+import time
 
 from natsort import natsorted
 
@@ -203,6 +204,8 @@ result['asic_nexthop_table'] = asic_nexthop_table
 return redis.status_reply(cjson.encode(result))
 """
 
+POST_FLUSH_CHECK_DELAY_SEC = 10
+
 DB_READ_SCRIPT_CONFIG_DB_KEY = "_DUALTOR_NEIGHBOR_CHECK_SCRIPT_SHA1"
 ZERO_MAC = "00:00:00:00:00:00"
 NEIGHBOR_ATTRIBUTES_HOST_ROUTE = ["NEIGHBOR", "MAC", "PORT", "MUX_STATE", "IN_MUX_TOGGLE", "NEIGHBOR_IN_ASIC",
@@ -268,7 +271,7 @@ def parse_args():
     parser.add_argument(
         "--flush-inconsistent-neighbors",
         action="store_true",
-        help="flush inconsistent prefix-route mux-port kernel neighbor entries and rerun the check"
+        help="flush inconsistent kernel neighbor entries and rerun the check"
     )
     args = parser.parse_args()
 
@@ -366,19 +369,11 @@ def flush_neighbor(neighbor_ip):
 
 
 def flush_inconsistent_neighbors(failed_neighbors):
-    """Flush kernel neighbor entries for failed prefix-route mux-port neighbors."""
+    """Flush kernel neighbor entries for failed neighbors."""
     flushed_neighbors = set()
 
     for neighbor in failed_neighbors:
-        if (neighbor.get("_NEIGHBOR_MODE") != "prefix-route" or
-                neighbor.get("PORT") == NOT_AVAILABLE):
-            WRITE_LOG_DEBUG(
-                "Skip flushing inconsistent neighbor %s because only "
-                "prefix-route mux-port neighbors are remediated",
-                neighbor["NEIGHBOR"]
-            )
-            continue
-
+        # Inconsistency can affect both host-route and prefix-route neighbors.
         neighbor_ip = neighbor["NEIGHBOR"]
         if neighbor_ip in flushed_neighbors:
             continue
@@ -627,7 +622,7 @@ def check_neighbor_consistency(neighbors, mux_states, hw_mux_states, mac_to_port
     return check_results
 
 
-def parse_check_results(check_results, return_failed_neighbors=False):
+def parse_check_results(check_results):
     """Parse the check results to see if there are neighbors that are inconsistent with mux state."""
     failed_neighbors = []
     bool_to_yes_no = ("no", "yes")
@@ -665,16 +660,6 @@ def parse_check_results(check_results, return_failed_neighbors=False):
                 failed_neighbors.append(check_result)
             elif not in_toggle:
                 failed_neighbors.append(check_result)
-
-    # Keep the original no-neighbor output behavior by printing an empty prefix-route table.
-    if not prefix_route_results and not host_route_results:
-        output_lines = tabulate.tabulate(
-            [],
-            headers=NEIGHBOR_ATTRIBUTES_PREFIX_ROUTE,
-            tablefmt="simple"
-        )
-        for output_line in output_lines.split("\n"):
-            WRITE_LOG_WARN(output_line)
 
     # Display prefix-route neighbors if any
     if prefix_route_results:
@@ -730,12 +715,8 @@ def parse_check_results(check_results, return_failed_neighbors=False):
             )
             for output_line in err_output_lines.split("\n"):
                 WRITE_LOG_ERROR(output_line)
-        if return_failed_neighbors:
-            return False, failed_neighbors
-        return False
-    if return_failed_neighbors:
-        return True, failed_neighbors
-    return True
+        return False, failed_neighbors
+    return True, failed_neighbors
 
 
 def run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map):
@@ -776,14 +757,21 @@ def main():
     if_oid_to_port_name_map = get_if_br_oid_to_port_name_map()
 
     check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
-    res, failed_neighbors = parse_check_results(check_results, return_failed_neighbors=True)
+    res, failed_neighbors = parse_check_results(check_results)
 
     if not res and args.flush_inconsistent_neighbors:
         flush_count = flush_inconsistent_neighbors(failed_neighbors)
         if flush_count:
-            WRITE_LOG_WARN("Flushed %d inconsistent neighbor entries. Rerunning dualtor neighbor check.", flush_count)
+            WRITE_LOG_WARN("Flushed %d inconsistent neighbor entries.", flush_count)
+            WRITE_LOG_WARN(
+                "Waiting %d seconds before rerunning dualtor neighbor check.",
+                POST_FLUSH_CHECK_DELAY_SEC
+            )
+            time.sleep(POST_FLUSH_CHECK_DELAY_SEC)
             check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
-            res = parse_check_results(check_results)
+            res, _ = parse_check_results(check_results)
+            if not res:
+                WRITE_LOG_WARN("Post-flush dualtor neighbor check still found inconsistent neighbors.")
 
     return 0 if res else 1
 

--- a/scripts/dualtor_neighbor_check.py
+++ b/scripts/dualtor_neighbor_check.py
@@ -268,7 +268,7 @@ def parse_args():
     parser.add_argument(
         "--flush-inconsistent-neighbors",
         action="store_true",
-        help="flush inconsistent kernel neighbor entries and rerun the check"
+        help="flush inconsistent prefix-route mux-port kernel neighbor entries and rerun the check"
     )
     args = parser.parse_args()
 
@@ -366,10 +366,19 @@ def flush_neighbor(neighbor_ip):
 
 
 def flush_inconsistent_neighbors(failed_neighbors):
-    """Flush the kernel neighbor entries for failed neighbors."""
+    """Flush kernel neighbor entries for failed prefix-route mux-port neighbors."""
     flushed_neighbors = set()
 
     for neighbor in failed_neighbors:
+        if (neighbor.get("_NEIGHBOR_MODE") != "prefix-route" or
+                neighbor.get("PORT") == NOT_AVAILABLE):
+            WRITE_LOG_DEBUG(
+                "Skip flushing inconsistent neighbor %s because only "
+                "prefix-route mux-port neighbors are remediated",
+                neighbor["NEIGHBOR"]
+            )
+            continue
+
         neighbor_ip = neighbor["NEIGHBOR"]
         if neighbor_ip in flushed_neighbors:
             continue
@@ -760,8 +769,9 @@ if __name__ == "__main__":
 
     if not res and args.flush_inconsistent_neighbors:
         flush_count = flush_inconsistent_neighbors(failed_neighbors)
-        WRITE_LOG_WARN("Flushed %d inconsistent neighbor entries. Rerunning dualtor neighbor check.", flush_count)
-        check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
-        res = parse_check_results(check_results)
+        if flush_count:
+            WRITE_LOG_WARN("Flushed %d inconsistent neighbor entries. Rerunning dualtor neighbor check.", flush_count)
+            check_results = run_neighbor_check(appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
+            res = parse_check_results(check_results)
 
     sys.exit(0 if res else 1)

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -124,6 +124,21 @@ class TestDualtorNeighborCheck(object):
         assert res is True
         assert failed_neighbors == []
 
+    def test_parse_check_results_empty_keeps_original_table_output(self, mock_log_functions):
+        _, mock_log_warn, _, _ = mock_log_functions
+
+        res, failed_neighbors = dualtor_neighbor_check.parse_check_results(
+            [], return_failed_neighbors=True)
+
+        expected_output_lines = tabulate.tabulate(
+            [],
+            headers=dualtor_neighbor_check.NEIGHBOR_ATTRIBUTES_PREFIX_ROUTE,
+            tablefmt="simple"
+        ).split("\n")
+        assert res is True
+        assert failed_neighbors == []
+        mock_log_warn.assert_has_calls([call(line) for line in expected_output_lines])
+
     def test_run_neighbor_check(self, mock_log_functions):
         appl_db = MagicMock()
         mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -244,7 +244,6 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_flushes_and_reruns_inconsistent_neighbors(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -285,7 +284,6 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_waits_once_before_post_flush_check(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -317,7 +315,6 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_returns_failure_when_post_flush_check_remains_inconsistent(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -349,7 +346,6 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_skips_rerun_when_no_neighbors_are_flushed(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -382,7 +378,6 @@ class TestDualtorNeighborCheck(object):
     def test_main_logs_alert_when_post_flush_check_remains_inconsistent(self, mock_log_functions):
         mock_log_err, _, _, _ = mock_log_functions
         args = MagicMock()
-        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -453,18 +448,10 @@ class TestDualtorNeighborCheck(object):
             assert args.log_output == dualtor_neighbor_check.LogOutput.STDOUT
             assert args.log_level == dualtor_neighbor_check.logging.WARNING
             assert args.syslog_level is None
-            assert args.flush_inconsistent_neighbors is False
             mock_log_err.assert_called_once_with("test_error")
             mock_log_warn.assert_called_once_with("test_warn")
             mock_log_info.assert_called_once_with("test_info")
             mock_log_debug.assert_called_once_with("test_debug")
-
-    def test_parse_args_flush_inconsistent_neighbors(self):
-        with patch("dualtor_neighbor_check.sys.argv",
-                   ["dualtor_neighbor_check.py", "--flush-inconsistent-neighbors"]):
-            args = dualtor_neighbor_check.parse_args()
-
-            assert args.flush_inconsistent_neighbors is True
 
     def test_log_config_syslog_default_level(self, mock_syslog_log_function):
         expected_syslog_calls = [

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -76,7 +76,7 @@ class TestDualtorNeighborCheck(object):
             mock_run_command.assert_called_once_with("sudo ip -6 neigh flush to fc02:1000::1")
 
     def test_flush_inconsistent_neighbors_prefix_route_mux_ports_only(self, mock_log_functions):
-        _, mock_log_warn, _, _ = mock_log_functions
+        _, mock_log_warn, _, mock_log_debug = mock_log_functions
         failed_neighbors = [
             {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
             {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
@@ -98,6 +98,130 @@ class TestDualtorNeighborCheck(object):
                 call("Flushing inconsistent neighbor entry: %s", "192.168.0.2"),
                 call("Flushing inconsistent neighbor entry: %s", "192.168.0.3")
             ])
+            mock_log_debug.assert_has_calls([
+                call("Skip flushing inconsistent neighbor %s because only "
+                     "prefix-route mux-port neighbors are remediated", "192.168.0.4"),
+                call("Skip flushing inconsistent neighbor %s because only "
+                     "prefix-route mux-port neighbors are remediated", "192.168.0.5")
+            ])
+
+    def test_parse_check_results_return_failed_neighbors_consistent(self, mock_log_functions):
+        check_results = [{
+            "NEIGHBOR": "192.168.0.2",
+            "MAC": "ee:86:d8:46:7d:01",
+            "PORT": "Ethernet4",
+            "MUX_STATE": "active",
+            "IN_MUX_TOGGLE": False,
+            "NEIGHBOR_IN_ASIC": True,
+            "TUNNEL_IN_ASIC": False,
+            "HWSTATUS": True,
+            "_NEIGHBOR_MODE": "host-route"
+        }]
+
+        res, failed_neighbors = dualtor_neighbor_check.parse_check_results(
+            check_results, return_failed_neighbors=True)
+
+        assert res is True
+        assert failed_neighbors == []
+
+    def test_run_neighbor_check(self, mock_log_functions):
+        appl_db = MagicMock()
+        mux_server_to_port_map = {"192.168.0.2": "Ethernet4"}
+        if_oid_to_port_name_map = {"1001": "Ethernet4"}
+        tables = (
+            {"192.168.0.2": "ee:86:d8:46:7d:01"},
+            {"Ethernet4": "active"},
+            {"Ethernet4": "active"},
+            {"Ethernet4": "prefix-route"},
+            {"ee:86:d8:46:7d:01": "1001"},
+            [],
+            [],
+            {}
+        )
+        expected_check_results = [{"NEIGHBOR": "192.168.0.2"}]
+
+        with patch("dualtor_neighbor_check.read_tables_from_db", return_value=tables) as mock_read_tables, \
+                patch("dualtor_neighbor_check.get_mac_to_port_name_map",
+                      return_value={"ee:86:d8:46:7d:01": "Ethernet4"}) as mock_get_mac_map, \
+                patch("dualtor_neighbor_check.check_neighbor_consistency",
+                      return_value=expected_check_results) as mock_check:
+            result = dualtor_neighbor_check.run_neighbor_check(
+                appl_db, mux_server_to_port_map, if_oid_to_port_name_map)
+
+            assert result == expected_check_results
+            mock_read_tables.assert_called_once_with(appl_db)
+            mock_get_mac_map.assert_called_once_with(tables[4], if_oid_to_port_name_map)
+            mock_check.assert_called_once_with(
+                tables[0],
+                tables[1],
+                tables[2],
+                {"ee:86:d8:46:7d:01": "Ethernet4"},
+                tables[5],
+                tables[6],
+                tables[7],
+                mux_server_to_port_map,
+                tables[3]
+            )
+
+    def test_main_skips_non_dualtor(self, mock_log_functions):
+        args = MagicMock()
+        config_db = MagicMock()
+
+        with patch("dualtor_neighbor_check.parse_args", return_value=args), \
+                patch("dualtor_neighbor_check.config_logging") as mock_config_logging, \
+                patch("dualtor_neighbor_check.swsscommon.ConfigDBConnector",
+                      return_value=config_db) as mock_config_db_connector, \
+                patch("dualtor_neighbor_check.daemon_base.db_connect") as mock_db_connect, \
+                patch("dualtor_neighbor_check.get_mux_cable_config", return_value={}), \
+                patch("dualtor_neighbor_check.is_dualtor", return_value=False), \
+                patch("dualtor_neighbor_check.run_neighbor_check") as mock_run_neighbor_check:
+            result = dualtor_neighbor_check.main()
+
+            assert result == 0
+            mock_config_logging.assert_called_once_with(args)
+            mock_config_db_connector.assert_called_once_with(use_unix_socket_path=False)
+            config_db.connect.assert_called_once()
+            mock_db_connect.assert_called_once_with("APPL_DB")
+            mock_run_neighbor_check.assert_not_called()
+
+    def test_main_flushes_and_reruns_prefix_route_neighbors(self, mock_log_functions):
+        args = MagicMock()
+        args.flush_inconsistent_neighbors = True
+        config_db = MagicMock()
+        appl_db = MagicMock()
+        failed_neighbors = [
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"}
+        ]
+
+        with patch("dualtor_neighbor_check.parse_args", return_value=args), \
+                patch("dualtor_neighbor_check.config_logging"), \
+                patch("dualtor_neighbor_check.swsscommon.ConfigDBConnector", return_value=config_db), \
+                patch("dualtor_neighbor_check.daemon_base.db_connect", return_value=appl_db), \
+                patch("dualtor_neighbor_check.get_mux_cable_config", return_value={"Ethernet4": {}}), \
+                patch("dualtor_neighbor_check.is_dualtor", return_value=True), \
+                patch("dualtor_neighbor_check.get_mux_server_to_port_map",
+                      return_value={"192.168.0.2": "Ethernet4"}) as mock_mux_server_map, \
+                patch("dualtor_neighbor_check.get_if_br_oid_to_port_name_map",
+                      return_value={"1001": "Ethernet4"}) as mock_oid_map, \
+                patch("dualtor_neighbor_check.run_neighbor_check",
+                      side_effect=[[{"first": "result"}], [{"second": "result"}]]) as mock_run_neighbor_check, \
+                patch("dualtor_neighbor_check.parse_check_results",
+                      side_effect=[(False, failed_neighbors), True]) as mock_parse_results, \
+                patch("dualtor_neighbor_check.flush_inconsistent_neighbors", return_value=1) as mock_flush:
+            result = dualtor_neighbor_check.main()
+
+            assert result == 0
+            mock_mux_server_map.assert_called_once_with({"Ethernet4": {}})
+            mock_oid_map.assert_called_once_with()
+            mock_run_neighbor_check.assert_has_calls([
+                call(appl_db, {"192.168.0.2": "Ethernet4"}, {"1001": "Ethernet4"}),
+                call(appl_db, {"192.168.0.2": "Ethernet4"}, {"1001": "Ethernet4"})
+            ])
+            mock_parse_results.assert_has_calls([
+                call([{"first": "result"}], return_failed_neighbors=True),
+                call([{"second": "result"}])
+            ])
+            mock_flush.assert_called_once_with(failed_neighbors)
 
     def test_redis_cli(self, mock_log_functions):
         with patch("dualtor_neighbor_check.subprocess.Popen") as mock_popen:

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -75,12 +75,15 @@ class TestDualtorNeighborCheck(object):
 
             mock_run_command.assert_called_once_with("sudo ip -6 neigh flush to fc02:1000::1")
 
-    def test_flush_inconsistent_neighbors_deduplicates(self, mock_log_functions):
+    def test_flush_inconsistent_neighbors_prefix_route_mux_ports_only(self, mock_log_functions):
         _, mock_log_warn, _, _ = mock_log_functions
         failed_neighbors = [
-            {"NEIGHBOR": "192.168.0.2"},
-            {"NEIGHBOR": "192.168.0.2"},
-            {"NEIGHBOR": "192.168.0.3"}
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
+            {"NEIGHBOR": "192.168.0.3", "PORT": "Ethernet8", "_NEIGHBOR_MODE": "prefix-route"},
+            {"NEIGHBOR": "192.168.0.4", "PORT": "Ethernet12", "_NEIGHBOR_MODE": "host-route"},
+            {"NEIGHBOR": "192.168.0.5", "PORT": dualtor_neighbor_check.NOT_AVAILABLE,
+             "_NEIGHBOR_MODE": "prefix-route"}
         ]
 
         with patch("dualtor_neighbor_check.flush_neighbor") as mock_flush_neighbor:

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -7,6 +7,7 @@ import subprocess
 import tabulate
 
 from unittest.mock import call
+from unittest.mock import ANY
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -103,6 +104,57 @@ class TestDualtorNeighborCheck(object):
                 call("Flushing inconsistent neighbor entry: %s", "192.168.0.5")
             ])
 
+    def test_flush_inconsistent_neighbors_continues_after_flush_failure(self, mock_log_functions):
+        mock_log_err, mock_log_warn, _, _ = mock_log_functions
+        failed_neighbors = [
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
+            {"NEIGHBOR": "192.168.0.3", "PORT": "Ethernet8", "_NEIGHBOR_MODE": "prefix-route"},
+            {"NEIGHBOR": "192.168.0.4", "PORT": "Ethernet12", "_NEIGHBOR_MODE": "host-route"},
+        ]
+
+        with patch("dualtor_neighbor_check.flush_neighbor",
+                   side_effect=[None, RuntimeError("flush failed"), None]) as mock_flush_neighbor:
+            flush_count = dualtor_neighbor_check.flush_inconsistent_neighbors(failed_neighbors)
+
+            assert flush_count == 2
+            mock_flush_neighbor.assert_has_calls([
+                call("192.168.0.2"),
+                call("192.168.0.3"),
+                call("192.168.0.4")
+            ])
+            mock_log_warn.assert_has_calls([
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.2"),
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.3"),
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.4")
+            ])
+            mock_log_err.assert_called_once_with(
+                "Failed to flush inconsistent neighbor entry %s: %s",
+                "192.168.0.3",
+                ANY
+            )
+
+    def test_flush_inconsistent_neighbors_continues_after_invalid_ip(self, mock_log_functions):
+        mock_log_err, _, _, _ = mock_log_functions
+        failed_neighbors = [
+            {"NEIGHBOR": "not-an-ip", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
+            {"NEIGHBOR": "192.168.0.3", "PORT": "Ethernet8", "_NEIGHBOR_MODE": "prefix-route"},
+        ]
+
+        with patch("dualtor_neighbor_check.flush_neighbor",
+                   side_effect=[ValueError("invalid IP"), None]) as mock_flush_neighbor:
+            flush_count = dualtor_neighbor_check.flush_inconsistent_neighbors(failed_neighbors)
+
+            assert flush_count == 1
+            mock_flush_neighbor.assert_has_calls([
+                call("not-an-ip"),
+                call("192.168.0.3")
+            ])
+            mock_log_err.assert_called_once_with(
+                "Failed to flush inconsistent neighbor entry %s: %s",
+                "not-an-ip",
+                ANY
+            )
+
     def test_parse_check_results_returns_failed_neighbors_consistent(self, mock_log_functions):
         check_results = [{
             "NEIGHBOR": "192.168.0.2",
@@ -192,7 +244,7 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_flushes_and_reruns_inconsistent_neighbors(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = True
+        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -233,7 +285,7 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_waits_once_before_post_flush_check(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = True
+        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -265,7 +317,7 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_returns_failure_when_post_flush_check_remains_inconsistent(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = True
+        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -297,7 +349,7 @@ class TestDualtorNeighborCheck(object):
 
     def test_main_skips_rerun_when_no_neighbors_are_flushed(self, mock_log_functions):
         args = MagicMock()
-        args.flush_inconsistent_neighbors = True
+        args.flush_inconsistent_neighbors = False
         config_db = MagicMock()
         appl_db = MagicMock()
         failed_neighbors = [
@@ -326,6 +378,37 @@ class TestDualtorNeighborCheck(object):
             mock_run_neighbor_check.assert_called_once()
             mock_parse_results.assert_called_once_with([{"first": "result"}])
             mock_sleep.assert_not_called()
+
+    def test_main_logs_alert_when_post_flush_check_remains_inconsistent(self, mock_log_functions):
+        mock_log_err, _, _, _ = mock_log_functions
+        args = MagicMock()
+        args.flush_inconsistent_neighbors = False
+        config_db = MagicMock()
+        appl_db = MagicMock()
+        failed_neighbors = [
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"}
+        ]
+
+        with patch("dualtor_neighbor_check.parse_args", return_value=args), \
+                patch("dualtor_neighbor_check.config_logging"), \
+                patch("dualtor_neighbor_check.swsscommon.ConfigDBConnector", return_value=config_db), \
+                patch("dualtor_neighbor_check.daemon_base.db_connect", return_value=appl_db), \
+                patch("dualtor_neighbor_check.get_mux_cable_config", return_value={"Ethernet4": {}}), \
+                patch("dualtor_neighbor_check.is_dualtor", return_value=True), \
+                patch("dualtor_neighbor_check.get_mux_server_to_port_map",
+                      return_value={"192.168.0.2": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.get_if_br_oid_to_port_name_map",
+                      return_value={"1001": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.run_neighbor_check",
+                      side_effect=[[{"first": "result"}], [{"second": "result"}]]), \
+                patch("dualtor_neighbor_check.parse_check_results",
+                      side_effect=[(False, failed_neighbors), (False, failed_neighbors)]), \
+                patch("dualtor_neighbor_check.flush_inconsistent_neighbors", return_value=1), \
+                patch("dualtor_neighbor_check.time.sleep"):
+            result = dualtor_neighbor_check.main()
+
+            assert result == 1
+            mock_log_err.assert_called_with("ALERT: post-flush dualtor neighbor check still found inconsistent neighbors.")
 
     def test_redis_cli(self, mock_log_functions):
         with patch("dualtor_neighbor_check.subprocess.Popen") as mock_popen:

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -63,6 +63,39 @@ class TestDualtorNeighborCheck(object):
             mock_popen.assert_called_once_with(shlex.split("ls /tmp/not-existed"), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             mock_proc.communicate.assert_called_once()
 
+    def test_flush_neighbor_ipv4(self, mock_log_functions):
+        with patch("dualtor_neighbor_check.run_command") as mock_run_command:
+            dualtor_neighbor_check.flush_neighbor("192.168.0.2")
+
+            mock_run_command.assert_called_once_with("sudo ip -4 neigh flush to 192.168.0.2")
+
+    def test_flush_neighbor_ipv6(self, mock_log_functions):
+        with patch("dualtor_neighbor_check.run_command") as mock_run_command:
+            dualtor_neighbor_check.flush_neighbor("fc02:1000::1")
+
+            mock_run_command.assert_called_once_with("sudo ip -6 neigh flush to fc02:1000::1")
+
+    def test_flush_inconsistent_neighbors_deduplicates(self, mock_log_functions):
+        _, mock_log_warn, _, _ = mock_log_functions
+        failed_neighbors = [
+            {"NEIGHBOR": "192.168.0.2"},
+            {"NEIGHBOR": "192.168.0.2"},
+            {"NEIGHBOR": "192.168.0.3"}
+        ]
+
+        with patch("dualtor_neighbor_check.flush_neighbor") as mock_flush_neighbor:
+            flush_count = dualtor_neighbor_check.flush_inconsistent_neighbors(failed_neighbors)
+
+            assert flush_count == 2
+            mock_flush_neighbor.assert_has_calls([
+                call("192.168.0.2"),
+                call("192.168.0.3")
+            ])
+            mock_log_warn.assert_has_calls([
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.2"),
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.3")
+            ])
+
     def test_redis_cli(self, mock_log_functions):
         with patch("dualtor_neighbor_check.subprocess.Popen") as mock_popen:
             mock_proc = MagicMock()
@@ -104,10 +137,18 @@ class TestDualtorNeighborCheck(object):
             assert args.log_output == dualtor_neighbor_check.LogOutput.STDOUT
             assert args.log_level == dualtor_neighbor_check.logging.WARNING
             assert args.syslog_level is None
+            assert args.flush_inconsistent_neighbors is False
             mock_log_err.assert_called_once_with("test_error")
             mock_log_warn.assert_called_once_with("test_warn")
             mock_log_info.assert_called_once_with("test_info")
             mock_log_debug.assert_called_once_with("test_debug")
+
+    def test_parse_args_flush_inconsistent_neighbors(self):
+        with patch("dualtor_neighbor_check.sys.argv",
+                   ["dualtor_neighbor_check.py", "--flush-inconsistent-neighbors"]):
+            args = dualtor_neighbor_check.parse_args()
+
+            assert args.flush_inconsistent_neighbors is True
 
     def test_log_config_syslog_default_level(self, mock_syslog_log_function):
         expected_syslog_calls = [

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -75,8 +75,8 @@ class TestDualtorNeighborCheck(object):
 
             mock_run_command.assert_called_once_with("sudo ip -6 neigh flush to fc02:1000::1")
 
-    def test_flush_inconsistent_neighbors_prefix_route_mux_ports_only(self, mock_log_functions):
-        _, mock_log_warn, _, mock_log_debug = mock_log_functions
+    def test_flush_inconsistent_neighbors_flushes_all_failed_neighbors(self, mock_log_functions):
+        _, mock_log_warn, _, _ = mock_log_functions
         failed_neighbors = [
             {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
             {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"},
@@ -89,23 +89,21 @@ class TestDualtorNeighborCheck(object):
         with patch("dualtor_neighbor_check.flush_neighbor") as mock_flush_neighbor:
             flush_count = dualtor_neighbor_check.flush_inconsistent_neighbors(failed_neighbors)
 
-            assert flush_count == 2
+            assert flush_count == 4
             mock_flush_neighbor.assert_has_calls([
                 call("192.168.0.2"),
-                call("192.168.0.3")
+                call("192.168.0.3"),
+                call("192.168.0.4"),
+                call("192.168.0.5")
             ])
             mock_log_warn.assert_has_calls([
                 call("Flushing inconsistent neighbor entry: %s", "192.168.0.2"),
-                call("Flushing inconsistent neighbor entry: %s", "192.168.0.3")
-            ])
-            mock_log_debug.assert_has_calls([
-                call("Skip flushing inconsistent neighbor %s because only "
-                     "prefix-route mux-port neighbors are remediated", "192.168.0.4"),
-                call("Skip flushing inconsistent neighbor %s because only "
-                     "prefix-route mux-port neighbors are remediated", "192.168.0.5")
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.3"),
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.4"),
+                call("Flushing inconsistent neighbor entry: %s", "192.168.0.5")
             ])
 
-    def test_parse_check_results_return_failed_neighbors_consistent(self, mock_log_functions):
+    def test_parse_check_results_returns_failed_neighbors_consistent(self, mock_log_functions):
         check_results = [{
             "NEIGHBOR": "192.168.0.2",
             "MAC": "ee:86:d8:46:7d:01",
@@ -118,26 +116,19 @@ class TestDualtorNeighborCheck(object):
             "_NEIGHBOR_MODE": "host-route"
         }]
 
-        res, failed_neighbors = dualtor_neighbor_check.parse_check_results(
-            check_results, return_failed_neighbors=True)
+        res, failed_neighbors = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         assert failed_neighbors == []
 
-    def test_parse_check_results_empty_keeps_original_table_output(self, mock_log_functions):
+    def test_parse_check_results_empty_matches_original_no_output(self, mock_log_functions):
         _, mock_log_warn, _, _ = mock_log_functions
 
-        res, failed_neighbors = dualtor_neighbor_check.parse_check_results(
-            [], return_failed_neighbors=True)
+        res, failed_neighbors = dualtor_neighbor_check.parse_check_results([])
 
-        expected_output_lines = tabulate.tabulate(
-            [],
-            headers=dualtor_neighbor_check.NEIGHBOR_ATTRIBUTES_PREFIX_ROUTE,
-            tablefmt="simple"
-        ).split("\n")
         assert res is True
         assert failed_neighbors == []
-        mock_log_warn.assert_has_calls([call(line) for line in expected_output_lines])
+        mock_log_warn.assert_not_called()
 
     def test_run_neighbor_check(self, mock_log_functions):
         appl_db = MagicMock()
@@ -199,7 +190,7 @@ class TestDualtorNeighborCheck(object):
             mock_db_connect.assert_called_once_with("APPL_DB")
             mock_run_neighbor_check.assert_not_called()
 
-    def test_main_flushes_and_reruns_prefix_route_neighbors(self, mock_log_functions):
+    def test_main_flushes_and_reruns_inconsistent_neighbors(self, mock_log_functions):
         args = MagicMock()
         args.flush_inconsistent_neighbors = True
         config_db = MagicMock()
@@ -221,8 +212,9 @@ class TestDualtorNeighborCheck(object):
                 patch("dualtor_neighbor_check.run_neighbor_check",
                       side_effect=[[{"first": "result"}], [{"second": "result"}]]) as mock_run_neighbor_check, \
                 patch("dualtor_neighbor_check.parse_check_results",
-                      side_effect=[(False, failed_neighbors), True]) as mock_parse_results, \
-                patch("dualtor_neighbor_check.flush_inconsistent_neighbors", return_value=1) as mock_flush:
+                      side_effect=[(False, failed_neighbors), (True, [])]) as mock_parse_results, \
+                patch("dualtor_neighbor_check.flush_inconsistent_neighbors", return_value=1) as mock_flush, \
+                patch("dualtor_neighbor_check.time.sleep") as mock_sleep:
             result = dualtor_neighbor_check.main()
 
             assert result == 0
@@ -233,10 +225,107 @@ class TestDualtorNeighborCheck(object):
                 call(appl_db, {"192.168.0.2": "Ethernet4"}, {"1001": "Ethernet4"})
             ])
             mock_parse_results.assert_has_calls([
-                call([{"first": "result"}], return_failed_neighbors=True),
+                call([{"first": "result"}]),
                 call([{"second": "result"}])
             ])
             mock_flush.assert_called_once_with(failed_neighbors)
+            mock_sleep.assert_called_once_with(dualtor_neighbor_check.POST_FLUSH_CHECK_DELAY_SEC)
+
+    def test_main_waits_once_before_post_flush_check(self, mock_log_functions):
+        args = MagicMock()
+        args.flush_inconsistent_neighbors = True
+        config_db = MagicMock()
+        appl_db = MagicMock()
+        failed_neighbors = [
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "host-route"}
+        ]
+
+        with patch("dualtor_neighbor_check.parse_args", return_value=args), \
+                patch("dualtor_neighbor_check.config_logging"), \
+                patch("dualtor_neighbor_check.swsscommon.ConfigDBConnector", return_value=config_db), \
+                patch("dualtor_neighbor_check.daemon_base.db_connect", return_value=appl_db), \
+                patch("dualtor_neighbor_check.get_mux_cable_config", return_value={"Ethernet4": {}}), \
+                patch("dualtor_neighbor_check.is_dualtor", return_value=True), \
+                patch("dualtor_neighbor_check.get_mux_server_to_port_map",
+                      return_value={"192.168.0.2": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.get_if_br_oid_to_port_name_map",
+                      return_value={"1001": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.run_neighbor_check",
+                      side_effect=[[{"first": "result"}], [{"second": "result"}]]) as mock_run_neighbor_check, \
+                patch("dualtor_neighbor_check.parse_check_results",
+                      side_effect=[(False, failed_neighbors), (True, [])]) as mock_parse_results, \
+                patch("dualtor_neighbor_check.flush_inconsistent_neighbors", return_value=1), \
+                patch("dualtor_neighbor_check.time.sleep") as mock_sleep:
+            result = dualtor_neighbor_check.main()
+
+            assert result == 0
+            assert mock_run_neighbor_check.call_count == 2
+            assert mock_parse_results.call_count == 2
+            mock_sleep.assert_called_once_with(dualtor_neighbor_check.POST_FLUSH_CHECK_DELAY_SEC)
+
+    def test_main_returns_failure_when_post_flush_check_remains_inconsistent(self, mock_log_functions):
+        args = MagicMock()
+        args.flush_inconsistent_neighbors = True
+        config_db = MagicMock()
+        appl_db = MagicMock()
+        failed_neighbors = [
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"}
+        ]
+
+        with patch("dualtor_neighbor_check.parse_args", return_value=args), \
+                patch("dualtor_neighbor_check.config_logging"), \
+                patch("dualtor_neighbor_check.swsscommon.ConfigDBConnector", return_value=config_db), \
+                patch("dualtor_neighbor_check.daemon_base.db_connect", return_value=appl_db), \
+                patch("dualtor_neighbor_check.get_mux_cable_config", return_value={"Ethernet4": {}}), \
+                patch("dualtor_neighbor_check.is_dualtor", return_value=True), \
+                patch("dualtor_neighbor_check.get_mux_server_to_port_map",
+                      return_value={"192.168.0.2": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.get_if_br_oid_to_port_name_map",
+                      return_value={"1001": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.run_neighbor_check",
+                      side_effect=[[{"first": "result"}], [{"second": "result"}]]) as mock_run_neighbor_check, \
+                patch("dualtor_neighbor_check.parse_check_results",
+                      side_effect=[(False, failed_neighbors), (False, failed_neighbors)]) as mock_parse_results, \
+                patch("dualtor_neighbor_check.flush_inconsistent_neighbors", return_value=1), \
+                patch("dualtor_neighbor_check.time.sleep") as mock_sleep:
+            result = dualtor_neighbor_check.main()
+
+            assert result == 1
+            assert mock_run_neighbor_check.call_count == 2
+            assert mock_parse_results.call_count == 2
+            mock_sleep.assert_called_once_with(dualtor_neighbor_check.POST_FLUSH_CHECK_DELAY_SEC)
+
+    def test_main_skips_rerun_when_no_neighbors_are_flushed(self, mock_log_functions):
+        args = MagicMock()
+        args.flush_inconsistent_neighbors = True
+        config_db = MagicMock()
+        appl_db = MagicMock()
+        failed_neighbors = [
+            {"NEIGHBOR": "192.168.0.2", "PORT": "Ethernet4", "_NEIGHBOR_MODE": "prefix-route"}
+        ]
+
+        with patch("dualtor_neighbor_check.parse_args", return_value=args), \
+                patch("dualtor_neighbor_check.config_logging"), \
+                patch("dualtor_neighbor_check.swsscommon.ConfigDBConnector", return_value=config_db), \
+                patch("dualtor_neighbor_check.daemon_base.db_connect", return_value=appl_db), \
+                patch("dualtor_neighbor_check.get_mux_cable_config", return_value={"Ethernet4": {}}), \
+                patch("dualtor_neighbor_check.is_dualtor", return_value=True), \
+                patch("dualtor_neighbor_check.get_mux_server_to_port_map",
+                      return_value={"192.168.0.2": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.get_if_br_oid_to_port_name_map",
+                      return_value={"1001": "Ethernet4"}), \
+                patch("dualtor_neighbor_check.run_neighbor_check",
+                      return_value=[{"first": "result"}]) as mock_run_neighbor_check, \
+                patch("dualtor_neighbor_check.parse_check_results",
+                      return_value=(False, failed_neighbors)) as mock_parse_results, \
+                patch("dualtor_neighbor_check.flush_inconsistent_neighbors", return_value=0), \
+                patch("dualtor_neighbor_check.time.sleep") as mock_sleep:
+            result = dualtor_neighbor_check.main()
+
+            assert result == 1
+            mock_run_neighbor_check.assert_called_once()
+            mock_parse_results.assert_called_once_with([{"first": "result"}])
+            mock_sleep.assert_not_called()
 
     def test_redis_cli(self, mock_log_functions):
         with patch("dualtor_neighbor_check.subprocess.Popen") as mock_popen:
@@ -581,7 +670,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -654,7 +743,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -690,7 +779,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -737,7 +826,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -785,7 +874,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is False
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -833,7 +922,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is False
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -869,7 +958,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -911,7 +1000,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -950,7 +1039,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is False
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -996,7 +1085,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is False
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -1032,7 +1121,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -1074,7 +1163,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -1110,7 +1199,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is True
         mock_log_warn.assert_has_calls(expected_log_warn_calls)
@@ -1149,7 +1238,7 @@ class TestDualtorNeighborCheck(object):
             mux_server_to_port_map,
             port_neighbor_modes
         )
-        res = dualtor_neighbor_check.parse_check_results(check_results)
+        res, _ = dualtor_neighbor_check.parse_check_results(check_results)
 
         assert res is False
         mock_log_warn.assert_has_calls(expected_log_warn_calls)

--- a/tests/dualtor_neighbor_check_test.py
+++ b/tests/dualtor_neighbor_check_test.py
@@ -408,7 +408,9 @@ class TestDualtorNeighborCheck(object):
             result = dualtor_neighbor_check.main()
 
             assert result == 1
-            mock_log_err.assert_called_with("ALERT: post-flush dualtor neighbor check still found inconsistent neighbors.")
+            mock_log_err.assert_called_with(
+                "ALERT: post-flush dualtor neighbor check still found inconsistent neighbors."
+            )
 
     def test_redis_cli(self, mock_log_functions):
         with patch("dualtor_neighbor_check.subprocess.Popen") as mock_popen:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Made neighbor inconsistency mitigation the default behavior in dualtor_neighbor_check.py. When inconsistent neighbor entries are detected on mux ports, the script now flushes those entries once, waits 10 seconds, then reruns the consistency check once to verify recovery.
 
If inconsistency remains after the post-flush check, the script logs an ALERT and exits non-zero.

#### How I did it
1. Added helper logic to flush inconsistent neighbor entries with:
   - `sudo ip -4 neigh flush to <neighbor-ip>` for IPv4
   - `sudo ip -6 neigh flush to <neighbor-ip>` for IPv6
2. Iterates failed neighbors, deduplicates by IP, flushes all inconsistent entries (both host-route and prefix-route).
3. After flush, waits 10 seconds for kernel ARP/ND relearning and orchagent reconvergence, then reruns the consistency check once to allow orchagent to re-learn correct state.
4. Logs an ALERT if the post-flush check still finds inconsistent neighbors.

#### How to verify it
 Verified by:
 
 ```bash
yawenni@sonic-mgmt-yawenni_master:/var/src/sonic-utilities$ python -m py_compile scripts/dualtor_neighbor_check.py tests/dualtor_neighbor_check_test.py
yawenni@sonic-mgmt-yawenni_master:/var/src/sonic-utilities$ 
 ```
Mocked DB/ASIC state stayed inconsistent, and correctly preserved failure and printed post-flush check still found inconsistent neighbors.
 ```bash
admin@str2-8101c1-02:~$  dualtor_neighbor_check.py
================================================================================
Neighbors in PREFIX-ROUTE mode:
================================================================================
NEIGHBOR       MAC                PORT       MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    PREFIX_ROUTE    NEXTHOP_TYPE    HWSTATUS
-------------  -----------------  ---------  -----------  ---------------  ------------------  --------------  --------------  ------------
192.168.0.129  1a:91:34:a2:90:01  Ethernet8  active       no               no                  no              N/A             inconsistent
fc02:1000::81  1a:91:34:a2:90:01  Ethernet8  active       no               yes                 yes             NEIGHBOR        consistent

Found neighbors that are inconsistent with mux states: ['192.168.0.129']
Failed PREFIX-ROUTE neighbors:
NEIGHBOR       MAC                PORT       MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    PREFIX_ROUTE    NEXTHOP_TYPE    HWSTATUS
-------------  -----------------  ---------  -----------  ---------------  ------------------  --------------  --------------  ------------
192.168.0.129  1a:91:34:a2:90:01  Ethernet8  active       no               no                  no              N/A             inconsistent
Flushing inconsistent neighbor entry: 192.168.0.129
Flushed 1 inconsistent neighbor entries.
Waiting 10 seconds before rerunning dualtor neighbor check.
================================================================================
Neighbors in PREFIX-ROUTE mode:
================================================================================
NEIGHBOR       MAC                PORT       MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    PREFIX_ROUTE    NEXTHOP_TYPE    HWSTATUS
-------------  -----------------  ---------  -----------  ---------------  ------------------  --------------  --------------  ------------
192.168.0.129  1a:91:34:a2:90:01  Ethernet8  active       no               no                  no              N/A             inconsistent
fc02:1000::81  1a:91:34:a2:90:01  Ethernet8  active       no               yes                 yes             NEIGHBOR        consistent

Found neighbors that are inconsistent with mux states: ['192.168.0.129']
Failed PREFIX-ROUTE neighbors:
NEIGHBOR       MAC                PORT       MUX_STATE    IN_MUX_TOGGLE    NEIGHBOR_IN_ASIC    PREFIX_ROUTE    NEXTHOP_TYPE    HWSTATUS
-------------  -----------------  ---------  -----------  ---------------  ------------------  --------------  --------------  ------------
192.168.0.129  1a:91:34:a2:90:01  Ethernet8  active       no               no                  no              N/A             inconsistent
ALERT: post-flush dualtor neighbor check still found inconsistent neighbors.
 ```

#### Previous command output (if the output of a command-line utility has changed)
The script reported inconsistent neighbors and exited non-zero. It did not attempt mitigation.

#### New command output (if the output of a command-line utility has changed)
The script reports inconsistent neighbors, flushes each unique inconsistent neighbor IP once, waits 10 seconds, reruns the consistency check once, and exits based on the post-flush result.
