### PR TITLE
Copy the HWSKU SAI files for all the asics in generate_dump for BCM platform

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -1783,9 +1783,19 @@ collect_broadcom() {
     if [ -d /usr/share/sonic/device/${platform}/${hwsku} ]; then
         # copy all the files in the HWSKU directory
         pushd /usr/share/sonic/device/${platform}/${hwsku} > /dev/null
-        for file in $(find . -maxdepth 2 -type f); do
-            save_file ${file} sai false
-        done
+        # Preserve immediate subdirs (e.g. per-ASIC 0/, 1/) under sai/; basename-only
+        local rel parent supp_sub file
+        while IFS= read -r file; do
+            rel="${file#./}"
+            parent=$(dirname "$rel")
+            if [ "$parent" = "." ]; then
+                supp_sub="sai"
+            else
+                supp_sub="sai/${parent}"
+            fi
+            save_file "${file}" "$supp_sub" false
+        done < <(find . -maxdepth 2 -type f)
+
         popd > /dev/null
 
         if [[ ("$NUM_ASICS" > 1) ]]; then


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
The generate_dump script is not copying the sai files (.bcm config, sai.profile, buffer_profiles etc) for all the asics in broadcom multi asic platform. It copies the asic0 files to sai folder and then overwrites with asic1 files since it was not creating 0 or 1 subfolder in the sai directory in show tech output.

Modified code to create sub folder 0/1 to copy the corresponding files.
#### How I did it
Modified code to create sub folder 0/1 to copy the corresponding files.
#### How to verify it
Generated show tech and verified that the files from both asics are copied to sai folder in show tech tar file.
#### Previous command output (if the output of a command-line utility has changed)
sonic_dump_ixre-egl-board211_20260616_203640$ ls sai/
0  1  fabric_monitor_config.json  fabric_port_config.ini

sonic_dump_ixre-egl-board211_20260616_203640$ ls sai/0/ sai/1
sai/0/:
buffers_defaults_t2.j2  context_config.json             pg_profile_lookup.ini  qos.json.j2           sai.profile
buffers.json.j2         jr2cp-nokia-18x400g-config.bcm  port_config.ini        sai_postinit_cmd.soc

sai/1:
buffers_defaults_t2.j2  context_config.json             pg_profile_lookup.ini  qos.json.j2           sai.profile
buffers.json.j2         jr2cp-nokia-18x400g-config.bcm  port_config.ini        sai_postinit_cmd.soc

None
#### New command output (if the output of a command-line utility has changed)

None