### PR TITLE
fix(tests): centralize sonic_platform mock in conftest.py

### DIFF
--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -14,17 +14,6 @@ from .utils import get_result_and_return_code
 sys.modules['clicommon'] = mock.Mock()
 
 
-@pytest.fixture(autouse=True)
-def _inject_sonic_platform():
-    # conftest._reset_between_files() clears sys.modules['sonic_platform']
-    # before the first test of each file. Re-inject before every test so that
-    # chassis command handlers that import sonic_platform at call time can find
-    # it. Module-level injection is not sufficient because it runs before the
-    # conftest hook that clears it.
-    sys.modules['sonic_platform'] = mock.MagicMock()
-    yield
-
-
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,6 +293,31 @@ generated_services_list = [
 
 
 @pytest.fixture(autouse=True)
+def _ensure_sonic_platform_mock():
+    """Ensure sonic_platform is always mockable in sys.modules.
+
+    _reset_between_files() clears sonic_platform entries from sys.modules
+    between test files to prevent cross-file mock leakage under xdist.
+    This fixture re-injects a MagicMock stub so that any test using
+    @patch('sonic_platform.platform.Platform') (or similar) can resolve
+    the target without ModuleNotFoundError — even if the test file forgot
+    to inject it manually.
+
+    Note: test files that import sonic_platform at module level (e.g.
+    fwutil_test.py, psuutil_test.py, sfputil_test.py) still need their
+    own sys.modules injection before the import line, because module
+    collection happens before fixtures run.
+
+    Runs before every test function (autouse=True).
+    """
+    if 'sonic_platform' not in sys.modules:
+        sys.modules['sonic_platform'] = mock.MagicMock()
+    if 'sonic_platform.platform' not in sys.modules:
+        sys.modules['sonic_platform.platform'] = mock.MagicMock()
+    yield
+
+
+@pytest.fixture(autouse=True)
 def setup_env():
     # This is needed because we call scripts from this module as a separate
     # process when running tests, and so the PYTHONPATH needs to be set

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -14,18 +14,6 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 
-sys.modules['sonic_platform'] = mock.MagicMock()
-
-
-@pytest.fixture(autouse=True)
-def _inject_sonic_platform():
-    # conftest._reset_between_files() clears sys.modules['sonic_platform']
-    # before the first test of each file; re-inject before every test so that
-    # lazy imports inside scripts (e.g. instantiate_eeprom_object) still find
-    # the mock. Module-level injection runs before the conftest hook clears it.
-    sys.modules['sonic_platform'] = mock.MagicMock()
-    yield
-
 
 decode_syseeprom_path = os.path.join(scripts_path, 'decode-syseeprom')
 decode_syseeprom = load_module_from_source('decode_syseeprom', decode_syseeprom_path)

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -5,6 +5,9 @@ import sys
 import pytest
 from unittest.mock import call, patch, MagicMock
 
+# fwutil/__init__.py imports sonic_platform at module level;
+# inject before importing fwutil.lib so collection succeeds.
+sys.modules['sonic_platform'] = MagicMock()
 sys.modules['sonic_platform.platform'] = MagicMock()
 import fwutil.lib as fwutil_lib
 

--- a/tests/psushow_test.py
+++ b/tests/psushow_test.py
@@ -13,8 +13,6 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 
-sys.modules['sonic_platform'] = mock.MagicMock()
-
 # Load the file under test
 psushow_path = os.path.join(scripts_path, 'psushow')
 psushow = load_module_from_source('psushow', psushow_path)

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -10,6 +10,8 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+# psuutil.main imports sonic_platform at module level;
+# inject before importing so collection succeeds.
 sys.modules['sonic_platform'] = mock.MagicMock()
 import psuutil.main as psuutil
 

--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -1,19 +1,6 @@
-import sys
-
-import pytest
 from click.testing import CliRunner
 from mock import patch, MagicMock
 import config.main as config
-
-sys.modules['sonic_platform'] = MagicMock()
-
-
-@pytest.fixture(autouse=True)
-def _inject_sonic_platform():
-    # conftest._reset_between_files() clears sys.modules['sonic_platform']
-    # before the first test of each file; Need to re-inject before every test
-    sys.modules['sonic_platform'] = MagicMock()
-    yield
 
 
 class TestSed(object):

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -14,6 +14,8 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+# sfputil.main imports sonic_platform at module level;
+# inject before importing so collection succeeds.
 sys.modules['sonic_platform'] = mock.MagicMock()
 import sfputil.main as sfputil
 

--- a/tests/ssdutil_test.py
+++ b/tests/ssdutil_test.py
@@ -29,7 +29,6 @@ def load_ssdutil_with_mocked_libs(monkeypatch):
     yield
 
 
-sys.modules['sonic_platform'] = MagicMock()
 sys.modules['sonic_platform_base.sonic_ssd.ssd_generic'] = MagicMock()
 
 


### PR DESCRIPTION
#### Why I did it

`sonic_platform` is a hardware-specific package unavailable in the build/test environment. Tests that use `@patch('sonic_platform...')` need it pre-injected into `sys.modules` or the decorator raises `ModuleNotFoundError`.

Previously every test file had to know about this undocumented pattern and inject the mock individually. When contributors missed it, the sonic-buildimage submodule update PR failed across **all** platforms. This has happened multiple times:

| PR | What broke | Root cause |
|---|---|---|
| [#4583](https://github.com/sonic-net/sonic-utilities/pull/4583) | `sed_test.py` — `ModuleNotFoundError: No module named 'sonic_platform'` | [#4185](https://github.com/sonic-net/sonic-utilities/pull/4185) added SED tests without `sys.modules` injection |
| [#4530](https://github.com/sonic-net/sonic-utilities/pull/4530) | `sfp_test.py`, `pcieutil_test.py` — flaky failures under xdist | Mock leakage after [#4516](https://github.com/sonic-net/sonic-utilities/pull/4516) parallelized tests |
| [#4366](https://github.com/sonic-net/sonic-utilities/pull/4366) | `ssdutil_test.py` — `TypeError` from cached real module | Module cache pollution across test files |

Most recently, the missing mock in `sed_test.py` broke the 202605 sonic-buildimage submodule update ([sonic-net/sonic-buildimage#27773](https://github.com/sonic-net/sonic-buildimage/pull/27773)) across aspeed, broadcom, marvell, alpinevs, vpp, and vs — all 8 SED tests FAILED with `ModuleNotFoundError`.

#### How I did it

Added a global `autouse` fixture `_ensure_sonic_platform_mock()` in `tests/conftest.py` that re-injects `MagicMock()` stubs into `sys.modules` for `sonic_platform` and `sonic_platform.platform` before every test function. This runs after `_reset_between_files()` clears the mocks between test files (to prevent cross-file leakage under xdist), ensuring every test can resolve `@patch('sonic_platform...')` without any per-file boilerplate.

Removed the now-redundant per-file `sys.modules` injections and `_inject_sonic_platform` fixtures from 8 test files:
- `sed_test.py`
- `decode_syseeprom_test.py`
- `chassis_modules_test.py`
- `fwutil_test.py`
- `psushow_test.py`
- `psuutil_test.py`
- `sfputil_test.py`
- `ssdutil_test.py`

#### How to verify it

All tests that use `@patch('sonic_platform...')` should pass without needing per-file `sys.modules` injection. New test files added in the future will automatically have `sonic_platform` available — no tribal knowledge required.