### PR TITLE
[Mellanox] Add new SKU ACS-SN6810_LD

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -24,7 +24,7 @@
                           "Mellanox-SN4700-A96C8V8", "Mellanox-SN4700-C128", "Mellanox-SN4700-O28", "Mellanox-SN4700-O8V48", "Mellanox-SN4700-V48C32", "Mellanox-SN4280-O28", "Mellanox-SN4280-O8C80", "Mellanox-SN4280-C48", "Mellanox-SN4280-O8C40", "Mellanox-SN4280-O8V40", "Mellanox-SN4280-O4X96"],
                 "spc4": [ "ACS-SN5600", "Mellanox-SN5600-O128", "Mellanox-SN5600-V256", "Mellanox-SN5600-C256S1", "ACS-SN5400", "Mellanox-SN5600-C224O8", "Mellanox-SN5610N-C256S2", "Mellanox-SN5610N-C224O8" ],
                 "spc5": ["ACS-SN5640", "Mellanox-SN5640-C512S2", "Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512X2", "Mellanox-SN5640-C508O1X2", "Mellanox-SN5640-O128X2" ],
-                "spc6": ["ACS-SN6600_LD"]
+                "spc6": ["ACS-SN6600_LD", "ACS-SN6810_LD"]
             },
             "broadcom_asics": {
                 "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010" ],


### PR DESCRIPTION
#### What I did

Add new SKU `ACS-SN6810_LD` to `gcu_field_operation_validators.conf.json` under Mellanox `spc6` ASIC list for RDMA GCU field validation.

#### How I did it

Extended the `spc6` platform list in `generic_config_updater/gcu_field_operation_validators.conf.json`.

#### How to verify it

- Manual test with GCU on SN6810_LD platform
- sonic-mgmt test
