### PR TITLE
Add multi-asic support for Route flow counter cli command

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -491,7 +491,7 @@ def flowcnt_trap_disable(ctx):
 def flowcnt_route(ctx, namespace):
     """ Route flow counter commands """
     ctx.obj = connect_to_db(namespace)
-    exit_if_route_flow_counter_not_support()
+    exit_if_route_flow_counter_not_support(namespace)
 
 
 @flowcnt_route.command(name='interval')

--- a/flow_counter_util/route.py
+++ b/flow_counter_util/route.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from swsscommon.swsscommon import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector, SonicDBConfig
 
 try:
     if os.environ["UTILITIES_UNIT_TESTING"] == "1" or os.environ["UTILITIES_UNIT_TESTING"] == "2":
@@ -54,15 +54,18 @@ def build_route_pattern(vrf, prefix):
         return prefix
 
 
-def get_route_flow_counter_capability():
-    state_db = SonicV2Connector(host="127.0.0.1")
-    state_db.connect(state_db.STATE_DB)
+def get_route_flow_counter_capability(namespace=''):
+    if namespace != '':
+        if not SonicDBConfig.isGlobalInit():
+            SonicDBConfig.initializeGlobalConfig()
+    state_db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+    state_db.connect(state_db.STATE_DB, False)
 
     return state_db.get_all(state_db.STATE_DB, '{}|{}'.format(FLOW_COUNTER_CAPABILITY_TABLE, FLOW_COUNTER_CAPABILITY_KEY))
 
 
-def exit_if_route_flow_counter_not_support():
-    capabilities = get_route_flow_counter_capability()
+def exit_if_route_flow_counter_not_support(namespace=''):
+    capabilities = get_route_flow_counter_capability(namespace)
     if not capabilities:
         print('Waiting for swss to initialize route flow counter capability, please try again later')
         exit(1)

--- a/scripts/flow_counters_stat
+++ b/scripts/flow_counters_stat
@@ -575,7 +575,7 @@ Examples:
     if args.type == 'trap':
         stats = FlowCounterStats(args)
     elif args.type == 'route':
-        exit_if_route_flow_counter_not_support()
+        exit_if_route_flow_counter_not_support(args.namespace)
         stats = RouteFlowCounterStats(args)
     else:
         print('Invalid flow counter type: {}'.format(args.type))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix for https://github.com/sonic-net/sonic-buildimage/issues/27680 to address the wrong error message.  The test case should be updated since the  Route flow counter feature is not supported by BCM DNX platforms.
Added multi-asic support for Route flow counter cli command 
#### How I did it
Modified the Route flow counter cli code to check the capability in the respective namespace instead of checking in global name space's STATE_DB
#### How to verify it
Verified counterpoll flowcnt_route [-n namespace]  enable/disable commands in asic namespaces and also global name spaces.
#### Previous command output (if the output of a command-line utility has changed)
Waiting for swss to initialize route flow counter capability, please try again later
#### New command output (if the output of a command-line utility has changed)
The following  message is printed if the Route flow counter capability is not supported. It was existing message
Route flow counter is not supported on this platform
