### PR TITLE
[202511] Fix Counterpoll Phy CLI to run in a network namespace

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -188,7 +188,8 @@ def port_buffer_drop_disable(ctx):
 @cli.group()
 @click.option('-n', '--namespace', help='Namespace name',
               required=False,
-              type=click.Choice(multi_asic.get_namespace_list()))
+              type=click.Choice(get_valid_namespace_choices()),
+              default=multi_asic.get_current_namespace())
 @click.pass_context
 def phy(ctx, namespace):
     """ PHY counter commands """


### PR DESCRIPTION
#### What I did
Make the phy subcommand consistent with all other counterpoll commands

* Include `default=multi_asic.get_current_namespace()` so the phy command also functions correctly when run in a network namespace with `sudo ip netns exec`
* Ensure to use get_valid_namespace_choices instead of get_namespace_list which does not include the global namespace on multi asic.


#### How I did it
Make use of get_valid_namespace_choices instead of get_namespace_list.


#### How to verify it
Before:
```
counterpoll phy enable
Try 'counterpoll phy --help' for help.

Error: Invalid value for '-n' / '--namespace': '' is not one of 'asic0', 'asic1'.
```
after: success, no output.