### PR TITLE
fix(tests): skip __pycache__ in per-worker mock_tables copytree

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,8 +84,22 @@ def setup_db_config():
     # Per-worker copy of mock_tables so tests that overwrite shared
     # JSON files (e.g. portstat_test replaces counters_db.json) only
     # affect their own worker's sandbox.
+    #
+    # Skip __pycache__ entries during the copy. CPython writes new
+    # bytecode caches atomically by creating .pyc.<nonce> temp files
+    # then os.rename()-ing them onto .pyc. When pytest-xdist starts
+    # workers in parallel and each runs this fixture, one worker's
+    # os.listdir() can return a .pyc.<nonce> path that has already been
+    # renamed to .pyc by another process by the time copytree tries to
+    # stat/copy it, surfacing as FileNotFoundError from shutil.Error.
+    # The bytecode cache is reproducible from the .py source on first
+    # import in each worker, so we simply don't copy it.
     worker_mock_tables = os.path.join(worker_root, 'mock_tables')
-    shutil.copytree(dbconnector.INPUT_DIR, worker_mock_tables)
+    shutil.copytree(
+        dbconnector.INPUT_DIR,
+        worker_mock_tables,
+        ignore=shutil.ignore_patterns('__pycache__', '*.pyc', '*.pyc.*'),
+    )
     dbconnector.INPUT_DIR = worker_mock_tables
     os.environ['MOCK_TABLES_DIR'] = worker_mock_tables
 


### PR DESCRIPTION
#### What I did

Fix a pytest-xdist race condition that surfaces as
`shutil.Error: [(... '__pycache__/foo.cpython-3X.pyc.<nonce>', ... '[Errno 2] No such file or directory: ...')]`
during the per-worker `mock_tables/` setup in `tests/conftest.py`, causing arbitrary tests to fail with ERROR status across parallel workers.

The race:

1. The worker fixture calls `shutil.copytree(tests/mock_tables/, /tmp/worker-gwN/mock_tables/)`.
2. `copytree()` walks the source via `os.listdir()`. Inside `mock_tables/__pycache__/` it sees CPython's transient bytecode temp files (`mock_multi_asic.cpython-311.pyc.<nonce>` etc.) — CPython writes new caches atomically by creating `.pyc.<nonce>` first, then `os.rename()`-ing onto `.pyc`.
3. Between `copytree`'s listdir and the subsequent stat/copy, another process (a second worker, an import in the same worker, or an unrelated interpreter) finishes writing the cache and renames `.pyc.<nonce>` → `.pyc`, removing the directory entry `copytree` was about to consume.
4. The copy raises `FileNotFoundError`, `copytree` aggregates it into `shutil.Error`, and the fixture aborts before yielding — marking every test in that worker as ERROR.

I observed this failing intermittently across SONiC builds; example log excerpt:

```
ERROR tests/test_sonic_installer.py::test_install_failed - shutil.Error: [(
    '/sonic/src/sonic-utilities/tests/mock_tables/__pycache__/mock_multi_asic.cpython-311.pyc.140220799282336',
    '/tmp/worker-gw5/mock_tables/__pycache__/mock_multi_asic.cpython-311.pyc.140220799282336',
    "[Errno 2] No such file or directory: ...")]
```

#### How I did it

Added `ignore=shutil.ignore_patterns('__pycache__', '*.pyc', '*.pyc.*')` to the `shutil.copytree()` call in the per-worker mock_tables fixture (`tests/conftest.py`).

The `mock_tables/` tree intentionally ships `.py` helpers (`mock_multi_asic`, etc.) that workers import; their bytecode caches are not part of the fixture data and are reproducible from the `.py` source on first import in each worker. Skipping `__pycache__` in the per-worker copy eliminates the race window entirely without changing what fixtures the tests see.

#### How to verify it

1. Apply the patch.
2. Run `pytest -n auto tests/` repeatedly. Without the fix, the `__pycache__` race surfaces intermittently as ERROR across many tests; with the fix, it does not.

Alternatively, reproduce the race more deterministically by pre-populating `tests/mock_tables/__pycache__/` with `.pyc.<nonce>` files and racing multiple `setup_db_config` fixtures: without the fix, the copy fails; with the fix, the copy succeeds (and the workers compile their own caches on first import as usual).

#### Previous command output (if the output of a command-line utility has changed)

n/a — this is a test-infrastructure fix; no CLI behavior changes.

#### New command output (if the output of a command-line utility has changed)

n/a