### PR TITLE
Support for ICMP-Echo stats

### DIFF
--- a/clear/icmp.py
+++ b/clear/icmp.py
@@ -1,0 +1,25 @@
+import click
+import utilities_common.cli as clicommon
+
+# `sonic-clear icmp counters` snapshots current per-session counters as
+# the new baseline; `show icmp stats` subtracts it. Implementation lives
+# in the show module so read and clear share one definition of the
+# baseline format / on-disk location (UserCache 'icmpstat').
+from show.icmp import IcmpShow
+
+
+@click.group(cls=clicommon.AliasedGroup)
+def icmp():
+    """Clear ICMP offload counters"""
+    pass
+
+
+@icmp.command()
+def counters():
+    """Clear ICMP echo session counter baseline.
+
+    Snapshots per-session per-direction (IN/OUT) packet and byte counts;
+    native sessions capture only packets (bytes render as 'N/A').
+    `show icmp stats` then subtracts this baseline until the next clear.
+    Hardware counters and COUNTERS_DB are untouched."""
+    IcmpShow(click).clear_baseline()

--- a/clear/main.py
+++ b/clear/main.py
@@ -13,6 +13,7 @@ from show.plugins.pbh import read_pbh_counters
 from config.plugins.pbh import serialize_pbh_counters
 from . import plugins
 from . import stp
+from . import icmp as icmp_clear
 # This is from the aliases example:
 # https://github.com/pallets/click/blob/57c6f09611fc47ca80db0bd010f05998b3c0aa95/examples/aliases/aliases.py
 class Config(object):
@@ -148,6 +149,7 @@ def ipv6():
 # 'STP'
 #
 cli.add_command(stp.spanning_tree)
+cli.add_command(icmp_clear.icmp)
 
 #
 # Inserting BGP functionality into cli's clear parse-chain.

--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -716,6 +716,46 @@ def srv6_disable(ctx):
     ctx.obj.mod_entry("FLEX_COUNTER_TABLE", "SRV6", srv6_info)
 
 
+# ICMP echo session counter commands. Drives the ICMP_SESSION row of
+# FLEX_COUNTER_TABLE which orchagent's flexcounterorch watches to toggle
+# ICMP echo session stat collection (selective or native back-end,
+# chosen per platform).
+@cli.group()
+@click.option('-n', '--namespace', help='Namespace name',
+              required=False,
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
+@click.pass_context
+def icmp(ctx, namespace):
+    """ ICMP echo session counter commands """
+    ctx.obj = connect_to_db(namespace)
+
+
+@icmp.command(name='interval')
+@click.argument('poll_interval', type=click.IntRange(1000, 30000))
+@click.pass_context
+def icmp_interval(ctx, poll_interval):
+    """ Set ICMP echo session counter query interval """
+    icmp_info = {'POLL_INTERVAL': poll_interval}
+    ctx.obj.mod_entry("FLEX_COUNTER_TABLE", "ICMP_SESSION", icmp_info)
+
+
+@icmp.command(name='enable')
+@click.pass_context
+def icmp_enable(ctx):
+    """ Enable ICMP echo session counter query """
+    icmp_info = {'FLEX_COUNTER_STATUS': ENABLE}
+    ctx.obj.mod_entry("FLEX_COUNTER_TABLE", "ICMP_SESSION", icmp_info)
+
+
+@icmp.command(name='disable')
+@click.pass_context
+def icmp_disable(ctx):
+    """ Disable ICMP echo session counter query """
+    icmp_info = {'FLEX_COUNTER_STATUS': DISABLE}
+    ctx.obj.mod_entry("FLEX_COUNTER_TABLE", "ICMP_SESSION", icmp_info)
+
+
 # Switch counter commands
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
@@ -798,6 +838,7 @@ def show(namespace):
     wred_queue_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'WRED_ECN_QUEUE')
     wred_port_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'WRED_ECN_PORT')
     srv6_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'SRV6')
+    icmp_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'ICMP_SESSION')
     switch_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'SWITCH')
 
     header = ("Type", "Interval (in ms)", "Status")
