### PR TITLE
fix(tests): mock sonic_platform module in sed_test.py

### DIFF
--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -1,5 +1,13 @@
+import sys
 from click.testing import CliRunner
 from mock import patch, MagicMock
+
+# sonic_platform is a hardware-specific package not available in the
+# build/test environment.  Inject stub modules so @patch can resolve
+# the dotted path without raising ModuleNotFoundError.
+sys.modules['sonic_platform'] = MagicMock()
+sys.modules['sonic_platform.platform'] = MagicMock()
+
 import config.main as config
 
 


### PR DESCRIPTION
#### Why I did it

`tests/sed_test.py` (added in #4185) uses `@patch('sonic_platform.platform.Platform')`, but `sonic_platform` is a hardware-specific package not available in the build/test environment. The `@patch` decorator tries to import the module and fails with `ModuleNotFoundError`, causing all 8 SED tests to fail.

This breaks sonic-buildimage CI across **all** platforms (aspeed, broadcom, marvell, alpinevs, vpp, vs) — see [sonic-buildimage#27773](https://github.com/sonic-net/sonic-buildimage/pull/27773).

#### How I did it

Inject `MagicMock()` stubs into `sys.modules` for `sonic_platform` and `sonic_platform.platform` before importing `config.main`, following the established pattern used by `psuutil_test.py`, `ssdutil_test.py`, `fwutil_test.py`, and `bmc_test.py`.

Without these stubs, `@patch('sonic_platform.platform.Platform')` attempts a real import of the module, which does not exist in the build environment. The other test files that mock `sonic_platform` all pre-inject it into `sys.modules` at module level — `sed_test.py` was the only one missing this step.

#### How to verify it

All 8 `sed_test.py` tests should pass in CI instead of failing with `ModuleNotFoundError: No module named 'sonic_platform'`.

Fixes: sonic-net/sonic-buildimage#27773