### PR TITLE
[sonic-installer] Add dedicated SONiC-BMC U-Boot bootloader

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -14784,7 +14784,7 @@ Installing a new image using the sonic-installer will keep using the packages in
 
 **sonic-installer set_default**
 
-This command is be used to change the image which can be loaded by default in all the subsequent reboots.
+This command is be used to change the image which can be loaded by default in all the subsequent reboots. It also clears any pending `set_next_boot` selection, so the next reboot uses this default image.
 
 - Usage:
   ```
@@ -14798,7 +14798,7 @@ This command is be used to change the image which can be loaded by default in al
 
 **sonic-installer set_next_boot**
 
-This command is used to change the image that can be loaded in the *next* reboot only. Note that it will fallback to current image in all other subsequent reboots after the next reboot.
+This command is used to change the image that can be loaded in the *next* reboot only; subsequent reboots fall back to the `set_default` image. Note that a later `set_default` overrides this one-time selection.
 
 - Usage:
   ```

--- a/sonic_installer/bootloader/__init__.py
+++ b/sonic_installer/bootloader/__init__.py
@@ -1,11 +1,13 @@
 
 from .aboot import AbootBootloader
 from .grub import GrubBootloader
+from .bmc_uboot import BmcUbootBootloader
 from .uboot import UbootBootloader
 
 BOOTLOADERS = [
     AbootBootloader,
     GrubBootloader,
+    BmcUbootBootloader,
     UbootBootloader,
 ]
 

--- a/sonic_installer/bootloader/__init__.py
+++ b/sonic_installer/bootloader/__init__.py
@@ -1,13 +1,15 @@
 
+from .bmc_uboot import BmcUbootBootloader
 from .aboot import AbootBootloader
 from .grub import GrubBootloader
-from .bmc_uboot import BmcUbootBootloader
 from .uboot import UbootBootloader
 
+# Probe BMC first so a stray /host/grub/grub.cfg can't preempt it; detect() is
+# is_bmc(), which is False on non-BMC platforms, so this is safe elsewhere.
 BOOTLOADERS = [
+    BmcUbootBootloader,
     AbootBootloader,
     GrubBootloader,
-    BmcUbootBootloader,
     UbootBootloader,
 ]
 

--- a/sonic_installer/bootloader/bmc_uboot.py
+++ b/sonic_installer/bootloader/bmc_uboot.py
@@ -172,10 +172,9 @@ class BmcUbootBootloader(OnieInstallerBootloader):
                 preexec_fn=default_sigpipe)
 
             p2.wait()
-            if p2.returncode != 0:
-                return True
-
             p3.wait()
+            # Fail closed: compatible only when grep matched the platform. Keying on
+            # grep (not tar) accepts an early-match SIGPIPE while rejecting bad manifests.
             return p3.returncode == 0
 
     def set_fips(self, image, enable):

