### PR TITLE
Add reusable disk-space validation helper for image installation and reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -189,6 +189,25 @@ function reboot_pre_check()
     fi
 }
 
+
+function check_local_reboot_disk_space()
+{
+    python3 - "$PLATFORM_JSON_PATH" <<'PYCODE'
+import sys
+
+from utilities_common.image_disk_space import (
+    check_local_reboot_free_disk_space,
+)
+
+platform_json_path = sys.argv[1] or None
+
+result = check_local_reboot_free_disk_space(
+    platform_json_path=platform_json_path,
+)
+sys.exit(0 if result else 1)
+PYCODE
+}
+
 function check_conflict_boot_in_fw_update()
 {
     # Make sure firmware auto update is not scheduled for a different reboot
@@ -286,6 +305,16 @@ if [[ "$EUID" -ne 0 ]]; then
 fi
 
 debug "User requested rebooting device ..."
+
+# Validate local disk space before beginning reboot side effects.
+# The remote DPU path is validated separately by reboot_smartswitch_helper.
+if [[ "$REBOOT_DPU" == "no" && "$PRE_SHUTDOWN" == "no" ]]; then
+    check_local_reboot_disk_space
+    if [ $? -ne 0 ]; then
+        VERBOSE=yes debug "Reboot aborted due to insufficient free disk space"
+        exit ${EXIT_ERROR}
+    fi
+fi
 
 # SmartSwitch NPU only: close the DHCP gate so DPUs that come back up during
 # the NPU reboot window cannot acquire midplane IPs and therefore cannot bring

--- a/scripts/reboot_smartswitch_helper
+++ b/scripts/reboot_smartswitch_helper
@@ -157,6 +157,31 @@ function get_module_state_transition_flag()
     fi
 }
 
+
+# Validate target DPU disk space before reboot.
+# A missing platform threshold is a no-op for backward compatibility.
+function check_dpu_reboot_disk_space()
+{
+    local DPU_NAME=$1
+
+    python3 - "$DPU_NAME" "$PLATFORM_JSON_PATH" <<'PYCODE'
+import sys
+
+from utilities_common.image_disk_space import (
+    check_remote_dpu_reboot_free_disk_space,
+)
+
+dpu_name = sys.argv[1]
+platform_json_path = sys.argv[2] or None
+
+result = check_remote_dpu_reboot_free_disk_space(
+    dpu_name=dpu_name,
+    platform_json_path=platform_json_path,
+)
+sys.exit(0 if result else 1)
+PYCODE
+}
+
 # Function to reboot DPU
 function reboot_dpu_platform()
 {
@@ -277,6 +302,12 @@ function reboot_dpu()
         return ${EXIT_DPU_DOWN}
     fi
 
+    check_dpu_reboot_disk_space "${DPU_NAME}"
+    if [ $? -ne 0 ]; then
+        log_message "ERROR: ${DPU_NAME} reboot aborted due to insufficient free disk space"
+        return ${EXIT_ERROR}
+    fi
+
     if [[ "$REBOOT_TYPE" != $MODULE_REBOOT_SMARTSWITCH ]]; then
         # get and set the state_transition_in_progress flag before reboot
         if ! get_module_state_transition_flag "${DPU_NAME}"; then
@@ -355,11 +386,14 @@ function reboot_all_dpus() {
         pids+=("$!")
     done
     local pid
+
+    # Wait on each PID individually so we can capture its exit status.
     for pid in "${pids[@]}"; do
         if ! wait "$pid"; then
             ((failures++))
         fi
     done
+
     return $failures
 }
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -6,6 +6,9 @@ import subprocess
 import sys
 import time
 import utilities_common.cli as clicommon
+from utilities_common.image_disk_space import (
+    check_image_install_free_disk_space,
+)
 from urllib.request import urlopen, urlretrieve
 
 import click
@@ -587,6 +590,16 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
             echo_and_log('Error: Failed to set image as default', LOG_ERR)
             raise click.Abort()
     else:
+        # Validate that enough disk space is available before modifying the
+        # installed image state. The helper automatically applies the NPU or
+        # DPU threshold based on the system on which this command is running.
+        if not check_image_install_free_disk_space():
+            echo_and_log(
+                "Insufficient free disk space to install the image. Aborting...",
+                LOG_ERR,
+            )
+            raise click.Abort()
+
         # Verify not installing non-secure image in a secure running image
         if not force and not bootloader.verify_secureboot_image(image_path):
             echo_and_log("Image file '{}' is of a different type than running image.\n".format(url) +

--- a/tests/image_disk_space_reboot_test.py
+++ b/tests/image_disk_space_reboot_test.py
@@ -1,0 +1,256 @@
+# tests/image_disk_space_reboot_test.py
+
+import json
+
+import pytest
+
+from utilities_common import image_disk_space
+
+
+GB = 1024 * 1024 * 1024
+
+
+def write_platform_json(tmp_path, data):
+    path = tmp_path / "platform.json"
+    path.write_text(json.dumps(data))
+    return str(path)
+
+
+@pytest.mark.parametrize(
+    "device_type,key,value",
+    [
+        (
+            image_disk_space.IMAGE_TYPE_SWITCH,
+            image_disk_space.SWITCH_MIN_FREE_DISK_REBOOT_KEY,
+            4,
+        ),
+        (
+            image_disk_space.IMAGE_TYPE_DPU,
+            image_disk_space.DPU_MIN_FREE_DISK_REBOOT_KEY,
+            5,
+        ),
+    ],
+)
+def test_get_reboot_threshold(tmp_path, device_type, key, value):
+    path = write_platform_json(tmp_path, {key: value})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb_for_reboot(
+            device_type,
+            path,
+        )
+        == value
+    )
+
+
+@pytest.mark.parametrize(
+    "device_type",
+    [
+        image_disk_space.IMAGE_TYPE_SWITCH,
+        image_disk_space.IMAGE_TYPE_DPU,
+    ],
+)
+def test_missing_reboot_threshold_disables_check(tmp_path, device_type):
+    path = write_platform_json(tmp_path, {})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb_for_reboot(
+            device_type,
+            path,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("value", [0, -1, "bad", None])
+def test_invalid_reboot_threshold_fails_closed(tmp_path, value):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.SWITCH_MIN_FREE_DISK_REBOOT_KEY: value,
+        },
+    )
+
+    with pytest.raises(ValueError):
+        image_disk_space.get_min_free_disk_in_gb_for_reboot(
+            image_disk_space.IMAGE_TYPE_SWITCH,
+            path,
+        )
+
+
+@pytest.mark.parametrize(
+    "available_gb,expected",
+    [
+        (8, True),
+        (3, False),
+        (None, False),
+    ],
+)
+def test_check_local_reboot_free_disk_space(
+    monkeypatch,
+    tmp_path,
+    available_gb,
+    expected,
+):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.SWITCH_MIN_FREE_DISK_REBOOT_KEY: 4,
+        },
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        lambda disk_path: available_gb,
+    )
+
+    assert (
+        image_disk_space.check_local_reboot_free_disk_space(
+            device_type=image_disk_space.IMAGE_TYPE_SWITCH,
+            platform_json_path=path,
+        )
+        is expected
+    )
+
+
+def test_local_reboot_without_policy_is_noop(monkeypatch, tmp_path):
+    path = write_platform_json(tmp_path, {})
+    called = {"value": False}
+
+    def get_free_disk(_):
+        called["value"] = True
+        return 0
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        get_free_disk,
+    )
+
+    assert image_disk_space.check_local_reboot_free_disk_space(
+        platform_json_path=path,
+    )
+    assert not called["value"]
+
+
+@pytest.mark.parametrize(
+    "available_bytes,expected",
+    [
+        (4 * GB, True),
+        (4 * GB - 1, False),
+        (None, False),
+    ],
+)
+def test_check_remote_dpu_reboot_free_disk_space(
+    monkeypatch,
+    tmp_path,
+    available_bytes,
+    expected,
+):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.DPU_MIN_FREE_DISK_REBOOT_KEY: 4,
+        },
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_bytes",
+        lambda *args, **kwargs: available_bytes,
+    )
+
+    assert (
+        image_disk_space.check_remote_dpu_reboot_free_disk_space(
+            "dpu0",
+            platform_json_path=path,
+        )
+        is expected
+    )
+
+
+def test_remote_dpu_reboot_without_policy_is_noop(
+    monkeypatch,
+    tmp_path,
+):
+    path = write_platform_json(tmp_path, {})
+    called = {"value": False}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+
+    def get_remote(*args, **kwargs):
+        called["value"] = True
+        return 0
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_bytes",
+        get_remote,
+    )
+
+    assert image_disk_space.check_remote_dpu_reboot_free_disk_space(
+        "dpu0",
+        platform_json_path=path,
+    )
+    assert not called["value"]
+
+
+def test_remote_dpu_reboot_rejected_on_dpu(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: True,
+    )
+
+    assert not image_disk_space.check_remote_dpu_reboot_free_disk_space(
+        "dpu0"
+    )
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("Avail\n4294967296", 4 * GB),
+        ("Avail\n4294967295", 4 * GB - 1),
+        ("Filesystem\n/dev/mmcblk0p10\nAvail\n32212254720", 30 * GB),
+    ],
+)
+def test_parse_df_available_bytes_success(output, expected):
+    assert image_disk_space._parse_df_available_bytes(output) == expected
+
+
+@pytest.mark.parametrize(
+    "output",
+    ["", "Avail", "Avail\nbad", "Avail\n-1", "Avail\n18.5"],
+)
+def test_parse_df_available_bytes_failure(output):
+    assert image_disk_space._parse_df_available_bytes(output) is None
+
+
+def test_get_remote_dpu_free_disk_in_bytes_command(monkeypatch):
+    captured = {}
+
+    def run_cmd(cmd):
+        captured["cmd"] = cmd
+        return 0, "Avail\n4294967296"
+
+    monkeypatch.setattr(image_disk_space, "_run_cmd", run_cmd)
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_bytes(
+            "dpu0",
+            disk_path="/host",
+            ssh_options=["-o", "BatchMode=yes"],
+        )
+        == 4 * GB
+    )
+    assert "-B1" in captured["cmd"]
+    assert "--output=avail" in captured["cmd"]