@@ -839,6 +880,9 @@ def show(namespace):
     if srv6_info:
         data.append(["SRV6_STAT", srv6_info.get("POLL_INTERVAL", DEFLT_10_SEC),
                     srv6_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+    if icmp_info:
+        data.append(["ICMP_SESSION_STAT", icmp_info.get("POLL_INTERVAL", DEFLT_10_SEC),
+                    icmp_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if switch_info:
         data.append([
             "SWITCH_STAT",

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -89,6 +89,9 @@
 * [Hash](#hash)
   * [Hash show commands](#hash-show-commands)
   * [Hash config commands](#hash-config-commands)
+* [ICMP](#icmp)
+  * [ICMP show commands](#icmp-show-commands)
+  * [ICMP clear commands](#icmp-clear-commands)
 * [Interfaces](#interfaces)
   * [Interface Show Commands](#interface-show-commands)
   * [Interface Config Commands](#interface-config-commands)
@@ -472,6 +475,7 @@ This command displays the full list of show commands available in the software; 
     ecn                   Show ECN configuration
     environment           Show environmentals (voltages, fans, temps)
     feature               Show feature status
+    icmp                  Show icmp-offload information
     interfaces            Show details of the network interfaces
     ip                    Show IP (IPv4) commands
     ipv6                  Show IPv6 commands
@@ -6003,6 +6007,94 @@ Enable/disable Fast Link-Up per interface.
   admin@sonic:~$ config interface fast-linkup Ethernet0 enabled
   admin@sonic:~$ config interface fast-linkup Ethernet4 disabled
   ```
+
+## ICMP
+
+This section explains the show commands available for ICMP offload sessions and counters.
+
+### ICMP show commands
+
+**show icmp sessions**
+
+This command displays ICMP echo session information from `STATE_DB`.
+
+- Usage:
+  ```bash
+  show icmp sessions [<key>]
+  ```
+
+  - `<key>` format: `scope:port:guid:mode` (for example, `default:Ethernet0:0x4eb39592:RX`).
+  - `|` separators are accepted as input for compatibility.
+
+- Example:
+  ```bash
+  admin@sonic:~$ show icmp sessions
+  Key                                    Dst IP          Tx Interval    Rx Interval  HW lookup    Cookie      State
+  -------------------------------------  ------------  -------------  -------------  -----------  ----------  -------
+  default|Ethernet0|0x4eb39592|RX        192.168.0.3               0            300  false        0x58767e7a  Up
+  default|Ethernet8|0x69f578f5|NORMAL    192.168.0.5             100            300  false        0x58767e7a  Up
+  ```
+
+**show icmp summary**
+
+This command displays aggregate ICMP echo session counts.
+
+- Usage:
+  ```bash
+  show icmp summary
+  ```
+
+- Example:
+  ```bash
+  admin@sonic:~$ show icmp summary
+  Total Sessions: 4
+  Up sessions: 3
+  RX sessions: 1
+  ```
+
+**show icmp stats**
+
+This command displays per-session ICMP echo counters from `COUNTERS_DB`.
+The output includes receive/transmit packet and byte counters. In native mode, byte counters are shown as `N/A`.
+
+- Usage:
+  ```bash
+  show icmp stats [<key>] [-c|--clear]
+  ```
+
+  - Without `<key>`, all sessions with counters are displayed.
+  - With `<key>`, only the selected session is displayed.
+  - `-c`/`--clear` snapshots current counters as a local baseline. Subsequent `show icmp stats` output is shown as deltas from that baseline.
+  - `show icmp stats -c` is equivalent to `sonic-clear icmp counters`.
+
+- Example:
+  ```bash
+  admin@sonic:~$ show icmp stats default:Ethernet0:0x4eb39592:RX
+  Key                              State      RX Pkts    RX Bytes    TX Pkts    TX Bytes
+  -------------------------------  -------  ---------  ----------  ---------  ----------
+  default:Ethernet0:0x4eb39592:RX  Up            1234      188802          0           0
+  ```
+
+### ICMP clear commands
+
+**sonic-clear icmp counters**
+
+This command snapshots current ICMP echo session counters as the new baseline.
+Subsequent `show icmp stats` output is displayed as deltas from this baseline.
+Hardware counters in `COUNTERS_DB` are not reset.
+
+- Usage:
+  ```bash
+  sonic-clear icmp counters
+  ```
+
+- Example:
+  ```bash
+  admin@sonic:~$ sonic-clear icmp counters
+  Cleared ICMP echo session counter baseline at 2026-06-16 10:00:00
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#icmp)
 
 ## Interfaces
 

--- a/show/icmp.py
+++ b/show/icmp.py
@@ -2,11 +2,24 @@
 
 import click
 import utilities_common.cli as clicommon
+import datetime
+import json
+import os
 import socket
 
 from swsscommon.swsscommon import SonicV2Connector
 from sonic_py_common import multi_asic
 from tabulate import tabulate
+from utilities_common.cli import UserCache
+
+
+COUNTERS_ICMP_ECHO_SESSION_NAME_MAP = "COUNTERS_ICMP_ECHO_SESSION_NAME_MAP"
+ICMP_ECHO_SESSION_STATE_TABLE = "ICMP_ECHO_SESSION_TABLE"
+
+# Baseline cache file written by `show icmp stats -c` / `sonic-clear
+# icmp counters`. Per-user via UserCache(app_name='icmpstat'), matching
+# portstat / switchstat / srv6stat.
+ICMP_STATS_CACHE_FILE = "icmpstat"
 
 
 class IcmpShow:
@@ -15,7 +28,9 @@ class IcmpShow:
         namespaces = multi_asic.get_front_end_namespaces()
         self.asic_ids = []
         self.per_npu_statedb = {}
+        self.per_npu_countersdb = {}
         self.icmp_echo_table_keys = {}
+        self.icmp_counter_name_map = {}
         self.ctx = self.click.get_current_context()
         for namespace in namespaces:
             asic_id = multi_asic.get_asic_index_from_namespace(namespace)
@@ -30,6 +45,23 @@ class IcmpShow:
                 self.ctx.fail("Socket error in connecting with ICMP_ECHO_SESSION_TABLE: {}".format(str(e)))
             except (KeyError, ValueError) as e:
                 self.ctx.fail("Error getting keys from ICMP_ECHO_SESSION_TABLE: {}".format(str(e)))
+
+            # COUNTERS_DB is best-effort: counters only appear when the
+            # ICMP session flex-counter group is enabled. The name-map
+            # can carry selective rows (one OID per direction, suffixed
+            # '|IN'/'|OUT') and native rows (one OID per session, no
+            # suffix) depending on what orchagent negotiated per session.
+            self.per_npu_countersdb[asic_id] = SonicV2Connector(use_unix_socket_path=False, namespace=namespace)
+            try:
+                self.per_npu_countersdb[asic_id].connect(self.per_npu_countersdb[asic_id].COUNTERS_DB)
+                name_map = self.per_npu_countersdb[asic_id].get_all(
+                        self.per_npu_countersdb[asic_id].COUNTERS_DB,
+                        COUNTERS_ICMP_ECHO_SESSION_NAME_MAP) or {}
+                self.icmp_counter_name_map[asic_id] = name_map
+            except (socket.error, IOError, KeyError, ValueError):
+                # Counters are optional; leave the map empty so the
+                # shared command still serves sessions / summary.
+                self.icmp_counter_name_map[asic_id] = {}
 
     def get_icmp_echo_entry(self, asic_id, key):
         """Show icmp echo session entry from state db."""
@@ -74,6 +106,268 @@ class IcmpShow:
         else:
             click.echo("Keys not found in ICMP_ECHO_SESSION_TABLE")
 
+    def _get_session_state(self, asic_id, session_key):
+        """Look up Up/Down state in STATE_DB. session_key uses ':';
+        STATE_DB redis keys use '|' so translate before lookup."""
+        state_db = self.per_npu_statedb[asic_id]
+        state_key = "{}|{}".format(ICMP_ECHO_SESSION_STATE_TABLE,
+                                   session_key.replace(":", "|"))
+        tbl = state_db.get_all(state_db.STATE_DB, state_key) or {}
+        return tbl.get("state", "N/A")
+
+    # Direction suffixes orchagent appends to the COUNTERS_DB name-map
+    # key in selective mode.
+    _DIRECTIONS = ("IN", "OUT")
+    _NAMEMAP_SEP = "|"
+
+    # Counter mode tags. selective: per-direction OID with '|IN'/'|OUT'
+    # suffix; native: per-session OID, no suffix.
+    _MODE_SELECTIVE = "selective"
+    _MODE_NATIVE = "native"
+
+    # Stat field names published by syncd per mode.
+    _SELECTIVE_PACKETS_FIELD = "SAI_COUNTER_STAT_PACKETS"
+    _SELECTIVE_BYTES_FIELD = "SAI_COUNTER_STAT_BYTES"
+    _NATIVE_IN_PACKETS_FIELD = "SAI_ICMP_ECHO_SESSION_STAT_IN_PACKETS"
+    _NATIVE_OUT_PACKETS_FIELD = "SAI_ICMP_ECHO_SESSION_STAT_OUT_PACKETS"
+
+    @classmethod
+    def _classify_namemap_key(cls, raw_key):
+        """Classify a name-map key as selective or native.
+
+        Returns (session_key, direction_or_None):
+          - selective: ('<session_key>', 'IN'|'OUT')
+          - native:    ('<raw_key>', None)
+        """
+        for direction in cls._DIRECTIONS:
+            suffix = cls._NAMEMAP_SEP + direction
+            if raw_key.endswith(suffix):
+                return raw_key[:-len(suffix)], direction
+        return raw_key, None
+
+    def _read_selective_counter(self, asic_id, counter_oid):
+        """(packets, bytes) for a selective counter OID; 'N/A' when not
+        yet polled by syncd."""
+        counters_db = self.per_npu_countersdb[asic_id]
+        cdict = counters_db.get_all(counters_db.COUNTERS_DB,
+                                    "COUNTERS:" + counter_oid) or {}
+        # Each ICMP variant declares one stat_id (IN_PACKETS or
+        # OUT_PACKETS), so SAI_COUNTER_STAT_PACKETS is per-direction.
+        return (cdict.get(self._SELECTIVE_PACKETS_FIELD, "N/A"),
+                cdict.get(self._SELECTIVE_BYTES_FIELD, "N/A"))
+
+    def _read_native_counter(self, asic_id, session_oid):
+        """{'IN': (pkts, 'N/A'), 'OUT': (pkts, 'N/A')} for a native
+        session OID. Native SAI stats expose only packets; bytes
+        always 'N/A'."""
+        counters_db = self.per_npu_countersdb[asic_id]
+        cdict = counters_db.get_all(counters_db.COUNTERS_DB,
+                                    "COUNTERS:" + session_oid) or {}
+        return {
+            "IN":  (cdict.get(self._NATIVE_IN_PACKETS_FIELD,  "N/A"), "N/A"),
+            "OUT": (cdict.get(self._NATIVE_OUT_PACKETS_FIELD, "N/A"), "N/A"),
+        }
+
+    def _build_session_index(self, asic_id):
+        """Group raw name_map into per-session entries keyed by session_key:
+
+            selective: {'mode': 'selective', 'IN': <oid>, 'OUT': <oid>}
+            native:    {'mode': 'native',    'oid': <oid>}
+
+        Callers iterate sorted(session_key) for stable output."""
+        name_map = self.icmp_counter_name_map.get(asic_id, {})
+        index = {}
+        for raw_key, oid in name_map.items():
+            session_key, direction = self._classify_namemap_key(raw_key)
+            if direction is None:
+                index[session_key] = {"mode": self._MODE_NATIVE,
+                                      "oid":  oid}
+            else:
+                entry = index.setdefault(session_key,
+                                         {"mode": self._MODE_SELECTIVE})
+                # Mixed forms shouldn't occur; if they do, selective wins.
+                entry["mode"] = self._MODE_SELECTIVE
+                entry[direction] = oid
+        return index
+
+    def _read_session_counters(self, asic_id, session_entry):
+        """{'IN': (pkts, bytes), 'OUT': (pkts, bytes)} for one
+        session_entry. Missing directions surface as ('N/A', 'N/A')."""
+        if session_entry.get("mode") == self._MODE_NATIVE:
+            return self._read_native_counter(asic_id, session_entry["oid"])
+
+        per_dir = {}
+        for d in self._DIRECTIONS:
+            oid = session_entry.get(d)
+            if oid is None:
+                per_dir[d] = ("N/A", "N/A")
+                continue
+            per_dir[d] = self._read_selective_counter(asic_id, oid)
+        return per_dir
+
+    @staticmethod
+    def _to_int(val):
+        """Coerce a redis counter cell to int; None for missing /
+        non-numeric so callers can render 'N/A' without raising."""
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return None
+
+    def _snapshot_counters(self):
+        """Walk every session and return
+        {session_key: {'IN': (pkts, bytes), 'OUT': (pkts, bytes)}}
+        with ints, or None for missing / native bytes. Single source of
+        truth for both snapshot and baseline-diff paths."""
+        snapshot = {}
+        for asic_id in self.asic_ids:
+            session_index = self._build_session_index(asic_id)
+            for sk, entry in session_index.items():
+                per_dir_raw = self._read_session_counters(asic_id, entry)
+                snapshot[sk] = {
+                    d: (self._to_int(per_dir_raw[d][0]),
+                        self._to_int(per_dir_raw[d][1]))
+                    for d in self._DIRECTIONS
+                }
+        return snapshot
+
+    @staticmethod
+    def _baseline_path():
+        """Absolute path of this user's baseline cache file (created
+        on first call as a UserCache side-effect)."""
+        cache = UserCache(app_name="icmpstat")
+        return os.path.join(cache.get_directory(), ICMP_STATS_CACHE_FILE)
+
+    @classmethod
+    def _load_baseline(cls):
+        """(timestamp, snapshot) or (None, {}) when missing. Corrupt
+        files are treated as missing so callers see absolute counters."""
+        path = cls._baseline_path()
+        if not os.path.isfile(path):
+            return None, {}
+        try:
+            with open(path, "r") as fh:
+                payload = json.load(fh)
+            return payload.get("timestamp"), payload.get("data") or {}
+        except (OSError, ValueError):
+            return None, {}
+
+    def clear_baseline(self):
+        """Snapshot current counters as the baseline. Subsequent
+        `show icmp stats` subtracts it. Hardware counters are untouched."""
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        snapshot = self._snapshot_counters()
+        # Tuples become 2-element lists for JSON.
+        serializable = {
+            sk: {d: list(v) for d, v in per_dir.items()}
+            for sk, per_dir in snapshot.items()
+        }
+        path = self._baseline_path()
+        # Atomic write to avoid leaving a half-written file behind.
+        tmp_path = path + ".tmp"
+        with open(tmp_path, "w") as fh:
+            json.dump({"timestamp": timestamp, "data": serializable}, fh)
+        os.replace(tmp_path, path)
+        click.echo("Cleared ICMP echo session counter baseline at {}"
+                   .format(timestamp))
+
+    @staticmethod
+    def _apply_baseline(current, baseline_pair):
+        """current - baseline, clamped at zero; pass non-numeric values
+        through. The clamp guards against counter resets (e.g. session
+        recreated since the snapshot)."""
+        cur_i = IcmpShow._to_int(current)
+        if cur_i is None or baseline_pair is None:
+            return current
+        base_i = IcmpShow._to_int(baseline_pair)
+        if base_i is None:
+            return current
+        return max(0, cur_i - base_i)
+
+    def get_icmp_stats_entry(self, asic_id, session_key, session_entry,
+                             baseline=None):
+        """One tabulate row for one session. With `baseline`, values are
+        rendered as deltas. Native sessions render 'N/A' for bytes."""
+        per_dir = self._read_session_counters(asic_id, session_entry)
+
+        state = self._get_session_state(asic_id, session_key)
+
+        in_packets, in_bytes = per_dir["IN"]
+        out_packets, out_bytes = per_dir["OUT"]
+
+        if baseline:
+            base_in = baseline.get("IN") or [None, None]
+            base_out = baseline.get("OUT") or [None, None]
+            in_packets = self._apply_baseline(in_packets, base_in[0])
+            in_bytes = self._apply_baseline(in_bytes, base_in[1])
+            out_packets = self._apply_baseline(out_packets, base_out[0])
+            out_bytes = self._apply_baseline(out_bytes, base_out[1])
+
+        return [
+            session_key, state,
+            in_packets, in_bytes,
+            out_packets, out_bytes,
+        ]
+
+    def show_icmp_stats(self, key, clear=False):
+        """Tabulated per-session ICMP echo stats with IN (RX) / OUT (TX)
+        columns. Native sessions render bytes as 'N/A'.
+
+        <key> uses 'scope:port:guid:mode' (':' or '|' separators).
+
+        clear=True snapshots current counters as the baseline; <key> is
+        ignored (clear is global, mirroring `portstat -c`)."""
+        if clear:
+            self.clear_baseline()
+            return
+
+        if key is not None:
+            normalized_key = key.replace("|", ":")
+        else:
+            normalized_key = None
+
+        baseline_ts, baseline_data = self._load_baseline()
+
+        rows = []
+        for asic_id in self.asic_ids:
+            session_index = self._build_session_index(asic_id)
+            if normalized_key is not None:
+                if normalized_key in session_index:
+                    rows.append(self.get_icmp_stats_entry(
+                            asic_id, normalized_key,
+                            session_index[normalized_key],
+                            baseline=baseline_data.get(normalized_key)))
+                continue
+
+            for sk in sorted(session_index.keys()):
+                rows.append(self.get_icmp_stats_entry(
+                        asic_id, sk, session_index[sk],
+                        baseline=baseline_data.get(sk)))
+
+        if not rows:
+            if normalized_key is not None:
+                click.echo("No counters found for session '{}'. "
+                           "Make sure the ICMP session counter group is "
+                           "enabled and the session exists in "
+                           "COUNTERS_ICMP_ECHO_SESSION_NAME_MAP."
+                           .format(normalized_key))
+            else:
+                click.echo("No ICMP echo session counters found in COUNTERS_DB. "
+                           "ICMP session counters may not be enabled, or no "
+                           "sessions are currently provisioned.")
+            return
+
+        if baseline_ts is not None:
+            click.echo("Last cached time was {}".format(baseline_ts))
+
+        headers = [
+            "Key", "State",
+            "RX Pkts", "RX Bytes",
+            "TX Pkts", "TX Bytes",
+        ]
+        click.echo(tabulate(rows, headers=headers,
+                            tablefmt="simple", numalign="right"))
+
     def show_summary(self):
         total_sessions = 0
         total_up = 0
@@ -111,3 +405,29 @@ def sessions(key):
 def summary():
     s_icmp = IcmpShow(click)
     s_icmp.show_summary()
+
+
+@icmp.command()
+@click.argument('key', required=False)
+@click.option('-c', '--clear', 'clear', is_flag=True, default=False,
+              help='Snapshot current counters as baseline; subsequent '
+                   '`show icmp stats` calls subtract it. Same as '
+                   '`sonic-clear icmp counters`.')
+def stats(key, clear):
+    """Per-session ICMP echo counter stats.
+
+    Selective back-end reports packets + bytes; native back-end reports
+    packets only (bytes 'N/A').
+
+    Without <key>: list every session in
+    COUNTERS_ICMP_ECHO_SESSION_NAME_MAP. With <key> 'scope:port:guid:mode'
+    (e.g. 'default:Ethernet8:0x00270003:NORMAL'; ':' or '|'): just that
+    session.
+
+    With `-c`: snapshot current values as the new baseline and exit.
+    """
+    if clear and key is not None:
+        click.echo("Note: -c clears the baseline for all sessions; "
+                   "ignoring filter '{}'.".format(key))
+    s_icmp = IcmpShow(click)
+    s_icmp.show_icmp_stats(key, clear=clear)

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -615,5 +615,8 @@ class TestCounterpoll(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        path_parts = os.environ.get("PATH", "").split(os.pathsep)
+        if path_parts and path_parts[-1] == scripts_path:
+            path_parts = path_parts[:-1]
+        os.environ["PATH"] = os.pathsep.join(path_parts)
         os.environ["UTILITIES_UNIT_TESTING"] = "0"

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -63,6 +63,7 @@ class TestCounterpoll(object):
     @classmethod
     def setup_class(cls):
         print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
         os.environ["UTILITIES_UNIT_TESTING"] = "1"
 
     def test_show(self):
@@ -404,6 +405,74 @@ class TestCounterpoll(object):
         assert test_interval == table["SRV6"]["POLL_INTERVAL"]
 
     @pytest.mark.parametrize("status", ["disable", "enable"])
+    def test_update_icmp_status(self, status):
+        """`counterpoll icmp {enable,disable}` flips
+        FLEX_COUNTER_TABLE|ICMP_SESSION.FLEX_COUNTER_STATUS."""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(counterpoll.cli.commands["icmp"].commands[status], [], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
+        assert status == table["ICMP_SESSION"]["FLEX_COUNTER_STATUS"]
+
+    def test_update_icmp_interval(self):
+        """`counterpoll icmp interval <ms>` persists on
+        FLEX_COUNTER_TABLE|ICMP_SESSION.POLL_INTERVAL (1000-30000 ms)."""
+        runner = CliRunner()
+        db = Db()
+        test_interval = "20000"
+
+        result = runner.invoke(counterpoll.cli.commands["icmp"].commands["interval"],
+                               [test_interval], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
+        assert test_interval == table["ICMP_SESSION"]["POLL_INTERVAL"]
+
+    def test_update_icmp_interval_out_of_range_rejected(self):
+        """Intervals outside 1000-30000 ms are rejected by click's
+        IntRange before reaching FLEX_COUNTER_TABLE."""
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(counterpoll.cli.commands["icmp"].commands["interval"],
+                               ["999"], obj=db.cfgdb)
+        assert result.exit_code != 0
+        result = runner.invoke(counterpoll.cli.commands["icmp"].commands["interval"],
+                               ["30001"], obj=db.cfgdb)
+        assert result.exit_code != 0
+
+    def test_icmp_session_stat_appears_in_show_when_configured(self):
+        """When ICMP_SESSION is provisioned in CONFIG_DB,
+        `counterpoll show` lists an ICMP_SESSION_STAT row with the
+        persisted interval/status.
+
+        `counterpoll show` builds its own ConfigDBConnector via
+        `connect_to_db()`, so patch it to return the seeded Db()."""
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.mod_entry("FLEX_COUNTER_TABLE", "ICMP_SESSION", {
+            "POLL_INTERVAL": "10000",
+            "FLEX_COUNTER_STATUS": "enable",
+        })
+
+        with mock.patch("counterpoll.main.connect_to_db", return_value=db.cfgdb):
+            result = runner.invoke(counterpoll.cli.commands["show"], [], obj=db.cfgdb)
+        assert result.exit_code == 0
+        assert "ICMP_SESSION_STAT" in result.output
+        # Row must report the persisted interval and status.
+        icmp_lines = [line for line in result.output.splitlines()
+                      if line.startswith("ICMP_SESSION_STAT")]
+        assert len(icmp_lines) == 1
+        tokens = icmp_lines[0].split()
+        assert "10000" in tokens
+        assert "enable" in tokens
+
+    @pytest.mark.parametrize("status", ["disable", "enable"])
     def test_update_switch_status(self, status):
         runner = CliRunner()
         db = Db()
@@ -546,3 +615,5 @@ class TestCounterpoll(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"

--- a/tests/icmp_test.py
+++ b/tests/icmp_test.py
@@ -1,9 +1,15 @@
+import json
 import os
+import shutil
+import tempfile
 
 from click.testing import CliRunner
+from utilities_common.cli import UserCache
 from utilities_common.db import Db
 
+import clear.main as clear
 import show.main as show
+from show.icmp import ICMP_STATS_CACHE_FILE
 
 
 tabular_session_status_output_expected = """\
@@ -25,6 +31,46 @@ tabular_session_key_status_output_expected = """\
 Key                              Dst IP         Tx Interval    Rx Interval  HW lookup    Cookie      State
 -------------------------------  -----------  -------------  -------------  -----------  ----------  -------
 default|Ethernet0|0x4eb39592|RX  192.168.0.3              0            300  false        0x58767e7a  Up
+"""
+
+
+# Counter mock fixture (mock_tables/counters_db.json) wires:
+#   Ethernet0   RX     (selective): RX 1234/188802, TX 0/0
+#   Ethernet8   NORMAL (selective): RX 9876/1511028, TX 9870/800370
+#   Ethernet152 NORMAL (native):    RX 5555/N/A,    TX 4444/N/A
+# Ethernet128 has no counter wiring and must not appear in stats.
+# Native rows make the byte columns mixed-type, so tabulate left-aligns
+# them; the expected outputs below capture that exactly.
+tabular_stats_output_expected = """\
+Key                                    State      RX Pkts  RX Bytes      TX Pkts  TX Bytes
+-------------------------------------  -------  ---------  ----------  ---------  ----------
+default:Ethernet0:0x4eb39592:RX        Up            1234  188802              0  0
+default:Ethernet152:0x39e05375:NORMAL  Up            5555  N/A              4444  N/A
+default:Ethernet8:0x69f578f5:NORMAL    Up            9876  1511028          9870  800370
+"""
+
+tabular_stats_single_key_output_expected = """\
+Key                              State      RX Pkts    RX Bytes    TX Pkts    TX Bytes
+-------------------------------  -------  ---------  ----------  ---------  ----------
+default:Ethernet0:0x4eb39592:RX  Up            1234      188802          0           0
+"""
+
+# Native single-key view: bytes columns render 'N/A' (no byte stat in
+# the SAI enum).
+tabular_stats_native_single_key_output_expected = """\
+Key                                    State      RX Pkts  RX Bytes      TX Pkts  TX Bytes
+-------------------------------------  -------  ---------  ----------  ---------  ----------
+default:Ethernet152:0x39e05375:NORMAL  Up            5555  N/A              4444  N/A
+"""
+
+# After clear, baseline equals current, so the next read yields zeros
+# (native bytes stay 'N/A' since they were never numeric).
+tabular_stats_zero_deltas_output_expected_body = """\
+Key                                    State      RX Pkts  RX Bytes      TX Pkts  TX Bytes
+-------------------------------------  -------  ---------  ----------  ---------  ----------
+default:Ethernet0:0x4eb39592:RX        Up               0  0                   0  0
+default:Ethernet152:0x39e05375:NORMAL  Up               0  N/A                 0  N/A
+default:Ethernet8:0x69f578f5:NORMAL    Up               0  0                   0  0
 """
 
 
@@ -66,4 +112,245 @@ class TestIcmpSession(object):
 
     @classmethod
     def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
         print("TEARDOWN")
+
+
+class TestIcmpStats(object):
+    """Tests for `show icmp stats [-c]` and `sonic-clear icmp counters`.
+
+    Each test gets its own temp UserCache dir to keep baselines isolated."""
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+    def setup_method(self, _method):
+        self._cache_root = tempfile.mkdtemp(prefix="icmpstat-test-")
+        # UserCache.__init__ reads SONIC_CLI_CACHE_DIR first (conftest
+        # sets it per-worker), then falls back to UserCache.CACHE_DIR.
+        # Override both so each test gets its own baseline directory.
+        self._orig_cache_dir = UserCache.CACHE_DIR
+        self._orig_env_cache = os.environ.get("SONIC_CLI_CACHE_DIR")
+        UserCache.CACHE_DIR = self._cache_root + "/"
+        os.environ["SONIC_CLI_CACHE_DIR"] = self._cache_root + "/"
+
+    def teardown_method(self, _method):
+        UserCache.CACHE_DIR = self._orig_cache_dir
+        if self._orig_env_cache is None:
+            os.environ.pop("SONIC_CLI_CACHE_DIR", None)
+        else:
+            os.environ["SONIC_CLI_CACHE_DIR"] = self._orig_env_cache
+        shutil.rmtree(self._cache_root, ignore_errors=True)
+
+    def _baseline_path(self):
+        # Mirrors IcmpShow._baseline_path(): <CACHE>/icmpstat/<uid>/icmpstat
+        return os.path.join(self._cache_root, "icmpstat",
+                            str(os.getuid()), ICMP_STATS_CACHE_FILE)
+
+    @staticmethod
+    def _stats_cmd():
+        return show.cli.commands["icmp"].commands["stats"]
+
+    @staticmethod
+    def _clear_icmp_counters_cmd():
+        return clear.cli.commands["icmp"].commands["counters"]
+
+    # ----- absolute-counter rendering -----
+
+    def test_stats_all_sessions_absolute(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(), obj=db)
+        assert result.exit_code == 0
+        assert result.output == tabular_stats_output_expected
+
+    def test_stats_single_key_absolute(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(),
+                               ["default:Ethernet0:0x4eb39592:RX"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == tabular_stats_single_key_output_expected
+
+    def test_stats_pipe_separated_key_normalized(self):
+        """`show icmp stats` accepts '|' and normalizes it to ':'."""
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(),
+                               ["default|Ethernet0|0x4eb39592|RX"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == tabular_stats_single_key_output_expected
+
+    def test_stats_native_session_renders_packets_and_na_bytes(self):
+        """Native session: name-map key has no '|<DIR>' suffix; render
+        must show packets from SAI_ICMP_ECHO_SESSION_STAT_{IN,OUT}_PACKETS
+        and 'N/A' in both bytes columns."""
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(),
+                               ["default:Ethernet152:0x39e05375:NORMAL"],
+                               obj=db)
+        assert result.exit_code == 0
+        assert result.output == tabular_stats_native_single_key_output_expected
+        # Structural assertion: last 4 columns are pkts/N/A/pkts/N/A.
+        data_lines = [line for line in result.output.splitlines()
+                      if line.startswith("default:Ethernet152:0x39e05375:NORMAL")]
+        assert len(data_lines) == 1
+        tokens = data_lines[0].split()
+        # 'default:...:NORMAL Up 5555 N/A 4444 N/A'
+        assert tokens[-4:] == ["5555", "N/A", "4444", "N/A"]
+
+    def test_stats_unknown_key_emits_helpful_error(self):
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(),
+                               ["default:Ethernet999:0xdeadbeef:RX"], obj=db)
+        assert result.exit_code == 0
+        assert "No counters found for session 'default:Ethernet999:0xdeadbeef:RX'" in result.output
+
+    # ----- baseline lifecycle: write -----
+
+    def test_clear_writes_baseline_file(self):
+        runner = CliRunner()
+        db = Db()
+        assert not os.path.exists(self._baseline_path())
+
+        result = runner.invoke(self._clear_icmp_counters_cmd(), obj=db)
+        assert result.exit_code == 0
+        assert "Cleared ICMP echo session counter baseline at" in result.output
+
+        assert os.path.isfile(self._baseline_path())
+        with open(self._baseline_path()) as fh:
+            payload = json.load(fh)
+        assert "timestamp" in payload
+        # Baseline must capture every wired direction. Native rows
+        # persist packets as ints and 'null' for bytes (Python None,
+        # because the SAI enum has no byte counterpart).
+        assert payload["data"] == {
+            "default:Ethernet0:0x4eb39592:RX": {
+                "IN": [1234, 188802], "OUT": [0, 0],
+            },
+            "default:Ethernet8:0x69f578f5:NORMAL": {
+                "IN": [9876, 1511028], "OUT": [9870, 800370],
+            },
+            "default:Ethernet152:0x39e05375:NORMAL": {
+                "IN": [5555, None], "OUT": [4444, None],
+            },
+        }
+
+    def test_inline_clear_writes_baseline_file(self):
+        """`show icmp stats -c` must produce the same baseline file as
+        `sonic-clear icmp counters`."""
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(), ["-c"], obj=db)
+        assert result.exit_code == 0
+        assert "Cleared ICMP echo session counter baseline at" in result.output
+        assert os.path.isfile(self._baseline_path())
+
+    # ----- baseline lifecycle: subtraction -----
+
+    def test_show_after_clear_yields_zero_deltas(self):
+        runner = CliRunner()
+        db = Db()
+        # Snapshot then read; with unchanged mock values the deltas are 0.
+        result = runner.invoke(self._clear_icmp_counters_cmd(), obj=db)
+        assert result.exit_code == 0
+
+        result = runner.invoke(self._stats_cmd(), obj=db)
+        assert result.exit_code == 0
+        # Strip the timestamp-dependent "Last cached time was ..." line.
+        body = "\n".join(line for line in result.output.splitlines()
+                         if not line.startswith("Last cached time was "))
+        assert body + "\n" == tabular_stats_zero_deltas_output_expected_body
+        assert "Last cached time was " in result.output
+
+    def test_show_with_smaller_baseline_shows_positive_deltas(self):
+        """Inject a baseline strictly smaller than current; deltas
+        should be deterministic."""
+        os.makedirs(os.path.dirname(self._baseline_path()), exist_ok=True)
+        with open(self._baseline_path(), "w") as fh:
+            json.dump({
+                "timestamp": "2026-05-01 00:00:00",
+                "data": {
+                    "default:Ethernet0:0x4eb39592:RX": {
+                        "IN": [1000, 150000], "OUT": [0, 0],
+                    },
+                    "default:Ethernet8:0x69f578f5:NORMAL": {
+                        "IN": [9000, 1400000], "OUT": [9000, 750000],
+                    },
+                },
+            }, fh)
+
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(), obj=db)
+        assert result.exit_code == 0
+        # Expected deltas: Ethernet0 RX 234/38802, TX 0/0; Ethernet8 RX 876/111028, TX 870/50370.
+        assert "Last cached time was 2026-05-01 00:00:00" in result.output
+        assert "default:Ethernet0:0x4eb39592:RX" in result.output
+        assert "234" in result.output and "38802" in result.output
+        assert "876" in result.output and "111028" in result.output
+        assert "870" in result.output and "50370" in result.output
+
+    def test_show_with_larger_baseline_clamps_to_zero(self):
+        """A recreated session resets its counters below the saved
+        baseline; the delta must clamp to zero, not go negative."""
+        os.makedirs(os.path.dirname(self._baseline_path()), exist_ok=True)
+        with open(self._baseline_path(), "w") as fh:
+            json.dump({
+                "timestamp": "2026-05-01 00:00:00",
+                "data": {
+                    "default:Ethernet0:0x4eb39592:RX": {
+                        "IN": [10**9, 10**9], "OUT": [10**9, 10**9],
+                    },
+                },
+            }, fh)
+
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(),
+                               ["default:Ethernet0:0x4eb39592:RX"], obj=db)
+        assert result.exit_code == 0
+        # No negative numbers anywhere; clamp must have fired.
+        assert "-" not in [token for token in result.output.split()
+                           if token.lstrip("-").isdigit()]
+        data_lines = [line for line in result.output.splitlines()
+                      if line.startswith("default:Ethernet0:0x4eb39592:RX")]
+        assert len(data_lines) == 1
+        assert data_lines[0].split()[-4:] == ["0", "0", "0", "0"]
+
+    # ----- UX guard -----
+
+    def test_inline_clear_with_key_arg_emits_note(self):
+        """`show icmp stats <key> -c` clears globally and warns that
+        the key filter is ignored."""
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(self._stats_cmd(),
+                               ["default:Ethernet0:0x4eb39592:RX", "-c"],
+                               obj=db)
+        assert result.exit_code == 0
+        assert ("Note: -c clears the baseline for all sessions; "
+                "ignoring filter 'default:Ethernet0:0x4eb39592:RX'.") in result.output
+        assert "Cleared ICMP echo session counter baseline at" in result.output
+
+    def test_clear_then_show_with_key_filter_still_subtracts(self):
+        """Single-key path must use the same baseline as the all-sessions path."""
+        runner = CliRunner()
+        db = Db()
+        runner.invoke(self._clear_icmp_counters_cmd(), obj=db)
+
+        result = runner.invoke(self._stats_cmd(),
+                               ["default:Ethernet0:0x4eb39592:RX"], obj=db)
+        assert result.exit_code == 0
+        assert "Last cached time was " in result.output
+        data_lines = [line for line in result.output.splitlines()
+                      if line.startswith("default:Ethernet0:0x4eb39592:RX")]
+        assert len(data_lines) == 1
+        assert data_lines[0].split()[-4:] == ["0", "0", "0", "0"]

--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -2985,6 +2985,33 @@
         "SAI_COUNTER_STAT_PACKETS": 200,
         "SAI_COUNTER_STAT_BYTES": 204800
     },
+    "COUNTERS_ICMP_ECHO_SESSION_NAME_MAP": {
+        "default:Ethernet0:0x4eb39592:RX|IN":            "oid:0x540000000005a1",
+        "default:Ethernet0:0x4eb39592:RX|OUT":           "oid:0x540000000005a2",
+        "default:Ethernet8:0x69f578f5:NORMAL|IN":        "oid:0x540000000005a3",
+        "default:Ethernet8:0x69f578f5:NORMAL|OUT":       "oid:0x540000000005a4",
+        "default:Ethernet152:0x39e05375:NORMAL":         "oid:0x540000000005b1"
+    },
+    "COUNTERS:oid:0x540000000005a1": {
+        "SAI_COUNTER_STAT_PACKETS": 1234,
+        "SAI_COUNTER_STAT_BYTES":   188802
+    },
+    "COUNTERS:oid:0x540000000005a2": {
+        "SAI_COUNTER_STAT_PACKETS": 0,
+        "SAI_COUNTER_STAT_BYTES":   0
+    },
+    "COUNTERS:oid:0x540000000005a3": {
+        "SAI_COUNTER_STAT_PACKETS": 9876,
+        "SAI_COUNTER_STAT_BYTES":   1511028
+    },
+    "COUNTERS:oid:0x540000000005a4": {
+        "SAI_COUNTER_STAT_PACKETS": 9870,
+        "SAI_COUNTER_STAT_BYTES":   800370
+    },
+    "COUNTERS:oid:0x540000000005b1": {
+        "SAI_ICMP_ECHO_SESSION_STAT_IN_PACKETS":  5555,
+        "SAI_ICMP_ECHO_SESSION_STAT_OUT_PACKETS": 4444
+    },
     "PERSISTENT_DROP_ALERTS":{
         "DEBUG_0|1746495543": "Persistent packet drops detected on Ethernet0",
         "DEBUG_0|1746495767": "Persistent packet drops detected on Ethernet1"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added CLI support for ICMP-echo session stats

#### How I did it
Following CLIs are added to support this:
$ show icmp stats <optional-session-key>
$ sonic-clear icmp counters
$ counterpoll icmp enable/disable
$ counterpoll icmp interval <period_ms>

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
# show icmp stats
Key                                  State      RX Pkts    RX Bytes    TX Pkts    TX Bytes
-----------------------------------  -------  ---------  ----------  ---------  ----------
default:Ethernet8:0x00260003:NORMAL  Up             150       22950        150       12150
default:Ethernet8:0x00270003:RX      Up             151       23103          0           0
```