--- a/sonic_installer/bootloader/bmc_uboot.py
+++ b/sonic_installer/bootloader/bmc_uboot.py
@@ -1,0 +1,203 @@
+"""
+Bootloader for BMC platforms (ASPEED U-Boot, two-slot environment).
+"""
+
+import os
+import subprocess
+import sys
+
+import click
+from sonic_py_common import device_info
+from utilities_common.chassis import is_bmc
+
+from ..common import (
+   HOST_PATH,
+   IMAGE_DIR_PREFIX,
+   IMAGE_PREFIX,
+   default_sigpipe,
+   run_command,
+)
+from .onie import OnieInstallerBootloader
+
+PLATFORMS_ASIC = "installer/platforms_asic"
+
+
+class BmcUbootBootloader(OnieInstallerBootloader):
+
+    NAME = 'bmc-uboot'
+
+    SLOT_VERSION_VAR = {
+        1: 'sonic_version_1',
+        2: 'sonic_version_2',
+    }
+    SLOT_IMAGE_CMD = {
+        1: 'run sonic_image_1',
+        2: 'run sonic_image_2',
+    }
+    SLOT_LINUXARGS_VAR = {
+        1: 'linuxargs',
+        2: 'linuxargs_old',
+    }
+    SLOT_AUX_VARS = {
+        1: ['image_dir', 'fit_name', 'linuxargs', 'sonic_bootargs', 'sonic_boot_load'],
+        2: ['image_dir_old', 'fit_name_old', 'linuxargs_old', 'sonic_bootargs_old', 'sonic_boot_load_old'],
+    }
+    EMPTY_WRITE = 'None'
+
+    def _fw_printenv(self, var):
+        proc = subprocess.Popen(
+            ['/usr/bin/fw_printenv', '-n', var],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        out, _ = proc.communicate()
+        if proc.returncode != 0:
+            return None
+        return out.rstrip('\n')
+
+    def _fw_setenv(self, var, value):
+        run_command(['/usr/bin/fw_setenv', var, value])
+
+    def _get_slot_image(self, slot):
+        """Image name in `slot` (from sonic_version_N), or None if empty."""
+        value = self._fw_printenv(self.SLOT_VERSION_VAR[slot])
+        # Empty markers: '', 'None', 'NONE' (case-insensitive).
+        if value is None or value.strip().lower() in ('', 'none'):
+            return None
+        if not value.startswith(IMAGE_PREFIX):
+            return None
+        return value
+
+    def _get_image_slot(self, image):
+        for slot in (1, 2):
+            if self._get_slot_image(slot) == image:
+                return slot
+        return None
+
+    def _boot_slot(self, var):
+        """Slot that boot variable `var` ('boot_once'/'boot_next') selects, or None."""
+        selector = (self._fw_printenv(var) or '').strip()
+        for slot, command in self.SLOT_IMAGE_CMD.items():
+            if selector == command:
+                return slot
+        return None
+
+    # get_current_image is inherited from OnieInstallerBootloader: it parses
+    # loop=<dir>/fs.squashfs from the cmdline, the format the BMC uses.
+
+    def get_installed_images(self):
+        images = []
+        for slot in (1, 2):
+            image = self._get_slot_image(slot)
+            if image:
+                images.append(image)
+        return images
+
+    def get_next_image(self):
+        # boot_once (one-shot) wins over boot_next, matching U-Boot's bootcmd.
+        for var in ('boot_once', 'boot_next'):
+            slot = self._boot_slot(var)
+            if slot:
+                # Populated slot -> its image; empty slot -> raw marker, so state stays visible.
+                return self._get_slot_image(slot) or self._fw_printenv(self.SLOT_VERSION_VAR[slot]) or self.SLOT_IMAGE_CMD[slot]
+            selector = (self._fw_printenv(var) or '').strip()
+            if selector:
+                return selector  # set but unrecognized selector -> surface it
+        return ''
+
+    def set_default_image(self, image):
+        slot = self._get_image_slot(image)
+        if slot is None:
+            return False
+        self._fw_setenv('boot_next', self.SLOT_IMAGE_CMD[slot])
+        self._fw_setenv('boot_once', '')
+        return True
+
+    def set_next_image(self, image):
+        slot = self._get_image_slot(image)
+        if slot is None:
+            return False
+        self._fw_setenv('boot_once', self.SLOT_IMAGE_CMD[slot])
+        return True
+
+    def install_image(self, image_path):
+        run_command(['bash', image_path])
+        # Installer set boot_next to slot 1; clear any stale boot_once that would shadow it.
+        self._fw_setenv('boot_once', '')
+
+    def remove_image(self, image):
+        click.echo('Updating next boot ...')
+        slot = self._get_image_slot(image)
+        if slot is None:
+            sys.exit('Image does not map to a BMC U-Boot slot')
+
+        survivor = 2 if slot == 1 else 1
+        if self._get_slot_image(survivor) is None:
+            sys.exit('Cannot remove the only populated BMC image slot')
+
+        if self._boot_slot('boot_once') == slot:
+            self._fw_setenv('boot_once', '')
+
+        if self._boot_slot('boot_next') == slot:
+            self._fw_setenv('boot_next', self.SLOT_IMAGE_CMD[survivor])
+
+        self._fw_setenv(self.SLOT_VERSION_VAR[slot], self.EMPTY_WRITE)
+        for var in self.SLOT_AUX_VARS[slot]:
+            self._fw_setenv(var, '')
+
+        image_dir = image.replace(IMAGE_PREFIX, IMAGE_DIR_PREFIX, 1)
+        click.echo('Removing image root filesystem...')
+        subprocess.call(['rm', '-rf', os.path.join(HOST_PATH, image_dir)])
+        click.echo('Done')
+
+    def verify_image_platform(self, image_path):
+        if not os.path.isfile(image_path):
+            return False
+
+        platform = device_info.get_platform()
+        with open(os.devnull, 'w') as fnull:
+            p1 = subprocess.Popen(
+                ['sed', '-e', '1,/^exit_marker$/d', image_path],
+                stdout=subprocess.PIPE,
+                preexec_fn=default_sigpipe)
+            p2 = subprocess.Popen(
+                ['tar', 'xf', '-', PLATFORMS_ASIC, '-O'],
+                stdin=p1.stdout,
+                stdout=subprocess.PIPE,
+                stderr=fnull,
+                preexec_fn=default_sigpipe)
+            p3 = subprocess.Popen(
+                ['grep', '-Fxq', '-m', '1', platform],
+                stdin=p2.stdout,
+                preexec_fn=default_sigpipe)
+
+            p2.wait()
+            if p2.returncode != 0:
+                return True
+
+            p3.wait()
+            return p3.returncode == 0
+
+    def set_fips(self, image, enable):
+        slot = self._get_image_slot(image)
+        if slot is None:
+            return False
+
+        value = self._fw_printenv(self.SLOT_LINUXARGS_VAR[slot]) or ''
+        tokens = [token for token in value.split() if not token.startswith('sonic_fips=')]
+        tokens.append('sonic_fips={}'.format('1' if enable else '0'))
+        self._fw_setenv(self.SLOT_LINUXARGS_VAR[slot], ' '.join(tokens))
+        click.echo('Done')
+        return True
+
+    def get_fips(self, image):
+        slot = self._get_image_slot(image)
+        if slot is None:
+            return False
+
+        value = self._fw_printenv(self.SLOT_LINUXARGS_VAR[slot]) or ''
+        return any(token == 'sonic_fips=1' for token in value.split())
+
+    @classmethod
+    def detect(cls):
+        return is_bmc()

--- a/sonic_installer/bootloader/bmc_uboot.py
+++ b/sonic_installer/bootloader/bmc_uboot.py
@@ -82,9 +82,6 @@ class BmcUbootBootloader(OnieInstallerBootloader):
                 return slot
         return None
 
-    # get_current_image is inherited from OnieInstallerBootloader: it parses
-    # loop=<dir>/fs.squashfs from the cmdline, the format the BMC uses.
-
     def get_installed_images(self):
         images = []
         for slot in (1, 2):

--- a/sonic_installer/bootloader/bmc_uboot.py
+++ b/sonic_installer/bootloader/bmc_uboot.py
@@ -187,7 +187,7 @@ class BmcUbootBootloader(OnieInstallerBootloader):
         tokens = [token for token in value.split() if not token.startswith('sonic_fips=')]
         tokens.append('sonic_fips={}'.format('1' if enable else '0'))
         self._fw_setenv(self.SLOT_LINUXARGS_VAR[slot], ' '.join(tokens))
-        click.echo('Done')
+        # CLI prints the success message; don't duplicate it here.
         return True
 
     def get_fips(self, image):

--- a/sonic_installer/bootloader/bmc_uboot.py
+++ b/sonic_installer/bootloader/bmc_uboot.py
@@ -96,7 +96,11 @@ class BmcUbootBootloader(OnieInstallerBootloader):
             slot = self._boot_slot(var)
             if slot:
                 # Populated slot -> its image; empty slot -> raw marker, so state stays visible.
-                return self._get_slot_image(slot) or self._fw_printenv(self.SLOT_VERSION_VAR[slot]) or self.SLOT_IMAGE_CMD[slot]
+                return (
+                    self._get_slot_image(slot)
+                    or self._fw_printenv(self.SLOT_VERSION_VAR[slot])
+                    or self.SLOT_IMAGE_CMD[slot]
+                )
             selector = (self._fw_printenv(var) or '').strip()
             if selector:
                 return selector  # set but unrecognized selector -> surface it

--- a/sonic_installer/bootloader/uboot.py
+++ b/sonic_installer/bootloader/uboot.py
@@ -8,6 +8,7 @@ import os
 import re
 from shlex import split
 import click
+from utilities_common.chassis import is_bmc
 
 from ..common import (
    HOST_PATH,
@@ -99,5 +100,8 @@ class UbootBootloader(OnieInstallerBootloader):
 
     @classmethod
     def detect(cls):
+        # BMC runs U-Boot too but is owned by BmcUbootBootloader; exclude it here.
+        if is_bmc():
+            return False
         arch = platform.machine()
         return ("arm" in arch) or ("aarch64" in arch)

--- a/tests/installer_bootloader_bmc_uboot_test.py
+++ b/tests/installer_bootloader_bmc_uboot_test.py
@@ -1,0 +1,153 @@
+import os
+from unittest.mock import Mock, call, patch
+
+import sonic_installer.bootloader.bmc_uboot as bmc
+import sonic_installer.bootloader.uboot as generic_uboot
+
+
+IMAGE1 = bmc.IMAGE_PREFIX + '202401.0'
+IMAGE2 = bmc.IMAGE_PREFIX + '202402.0'
+DIR1 = bmc.IMAGE_DIR_PREFIX + '202401.0'
+DIR2 = bmc.IMAGE_DIR_PREFIX + '202402.0'
+
+
+def base_env():
+    return {
+        'sonic_version_1': IMAGE1,
+        'sonic_version_2': IMAGE2,
+        'boot_next': 'run sonic_image_1',
+        'boot_once': '',
+        'image_dir': DIR1,
+        'image_dir_old': DIR2,
+        'fit_name': 'sonic-itb.bin',
+        'fit_name_old': 'sonic-itb-old.bin',
+        'linuxargs': 'console=ttyS0',
+        'linuxargs_old': 'console=ttyS1 sonic_fips=1 rootwait',
+        'sonic_bootargs': 'console=${baudrate} ${linuxargs}',
+        'sonic_bootargs_old': 'console=${baudrate} ${linuxargs_old}',
+        'sonic_boot_load': 'load slot1',
+        'sonic_boot_load_old': 'load slot2',
+    }
+
+
+def fake_popen(env):
+    def _popen(cmd, *args, **kwargs):
+        proc = Mock()
+        assert cmd[:2] == ['/usr/bin/fw_printenv', '-n']
+        value = env.get(cmd[2])
+        if value is None:
+            proc.returncode = 1
+            proc.communicate.return_value = ('', '')
+        else:
+            proc.returncode = 0
+            proc.communicate.return_value = (value + '\n', '')
+        return proc
+
+    return _popen
+
+
+def fake_run_command(env):
+    def _run_command(cmd, *args, **kwargs):
+        if cmd[0] == 'bash':
+            return None
+        assert cmd[0] == '/usr/bin/fw_setenv'
+        env[cmd[1]] = cmd[2] if len(cmd) > 2 else ''
+        return None
+
+    return _run_command
+
+
+def test_set_default_slot2_updates_default_and_clears_boot_once():
+    env = base_env()
+    env['boot_once'] = 'run sonic_image_1'
+
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=fake_popen(env)), \
+         patch('sonic_installer.bootloader.bmc_uboot.run_command', side_effect=fake_run_command(env)):
+        assert bmc.BmcUbootBootloader().set_default_image(IMAGE2)
+
+    assert env['boot_next'] == 'run sonic_image_2'
+    assert env['boot_once'] == ''
+
+
+def test_set_next_image_sets_boot_once_without_changing_default():
+    env = base_env()
+
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=fake_popen(env)), \
+         patch('sonic_installer.bootloader.bmc_uboot.run_command', side_effect=fake_run_command(env)):
+        assert bmc.BmcUbootBootloader().set_next_image(IMAGE2)
+
+    assert env['boot_once'] == 'run sonic_image_2'
+    assert env['boot_next'] == 'run sonic_image_1'
+
+
+def test_get_next_image_prefers_boot_once_and_returns_unknown_selector_raw():
+    env = base_env()
+    env['boot_once'] = 'run sonic_image_2'
+    bootloader = bmc.BmcUbootBootloader()
+
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=fake_popen(env)):
+        assert bootloader.get_next_image() == IMAGE2
+
+        env['boot_once'] = 'run unexpected_selector'
+        assert bootloader.get_next_image() == 'run unexpected_selector'
+
+        env['boot_once'] = ''
+        assert bootloader.get_next_image() == IMAGE1
+
+
+def test_install_image_runs_installer_and_clears_boot_once():
+    env = base_env()
+    env['boot_once'] = 'run sonic_image_2'
+
+    with patch('sonic_installer.bootloader.bmc_uboot.run_command', side_effect=fake_run_command(env)) as run_command:
+        bmc.BmcUbootBootloader().install_image('/tmp/sonic-bmc.bin')
+
+    assert call(['bash', '/tmp/sonic-bmc.bin']) in run_command.call_args_list
+    # Installer owns boot_next; we only drop the stale one-shot.
+    assert env['boot_next'] == 'run sonic_image_1'
+    assert env['boot_once'] == ''
+
+
+def test_remove_image_repoints_selectors_clears_slot_and_removes_rootfs():
+    env = base_env()
+    env['boot_next'] = 'run sonic_image_2'
+    env['boot_once'] = 'run sonic_image_2'
+
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=fake_popen(env)), \
+         patch('sonic_installer.bootloader.bmc_uboot.run_command', side_effect=fake_run_command(env)), \
+         patch('sonic_installer.bootloader.bmc_uboot.subprocess.call') as subprocess_call:
+        bmc.BmcUbootBootloader().remove_image(IMAGE2)
+
+    assert env['boot_next'] == 'run sonic_image_1'
+    assert env['boot_once'] == ''
+    assert env['sonic_version_2'] == 'None'
+    for var in bmc.BmcUbootBootloader.SLOT_AUX_VARS[2]:
+        assert env[var] == ''
+    subprocess_call.assert_called_once_with(['rm', '-rf', os.path.join(bmc.HOST_PATH, DIR2)])
+
+
+def test_set_fips_updates_only_target_slot_linuxargs_token():
+    env = base_env()
+
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=fake_popen(env)), \
+         patch('sonic_installer.bootloader.bmc_uboot.run_command', side_effect=fake_run_command(env)):
+        bootloader = bmc.BmcUbootBootloader()
+        assert bootloader.get_fips(IMAGE2)
+        assert bootloader.set_fips(IMAGE2, False)
+        assert not bootloader.get_fips(IMAGE2)
+
+    # Only slot 2's linuxargs_old is rewritten; slot 1's linuxargs is untouched.
+    assert env['linuxargs'] == 'console=ttyS0'
+    assert env['linuxargs_old'] == 'console=ttyS1 rootwait sonic_fips=0'
+
+
+def test_detect_uses_bmc_and_generic_uboot_excludes_bmc():
+    with patch('sonic_installer.bootloader.bmc_uboot.is_bmc', return_value=True):
+        assert bmc.BmcUbootBootloader.detect()
+
+    with patch('sonic_installer.bootloader.uboot.is_bmc', return_value=True):
+        assert not generic_uboot.UbootBootloader.detect()
+
+    with patch('sonic_installer.bootloader.uboot.is_bmc', return_value=False), \
+         patch('sonic_installer.bootloader.uboot.platform.machine', return_value='aarch64'):
+        assert generic_uboot.UbootBootloader.detect()