--- a/tests/image_disk_space_reboot_test.py
+++ b/tests/image_disk_space_reboot_test.py
@@ -63,7 +63,11 @@ def test_missing_reboot_threshold_disables_check(tmp_path, device_type):
 
 
 @pytest.mark.parametrize("value", [0, -1, "bad", None])
-def test_invalid_reboot_threshold_fails_closed(tmp_path, value):
+def test_invalid_reboot_threshold_skips_check(
+    tmp_path,
+    caplog,
+    value,
+):
     path = write_platform_json(
         tmp_path,
         {
@@ -71,11 +75,14 @@ def test_invalid_reboot_threshold_fails_closed(tmp_path, value):
         },
     )
 
-    with pytest.raises(ValueError):
+    assert (
         image_disk_space.get_min_free_disk_in_gb_for_reboot(
             image_disk_space.IMAGE_TYPE_SWITCH,
             path,
         )
+        is None
+    )
+    assert "skipping the disk-space check" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/image_disk_space_test.py
+++ b/tests/image_disk_space_test.py
@@ -385,111 +385,6 @@ def test_run_cmd_os_error(monkeypatch):
     assert output == "command unavailable"
 
 
-@pytest.mark.parametrize(
-    "output,expected",
-    [
-        ("Avail\n18G", 18),
-        ("Avail\n18", 18),
-        ("Available\n  25G\n", 25),
-        ("Filesystem\n/dev/sda1\nAvail\n30G", 30),
-    ],
-)
-def test_parse_df_available_gb_success(output, expected):
-    assert image_disk_space._parse_df_available_gb(output) == expected
-
-
-@pytest.mark.parametrize(
-    "output",
-    [
-        "",
-        "Avail",
-        "Avail\nbad",
-        "Avail\n18GB",
-        "Avail\n18.5G",
-    ],
-)
-def test_parse_df_available_gb_failure(output):
-    assert image_disk_space._parse_df_available_gb(output) is None
-
-
-def test_get_remote_dpu_free_disk_in_gb_success(monkeypatch):
-    monkeypatch.setattr(
-        image_disk_space,
-        "_run_cmd",
-        lambda cmd: (0, "Avail\n18G"),
-    )
-
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
-        == 18
-    )
-
-
-def test_get_remote_dpu_free_disk_in_gb_custom_ssh_options(
-    monkeypatch,
-):
-    captured = {}
-
-    def fake_run_cmd(cmd):
-        captured["cmd"] = cmd
-        return 0, "Avail\n18G"
-
-    monkeypatch.setattr(
-        image_disk_space,
-        "_run_cmd",
-        fake_run_cmd,
-    )
-
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb(
-            "DPU0",
-            ssh_options=["-o", "ConnectTimeout=3"],
-        )
-        == 18
-    )
-    assert captured["cmd"] == [
-        "ssh",
-        "-o",
-        "ConnectTimeout=3",
-        "DPU0",
-        "df",
-        "-BG",
-        "--output=avail",
-        "/host",
-    ]
-
-
-def test_get_remote_dpu_free_disk_in_gb_command_failure(
-    monkeypatch,
-):
-    monkeypatch.setattr(
-        image_disk_space,
-        "_run_cmd",
-        lambda cmd: (1, "ssh failed"),
-    )
-
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
-        is None
-    )
-
-
-@pytest.mark.parametrize("output", ["", "Avail\nbad"])
-def test_get_remote_dpu_free_disk_in_gb_parse_failure(
-    monkeypatch, output
-):
-    monkeypatch.setattr(
-        image_disk_space,
-        "_run_cmd",
-        lambda cmd: (0, output),
-    )
-
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
-        is None
-    )
-
-
 def test_remote_dpu_check_rejected_when_running_on_dpu(
     monkeypatch,
 ):
