### PR TITLE
[show] add 'show orchagent queue' CLI for per-consumer pending task counts

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -55,6 +55,7 @@ from . import kube
 from . import muxcable
 from . import nat
 from . import platform
+from . import orchagent
 from . import p4_table
 from . import processes
 from . import reboot_cause
@@ -318,6 +319,7 @@ cli.add_command(kdump.kdump)
 cli.add_command(kube.kubernetes)
 cli.add_command(muxcable.muxcable)
 cli.add_command(nat.nat)
+cli.add_command(orchagent.orchagent)
 cli.add_command(platform.platform)
 cli.add_command(p4_table.p4_table)
 cli.add_command(processes.processes)

--- a/show/orchagent.py
+++ b/show/orchagent.py
@@ -1,0 +1,66 @@
+import click
+import utilities_common.cli as clicommon
+from swsscommon.swsscommon import SonicV2Connector
+from tabulate import tabulate
+
+
+ORCHAGENT_QUEUE_TABLE = "ORCHAGENT_QUEUE"
+
+
+@click.group(cls=clicommon.AliasedGroup)
+def orchagent():
+    """Show orchagent state."""
+    pass
+
+
+@orchagent.command()
+@click.option('--all', 'show_all', is_flag=True, default=False,
+              help='Show all consumers including those with zero pending tasks.')
+def queue(show_all):
+    """Show per-consumer pending task counts in orchagent's m_toSync queues.
+
+    Each row is one Redis-table consumer registered with an orchagent Orch.
+    A non-zero pending_count indicates either dependency-driven retries
+    (e.g., RIF not ready yet) or SAI-level retries (sync mode).
+
+    By default, consumers with zero pending tasks are hidden. Use --all to
+    show every consumer."""
+    state_db = SonicV2Connector()
+    state_db.connect(state_db.STATE_DB)
+
+    keys = state_db.keys(state_db.STATE_DB, f"{ORCHAGENT_QUEUE_TABLE}|*") or []
+
+    rows = []
+    for key in keys:
+        # key format: ORCHAGENT_QUEUE|<consumer_name>
+        try:
+            _, consumer_name = key.split("|", 1)
+        except ValueError:
+            continue
+
+        entry = state_db.get_all(state_db.STATE_DB, key) or {}
+        try:
+            pending = int(entry.get("pending_count", "0"))
+        except (TypeError, ValueError):
+            pending = 0
+
+        if pending == 0 and not show_all:
+            continue
+
+        rows.append([consumer_name, pending])
+
+    if not rows:
+        if show_all:
+            click.echo("No orchagent queue entries found in STATE_DB. "
+                       "Is orchagent running and does this build include the "
+                       "queue-depth telemetry change?")
+        else:
+            click.echo("No consumers with pending tasks. Use --all to see all consumers.")
+        return
+
+    # Sort by pending_count descending so the most-loaded consumers are at the top,
+    # then by name (natural sort) for deterministic output among equal counts.
+    rows = sorted(rows, key=lambda r: (-r[1], r[0]))
+
+    header = ["Consumer", "Pending Count"]
+    click.echo(tabulate(rows, header, tablefmt="simple"))

--- a/show/orchagent.py
+++ b/show/orchagent.py
@@ -30,14 +30,24 @@ def queue(db, show_all):
 
     rows = []
     for key in keys:
-        # key format: ORCHAGENT_QUEUE|<consumer_name>. split with maxsplit=1
-        # so consumer names containing '|' (none today, but future-safe) round-trip.
-        try:
-            _, consumer_name = key.split("|", 1)
-        except ValueError:
-            continue
-
         entry = state_db.get_all(state_db.STATE_DB, key) or {}
+
+        # Prefer the orch/consumer fields written by orchagent. Fall back to
+        # parsing the key as ORCHAGENT_QUEUE|<Orch>|<consumer> if the row was
+        # written by a build that did not include those fields.
+        orch_name = entry.get("orch")
+        consumer_name = entry.get("consumer")
+        if not orch_name or not consumer_name:
+            parts = key.split("|", 2)
+            if len(parts) == 3:
+                _, orch_name, consumer_name = parts
+            elif len(parts) == 2:
+                # Legacy single-segment key written by older orchagent.
+                _, consumer_name = parts
+                orch_name = "-"
+            else:
+                continue
+
         try:
             pending = int(entry.get("pending_count", "0"))
         except (TypeError, ValueError):
@@ -46,7 +56,7 @@ def queue(db, show_all):
         if pending == 0 and not show_all:
             continue
 