--- a/tests/installer_bootloader_bmc_uboot_test.py
+++ b/tests/installer_bootloader_bmc_uboot_test.py
@@ -151,3 +151,13 @@ def test_detect_uses_bmc_and_generic_uboot_excludes_bmc():
     with patch('sonic_installer.bootloader.uboot.is_bmc', return_value=False), \
          patch('sonic_installer.bootloader.uboot.platform.machine', return_value='aarch64'):
         assert generic_uboot.UbootBootloader.detect()
+
+
+def test_get_bootloader_prefers_bmc_over_grub_when_both_detect():
+    # On a BMC with a stale/accidental /host/grub/grub.cfg present, both the BMC
+    # and GRUB detectors would return True. BmcUbootBootloader must win because
+    # it is probed first in BOOTLOADERS.
+    import sonic_installer.bootloader as loader
+    with patch('sonic_installer.bootloader.bmc_uboot.is_bmc', return_value=True), \
+         patch('sonic_installer.bootloader.grub.os.path.isfile', return_value=True):
+        assert isinstance(loader.get_bootloader(), bmc.BmcUbootBootloader)

--- a/tests/installer_bootloader_bmc_uboot_test.py
+++ b/tests/installer_bootloader_bmc_uboot_test.py
@@ -1,8 +1,27 @@
 import os
 from unittest.mock import Mock, call, patch
 
