### PR TITLE
[BMC] Align is_bmc_supported check for the new infra

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2233,13 +2233,7 @@ save_log_files() {
 #  0 if BMC is supported, 1 otherwise
 ###############################################################################
 is_bmc_supported() {
-    local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
-    # Check if the required file exists
-    if [ ! -f /usr/share/sonic/device/$platform/bmc.json ]; then
-        return 1
-    else
-        return 0
-    fi
+    python3 -c "from sonic_py_common import device_info; import sys; sys.exit(0 if (device_info.is_switch_host() and device_info.get_bmc_data()) else 1)"
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The BMC support check in `generate_dump` was aligned with the new infrastructure flow
(https://github.com/sonic-net/sonic-buildimage/pull/26544).
Instead of checking for platform-local `bmc.json` assumptions, the logic now validates host-side role and runtime BMC data from the canonical source used by the system.

#### How I did it
- Updated `generate_dump` BMC detection to use `device_info.is_switch_host()` together with
  `device_info.get_bmc_data()`.
- Removed reliance on legacy platform-folder `bmc.json` existence behavior for this path.
- Kept the `generate_dump` flow behavior intact while aligning detection to runtime
  `/etc/sonic/bmc.json`-based APIs.
  
#### How to verify it
- Run `show techsupport` (or `generate_dump`) on:
  - a switch-host platform with valid BMC data and verify BMC-related flow executes.
  - a non-switch-host / missing-BMC-data platform and verify BMC path is skipped.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

