### PR TITLE
[fwutil]: Fix to report up-to-date if current version is newer than available fw image

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -599,6 +599,72 @@ class ComponentUpdateProvider(PlatformDataProvider):
             pcp.module_component_map
         )
 
+    @staticmethod
+    def __compare_versions(current, available):
+        """
+        Compare two dotted, purely-numeric firmware versions.
+
+        Returns:
+             1  if current  >  available
+             0  if current  == available
+            -1  if current  <  available
+            None if either version is not a clean dotted-decimal string
+                 (e.g. SSD vendor strings like "SBR10021"/"0710-001" or hex
+                 CPLD/FPGA revisions like "0x13"/"240622.1D"). In that case the
+                 caller should fall back to a strict equality comparison.
+        """
+        def parse(version):
+            if version is None:
+                return None
+            tokens = str(version).strip().split('.')
+            numeric = []
+            for token in tokens:
+                if not token.isdigit():
+                    return None
+                numeric.append(int(token))
+            return tuple(numeric) if numeric else None
+
+        current_tuple = parse(current)
+        available_tuple = parse(available)
+
+        if current_tuple is None or available_tuple is None:
+            return None
+
+        # Pad the shorter tuple with zeros so "4.8" and "4.8.0" compare equal.
+        length = max(len(current_tuple), len(available_tuple))
+        current_tuple += (0,) * (length - len(current_tuple))
+        available_tuple += (0,) * (length - len(available_tuple))
+
+        if current_tuple > available_tuple:
+            return 1
+        if current_tuple < available_tuple:
+            return -1
+        return 0
+
+    def __get_update_status(self, firmware_version_current, firmware_version_available):
+        """
+        Decide whether a component needs a firmware update.
+
+        A component is considered up-to-date when the running version is the
+        same as, or comparably newer than, the version shipped in the SONiC
+        image, so operators are never asked to "downgrade" (e.g. PSM running
+        0212.0216 vs 0212.0215 available). When the versions are not cleanly
+        comparable as dotted-decimal numbers, fall back to the legacy strict
+        equality check to preserve existing behavior.
+        """
+        if firmware_version_current == firmware_version_available:
+            return self.FW_STATUS_UP_TO_DATE
+
+        comparison = self.__compare_versions(
+            firmware_version_current,
+            firmware_version_available
+        )
+
+        if comparison is not None and comparison >= 0:
+            return self.FW_STATUS_UP_TO_DATE
+
+        return self.FW_STATUS_UPDATE_REQUIRED
+
     def get_updates_status(self):
         status_table = [ ]
         auto_update_status_table = [ ]
@@ -631,10 +697,10 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                     firmware_version = "{} / {}".format(firmware_version_current, firmware_version_available)
 
-                    if firmware_version_current != firmware_version_available:
-                        status = self.FW_STATUS_UPDATE_REQUIRED
-                    else:
-                        status = self.FW_STATUS_UP_TO_DATE
+                    status = self.__get_update_status(
+                        firmware_version_current,
+                        firmware_version_available
+                    )
 
                     if self.__pcp.UTILITY_KEY in component:
                         update_utility = component[self.__pcp.UTILITY_KEY]
@@ -698,10 +764,10 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                         firmware_version = "{} / {}".format(firmware_version_current, firmware_version_available)
 
-                        if firmware_version_current != firmware_version_available:
-                            status = self.FW_STATUS_UPDATE_REQUIRED
-                        else:
-                            status = self.FW_STATUS_UP_TO_DATE
+                        status = self.__get_update_status(
+                            firmware_version_current,
+                            firmware_version_available
+                        )
 
                         if self.__pcp.UTILITY_KEY in component:
                             update_utility = component[self.__pcp.UTILITY_KEY]

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -410,3 +410,66 @@ class TestFWPackageUntar(object):
         with patch('fwutil.lib.FWUPDATE_FWPACKAGE_DIR', extract_dir):
             result = pkg.untar_fwpackage()
         assert result is True