+import pytest
+
 import sonic_installer.bootloader.bmc_uboot as bmc
 import sonic_installer.bootloader.uboot as generic_uboot
+
+
+def fake_verify_popen(tar_rc, grep_rc):
+    """Stub sed|tar|grep for verify_image_platform; set tar (p2)/grep (p3) rc."""
+    def _popen(cmd, *args, **kwargs):
+        proc = Mock()
+        proc.stdout = Mock()
+        proc.wait = Mock(return_value=None)
+        if cmd[0] == 'tar':
+            proc.returncode = tar_rc
+        elif cmd[0] == 'grep':
+            proc.returncode = grep_rc
+        else:  # sed
+            proc.returncode = 0
+        return proc
+
+    return _popen
 
 
 IMAGE1 = bmc.IMAGE_PREFIX + '202401.0'
@@ -151,6 +170,68 @@ def test_detect_uses_bmc_and_generic_uboot_excludes_bmc():
     with patch('sonic_installer.bootloader.uboot.is_bmc', return_value=False), \
          patch('sonic_installer.bootloader.uboot.platform.machine', return_value='aarch64'):
         assert generic_uboot.UbootBootloader.detect()
+
+
+def test_verify_image_platform_match_mismatch_and_fail_closed():
+    b = bmc.BmcUbootBootloader()
+    with patch('sonic_installer.bootloader.bmc_uboot.os.path.isfile', return_value=True), \
+         patch('sonic_installer.bootloader.bmc_uboot.device_info.get_platform',
+               return_value='arm64-plat-r0'):
+        # platform listed -> grep matches
+        with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen',
+                   side_effect=fake_verify_popen(tar_rc=0, grep_rc=0)):
+            assert b.verify_image_platform('/img.bin') is True
+        # platforms_asic present but platform not listed -> grep no match
+        with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen',
+                   side_effect=fake_verify_popen(tar_rc=0, grep_rc=1)):
+            assert b.verify_image_platform('/img.bin') is False
+        # malformed / missing platforms_asic -> tar fails: must FAIL CLOSED
+        with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen',
+                   side_effect=fake_verify_popen(tar_rc=2, grep_rc=1)):
+            assert b.verify_image_platform('/img.bin') is False
+        # early grep match where tar is then SIGPIPE'd (tar rc != 0) -> compatible
+        with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen',
+                   side_effect=fake_verify_popen(tar_rc=-13, grep_rc=0)):
+            assert b.verify_image_platform('/img.bin') is True
+    # non-existent file -> False
+    with patch('sonic_installer.bootloader.bmc_uboot.os.path.isfile', return_value=False):
+        assert b.verify_image_platform('/missing.bin') is False
+
+
+def test_fw_printenv_failure_handled_gracefully():
+    def failing_popen(cmd, *args, **kwargs):
+        assert cmd[:2] == ['/usr/bin/fw_printenv', '-n']
+        proc = Mock()
+        proc.returncode = 1
+        proc.communicate.return_value = ('', '')
+        return proc
+
+    b = bmc.BmcUbootBootloader()
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=failing_popen):
+        assert b._fw_printenv('sonic_version_1') is None
+        assert b.get_installed_images() == []
+        assert b.get_next_image() == ''
+
+
+def test_get_installed_images_skips_empty_slots():
+    env = base_env()
+    env['sonic_version_2'] = 'None'  # empty marker
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=fake_popen(env)):
+        assert bmc.BmcUbootBootloader().get_installed_images() == [IMAGE1]
+
+
+def test_remove_image_only_populated_slot_aborts():
+    env = base_env()
+    env['sonic_version_2'] = 'None'  # only slot 1 populated
+    with patch('sonic_installer.bootloader.bmc_uboot.subprocess.Popen', side_effect=fake_popen(env)), \
+         patch('sonic_installer.bootloader.bmc_uboot.run_command', side_effect=fake_run_command(env)), \
+         patch('sonic_installer.bootloader.bmc_uboot.subprocess.call') as subprocess_call:
+        with pytest.raises(SystemExit):
+            bmc.BmcUbootBootloader().remove_image(IMAGE1)
+    # guard fires before any env mutation or rootfs removal
+    assert env['sonic_version_1'] == IMAGE1
+    assert env['boot_next'] == 'run sonic_image_1'
+    subprocess_call.assert_not_called()
 
 
 def test_get_bootloader_prefers_bmc_over_grub_when_both_detect():