@@ -530,8 +425,8 @@ def test_remote_dpu_check_single_success(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         image_disk_space,
-        "get_remote_dpu_free_disk_in_gb",
-        lambda dpu_name, disk_path, ssh_options=None: 20,
+        "get_remote_dpu_free_disk_in_bytes",
+        lambda dpu_name, disk_path, ssh_options=None: 20 * GB,
     )
 
     assert (
@@ -550,9 +445,9 @@ def test_remote_dpu_check_multi_success(monkeypatch, tmp_path):
         {image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12},
     )
     free_space = {
-        "DPU0": 20,
-        "DPU1": 18,
-        "DPU2": 16,
+        "DPU0": 20 * GB,
+        "DPU1": 18 * GB,
+        "DPU2": 16 * GB,
     }
     monkeypatch.setattr(
         image_disk_space,
@@ -561,7 +456,7 @@ def test_remote_dpu_check_multi_success(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         image_disk_space,
-        "get_remote_dpu_free_disk_in_gb",
+        "get_remote_dpu_free_disk_in_bytes",
         lambda dpu_name, disk_path, ssh_options=None: (
             free_space[dpu_name]
         ),
@@ -577,9 +472,16 @@ def test_remote_dpu_check_multi_success(monkeypatch, tmp_path):
     )
 
 
-@pytest.mark.parametrize("available_gb", [8, None])
-def test_remote_dpu_check_failure(
-    monkeypatch, tmp_path, available_gb
+@pytest.mark.parametrize(
+    "available_bytes,expected",
+    [
+        (12 * GB, True),
+        (12 * GB - 1, False),
+        (None, False),
+    ],
+)
+def test_remote_dpu_check_boundary(
+    monkeypatch, tmp_path, available_bytes, expected
 ):
     path = write_platform_json(
         tmp_path,
@@ -592,17 +494,18 @@ def test_remote_dpu_check_failure(
     )
     monkeypatch.setattr(
         image_disk_space,
-        "get_remote_dpu_free_disk_in_gb",
-        lambda dpu_name, disk_path, ssh_options=None: available_gb,
+        "get_remote_dpu_free_disk_in_bytes",
+        lambda dpu_name, disk_path, ssh_options=None: available_bytes,
     )
 
-    assert not (
+    assert (
         image_disk_space
         .check_remote_dpu_image_install_free_disk_space(
             ["DPU0"],
             disk_path="/host",
             platform_json_path=path,
         )
+        is expected
     )
 
 
@@ -614,9 +517,9 @@ def test_remote_dpu_check_mixed_results_fail(
         {image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12},
     )
     free_space = {
-        "DPU0": 20,
-        "DPU1": 8,
-        "DPU2": 18,
+        "DPU0": 20 * GB,
+        "DPU1": 8 * GB,
+        "DPU2": 18 * GB,
     }
     monkeypatch.setattr(
         image_disk_space,
@@ -625,7 +528,7 @@ def test_remote_dpu_check_mixed_results_fail(
     )
     monkeypatch.setattr(
         image_disk_space,
-        "get_remote_dpu_free_disk_in_gb",
+        "get_remote_dpu_free_disk_in_bytes",
         lambda dpu_name, disk_path, ssh_options=None: (
             free_space[dpu_name]
         ),
@@ -657,9 +560,9 @@ def test_remote_dpu_check_stops_on_first_failure(
     ):
         checked_dpus.append(dpu_name)
         return {
-            "DPU0": 20,
-            "DPU1": 8,
-            "DPU2": 20,
+            "DPU0": 20 * GB,
+            "DPU1": 8 * GB,
+            "DPU2": 20 * GB,
         }[dpu_name]
 
     monkeypatch.setattr(
@@ -669,7 +572,7 @@ def test_remote_dpu_check_stops_on_first_failure(
     )
     monkeypatch.setattr(
         image_disk_space,
-        "get_remote_dpu_free_disk_in_gb",
+        "get_remote_dpu_free_disk_in_bytes",
         fake_get_remote_disk,
     )
 

--- a/tests/image_disk_space_test.py
+++ b/tests/image_disk_space_test.py
@@ -1,0 +1,789 @@
+# tests/image_disk_space_test.py
+
+import json
+import subprocess
+
+import pytest
+
+from utilities_common import image_disk_space
+
+
+GB = 1024 * 1024 * 1024
+
+
+def write_platform_json(tmp_path, data):
+    """Write platform data to a temporary platform.json file."""
+    path = tmp_path / "platform.json"
+    path.write_text(json.dumps(data))
+    return str(path)
+
+
+@pytest.mark.parametrize(
+    "image_type,key,value",
+    [
+        (
+            image_disk_space.IMAGE_TYPE_NPU,
+            image_disk_space.NPU_MIN_FREE_DISK_KEY,
+            16,
+        ),
+        (
+            image_disk_space.IMAGE_TYPE_DPU,
+            image_disk_space.DPU_MIN_FREE_DISK_KEY,
+            14,
+        ),
+    ],
+)
+def test_get_min_free_disk_from_platform_json(
+    tmp_path, image_type, key, value
+):
+    path = write_platform_json(tmp_path, {key: value})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb_for_image(
+            image_type,
+            platform_json_path=path,
+        )
+        == value
+    )
+
+
+@pytest.mark.parametrize(
+    "image_type,default_value",
+    [
+        (
+            image_disk_space.IMAGE_TYPE_NPU,
+            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE,
+        ),
+        (
+            image_disk_space.IMAGE_TYPE_DPU,
+            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE,
+        ),
+    ],
+)
+def test_get_min_free_disk_missing_key_uses_default(
+    tmp_path, image_type, default_value
+):
+    path = write_platform_json(tmp_path, {})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb_for_image(
+            image_type,
+            platform_json_path=path,
+        )
+        == default_value
+    )
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, "bad", None])
+@pytest.mark.parametrize(
+    "image_type,key,default_value",
+    [
+        (
+            image_disk_space.IMAGE_TYPE_NPU,
+            image_disk_space.NPU_MIN_FREE_DISK_KEY,
+            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE,
+        ),
+        (
+            image_disk_space.IMAGE_TYPE_DPU,
+            image_disk_space.DPU_MIN_FREE_DISK_KEY,
+            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE,
+        ),
+    ],
+)
+def test_invalid_platform_json_value_uses_default(
+    tmp_path,
+    bad_value,
+    image_type,
+    key,
+    default_value,
+):
+    path = write_platform_json(tmp_path, {key: bad_value})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb_for_image(
+            image_type,
+            platform_json_path=path,
+        )
+        == default_value
+    )
+
+
+def test_missing_platform_json_uses_default():
+    assert (
+        image_disk_space.get_min_free_disk_in_gb_for_image(
+            image_disk_space.IMAGE_TYPE_NPU,
+            platform_json_path="/bad/path/platform.json",
+        )
+        == image_disk_space.MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE
+    )
+
+
+def test_invalid_platform_json_uses_default(tmp_path):
+    path = tmp_path / "platform.json"
+    path.write_text("{invalid-json")
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb_for_image(
+            image_disk_space.IMAGE_TYPE_DPU,
+            platform_json_path=str(path),
+        )
+        == image_disk_space.MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE
+    )
+
+
+def test_get_min_free_disk_invalid_image_type():
+    with pytest.raises(ValueError):
+        image_disk_space.get_min_free_disk_in_gb_for_image("invalid")
+
+
+def test_get_free_disk_in_gb_success(monkeypatch):
+    class Usage:
+        free = 20 * GB
+
+    monkeypatch.setattr(
+        image_disk_space.os.path,
+        "exists",
+        lambda path: True,
+    )
+    monkeypatch.setattr(
+        image_disk_space.shutil,
+        "disk_usage",
+        lambda path: Usage,
+    )
+
+    assert image_disk_space.get_free_disk_in_gb("/host") == 20
+
+
+def test_get_free_disk_in_gb_missing_path(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space.os.path,
+        "exists",
+        lambda path: False,
+    )
+
+    assert image_disk_space.get_free_disk_in_gb("/missing") is None
+
+
+def test_get_free_disk_in_gb_disk_usage_failure(monkeypatch):
+    def raise_error(path):
+        raise OSError("disk usage failed")
+
+    monkeypatch.setattr(
+        image_disk_space.os.path,
+        "exists",
+        lambda path: True,
+    )
+    monkeypatch.setattr(
+        image_disk_space.shutil,
+        "disk_usage",
+        raise_error,
+    )
+
+    assert image_disk_space.get_free_disk_in_gb("/host") is None
+
+
+def test_is_running_on_dpu_true(monkeypatch):
+    class DeviceInfo:
+        @staticmethod
+        def is_dpu():
+            return True
+
+    monkeypatch.setattr(image_disk_space, "device_info", DeviceInfo)
+
+    assert image_disk_space.is_running_on_dpu()
+
+
+def test_is_running_on_dpu_false(monkeypatch):
+    class DeviceInfo:
+        @staticmethod
+        def is_dpu():
+            return False
+
+    monkeypatch.setattr(image_disk_space, "device_info", DeviceInfo)
+
+    assert not image_disk_space.is_running_on_dpu()
+
+
+def test_is_running_on_dpu_false_when_device_info_missing(monkeypatch):
+    monkeypatch.setattr(image_disk_space, "device_info", None)
+
+    assert not image_disk_space.is_running_on_dpu()
+
+
+def test_is_running_on_dpu_exception(monkeypatch):
+    class DeviceInfo:
+        @staticmethod
+        def is_dpu():
+            raise RuntimeError("failed")
+
+    monkeypatch.setattr(image_disk_space, "device_info", DeviceInfo)
+
+    assert not image_disk_space.is_running_on_dpu()
+
+
+@pytest.mark.parametrize(
+    "running_on_dpu,expected_type",
+    [
+        (False, image_disk_space.IMAGE_TYPE_NPU),
+        (True, image_disk_space.IMAGE_TYPE_DPU),
+    ],
+)
+def test_get_local_image_type(
+    monkeypatch, running_on_dpu, expected_type
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: running_on_dpu,
+    )
+
+    assert image_disk_space.get_local_image_type() == expected_type
+
+
+@pytest.mark.parametrize(
+    "image_type,available_gb,expected",
+    [
+        (image_disk_space.IMAGE_TYPE_NPU, 20, True),
+        (image_disk_space.IMAGE_TYPE_NPU, 8, False),
+        (image_disk_space.IMAGE_TYPE_DPU, 20, True),
+        (image_disk_space.IMAGE_TYPE_DPU, 8, False),
+        (image_disk_space.IMAGE_TYPE_DPU, None, False),
+    ],
+)
+def test_check_local_image_install_free_disk_space(
+    monkeypatch,
+    tmp_path,
+    image_type,
+    available_gb,
+    expected,
+):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.NPU_MIN_FREE_DISK_KEY: 12,
+            image_disk_space.DPU_MIN_FREE_DISK_KEY: 12,
+        },
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        lambda disk_path: available_gb,
+    )
+
+    result = image_disk_space.check_local_image_install_free_disk_space(
+        image_type=image_type,
+        disk_path="/host",
+        platform_json_path=path,
+    )
+
+    assert result is expected
+
+
+def test_check_local_image_install_free_disk_space_auto_detects_npu(
+    monkeypatch,
+):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_local_image_type",
+        lambda: image_disk_space.IMAGE_TYPE_NPU,
+    )
+
+    def fake_get_threshold(image_type, platform_json_path):
+        captured["image_type"] = image_type
+        return 12
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_min_free_disk_in_gb_for_image",
+        fake_get_threshold,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        lambda disk_path: 20,
+    )
+
+    assert image_disk_space.check_local_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_NPU
+
+
+def test_check_local_image_install_free_disk_space_auto_detects_dpu(
+    monkeypatch,
+):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_local_image_type",
+        lambda: image_disk_space.IMAGE_TYPE_DPU,
+    )
+
+    def fake_get_threshold(image_type, platform_json_path):
+        captured["image_type"] = image_type
+        return 12
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_min_free_disk_in_gb_for_image",
+        fake_get_threshold,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        lambda disk_path: 20,
+    )
+
+    assert image_disk_space.check_local_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_DPU
+
+
+def test_check_local_image_install_free_disk_space_invalid_type():
+    assert not image_disk_space.check_local_image_install_free_disk_space(
+        image_type="invalid"
+    )
+
+
+def test_run_cmd_success(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "Avail\n20G\n",
+    )
+
+    rc, output = image_disk_space._run_cmd(["dummy"])
+
+    assert rc == 0
+    assert output == "Avail\n20G"
+
+
+def test_run_cmd_called_process_failure(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            1,
+            "cmd",
+            output="error",
+        )
+
+    monkeypatch.setattr(
+        image_disk_space.subprocess,
+        "check_output",
+        raise_error,
+    )
+
+    rc, output = image_disk_space._run_cmd(["dummy"])
+
+    assert rc == 1
+    assert output == "error"
+
+
+def test_run_cmd_os_error(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise OSError("command unavailable")
+
+    monkeypatch.setattr(
+        image_disk_space.subprocess,
+        "check_output",
+        raise_error,
+    )
+
+    rc, output = image_disk_space._run_cmd(["dummy"])
+
+    assert rc == 1
+    assert output == "command unavailable"
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("Avail\n18G", 18),
+        ("Avail\n18", 18),
+        ("Available\n  25G\n", 25),
+        ("Filesystem\n/dev/sda1\nAvail\n30G", 30),
+    ],
+)
+def test_parse_df_available_gb_success(output, expected):
+    assert image_disk_space._parse_df_available_gb(output) == expected
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "",
+        "Avail",
+        "Avail\nbad",
+        "Avail\n18GB",
+        "Avail\n18.5G",
+    ],
+)
+def test_parse_df_available_gb_failure(output):
+    assert image_disk_space._parse_df_available_gb(output) is None
+
+
+def test_get_remote_dpu_free_disk_in_gb_success(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (0, "Avail\n18G"),
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
+        == 18
+    )
+
+
+def test_get_remote_dpu_free_disk_in_gb_custom_ssh_options(
+    monkeypatch,
+):
+    captured = {}
+
+    def fake_run_cmd(cmd):
+        captured["cmd"] = cmd
+        return 0, "Avail\n18G"
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        fake_run_cmd,
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb(
+            "DPU0",
+            ssh_options=["-o", "ConnectTimeout=3"],
+        )
+        == 18
+    )
+    assert captured["cmd"] == [
+        "ssh",
+        "-o",
+        "ConnectTimeout=3",
+        "DPU0",
+        "df",
+        "-BG",
+        "--output=avail",
+        "/host",
+    ]
+
+
+def test_get_remote_dpu_free_disk_in_gb_command_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (1, "ssh failed"),
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
+        is None
+    )
+
+
+@pytest.mark.parametrize("output", ["", "Avail\nbad"])
+def test_get_remote_dpu_free_disk_in_gb_parse_failure(
+    monkeypatch, output
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (0, output),
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
+        is None
+    )
+
+
+def test_remote_dpu_check_rejected_when_running_on_dpu(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: True,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space("DPU0")
+    )
+
+
+def test_remote_dpu_check_requires_name(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space([])
+    )
+
+
+def test_remote_dpu_check_single_success(monkeypatch, tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: 20,
+    )
+
+    assert (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            "DPU0",
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+def test_remote_dpu_check_multi_success(monkeypatch, tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+    )
+    free_space = {
+        "DPU0": 20,
+        "DPU1": 18,
+        "DPU2": 16,
+    }
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: (
+            free_space[dpu_name]
+        ),
+    )
+
+    assert (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0", "DPU1", "DPU2"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+@pytest.mark.parametrize("available_gb", [8, None])
+def test_remote_dpu_check_failure(
+    monkeypatch, tmp_path, available_gb
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: available_gb,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+def test_remote_dpu_check_mixed_results_fail(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+    )
+    free_space = {
+        "DPU0": 20,
+        "DPU1": 8,
+        "DPU2": 18,
+    }
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: (
+            free_space[dpu_name]
+        ),
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0", "DPU1", "DPU2"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+def test_remote_dpu_check_stops_on_first_failure(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+    )
+    checked_dpus = []
+
+    def fake_get_remote_disk(
+        dpu_name,
+        disk_path,
+        ssh_options=None,
+    ):
+        checked_dpus.append(dpu_name)
+        return {
+            "DPU0": 20,
+            "DPU1": 8,
+            "DPU2": 20,
+        }[dpu_name]
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        fake_get_remote_disk,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0", "DPU1", "DPU2"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+    assert checked_dpus == ["DPU0", "DPU1"]
+
+
+def test_smart_check_local_npu(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+
+    def fake_local_check(
+        image_type=None,
+        disk_path=image_disk_space.DEFAULT_DISK_PATH,
+        platform_json_path=None,
+    ):
+        captured["image_type"] = image_type
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "check_local_image_install_free_disk_space",
+        fake_local_check,
+    )
+
+    assert image_disk_space.check_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_NPU
+
+
+def test_smart_check_local_dpu(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: True,
+    )
+
+    def fake_local_check(
+        image_type=None,
+        disk_path=image_disk_space.DEFAULT_DISK_PATH,
+        platform_json_path=None,
+    ):
+        captured["image_type"] = image_type
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "check_local_image_install_free_disk_space",
+        fake_local_check,
+    )
+
+    assert image_disk_space.check_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_DPU
+
+
+def test_smart_check_remote_dpus_from_npu(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+
+    def fake_remote_check(
+        dpu_names,
+        disk_path=image_disk_space.DEFAULT_DISK_PATH,
+        platform_json_path=None,
+        ssh_options=None,
+    ):
+        captured["dpu_names"] = dpu_names
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "check_remote_dpu_image_install_free_disk_space",
+        fake_remote_check,
+    )
+
+    assert image_disk_space.check_image_install_free_disk_space(
+        dpu_names=["DPU0", "DPU1"]
+    )
+    assert captured["dpu_names"] == ["DPU0", "DPU1"]
+
+
+def test_smart_check_rejects_dpu_names_on_dpu(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: True,
+    )
+
+    assert not image_disk_space.check_image_install_free_disk_space(
+        dpu_names=["DPU0"]
+    )

--- a/tests/image_disk_space_test.py
+++ b/tests/image_disk_space_test.py
@@ -22,13 +22,13 @@ def write_platform_json(tmp_path, data):
     "image_type,key,value",
     [
         (
-            image_disk_space.IMAGE_TYPE_NPU,
-            image_disk_space.NPU_MIN_FREE_DISK_KEY,
+            image_disk_space.IMAGE_TYPE_SWITCH,
+            image_disk_space.SWITCH_MIN_FREE_DISK_IMAGE_KEY,
             16,
         ),
         (
             image_disk_space.IMAGE_TYPE_DPU,
-            image_disk_space.DPU_MIN_FREE_DISK_KEY,
+            image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY,
             14,
         ),
     ],
@@ -48,20 +48,14 @@ def test_get_min_free_disk_from_platform_json(
 
 
 @pytest.mark.parametrize(
-    "image_type,default_value",
+    "image_type",
     [
-        (
-            image_disk_space.IMAGE_TYPE_NPU,
-            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE,
-        ),
-        (
-            image_disk_space.IMAGE_TYPE_DPU,
-            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE,
-        ),
+        image_disk_space.IMAGE_TYPE_SWITCH,
+        image_disk_space.IMAGE_TYPE_DPU,
     ],
 )
-def test_get_min_free_disk_missing_key_uses_default(
-    tmp_path, image_type, default_value
+def test_get_min_free_disk_missing_key_returns_none(
+    tmp_path, image_type
 ):
     path = write_platform_json(tmp_path, {})
 
@@ -70,32 +64,29 @@ def test_get_min_free_disk_missing_key_uses_default(
             image_type,
             platform_json_path=path,
         )
-        == default_value
+        is None
     )
 
 
 @pytest.mark.parametrize("bad_value", [0, -1, "bad", None])
 @pytest.mark.parametrize(
-    "image_type,key,default_value",
+    "image_type,key",
     [
         (
-            image_disk_space.IMAGE_TYPE_NPU,
-            image_disk_space.NPU_MIN_FREE_DISK_KEY,
-            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE,
+            image_disk_space.IMAGE_TYPE_SWITCH,
+            image_disk_space.SWITCH_MIN_FREE_DISK_IMAGE_KEY,
         ),
         (
             image_disk_space.IMAGE_TYPE_DPU,
-            image_disk_space.DPU_MIN_FREE_DISK_KEY,
-            image_disk_space.MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE,
+            image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY,
         ),
     ],
 )
-def test_invalid_platform_json_value_uses_default(
+def test_invalid_platform_json_value_returns_none(
     tmp_path,
     bad_value,
     image_type,
     key,
-    default_value,
 ):
     path = write_platform_json(tmp_path, {key: bad_value})
 
@@ -104,21 +95,21 @@ def test_invalid_platform_json_value_uses_default(
             image_type,
             platform_json_path=path,
         )
-        == default_value
+        is None
     )
 
 
-def test_missing_platform_json_uses_default():
+def test_missing_platform_json_returns_none():
     assert (
         image_disk_space.get_min_free_disk_in_gb_for_image(
-            image_disk_space.IMAGE_TYPE_NPU,
+            image_disk_space.IMAGE_TYPE_SWITCH,
             platform_json_path="/bad/path/platform.json",
         )
-        == image_disk_space.MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE
+        is None
     )
 
 
-def test_invalid_platform_json_uses_default(tmp_path):
+def test_invalid_platform_json_returns_none(tmp_path):
     path = tmp_path / "platform.json"
     path.write_text("{invalid-json")
 
@@ -127,7 +118,7 @@ def test_invalid_platform_json_uses_default(tmp_path):
             image_disk_space.IMAGE_TYPE_DPU,
             platform_json_path=str(path),
         )
-        == image_disk_space.MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE
+        is None
     )
 
 
