### PR TITLE
[route_check]: Add truncation indicator and mismatch summary counts

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -1019,7 +1019,8 @@ def check_routes(namespace):
                 return -1, results
 
     if results:
-        print_message(syslog.LOG_WARNING, "Route mismatch counts: ", json.dumps(summarize_results(results), separators=(",", ":")))
+        print_message(syslog.LOG_WARNING, "Route mismatch counts: ",
+                     json.dumps(summarize_results(results), separators=(",", ":")))
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
         print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
         print_message(syslog.LOG_WARNING, "add: ", json.dumps(all_adds, indent=4))
@@ -1090,7 +1091,8 @@ def check_sids(namespace):
                 return -1, results
 
     if results:
-        print_message(syslog.LOG_WARNING, "SID mismatch counts: ", json.dumps(summarize_results(results), separators=(",", ":")))
+        print_message(syslog.LOG_WARNING, "SID mismatch counts: ",
+                     json.dumps(summarize_results(results), separators=(",", ":")))
         print_message(syslog.LOG_WARNING, "SIDs Check Failure results: {",  json.dumps(results, indent=4), "}")
         return -1, results
     else:

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -1020,7 +1020,7 @@ def check_routes(namespace):
 
     if results:
         print_message(syslog.LOG_WARNING, "Route mismatch counts: ",
-                     json.dumps(summarize_results(results), separators=(",", ":")))
+                      json.dumps(summarize_results(results), separators=(",", ":")))
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
         print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
         print_message(syslog.LOG_WARNING, "add: ", json.dumps(all_adds, indent=4))
@@ -1092,7 +1092,7 @@ def check_sids(namespace):
 
     if results:
         print_message(syslog.LOG_WARNING, "SID mismatch counts: ",
-                     json.dumps(summarize_results(results), separators=(",", ":")))
+                      json.dumps(summarize_results(results), separators=(",", ":")))
         print_message(syslog.LOG_WARNING, "SIDs Check Failure results: {",  json.dumps(results, indent=4), "}")
         return -1, results
     else:

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -76,6 +76,7 @@ MIN_SCAN_INTERVAL = 10      # Every 10 seconds
 MAX_SCAN_INTERVAL = 3600    # An hour
 
 PRINT_MSG_LEN_MAX = 1000
+PRINT_MSG_TRUNCATION_SUFFIX = " ... (truncated)"
 
 FRR_CHECK_RETRIES = 3
 FRR_WAIT_TIME = 15
@@ -129,15 +130,23 @@ def print_message(lvl, *args, write_to_stdout=True):
     :param lvl: Log level for this message as ERR/INFO/DEBUG
     :param args: message as list of strings or convertible to string
     :param write_to_stdout: print the message to stdout if set to true
-    :return None
+    :return msg string (may be truncated)
     """
     msg = ""
+    truncated = False
     if (lvl <= report_level):
         for arg in args:
             rem_len = PRINT_MSG_LEN_MAX - len(msg)
             if rem_len <= 0:
+                truncated = True
                 break
-            msg += str(arg)[0:rem_len]
+            s = str(arg)
+            if len(s) > rem_len:
+                truncated = True
+            msg += s[0:rem_len]
+
+        if truncated and PRINT_MSG_LEN_MAX > len(PRINT_MSG_TRUNCATION_SUFFIX):
+            msg = msg[:PRINT_MSG_LEN_MAX - len(PRINT_MSG_TRUNCATION_SUFFIX)] + PRINT_MSG_TRUNCATION_SUFFIX
 
         if write_to_stdout:
             print(msg)
@@ -966,6 +975,16 @@ def check_routes_for_namespace(namespace):
     return results, adds, deletes
 
 
+def summarize_results(results):
+    """
+    Summarize mismatch results by counting entries per namespace/category.
+    :param results: dict of {namespace: {category: [entries]}}
+    :return dict of {namespace: {category: count}}
+    """
+    return {ns: {k: len(v) for k, v in entries.items()}
+            for ns, entries in results.items()}
+
+
 def check_routes(namespace):
     """
     Main function to parallelize route checks across all namespaces.
@@ -1000,6 +1019,7 @@ def check_routes(namespace):
                 return -1, results
 
     if results:
