### PR TITLE
Display Broadcom Bailly RLM DOM data

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -147,6 +147,28 @@ DOM_MODULE_MONITOR_MAP = {
     'tx_config_power': 'Requested Tx Power'
 }
 
+RLM_DOM_MONITOR_MAP = {
+    'rlm_temperature': 'RLM Temperature',
+    'rlm_voltage': 'RLM Vcc',
+    'rlm_tec_current': 'RLM TEC Current'
+}
+
+RLM_THRESHOLD_MAP = {
+    'rlm_temphighalarm': 'RLM TempHighAlarm',
+    'rlm_templowalarm': 'RLM TempLowAlarm',
+    'rlm_temphighwarning': 'RLM TempHighWarning',
+    'rlm_templowwarning': 'RLM TempLowWarning',
+    'rlm_vcchighalarm': 'RLM VccHighAlarm',
+    'rlm_vcclowalarm': 'RLM VccLowAlarm',
+    'rlm_vcchighwarning': 'RLM VccHighWarning',
+    'rlm_vcclowwarning': 'RLM VccLowWarning',
+    'rlm_txpowerhighalarm': 'RLM TxPowerHighAlarm',
+    'rlm_txpowerlowalarm': 'RLM TxPowerLowAlarm',
+    'rlm_txpowerhighwarning': 'RLM TxPowerHighWarning',
+    'rlm_txpowerlowwarning': 'RLM TxPowerLowWarning',
+    'rlm_txbiashighalarm': 'RLM TxBiasHighAlarm',
+    'rlm_txbiashighwarning': 'RLM TxBiasHighWarning'
+}
 DOM_CHANNEL_THRESHOLD_UNIT_MAP = {
     'txpowerhighalarm':   'dBm',
     'txpowerlowalarm':    'dBm',
@@ -173,6 +195,28 @@ DOM_MODULE_THRESHOLD_UNIT_MAP = {
     'vcclowwarning':   'Volts'
 }
 
+RLM_DOM_MONITOR_UNIT_MAP = {
+    'rlm_temperature': 'C',
+    'rlm_voltage': 'Volts',
+    'rlm_tec_current': '%'
+}
+
+RLM_THRESHOLD_UNIT_MAP = {
+    'rlm_temphighalarm': 'C',
+    'rlm_templowalarm': 'C',
+    'rlm_temphighwarning': 'C',
+    'rlm_templowwarning': 'C',
+    'rlm_vcchighalarm': 'Volts',
+    'rlm_vcclowalarm': 'Volts',
+    'rlm_vcchighwarning': 'Volts',
+    'rlm_vcclowwarning': 'Volts',
+    'rlm_txpowerhighalarm': 'mW',
+    'rlm_txpowerlowalarm': 'mW',
+    'rlm_txpowerhighwarning': 'mW',
+    'rlm_txpowerlowwarning': 'mW',
+    'rlm_txbiashighalarm': 'mA',
+    'rlm_txbiashighwarning': 'mA'
+}
 DOM_VALUE_UNIT_MAP = {
     'rx1power': 'dBm',
     'rx2power': 'dBm',
@@ -430,6 +474,33 @@ class SFPShow(object):
                 DOM_MODULE_THRESHOLD_UNIT_MAP,
                 module_threshold_align)
             output_dom += output_module_threshold
+
+            # RLM Monitor
+            # This is specific for Broadcom CPO DOM value parsing.
+            is_rlm = sfp_type.startswith('CPO Bailly')
+            if is_rlm:
+                laser_keys = [key for key in dom_info_dict if key.startswith('RLM') and 'Laser' in key]
+                rlm_dom_monitor_map = RLM_DOM_MONITOR_MAP.copy()
+                rlm_dom_monitor_map.update({key: key for key in laser_keys})
+                rlm_dom_monitor_unit_map = RLM_DOM_MONITOR_UNIT_MAP.copy()
+                rlm_dom_monitor_unit_map.update({key: '' for key in laser_keys})  # laser monitor values include units
+                output_dom += (indent + 'RLMMonitorValues:\n')
+                sorted_key_table = natsorted(rlm_dom_monitor_map)
+                output_rlm_monitor = self.format_dict_value_to_string(
+                    sorted_key_table, dom_info_dict,
+                    rlm_dom_monitor_map,
+                    rlm_dom_monitor_unit_map)
+                output_dom += output_rlm_monitor
+
+            # RLM Threshold
+            if is_rlm:
+                output_dom += (indent + 'RLMThresholdValues:\n')
+                sorted_key_table = natsorted(RLM_THRESHOLD_MAP)
+                output_rlm_threshold = self.format_dict_value_to_string(
+                    sorted_key_table, dom_info_dict,
+                    RLM_THRESHOLD_MAP,
+                    RLM_THRESHOLD_UNIT_MAP)
+                output_dom += output_rlm_threshold
 
         else:
             output_dom += (indent + 'MonitorData:\n')

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -111,7 +111,19 @@ QSFP_DD_DATA_MAP = {
     'supported_max_tx_power': 'Supported Max TX Power',
     'supported_min_tx_power': 'Supported Min TX Power',
     'supported_max_laser_freq': 'Supported Max Laser Frequency',
-    'supported_min_laser_freq': 'Supported Min Laser Frequency'
+    'supported_min_laser_freq': 'Supported Min Laser Frequency',
+    'rlm_identifier': 'RLM Identifier',
+    'rlm_revision': 'RLM Revision',
+    'rlm_laser_wavelength_grid': 'RLM Laser Wavelength Grid',
+    'rlm_laser_count': 'RLM Laser Count',
+    'rlm_vendor_name': 'RLM Vendor Name',
+    'rlm_vendor_oui': 'RLM Vendor OUI',
+    'rlm_vendor_pn': 'RLM Vendor PN',
+    'rlm_vendor_rev': 'RLM Vendor Rev',
+    'rlm_vendor_sn': 'RLM Vendor SN',
+    'rlm_date_code': 'RLM Vendor Date Code(YYYY-MM-DD Lot)',
+    'rlm_max_power': 'RLM Maximum Power Consumption',
+    'rlm_laser_power_mode_control': 'RLM Laser Power Mode Control'
 }
 
 SFP_DOM_CHANNEL_MONITOR_MAP = {
@@ -204,6 +216,28 @@ DOM_MODULE_MONITOR_MAP = {
     'voltage': 'Vcc'
 }
 
+RLM_DOM_MONITOR_MAP = {
+    'rlm_temperature': 'RLM Temperature',
+    'rlm_voltage': 'RLM Vcc',
+    'rlm_tec_current': 'RLM TEC Current'
+}
+
+RLM_THRESHOLD_MAP = {
+    'rlm_temphighalarm': 'RLM TempHighAlarm',
+    'rlm_templowalarm': 'RLM TempLowAlarm',
+    'rlm_temphighwarning': 'RLM TempHighWarning',
+    'rlm_templowwarning': 'RLM TempLowWarning',
+    'rlm_vcchighalarm': 'RLM VccHighAlarm',
+    'rlm_vcclowalarm': 'RLM VccLowAlarm',
+    'rlm_vcchighwarning': 'RLM VccHighWarning',
+    'rlm_vcclowwarning': 'RLM VccLowWarning',
+    'rlm_txpowerhighalarm': 'RLM TxPowerHighAlarm',
+    'rlm_txpowerlowalarm': 'RLM TxPowerLowAlarm',
+    'rlm_txpowerhighwarning': 'RLM TxPowerHighWarning',
+    'rlm_txpowerlowwarning': 'RLM TxPowerLowWarning',
+    'rlm_txbiashighalarm': 'RLM TxBiasHighAlarm',
+    'rlm_txbiashighwarning': 'RLM TxBiasHighWarning'
+}
 DOM_CHANNEL_THRESHOLD_UNIT_MAP = {
     'txpowerhighalarm':   'dBm',
     'txpowerlowalarm':    'dBm',
@@ -230,6 +264,28 @@ DOM_MODULE_THRESHOLD_UNIT_MAP = {
     'vcclowwarning':   'Volts'
 }
 
+RLM_DOM_MONITOR_UNIT_MAP = {
+    'rlm_temperature': 'C',
+    'rlm_voltage': 'Volts',
+    'rlm_tec_current': '%'
+}
+
+RLM_THRESHOLD_UNIT_MAP = {
+    'rlm_temphighalarm': 'C',
+    'rlm_templowalarm': 'C',
+    'rlm_temphighwarning': 'C',
+    'rlm_templowwarning': 'C',
+    'rlm_vcchighalarm': 'Volts',
+    'rlm_vcclowalarm': 'Volts',
+    'rlm_vcchighwarning': 'Volts',
+    'rlm_vcclowwarning': 'Volts',
+    'rlm_txpowerhighalarm': 'mW',
+    'rlm_txpowerlowalarm': 'mW',
+    'rlm_txpowerhighwarning': 'mW',
+    'rlm_txpowerlowwarning': 'mW',
+    'rlm_txbiashighalarm': 'mA',
+    'rlm_txbiashighwarning': 'mA'
+}
 DOM_VALUE_UNIT_MAP = {
     'rx1power': 'dBm',
     'rx2power': 'dBm',
@@ -452,6 +508,33 @@ def convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict):
             DOM_MODULE_THRESHOLD_UNIT_MAP,
             module_threshold_align)
         output_dom += output_module_threshold
+
+        # RLM Monitor
+        # This is specific for Broadcom CPO DOM value parsing.
+        is_rlm = sfp_type.startswith('CPO Bailly')
+        if is_rlm:
+            laser_keys = [key for key in dom_info_dict if key.startswith('RLM') and 'Laser' in key]
+            rlm_dom_monitor_map = RLM_DOM_MONITOR_MAP.copy()
+            rlm_dom_monitor_map.update({key: key for key in laser_keys})
+            rlm_dom_monitor_unit_map = RLM_DOM_MONITOR_UNIT_MAP.copy()
+            rlm_dom_monitor_unit_map.update({key: '' for key in laser_keys})  # laser monitor values include units
+            output_dom += (indent + 'RLMMonitorValues:\n')
+            sorted_key_table = natsorted(rlm_dom_monitor_map)
+            output_rlm_monitor = format_dict_value_to_string(
+                sorted_key_table, dom_info_dict,
+                rlm_dom_monitor_map,
+                rlm_dom_monitor_unit_map)
+            output_dom += output_rlm_monitor
+
+        # RLM Threshold
+        if is_rlm:
+            output_dom += (indent + 'RLMThresholdValues:\n')
+            sorted_key_table = natsorted(RLM_THRESHOLD_MAP)
+            output_rlm_threshold = format_dict_value_to_string(
+                sorted_key_table, dom_info_dict,
+                RLM_THRESHOLD_MAP,
+                RLM_THRESHOLD_UNIT_MAP)
+            output_dom += output_rlm_threshold
 
     else:
         output_dom += (indent + 'MonitorData:\n')

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -9,6 +9,7 @@ from utilities_common.platform_sfputil_helper import (
     logical_port_name_to_physical_port_list, is_sfp_present,
     get_first_subport, get_subport, get_sfp_object, get_value_from_db_by_field
 )
+from .utils import load_source
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -17,6 +18,7 @@ sys.path.insert(0, modules_path)
 
 import show.main as show
 import show as show_module
+sfpshow = load_source("sfpshow", os.path.join(scripts_path, "sfpshow"))
 
 ERROR_INVALID_PORT = 1
 EXIT_FAIL = -1
@@ -898,6 +900,52 @@ Ethernet4: Transceiver status info not applicable
 Ethernet64: Transceiver status info not applicable
 """
 
+test_rlm_dom_info_dict = {
+    'rlm_temperature': '16.16',
+    'rlm_voltage': '3.396',
+    'rlm_tec_current': '0.0',
+    'rlm_temphighalarm': '80.0',
+    'rlm_templowalarm': '-5.0',
+    'rlm_temphighwarning': '70.0',
+    'rlm_templowwarning': '0.0',
+    'rlm_vcchighalarm': '3.63',
+    'rlm_vcclowalarm': '2.97',
+    'rlm_vcchighwarning': '3.465',
+    'rlm_vcclowwarning': '3.135',
+    'rlm_txpowerhighalarm': '7.0',
+    'rlm_txpowerlowalarm': '-6.9',
+    'rlm_txpowerhighwarning': '4.0',
+    'rlm_txpowerlowwarning': '-2.9',
+    'rlm_txbiashighalarm': '162.5',
+    'rlm_txbiashighwarning': '156.248',
+}
+
+test_rlm_dom_output = """\
+        ChannelMonitorValues:
+        ChannelThresholdValues:
+        ModuleMonitorValues:
+        ModuleThresholdValues:
+        RLMMonitorValues:
+                RLM TEC Current: 0.0%
+                RLM Temperature: 16.16C
+                RLM Vcc: 3.396Volts
+        RLMThresholdValues:
+                RLM TempHighAlarm: 80.0C
+                RLM TempHighWarning: 70.0C
+                RLM TempLowAlarm: -5.0C
+                RLM TempLowWarning: 0.0C
+                RLM TxBiasHighAlarm: 162.5mA
+                RLM TxBiasHighWarning: 156.248mA
+                RLM TxPowerHighAlarm: 7.0mW
+                RLM TxPowerHighWarning: 4.0mW
+                RLM TxPowerLowAlarm: -6.9mW
+                RLM TxPowerLowWarning: -2.9mW
+                RLM VccHighAlarm: 3.63Volts
+                RLM VccHighWarning: 3.465Volts
+                RLM VccLowAlarm: 2.97Volts
+                RLM VccLowWarning: 3.135Volts
+"""
+
 class TestSFP(object):
     @classmethod
     def setup_class(cls):
@@ -974,6 +1022,11 @@ Ethernet36  Present
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["info"])
         assert result.exit_code == 0
         assert "Ethernet24" not in result.output
+
+    def test_sfpshow_convert_dom_to_output_string_with_rlm(self):
+        sfp_show = sfpshow.SFPShow(None, None, dump_dom=True)
+        output = sfp_show.convert_dom_to_output_string("CPO Bailly", True, test_rlm_dom_info_dict)
+        assert output == test_rlm_dom_output
 
     def test_sfp_eeprom_with_dom(self):
         runner = CliRunner()

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -410,6 +410,54 @@ class TestSfputil(object):
                 Vcc: 3.2577Volts
         ModuleThresholdValues:
 '''
+        ),
+        (
+            'CPO Bailly',
+            True,
+            {
+                'rlm_temperature': '16.16',
+                'rlm_voltage': '3.396',
+                'rlm_tec_current': '0.0',
+                'rlm_temphighalarm': '80.0',
+                'rlm_templowalarm': '-5.0',
+                'rlm_temphighwarning': '70.0',
+                'rlm_templowwarning': '0.0',
+                'rlm_vcchighalarm': '3.63',
+                'rlm_vcclowalarm': '2.97',
+                'rlm_vcchighwarning': '3.465',
+                'rlm_vcclowwarning': '3.135',
+                'rlm_txpowerhighalarm': '7.0',
+                'rlm_txpowerlowalarm': '-6.9',
+                'rlm_txpowerhighwarning': '4.0',
+                'rlm_txpowerlowwarning': '-2.9',
+                'rlm_txbiashighalarm': '162.5',
+                'rlm_txbiashighwarning': '156.248',
+            },
+            '''\
+        ChannelMonitorValues:
+        ChannelThresholdValues:
+        ModuleMonitorValues:
+        ModuleThresholdValues:
+        RLMMonitorValues:
+                RLM TEC Current: 0.0%
+                RLM Temperature: 16.16C
+                RLM Vcc: 3.396Volts
+        RLMThresholdValues:
+                RLM TempHighAlarm: 80.0C
+                RLM TempHighWarning: 70.0C
+                RLM TempLowAlarm: -5.0C
+                RLM TempLowWarning: 0.0C
+                RLM TxBiasHighAlarm: 162.5mA
+                RLM TxBiasHighWarning: 156.248mA
+                RLM TxPowerHighAlarm: 7.0mW
+                RLM TxPowerHighWarning: 4.0mW
+                RLM TxPowerLowAlarm: -6.9mW
+                RLM TxPowerLowWarning: -2.9mW
+                RLM VccHighAlarm: 3.63Volts
+                RLM VccHighWarning: 3.465Volts
+                RLM VccLowAlarm: 2.97Volts
+                RLM VccLowWarning: 3.135Volts
+'''
         )])
     def test_convert_dom_to_output_string(self, sfp_type, is_sfp_cmis, dom_info_dict, expected_output):
         output = sfputil.convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict)

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -43,6 +43,21 @@ QSFP_CMIS_DELTA_DATA_MAP = {
     'e2_server_firmware': 'E2 Server Firmware'
 }
 
+BAILLY_RLM_DATA_MAP = {
+    'rlm_identifier': 'RLM Identifier',
+    'rlm_revision': 'RLM Revision',
+    'rlm_laser_wavelength_grid': 'RLM Laser Wavelength Grid',
+    'rlm_laser_count': 'RLM Laser Count',
+    'rlm_vendor_name': 'RLM Vendor Name',
+    'rlm_vendor_oui': 'RLM Vendor OUI',
+    'rlm_vendor_pn': 'RLM Vendor PN',
+    'rlm_vendor_rev': 'RLM Vendor Rev',
+    'rlm_vendor_sn': 'RLM Vendor SN',
+    'rlm_date_code': 'RLM Vendor Date Code(YYYY-MM-DD Lot)',
+    'rlm_max_power': 'RLM Maximum Power Consumption',
+    'rlm_laser_power_mode_control': 'RLM Laser Power Mode Control'
+}
+
 C_CMIS_DELTA_DATA_MAP = {
     'supported_max_tx_power': 'Supported Max TX Power',
     'supported_min_tx_power': 'Supported Min TX Power',
@@ -50,7 +65,7 @@ C_CMIS_DELTA_DATA_MAP = {
     'supported_min_laser_freq': 'Supported Min Laser Frequency',
 }
 
-CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP}
+CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP, **BAILLY_RLM_DATA_MAP}
 C_CMIS_DATA_MAP = {**CMIS_DATA_MAP, **C_CMIS_DELTA_DATA_MAP}
 
 # Common fields for all types:
@@ -82,7 +97,17 @@ QSFP_STATUS_MAP = {
     'tx6disable': 'TX disable status on lane 6',
     'tx7disable': 'TX disable status on lane 7',
     'tx8disable': 'TX disable status on lane 8',
-    'tx_disabled_channel': 'Disabled TX channels'
+    'tx_disabled_channel': 'Disabled TX channels',
+    'rlm_tempHAlarm': 'RLM temperature high alarm flag',
+    'rlm_tempLAlarm': 'RLM temperature low alarm flag',
+    'rlm_tempHWarn': 'RLM temperature high warning flag',
+    'rlm_tempLWarn': 'RLM temperature low warning flag',
+    'rlm_vccHAlarm': 'RLM Vcc high alarm flag',
+    'rlm_vccLAlarm': 'RLM Vcc low alarm flag',
+    'rlm_vccHWarn': 'RLM Vcc high warning flag',
+    'rlm_vccLWarn': 'RLM Vcc low warning flag',
+    'rlm_module_low_power_state': 'RLM module state',
+    'rlm_interrupt_status': 'RLM interrupt status'
 }
 
 # CMIS specific fields (excluding C-CMIS specific):


### PR DESCRIPTION
﻿## Summary
- display Broadcom Bailly RLM monitor and threshold values in transceiver EEPROM DOM output
- add RLM display mappings for transceiver info/status paths
- keep RLM laser monitor values grouped under RLMMonitorValues

## Validation
- python compile check for scripts/sfpshow, sfputil/main.py, and utilities_common/sfp_helper.py
