### PR TITLE
Add missing gcu topo mapping for Arista-7260CX3-Q44

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -28,7 +28,7 @@
             },
             "broadcom_asics": {
                 "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010" ],
-                "th2": [ "Arista-7260CX3-D108C10", "Arista-7260CX3-D108C8",  "Arista-7260CX3-C64", "Arista-7260CX3-Q64" ],
+                "th2": [ "Arista-7260CX3-D108C10", "Arista-7260CX3-D108C8",  "Arista-7260CX3-C64", "Arista-7260CX3-Q44", "Arista-7260CX3-Q64" ],
                 "th3": [ "Nokia-IXR7220-H3" ],
                 "th4": [ "Nokia-IXR7220-H4-64D", "Nokia-IXR7220-H4-32D" ],
                 "th5": [ "Nokia-IXR7220-H5-64D", "Arista-7060X6-64DE", "Arista-7060X6-64PE", "Arista-7060X6-64PE-C224O8", "Arista-7060X6-64PE-C256S2", "Nokia-IXR7220-H5-64O", "Nokia-IXR7220-H5-32D",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
`generic_config_updater/*` `sonic-mgmt` tests need topo-asic definitions to work properly. The definition for the topo `Arista-7260CX3-Q44` is missing.

Adding the mapping for `Arista-7260CX3-Q44`.
*Needs backport to 202511 and 202605*.

#### How I did it
Adding the HwSKU entry `Arista-7260CX3-Q44` to `generic_config_updater/gcu_field_operation_validators.conf.json`.

#### How to verify it
generic_config_updater/test_pfcwd_status.py no longer fails on 202511.

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

202605 testing pass Kusto ID: 2635c5d8-21df-47c3-b183-034846021f01
Image versoin: Arista internal build on Aug 11, 2026



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