### PR DESCRIPTION
Address issue - https://github.com/sonic-net/sonic-utilities/issues/4548

#### What I did

Added a **dedicated `BmcUbootBootloader`** so `sonic-installer` manages SONiC-BMC boot state correctly. SONiC-BMC platforms (ASPEED AST2700) run U-Boot with a **two-slot** environment, which the generic `UbootBootloader` does not model — on a BMC it previously fell through to that generic handler and operated on the wrong environment variables. 

Specifically:
- New `sonic_installer/bootloader/bmc_uboot.py` (`BmcUbootBootloader`, `NAME = 'bmc-uboot'`), selected via `utilities_common.chassis.is_bmc()`.
- Registered **first** in `BOOTLOADERS` so a stray `/host/grub/grub.cfg` cannot preempt it, and guarded `UbootBootloader.detect()` to exclude BMC.
- Full two-slot lifecycle: `list`, `set-default`, `set-next-boot`, `install`, `remove`, `cleanup`, `verify-next-image`, `set-fips`/`get-fips`, `binary-version`, plus a BMC-specific `verify_image_platform` (fails closed).
- Unit tests in `tests/installer_bootloader_bmc_uboot_test.py` (12 tests).

No change to `sonic_installer/main.py` — the work is confined to the bootloader plugin and its test.

