### PR TITLE
Add validation for malformed interface ranges

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5241,7 +5241,11 @@ def startup(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    intf_fs = parse_interface_in_filter(interface_name)
+    try:
+        intf_fs = parse_interface_in_filter(interface_name)
+    except ValueError as e:
+        ctx.fail(str(e))
+
     if len(intf_fs) > 1 and multi_asic.is_multi_asic():
         ctx.fail("Interface range not supported in multi-asic platforms !!")
 
@@ -5287,7 +5291,11 @@ def shutdown(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    intf_fs = parse_interface_in_filter(interface_name)
+    try:
+        intf_fs = parse_interface_in_filter(interface_name)
+    except ValueError as e:
+        ctx.fail(str(e))
+
     if len(intf_fs) > 1 and multi_asic.is_multi_asic():
         ctx.fail("Interface range not supported in multi-asic platforms !!")
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -509,7 +509,11 @@ class IntfStatus(object):
         table = []
         key = []
 
-        intf_fs = parse_interface_in_filter(self.intf_name)
+        try:
+            intf_fs = parse_interface_in_filter(self.intf_name)
+        except ValueError as e:
+            print("Error: {}".format(e), file=sys.stderr)
+            sys.exit(1)
         #
         # Iterate through all the keys and append port's associated state to
         # the result table.
@@ -756,7 +760,11 @@ class IntfTpid(object):
         table = []
         key = []
 
-        intf_fs = parse_interface_in_filter(self.intf_name)
+        try:
+            intf_fs = parse_interface_in_filter(self.intf_name)
+        except ValueError as e:
+            print("Error: {}".format(e), file=sys.stderr)
+            sys.exit(1)
         #
         # Iterate through all the keys and append port's associated state to
         # the result table.

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -116,7 +116,11 @@ Examples:
     if delete_saved_stats:
         cache.remove()
 
-    intf_list = parse_interface_in_filter(intf_fs)
+    try:
+        intf_list = parse_interface_in_filter(intf_fs)
+    except ValueError as e:
+        print("Error: {}".format(e), file=sys.stderr)
+        sys.exit(1)
 
     # When saving counters to the file, save counters
     # for all ports(Internal and External)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4200,6 +4200,38 @@ class TestConfigInterface(object):
         assert result.exit_code == 0
         assert db.cfgdb.get_table('LOOPBACK_INTERFACE')['Loopback0']['admin_status'] == 'up'
 
+    @pytest.mark.parametrize("interface_name", [
+        "Ethernet320-Ethernet376",  # range bounds not numeric
+        "Ethernet0-",               # missing end of range
+        "Ethernet0-foo",            # non-numeric end of range
+        "Eth0-3",                   # range with unsupported prefix
+    ])
+    def test_startup_malformed_range(self, interface_name):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands['interface'].commands['startup'],
+                               [interface_name], obj=obj)
+        assert result.exit_code != 0
+        assert "Invalid interface range" in result.output
+
+    @pytest.mark.parametrize("interface_name", [
+        "Ethernet320-Ethernet376",  # range bounds not numeric
+        "Ethernet0-",               # missing end of range
+        "Ethernet0-foo",            # non-numeric end of range
+        "Eth0-3",                   # range with unsupported prefix
+    ])
+    def test_shutdown_malformed_range(self, interface_name):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                               [interface_name], obj=obj)
+        assert result.exit_code != 0
+        assert "Invalid interface range" in result.output
+
     def teardown_method(self):
         print("TEARDOWN")
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4205,6 +4205,7 @@ class TestConfigInterface(object):
         "Ethernet0-",               # missing end of range
         "Ethernet0-foo",            # non-numeric end of range
         "Eth0-3",                   # range with unsupported prefix
+        "Ethernet8-4",              # start of range greater than the end
     ])
     def test_startup_malformed_range(self, interface_name):
         db = Db()
@@ -4221,6 +4222,7 @@ class TestConfigInterface(object):
         "Ethernet0-",               # missing end of range
         "Ethernet0-foo",            # non-numeric end of range
         "Eth0-3",                   # range with unsupported prefix
+        "Ethernet8-4",              # start of range greater than the end
     ])
     def test_shutdown_malformed_range(self, interface_name):
         db = Db()

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -656,7 +656,9 @@ class TestInterfaces(object):
         assert intf_list == ["Ethernet-BP10", "Ethernet-BP11", "Ethernet-BP12"]
         # Malformed ranges must raise instead of being silently dropped
         for intf_filter in ["Ethernet320-Ethernet376", "Ethernet0-", "Ethernet0-foo",
-                            "Eth0-3", "Ethernet-BP10-Ethernet-BP12"]:
+                            "Eth0-3", "Ethernet-BP10-Ethernet-BP12",
+                            # start of range greater than the end
+                            "Ethernet8-4", "PortChannel10-2", "Ethernet-BP12-10"]:
             with pytest.raises(ValueError):
                 parse_interface_in_filter(intf_filter)
 

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import traceback
 
 from click.testing import CliRunner