-        rows.append([consumer_name, pending])
+        rows.append([orch_name, consumer_name, pending])
 
     if not rows:
         if show_all:
@@ -59,8 +69,8 @@ def queue(db, show_all):
         return
 
     # Sort by pending_count descending so the most-loaded consumers are at the
-    # top, then by name ascending for a deterministic tiebreak.
-    rows.sort(key=lambda r: (-r[1], r[0]))
+    # top, then by (orch, consumer) ascending for a deterministic tiebreak.
+    rows.sort(key=lambda r: (-r[2], r[0], r[1]))
 
-    header = ["Consumer", "Pending Count"]
+    header = ["Orch", "Consumer", "Pending Count"]
     click.echo(tabulate(rows, header, tablefmt="simple"))

--- a/show/orchagent.py
+++ b/show/orchagent.py
@@ -1,6 +1,5 @@
 import click
 import utilities_common.cli as clicommon
-from swsscommon.swsscommon import SonicV2Connector
 from tabulate import tabulate
 
 
@@ -16,7 +15,8 @@ def orchagent():
 @orchagent.command()
 @click.option('--all', 'show_all', is_flag=True, default=False,
               help='Show all consumers including those with zero pending tasks.')
-def queue(show_all):
+@clicommon.pass_db
+def queue(db, show_all):
     """Show per-consumer pending task counts in orchagent's m_toSync queues.
 
     Each row is one Redis-table consumer registered with an orchagent Orch.
@@ -25,14 +25,13 @@ def queue(show_all):
 
     By default, consumers with zero pending tasks are hidden. Use --all to
     show every consumer."""
-    state_db = SonicV2Connector()
-    state_db.connect(state_db.STATE_DB)
-
+    state_db = db.db
     keys = state_db.keys(state_db.STATE_DB, f"{ORCHAGENT_QUEUE_TABLE}|*") or []
 
     rows = []
     for key in keys:
-        # key format: ORCHAGENT_QUEUE|<consumer_name>
+        # key format: ORCHAGENT_QUEUE|<consumer_name>. split with maxsplit=1
+        # so consumer names containing '|' (none today, but future-safe) round-trip.
         try:
             _, consumer_name = key.split("|", 1)
         except ValueError:
@@ -55,12 +54,13 @@ def queue(show_all):
                        "Is orchagent running and does this build include the "
                        "queue-depth telemetry change?")
         else:
-            click.echo("No consumers with pending tasks. Use --all to see all consumers.")
+            click.echo("No consumers with pending tasks. "
+                       "Use --all to see all consumers.")
         return
 
-    # Sort by pending_count descending so the most-loaded consumers are at the top,
-    # then by name (natural sort) for deterministic output among equal counts.
-    rows = sorted(rows, key=lambda r: (-r[1], r[0]))
+    # Sort by pending_count descending so the most-loaded consumers are at the
+    # top, then by name ascending for a deterministic tiebreak.
+    rows.sort(key=lambda r: (-r[1], r[0]))
 
     header = ["Consumer", "Pending Count"]
     click.echo(tabulate(rows, header, tablefmt="simple"))

--- a/tests/show_orchagent_test.py
+++ b/tests/show_orchagent_test.py
@@ -16,6 +16,18 @@ class TestShowOrchagentQueue:
         for f, v in kvs.items():
             db.set(db.STATE_DB, key, f, v)
 
+    @staticmethod
+    def _clear_orchagent_queue(db):
+        """Remove any ORCHAGENT_QUEUE|* keys so each test starts clean. The
+        mock dbconnector backing is shared across tests in the same process."""
+        for key in db.keys(db.STATE_DB, "ORCHAGENT_QUEUE|*") or []:
+            db.delete(db.STATE_DB, key)
+
+    def setup_method(self, method):
+        # Per-test fresh DB. Pytest invokes this before each test method.
+        db = Db().db
+        self._clear_orchagent_queue(db)
+
     def test_queue_only_nonzero_by_default(self):
         runner = CliRunner()
         db = Db()
@@ -57,9 +69,28 @@ class TestShowOrchagentQueue:
         runner = CliRunner()
         db = Db()
 
+        # setup_method has cleared ORCHAGENT_QUEUE|* keys; nothing else
+        # populates them.
         result = runner.invoke(
             show.cli.commands['orchagent'].commands['queue'], [], obj=db
         )
         assert result.exit_code == 0
         # No keys → friendly message, not a crash
