### PR TITLE
[pfcwd]: Reject start when detection or restoration time is below polling interval

### DIFF
--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -323,6 +323,31 @@ class PfcwdCli(object):
         if os.geteuid() != 0:
             sys.exit("Root privileges are required for this operation")
 
+        poll_interval = (self.config_db.get_entry(
+            CONFIG_DB_PFC_WD_TABLE_NAME, 'GLOBAL'
+        ) or {}).get('POLL_INTERVAL')
+        # Strict gt: equal values are allowed (consistent with interval cmd)
+        if poll_interval is not None:
+            poll_interval_int = int(poll_interval)
+            if poll_interval_int > detection_time:
+                click.echo(
+                    "detection time {}ms is smaller than the configured "
+                    "polling interval {}ms, please use a larger detection "
+                    "time or reduce the polling interval".format(
+                        detection_time, poll_interval_int
+                    ), err=True
+                )
+                sys.exit(1)
+            if restoration_time is not None and poll_interval_int > restoration_time:
+                click.echo(
+                    "restoration time {}ms is smaller than the configured "
+                    "polling interval {}ms, please use a larger restoration "
+                    "time or reduce the polling interval".format(
+                        restoration_time, poll_interval_int
+                    ), err=True
+                )
+                sys.exit(1)
+
         pfcwd_info = {
             'detection_time': detection_time,
         }

--- a/tests/pfcwd_input/pfcwd_test_vectors.py
+++ b/tests/pfcwd_input/pfcwd_test_vectors.py
@@ -11,7 +11,7 @@ pfcwd_show_start_config_output_pass = """\
 Changed polling interval to 600ms
      PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
 ---------  --------  ----------------  ------------------  ---------
-Ethernet0   forward               102                 101    disable
+Ethernet0   forward               602                 601    disable
 Ethernet4      drop               600                 600    disable
 Ethernet8      drop               600                 600    disable
 """
@@ -29,8 +29,8 @@ pfcwd_show_start_action_forward_output = """\
 Changed polling interval to 600ms
      PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
 ---------  --------  ----------------  ------------------  ---------
-Ethernet0   forward               302                 301    disable
-Ethernet4   forward               302                 301    disable
+Ethernet0   forward               602                 601    disable
+Ethernet4   forward               602                 601    disable
 Ethernet8      drop               600                 600    disable
 """
 
@@ -38,8 +38,8 @@ pfcwd_show_start_action_alert_output = """\
 Changed polling interval to 600ms
      PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
 ---------  --------  ----------------  ------------------  ---------
-Ethernet0     alert               502                 501    disable
-Ethernet4     alert               502                 501    disable
+Ethernet0     alert               702                 701    disable
+Ethernet4     alert               702                 701    disable
 Ethernet8      drop               600                 600    disable
 """
 
@@ -47,8 +47,8 @@ pfcwd_show_start_action_drop_output = """\
 Changed polling interval to 600ms
      PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
 ---------  --------  ----------------  ------------------  ---------
-Ethernet0      drop               602                 601    disable
-Ethernet4      drop               602                 601    disable
+Ethernet0      drop               802                 801    disable
+Ethernet4      drop               802                 801    disable
 Ethernet8      drop               600                 600    disable
 """
 
@@ -320,10 +320,10 @@ Changed polling interval to 199ms on asic1
 BIG_RED_SWITCH status is enable on asic1
           PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
 --------------  --------  ----------------  ------------------  ---------
-     Ethernet0   forward               102                 101    disable
+     Ethernet0   forward               202                 201    disable
      Ethernet4      drop               200                 200    disable
   Ethernet-BP0      drop               200                 200    disable
