### PR TITLE
[route_check] exclude BMC interface from ROUTE_TABLE/ASIC_DB consistency check

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -579,6 +579,13 @@ def filter_out_local_interfaces(namespace, keys):
     chassis_local_intfs = chassis.get_chassis_local_interfaces()
     local_if_lst.update(set(chassis_local_intfs))
 
+    # Exclude BMC interface (e.g. usb0) — connected route for BMC subnet is a management
+    # route that will never be programmed into the ASIC.
+    cfg_db = multi_asic.connect_config_db_for_ns(namespace)
+    bmc_if_name = cfg_db.get_entry('DEVICE_METADATA', 'bmc').get('bmc_if_name', '')
+    if bmc_if_name:
+        local_if_lst.add(bmc_if_name)
+
     db = swsscommon.DBConnector(APPL_DB_NAME, REDIS_TIMEOUT_MSECS, True, namespace)
     tbl = swsscommon.Table(db, 'ROUTE_TABLE')
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -579,7 +579,7 @@ def filter_out_local_interfaces(namespace, keys):
     chassis_local_intfs = chassis.get_chassis_local_interfaces()
     local_if_lst.update(set(chassis_local_intfs))
 
-    # Exclude BMC interface (e.g. usb0) — connected route for BMC subnet is a management
+    # Exclude BMC interface (e.g. bmc0) — connected route for BMC subnet is a management
     # route that will never be programmed into the ASIC.
     cfg_db = multi_asic.connect_config_db_for_ns(namespace)
     bmc_if_name = cfg_db.get_entry('DEVICE_METADATA', 'bmc').get('bmc_if_name', '')

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -1752,4 +1752,37 @@ TEST_DATA = {
             }
         }
     },
+    "35": {
+        DESCR: "BMC interface route in ROUTE_TABLE should be ignored (not in ASIC_DB)",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0": {"ifname": "portchannel0"},
+                        "10.10.196.12/31": {"ifname": "portchannel0"},
+                        "169.254.100.1/30": {"ifname": "bmc0"},
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + ASIC_RT_ENTRY_KEY_SUFFIX: {},
+                        ASIC_RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + ASIC_RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+                CONFIG_DB: {
+                    DEVICE_METADATA: {
+                        LOCALHOST: {},
+                        "bmc": {"bmc_if_name": "bmc0", "bmc_addr": "169.254.100.1", "bmc_net_mask": "255.255.255.252"}
+                    }
+                }
+            }
+        }
+    },
 }


### PR DESCRIPTION
#### What I did

- `routeCheck` was generating false-positive `missed_ROUTE_TABLE_routes` alarms for `169.254.100.0/30` (BMC subnet) on platforms with BMCs (bmc.json)
- The BMC interface connected route exists in `ROUTE_TABLE` (APPL_DB) but is never programmed into `ASIC_DB` — it is a management/OOB route, not a dataplane route
- This caused `monit routeCheck` to fire continuously after 8 retries, which loganalyzer caught as an ERR during teardown, failing unrelated tests across many packages

#### How I did it

`filter_out_local_interfaces()` excluded `eth0`, `eth1`, `docker0` but not the BMC interface (`bmc0`). The fix reads
`DEVICE_METADATA.bmc.bmc_if_name` from CONFIG_DB and adds it to the local interface exclusion set.

#### How to verify it

- Added test case `"35"` to `route_check_test_data.py`: ROUTE_TABLE has `169.254.100.0/30` with `ifname=bmc0`, CONFIG_DB has `DEVICE_METADATA.bmc.bmc_if_name=bmc0`, ASIC_DB has no entry for it — expects pass (RET=0)
- Tests which were failing due to loganaylzer errors concerning route inconsistencies fixed

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

