### PR TITLE
Fixes #4579: Fix pfc prio config errors

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -84,7 +84,7 @@ class Pfc(object):
 
         """Current lossless priorities on the interface"""
         entry = self.config_db.get_entry('PORT_QOS_MAP', interface)
-        enable_prio = entry.get('pfc_enable').split(',')
+        enable_prio = entry.get('pfc_enable', '').split(',')
 
         """Avoid '' in enable_prio"""
         enable_prio = [x.strip() for x in enable_prio if x.strip()]


### PR DESCRIPTION


#### What I did

if PFC is not enabled on a port, unable to configure PFC via CLI. it generates the error as shown in the ticket.

#### How I did it

SImilar to "show pfc prio", if there is no entry for "pfc_enable" under PORT_QOS_MAP for that part, just treat as empty and add the new PFC prio instead out erroring out.


#### How to verify it

```
Before the fix:
admin@humm223:~$ show pfc prio

Interface    Lossless priorities
-----------  ---------------------
Ethernet32   N/A
Ethernet36   3,4
Ethernet40   3,4
Ethernet44   3,4
Ethernet160  3,4
Ethernet164  3,4
admin@humm223:~$ sudo config interface pfc priority  Ethernet32 3 on
Traceback (most recent call last):
  File "/usr/local/bin/pfc", line 8, in <module>
    sys.exit(cli())
             ~~~^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.13/dist-packages/pfc/main.py", line 177, in configPrio
    Pfc(namespace).configPfcPrio(status, interface, priority)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/utilities_common/multi_asic.py", line 153, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/pfc/main.py", line 87, in configPfcPrio
    enable_prio = entry.get('pfc_enable').split(',')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
admin@humm223:~$

WITH THE FIX:

admin@humm223:~$ sudo config interface pfc priority  Ethernet32 3 on
admin@humm223:~$ show pfc pri

Interface    Lossless priorities
-----------  ---------------------
Ethernet32   3
Ethernet36   3,4
Ethernet40   3,4
Ethernet44   3,4
Ethernet160  3,4
Ethernet164  3,4

admin@humm223:~$
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

