### PR TITLE
FIX for Issue 4579: PFC config CLI errors out

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -84,7 +84,7 @@ class Pfc(object):
 
         """Current lossless priorities on the interface"""
         entry = self.config_db.get_entry('PORT_QOS_MAP', interface)
-        enable_prio = entry.get('pfc_enable').split(',')
+        enable_prio = entry.get('pfc_enable', '').split(',')
 
         """Avoid '' in enable_prio"""
         enable_prio = [x.strip() for x in enable_prio if x.strip()]


### PR DESCRIPTION
Fix for https://github.com/sonic-net/sonic-utilities/issues/4579

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`enable_prio = entry.get('pfc_enable').split(',')`
update to
`enable_prio = entry.get('pfc_enable', '').split(',')`
#### How I did it
entry.get('pfc_enable', '') returns an empty string as the default. 
Splitting an empty string gives [''], and the filter on next line (if x.strip()) already strips that out, leaving enable_prio as an empty list 
#### How to verify it
```
admin@sonic:~$ sudo config interface pfc priority Ethernet24 3 on
Traceback (most recent call last):
  File "/usr/local/bin/pfc", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pfc/main.py", line 177, in configPrio
    Pfc(namespace).configPfcPrio(status, interface, priority)
  File "/usr/local/lib/python3.11/dist-packages/utilities_common/multi_asic.py", line 156, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
  File "/usr/local/lib/python3.11/dist-packages/pfc/main.py", line 87, in configPfcPrio
    enable_prio = entry.get('pfc_enable').split(',')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
admin@sonic:~$ sudo vi /usr/local/lib/python3.11/dist-packages/pfc/main.py
admin@sonic:~$ sudo config interface pfc priority Ethernet24 3 on
admin@sonic:~$



```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