+        print_message(syslog.LOG_WARNING, "Route mismatch counts: ", json.dumps(summarize_results(results), separators=(",", ":")))
         print_message(syslog.LOG_WARNING, "Failure results: {",  json.dumps(results, indent=4), "}")
         print_message(syslog.LOG_WARNING, "Failed. Look at reported mismatches above")
         print_message(syslog.LOG_WARNING, "add: ", json.dumps(all_adds, indent=4))
@@ -1070,6 +1090,7 @@ def check_sids(namespace):
                 return -1, results
 
     if results:
+        print_message(syslog.LOG_WARNING, "SID mismatch counts: ", json.dumps(summarize_results(results), separators=(",", ":")))
         print_message(syslog.LOG_WARNING, "SIDs Check Failure results: {",  json.dumps(results, indent=4), "}")
         return -1, results
     else:

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -340,6 +340,24 @@ class TestRouteCheck(object):
         msg = route_check.print_message(syslog.LOG_ERR, "a", "b", "c", "d", "e", "f")
         assert len(msg) == 5
 
+    def test_logging_truncation_indicator(self):
+        # Test truncation indicator with realistic PRINT_MSG_LEN_MAX
+        route_check.PRINT_MSG_LEN_MAX = 50
+        msg = route_check.print_message(syslog.LOG_ERR, "x" * 100)
+        assert len(msg) == 50
+        assert msg.endswith(" ... (truncated)")
+
+        # Short message should not have truncation indicator
+        msg = route_check.print_message(syslog.LOG_ERR, "short")
+        assert msg == "short"
+        assert " ... (truncated)" not in msg
+
+        # When PRINT_MSG_LEN_MAX is smaller than suffix, no suffix appended
+        route_check.PRINT_MSG_LEN_MAX = 5
+        msg = route_check.print_message(syslog.LOG_ERR, "abcdefghi")
+        assert len(msg) == 5
+        assert " ... (truncated)" not in msg
+
     def test_mitigate_routes(self, mock_dbs):
         namespace = DEFAULTNS
         missed_frr_rt = [{'prefix': '192.168.0.1', 'protocol': 'bgp'}]


### PR DESCRIPTION
#### What I did

Fix https://github.com/sonic-net/sonic-buildimage/issues/27509

Added a truncation indicator and mismatch summary counts to `route_check.py` failure output.

When `print_message()` truncates output at `PRINT_MSG_LEN_MAX` (1000 chars), it now appends `... (truncated)` within the length budget so operators know data was omitted. Additionally, a compact per-namespace mismatch count summary line is emitted before the detailed (potentially truncated) JSON dump.

#### How I did it
* Add `PRINT_MSG_TRUNCATION_SUFFIX` module-level constant and truncation marker logic in `print_message()` that keeps total length ≤ `PRINT_MSG_LEN_MAX`
* Extract `summarize_results()` helper to produce `{namespace: {category: count}}` dict
* Emit compact summary via `json.dumps(..., separators=(",",":"))` before the detailed failure results in both `check_routes()` and `check_sids()`

#### How to verify it
1. Run existing `test_logging` — confirms backward compatibility (all length assertions pass unchanged)
2. Run new `test_logging_truncation_indicator` — confirms truncation suffix behavior at realistic `PRINT_MSG_LEN_MAX=50`, short message passthrough, and edge case where max < suffix length
3. Manually: inject 200+ route mismatches on a VS image, run `route_check.py -l INFO`, verify summary count line appears and truncated output ends with `... (truncated)`

#### Previous command output (if the output of a command-line utility has changed)
```
Failure results: {
    "": {
        "missed_ROUTE_TABLE_routes": [
            "2001:db8:1001::/64",
            "2001:db8:1002::/64",
            "2001:db8:10
Failed. Look at reported mismatches above
```

#### New command output (if the output of a command-line utility has changed)
```
Route mismatch counts: {"":{"missed_ROUTE_TABLE_routes":47,"missed_INTF_TABLE_entries":2}}
Failure results: {
    "": {
        "missed_ROUTE_TABLE_routes": [
            "2001:db8:1001::/64",
            "2001:db8:1002::/64",
            "2001:db8:10 ... (truncated)
Failed. Look at reported mismatches above
```