-        assert "pending tasks" in result.output or "No orchagent queue" in result.output
+        assert ("pending tasks" in result.output
+                or "No orchagent queue" in result.output)
+
+    def test_queue_garbage_pending_count_treated_as_zero(self):
+        """If the producer ever writes a non-integer pending_count (shouldn't
+        happen, but be defensive), the row is treated as zero and hidden by
+        default."""
+        runner = CliRunner()
+        db = Db()
+        d = db.db
+
+        self._set(d, "ORCHAGENT_QUEUE|BUSTED_TABLE", {"pending_count": "n/a"})
+
+        result = runner.invoke(
+            show.cli.commands['orchagent'].commands['queue'], [], obj=db
+        )
+        assert result.exit_code == 0
+        assert "BUSTED_TABLE" not in result.output

--- a/tests/show_orchagent_test.py
+++ b/tests/show_orchagent_test.py
@@ -1,0 +1,65 @@
+import os
+
+from click.testing import CliRunner
+
+import show.main as show
+from utilities_common.db import Db
+
+
+class TestShowOrchagentQueue:
+    @classmethod
+    def setup_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @staticmethod
+    def _set(db, key, kvs):
+        for f, v in kvs.items():
+            db.set(db.STATE_DB, key, f, v)
+
+    def test_queue_only_nonzero_by_default(self):
+        runner = CliRunner()
+        db = Db()
+        d = db.db
+
+        self._set(d, "ORCHAGENT_QUEUE|ROUTE_TABLE", {"pending_count": "12"})
+        self._set(d, "ORCHAGENT_QUEUE|NEIGH_TABLE", {"pending_count": "0"})
+        self._set(d, "ORCHAGENT_QUEUE|PORT_TABLE", {"pending_count": "3"})
+
+        result = runner.invoke(
+            show.cli.commands['orchagent'].commands['queue'], [], obj=db
+        )
+        assert result.exit_code == 0
+        # NEIGH_TABLE has pending_count=0, should NOT appear by default
+        assert "NEIGH_TABLE" not in result.output
+        # ROUTE_TABLE should be listed before PORT_TABLE because 12 > 3
+        idx_route = result.output.find("ROUTE_TABLE")
+        idx_port = result.output.find("PORT_TABLE")
+        assert idx_route != -1 and idx_port != -1
+        assert idx_route < idx_port
+
+    def test_queue_show_all_includes_zero(self):
+        runner = CliRunner()
+        db = Db()
+        d = db.db
+
+        self._set(d, "ORCHAGENT_QUEUE|ROUTE_TABLE", {"pending_count": "5"})
+        self._set(d, "ORCHAGENT_QUEUE|FDB_TABLE", {"pending_count": "0"})
+
+        result = runner.invoke(
+            show.cli.commands['orchagent'].commands['queue'],
+            ['--all'], obj=db
+        )
+        assert result.exit_code == 0
+        assert "ROUTE_TABLE" in result.output
+        assert "FDB_TABLE" in result.output
+
+    def test_queue_empty_state_db(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(
+            show.cli.commands['orchagent'].commands['queue'], [], obj=db
+        )
+        assert result.exit_code == 0
+        # No keys → friendly message, not a crash
+        assert "pending tasks" in result.output or "No orchagent queue" in result.output

--- a/tests/show_orchagent_test.py
+++ b/tests/show_orchagent_test.py
@@ -33,9 +33,12 @@ class TestShowOrchagentQueue:
         db = Db()
         d = db.db
 
-        self._set(d, "ORCHAGENT_QUEUE|ROUTE_TABLE", {"pending_count": "12"})
-        self._set(d, "ORCHAGENT_QUEUE|NEIGH_TABLE", {"pending_count": "0"})
-        self._set(d, "ORCHAGENT_QUEUE|PORT_TABLE", {"pending_count": "3"})
+        self._set(d, "ORCHAGENT_QUEUE|RouteOrch|ROUTE_TABLE",
+                  {"pending_count": "12", "orch": "RouteOrch", "consumer": "ROUTE_TABLE"})
+        self._set(d, "ORCHAGENT_QUEUE|NeighOrch|NEIGH_TABLE",
+                  {"pending_count": "0", "orch": "NeighOrch", "consumer": "NEIGH_TABLE"})
+        self._set(d, "ORCHAGENT_QUEUE|PortsOrch|PORT_TABLE",
+                  {"pending_count": "3", "orch": "PortsOrch", "consumer": "PORT_TABLE"})
 
         result = runner.invoke(
             show.cli.commands['orchagent'].commands['queue'], [], obj=db
@@ -48,14 +51,19 @@ class TestShowOrchagentQueue:
         idx_port = result.output.find("PORT_TABLE")
         assert idx_route != -1 and idx_port != -1
         assert idx_route < idx_port
+        # Owning Orch name must be visible.
+        assert "RouteOrch" in result.output
+        assert "PortsOrch" in result.output
 
     def test_queue_show_all_includes_zero(self):
         runner = CliRunner()
         db = Db()
         d = db.db
 
-        self._set(d, "ORCHAGENT_QUEUE|ROUTE_TABLE", {"pending_count": "5"})
-        self._set(d, "ORCHAGENT_QUEUE|FDB_TABLE", {"pending_count": "0"})
+        self._set(d, "ORCHAGENT_QUEUE|RouteOrch|ROUTE_TABLE",
+                  {"pending_count": "5", "orch": "RouteOrch", "consumer": "ROUTE_TABLE"})
+        self._set(d, "ORCHAGENT_QUEUE|FdbOrch|FDB_TABLE",
+                  {"pending_count": "0", "orch": "FdbOrch", "consumer": "FDB_TABLE"})
 
         result = runner.invoke(
             show.cli.commands['orchagent'].commands['queue'],
@@ -64,6 +72,35 @@ class TestShowOrchagentQueue:
         assert result.exit_code == 0
         assert "ROUTE_TABLE" in result.output
         assert "FDB_TABLE" in result.output
+
+    def test_queue_disambiguates_consumer_shared_across_orchs(self):
+        """The same consumer table name (e.g. CFG_FLEX_COUNTER_TABLE) is
+        registered in multiple Orchs. The CLI must show both rows with their
+        owning Orch in the output, not collapse them."""
+        runner = CliRunner()
+        db = Db()
+        d = db.db
+
+        self._set(d,
+                  "ORCHAGENT_QUEUE|WatermarkOrch|CFG_FLEX_COUNTER_TABLE",
+                  {"pending_count": "7",
+                   "orch": "WatermarkOrch",
+                   "consumer": "CFG_FLEX_COUNTER_TABLE"})
+        self._set(d,
+                  "ORCHAGENT_QUEUE|FlexCounterOrch|CFG_FLEX_COUNTER_TABLE",
+                  {"pending_count": "4",
+                   "orch": "FlexCounterOrch",
+                   "consumer": "CFG_FLEX_COUNTER_TABLE"})
+
+        result = runner.invoke(
+            show.cli.commands['orchagent'].commands['queue'], [], obj=db
+        )
+        assert result.exit_code == 0
+        assert "WatermarkOrch" in result.output
+        assert "FlexCounterOrch" in result.output
+        # Both pending counts must be visible.
+        assert "7" in result.output
+        assert "4" in result.output
 
     def test_queue_empty_state_db(self):
         runner = CliRunner()
@@ -87,10 +124,31 @@ class TestShowOrchagentQueue:
         db = Db()
         d = db.db
 
-        self._set(d, "ORCHAGENT_QUEUE|BUSTED_TABLE", {"pending_count": "n/a"})
+        self._set(d, "ORCHAGENT_QUEUE|TestOrch|BUSTED_TABLE",
+                  {"pending_count": "n/a",
+                   "orch": "TestOrch",
+                   "consumer": "BUSTED_TABLE"})
 
         result = runner.invoke(
             show.cli.commands['orchagent'].commands['queue'], [], obj=db
         )
         assert result.exit_code == 0
         assert "BUSTED_TABLE" not in result.output
+
+    def test_queue_legacy_two_part_key_still_renders(self):
+        """If a row was written by a pre-upgrade orchagent that used the
+        ORCHAGENT_QUEUE|<consumer> key format (no Orch prefix, no orch/
+        consumer fields), the CLI should still render it rather than crash.
+        Orch column shows '-' as a placeholder."""
+        runner = CliRunner()
+        db = Db()
+        d = db.db
+
+        self._set(d, "ORCHAGENT_QUEUE|ROUTE_TABLE", {"pending_count": "9"})
+
+        result = runner.invoke(
+            show.cli.commands['orchagent'].commands['queue'], [], obj=db
+        )
+        assert result.exit_code == 0
+        assert "ROUTE_TABLE" in result.output
+        assert "9" in result.output


### PR DESCRIPTION
#### What I did

Add a new top-level `orchagent` show command group with a `queue` subcommand:

```
$ show orchagent queue
Orch            Consumer                  Pending Count
--------------  ----------------------  ---------------
RouteOrch       ROUTE_TABLE                         142
WatermarkOrch   CFG_FLEX_COUNTER_TABLE                7
FlexCounterOrch CFG_FLEX_COUNTER_TABLE                4
NeighOrch       NEIGH_TABLE                           3

$ show orchagent queue --all
# also includes consumers with pending_count == 0
```

Reads `STATE_DB:ORCHAGENT_QUEUE|*` (written periodically by `OrchDaemon` — see companion PR below) and prints one row per (Orch, consumer) pair with its `pending_count`. By default only consumers with non-zero pending tasks are shown; `--all` includes all consumers.

The `Orch` column matters because the same consumer table name (e.g. `CFG_FLEX_COUNTER_TABLE`) is registered in multiple Orchs; without the Orch name those rows would be indistinguishable.

Files added/modified:
- `show/orchagent.py` (new) — click group + `queue` command, uses `@clicommon.pass_db`
- `show/main.py` — register `orchagent` group
- `tests/show_orchagent_test.py` (new) — unit tests with per-test cleanup of `ORCHAGENT_QUEUE|*` keys

#### How I did it

- New module `show/orchagent.py` with `@click.group` and one `@orchagent.command` for `queue`.
- Wired up in `show/main.py` via `cli.add_command(orchagent.orchagent)` alongside other top-level groups.
- Reads STATE_DB via the `db` parameter from `@clicommon.pass_db`, matching the pattern of `show bfd summary` and other sibling commands.
- Key format from the swss producer side is `ORCHAGENT_QUEUE|<Orch>|<consumer>` with `orch` and `consumer` fields in the row. The CLI prefers those row fields when present and falls back to splitting the key, so it gracefully handles both the new 3-part format and the legacy 2-part format (in which case the Orch column shows `-`).
- Sorts output by `pending_count` descending so most-loaded consumers are at the top, with `(Orch, Consumer)` as a deterministic tiebreaker.
- Empty STATE_DB / missing table produces a friendly hint instead of a crash, so the command works gracefully on a build that does not yet include the companion swss-side telemetry PR.
- Defensive `int()` parse on `pending_count`; non-integer values (shouldn't happen, but be safe) are treated as zero.

#### How to verify it

Unit tests:

```
pytest tests/show_orchagent_test.py -v
```

Six cases:
- default mode hides zero-count consumers and sort order is `pending_count` descending
- `--all` flag shows zero-count rows
- the same consumer name owned by different Orchs (e.g. `CFG_FLEX_COUNTER_TABLE` in `WatermarkOrch` + `FlexCounterOrch`) renders as two distinct rows with both Orchs visible
- empty STATE_DB produces a friendly message, not a crash
- garbage `pending_count` value is treated as zero (defensive parse)
- legacy 2-part key (`ORCHAGENT_QUEUE|<consumer>`) still renders, with `-` in the Orch column

Manual on a live device (requires the companion swss PR):

```
$ redis-cli -n 6 KEYS 'ORCHAGENT_QUEUE|*'
ORCHAGENT_QUEUE|RouteOrch|ROUTE_TABLE
ORCHAGENT_QUEUE|NeighOrch|NEIGH_TABLE
...

$ show orchagent queue
Orch            Consumer       Pending Count
--------------  -----------  ---------------
RouteOrch       ROUTE_TABLE               12
NeighOrch       NEIGH_TABLE                3
```

#### Previous command output (if the output of a command-line utility has changed)

N/A — new command, no previous output.

#### New command output (if the output of a command-line utility has changed)

```
$ show orchagent queue --help
Usage: show orchagent queue [OPTIONS]

  Show per-consumer pending task counts in orchagent's m_toSync queues.

  Each row is one Redis-table consumer registered with an orchagent Orch. A
  non-zero pending_count indicates either dependency-driven retries (e.g.,
  RIF not ready yet) or SAI-level retries (sync mode).

  By default, consumers with zero pending tasks are hidden. Use --all to
  show every consumer.

Options:
  --all   Show all consumers including those with zero pending tasks.
  --help  Show this message and exit.

$ show orchagent queue
Orch            Consumer       Pending Count
--------------  -----------  ---------------
RouteOrch       ROUTE_TABLE              142
NeighOrch       NEIGH_TABLE                7
```

#### Details if related

Companion PR adds the telemetry producer side in orchagent:
- **sonic-net/sonic-swss#4606**: `[orchagent] publish per-consumer queue depth to STATE_DB` — https://github.com/sonic-net/sonic-swss/pull/4606

These two PRs together implement queue-depth telemetry. They are independent: this CLI fails gracefully on builds without the swss-side change.
