### PR TITLE
[smartswitch][reboot]: gate DPU midplane DHCP during NPU reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -287,6 +287,16 @@ fi
 
 debug "User requested rebooting device ..."
 
+# SmartSwitch NPU only: close the DHCP gate so DPUs that come back up during
+# the NPU reboot window cannot acquire midplane IPs and therefore cannot bring
+# up pmon/chassisd against a chassis_db that is about to disappear.
+smartswitch=$(is_smartswitch)
+if [ "$smartswitch" == "True" ] && [ "$REBOOT_DPU" == "no" ]; then
+    debug "SmartSwitch NPU: disable dhcp_server on bridge-midplane before reboot"
+    config dhcp_server ipv4 disable bridge-midplane 2>/dev/null || \
+        debug "Failed to disable dhcp_server on bridge-midplane"
+fi
+
 handle_smart_switch "$REBOOT_DPU" "$PRE_SHUTDOWN" "$DPU_MODULE_NAME"
 smart_switch_result=$?
 if [[ $smart_switch_result -ne 0 ]]; then
@@ -294,7 +304,6 @@ if [[ $smart_switch_result -ne 0 ]]; then
 fi
 
 # On a smartswitch, complete the DPU reboot and exit
-smartswitch=$(is_smartswitch)
 if [ "$smartswitch" == "True" ] && [ "$REBOOT_DPU" == "yes" ]; then
     exit $smart_switch_result
 fi


### PR DESCRIPTION
#### What I did

On a SmartSwitch NPU reboot, DPUs can renew their midplane DHCP lease while
the NPU is tearing down `chassis_db` / `pmon`, and then bring `pmon` /
`chassisd` back up against a `chassis_db` that is about to disappear.
Disable the NPU-side `dhcp_server` entry for `bridge-midplane` before the
NPU goes down to close that window.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

In `scripts/reboot`, only when
`is_smartswitch == "True"` and `REBOOT_DPU == "no"`, run
`config dhcp_server ipv4 disable bridge-midplane` before DPU reboot. The call is best-effort:
stderr is silenced and failure logs a `debug` line. DPU reboot (`-d`) and
non-SmartSwitch platforms are unchanged.

The pre-existing `smartswitch=$(is_smartswitch)` assignment used later for
the DPU-only exit path is removed, since the new block already
evaluates `is_smartswitch` and the variable is reused below.

#### How to verify it

On a SmartSwitch NPU:
1. `sudo reboot` and confirm the log line
   `SmartSwitch NPU: disable dhcp_server on bridge-midplane before reboot`.
2. From a DPU, confirm the midplane DHCP lease is not renewed during the NPU
   reboot window.
3. `sudo reboot -d DPU0` and `sudo reboot` on a non-SmartSwitch: new debug
   line is not emitted, behavior unchanged.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Tested branch (Please provide the tested image version)
- [x] master_RC Internal (latest internal build)

#### Description for the changelog

SmartSwitch: disable DHCP server on bridge-midplane before NPU reboot to prevent DPUs from racing chassis_db teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized system reboot sequence with improved pre-reboot preparation and cleanup steps.
  * Enhanced error handling to ensure system shutdown continues smoothly even when cleanup encounters issues, with detailed logging for diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-sonic/sonic-utilities/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->