### PR TITLE
ecnconfig: fix -n/--namespace for single-chip VOQ platforms

### DIFF
--- a/scripts/ecnconfig
+++ b/scripts/ecnconfig
@@ -55,6 +55,7 @@ import sys
 
 from tabulate import tabulate
 from sonic_py_common import device_info
+from utilities_common.multi_asic import multi_asic_ns_choices, LazyChoice
 
 # mock the redis for unit test purposes #
 try:
@@ -382,7 +383,7 @@ class EcnQ(object):
 @click.option('-gdrop', '--green-drop-prob', type=str, help='set max drop/mark probability for packets marked \'green\'', default=None)
 @click.option('-ydrop', '--yellow-drop-prob', type=str, help='set max drop/mark probability for packets marked \'yellow\'', default=None)
 @click.option('-rdrop', '--red-drop-prob', type=str, help='set max drop/mark probability for packets marked \'red\'', default=None)
-@click.option('-n', '--namespace', type=click.Choice(multi_asic.get_namespace_list()), help='Namespace name or skip for all', default=None)
+@click.option('-n', '--namespace', type=LazyChoice(multi_asic_ns_choices), help='Namespace name or all', default=None)
 @click.option('-vv', '--verbose', is_flag=True, help='Verbose output', default=False)
 @click.option('-q', '--queue', type=str, help='specify queue index list: 3,4', default=None)
 @click.version_option(version='1.0')
@@ -396,6 +397,11 @@ def main(command, show_config, profile, green_min,
 
     try:
         load_db_config()
+
+        if namespace and not multi_asic.is_multi_asic():
+            click.echo("Error: -n/--namespace is not available for single ASIC platforms", err=True)
+            sys.exit(1)
+
         if show_config or profile:
             # Check if a set option has been provided
             setOption = (green_min or green_max or yellow_min or yellow_max or red_min or red_max

--- a/tests/ecn_test.py
+++ b/tests/ecn_test.py
@@ -2,12 +2,13 @@ import ast
 import json
 import os
 import sys
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 import config.main as config
 from .ecn_input.ecn_test_vectors import testData
-from .utils import get_result_and_return_code
+from .utils import get_result_and_return_code, load_source
 from utilities_common.db import Db
 import show.main as show
 
@@ -225,3 +226,21 @@ class TestEcnConfig(TestEcnConfigBase):
 
     def test_ecn_queue_set_lossy_q_on(self):
         self.executor(testData['ecn_cfg_lossy_q_on'])
+
+    def test_ecn_namespace_rejected_on_single_asic(self):
+        """Verify -n is rejected with a clear error on single-ASIC platforms."""
+        runner = CliRunner(mix_stderr=False)
+        ecnconfig_mod = load_source('ecnconfig',
+                                    os.path.join(scripts_path, 'ecnconfig'))
+
+        ns_param = next(p for p in ecnconfig_mod.main.params if p.name == 'namespace')
+        original_choices_func = ns_param.type._choices_func
+        try:
+            ns_param.type._choices_func = lambda: ['', 'asic0']
+            with patch.object(ecnconfig_mod.multi_asic, 'is_multi_asic', return_value=False), \
+                 patch.object(ecnconfig_mod, 'load_db_config'):
+                result = runner.invoke(ecnconfig_mod.main, ['-l', '-n', 'asic0'])
+                assert result.exit_code != 0
+                assert "not available for single ASIC" in result.stderr
+        finally:
+            ns_param.type._choices_func = original_choices_func


### PR DESCRIPTION
# Replace `click.Choice(multi_asic.get_namespace_list())` with `LazyChoice(multi_asic_ns_choices)` to properly handle single-ASIC platforms. Add explicit validation that rejects `-n` on non-multi-ASIC systems with a clear error message.

Fixes #4605

#### What I did

Fixed `ecnconfig` CLI to properly handle the `-n/--namespace` option on single-chip VOQ platforms. Previously, `-n` was advertised in `--help` but only accepted an empty string on single-ASIC systems, leading to confusing argparse errors.

#### How I did it

1. Replaced `click.Choice(multi_asic.get_namespace_list())` with `LazyChoice(multi_asic_ns_choices)` — this computes valid namespace choices at runtime (not import time), and correctly returns `DEFAULT_NAMESPACE` on single-ASIC platforms.

2. Added an explicit validation check in `main()` that prints a clear error (`-n/--namespace is not available for single ASIC platforms`) and exits if a user provides `-n` on a non-multi-ASIC system.

3. This aligns `ecnconfig` with the pattern used by all other SONiC CLI commands (e.g., `show interfaces`, `config syslog`, `show flow_counters`).

#### How to verify it

1. On a single-ASIC VOQ platform, run:

```bash
ecnconfig -n Asic0 -l
```

**Before fix:** Confusing argparse error about invalid choice.

**After fix:**

```text
Error: -n/--namespace is not available for single ASIC platforms
```

2. On a multi-ASIC platform, run:

```bash
ecnconfig -n asic0 -l
```

Should continue to work as before.

3. Run existing unit tests:

```bash
pytest tests/ecn_test.py -v
```

#### Previous command output (if the output of a command-line utility has changed)

On single-chip VOQ with the old code:

```text
$ ecnconfig -n Asic0 -l
Error: Invalid value for '-n' / '--namespace': 'Asic0' is not one of ''.
```

#### New command output (if the output of a command-line utility has changed)

On single-chip VOQ with the fix:

```text
$ ecnconfig -n Asic0 -l
Error: -n/--namespace is not available for single ASIC platforms
```