### PR TITLE
[smartswitch]: Use reboot_gracefully() to record DPU reboot time at command invocation

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -78,12 +78,60 @@ class TestModuleHelper:
         result = module_helper.reboot_module("DPU1", "cold")
         assert result is True
 
+    def test_reboot_module_uses_reboot_gracefully_when_available(self, mock_load_platform_chassis):
+        """When the module has reboot_gracefully(), it should be called instead of reboot()."""
+        mock_module = mock.MagicMock()
+        mock_module.reboot_gracefully.return_value = True
+        module_helper.platform_chassis = mock_load_platform_chassis.return_value
+        mock_load_platform_chassis.return_value.get_module_index.return_value = 1
+        mock_load_platform_chassis.return_value.get_module.return_value = mock_module
+
+        result = module_helper.reboot_module("DPU1", "cold")
+        assert result is True
+        mock_module.reboot_gracefully.assert_called_once_with("cold")
+        mock_module.reboot.assert_not_called()
+
+    def test_reboot_module_falls_back_to_reboot_without_gracefully(self, mock_load_platform_chassis):
+        """When the module lacks reboot_gracefully(), reboot() should be called."""
+        mock_module = mock.MagicMock(spec=['reboot'])
+        mock_module.reboot.return_value = True
+        module_helper.platform_chassis = mock_load_platform_chassis.return_value
+        mock_load_platform_chassis.return_value.get_module_index.return_value = 1
+        mock_load_platform_chassis.return_value.get_module.return_value = mock_module
+
+        result = module_helper.reboot_module("DPU1", "cold")
+        assert result is True
+        mock_module.reboot.assert_called_once_with("cold")
+
+    def test_reboot_module_gracefully_failure(self, mock_load_platform_chassis, mock_log_error):
+        """When reboot_gracefully() returns False, reboot_module should return False."""
+        mock_module = mock.MagicMock()
+        mock_module.reboot_gracefully.return_value = False
+        module_helper.platform_chassis = mock_load_platform_chassis.return_value
+        mock_load_platform_chassis.return_value.get_module_index.return_value = 1
+        mock_load_platform_chassis.return_value.get_module.return_value = mock_module
+
+        result = module_helper.reboot_module("DPU1", "cold")
+        assert result is False
+        mock_log_error.assert_called_with("Reboot status for module DPU1: False")
+
     def test_reboot_module_invalid_index(self, mock_load_platform_chassis, mock_try_get_args):
         mock_try_get_args.return_value = INVALID_MODULE_INDEX
         mock_load_platform_chassis.return_value.get_module_index.return_value = INVALID_MODULE_INDEX
 
         result = module_helper.reboot_module("DPU1", "cold")
         assert result is False
+
+    def test_reboot_module_no_reboot_method(self, mock_load_platform_chassis,
+                                            mock_try_get_args, mock_log_error):
+        """When the module has neither reboot nor reboot_gracefully, should return False."""
+        mock_try_get_args.return_value = 1
+        mock_module = object()
+        module_helper.platform_chassis.get_module.return_value = mock_module
+
+        result = module_helper.reboot_module("DPU1", "cold")
+        assert result is False
+        mock_log_error.assert_called_once_with("Reboot method not found in platform chassis")
 
     def test_module_pre_shutdown_success(self, mock_load_platform_chassis, mock_try_get_args, mock_try_get):
         mock_try_get_args.return_value = True

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -18,6 +18,13 @@ def _mock_sonic_platform_module():
 
 
 class TestModuleHelper:
+    @pytest.fixture(autouse=True)
+    def _restore_platform_chassis(self):
+        """Save and restore module_helper.platform_chassis between tests."""
+        original = module_helper.platform_chassis
+        yield
+        module_helper.platform_chassis = original
+
     @pytest.fixture(scope="function")
     def mock_load_platform_chassis(self):
         with mock.patch('utilities_common.module.util.load_platform_chassis') as mock_load_platform_chassis:
@@ -127,7 +134,8 @@ class TestModuleHelper:
         """When the module has neither reboot nor reboot_gracefully, should return False."""
         mock_try_get_args.return_value = 1
         mock_module = object()
-        module_helper.platform_chassis.get_module.return_value = mock_module
+        module_helper.platform_chassis = mock_load_platform_chassis.return_value
+        mock_load_platform_chassis.return_value.get_module.return_value = mock_module
 
         result = module_helper.reboot_module("DPU1", "cold")
         assert result is False

--- a/utilities_common/module.py
+++ b/utilities_common/module.py
@@ -61,12 +61,16 @@ class ModuleHelper:
             log.log_error("Unable to get module-index for {}". format(module_name))
             return False
 
-        if not hasattr(self.platform_chassis.get_module(module_index), 'reboot'):
+        module = self.platform_chassis.get_module(module_index)
+        if not hasattr(module, 'reboot'):
             log.log_error("Reboot method not found in platform chassis")
             return False
 
         log.log_info("Rebooting module {} with reboot_type {}...".format(module_name, reboot_type))
-        status = self.try_get_args(self.platform_chassis.get_module(module_index).reboot, reboot_type, default=False)
+        if hasattr(module, 'reboot_gracefully'):
+            status = self.try_get_args(module.reboot_gracefully, reboot_type, default=False)
+        else:
+            status = self.try_get_args(module.reboot, reboot_type, default=False)
         if not status:
             log.log_error("Reboot status for module {}: {}".format(module_name, status))
             return False


### PR DESCRIPTION
#### What I did

Updated `ModuleHelper.reboot_module()` to call `reboot_gracefully()` (when available) instead of `reboot()` directly. This ensures `prev_reboot_time.txt` is written at the moment the user issues `reboot -d DPUx`, before any race with `config reload` or chassisd restart.

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/24275

#### How I did it

In `utilities_common/module.py`, the `reboot_module()` method now:
1. Checks if the platform module exposes `reboot_gracefully()` (introduced in sonic-net/sonic-platform-common#680).
2. If available, calls `reboot_gracefully(reboot_type)` which records the reboot timestamp then delegates to `reboot()`.
3. Falls back to `reboot(reboot_type)` for platforms that have not yet picked up the new method.

#### How to verify it

1. On a SmartSwitch with sonic-platform-common including sonic-net/sonic-platform-common#680:
   ```
   sudo reboot -d DPU0
   ```
2. Verify `/host/reboot-cause/module/DPU0/prev_reboot_time.txt` is created immediately.
3. Issue `config reload` right after — the reboot time file should persist and not be lost.
4. On a platform without `reboot_gracefully()`, verify `reboot -d DPU0` still works via the fallback path.

#### Previous command output (if the output of a command-line utility has changed)

N/A — no CLI output changes.

#### New command output (if the output of a command-line utility has changed)

N/A — no CLI output changes.

---

**Related PRs:**
- sonic-net/sonic-platform-common#680 — Adds `reboot_gracefully()` and `_record_dpu_reboot_time()` to `ModuleBase`
- sonic-net/sonic-platform-daemons#771 — Chassisd reboot-cause persistence on EMPTY→Offline transition