@@ -653,6 +654,11 @@ class TestInterfaces(object):
         intf_list = parse_interface_in_filter(intf_filter)
         assert len(intf_list) == 3
         assert intf_list == ["Ethernet-BP10", "Ethernet-BP11", "Ethernet-BP12"]
+        # Malformed ranges must raise instead of being silently dropped
+        for intf_filter in ["Ethernet320-Ethernet376", "Ethernet0-", "Ethernet0-foo",
+                            "Eth0-3", "Ethernet-BP10-Ethernet-BP12"]:
+            with pytest.raises(ValueError):
+                parse_interface_in_filter(intf_filter)
 
     def test_show_interfaces_switchport_status(self):
         runner = CliRunner()

--- a/tests/intfutil_test.py
+++ b/tests/intfutil_test.py
@@ -6,6 +6,8 @@ import subprocess
 
 import show.main as show
 
+from .utils import get_result_and_return_code
+
 root_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(root_path)
 scripts_path = os.path.join(modules_path, "scripts")
@@ -174,6 +176,32 @@ class TestIntfutil(TestCase):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == show_interface_status_Ethernet32_output
+
+    # malformed interface ranges must fail loudly instead of silently dropping the bad input
+    malformed_ranges = [
+        "Ethernet320-Ethernet376",  # range bounds not numeric
+        "Ethernet0-",               # missing end of range
+        "Ethernet0-foo",            # non-numeric end of range
+        "Eth0-3",                   # range with unsupported prefix
+    ]
+
+    def test_intf_status_malformed_range(self):
+        for intf_fs in self.malformed_ranges:
+            return_code, output = get_result_and_return_code(
+                ['intfutil', '-c', 'status', '-i', intf_fs])
+            print("return_code: {}".format(return_code))
+            print("output = {}".format(output))
+            assert return_code == 1
+            assert "Error: Invalid interface range" in output
+
+    def test_intf_tpid_malformed_range(self):
+        for intf_fs in self.malformed_ranges:
+            return_code, output = get_result_and_return_code(
+                ['intfutil', '-c', 'tpid', '-i', intf_fs])
+            print("return_code: {}".format(return_code))
+            print("output = {}".format(output))
+            assert return_code == 1
+            assert "Error: Invalid interface range" in output
 
     def test_show_interfaces_description(self):
         result = self.runner.invoke(show.cli.commands["interfaces"].commands["description"], [])

--- a/tests/intfutil_test.py
+++ b/tests/intfutil_test.py
@@ -183,6 +183,7 @@ class TestIntfutil(TestCase):
         "Ethernet0-",               # missing end of range
         "Ethernet0-foo",            # non-numeric end of range
         "Eth0-3",                   # range with unsupported prefix
+        "Ethernet8-4",              # start of range greater than the end
     ]
 
     def test_intf_status_malformed_range(self):

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -571,6 +571,19 @@ class TestPortStat(object):
         assert return_code == 0
         assert result == intf_rates
 
+    @pytest.mark.parametrize("intf_fs", [
+        "Ethernet320-Ethernet376",  # range bounds not numeric
+        "Ethernet0-",               # missing end of range
+        "Ethernet0-foo",            # non-numeric end of range
+        "Eth0-3",                   # range with unsupported prefix
+    ])
+    def test_show_intf_counters_malformed_range(self, intf_fs):
+        return_code, result = get_result_and_return_code(['portstat', '-i', intf_fs])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 1
+        assert "Error: Invalid interface range" in result
+
     def test_clear_intf_counters(self):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands["counters"], [])

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -576,6 +576,7 @@ class TestPortStat(object):
         "Ethernet0-",               # missing end of range
         "Ethernet0-foo",            # non-numeric end of range
         "Eth0-3",                   # range with unsupported prefix
+        "Ethernet8-4",              # start of range greater than the end
     ])
     def test_show_intf_counters_malformed_range(self, intf_fs):
         return_code, result = get_result_and_return_code(['portstat', '-i', intf_fs])

--- a/utilities_common/intf_filter.py
+++ b/utilities_common/intf_filter.py
@@ -22,6 +22,10 @@ def parse_interface_in_filter(intf_filter):
                     raise ValueError(
                         "Invalid interface range '{}{}'. Expected a range like "
                         "'{}0-3'.".format(intf, x, intf))
