### PR TITLE
[multi-ASIC] counterpoll flowcnt-route namespace-aware capability check

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -491,7 +491,7 @@ def flowcnt_trap_disable(ctx):
 def flowcnt_route(ctx, namespace):
     """ Route flow counter commands """
     ctx.obj = connect_to_db(namespace)
-    exit_if_route_flow_counter_not_support()
+    exit_if_route_flow_counter_not_support(namespace)
 
 
 @flowcnt_route.command(name='interval')

--- a/flow_counter_util/route.py
+++ b/flow_counter_util/route.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from swsscommon.swsscommon import SonicV2Connector
+from swsscommon.swsscommon import SonicV2Connector, SonicDBConfig
 
 try:
     if os.environ["UTILITIES_UNIT_TESTING"] == "1" or os.environ["UTILITIES_UNIT_TESTING"] == "2":
@@ -54,15 +54,20 @@ def build_route_pattern(vrf, prefix):
         return prefix
 
 
-def get_route_flow_counter_capability():
-    state_db = SonicV2Connector(host="127.0.0.1")
+def get_route_flow_counter_capability(namespace=None):
+    if namespace:
+        if not SonicDBConfig.isGlobalInit():
+            SonicDBConfig.initializeGlobalConfig()
+        state_db = SonicV2Connector(use_unix_socket_path=True, namespace=str(namespace))
+    else:
+        state_db = SonicV2Connector(host="127.0.0.1")
     state_db.connect(state_db.STATE_DB)
 
     return state_db.get_all(state_db.STATE_DB, '{}|{}'.format(FLOW_COUNTER_CAPABILITY_TABLE, FLOW_COUNTER_CAPABILITY_KEY))
 
 
-def exit_if_route_flow_counter_not_support():
-    capabilities = get_route_flow_counter_capability()
+def exit_if_route_flow_counter_not_support(namespace=None):
+    capabilities = get_route_flow_counter_capability(namespace)
     if not capabilities:
         print('Waiting for swss to initialize route flow counter capability, please try again later')
         exit(1)

--- a/tests/flow_counter_stats_test.py
+++ b/tests/flow_counter_stats_test.py
@@ -10,7 +10,12 @@ import clear.main as clear
 import config.main as config
 
 from .utils import get_result_and_return_code
-from flow_counter_util.route import FLOW_COUNTER_ROUTE_PATTERN_TABLE, FLOW_COUNTER_ROUTE_MAX_MATCH_FIELD
+from flow_counter_util.route import (
+    FLOW_COUNTER_ROUTE_PATTERN_TABLE,
+    FLOW_COUNTER_ROUTE_MAX_MATCH_FIELD,
+    get_route_flow_counter_capability,
+    FLOW_COUNTER_CAPABILITY_SUPPORT_FIELD,
+)
 from utilities_common.db import Db
 from utilities_common.general import load_module_from_source
 
@@ -917,3 +922,40 @@ class TestRouteStatsMultiAsic:
         assert result.exit_code == 0
         assert expect_after_clear_route_stats_all_multi_asic == result.output
         print(result.output)
+
+
+class TestGetRouteFlowCounterCapability:
+    """Pin the two STATE_DB connector branches introduced for multi-ASIC support.
+
+    namespace=None / ''  → legacy SonicV2Connector(host='127.0.0.1')
+    namespace='asic0'    → SonicV2Connector(use_unix_socket_path=True, namespace='asic0')
+                           + SonicDBConfig.initializeGlobalConfig() when not yet initialised
+    """
+
+    @mock.patch('flow_counter_util.route.SonicV2Connector')
+    def test_no_namespace_uses_host_connector(self, mock_connector):
+        mock_db = mock.MagicMock()
+        mock_connector.return_value = mock_db
+        mock_db.get_all.return_value = {FLOW_COUNTER_CAPABILITY_SUPPORT_FIELD: 'true'}
+
+        for ns in (None, ''):
+            mock_connector.reset_mock()
+            get_route_flow_counter_capability(ns)
+            mock_connector.assert_called_once_with(host='127.0.0.1')
+            mock_db.connect.assert_called_with(mock_db.STATE_DB)
+
+    @mock.patch('flow_counter_util.route.SonicDBConfig')
+    @mock.patch('flow_counter_util.route.SonicV2Connector')
+    def test_namespace_uses_unix_socket_connector(self, mock_connector, mock_db_config):
+        mock_db_config.isGlobalInit.return_value = False
+        mock_db = mock.MagicMock()
+        mock_connector.return_value = mock_db
+        mock_db.get_all.return_value = {FLOW_COUNTER_CAPABILITY_SUPPORT_FIELD: 'true'}
+
+        get_route_flow_counter_capability('asic0')
+
+        mock_db_config.isGlobalInit.assert_called_once()
+        mock_db_config.initializeGlobalConfig.assert_called_once()
+        mock_connector.assert_called_once_with(use_unix_socket_path=True, namespace='asic0')
+        mock_db.connect.assert_called_with(mock_db.STATE_DB)
+

--- a/tests/flow_counter_stats_test.py
+++ b/tests/flow_counter_stats_test.py
@@ -958,4 +958,3 @@ class TestGetRouteFlowCounterCapability:
         mock_db_config.initializeGlobalConfig.assert_called_once()
         mock_connector.assert_called_once_with(use_unix_socket_path=True, namespace='asic0')
         mock_db.connect.assert_called_with(mock_db.STATE_DB)
-


### PR DESCRIPTION
Pass the namespace to exit_if_route_flow_counter_not_support() so the STATE_DB capability check queries the correct per-namespace instance instead of the hardcoded 127.0.0.1 address.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added multi-ASIC support for counterpoll flowcnt-route by making the route flow counter capability check namespace-aware.

#### How I did it

The flowcnt_route group in counterpoll/main.py already accepted a -n/--namespace option and connected to the correct per-namespace ConfigDB, but the capability check (exit_if_route_flow_counter_not_support) was still querying STATE_DB at the hardcoded address 127.0.0.1, ignoring the selected namespace.

Two changes were made:

- flow_counter_util/route.py: Added an optional namespace parameter to get_route_flow_counter_capability() and exit_if_route_flow_counter_not_support(). When a namespace is provided, the STATE_DB connection uses the unix socket path with the namespace (consistent with connect_to_db in counterpoll). Falls back to host="127.0.0.1" for single-ASIC, preserving backward compatibility for all existing callers.
- counterpoll/main.py: Pass namespace to exit_if_route_flow_counter_not_support(namespace) in the flowcnt_route group callback.

#### How to verify it

Should check capability against the correct namespace STATE_DB
counterpoll flowcnt-route -n asic0 enable
counterpoll flowcnt-route -n asic1 enable

Single-ASIC / no namespace — backward-compatible behavior unchanged
counterpoll flowcnt-route enable
counterpoll flowcnt-route disable
counterpoll flowcnt-route interval 5000

Confirm that on a namespace where route flow counters are not supported, the command correctly exits with "Route flow counter is not supported on this platform" rather than silently succeeding or querying the wrong STATE_DB instance.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