@@ -224,7 +215,7 @@ def test_is_running_on_dpu_exception(monkeypatch):
 @pytest.mark.parametrize(
     "running_on_dpu,expected_type",
     [
-        (False, image_disk_space.IMAGE_TYPE_NPU),
+        (False, image_disk_space.IMAGE_TYPE_SWITCH),
         (True, image_disk_space.IMAGE_TYPE_DPU),
     ],
 )
@@ -243,8 +234,8 @@ def test_get_local_image_type(
 @pytest.mark.parametrize(
     "image_type,available_gb,expected",
     [
-        (image_disk_space.IMAGE_TYPE_NPU, 20, True),
-        (image_disk_space.IMAGE_TYPE_NPU, 8, False),
+        (image_disk_space.IMAGE_TYPE_SWITCH, 20, True),
+        (image_disk_space.IMAGE_TYPE_SWITCH, 8, False),
         (image_disk_space.IMAGE_TYPE_DPU, 20, True),
         (image_disk_space.IMAGE_TYPE_DPU, 8, False),
         (image_disk_space.IMAGE_TYPE_DPU, None, False),
@@ -260,8 +251,8 @@ def test_check_local_image_install_free_disk_space(
     path = write_platform_json(
         tmp_path,
         {
-            image_disk_space.NPU_MIN_FREE_DISK_KEY: 12,
-            image_disk_space.DPU_MIN_FREE_DISK_KEY: 12,
+            image_disk_space.SWITCH_MIN_FREE_DISK_IMAGE_KEY: 12,
+            image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12,
         },
     )
     monkeypatch.setattr(
@@ -279,7 +270,7 @@ def test_check_local_image_install_free_disk_space(
     assert result is expected
 
 
-def test_check_local_image_install_free_disk_space_auto_detects_npu(
+def test_check_local_image_install_free_disk_space_auto_detects_switch(
     monkeypatch,
 ):
     captured = {}
@@ -287,7 +278,7 @@ def test_check_local_image_install_free_disk_space_auto_detects_npu(
     monkeypatch.setattr(
         image_disk_space,
         "get_local_image_type",
-        lambda: image_disk_space.IMAGE_TYPE_NPU,
+        lambda: image_disk_space.IMAGE_TYPE_SWITCH,
     )
 
     def fake_get_threshold(image_type, platform_json_path):
@@ -306,7 +297,7 @@ def test_check_local_image_install_free_disk_space_auto_detects_npu(
     )
 
     assert image_disk_space.check_local_image_install_free_disk_space()
-    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_NPU
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_SWITCH
 
 
 def test_check_local_image_install_free_disk_space_auto_detects_dpu(
@@ -530,7 +521,7 @@ def test_remote_dpu_check_requires_name(monkeypatch):
 def test_remote_dpu_check_single_success(monkeypatch, tmp_path):
     path = write_platform_json(
         tmp_path,
-        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+        {image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12},
     )
     monkeypatch.setattr(
         image_disk_space,
@@ -556,7 +547,7 @@ def test_remote_dpu_check_single_success(monkeypatch, tmp_path):
 def test_remote_dpu_check_multi_success(monkeypatch, tmp_path):
     path = write_platform_json(
         tmp_path,
-        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+        {image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12},
     )
     free_space = {
         "DPU0": 20,
@@ -592,7 +583,7 @@ def test_remote_dpu_check_failure(
 ):
     path = write_platform_json(
         tmp_path,
-        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+        {image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12},
     )
     monkeypatch.setattr(
         image_disk_space,
@@ -620,7 +611,7 @@ def test_remote_dpu_check_mixed_results_fail(
 ):
     path = write_platform_json(
         tmp_path,
-        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+        {image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12},
     )
     free_space = {
         "DPU0": 20,
@@ -655,7 +646,7 @@ def test_remote_dpu_check_stops_on_first_failure(
 ):
     path = write_platform_json(
         tmp_path,
-        {image_disk_space.DPU_MIN_FREE_DISK_KEY: 12},
+        {image_disk_space.DPU_MIN_FREE_DISK_IMAGE_KEY: 12},
     )
     checked_dpus = []
 
@@ -693,7 +684,7 @@ def test_remote_dpu_check_stops_on_first_failure(
     assert checked_dpus == ["DPU0", "DPU1"]
 
 
-def test_smart_check_local_npu(monkeypatch):
+def test_smart_check_local_switch(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(
@@ -717,7 +708,7 @@ def test_smart_check_local_npu(monkeypatch):
     )
 
     assert image_disk_space.check_image_install_free_disk_space()
-    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_NPU
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_SWITCH
 
 
 def test_smart_check_local_dpu(monkeypatch):
@@ -747,7 +738,7 @@ def test_smart_check_local_dpu(monkeypatch):
     assert captured["image_type"] == image_disk_space.IMAGE_TYPE_DPU
 
 
-def test_smart_check_remote_dpus_from_npu(monkeypatch):
+def test_smart_check_remote_dpus_from_switch(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -13,7 +13,7 @@ def test_run_command():
         output = sonic_installer_common.run_command([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert e.value.code == 6
 
-
+@patch("sonic_installer.main.check_image_install_free_disk_space", return_value=True)
 @pytest.mark.parametrize("resolv_conf_symlink_target", [
     "/run/resolvconf/resolv.conf",       # absolute symlink
     "../run/resolvconf/resolv.conf",     # relative symlink (resolvconf package default)
@@ -24,9 +24,16 @@ def test_run_command():
 @patch("sonic_installer.main.get_bootloader")
 @patch("sonic_installer.main.run_command_or_raise")
 @patch("sonic_installer.main.run_command")
-def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs, resolv_conf_symlink_target):
+def test_install(
+    run_command,
+    run_command_or_raise,
+    get_bootloader,
+    swap,
+    _,
+    fs,
+    resolv_conf_symlink_target,
+):
     """ This test covers the execution of "sonic-installer install" command. """
-
     sonic_image_filename = "sonic.bin"
     current_image_version = "image_1"
     new_image_version = "image_2"
@@ -180,12 +187,21 @@ def test_runtime_exception(mock_popen):
     assert all(v in str(sre.value) for v in ['test.sh', 'Running', 'Failed']), "Invalid message"
 
 
+@patch("sonic_installer.main.check_image_install_free_disk_space", return_value=True)
 @patch("sonic_installer.main.SWAPAllocator")
 @patch("sonic_installer.main.get_bootloader")
 @patch("sonic_installer.main.run_command_or_raise")
 @patch("sonic_installer.main.run_command")
 @patch('shutil.rmtree')
-def test_install_failed(rmtree, run_command, run_command_or_raise, get_bootloader, swap, fs):
+def test_install_failed(
+    rmtree,
+    run_command,
+    run_command_or_raise,
+    get_bootloader,
+    swap,
+    _,
+    fs,
+):
     """ This test covers the "sonic-installer" install image failed handling. """
 
     sonic_image_filename = "sonic.bin"

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -13,6 +13,7 @@ def test_run_command():
         output = sonic_installer_common.run_command([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert e.value.code == 6
 
+
 @patch("sonic_installer.main.check_image_install_free_disk_space", return_value=True)
 @pytest.mark.parametrize("resolv_conf_symlink_target", [
     "/run/resolvconf/resolv.conf",       # absolute symlink

--- a/utilities_common/image_disk_space.py
+++ b/utilities_common/image_disk_space.py
@@ -1,0 +1,422 @@
+# utilities_common/image_disk_space.py
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from typing import Dict, List, Optional, Tuple, Union
+
+try:
+    from sonic_py_common import device_info
+except ImportError:
+    device_info = None
+
+
+MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE = 12
+MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE = 12
+
+NPU_MIN_FREE_DISK_KEY = "min_free_disk_in_gb_for_npu_image"
+DPU_MIN_FREE_DISK_KEY = "min_free_disk_in_gb_for_dpu_image"
+
+DEFAULT_DISK_PATH = "/host"
+
+IMAGE_TYPE_NPU = "npu"
+IMAGE_TYPE_DPU = "dpu"
+
+DEFAULT_SSH_OPTIONS = [
+    "-o", "BatchMode=yes",
+    "-o", "ConnectTimeout=10",
+    "-o", "StrictHostKeyChecking=no",
+]
+
+
+def get_default_platform_json_path() -> Optional[str]:
+    """Return the platform.json path for the current platform."""
+    if device_info is None:
+        return None
+
+    try:
+        platform = device_info.get_platform()
+    except Exception as error:
+        logging.warning(
+            "Failed to determine platform: %s",
+            error,
+        )
+        return None
+
+    if not platform:
+        return None
+
+    return f"/usr/share/sonic/device/{platform}/platform.json"
+
+
+def _load_platform_json(
+    platform_json_path: Optional[str] = None,
+) -> Dict:
+    if platform_json_path is None:
+        platform_json_path = get_default_platform_json_path()
+
+    if platform_json_path is None:
+        logging.warning("Unable to determine platform.json path")
+        return {}
+
+    try:
+        with open(platform_json_path, "r") as platform_json_file:
+            return json.load(platform_json_file)
+    except (OSError, ValueError, TypeError) as error:
+        logging.warning(
+            "Failed to read platform.json %s: %s",
+            platform_json_path,
+            error,
+        )
+        return {}
+
+
+def _get_positive_int(
+    data: Dict,
+    key: str,
+    default_value: int,
+) -> int:
+    try:
+        value = data.get(key)
+        if value is None:
+            return default_value
+
+        value = int(value)
+        if value <= 0:
+            logging.warning(
+                "Invalid %s=%s, using default %s",
+                key,
+                value,
+                default_value,
+            )
+            return default_value
+
+        return value
+    except (TypeError, ValueError) as error:
+        logging.warning(
+            "Failed to parse %s, using default %s: %s",
+            key,
+            default_value,
+            error,
+        )
+        return default_value
+
+
+def get_min_free_disk_in_gb_for_image(
+    image_type: str,
+    platform_json_path: Optional[str] = None,
+) -> int:
+    """
+    Return the configured minimum free disk space for an image type.
+
+    image_type:
+        "npu" - NPU or regular switch image
+        "dpu" - DPU image
+    """
+    platform_data = _load_platform_json(platform_json_path)
+
+    if image_type == IMAGE_TYPE_NPU:
+        return _get_positive_int(
+            platform_data,
+            NPU_MIN_FREE_DISK_KEY,
+            MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE,
+        )
+
+    if image_type == IMAGE_TYPE_DPU:
+        return _get_positive_int(
+            platform_data,
+            DPU_MIN_FREE_DISK_KEY,
+            MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE,
+        )
+
+    raise ValueError("Unsupported image type: {}".format(image_type))
+
+
+def get_free_disk_in_gb(
+    path: str = DEFAULT_DISK_PATH,
+) -> Optional[int]:
+    if not os.path.exists(path):
+        logging.warning("Disk path does not exist: %s", path)
+        return None
+
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError as error:
+        logging.warning(
+            "Failed to get disk usage for %s: %s",
+            path,
+            error,
+        )
+        return None
+
+    return usage.free // (1024 * 1024 * 1024)
+
+
+def is_running_on_dpu() -> bool:
+    """
+    Return True when this utility is running on a DPU.
+    """
+    try:
+        return bool(device_info and device_info.is_dpu())
+    except Exception as error:
+        logging.warning(
+            "Failed to determine whether the system is a DPU: %s",
+            error,
+        )
+        return False
+
+
+def get_local_image_type() -> str:
+    """
+    Determine which image threshold applies to the local system.
+    """
+    if is_running_on_dpu():
+        return IMAGE_TYPE_DPU
+
+    return IMAGE_TYPE_NPU
+
+
+def check_local_image_install_free_disk_space(
+    image_type: Optional[str] = None,
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+) -> bool:
+    """
+    Check free disk space on the system where this function is running.
+
+    When image_type is omitted, the function automatically determines
+    whether it is running on an NPU/regular switch or on a DPU.
+    """
+    resolved_image_type = image_type or get_local_image_type()
+
+    try:
+        required_gb = get_min_free_disk_in_gb_for_image(
+            resolved_image_type,
+            platform_json_path,
+        )
+    except ValueError as error:
+        logging.error("%s", error)
+        return False
+
+    available_gb = get_free_disk_in_gb(disk_path)
+
+    if available_gb is None:
+        logging.error(
+            "Unable to determine local free disk space: "
+            "image_type=%s path=%s",
+            resolved_image_type,
+            disk_path,
+        )
+        return False
+
+    if available_gb < required_gb:
+        logging.error(
+            "Insufficient local disk space: "
+            "image_type=%s available=%sGB required=%sGB path=%s",
+            resolved_image_type,
+            available_gb,
+            required_gb,
+            disk_path,
+        )
+        return False
+
+    return True
+
+
+def _run_cmd(cmd: List[str]) -> Tuple[int, str]:
+    try:
+        output = subprocess.check_output(
+            cmd,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        return 0, output.strip()
+    except subprocess.CalledProcessError as error:
+        output = error.output or ""
+        return error.returncode, output.strip()
+    except OSError as error:
+        return 1, str(error)
+
+
+def _parse_df_available_gb(output: str) -> Optional[int]:
+    """
+    Parse output from:
+
+        df -BG --output=avail <path>
+
+    Expected output resembles:
+
+        Avail
+          18G
+    """
+    lines = [
+        line.strip()
+        for line in output.splitlines()
+        if line.strip()
+    ]
+
+    if len(lines) < 2:
+        return None
+
+    match = re.fullmatch(r"(\d+)G?", lines[-1])
+    if not match:
+        return None
+
+    return int(match.group(1))
+
+
+def get_remote_dpu_free_disk_in_gb(
+    dpu_name: str,
+    disk_path: str = DEFAULT_DISK_PATH,
+    ssh_options: Optional[List[str]] = None,
+) -> Optional[int]:
+    """
+    Get free disk space from a DPU reachable over SSH.
+    """
+    resolved_ssh_options = (
+        ssh_options
+        if ssh_options is not None
+        else DEFAULT_SSH_OPTIONS
+    )
+
+    command = [
+        "ssh",
+        *resolved_ssh_options,
+        dpu_name,
+        "df",
+        "-BG",
+        "--output=avail",
+        disk_path,
+    ]
+
+    return_code, output = _run_cmd(command)
+    if return_code != 0:
+        logging.warning(
+            "Failed to get free disk space from %s: %s",
+            dpu_name,
+            output,
+        )
+        return None
+
+    available_gb = _parse_df_available_gb(output)
+    if available_gb is None:
+        logging.warning(
+            "Failed to parse disk space from %s: %s",
+            dpu_name,
+            output,
+        )
+
+    return available_gb
+
+
+def check_remote_dpu_image_install_free_disk_space(
+    dpu_names: Union[str, List[str]],
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+    ssh_options: Optional[List[str]] = None,
+) -> bool:
+    """
+    Check one or more remote DPUs from an NPU.
+
+    The complete check fails if any DPU has insufficient disk space or
+    if the free disk space cannot be determined for any DPU.
+    """
+    if is_running_on_dpu():
+        logging.error(
+            "Remote DPU disk-space checks must be initiated from an NPU"
+        )
+        return False
+
+    if isinstance(dpu_names, str):
+        resolved_dpu_names = [dpu_names]
+    else:
+        resolved_dpu_names = dpu_names
+
+    if not resolved_dpu_names:
+        logging.error(
+            "Remote DPU disk-space check requires at least one DPU name"
+        )
+        return False
+
+    required_gb = get_min_free_disk_in_gb_for_image(
+        IMAGE_TYPE_DPU,
+        platform_json_path,
+    )
+
+    for dpu_name in resolved_dpu_names:
+        available_gb = get_remote_dpu_free_disk_in_gb(
+            dpu_name,
+            disk_path,
+            ssh_options,
+        )
+
+        if available_gb is None:
+            logging.error(
+                "Unable to determine free disk space for %s",
+                dpu_name,
+            )
+            return False
+
+        if available_gb < required_gb:
+            logging.error(
+                "Insufficient remote DPU disk space: "
+                "dpu=%s available=%sGB required=%sGB path=%s",
+                dpu_name,
+                available_gb,
+                required_gb,
+                disk_path,
+            )
+            return False
+
+    return True
+
+
+def check_image_install_free_disk_space(
+    dpu_names: Optional[Union[str, List[str]]] = None,
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+    ssh_options: Optional[List[str]] = None,
+) -> bool:
+    """
+    Smart image-installation disk-space validation entry point.
+
+    Behavior:
+
+    Running on a DPU:
+        Checks the local DPU using the DPU image threshold.
+
+    Running on an NPU or regular switch without dpu_names:
+        Checks the local system using the NPU image threshold.
+
+    Running on an NPU with dpu_names:
+        Checks the specified remote DPUs using the DPU image threshold.
+    """
+    if is_running_on_dpu():
+        if dpu_names:
+            logging.error(
+                "dpu_names must not be supplied when running locally on a DPU"
+            )
+            return False
+
+        return check_local_image_install_free_disk_space(
+            image_type=IMAGE_TYPE_DPU,
+            disk_path=disk_path,
+            platform_json_path=platform_json_path,
+        )
+
+    if dpu_names:
+        return check_remote_dpu_image_install_free_disk_space(
+            dpu_names=dpu_names,
+            disk_path=disk_path,
+            platform_json_path=platform_json_path,
+            ssh_options=ssh_options,
+        )
+
+    return check_local_image_install_free_disk_space(
+        image_type=IMAGE_TYPE_NPU,
+        disk_path=disk_path,
+        platform_json_path=platform_json_path,
+    )

--- a/utilities_common/image_disk_space.py
+++ b/utilities_common/image_disk_space.py
@@ -14,16 +14,24 @@ except ImportError:
     device_info = None
 
 
-MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE = 12
+MIN_FREE_DISK_IN_GB_FOR_SWITCH_IMAGE = 12
 MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE = 12
 
-NPU_MIN_FREE_DISK_KEY = "min_free_disk_in_gb_for_npu_image"
-DPU_MIN_FREE_DISK_KEY = "min_free_disk_in_gb_for_dpu_image"
+SWITCH_MIN_FREE_DISK_IMAGE_KEY = "min_free_disk_in_gb_for_switch_image"
+DPU_MIN_FREE_DISK_IMAGE_KEY = "min_free_disk_in_gb_for_dpu_image"
+SWITCH_MIN_FREE_DISK_REBOOT_KEY = "min_free_disk_in_gb_for_switch_reboot"
+DPU_MIN_FREE_DISK_REBOOT_KEY = "min_free_disk_in_gb_for_dpu_reboot"
 
 DEFAULT_DISK_PATH = "/host"
 
-IMAGE_TYPE_NPU = "npu"
+IMAGE_TYPE_SWITCH = "switch"
 IMAGE_TYPE_DPU = "dpu"
+
+# Backward-compatible aliases for the current PR tests and callers.
+MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE = MIN_FREE_DISK_IN_GB_FOR_SWITCH_IMAGE
+NPU_MIN_FREE_DISK_KEY = SWITCH_MIN_FREE_DISK_IMAGE_KEY
+DPU_MIN_FREE_DISK_KEY = DPU_MIN_FREE_DISK_IMAGE_KEY
+IMAGE_TYPE_NPU = IMAGE_TYPE_SWITCH
 
 DEFAULT_SSH_OPTIONS = [
     "-o", "BatchMode=yes",
@@ -40,10 +48,7 @@ def get_default_platform_json_path() -> Optional[str]:
     try:
         platform = device_info.get_platform()
     except Exception as error:
-        logging.warning(
-            "Failed to determine platform: %s",
-            error,
-        )
+        logging.warning("Failed to determine platform: %s", error)
         return None
 
     if not platform:
@@ -105,34 +110,68 @@ def _get_positive_int(
         return default_value
 
 
+def _get_optional_positive_int(data: Dict, key: str) -> Optional[int]:
+    """Return an optional positive integer.
+
+    A missing key disables the optional check. A configured invalid value
+    raises ValueError so an enabled safety check fails closed.
+    """
+    if key not in data:
+        return None
+
+    try:
+        value = int(data[key])
+    except (TypeError, ValueError) as error:
+        raise ValueError("Invalid {}: {}".format(key, error))
+
+    if value <= 0:
+        raise ValueError("{} must be a positive integer".format(key))
+
+    return value
+
+
 def get_min_free_disk_in_gb_for_image(
     image_type: str,
     platform_json_path: Optional[str] = None,
 ) -> int:
-    """
-    Return the configured minimum free disk space for an image type.
-
-    image_type:
-        "npu" - NPU or regular switch image
-        "dpu" - DPU image
-    """
+    """Return the configured image-install free-space threshold."""
     platform_data = _load_platform_json(platform_json_path)
 
-    if image_type == IMAGE_TYPE_NPU:
+    if image_type == IMAGE_TYPE_SWITCH:
         return _get_positive_int(
             platform_data,
-            NPU_MIN_FREE_DISK_KEY,
-            MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE,
+            SWITCH_MIN_FREE_DISK_IMAGE_KEY,
+            MIN_FREE_DISK_IN_GB_FOR_SWITCH_IMAGE,
         )
 
     if image_type == IMAGE_TYPE_DPU:
         return _get_positive_int(
             platform_data,
-            DPU_MIN_FREE_DISK_KEY,
+            DPU_MIN_FREE_DISK_IMAGE_KEY,
             MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE,
         )
 
     raise ValueError("Unsupported image type: {}".format(image_type))
+
+
+def get_min_free_disk_in_gb_for_reboot(
+    device_type: str,
+    platform_json_path: Optional[str] = None,
+) -> Optional[int]:
+    """Return the optional reboot free-space threshold.
+
+    A missing threshold preserves the existing reboot behavior.
+    """
+    platform_data = _load_platform_json(platform_json_path)
+
+    if device_type == IMAGE_TYPE_SWITCH:
+        key = SWITCH_MIN_FREE_DISK_REBOOT_KEY
+    elif device_type == IMAGE_TYPE_DPU:
+        key = DPU_MIN_FREE_DISK_REBOOT_KEY
+    else:
+        raise ValueError("Unsupported device type: {}".format(device_type))
+
+    return _get_optional_positive_int(platform_data, key)
 
 
 def get_free_disk_in_gb(
@@ -145,20 +184,14 @@ def get_free_disk_in_gb(
     try:
         usage = shutil.disk_usage(path)
     except OSError as error:
-        logging.warning(
-            "Failed to get disk usage for %s: %s",
-            path,
-            error,
-        )
+        logging.warning("Failed to get disk usage for %s: %s", path, error)
         return None
 
     return usage.free // (1024 * 1024 * 1024)
 
 
 def is_running_on_dpu() -> bool:
-    """
-    Return True when this utility is running on a DPU.
-    """
+    """Return True when this utility is running on a DPU."""
     try:
         return bool(device_info and device_info.is_dpu())
     except Exception as error:
@@ -170,13 +203,11 @@ def is_running_on_dpu() -> bool:
 
 
 def get_local_image_type() -> str:
-    """
-    Determine which image threshold applies to the local system.
-    """
+    """Determine which image threshold applies to the local system."""
     if is_running_on_dpu():
         return IMAGE_TYPE_DPU
 
-    return IMAGE_TYPE_NPU
+    return IMAGE_TYPE_SWITCH
 
 
 def check_local_image_install_free_disk_space(
@@ -184,12 +215,7 @@ def check_local_image_install_free_disk_space(
     disk_path: str = DEFAULT_DISK_PATH,
     platform_json_path: Optional[str] = None,
 ) -> bool:
-    """
-    Check free disk space on the system where this function is running.
-
-    When image_type is omitted, the function automatically determines
-    whether it is running on an NPU/regular switch or on a DPU.
-    """
+    """Check local free space before image installation."""
     resolved_image_type = image_type or get_local_image_type()
 
     try:
@@ -202,7 +228,6 @@ def check_local_image_install_free_disk_space(
         return False
 
     available_gb = get_free_disk_in_gb(disk_path)
-
     if available_gb is None:
         logging.error(
             "Unable to determine local free disk space: "
@@ -217,6 +242,54 @@ def check_local_image_install_free_disk_space(
             "Insufficient local disk space: "
             "image_type=%s available=%sGB required=%sGB path=%s",
             resolved_image_type,
+            available_gb,
+            required_gb,
+            disk_path,
+        )
+        return False
+
+    return True
+
+
+def check_local_reboot_free_disk_space(
+    device_type: Optional[str] = None,
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+) -> bool:
+    """Check local free space before reboot.
+
+    If the platform does not configure a reboot threshold, this check is a
+    no-op to preserve existing behavior.
+    """
+    resolved_device_type = device_type or get_local_image_type()
+
+    try:
+        required_gb = get_min_free_disk_in_gb_for_reboot(
+            resolved_device_type,
+            platform_json_path,
+        )
+    except ValueError as error:
+        logging.error("%s", error)
+        return False
+
+    if required_gb is None:
+        return True
+
+    available_gb = get_free_disk_in_gb(disk_path)
+    if available_gb is None:
+        logging.error(
+            "Unable to determine local free disk space before reboot: "
+            "device_type=%s path=%s",
+            resolved_device_type,
+            disk_path,
+        )
+        return False
+
+    if available_gb < required_gb:
+        logging.error(
+            "Insufficient local disk space for reboot: "
+            "device_type=%s available=%sGB required=%sGB path=%s",
+            resolved_device_type,
             available_gb,
             required_gb,
             disk_path,
@@ -242,16 +315,7 @@ def _run_cmd(cmd: List[str]) -> Tuple[int, str]:
 
 
 def _parse_df_available_gb(output: str) -> Optional[int]:
-    """
-    Parse output from:
-
-        df -BG --output=avail <path>
-
-    Expected output resembles:
-
-        Avail
-          18G
-    """
+    """Parse output from ``df -BG --output=avail``."""
     lines = [
         line.strip()
         for line in output.splitlines()
@@ -268,14 +332,26 @@ def _parse_df_available_gb(output: str) -> Optional[int]:
     return int(match.group(1))
 
 
+def _parse_df_available_bytes(output: str) -> Optional[int]:
+    """Parse output from ``df -B1 --output=avail``."""
+    lines = [
+        line.strip()
+        for line in output.splitlines()
+        if line.strip()
+    ]
+
+    if len(lines) < 2 or not re.fullmatch(r"\d+", lines[-1]):
+        return None
+
+    return int(lines[-1])
+
+
 def get_remote_dpu_free_disk_in_gb(
     dpu_name: str,
     disk_path: str = DEFAULT_DISK_PATH,
     ssh_options: Optional[List[str]] = None,
 ) -> Optional[int]:
-    """
-    Get free disk space from a DPU reachable over SSH.
-    """
+    """Get free disk space from a DPU reachable over SSH."""
     resolved_ssh_options = (
         ssh_options
         if ssh_options is not None
@@ -312,21 +388,58 @@ def get_remote_dpu_free_disk_in_gb(
     return available_gb
 
 
+def get_remote_dpu_free_disk_in_bytes(
+    dpu_name: str,
+    disk_path: str = DEFAULT_DISK_PATH,
+    ssh_options: Optional[List[str]] = None,
+) -> Optional[int]:
+    """Get exact free bytes from a remote DPU."""
+    resolved_ssh_options = (
+        ssh_options
+        if ssh_options is not None
+        else DEFAULT_SSH_OPTIONS
+    )
+
+    command = [
+        "ssh",
+        *resolved_ssh_options,
+        dpu_name,
+        "df",
+        "-B1",
+        "--output=avail",
+        disk_path,
+    ]
+
+    return_code, output = _run_cmd(command)
+    if return_code != 0:
+        logging.warning(
+            "Failed to get free disk space from %s: %s",
+            dpu_name,
+            output,
+        )
+        return None
+
+    available_bytes = _parse_df_available_bytes(output)
+    if available_bytes is None:
+        logging.warning(
+            "Failed to parse disk space from %s: %s",
+            dpu_name,
+            output,
+        )
+
+    return available_bytes
+
+
 def check_remote_dpu_image_install_free_disk_space(
     dpu_names: Union[str, List[str]],
     disk_path: str = DEFAULT_DISK_PATH,
     platform_json_path: Optional[str] = None,
     ssh_options: Optional[List[str]] = None,
 ) -> bool:
-    """
-    Check one or more remote DPUs from an NPU.
-
-    The complete check fails if any DPU has insufficient disk space or
-    if the free disk space cannot be determined for any DPU.
-    """
+    """Check one or more remote DPUs before image installation."""
     if is_running_on_dpu():
         logging.error(
-            "Remote DPU disk-space checks must be initiated from an NPU"
+            "Remote DPU disk-space checks must be initiated from a switch"
         )
         return False
 
@@ -352,7 +465,6 @@ def check_remote_dpu_image_install_free_disk_space(
             disk_path,
             ssh_options,
         )
-
         if available_gb is None:
             logging.error(
                 "Unable to determine free disk space for %s",
@@ -374,26 +486,70 @@ def check_remote_dpu_image_install_free_disk_space(
     return True
 
 
+def check_remote_dpu_reboot_free_disk_space(
+    dpu_name: str,
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+    ssh_options: Optional[List[str]] = None,
+) -> bool:
+    """Check remote DPU free space before ``reboot -d``.
+
+    If the platform does not configure the DPU reboot threshold, this check is
+    a no-op to preserve existing behavior.
+    """
+    if is_running_on_dpu():
+        logging.error(
+            "Remote DPU reboot disk-space checks must be initiated "
+            "from a switch"
+        )
+        return False
+
+    try:
+        required_gb = get_min_free_disk_in_gb_for_reboot(
+            IMAGE_TYPE_DPU,
+            platform_json_path,
+        )
+    except ValueError as error:
+        logging.error("%s", error)
+        return False
+
+    if required_gb is None:
+        return True
+
+    available_bytes = get_remote_dpu_free_disk_in_bytes(
+        dpu_name,
+        disk_path,
+        ssh_options,
+    )
+    if available_bytes is None:
+        logging.error(
+            "Unable to determine free disk space for %s before reboot",
+            dpu_name,
+        )
+        return False
+
+    required_bytes = required_gb * 1024 * 1024 * 1024
+    if available_bytes < required_bytes:
+        logging.error(
+            "Insufficient remote DPU disk space for reboot: "
+            "dpu=%s available=%s bytes required=%s bytes path=%s",
+            dpu_name,
+            available_bytes,
+            required_bytes,
+            disk_path,
+        )
+        return False
+
+    return True
+
+
 def check_image_install_free_disk_space(
     dpu_names: Optional[Union[str, List[str]]] = None,
     disk_path: str = DEFAULT_DISK_PATH,
     platform_json_path: Optional[str] = None,
     ssh_options: Optional[List[str]] = None,
 ) -> bool:
-    """
-    Smart image-installation disk-space validation entry point.
-
-    Behavior:
-
-    Running on a DPU:
-        Checks the local DPU using the DPU image threshold.
-
-    Running on an NPU or regular switch without dpu_names:
-        Checks the local system using the NPU image threshold.
-
-    Running on an NPU with dpu_names:
-        Checks the specified remote DPUs using the DPU image threshold.
-    """
+    """Smart image-installation disk-space validation entry point."""
     if is_running_on_dpu():
         if dpu_names:
             logging.error(
@@ -416,7 +572,7 @@ def check_image_install_free_disk_space(
         )
 
     return check_local_image_install_free_disk_space(
-        image_type=IMAGE_TYPE_NPU,
+        image_type=IMAGE_TYPE_SWITCH,
         disk_path=disk_path,
         platform_json_path=platform_json_path,
     )

--- a/utilities_common/image_disk_space.py
+++ b/utilities_common/image_disk_space.py
@@ -28,7 +28,7 @@ IMAGE_TYPE_DPU = "dpu"
 DEFAULT_SSH_OPTIONS = [
     "-o", "BatchMode=yes",
     "-o", "ConnectTimeout=10",
-    "-o", "StrictHostKeyChecking=no",
+    "-o", "StrictHostKeyChecking=accept-new",
 ]
 
 

--- a/utilities_common/image_disk_space.py
+++ b/utilities_common/image_disk_space.py
@@ -290,24 +290,6 @@ def _run_cmd(cmd: List[str]) -> Tuple[int, str]:
         return 1, str(error)
 
 
-def _parse_df_available_gb(output: str) -> Optional[int]:
-    """Parse output from ``df -BG --output=avail``."""
-    lines = [
-        line.strip()
-        for line in output.splitlines()
-        if line.strip()
-    ]
-
-    if len(lines) < 2:
-        return None
-
-    match = re.fullmatch(r"(\d+)G?", lines[-1])
-    if not match:
-        return None
-
-    return int(match.group(1))
-
-
 def _parse_df_available_bytes(output: str) -> Optional[int]:
     """Parse output from ``df -B1 --output=avail``."""
     lines = [
@@ -320,48 +302,6 @@ def _parse_df_available_bytes(output: str) -> Optional[int]:
         return None
 
     return int(lines[-1])
-
-
-def get_remote_dpu_free_disk_in_gb(
-    dpu_name: str,
-    disk_path: str = DEFAULT_DISK_PATH,
-    ssh_options: Optional[List[str]] = None,
-) -> Optional[int]:
-    """Get free disk space from a DPU reachable over SSH."""
-    resolved_ssh_options = (
-        ssh_options
-        if ssh_options is not None
-        else DEFAULT_SSH_OPTIONS
-    )
-
-    command = [
-        "ssh",
-        *resolved_ssh_options,
-        dpu_name,
-        "df",
-        "-BG",
-        "--output=avail",
-        disk_path,
-    ]
-
-    return_code, output = _run_cmd(command)
-    if return_code != 0:
-        logging.warning(
-            "Failed to get free disk space from %s: %s",
-            dpu_name,
-            output,
-        )
-        return None
-
-    available_gb = _parse_df_available_gb(output)
-    if available_gb is None:
-        logging.warning(
-            "Failed to parse disk space from %s: %s",
-            dpu_name,
-            output,
-        )
-
-    return available_gb
 
 
 def get_remote_dpu_free_disk_in_bytes(
@@ -441,26 +381,28 @@ def check_remote_dpu_image_install_free_disk_space(
         )
         return True
 
+    required_bytes = required_gb * 1024 * 1024 * 1024
+
     for dpu_name in resolved_dpu_names:
-        available_gb = get_remote_dpu_free_disk_in_gb(
+        available_bytes = get_remote_dpu_free_disk_in_bytes(
             dpu_name,
             disk_path,
             ssh_options,
         )
-        if available_gb is None:
+        if available_bytes is None:
             logging.error(
                 "Unable to determine free disk space for %s",
                 dpu_name,
             )
             return False
 
-        if available_gb < required_gb:
+        if available_bytes < required_bytes:
             logging.error(
                 "Insufficient remote DPU disk space: "
-                "dpu=%s available=%sGB required=%sGB path=%s",
+                "dpu=%s available=%s bytes required=%s bytes path=%s",
                 dpu_name,
-                available_gb,
-                required_gb,
+                available_bytes,
+                required_bytes,
                 disk_path,
             )
             return False

--- a/utilities_common/image_disk_space.py
+++ b/utilities_common/image_disk_space.py
@@ -14,9 +14,6 @@ except ImportError:
     device_info = None
 
 
-MIN_FREE_DISK_IN_GB_FOR_SWITCH_IMAGE = 12
-MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE = 12
-
 SWITCH_MIN_FREE_DISK_IMAGE_KEY = "min_free_disk_in_gb_for_switch_image"
 DPU_MIN_FREE_DISK_IMAGE_KEY = "min_free_disk_in_gb_for_dpu_image"
 SWITCH_MIN_FREE_DISK_REBOOT_KEY = "min_free_disk_in_gb_for_switch_reboot"
@@ -26,12 +23,6 @@ DEFAULT_DISK_PATH = "/host"
 
 IMAGE_TYPE_SWITCH = "switch"
 IMAGE_TYPE_DPU = "dpu"
-
-# Backward-compatible aliases for the current PR tests and callers.
-MIN_FREE_DISK_IN_GB_FOR_NPU_IMAGE = MIN_FREE_DISK_IN_GB_FOR_SWITCH_IMAGE
-NPU_MIN_FREE_DISK_KEY = SWITCH_MIN_FREE_DISK_IMAGE_KEY
-DPU_MIN_FREE_DISK_KEY = DPU_MIN_FREE_DISK_IMAGE_KEY
-IMAGE_TYPE_NPU = IMAGE_TYPE_SWITCH
 
 DEFAULT_SSH_OPTIONS = [
     "-o", "BatchMode=yes",
@@ -79,42 +70,10 @@ def _load_platform_json(
         return {}
 
 
-def _get_positive_int(
-    data: Dict,
-    key: str,
-    default_value: int,
-) -> int:
-    try:
-        value = data.get(key)
-        if value is None:
-            return default_value
-
-        value = int(value)
-        if value <= 0:
-            logging.warning(
-                "Invalid %s=%s, using default %s",
-                key,
-                value,
-                default_value,
-            )
-            return default_value
-
-        return value
-    except (TypeError, ValueError) as error:
-        logging.warning(
-            "Failed to parse %s, using default %s: %s",
-            key,
-            default_value,
-            error,
-        )
-        return default_value
-
-
 def _get_optional_positive_int(data: Dict, key: str) -> Optional[int]:
     """Return an optional positive integer.
 
-    A missing key disables the optional check. A configured invalid value
-    raises ValueError so an enabled safety check fails closed.
+    A missing or invalid key disables the corresponding disk-space check.
     """
     if key not in data:
         return None
@@ -122,10 +81,21 @@ def _get_optional_positive_int(data: Dict, key: str) -> Optional[int]:
     try:
         value = int(data[key])
     except (TypeError, ValueError) as error:
-        raise ValueError("Invalid {}: {}".format(key, error))
+        logging.error(
+            "Invalid %s=%s; skipping the disk-space check: %s",
+            key,
+            data.get(key),
+            error,
+        )
+        return None
 
     if value <= 0:
-        raise ValueError("{} must be a positive integer".format(key))
+        logging.error(
+            "Invalid %s=%s; skipping the disk-space check",
+            key,
+            value,
+        )
+        return None
 
     return value
 
@@ -133,22 +103,20 @@ def _get_optional_positive_int(data: Dict, key: str) -> Optional[int]:
 def get_min_free_disk_in_gb_for_image(
     image_type: str,
     platform_json_path: Optional[str] = None,
-) -> int:
-    """Return the configured image-install free-space threshold."""
+) -> Optional[int]:
+    """Return the optional image-install free-space threshold."""
     platform_data = _load_platform_json(platform_json_path)
 
     if image_type == IMAGE_TYPE_SWITCH:
-        return _get_positive_int(
+        return _get_optional_positive_int(
             platform_data,
             SWITCH_MIN_FREE_DISK_IMAGE_KEY,
-            MIN_FREE_DISK_IN_GB_FOR_SWITCH_IMAGE,
         )
 
     if image_type == IMAGE_TYPE_DPU:
-        return _get_positive_int(
+        return _get_optional_positive_int(
             platform_data,
             DPU_MIN_FREE_DISK_IMAGE_KEY,
-            MIN_FREE_DISK_IN_GB_FOR_DPU_IMAGE,
         )
 
     raise ValueError("Unsupported image type: {}".format(image_type))
@@ -226,6 +194,14 @@ def check_local_image_install_free_disk_space(
     except ValueError as error:
         logging.error("%s", error)
         return False
+
+    if required_gb is None:
+        logging.info(
+            "No valid image-install disk-space threshold configured for %s; "
+            "skipping the check",
+            resolved_image_type,
+        )
+        return True
 
     available_gb = get_free_disk_in_gb(disk_path)
     if available_gb is None:
@@ -458,6 +434,12 @@ def check_remote_dpu_image_install_free_disk_space(
         IMAGE_TYPE_DPU,
         platform_json_path,
     )
+    if required_gb is None:
+        logging.info(
+            "No valid DPU image-install disk-space threshold configured; "
+            "skipping the check"
+        )
+        return True
 
     for dpu_name in resolved_dpu_names:
         available_gb = get_remote_dpu_free_disk_in_gb(


### PR DESCRIPTION
Add reusable disk-space validation helper for image installation and reboot

Fixes:  #4661
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/28734

#### What this PR does

This PR introduces a reusable disk-space validation helper that validates sufficient free disk space before critical operations begin and prevents the operation from proceeding when the required free space is not available.

The helper is designed to be reusable across multiple workflows, avoiding duplicated disk-space validation logic.

The current implementation supports:

Regular switch image installation
SmartSwitch switch image installation
Local DPU image installation
Remote single-DPU image installation
Remote multi-DPU image installation
Switch reboot
DPU reboot (reboot -d)

The helper automatically detects whether it is running on a switch or DPU and applies the appropriate disk-space threshold.

##### Platform configuration

Disk-space validation is opt-in. The corresponding check is performed only when the appropriate threshold is configured in platform.json.
```
{
    "min_free_disk_in_gb_for_switch_image": 16,
    "min_free_disk_in_gb_for_dpu_image": 12,
    "min_free_disk_in_gb_for_switch_reboot": 4,
    "min_free_disk_in_gb_for_dpu_reboot": 4
}
```
Skip disk-space validation when the corresponding threshold is not configured or is invalid, preserving the existing
behavior. Log an error when an invalid configuration is encountered.

##### Implementation

Added a reusable helper:

utilities_common/image_disk_space.py

The module provides reusable APIs for:

1. Local image installation validation
2. Remote DPU image installation validation
3. Local reboot validation
4. Remote DPU reboot validation
5. Automatic runtime selection based on the current execution environment

The implementation includes:

1. Runtime platform detection
2. Platform-specific threshold lookup from platform.json
3. Safe default values for image installation
4. Optional reboot thresholds
5. Local filesystem validation
6. Remote DPU validation over SSH
7. Configurable SSH options
8. Robust parsing of remote df output
9. Fail-fast behavior
10. Clear logging for configuration, connectivity, parsing, and insufficient disk-space failures
##### Integration

The helper is integrated into:

sonic-installer install
reboot
reboot -d

Each workflow performs disk-space validation before beginning any operation that could leave the filesystem or boot state in an inconsistent state.

The implementation is prevention-only. It does not perform automatic cleanup, recovery, or file deletion.

##### Example
```
if not check_image_install_free_disk_space():
    raise click.ClickException(
        "Image installation aborted: insufficient free disk space."
    )
```
Similarly, the reboot paths abort before initiating the reboot if the configured minimum free disk-space requirement is not satisfied.

#### Verification
##### Unit tests
Existing image installation unit tests updated
Added reboot disk-space validation tests
Existing functionality verified to remain unchanged
##### Functional testing

Validated on a Cisco SmartSwitch.

Verified that:

platform.json is correctly located using the current platform.
Image installation is prevented when insufficient disk space is available.
reboot is prevented when the configured reboot threshold is not met.
reboot -d is prevented when the target DPU does not satisfy the configured reboot threshold.

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A
