### PR TITLE
SFPUtil Loopback: Assume zero subport value when subport is not present in port config

### DIFF
--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -1360,6 +1360,13 @@ class TestMultiAsicSFP(object):
         result = get_subport("Ethernet0")
         assert result == 2
 
+        # A missing (None) or empty subport defaults to subport 0 instead of crashing
+        mock_get_value_from_db_by_field.return_value = None
+        assert get_subport("Ethernet0") == 0
+
+        mock_get_value_from_db_by_field.return_value = ''
+        assert get_subport("Ethernet0") == 0
+
     @patch('utilities_common.platform_sfputil_helper.SonicV2Connector')
     @patch('utilities_common.platform_sfputil_helper.ConfigDBConnector')
     @patch('utilities_common.platform_sfputil_helper.multi_asic.get_namespace_for_port', return_value='asic0')

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -1985,20 +1985,17 @@ EEPROM hexdump for port Ethernet4
         assert result.output == 'Ethernet0: Set loopback mode failed. Parameter is not supported\n'
         assert result.exit_code == EXIT_FAIL
 
+        # When the subport field cannot be read from CONFIG_DB, loopback should
+        # assume subport 0 and proceed instead of crashing.
+        mock_api.set_loopback_mode.side_effect = None
+        mock_api.set_loopback_mode.return_value = True
         mock_config_db = MagicMock()
         mock_config_db.get.side_effect = TypeError
         mock_config_db_connector.return_value = mock_config_db
         result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
                                ["Ethernet0", "media-side-input", "enable"])
-        assert result.output == 'Error: \nEthernet0: subport is not present in CONFIG_DB\n'
-        assert result.exit_code == EXIT_FAIL
-
-
-        mock_sonic_v2_connector.return_value = None
-        result = runner.invoke(sfputil.cli.commands['debug'].commands['loopback'],
-                               ["Ethernet0", "media-side-input", "enable"])
-        assert result.output == 'Error: \nEthernet0: subport is not present in CONFIG_DB\n'
-        assert result.exit_code == EXIT_FAIL
+        assert result.output == 'Error: \nEthernet0: enable media-side-input loopback\n'
+        assert result.exit_code == 0
 
     @pytest.mark.parametrize(
         "direction, lane_count, enable, disable_func_result, cmis_version, output_dict, expected_echo, expected_exit",

--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -279,10 +279,10 @@ def get_first_subport(logical_port):
 def get_subport(port_name):
     subport = get_value_from_db_by_field("CONFIG_DB", "PORT", "subport", port_name)
 
-    if subport is None:
-        click.echo(f"{port_name}: subport is not present in CONFIG_DB")
-        sys.exit(EXIT_FAIL)
-    elif subport == '':
+    # An absent or empty subport means the port is not breakout/split, so it
+    # occupies all lanes as subport 0. Default to 0 instead of bailing out so a
+    # missing subport does not crash loopback/output diagnostics.
+    if subport is None or subport == '':
         subport = 0
 
     return int(subport)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

I removed the crash for sfputil when subport is missing. When missing, we should assume all lanes are used and subport should be set to zero

#### How I did it

By logging the missing subport entry instead and setting it to zero

#### How to verify it

sfputil debug loopback should now work even if the subport number is omitted

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