+                if int(start) > int(end):
+                    raise ValueError(
+                        "Invalid interface range '{}{}'. The start of the range "
+                        "must not be greater than the end.".format(intf, x))
                 for i in range(int(start), int(end)+1):
                     intf_fs.append(intf+str(i))
             else:
@@ -43,6 +47,10 @@ def parse_interface_in_filter(intf_filter):
                 raise ValueError(
                     "Invalid interface range '{}'. Expected a range like "
                     "'{}0-3'.".format(x, intf))
+            if int(start) > int(end):
+                raise ValueError(
+                    "Invalid interface range '{}'. The start of the range "
+                    "must not be greater than the end.".format(x))
             for i in range(int(start), int(end)+1):
                 intf_fs.append(intf+str(i))
         else:

--- a/utilities_common/intf_filter.py
+++ b/utilities_common/intf_filter.py
@@ -19,24 +19,30 @@ def parse_interface_in_filter(intf_filter):
                 start = x.split('-')[0]
                 end = x.split('-')[1]
                 if not start.isdigit() or not end.isdigit():
-                    continue
+                    raise ValueError(
+                        "Invalid interface range '{}{}'. Expected a range like "
+                        "'{}0-3'.".format(intf, x, intf))
                 for i in range(int(start), int(end)+1):
                     intf_fs.append(intf+str(i))
             else:
                 intf_fs.append(intf+x)
         elif '-' in x:
             # handle range
-            if not x.startswith(SONIC_PORT_NAME_PREFIX) and not x.startswith(SONIC_LAG_NAME_PREFIX):
-                continue
             if x.startswith(SONIC_PORT_NAME_PREFIX):
                 intf = SONIC_PORT_NAME_PREFIX
-            if x.startswith(SONIC_LAG_NAME_PREFIX):
+            elif x.startswith(SONIC_LAG_NAME_PREFIX):
                 intf = SONIC_LAG_NAME_PREFIX
+            else:
+                raise ValueError(
+                    "Invalid interface range '{}'. A range must start with "
+                    "'{}' or '{}'.".format(x, SONIC_PORT_NAME_PREFIX, SONIC_LAG_NAME_PREFIX))
             start = x.split('-')[0].split(intf,1)[1]
             end = x.split('-')[1]
 
             if not start.isdigit() or not end.isdigit():
-                continue
+                raise ValueError(
+                    "Invalid interface range '{}'. Expected a range like "
+                    "'{}0-3'.".format(x, intf))
             for i in range(int(start), int(end)+1):
                 intf_fs.append(intf+str(i))
         else:


### PR DESCRIPTION
Fixes #4574.

#### What I did
It is possible to run `sudo config interface startup Ethernet320-Ethernet376` or `sudo config interface shutdown Ethernet320-Ethernet376` and the command will return silently without actually having done anything because the valid format for a range specifier is `Ethernet320-376`.

This PR adds validation to these CLI commands so that malformed range specifiers will cause the CLI to print an error message.

#### How I did it
I added logic to raise an exception when a malformed range specifier is provided by the user to the CLI.

#### How to verify it
Added unit-tests, manually tested below.

#### Previous command output (if the output of a command-line utility has changed)
Before the change:
```
admin@device:~$ show int stat Ethernet0-8
  Interface                   Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ----------------------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0  9,10,11,12,13,14,15,16     800G   9100     rs    Port1  routed    down       up     N/A         N/A
  Ethernet8         1,2,3,4,5,6,7,8     800G   9100     rs    Port2  routed    down       up     N/A         N/A
admin@device:~$ sudo config interface shutdown Ethernet0-Ethernet8
admin@device:~$ show int stat Ethernet0-8
  Interface                   Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ----------------------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0  9,10,11,12,13,14,15,16     800G   9100     rs    Port1  routed    down       up     N/A         N/A
  Ethernet8         1,2,3,4,5,6,7,8     800G   9100     rs    Port2  routed    down       up     N/A         N/A
```

#### New command output (if the output of a command-line utility has changed)
After the change:
```
admin@device:~$ sudo config interface shutdown Ethernet0-Ethernet8
Usage: config interface shutdown [OPTIONS] <interface_name>
Try 'config interface shutdown -h' for help.

Error: Invalid interface range 'Ethernet0-Ethernet8'. Expected a range like 'Ethernet0-3'.
admin@device:~$ sudo config interface startup Ethernet0-Ethernet8
Usage: config interface startup [OPTIONS] <interface_name>
Try 'config interface startup -h' for help.

Error: Invalid interface range 'Ethernet0-Ethernet8'. Expected a range like 'Ethernet0-3'.
```