### PR TITLE
[port_config_update_validator] Skip fec validation for chassis devices

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -217,6 +217,9 @@ def port_config_update_validator(scope, patch_element):
 
     def _validate_field(field, port, value):
         if field == "fec":
+            # For chassis, skip fec validation as desired fec is not in supported_fecs of StateDB.
+            if device_info.is_chassis():
+                return True
             supported_fecs_str = read_statedb_entry(scope, "PORT_TABLE", port, "supported_fecs")
             if supported_fecs_str:
                 if supported_fecs_str != 'N/A':

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -202,6 +202,36 @@ class TestValidateFieldOperation:
             assert generic_config_updater.field_operation_validators.\
                 port_config_update_validator(scope, patch_element) is False
 
+    @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
+    def test_port_config_update_validator_invalid_fec_for_chassis(self):
+        # "rsf" is not in supported fecs, but for chassis, skip fec validation
+        patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rsf"}}
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
+    @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=False))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
+    def test_port_config_update_validator_valid_fec_for_nonchassis(self):
+        # "rs" is in supported fecs; on non-chassis the normal validation should pass it
+        patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rs"}}
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
+    @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=False))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="rs, fc"))
+    def test_port_config_update_validator_invalid_fec_for_nonchassis(self):
+        # "rsf" is not in supported fecs; on non-chassis the normal validation must reject it
+        patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rsf"}}
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
     @patch("generic_config_updater.field_operation_validators.get_asic_name",
            mock.Mock(return_value="unknown"))
     def test_rdma_config_update_validator_unknown_asic(self):


### PR DESCRIPTION
#### What I did
For chassis devices, the desired FEC value may not appear in the `supported_fecs` field of STATE_DB `PORT_TABLE` — the same situation that already exists for `speed` in this validator. This caused legitimate FEC config updates to be rejected on chassis devices.

This change mirrors the existing chassis handling for `speed` (already present at lines 232-234 of `generic_config_updater/field_operation_validators.py`) by adding an early `return True` in `_validate_field` when `field == "fec"` and `device_info.is_chassis()` is `True`.

This is a port of internal PR https://github.com/Azure/sonic-utilities.msft/pull/363 (merged on the `202405` internal branch) to the public `master` branch.

#### How I did it
`generic_config_updater/field_operation_validators.py` — in `port_config_update_validator._validate_field`, before reading `supported_fecs` from STATE_DB, check `device_info.is_chassis()` and return `True` early when true (skip the FEC STATE_DB validation on chassis devices).

#### How to verify it
- Existing unit tests for `port_config_update_validator` continue to pass on non-chassis paths.
- On a chassis device, FEC updates in the PORT table will no longer be blocked by missing `supported_fecs` entries in STATE_DB.

#### Previous command output (if the output of a command-line utility has changed)
N/A — internal validator behavior only; no user-visible command output changes.

#### Related Internal PR
https://github.com/Azure/sonic-utilities.msft/pull/363