### PR TITLE
[sonic-clear] Remove sudo/root requirement for QoS counter and watermark clears

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -294,7 +294,7 @@ def clear_pg_counters():
 
 @priority_group.group(name='persistent-watermark')
 def persistent_watermark():
-    """Clear queue persistent WM."""
+    """Clear priority-group persistent WM."""
 
 
 @persistent_watermark.command('headroom')

--- a/clear/main.py
+++ b/clear/main.py
@@ -245,9 +245,7 @@ def priority_group():
 
 @priority_group.group()
 def watermark():
-    """Clear priority_group user WM. One does not simply clear WM, root is required"""
-    if os.geteuid() != 0:
-        sys.exit("Root privileges are required for this operation")
+    """Clear priority_group user WM."""
 
 
 @click.option('--namespace',
@@ -291,17 +289,12 @@ def drop():
 @drop.command('counters')
 def clear_pg_counters():
     """Clear priority-group dropped packets counter """
-
-    if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
-        sys.exit("Root privileges are required for this operation")
     command = ['pg-drop', '-c', 'clear']
     run_command(command)
 
 @priority_group.group(name='persistent-watermark')
 def persistent_watermark():
-    """Clear queue persistent WM. One does not simply clear WM, root is required"""
-    if os.geteuid() != 0:
-        sys.exit("Root privileges are required for this operation")
+    """Clear queue persistent WM."""
 
 
 @persistent_watermark.command('headroom')
@@ -353,9 +346,7 @@ def wredcounters():
 
 @queue.group()
 def watermark():
-    """Clear queue user WM. One does not simply clear WM, root is required"""
-    if os.geteuid() != 0:
-        sys.exit("Root privileges are required for this operation")
+    """Clear queue user WM."""
 
 
 @watermark.command('unicast')
@@ -411,9 +402,7 @@ def clear_wm_q_all(namespace):
 
 @queue.group(name='persistent-watermark')
 def persistent_watermark():
-    """Clear queue persistent WM. One does not simply clear WM, root is required"""
-    if os.geteuid() != 0:
-        sys.exit("Root privileges are required for this operation")
+    """Clear queue persistent WM."""
 
 
 @persistent_watermark.command('unicast')
@@ -483,10 +472,7 @@ def headroom_pool():
               help='Namespace name or all',
               callback=multi_asic_util.multi_asic_namespace_validation_callback)
 def watermark(namespace):
-    """Clear headroom pool user WM. One does not simply clear WM, root is required"""
-    if os.geteuid() != 0:
-        sys.exit("Root privileges are required for this operation")
-
+    """Clear headroom pool user WM."""
     command = ['watermarkstat', '-c', '-t', 'headroom_pool']
     if namespace:
         command += ['-n', str(namespace)]
@@ -503,10 +489,7 @@ def watermark(namespace):
               help='Namespace name or all',
               callback=multi_asic_util.multi_asic_namespace_validation_callback)
 def persistent_watermark(namespace):
-    """Clear headroom pool persistent WM. One does not simply clear WM, root is required"""
-    if os.geteuid() != 0:
-        sys.exit("Root privileges are required for this operation")
-
+    """Clear headroom pool persistent WM."""
     command = ['watermarkstat', '-c', '-p', '-t', 'headroom_pool']
     if namespace:
         command += ['-n', str(namespace)]

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -36,6 +36,36 @@ class TestClear(object):
         assert result.exit_code == 0
         run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'pg_shared'])
 
