### PR TITLE
[Mellanox] Preserve explicit buffer_model=dynamic in buffer migrator

### DIFF
--- a/scripts/mellanox_buffer_migrator.py
+++ b/scripts/mellanox_buffer_migrator.py
@@ -821,9 +821,11 @@ class MellanoxBufferMigrator():
         if not self.ready:
             return True
 
-        if not self.is_buffer_config_default and not self.is_buffer_config_empty or self.is_default_traditional_model:
+        metadata = self.configDB.get_entry('DEVICE_METADATA', 'localhost')
+        already_dynamic = metadata.get('buffer_model') == 'dynamic' and not self.is_default_traditional_model
+
+        if (not self.is_buffer_config_default and not self.is_buffer_config_empty or self.is_default_traditional_model) and not already_dynamic:
             log.log_notice("No item pending to be updated")
-            metadata = self.configDB.get_entry('DEVICE_METADATA', 'localhost')
             metadata['buffer_model'] = 'traditional'
             self.configDB.set_entry('DEVICE_METADATA', 'localhost', metadata)
             log.log_notice("Set buffer_model as traditional")


### PR DESCRIPTION
Guard the traditional-fallback in mlnx_flush_new_buffer_configuration() so it no longer overwrites buffer_model to "traditional" when the device has already declared buffer_model=dynamic.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix `MellanoxBufferMigrator.mlnx_flush_new_buffer_configuration()` so it no longer
overwrites `DEVICE_METADATA.buffer_model` from `dynamic` to `traditional` on newer
SKUs whose dynamic-mode pool layout is not registered in the migrator's static
`mellanox_default_parameter` table.

#### How I did it

The fix encodes that precondition into the existing condition rather than introducing a parallel code path.

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