-  Ethernet-BP4   forward               102                 101    disable
+  Ethernet-BP4   forward               202                 201    disable
 Ethernet-BP256      drop               200                 200    disable
 Ethernet-BP260      drop               200                 200    disable
 """

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -132,7 +132,7 @@ class TestPfcwd(object):
         )
         print(result.output)
         assert result.exit_code == 1
-        assert "detection time 200ms is smaller than the configured polling interval 600ms" in result.stderr
+        assert "detection time 200ms is smaller than the configured polling interval 600ms" in result.output
 
     @patch('pfcwd.main.os')
     def test_pfcwd_start_restoration_time_below_poll_interval(self, mock_os):
@@ -152,7 +152,7 @@ class TestPfcwd(object):
         )
         print(result.output)
         assert result.exit_code == 1
-        assert "restoration time 200ms is smaller than the configured polling interval 600ms" in result.stderr
+        assert "restoration time 200ms is smaller than the configured polling interval 600ms" in result.output
 
     @patch('pfcwd.main.os')
     def test_pfcwd_enable_history_ports_valid(self, mock_os):

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -132,7 +132,7 @@ class TestPfcwd(object):
         )
         print(result.output)
         assert result.exit_code == 1
-        assert "detection time 200ms is smaller than the configured polling interval 600ms" in result.output
+        assert "detection time 200ms is smaller than the configured polling interval 600ms" in result.stderr
 
     @patch('pfcwd.main.os')
     def test_pfcwd_start_restoration_time_below_poll_interval(self, mock_os):
@@ -152,7 +152,7 @@ class TestPfcwd(object):
         )
         print(result.output)
         assert result.exit_code == 1
-        assert "restoration time 200ms is smaller than the configured polling interval 600ms" in result.output
+        assert "restoration time 200ms is smaller than the configured polling interval 600ms" in result.stderr
 
     @patch('pfcwd.main.os')
     def test_pfcwd_enable_history_ports_valid(self, mock_os):

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -98,8 +98,8 @@ class TestPfcwd(object):
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
-                "--action", "forward", "--restoration-time", "101",
-                "Ethernet0", "102"
+                "--action", "forward", "--restoration-time", "601",
+                "Ethernet0", "602"
             ],
             obj=db
         )
@@ -114,6 +114,45 @@ class TestPfcwd(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == test_vectors.pfcwd_show_start_config_output_pass
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_detection_time_below_poll_interval(self, mock_os):
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        mock_os.geteuid.return_value = 0
+        result = runner.invoke(
+            pfcwd.cli.commands["start"],
+            [
+                "--action", "forward", "--restoration-time", "601",
+                "Ethernet0", "200"
+            ],
+            obj=db
+        )
+        print(result.output)
+        assert result.exit_code == 1
+        assert "detection time 200ms is smaller than the configured polling interval 600ms" in result.output
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_restoration_time_below_poll_interval(self, mock_os):
+        # detection_time=602 is valid, but restoration_time=200 is below POLL_INTERVAL=600
+        import pfcwd.main as pfcwd
+        runner = CliRunner()
+        db = Db()
+
+        mock_os.geteuid.return_value = 0
+        result = runner.invoke(
+            pfcwd.cli.commands["start"],
+            [
+                "--action", "drop", "--restoration-time", "200",
+                "Ethernet0", "602"
+            ],
+            obj=db
+        )
+        print(result.output)
+        assert result.exit_code == 1
+        assert "restoration time 200ms is smaller than the configured polling interval 600ms" in result.output
 
     @patch('pfcwd.main.os')
     def test_pfcwd_enable_history_ports_valid(self, mock_os):
@@ -171,8 +210,8 @@ class TestPfcwd(object):
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
-                "--action", "forward", "--restoration-time", "301",
-                "all", "302"
+                "--action", "forward", "--restoration-time", "601",
+                "all", "602"
             ],
             obj=db
         )
@@ -191,8 +230,8 @@ class TestPfcwd(object):
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
-                "--action", "alert", "--restoration-time", "501",
-                "all", "502"
+                "--action", "alert", "--restoration-time", "701",
+                "all", "702"
             ],
             obj=db
         )
@@ -211,8 +250,8 @@ class TestPfcwd(object):
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
-                "--action", "drop", "--restoration-time", "601",
-                "all", "602"
+                "--action", "drop", "--restoration-time", "801",
+                "all", "802"
             ],
             obj=db
         )
@@ -730,8 +769,8 @@ class TestMultiAsicPfcwdShow(object):
         result = runner.invoke(
             pfcwd.cli.commands["start"],
             [
-                "--action", "forward", "--restoration-time", "101",
-                "Ethernet0", "Ethernet-BP4", "102"
+                "--action", "forward", "--restoration-time", "201",
+                "Ethernet0", "Ethernet-BP4", "202"
             ],
             obj=db
         )


### PR DESCRIPTION
#### What I did

Fix https://github.com/sonic-net/sonic-utilities/issues/4520
Fix https://github.com/sonic-net/sonic-buildimage/issues/27865

Added validation to reject `pfcwd start` when detection time or restoration time is smaller than the configured polling interval. Previously, the CLI accepted any value within the Click argument range (100–5000ms for detection, 100–60000ms for restoration) without cross-checking against the global POLL_INTERVAL. This results in a nonsensical configuration where the watchdog cannot accurately detect or restore within the configured timeframe.

The reverse direction is already validated. `pfcwd interval` rejects values exceeding any configured detection/restoration time. The YANG model also enforces both constraints via `must` clauses, but only during `config load` / GCU operations and not through the `pfcwd start` CLI path which writes directly to ConfigDB.

Also fixed existing unit tests that were using detection/restoration values below the mock POLL_INTERVAL, which were never caught because no validation existed.

#### How I did it
* Read `POLL_INTERVAL` from `PFC_WD|GLOBAL` in `start_cmd` before writing config, reject invalid settings
* Use strict greater-than comparison (equal values are allowed, consistent with `interval` command)
* Update existing tests to use valid values (≥ POLL_INTERVAL)
* Add rejection tests for invalid values

#### How to verify it
```
admin@sonic:~$ sudo pfcwd interval 500
admin@sonic:~$ sudo pfcwd start --action drop Ethernet0 200
detection time 200ms is smaller than the configured polling interval 500ms, please use a larger detection time or reduce the polling interval
admin@sonic:~$ sudo pfcwd start --action drop --restoration-time 200 Ethernet0 600
restoration time 200ms is smaller than the configured polling interval 500ms, please use a larger restoration time or reduce the polling interval
admin@sonic:~$ sudo pfcwd start --action drop --restoration-time 500 Ethernet0 500
(succeeds — equal values are allowed)
```

#### Previous command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo pfcwd interval 500
admin@sonic:~$ sudo pfcwd start --action drop Ethernet0 200
(silently accepted — invalid configuration applied to ConfigDB)
```

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ sudo pfcwd interval 500
admin@sonic:~$ sudo pfcwd start --action drop Ethernet0 200
detection time 200ms is smaller than the configured polling interval 500ms, please use a larger detection time or reduce the polling interval
```