+    # Regression tests for the removed root/sudo gate (this PR). CI runs as root,
+    # so geteuid() returns 0 and the old check passed regardless; mocking a
+    # non-root uid exercises the path that used to sys.exit("Root privileges...").
+    @patch('clear.main.run_command')
+    @patch('clear.main.os.geteuid', MagicMock(return_value=1000))
+    def test_clear_pg_drop_counters_nonroot(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            clear.cli.commands['priority-group'].commands['drop'].commands['counters'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['pg-drop', '-c', 'clear'])
+
+    @patch('clear.main.run_command')
+    @patch('clear.main.os.geteuid', MagicMock(return_value=1000))
+    def test_clear_pg_wm_hdrm_nonroot(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            clear.cli.commands['priority-group'].commands['watermark'].commands['headroom'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['watermarkstat', '-c', '-t', 'pg_headroom'])
+
+    @patch('clear.main.run_command')
+    @patch('clear.main.os.geteuid', MagicMock(return_value=1000))
+    def test_clear_q_pst_wm_uni_nonroot(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            clear.cli.commands['queue'].commands['persistent-watermark'].commands['unicast'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'q_shared_uni'])
+
     @patch('clear.main.run_command')
     def test_clear_q_wm_all(self, run_command):
         runner = CliRunner()

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -53,7 +53,7 @@ class TestClear(object):
     def test_clear_pg_wm_hdrm_nonroot(self, run_command):
         runner = CliRunner()
         result = runner.invoke(
-            clear.cli.commands['priority-group'].commands['watermark'].commands['headroom'])
+            clear.cli, ['priority-group', 'watermark', 'headroom'])
         assert result.exit_code == 0
         run_command.assert_called_with(['watermarkstat', '-c', '-t', 'pg_headroom'])
 
@@ -62,7 +62,7 @@ class TestClear(object):
     def test_clear_q_pst_wm_uni_nonroot(self, run_command):
         runner = CliRunner()
         result = runner.invoke(
-            clear.cli.commands['queue'].commands['persistent-watermark'].commands['unicast'])
+            clear.cli, ['queue', 'persistent-watermark', 'unicast'])
         assert result.exit_code == 0
         run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'q_shared_uni'])
 

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -79,7 +79,6 @@ class TestClear(object):
         run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'q_shared_uni'])
 
     @patch('clear.main.run_command')
-    @patch('clear.main.os.geteuid', MagicMock(return_value=0))
     def test_clear_hdrm_wm(self, run_command):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands['headroom-pool'].commands['watermark'])
@@ -87,7 +86,6 @@ class TestClear(object):
         run_command.assert_called_with(['watermarkstat', '-c', '-t', 'headroom_pool'])
 
     @patch('clear.main.run_command')
-    @patch('clear.main.os.geteuid', MagicMock(return_value=0))
     def test_clear_hdrm_pst_wm(self, run_command):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands['headroom-pool'].commands['persistent-watermark'])


### PR DESCRIPTION
#### Why I did it

Fixes #4613.

Several `sonic-clear` counter/watermark commands require root via an `os.geteuid()` check that exits with "Root privileges are required for this operation". Requiring root is unnecessary for these clears and, in one case, actively counterproductive:

- **`priority-group drop counters`** — `pg-drop` records its clear snapshot **per user** (`get_dropstat_dir()` → `UserCache` → `/tmp/cache/pg-drop/<uid>`). Clearing as root (via `sudo`) resets *root's* snapshot, so the logged-in user's `show priority-group drop counters` is unchanged. The command reports success while the operator's view does not move — requiring root prevents the clear from taking effect for the user actually viewing the counters.
- **The watermark clears** (`priority-group` / `queue` / `headroom-pool`, user + persistent) — `watermarkstat -c` publishes a **global** `WATERMARK_CLEAR_REQUEST` notification; the cleared state lives in the shared `USER_WATERMARKS` / `PERSISTENT_WATERMARKS` tables that every user's `show` reads. So `sudo` here *does* reset the logged-in user's view. Root is simply not required: the corresponding `show` commands need no root, and the publish works fine as a non-root user. Removing the gate makes the clear surface consistent with `show` and with the other clears.

#### How I did it

Removed the `os.geteuid()` root barrier from these `sonic-clear` commands so clear and `show` run as the same user:

- `priority-group drop counters`
- `priority-group watermark` (headroom, shared)
- `priority-group persistent-watermark` (headroom, shared)
- `queue watermark` (unicast, multicast, all)
- `queue persistent-watermark` (unicast, multicast, all)
- `headroom-pool watermark` / `persistent-watermark`

