### PR TITLE
[202605] fix(tests): centralize sonic_platform mock in conftest.py

### DIFF
--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -14,17 +14,6 @@ from .utils import get_result_and_return_code
 sys.modules['clicommon'] = mock.Mock()
 
 
-@pytest.fixture(autouse=True)
-def _inject_sonic_platform():
-    # conftest._reset_between_files() clears sys.modules['sonic_platform']
-    # before the first test of each file. Re-inject before every test so that
-    # chassis command handlers that import sonic_platform at call time can find
-    # it. Module-level injection is not sufficient because it runs before the
-    # conftest hook that clears it.
-    sys.modules['sonic_platform'] = mock.MagicMock()
-    yield
-
-
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,6 +293,31 @@ generated_services_list = [
 
 
 @pytest.fixture(autouse=True)
+def _ensure_sonic_platform_mock():
+    """Ensure sonic_platform is always mockable in sys.modules.
+
+    _reset_between_files() clears sonic_platform entries from sys.modules
+    between test files to prevent cross-file mock leakage under xdist.
+    This fixture re-injects a MagicMock stub so that any test using
+    @patch('sonic_platform.platform.Platform') (or similar) can resolve
+    the target without ModuleNotFoundError — even if the test file forgot
+    to inject it manually.
+
+    Note: test files that import sonic_platform at module level (e.g.
+    fwutil_test.py, psuutil_test.py, sfputil_test.py) still need their
+    own sys.modules injection before the import line, because module
+    collection happens before fixtures run.
+
+    Runs before every test function (autouse=True).
+    """
+    if 'sonic_platform' not in sys.modules:
+        sys.modules['sonic_platform'] = mock.MagicMock()
+    if 'sonic_platform.platform' not in sys.modules:
+        sys.modules['sonic_platform.platform'] = mock.MagicMock()
+    yield
+
+
+@pytest.fixture(autouse=True)
 def setup_env():
     # This is needed because we call scripts from this module as a separate
     # process when running tests, and so the PYTHONPATH needs to be set

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -14,18 +14,6 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 
-sys.modules['sonic_platform'] = mock.MagicMock()
-
-
-@pytest.fixture(autouse=True)
-def _inject_sonic_platform():
-    # conftest._reset_between_files() clears sys.modules['sonic_platform']
-    # before the first test of each file; re-inject before every test so that
-    # lazy imports inside scripts (e.g. instantiate_eeprom_object) still find
-    # the mock. Module-level injection runs before the conftest hook clears it.
-    sys.modules['sonic_platform'] = mock.MagicMock()
-    yield
-
 
 decode_syseeprom_path = os.path.join(scripts_path, 'decode-syseeprom')
 decode_syseeprom = load_module_from_source('decode_syseeprom', decode_syseeprom_path)

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -5,6 +5,9 @@ import sys
 import pytest
 from unittest.mock import call, patch, MagicMock
 
+# fwutil/__init__.py imports sonic_platform at module level;
+# inject before importing fwutil.lib so collection succeeds.
+sys.modules['sonic_platform'] = MagicMock()
 sys.modules['sonic_platform.platform'] = MagicMock()
 import fwutil.lib as fwutil_lib
 

--- a/tests/psushow_test.py
+++ b/tests/psushow_test.py
@@ -13,8 +13,6 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 
-sys.modules['sonic_platform'] = mock.MagicMock()
-
 # Load the file under test
 psushow_path = os.path.join(scripts_path, 'psushow')
 psushow = load_module_from_source('psushow', psushow_path)

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -10,6 +10,8 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+# psuutil.main imports sonic_platform at module level;
+# inject before importing so collection succeeds.
 sys.modules['sonic_platform'] = mock.MagicMock()
 import psuutil.main as psuutil
 

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -14,6 +14,8 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+# sfputil.main imports sonic_platform at module level;
+# inject before importing so collection succeeds.
 sys.modules['sonic_platform'] = mock.MagicMock()
 import sfputil.main as sfputil
 

--- a/tests/ssdutil_test.py
+++ b/tests/ssdutil_test.py
@@ -29,7 +29,6 @@ def load_ssdutil_with_mocked_libs(monkeypatch):
     yield
 
 
-sys.modules['sonic_platform'] = MagicMock()
 sys.modules['sonic_platform_base.sonic_ssd.ssd_generic'] = MagicMock()
 
 


### PR DESCRIPTION
#### Why I did it

Cherry-pick of #4601 to 202605.

`tests/sed_test.py` uses `@patch('sonic_platform.platform.Platform')` but `sonic_platform` is a platform-specific package not available in the build environment. This causes `ModuleNotFoundError` and fails the sonic-utilities wheel build, blocking the sonic-utilities submodule update (#27773 in sonic-buildimage).

#### How I did it

Add a session-scoped `sonic_platform` mock to `conftest.py` that installs a fake `sonic_platform.platform.Platform` module before any test imports it. Remove per-file mock setups that are now redundant.

Cherry-pick of 37e2eeee from master.

#### How to verify it

`pytest tests/sed_test.py` passes without `sonic_platform` installed.