### PR TITLE
[config] Remove redundant "Error: " prefix from ctx.fail messages

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2909,7 +2909,8 @@ def remove_portchannel(ctx, portchannel_name):
                 ctx.fail("{} has vlan {} configured, remove vlan membership to proceed".format(portchannel_name, str(k)))
 
         if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0: # TODO: MISSING CONSTRAINT IN YANG MODEL
-            ctx.fail("Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
+            ctx.fail("Portchannel {} contains members. Remove members before deleting Portchannel!"
+                     .format(portchannel_name))
 
         # Dont proceed if the port channel is used in dhcpv4_relay
         try:

--- a/config/main.py
+++ b/config/main.py
@@ -1297,13 +1297,13 @@ def interface_has_mirror_config(ctx, mirror_table, dst_port, src_port, direction
         if src_port:
             for port in split_mirror_ports(src_port):
                 if 'dst_port' in v and v['dst_port'] == port:
-                    ctx.fail("Error: Source Interface {} already has mirror config".format(port))
+                    ctx.fail("Source Interface {} already has mirror config".format(port))
                 if mirror_entry_has_port(v, port):
                     if check_mirror_direction_config(v, direction):
-                        ctx.fail("Error: Source Interface {} already has mirror config in same direction".format(port))
+                        ctx.fail("Source Interface {} already has mirror config in same direction".format(port))
         if dst_port:
             if ('dst_port' in v and v['dst_port'] == dst_port) or mirror_entry_has_port(v, dst_port):
-                ctx.fail("Error: Destination Interface {} already has mirror config".format(dst_port))
+                ctx.fail("Destination Interface {} already has mirror config".format(dst_port))
 
     return False
 
@@ -1366,30 +1366,30 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
 
     if dst_port:
         if not interface_name_is_valid(config_db, dst_port):
-            ctx.fail("Error: Destination Interface {} is invalid".format(dst_port))
+            ctx.fail("Destination Interface {} is invalid".format(dst_port))
 
         if is_portchannel_present_in_db(config_db, dst_port):
-            ctx.fail("Error: Destination Interface {} is not supported".format(dst_port))
+            ctx.fail("Destination Interface {} is not supported".format(dst_port))
 
         if interface_is_in_vlan(vlan_member_table, dst_port):
-            ctx.fail("Error: Destination Interface {} has vlan config".format(dst_port))
+            ctx.fail("Destination Interface {} has vlan config".format(dst_port))
 
         if interface_is_in_portchannel(portchannel_member_table, dst_port):
-            ctx.fail("Error: Destination Interface {} has portchannel config".format(dst_port))
+            ctx.fail("Destination Interface {} has portchannel config".format(dst_port))
 
         if clicommon.is_port_router_interface(config_db, dst_port):
-            ctx.fail("Error: Destination Interface {} is a L3 interface".format(dst_port))
+            ctx.fail("Destination Interface {} is a L3 interface".format(dst_port))
 
         namespace_set.add(get_port_namespace(dst_port))
 
     if src_port:
         for port in split_mirror_ports(src_port):
             if not interface_name_is_valid(config_db, port):
-                ctx.fail("Error: Source Interface {} is invalid".format(port))
+                ctx.fail("Source Interface {} is invalid".format(port))
         normalized_src_port = normalize_mirror_src_port(config_db, src_port)
         for port in split_mirror_ports(normalized_src_port):
             if dst_port and dst_port == port:
-                ctx.fail("Error: Destination Interface can't be same as Source Interface")
+                ctx.fail("Destination Interface can't be same as Source Interface")
 
             namespace_set.add(get_port_namespace(port))
 
@@ -1398,7 +1398,7 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
 
     if direction:
         if direction not in ['rx', 'tx', 'both']:
-            ctx.fail("Error: Direction {} is invalid".format(direction))
+            ctx.fail("Direction {} is invalid".format(direction))
 
     # Check port mirror capability before allowing configuration.
     # ERSPAN sessions (dst_port=None) use src/dst IPs, not ports; the
@@ -1407,7 +1407,7 @@ def validate_mirror_session_config(config_db, session_name, dst_port, src_port, 
     if not is_erspan:
         for ns in namespace_set:
             if not is_port_mirror_capability_supported(direction, namespace=ns):
-                ctx.fail("Error: Port mirror direction '{}' is not supported by the ASIC".format(
+                ctx.fail("Port mirror direction '{}' is not supported by the ASIC".format(
                     direction if direction else 'both'))
 
     return True
@@ -2784,7 +2784,7 @@ def synchronous_mode(sync_mode):
         config_db.mod_entry('DEVICE_METADATA' , 'localhost', {"synchronous_mode" : sync_mode})
     except ValueError as e:
         ctx = click.get_current_context()
-        ctx.fail("Error: Invalid argument %s, expect either enable or disable" % sync_mode)
+        ctx.fail("Invalid argument %s, expect either enable or disable" % sync_mode)
 
     click.echo("""Wrote %s synchronous mode into CONFIG_DB, swss restart required to apply the configuration: \n
     Option 1. config save -y \n
@@ -2828,7 +2828,7 @@ def yang_config_validation(yang_config_validation):
         config_db.mod_entry('DEVICE_METADATA', 'localhost', {"yang_config_validation": yang_config_validation})
     except ValueError as e:
         ctx = click.get_current_context()
-        ctx.fail("Error: Invalid argument %s, expect either enable or disable" % yang_config_validation)
+        ctx.fail("Invalid argument %s, expect either enable or disable" % yang_config_validation)
 
     click.echo("""Wrote %s yang config validation into CONFIG_DB""" % yang_config_validation)
 
@@ -2909,7 +2909,7 @@ def remove_portchannel(ctx, portchannel_name):
                 ctx.fail("{} has vlan {} configured, remove vlan membership to proceed".format(portchannel_name, str(k)))
 
         if len([(k, v) for k, v in db.get_table('PORTCHANNEL_MEMBER') if k == portchannel_name]) != 0: # TODO: MISSING CONSTRAINT IN YANG MODEL
-            ctx.fail("Error: Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
+            ctx.fail("Portchannel {} contains members. Remove members before deleting Portchannel!".format(portchannel_name))
 
         # Dont proceed if the port channel is used in dhcpv4_relay
         try:
@@ -3290,10 +3290,10 @@ def add_erspan(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue,
             front_ns_set = set(namespaces['front_ns'])
             for orig in split_mirror_ports(raw_src_port):
                 if not interface_name_is_valid(None, orig):
-                    ctx.fail("Error: Source Interface {} is invalid".format(orig))
+                    ctx.fail("Source Interface {} is invalid".format(orig))
                 port_ns = get_port_namespace(orig)
                 if port_ns not in front_ns_set:
-                    ctx.fail("Error: Source Interface {} is not a front-panel port".format(orig))
+                    ctx.fail("Source Interface {} is not a front-panel port".format(orig))
                 ns_src_ports.setdefault(port_ns, []).append(orig)
 
         base_session_info = {k: v for k, v in session_info.items()
@@ -3412,19 +3412,19 @@ def add_span(session_name, dst_port, src_port, direction, queue, policer):
         # Auto-detect namespace from destination port
         dst_port_namespace = get_port_namespace(original_dst_port)
         if dst_port_namespace is None:
-            ctx.fail("Error: Destination Interface {} is invalid".format(original_dst_port))
+            ctx.fail("Destination Interface {} is invalid".format(original_dst_port))
         if dst_port_namespace not in namespaces['front_ns']:
-            ctx.fail("Error: Destination Interface {} is not a front-panel port".format(original_dst_port))
+            ctx.fail("Destination Interface {} is not a front-panel port".format(original_dst_port))
 
         # Verify all source ports are in the same namespace as destination port.
         if src_port:
             for port in split_mirror_ports(src_port):
                 port_ns = get_port_namespace(port)
                 if port_ns is None:
-                    ctx.fail("Error: Source Interface {} is invalid".format(port))
+                    ctx.fail("Source Interface {} is invalid".format(port))
                 if port_ns != dst_port_namespace:
                     ctx.fail(
-                        ("Error: Source Interface {} is not on the same ASIC as "
+                        ("Source Interface {} is not on the same ASIC as "
                          "Destination Interface {}").format(port, dst_port)
                     )
 
@@ -9183,7 +9183,7 @@ def global_sample_direction(ctx, direction):
     if ADHOC_VALIDATION:
         if direction:
             if direction not in ['rx', 'tx', 'both']:
-                ctx.fail("Error: Direction {} is invalid".format(direction))
+                ctx.fail("Direction {} is invalid".format(direction))
 
             if ((direction == 'tx' or direction == 'both') and (is_port_egress_sflow_supported() == 'false')):
                 ctx.fail("Sample direction {} is not supported on this platform".format(direction))
@@ -9324,7 +9324,7 @@ def interface_sample_direction(ctx, ifname, direction):
             return
         if direction:
             if direction not in ['rx', 'tx', 'both']:
-                ctx.fail("Error: Direction {} is invalid".format(direction))
+                ctx.fail("Direction {} is invalid".format(direction))
 
             if (direction == 'tx' or direction == 'both') and (is_port_egress_sflow_supported() == 'false'):
                 ctx.fail("Sample direction {} is not supported on this platform".format(direction))


### PR DESCRIPTION
#### What I did

Fixed duplicate `"Error:"` prefix in CLI error messages. `click`'s `ctx.fail()` automatically prepends `"Error: "` when printing, but the affected code also embedded `"Error: "` in the message string itself, resulting in output like:

```
Error: Error: Port mirror direction 'tx' is not supported by the ASIC
```

#### How I did it

Removed the redundant `"Error: "` string prefix from all `ctx.fail()` calls in `config/main.py`. Affected commands:
- `config mirror_session span add` / `erspan add` — validation of src/dst port, direction, ASIC capability
- `config synchronous-mode`
- `config yang-config-validation`
- `config portchannel del`
- `config interface sflow sample-direction` / `config sflow sample-direction`

No logic changes; error messages remain identical except the leading duplicate `"Error: "` is removed.

#### How to verify it

Run a command known to trigger a validation error, e.g.:
```
config mirror_session span add SPAN1 Ethernet496 Ethernet16 tx
```

Before: `Error: Error: Port mirror direction 'tx' is not supported by the ASIC`  
After:  `Error: Port mirror direction 'tx' is not supported by the ASIC`