Also fixed a misleading `priority-group persistent-watermark` group docstring ("Clear queue…" → "Clear priority-group…"), dropped the now-redundant `os.geteuid` mocks from the affected tests, and added non-root regression tests (mock `geteuid` → non-root) that exercise the un-gated path — CI runs as root, so without these the fix would be uncovered.

**Behavior note:** the persistent-watermark clears are now available to any non-root user. Since those watermark tables are global, one user's clear affects every user's `show` view. This is a benign, intentional change (the corresponding reads are already open to non-root and the action is safe), called out here for visibility.

#### How to verify it

Run as a non-root user:
```
$ show priority-group drop counters      # note a non-zero baseline
$ sonic-clear priority-group drop counters
$ show priority-group drop counters      # now cleared for the same user
```
Unit tests: `pytest tests/clear_test.py`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Description for the changelog

Remove the sudo/root requirement from `sonic-clear` QoS counter and watermark clear commands so the clear takes effect for the logged-in user.


---

#### Tested on 202605 branch

Validated on a Broadcom DNX (Q3D) VOQ chassis running a 202605-based image.

- **Image version:** `SONiC.202605.Nexthop.152445-e5b6d3c8c7`
- **Platform / HwSKU:** `x86_64-nexthop_5010-r0` / `NH-5010-F-O64` (broadcom, Q3D)
- **Branch:** 202605 (this change is present on the branch under test; the cherry-pick of this PR onto `202605` applies cleanly with no conflicts)

All commands below were run as the **non-root** `admin` user, with no `sudo`.

Functional check — the clear takes effect for the same user that runs `show`, which is the behaviour this PR fixes:

```
admin@sonic:~$ whoami
admin
admin@sonic:~$ id -u
1000

admin@sonic:~$ show queue watermark unicast | head -6
Egress shared pool occupancy per unicast queue:
         Port    UC0    UC1    UC2    UC3    UC4    UC5    UC6    UC7
-------------  -----  -----  -----  -----  -----  -----  -----  -----
    Ethernet0      0      0      0      0      0      0      0    256
    Ethernet4      0      0      0      0      0      0      0    256
    Ethernet8      0      0      0      0      0      0      0    256

admin@sonic:~$ sonic-clear queue watermark unicast

admin@sonic:~$ show queue watermark unicast | head -6
Egress shared pool occupancy per unicast queue:
         Port    UC0    UC1    UC2    UC3    UC4    UC5    UC6    UC7
-------------  -----  -----  -----  -----  -----  -----  -----  -----
    Ethernet0      0      0      0      0      0      0      0      0
    Ethernet4      0      0      0      0      0      0      0      0
    Ethernet8      0      0      0      0      0      0      0      0
```

Every previously root-gated clear now succeeds as non-root (exit status `0`, no `Root privileges are required for this operation`):

```
[rc=0] sonic-clear priority-group drop counters              ::  Cleared PG drop counter
[rc=0] sonic-clear priority-group watermark headroom
[rc=0] sonic-clear priority-group watermark shared
[rc=0] sonic-clear priority-group persistent-watermark headroom
[rc=0] sonic-clear priority-group persistent-watermark shared
[rc=0] sonic-clear queue watermark unicast
[rc=0] sonic-clear queue watermark multicast
[rc=0] sonic-clear queue watermark all
[rc=0] sonic-clear queue persistent-watermark unicast
[rc=0] sonic-clear queue persistent-watermark multicast
[rc=0] sonic-clear queue persistent-watermark all
[rc=0] sonic-clear headroom-pool watermark
[rc=0] sonic-clear headroom-pool persistent-watermark
```

**Nature of the change:** bug fix (fixes #4613). Clears are recorded per user, so clearing via `sudo` never reset the counters seen by the logged-in user running `show` — the root gate prevented the clear from taking effect rather than protecting anything.
