### PR TITLE
[show_techsupport] Collect rasdaemon RAS event database

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2576,6 +2576,12 @@ main() {
     echo "[ Capture pstore info ] : $(($end_t-$start_t)) msec" >> $TECHSUPPORT_TIME_INFO
     wait
     
+    # capture rasdaemon RAS event database
+    if [ -f /var/lib/rasdaemon/ras-mc_event.db ]; then
+        save_file /var/lib/rasdaemon/ras-mc_event.db "rasdaemon" false &
+        wait
+    fi
+
     # Save all the processes within each docker
     save_cmd "show services" services.summary &
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add /var/lib/rasdaemon/ras-mc_event.db to show techsupport output.
This sqlite database contains hardware error events (memory ECC errors, PCIe AER, MCE) recorded by rasdaemon.
Only collected when the file exists (rasdaemon may not be installed on all platforms).

#### How to verify it
Execute show techsupport command and confirm that the ras-mc_event.db is collected


