### PR TITLE
Fix flaky config_mgmt / ConfigMgmtDPB tests under pytest-xdist

### DIFF
--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -10,6 +10,8 @@ from utilities_common.general import load_module_from_source
 
 import config.main as config
 
+from .utils import worker_tmp_path
+
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
 
@@ -162,8 +164,9 @@ def config_mgmt_dpb(cfgdb):
     '''
     curConfig = read_config_db(cfgdb)
     # create object
-    config_mgmt.CONFIG_DB_JSON_FILE = "/tmp/startConfigDb.json"
-    config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "/tmp/portBreakOutConfigDb.json"
+    config_mgmt.CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
+    config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = worker_tmp_path(
+        'portBreakOutConfigDb.json')
     # write in temp file
     writeJson(curConfig, config_mgmt.CONFIG_DB_JSON_FILE)
     writeJson(portBreakOutConfigDbJson, config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
@@ -704,8 +707,8 @@ class TestConfigDPB(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-        os.system("rm -f /tmp/startConfigDb.json")
-        os.system("rm -f /tmp/portBreakOutConfigDb.json")
+        os.system("rm -f {}".format(worker_tmp_path('startConfigDb.json')))
+        os.system("rm -f {}".format(worker_tmp_path('portBreakOutConfigDb.json')))
 
 ###########GLOBAL Configs#####################################
 '''

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -707,8 +708,8 @@ class TestConfigDPB(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-        os.system("rm -f {}".format(worker_tmp_path('startConfigDb.json')))
-        os.system("rm -f {}".format(worker_tmp_path('portBreakOutConfigDb.json')))
+        Path(worker_tmp_path('startConfigDb.json')).unlink(missing_ok=True)
+        Path(worker_tmp_path('portBreakOutConfigDb.json')).unlink(missing_ok=True)
 
 ###########GLOBAL Configs#####################################
 '''

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -80,8 +80,9 @@ class TestConfigMgmt(TestCase):
         Libyang converts from 'XX:XX:XX:E4:B3:DD' -> 'xx:xx:xx:e4:b3:dd'
         '''
         curConfig = deepcopy(configDbJson)
-        # Keep only PORT part to skip dependencies.
-        curConfig = {'PORT': curConfig['PORT']}
+        # Use the full sample CONFIG_DB so YANG loadData() satisfies cross-table
+        # must/when constraints (a PORT-only snapshot can fail model validation on
+        # some branches). DEVICE_METADATA is added below for the MAC case test.
         # add DEVICE_METADATA Config
         curConfig['DEVICE_METADATA'] = {
             "localhost": {

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -7,6 +7,8 @@ from unittest import mock, TestCase
 import pytest
 from utilities_common.general import load_module_from_source
 
+from .utils import worker_tmp_path
+
 # Import file under test i.e., config_mgmt.py
 config_mgmt_py_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py')
 config_mgmt = load_module_from_source('config_mgmt', config_mgmt_py_path)
@@ -19,8 +21,11 @@ class TestConfigMgmt(TestCase):
     '''
 
     def setUp(self):
-        config_mgmt.CONFIG_DB_JSON_FILE = "startConfigDb.json"
-        config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "portBreakOutConfigDb.json"
+        # Per-worker paths: shared basenames in the repo root race under pytest-xdist
+        # (see sonic-utilities #4516 / config_override_test startConfigDb.json).
+        config_mgmt.CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
+        config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = worker_tmp_path(
+            'portBreakOutConfigDb.json')
         return
 
     def test_config_get_module_check(self):

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -11,6 +11,8 @@ from utilities_common.db import Db
 from utilities_common.general import load_module_from_source
 from minigraph import minigraph_encoder
 
+from .utils import worker_tmp_path
+
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 DATA_DIR = os.path.join(SCRIPT_DIR, "config_override_input")
 EMPTY_INPUT = os.path.join(DATA_DIR, "empty_input.json")
@@ -202,7 +204,7 @@ class TestConfigOverride(object):
         # ConfigMgmt will call ConfigDBConnector to load default config_db.json.
         # Here I modify the ConfigMgmt initialization and make it initiated with
         # a source file which share the same as what we write to cfgdb.
-        CONFIG_DB_JSON_FILE = "startConfigDb.json"
+        CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
         write_config_to_file(read_data['running_config'], CONFIG_DB_JSON_FILE)
         with mock.patch('config.main.device_info.is_yang_config_validation_enabled',
                         mock.MagicMock(side_effect=is_yang_config_validation_enabled_side_effect)), \
@@ -246,7 +248,7 @@ class TestConfigOverride(object):
         # ConfigMgmt will call ConfigDBConnector to load default config_db.json.
         # Here I modify the ConfigMgmt initialization and make it initiated with
         # a source file which share the same as what we write to cfgdb.
-        CONFIG_DB_JSON_FILE = "startConfigDb.json"
+        CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
         write_config_to_file(running_config, CONFIG_DB_JSON_FILE)
         with mock.patch('config.main.read_json_file',
                         mock.MagicMock(side_effect=read_json_file_side_effect)), \

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ import importlib.machinery
 import os
 import subprocess
 import sys
+import tempfile
 
 
 def worker_tmp_path(filename):
@@ -15,7 +16,14 @@ def worker_tmp_path(filename):
     Avoids races when multiple pytest workers read/write the same basename in
     the source tree (e.g. startConfigDb.json under --dist loadfile).
     """
-    return os.path.join(os.environ.get('WORKER_TMP', '/tmp'), filename)
+    base_dir = os.environ.get('WORKER_TMP')
+    if not base_dir:
+        worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'gw0')
+        base_dir = os.path.join(
+            tempfile.gettempdir(), f'sonic-utilities-{worker_id}')
+
+    os.makedirs(base_dir, exist_ok=True)
+    return os.path.join(base_dir, filename)
 
 
 def load_source(modname, filename, cache_module=False):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,19 @@
 
 import importlib.util
 import importlib.machinery
+import os
 import subprocess
 import sys
+
+
+def worker_tmp_path(filename):
+    """
+    Per-xdist-worker scratch file path (see tests/conftest.py setup_db_config).
+
+    Avoids races when multiple pytest workers read/write the same basename in
+    the source tree (e.g. startConfigDb.json under --dist loadfile).
+    """
+    return os.path.join(os.environ.get('WORKER_TMP', '/tmp'), filename)
 
 
 def load_source(modname, filename, cache_module=False):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
#### What I did

Fixed intermittent failures in `tests/config_mgmt_test.py`, `tests/config_dpb_test.py`, and `tests/config_override_test.py` during sonic-utilities CI (including parallel pytest-xdist runs).

Typical failures addressed:

- `TestConfigMgmt::test_upper_case_mac_fix` — `Exception: ConfigMgmtDPB Class creation failed`
- `TestConfigMgmt::test_table_without_yang` — `AssertionError: assert 'unknown_table' in {}`
- Other `ConfigMgmt` / `ConfigMgmtDPB` init paths — `Exception: ConfigMgmt Class creation failed`

Test-only changes; no production `config_mgmt.py` behavior changes.

#### How I did it

**YANG fixture fix (`test_upper_case_mac_fix`)**

- Use the full sample `configDbJson` instead of a `PORT`-only snapshot plus `DEVICE_METADATA`. A minimal CONFIG_DB can fail `sonic_yang` `loadData()` with `LYD_OPT_STRICT` when newer YANG models require cross-table context (`ACL_TABLE`, `VLAN_MEMBER`, `INTERFACE`, etc.).
- Keep the test intent: add `DEVICE_METADATA` with mixed-case MAC `00:11:22:BB:CC:DD` and the same assertions for libyang lower-casing of `yang:mac-address` during dynamic port breakout (`_createConfigToLoad()`).

**Per-worker JSON paths (pytest-xdist race)**

After parallel pytest (`-n auto --dist loadfile`, sonic-utilities #4516), several tests still used fixed `startConfigDb.json` / `portBreakOutConfigDb.json` paths in the source tree or shared `/tmp`. Concurrent xdist workers could overwrite those files, causing partial/empty/wrong JSON (constructor failures) or missing `unknown_table` (empty `tablesWithOutYang()`).

- Add `worker_tmp_path()` in `tests/utils.py`, using `WORKER_TMP` from `tests/conftest.py` when set, otherwise a per-worker directory under the system temp dir (`sonic-utilities-gwN/`).
- `tests/config_mgmt_test.py`: `setUp()` uses per-worker JSON paths.
- `tests/config_override_test.py`: `startConfigDb.json` via `worker_tmp_path()`.
- `tests/config_dpb_test.py`: replace shared `/tmp` paths with `worker_tmp_path()`; use `Path.unlink(missing_ok=True)` in teardown instead of `os.system("rm -f ...")`.

Same per-worker scratch pattern as other tests stabilized after #4516 (e.g. ecn/mmuconfig).

#### How to verify it

**Standalone sonic-utilities (parallel, matches CI):**

```bash
cd src/sonic-utilities
pip install ".[testing]"
python3 -m pytest tests/config_mgmt_test.py::TestConfigMgmt -n auto --dist loadfile -v
python3 -m pytest tests/config_override_test.py::TestConfigOverride -n auto --dist loadfile -v
python3 -m pytest tests/config_dpb_test.py -n auto --dist loadfile -v
```
Repeat several times; focus on `test_upper_case_mac_fix` and `test_table_without_yang`.

Focused checks:
```
python3 -m pytest tests/config_mgmt_test.py::TestConfigMgmt::test_upper_case_mac_fix -v
python3 -m pytest tests/config_mgmt_test.py::TestConfigMgmt::test_table_without_yang -v
```



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

