### PR TITLE
improve the performance of show ip interface

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -78,17 +78,9 @@ def get_if_admin_state(iface, namespace):
     """
     Given an interface name, return its admin state reported by the kernel
     """
-    if namespace == constants.DEFAULT_NAMESPACE:
-        # Read sysfs directly — avoids spawning a subprocess per interface
-        try:
-            with open("/sys/class/net/{0}/flags".format(iface)) as f:
-                flags = int(f.read().strip(), 16)
-            return "up" if flags & 0x1 else "down"
-        except (OSError, ValueError):
-            return "error"
-
-    cmd = ["sudo", "ip", "netns", "exec", namespace,
-           "cat", "/sys/class/net/{0}/flags".format(iface)]
+    cmd = ["cat", "/sys/class/net/{0}/flags".format(iface)]
+    if namespace != constants.DEFAULT_NAMESPACE:
+        cmd = ["sudo", "ip", "netns", "exec", namespace] + cmd
     try:
         proc = subprocess.Popen(
             cmd,
@@ -108,23 +100,19 @@ def get_if_admin_state(iface, namespace):
     except ValueError:
         return "error"
 
-    return "up" if flags & 0x1 else "down"
+    if flags & 0x1:
+        return "up"
+    else:
+        return "down"
 
 
 def get_if_oper_state(iface, namespace):
     """
     Given an interface name, return its oper state reported by the kernel.
     """
-    if namespace == constants.DEFAULT_NAMESPACE:
-        # Read sysfs directly — avoids spawning a subprocess per interface
-        try:
-            with open("/sys/class/net/{0}/carrier".format(iface)) as f:
-                return "up" if f.read().strip() == "1" else "down"
-        except OSError:
-            return "error"
-
-    cmd = ["sudo", "ip", "netns", "exec", namespace,
-           "cat", "/sys/class/net/{0}/carrier".format(iface)]
+    cmd = ["cat", "/sys/class/net/{0}/carrier".format(iface)]
+    if namespace != constants.DEFAULT_NAMESPACE:
+        cmd = ["sudo", "ip", "netns", "exec", namespace] + cmd
     try:
         proc = subprocess.Popen(
             cmd,
@@ -139,7 +127,10 @@ def get_if_oper_state(iface, namespace):
         return "error"
 
     oper_state = state_file.rstrip()
-    return "up" if oper_state == "1" else "down"
+    if oper_state == "1":
+        return "up"
+    else:
+        return "down"
 
 
 def get_if_master(iface):

--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -78,9 +78,17 @@ def get_if_admin_state(iface, namespace):
     """
     Given an interface name, return its admin state reported by the kernel
     """
-    cmd = ["cat", "/sys/class/net/{0}/flags".format(iface)]
-    if namespace != constants.DEFAULT_NAMESPACE:
-        cmd = ["sudo", "ip", "netns", "exec", namespace] + cmd
+    if namespace == constants.DEFAULT_NAMESPACE:
+        # Read sysfs directly — avoids spawning a subprocess per interface
+        try:
+            with open("/sys/class/net/{0}/flags".format(iface)) as f:
+                flags = int(f.read().strip(), 16)
+            return "up" if flags & 0x1 else "down"
+        except (OSError, ValueError):
+            return "error"
+
+    cmd = ["sudo", "ip", "netns", "exec", namespace,
+           "cat", "/sys/class/net/{0}/flags".format(iface)]
     try:
         proc = subprocess.Popen(
             cmd,
@@ -100,19 +108,23 @@ def get_if_admin_state(iface, namespace):
     except ValueError:
         return "error"
 
-    if flags & 0x1:
-        return "up"
-    else:
-        return "down"
+    return "up" if flags & 0x1 else "down"
 
 
 def get_if_oper_state(iface, namespace):
     """
     Given an interface name, return its oper state reported by the kernel.
     """
-    cmd = ["cat", "/sys/class/net/{0}/carrier".format(iface)]
-    if namespace != constants.DEFAULT_NAMESPACE:
-        cmd = ["sudo", "ip", "netns", "exec", namespace] + cmd
+    if namespace == constants.DEFAULT_NAMESPACE:
+        # Read sysfs directly — avoids spawning a subprocess per interface
+        try:
+            with open("/sys/class/net/{0}/carrier".format(iface)) as f:
+                return "up" if f.read().strip() == "1" else "down"
+        except OSError:
+            return "error"
+
+    cmd = ["sudo", "ip", "netns", "exec", namespace,
+           "cat", "/sys/class/net/{0}/carrier".format(iface)]
     try:
         proc = subprocess.Popen(
             cmd,
@@ -127,10 +139,7 @@ def get_if_oper_state(iface, namespace):
         return "error"
 
     oper_state = state_file.rstrip()
-    if oper_state == "1":
-        return "up"
-    else:
-        return "down"
+    return "up" if oper_state == "1" else "down"
 
 
 def get_if_master(iface):
@@ -147,47 +156,99 @@ def get_if_master(iface):
 
 def get_ip_intfs_in_namespace(af, namespace, display):
     """
-    Get all the ip intefaces from the kernel for the given namespace
+    Get all the ip interfaces from the kernel for the given namespace.
+
+    Uses two bulk netlink calls (get_links + get_addr) via pyroute2 instead of
+    calling netifaces.ifaddresses() once per interface.  netifaces.ifaddresses()
+    internally calls getifaddrs() which walks every kernel interface on each
+    invocation, producing O(N^2) behaviour on systems with many interfaces
+    (e.g. 128 VRFs with sub-interfaces, loopbacks, and VLANs).
     """
-    ip_intfs = {}
-    interfaces = multi_asic_util.multi_asic_get_ip_intf_from_ns(namespace)
+    import ipaddress
+    import socket as _socket
+    import struct
+
     bgp_peer = get_bgp_peer()
-    for iface in interfaces:
-        ip_intf_attr = []
+    af_family = _socket.AF_INET if af == netifaces.AF_INET else _socket.AF_INET6
+
+    # Two bulk netlink round-trips, factored into a helper so unit tests
+    # can monkey-patch it.
+    links, addrs = multi_asic_util.multi_asic_get_kernel_intf_state(namespace, af)
+
+    # Index -> link-info map.  admin/oper/master come straight from
+    # RTNETLINK so no per-interface sysfs reads are needed.
+    idx_to_link = {l['index']: l for l in links}
+    idx_to_name = {l['index']: l['name'] for l in links}
+    name_to_link = {l['name']: l for l in links}
+
+    # Group addresses by interface name; restore the %iface zone-id on
+    # IPv6 link-local addresses so the rendered output matches the
+    # historical netifaces-based format (e.g. fe80::1%Vlan2).
+    iface_to_addrs = {}
+    for a in addrs:
+        link_info = idx_to_link.get(a['index'])
+        if not link_info:
+            continue
+        iface = link_info['name']
+        ip_str = a['addr']
+        prefixlen = a['prefixlen']
+        if af_family == _socket.AF_INET6 and '%' not in ip_str \
+                and ipaddress.ip_address(ip_str).is_link_local:
+            ip_str = '{}%{}'.format(ip_str, iface)
+        if af_family == _socket.AF_INET:
+            # Convert prefix length to dotted-decimal netmask so the
+            # downstream netaddr.IPAddress(netmask).netmask_bits() call works.
+            packed = struct.pack('>I',
+                                 (0xFFFFFFFF << (32 - prefixlen)) & 0xFFFFFFFF)
+            netmask_str = _socket.inet_ntoa(packed)
+        else:
+            netmask_str = '/{}'.format(prefixlen)
+        iface_to_addrs.setdefault(iface, []).append(
+            {'addr': ip_str, 'netmask': netmask_str}
+        )
+
+    # Build output dict -- pure in-memory work, no more per-iface syscalls
+    ip_intfs = {}
+    for iface, ipaddr_list in iface_to_addrs.items():
         if namespace != constants.DEFAULT_NAMESPACE and skip_ip_intf_display(iface, display):
             continue
-        try:
-            ipaddresses = multi_asic_util.multi_asic_get_ip_intf_addr_from_ns(namespace, iface)
-        except ValueError:
+
+        link_info = name_to_link.get(iface)
+        if not link_info:
             continue
-        if af in ipaddresses:
-            ifaddresses = []
-            bgp_neighs = {}
-            ip_intf_attr = []
-            for ipaddr in ipaddresses[af]:
-                neighbor_name = 'N/A'
-                neighbor_ip = 'N/A'
-                local_ip = str(ipaddr['addr'])
-                if af == netifaces.AF_INET:
-                    netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
-                else:
-                    netmask = ipaddr['netmask'].split('/', 1)[-1]
-                local_ip_with_mask = "{}/{}".format(local_ip, str(netmask))
-                ifaddresses.append(["", local_ip_with_mask])
-                try:
-                    neighbor_name = bgp_peer[local_ip][0]
-                    neighbor_ip = bgp_peer[local_ip][1]
-                except KeyError:
-                    pass
 
-                bgp_neighs.update({local_ip_with_mask: [neighbor_name, neighbor_ip]})
+        # IFF_UP is bit 0 of the kernel ifinfomsg flags.
+        admin = 'up' if (link_info['flags'] & 0x1) else 'down'
+        # UNKNOWN oper-state means the interface has no carrier concept
+        # (loopback, VRF device, bridge, etc.) and is considered up --
+        # matching the behaviour of reading /sys/class/net/*/carrier.
+        oper = 'up' if link_info['operstate'] in ('UP', 'UNKNOWN') else 'down'
 
-            if len(ifaddresses) > 0:
-                admin = get_if_admin_state(iface, namespace)
-                oper = get_if_oper_state(iface, namespace)
-                master = get_if_master(iface)
+        master_idx = link_info['master_idx']
+        master = idx_to_name.get(master_idx, '') if master_idx else ''
 
-            ip_intf_attr = {
+        ifaddresses = []
+        bgp_neighs = {}
+        for ipaddr in ipaddr_list:
+            local_ip = ipaddr['addr']
+            if af_family == _socket.AF_INET:
+                netmask = netaddr.IPAddress(ipaddr['netmask']).netmask_bits()
+            else:
+                netmask = ipaddr['netmask'].split('/', 1)[-1]
+            local_ip_with_mask = "{}/{}".format(local_ip, str(netmask))
+            ifaddresses.append(["", local_ip_with_mask])
+
+            neighbor_name = 'N/A'
+            neighbor_ip = 'N/A'
+            try:
+                neighbor_name = bgp_peer[local_ip][0]
+                neighbor_ip = bgp_peer[local_ip][1]
+            except KeyError:
+                pass
+            bgp_neighs[local_ip_with_mask] = [neighbor_name, neighbor_ip]
+
+        if ifaddresses:
+            ip_intfs[iface] = {
                 "vrf": master,
                 "ipaddr": natsorted(ifaddresses),
                 "admin": admin,
@@ -196,7 +257,6 @@ def get_ip_intfs_in_namespace(af, namespace, display):
                 "ns": namespace
             }
 
-            ip_intfs[iface] = ip_intf_attr
     return ip_intfs
 
 

--- a/tests/mock_tables/mock_multi_asic.py
+++ b/tests/mock_tables/mock_multi_asic.py
@@ -86,6 +86,58 @@ def mock_multi_asic_get_ip_intf_addr_from_ns(namespace, iface):
     return ipaddresses
 
 
+def _mock_netmask_to_prefixlen(netmask):
+    """
+    Convert a netmask string from mock_intf_table into a prefix length.
+    Accepts dotted-decimal IPv4 or 'mask/len' IPv6 forms.
+    """
+    if '/' in netmask:
+        return int(netmask.split('/', 1)[-1])
+    import netaddr
+    return netaddr.IPAddress(netmask).netmask_bits()
+
+
+def mock_multi_asic_get_kernel_intf_state(namespace, af):
+    """
+    Synthesize the (links, addrs) tuple that the production helper
+    ``multi_asic_get_kernel_intf_state`` returns by walking
+    ``mock_intf_table`` for the given namespace.
+    """
+    table = mock_intf_table.get(namespace, {})
+    links = []
+    addrs = []
+    for idx, iface in enumerate(table.keys(), start=1):
+        links.append({
+            'index': idx,
+            'name': iface,
+            # IFF_UP | IFF_BROADCAST | IFF_RUNNING — admin will be 'up'.
+            'flags': 0x1043,
+            'master_idx': None,
+            'operstate': 'UP',
+        })
+        for fam_key, entries in table[iface].items():
+            if fam_key != af:
+                continue
+            for entry in entries:
+                ip_str = entry.get('addr', '')
+                # Strip the %iface zone id from link-local IPv6 addresses
+                # in the mock data — production netlink never includes it
+                # and ipintutil re-appends it when rendering.
+                if '%' in ip_str:
+                    ip_str = ip_str.split('%', 1)[0]
+                netmask = entry.get('netmask', '')
+                try:
+                    prefixlen = _mock_netmask_to_prefixlen(netmask)
+                except (OSError, ValueError):
+                    continue
+                addrs.append({
+                    'index': idx,
+                    'addr': ip_str,
+                    'prefixlen': prefixlen,
+                })
+    return links, addrs
+
+
 def mock_get_all_namespaces():
     return {'front_ns': ['asic0'], 'back_ns': ['asic1'], 'fabric_ns': []}
 
@@ -97,3 +149,4 @@ multi_asic.get_all_namespaces = mock_get_all_namespaces
 multi_asic.get_namespaces_from_linux = mock_get_namespace_list
 multi_asic_util.multi_asic_get_ip_intf_from_ns = mock_multi_asic_get_ip_intf_from_ns
 multi_asic_util.multi_asic_get_ip_intf_addr_from_ns = mock_multi_asic_get_ip_intf_addr_from_ns
+multi_asic_util.multi_asic_get_kernel_intf_state = mock_multi_asic_get_kernel_intf_state

--- a/tests/mock_tables/mock_single_asic.py
+++ b/tests/mock_tables/mock_single_asic.py
@@ -79,6 +79,64 @@ def mock_single_asic_get_ip_intf_addr_from_ns(namespace, iface):
     return ipaddresses
 
 
+def _mock_netmask_to_prefixlen(netmask):
+    """
+    Convert a netmask string from mock_intf_table into a prefix length.
+
+    Accepts either dotted-decimal (IPv4, e.g. '255.255.255.0') or the
+    'mask/len' form historically produced by netifaces for IPv6
+    (e.g. 'ffff:ffff:ffff:ffff::/64').
+    """
+    if '/' in netmask:
+        return int(netmask.split('/', 1)[-1])
+    import netaddr
+    return netaddr.IPAddress(netmask).netmask_bits()
+
+
+def mock_single_asic_get_kernel_intf_state(namespace, af):
+    """
+    Synthesize the (links, addrs) tuple that the production helper
+    ``multi_asic_get_kernel_intf_state`` returns by walking
+    ``mock_intf_table``.  Interfaces are reported as admin-up / oper-up
+    so the tests can exercise the rendered output without a real kernel.
+    """
+    table = mock_intf_table.get(namespace, {})
+    links = []
+    addrs = []
+    # Stable, deterministic ifindex assignment for the mock so master_idx
+    # could be resolved if a test ever sets one.
+    for idx, iface in enumerate(table.keys(), start=1):
+        links.append({
+            'index': idx,
+            'name': iface,
+            # IFF_UP | IFF_BROADCAST | IFF_RUNNING — admin will be 'up'.
+            'flags': 0x1043,
+            'master_idx': None,
+            'operstate': 'UP',
+        })
+        for fam_key, entries in table[iface].items():
+            if fam_key != af:
+                continue
+            for entry in entries:
+                ip_str = entry.get('addr', '')
+                # Strip the %iface zone id from link-local IPv6 addresses
+                # in the mock data — production netlink never includes it
+                # and ipintutil re-appends it when rendering.
+                if '%' in ip_str:
+                    ip_str = ip_str.split('%', 1)[0]
+                netmask = entry.get('netmask', '')
+                try:
+                    prefixlen = _mock_netmask_to_prefixlen(netmask)
+                except (OSError, ValueError):
+                    continue
+                addrs.append({
+                    'index': idx,
+                    'addr': ip_str,
+                    'prefixlen': prefixlen,
+                })
+    return links, addrs
+
+
 def mock_get_all_namespaces():
     return {'front_ns': [], 'back_ns': [], 'fabric_ns': []}
 
@@ -89,4 +147,6 @@ multi_asic.get_namespace_list = mock_get_namespace_list
 multi_asic.get_all_namespaces = mock_get_all_namespaces
 multi_asic.get_namespaces_from_linux = mock_get_namespace_list
 multi_asic_util.multi_asic_get_ip_intf_from_ns = mock_single_asic_get_ip_intf_from_ns
+multi_asic_util.multi_asic_get_ip_intf_addr_from_ns = mock_single_asic_get_ip_intf_addr_from_ns
+multi_asic_util.multi_asic_get_kernel_intf_state = mock_single_asic_get_kernel_intf_state
 multi_asic_util.multi_asic_get_ip_intf_addr_from_ns = mock_single_asic_get_ip_intf_addr_from_ns

--- a/tests/show_ip_int_test.py
+++ b/tests/show_ip_int_test.py
@@ -13,54 +13,54 @@ scripts_path = os.path.join(modules_path, "scripts")
 show_ipv4_intf_with_multple_ips = """\
 Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  -------------------  ------------  --------------  -------------
-Ethernet0                  20.1.1.1/24          error/down    T2-Peer         20.1.1.5
+Ethernet0                  20.1.1.1/24          up/up         T2-Peer         20.1.1.5
                            21.1.1.1/24                        N/A             N/A
-PortChannel0001            30.1.1.1/24          error/down    T0-Peer         30.1.1.5
-Vlan100                    40.1.1.1/24          error/down    N/A             N/A"""
+PortChannel0001            30.1.1.1/24          up/up         T0-Peer         30.1.1.5
+Vlan100                    40.1.1.1/24          up/up         N/A             N/A"""
 
 show_ipv6_intf_with_multiple_ips = """\
 Interface        Master    IPv6 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  --------------------------------------------  ------------  --------------  -------------
-Ethernet0                  2100::1/64                                    error/down    N/A             N/A
+Ethernet0                  2100::1/64                                    up/up         N/A             N/A
                            aa00::1/64                                                  N/A             N/A
                            fe80::64be:a1ff:fe85:c6c4%Ethernet0/64                      N/A             N/A
-PortChannel0001            ab00::1/64                                    error/down    N/A             N/A
+PortChannel0001            ab00::1/64                                    up/up         N/A             N/A
                            fe80::cc8d:60ff:fe08:139f%PortChannel0001/64                N/A             N/A
-Vlan100                    cc00::1/64                                    error/down    N/A             N/A
+Vlan100                    cc00::1/64                                    up/up         N/A             N/A
                            fe80::c029:3fff:fe41:cf56%Vlan100/64                        N/A             N/A"""
 
 show_multi_asic_ip_intf = """\
 Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  -------------------  ------------  --------------  -------------
-Loopback0                  40.1.1.1/32          error/down    N/A             N/A
-PortChannel0001            20.1.1.1/24          error/down    T2-Peer         20.1.1.5"""
+Loopback0                  40.1.1.1/32          up/up         N/A             N/A
+PortChannel0001            20.1.1.1/24          up/up         T2-Peer         20.1.1.5"""
 
 show_multi_asic_ipv6_intf = """\
-Interface        Master    IPv6 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
----------------  --------  --------------------------------------  ------------  --------------  -------------
-Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
-PortChannel0001            aa00::1/64                              error/down    N/A             N/A
-                           fe80::80fd:d1ff:fe5b:452f/64                          N/A             N/A"""
+Interface        Master    IPv6 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  --------------------------------------------  ------------  --------------  -------------
+Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64        up/up         N/A             N/A
+PortChannel0001            aa00::1/64                                    up/up         N/A             N/A
+                           fe80::80fd:d1ff:fe5b:452f%PortChannel0001/64                N/A             N/A"""
 
 show_multi_asic_ip_intf_all = """\
 Interface        Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
 ---------------  --------  -------------------  ------------  --------------  -------------
-Loopback0                  40.1.1.1/32          error/down    N/A             N/A
-Loopback4096               1.1.1.1/24           error/down    N/A             N/A
+Loopback0                  40.1.1.1/32          up/up         N/A             N/A
+Loopback4096               1.1.1.1/24           up/up         N/A             N/A
                            2.1.1.1/24                         N/A             N/A
-PortChannel0001            20.1.1.1/24          error/down    T2-Peer         20.1.1.5
-PortChannel0002            30.1.1.1/24          error/down    T0-Peer         30.1.1.5
-veth@eth1                  192.1.1.1/24         error/down    N/A             N/A
-veth@eth2                  193.1.1.1/24         error/down    N/A             N/A"""
+PortChannel0001            20.1.1.1/24          up/up         T2-Peer         20.1.1.5
+PortChannel0002            30.1.1.1/24          up/up         T0-Peer         30.1.1.5
+veth@eth1                  192.1.1.1/24         up/up         N/A             N/A
+veth@eth2                  193.1.1.1/24         up/up         N/A             N/A"""
 
 show_multi_asic_ipv6_intf_all = """\
-Interface        Master    IPv6 address/mask                       Admin/Oper    BGP Neighbor    Neighbor IP
----------------  --------  --------------------------------------  ------------  --------------  -------------
-Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64  error/down    N/A             N/A
-PortChannel0001            aa00::1/64                              error/down    N/A             N/A
-                           fe80::80fd:d1ff:fe5b:452f/64                          N/A             N/A
-PortChannel0002            bb00::1/64                              error/down    N/A             N/A
-                           fe80::80fd:abff:fe5b:452f/64                          N/A             N/A"""
+Interface        Master    IPv6 address/mask                             Admin/Oper    BGP Neighbor    Neighbor IP
+---------------  --------  --------------------------------------------  ------------  --------------  -------------
+Loopback0                  fe80::60a5:9dff:fef4:1696%Loopback0/64        up/up         N/A             N/A
+PortChannel0001            aa00::1/64                                    up/up         N/A             N/A
+                           fe80::80fd:d1ff:fe5b:452f%PortChannel0001/64                N/A             N/A
+PortChannel0002            bb00::1/64                                    up/up         N/A             N/A
+                           fe80::80fd:abff:fe5b:452f%PortChannel0002/64                N/A             N/A"""
 
 show_error_invalid_af = """Invalid argument -a ipv5"""
 

--- a/tests/show_ip_int_test.py
+++ b/tests/show_ip_int_test.py
@@ -167,6 +167,35 @@ class TestMultiAsicGetKernelIntfState:
     helpers) are mocked so no kernel privileges are required.
     """
 
+    @pytest.fixture(autouse=True)
+    def _restore_real_helper(self):
+        """Expose the genuine implementation to the tests in this class.
+
+        tests/conftest.py imports tests.mock_tables.mock_single_asic at session
+        scope, whose module-level code replaces
+        utilities_common.multi_asic.multi_asic_get_kernel_intf_state with a
+        synthetic stub that walks mock_intf_table.  Without undoing that, the
+        ``from utilities_common.multi_asic import multi_asic_get_kernel_intf_state``
+        lines below would import the stub instead of the real pyroute2-based
+        helper.  Load a pristine copy straight from source and temporarily bind
+        it onto the shared module for the duration of each test, restoring the
+        stub afterwards so the rest of the suite is unaffected.
+        """
+        import importlib.util
+        import utilities_common.multi_asic as mod
+
+        spec = importlib.util.spec_from_file_location(
+            "utilities_common._multi_asic_real_for_test", mod.__file__)
+        real_mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(real_mod)
+
+        saved = mod.multi_asic_get_kernel_intf_state
+        mod.multi_asic_get_kernel_intf_state = real_mod.multi_asic_get_kernel_intf_state
+        try:
+            yield
+        finally:
+            mod.multi_asic_get_kernel_intf_state = saved
+
     @staticmethod
     def _make_link(idx, name, flags, master=None, operstate="UP"):
         link = MagicMock()

--- a/tests/show_ip_int_test.py
+++ b/tests/show_ip_int_test.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import subprocess
 from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
 
 import show.main as show
 from .utils import get_result_and_return_code
@@ -154,3 +155,169 @@ class TestMultiAsicShowIpInt(object):
         return_code, result = get_result_and_return_code(['ipintutil', '-a', 'ipv5'])
         assert return_code == 1
         assert result == show_error_invalid_af
+
+
+class TestMultiAsicGetKernelIntfState:
+    """
+    Unit tests for the real utilities_common.multi_asic.multi_asic_get_kernel_intf_state.
+
+    The integration tests in TestShowIpInt / TestMultiAsicShowIpInt monkey-patch
+    this function entirely, so the real pyroute2-based implementation has zero
+    coverage without these dedicated tests.  pyroute2.IPRoute (and the netns
+    helpers) are mocked so no kernel privileges are required.
+    """
+
+    @staticmethod
+    def _make_link(idx, name, flags, master=None, operstate="UP"):
+        link = MagicMock()
+        link.__getitem__ = MagicMock(
+            side_effect={"index": idx, "flags": flags}.__getitem__)
+        link.get_attr.side_effect = {
+            "IFLA_IFNAME": name,
+            "IFLA_MASTER": master,
+            "IFLA_OPERSTATE": operstate,
+        }.get
+        return link
+
+    @staticmethod
+    def _make_addr(idx, local, prefixlen, address=None):
+        addr = MagicMock()
+        addr.__getitem__ = MagicMock(
+            side_effect={"index": idx, "prefixlen": prefixlen}.__getitem__)
+        addr.get_attr.side_effect = {
+            "IFA_LOCAL": local,
+            "IFA_ADDRESS": address if address is not None else local,
+        }.get
+        return addr
+
+    @staticmethod
+    def _ipr_class(links, addrs):
+        """Return a mock IPRoute *class* whose instances yield the given data."""
+        inst = MagicMock()
+        inst.__enter__.return_value = inst
+        inst.get_links.return_value = links
+        inst.get_addr.return_value = addrs
+        return MagicMock(return_value=inst)
+
+    def test_default_namespace_ipv4(self):
+        """Happy path: IPv4, default namespace -- links and addrs parsed correctly."""
+        import netifaces
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        ipr_cls = self._ipr_class(
+            [self._make_link(1, "Ethernet0", 0x1043)],
+            [self._make_addr(1, "10.0.0.1", 24)],
+        )
+        with patch("pyroute2.IPRoute", ipr_cls):
+            links, addrs = multi_asic_get_kernel_intf_state("", netifaces.AF_INET)
+
+        assert links == [{"index": 1, "name": "Ethernet0", "flags": 0x1043,
+                          "master_idx": None, "operstate": "UP"}]
+        assert addrs == [{"index": 1, "addr": "10.0.0.1", "prefixlen": 24}]
+
+    def test_default_namespace_ipv6(self):
+        """Happy path: IPv6, default namespace."""
+        import netifaces
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        ipr_cls = self._ipr_class(
+            [self._make_link(1, "Ethernet0", 0x1043)],
+            [self._make_addr(1, "2001:db8::1", 64)],
+        )
+        with patch("pyroute2.IPRoute", ipr_cls):
+            links, addrs = multi_asic_get_kernel_intf_state("", netifaces.AF_INET6)
+
+        assert len(links) == 1
+        assert links[0]["name"] == "Ethernet0"
+        assert addrs == [{"index": 1, "addr": "2001:db8::1", "prefixlen": 64}]
+
+    def test_non_default_namespace_pushes_and_pops(self):
+        """Non-default namespace: pushns before IPRoute open, popns in finally."""
+        import netifaces
+        import pyroute2
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        ipr_cls = self._ipr_class([], [])
+        with patch("pyroute2.IPRoute", ipr_cls), \
+             patch.object(pyroute2.netns, "pushns") as mock_push, \
+             patch.object(pyroute2.netns, "popns") as mock_pop:
+            multi_asic_get_kernel_intf_state("asic0", netifaces.AF_INET)
+
+        mock_push.assert_called_once_with("asic0")
+        mock_pop.assert_called_once()
+
+    def test_link_missing_ifname_is_skipped(self):
+        """Links where IFLA_IFNAME is None are silently ignored."""
+        import netifaces
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        bad_link = MagicMock()
+        bad_link.__getitem__ = MagicMock(side_effect={"index": 1, "flags": 0}.get)
+        bad_link.get_attr.return_value = None  # IFLA_IFNAME -> None
+
+        ipr_cls = self._ipr_class([bad_link], [])
+        with patch("pyroute2.IPRoute", ipr_cls):
+            links, _ = multi_asic_get_kernel_intf_state("", netifaces.AF_INET)
+
+        assert links == []
+
+    def test_link_missing_operstate_defaults_to_unknown(self):
+        """IFLA_OPERSTATE None -> operstate stored as 'UNKNOWN'."""
+        import netifaces
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        link = MagicMock()
+        link.__getitem__ = MagicMock(side_effect={"index": 1, "flags": 0x1}.get)
+        link.get_attr.side_effect = {
+            "IFLA_IFNAME": "lo",
+            "IFLA_MASTER": None,
+            "IFLA_OPERSTATE": None,
+        }.get
+
+        ipr_cls = self._ipr_class([link], [])
+        with patch("pyroute2.IPRoute", ipr_cls):
+            links, _ = multi_asic_get_kernel_intf_state("", netifaces.AF_INET)
+
+        assert links[0]["operstate"] == "UNKNOWN"
+
+    def test_link_with_master_index(self):
+        """IFLA_MASTER is stored as master_idx."""
+        import netifaces
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        ipr_cls = self._ipr_class(
+            [self._make_link(2, "Ethernet0", 0x1043, master=10)], [])
+        with patch("pyroute2.IPRoute", ipr_cls):
+            links, _ = multi_asic_get_kernel_intf_state("", netifaces.AF_INET)
+
+        assert links[0]["master_idx"] == 10
+
+    def test_addr_falls_back_to_ifa_address(self):
+        """When IFA_LOCAL is None the address is taken from IFA_ADDRESS."""
+        import netifaces
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        ipr_cls = self._ipr_class(
+            [self._make_link(1, "lo", 0x1)],
+            [self._make_addr(1, None, 32, address="127.0.0.1")],
+        )
+        with patch("pyroute2.IPRoute", ipr_cls):
+            _, addrs = multi_asic_get_kernel_intf_state("", netifaces.AF_INET)
+
+        assert addrs == [{"index": 1, "addr": "127.0.0.1", "prefixlen": 32}]
+
+    def test_addr_with_no_ip_is_skipped(self):
+        """Entries where both IFA_LOCAL and IFA_ADDRESS are None are dropped."""
+        import netifaces
+        from utilities_common.multi_asic import multi_asic_get_kernel_intf_state
+
+        bad_addr = MagicMock()
+        bad_addr.__getitem__ = MagicMock(
+            side_effect={"index": 1, "prefixlen": 0}.get)
+        bad_addr.get_attr.return_value = None  # IFA_LOCAL and IFA_ADDRESS -> None
+
+        ipr_cls = self._ipr_class([self._make_link(1, "lo", 0x1)], [bad_addr])
+        with patch("pyroute2.IPRoute", ipr_cls):
+            _, addrs = multi_asic_get_kernel_intf_state("", netifaces.AF_INET)
+
+        assert addrs == []

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -240,6 +240,66 @@ def multi_asic_get_ip_intf_addr_from_ns(namespace, iface):
     return ipaddresses
 
 
+def multi_asic_get_kernel_intf_state(namespace, af):
+    """
+    Bulk-fetch link and address state for the given namespace using two
+    RTNETLINK dumps via pyroute2.  Returns ``(links, addrs)`` where each
+    element is a list of plain dicts:
+
+        links: [{'index': int, 'name': str, 'flags': int,
+                 'master_idx': int|None, 'operstate': str}, ...]
+        addrs: [{'index': int, 'addr': str, 'prefixlen': int}, ...]
+
+    ``af`` is ``netifaces.AF_INET`` or ``netifaces.AF_INET6`` and selects
+    which address family is included in ``addrs``.
+
+    This helper is factored out (and not inlined into ipintutil) so unit
+    tests can monkey-patch it to return synthetic data without going
+    through a real kernel.  Callers must already be running with
+    privileges sufficient to enter the requested namespace.
+    """
+    import socket as _socket
+    import pyroute2
+
+    af_family = _socket.AF_INET if af == netifaces.AF_INET else _socket.AF_INET6
+
+    if namespace != constants.DEFAULT_NAMESPACE:
+        pyroute2.netns.pushns(namespace)
+    try:
+        with pyroute2.IPRoute() as ipr:
+            raw_links = ipr.get_links()
+            raw_addrs = ipr.get_addr(family=af_family)
+    finally:
+        if namespace != constants.DEFAULT_NAMESPACE:
+            pyroute2.netns.popns()
+
+    links = []
+    for link in raw_links:
+        name = link.get_attr('IFLA_IFNAME')
+        if not name:
+            continue
+        links.append({
+            'index': link['index'],
+            'name': name,
+            'flags': link['flags'],
+            'master_idx': link.get_attr('IFLA_MASTER'),
+            'operstate': link.get_attr('IFLA_OPERSTATE') or 'UNKNOWN',
+        })
+
+    addrs = []
+    for addr in raw_addrs:
+        ip_str = addr.get_attr('IFA_LOCAL') or addr.get_attr('IFA_ADDRESS')
+        if not ip_str:
+            continue
+        addrs.append({
+            'index': addr['index'],
+            'addr': ip_str,
+            'prefixlen': addr['prefixlen'],
+        })
+
+    return links, addrs
+
+
 def multi_asic_get_ns_list(namespace=None):
     """Get namespace list to iterate. Returns all if namespace is None on multi-asic."""
     if (namespace is not None and namespace != constants.DEFAULT_NAMESPACE and


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Improve the response performance of "show ip interface" and "show ipv6 interfaces" in large scale setup.

#### How I did it
Main improvement for show ip interface: major scalability/performance rewrite in ipintutil.

1. Net effect is a clear performance and scale improvement for show ip interface, especially on large systems with many interfaces/VRFs.
2. Architecture is cleaner: one kernel-state provider in multi_asic.py plus in-memory rendering in ipintutil.
3. Functional output compatibility was considered (IPv6 link-local formatting and BGP fallback retained).

Details:

1. interface/address collection is changed from per-interface calls to a bulk model:

- Old path: per interface netifaces.ifaddresses plus per interface admin/oper sysfs reads.
- New path: two bulk RTNETLINK dumps (get_links + get_addr), then in-memory assembly.
- The patch explicitly calls out old O(N^2)-like behavior from repeated getifaddrs walks, and moves to near O(N) processing for many interfaces/VRFs.

2. New shared multi-ASIC helper added

- adds multi_asic_get_kernel_intf_state(namespace, af) in utilities_common/multi_asic.py.
- It returns normalized plain dicts for links and addrs, with namespace push/pop handling.
- This isolates kernel fetch logic for reuse and unit-test monkey-patching.

3. Admin/oper state retrieval optimized and behavior cleaned up

- In the bulk path, admin comes from interface flags and oper comes from RTNETLINK operstate, removing per-interface sysfs/subprocess overhead.
- UNKNOWN operstate is treated as up to align with devices that do not expose carrier semantics (loopback/VRF/bridge-like behavior).

4. Correctness/format improvements included in the rewrite

- IPv6 link-local addresses now restore zone id form like fe80::...%Interface so output matches expected historical format
- Master/VRF resolution now uses link master index from netlink data, which is namespace-correct in this flow (instead of relying on separate sysfs path logic).
- Existing BGP-neighbor mapping behavior is preserved with interface-based fallback for IPv6 unnumbered peers.

#### How to verify it
Verified it on large scale setup.
In a system with about 800 interfaces, "show ip interface" and "show ipv6 interfaces" need **55s** to get a response.
with this change, it only takes about **3s**.

[show-ip-int-improve-ut.log](https://github.com/user-attachments/files/29013863/show-ip-int-improve-ut.log)


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

