### PR TITLE
azure-pipelines: install libyang3 instead of libyang1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,8 @@ The sonic-utilities package depends on a number of other packages, many of which
 Currently, this list of dependencies is as follows:
 
 
-- libyang_1.0.73_amd64.deb
-- libyang-cpp_1.0.73_amd64.deb
-- python3-yang_1.0.73_amd64.deb
-- libyang3_3.*_amd64.deb
-- python3-libyang_3.*_amd64.deb
+- libyang3_*.deb
+- python3-libyang_*.deb
 - redis_dump_load-1.1-py3-none-any.whl
 - sonic_py_common-1.0-py3-none-any.whl
 - sonic_config_engine-1.0-py3-none-any.whl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,11 +81,8 @@ stages:
         sudo dpkg -i libnl-genl-3-200_*.deb
         sudo dpkg -i libnl-route-3-200_*.deb
         sudo dpkg -i libnl-nf-3-200_*.deb
-        sudo dpkg -i libyang_1.0.73_amd64.deb
-        sudo dpkg -i libyang-cpp_1.0.73_amd64.deb
-        sudo dpkg -i python3-yang_1.0.73_amd64.deb
-        sudo dpkg -i libyang3_3.*_amd64.deb
-        sudo dpkg -i python3-libyang_3.*_amd64.deb
+        sudo dpkg -i libyang3_*.deb
+        sudo dpkg -i python3-libyang_*.deb
       workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
       displayName: 'Install Debian dependencies'
 
@@ -235,9 +232,8 @@ stages:
         sudo dpkg -i libnl-genl-3-200_*.deb
         sudo dpkg -i libnl-route-3-200_*.deb
         sudo dpkg -i libnl-nf-3-200_*.deb
-        sudo dpkg -i libyang_1.0.73_amd64.deb
-        sudo dpkg -i libyang-cpp_1.0.73_amd64.deb
-        sudo dpkg -i python3-yang_1.0.73_amd64.deb
+        sudo dpkg -i libyang3_*.deb
+        sudo dpkg -i python3-libyang_*.deb
       workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
       displayName: 'Install Debian dependencies'
 


### PR DESCRIPTION
#### What I did

sonic-buildimage no longer builds the libyang1 debs (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds only libyang3. This updates the sonic-utilities CI and documentation to install the libyang3 debs instead, so the build assets it pulls from sonic-buildimage match what is actually produced.

Part of sonic-net/sonic-buildimage#22385.

#### How I did it

Updated the deb install lists in `azure-pipelines.yml` (both `Install Debian dependencies` steps) and the dependency list in `README.md`, applying the following mapping:

- `libyang_1.0.73_amd64.deb` -> `libyang3_*.deb`
- `libyang-cpp_1.0.73_amd64.deb` -> removed (no libyang3 equivalent)
- `python3-yang_1.0.73_amd64.deb` -> `python3-libyang_*.deb`

Versionless globs are used throughout so the CI does not need to track exact package versions.

The `.semgrep/no-direct-libyang.yml` guard rule was left unchanged; it forbids direct `import libyang` (routing through sonic-yang-mgmt instead) and is not a deb reference.

#### How to verify it

In the CI `Install Debian dependencies` steps, the `dpkg -i` commands now reference `libyang3_*.deb` and `python3-libyang_*.deb`, which match the debs produced by current sonic-buildimage. No libyang1 deb references (`libyang_1`, `libyang-cpp`, `python3-yang`) remain in `azure-pipelines.yml` or `README.md`.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A
