### PR TITLE
Align SED tests to the new conftest code

### DIFF
--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -1,6 +1,19 @@
+import sys
+
+import pytest
 from click.testing import CliRunner
 from mock import patch, MagicMock
 import config.main as config
+
+sys.modules['sonic_platform'] = MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _inject_sonic_platform():
+    # conftest._reset_between_files() clears sys.modules['sonic_platform']
+    # before the first test of each file; Need to re-inject before every test
+    sys.modules['sonic_platform'] = MagicMock()
+    yield
 
 
 class TestSed(object):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
After https://github.com/sonic-net/sonic-utilities/pull/4516 landed in master
tests/conftest.py clears sonic_platform entries from sys.modules between test
files so pytest-xdist workers do not leak mocks across files. tests/sed_test.py used
@patch('sonic_platform.platform.Platform') without re-injecting a fake
sonic_platform module, so CI failed with ModuleNotFoundError: No module named 'sonic_platform' once the conftest reset ran before those tests. The same pattern was
already fixed for decode_syseeprom_test.py in #4516; this change applies the
equivalent fix to sed_test.py.

#### How I did it
- Added module-level `sys.modules['sonic_platform'] = MagicMock()` so
  `@patch('sonic_platform.platform.Platform')` can resolve its target.
- Added an autouse pytest fixture `_inject_sonic_platform` that re-injects the mock
  before every test, after `conftest._reset_between_files()` clears it between test
  files.

#### How to verify it
tests/sed_test.py

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