+
+
+class TestFirmwareVersionStatus(object):
+    """Unit tests for the firmware up-to-date decision in ComponentUpdateProvider.
+
+    Covers __compare_versions() and __get_update_status() -- the fix where a
+    component whose running firmware is the same as (or newer than) the version
+    shipped in the SONiC image is reported "up-to-date" instead of
+    "update is required", while non-numeric vendor labels (e.g. SSD
+    "SBR10021"/"0710-001" or hex CPLD/FPGA revisions like "0x13") fall back to
+    the legacy strict-equality behavior.
+    """
+
+    UP_TO_DATE = fwutil_lib.ComponentUpdateProvider.FW_STATUS_UP_TO_DATE
+    UPDATE_REQUIRED = fwutil_lib.ComponentUpdateProvider.FW_STATUS_UPDATE_REQUIRED
+
+    @staticmethod
+    def _compare(current, available):
+        # Reach the name-mangled private static method.
+        cls = fwutil_lib.ComponentUpdateProvider
+        return cls._ComponentUpdateProvider__compare_versions(current, available)
+
+    @staticmethod
+    def _status(current, available):
+        # __get_update_status only reads class constants and calls
+        # __compare_versions, so an uninitialized instance is sufficient
+        # (no Platform/parser construction required).
+        cup = fwutil_lib.ComponentUpdateProvider.__new__(
+            fwutil_lib.ComponentUpdateProvider)
+        return cup._ComponentUpdateProvider__get_update_status(current, available)
+
+    @pytest.mark.parametrize("current, available, expected", [
+        ("0212.0216", "0212.0215", 1),      # motivating case: running newer
+        ("0212.0215", "0212.0216", -1),     # running older
+        ("1.2.3", "1.2.3", 0),              # equal
+        ("4.8", "4.8.0", 0),                # zero-padding: 4.8 == 4.8.0
+        ("4.8.1", "4.8", 1),                # zero-padding: 4.8.1 > 4.8
+        ("29.10", "29.9", 1),               # numeric (10 > 9), not lexical
+        ("3.30", "3.5", 1),                 # numeric (30 > 5)
+        ("SBR10021", "0710-001", None),     # SSD vendor labels: not comparable
+        ("0x13", "0x12", None),             # hex CPLD/FPGA revision: not comparable
+        ("240622.1D", "240622.1C", None),   # mixed alnum token: not comparable
+        (None, "1.0", None),                # guard: missing current
+        ("1.0", None, None),                # guard: missing available
+        ("", "1.0", None),                  # guard: empty string has no number
+    ])
+    def test_compare_versions(self, current, available, expected):
+        assert self._compare(current, available) == expected
+
+    @pytest.mark.parametrize("current, available, up_to_date", [
+        ("1.0", "1.0", True),               # identical
+        ("0212.0216", "0212.0216", True),   # equal numeric
+        ("0212.0216", "0212.0215", True),   # running newer -> up-to-date (the fix)
+        ("0212.0215", "0212.0216", False),  # running older -> update required
+        ("4.8.1", "4.8", True),             # newer with zero-pad -> up-to-date
+        ("SBR10021", "SBR10021", True),     # vendor label equal -> up-to-date
+        ("0710-001", "SBR10021", False),    # vendor mismatch -> update required
+        ("0x13", "0x13", True),             # hex equal -> up-to-date (early equality)
+        ("0x13", "0x12", False),            # hex differ -> strict fallback -> required
+    ])
+    def test_get_update_status(self, current, available, up_to_date):
+        expected = self.UP_TO_DATE if up_to_date else self.UPDATE_REQUIRED
+        assert self._status(current, available) == expected


### PR DESCRIPTION
[fwutil]: Fix to report up-to-date if current version is newer than available fw image

[List of changes]
Fix to report up-to-date if the current fw version is newer than the available version for the fw update
Add unit tests for the fix

Signed-off-by: Sujin Kang <kangs@juniper.net>

#### What I did

Fixed `fwutil show status` update-status handling so a component is reported as `up-to-date` when the currently installed firmware version is the same as, or numerically newer than, the firmware version available in the SONiC image.

Previously, `fwutil` used strict string inequality (`current != available`), so a device running newer firmware than the image-provided firmware was incorrectly reported as `update is required`.

Also added unit tests for the new version comparison/status logic.

#### How I did it

Added helper logic in `fwutil/lib.py`:

- Added a dotted-decimal numeric version comparator.
- Added a centralized update-status helper.
- Changed both chassis and module `get_updates_status()` paths to use the helper instead of strict string inequality.

Behavior:

- Equal versions → `up-to-date`
- Numeric current version newer than available version → `up-to-date`
- Numeric current version older than available version → `update is required`
- Non-numeric/vendor-specific labels fall back to the previous strict equality behavior.

This preserves existing behavior for firmware labels such as:

- `SBR10021`
- `0710-001`
- `0x13`
- `240622.1D`

Added unit tests in `tests/fwutil_test.py` covering:

- Newer/equal/older numeric dotted versions
- Zero-padding comparisons such as `4.8` vs `4.8.0`
- Numeric comparison instead of lexical comparison, e.g. `29.10` > `29.9`
- Non-numeric fallback behavior
- Final `up-to-date` / `update is required` status decisions

#### How to verify it

Run `fwutil show updates` to see if it reports "up-to-date" for the device has newer version that fw update available version.

#### Previous command output (if the output of a command-line utility has changed)
Before this change, if the currently installed firmware was newer than the firmware available in the SONiC image, fwutil show status still reported that an update was required.

Example:
Component       Version (Current/Available)   Status
-------------   ---------------------------   ------------------
<component>     0212.0216 / 0212.0215         update is required

#### New command output (if the output of a command-line utility has changed)
After this change, the same condition is correctly reported as up-to-date because the installed version is newer than the available version.

Example:
Component       Version (Current/Available)   Status
-------------   ---------------------------   ----------
<component>     0212.0216 / 0212.0215         up-to-date

For non-numeric/vendor-specific firmware labels, behavior remains strict equality based:
0710-001 / SBR10021  -> update is required
SBR10021 / SBR10021  -> up-to-date

