### PR TITLE
Fix Counterpoll Phy CLI to allow global NS on MASIC

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -187,7 +187,7 @@ def port_buffer_drop_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()),
+              type=click.Choice(get_valid_namespace_choices()),
               default=multi_asic.get_current_namespace())
 @click.pass_context
 def phy(ctx, namespace):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Make the phy subcommand consistent with all other counterpoll commands

* Use get_valid_namespace_choices instead of get_namespace_list which does not include the global namespace on multi asic.

#### How I did it
Make use of get_valid_namespace_choices instead of get_namespace_list.

#### How to verify it
Before:
```
counterpoll phy enable
Try 'counterpoll phy --help' for help.

Error: Invalid value for '-n' / '--namespace': '' is not one of 'asic0', 'asic1'.
```
after: success, no output.