#### How I did it

`BmcUbootBootloader` subclasses `OnieInstallerBootloader` and models the ASPEED AST2700 two-slot U-Boot environment:

| Concept | Slot 1 | Slot 2 |
|---------|--------|--------|
| version var | `sonic_version_1` | `sonic_version_2` |
| boot command | `run sonic_image_1` | `run sonic_image_2` |
| kernel args | `linuxargs` | `linuxargs_old` |

Empty slots are written/read as the marker `None` (also accepts `NONE`/empty, case-insensitively).

- **Boot selection (Aboot-style contract):** `set-default` writes the persistent `boot_next` and clears the one-shot `boot_once`; `set-next-boot` writes only `boot_once`. `get_next_image()` resolves `boot_once` first (it wins, matching U-Boot `bootcmd`), then `boot_next`, and surfaces an empty/unrecognized selector as a raw string so a broken boot state stays visible rather than being masked.
- **Install:** `install_image()` runs the image's own installer (`bash <image>`, which performs the slot rotation and sets `boot_next`) and then clears any stale `boot_once` that would otherwise shadow the new default.
- **Remove:** `remove_image()` repoints `boot_once`/`boot_next` to the surviving slot before clearing the removed slot's version + auxiliary vars and deleting its rootfs; it refuses to remove the only populated slot.
- **FIPS:** `set-fips`/`get-fips` rewrite the `sonic_fips=` token in the target slot's `linuxargs`/`linuxargs_old` only (per-slot isolation).
- **Platform check:** `verify_image_platform()` mirrors the GRUB approach — extracts `installer/platforms_asic` from the image and matches the running `device_info.get_platform()` with `grep -Fxq` (whole-line). It **fails closed**: compatible only when grep matches, so a malformed/manifest-less payload is rejected rather than silently accepted.

#### How to verify it

On a SONiC-BMC (ASPEED AST2700) board, the dedicated bootloader is auto-selected and the full command surface was exercised end-to-end, cross-checking the U-Boot environment (`fw_printenv`) and, across real reboots, `/proc/cmdline`:

- `sonic-installer list` / `verify-next-image` reflect the two-slot state.
- `set-default <img>` sets `boot_next` and clears `boot_once`; `set-next-boot <img>` sets a one-shot `boot_once` that U-Boot consumes on the next reboot and then reverts to `boot_next`.
- `install <bmc.bin>` rotates the new image into a slot and boots it after reboot.
- `remove` / `cleanup` clear the slot's vars, repoint the boot selectors, and delete the rootfs.
- `set-fips`/`get-fips` toggle `sonic_fips=` in the correct per-slot args.
- A wrong-platform (switch) image is rejected by `verify_image_platform`; `--skip-platform-check` overrides it.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)