### PR TITLE
[Port Mirror][CLI] Align ERSPAN sample_rate range with YANG model

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -128,15 +128,16 @@ GUID_MAX_LEN = 255
 asic_type = None
 
 
-SAMPLE_RATE_MIN = 256
-SAMPLE_RATE_MAX = 8388608
+SAMPLE_RATE_MIN = 2
+SAMPLE_RATE_MAX = 0xFFFFFFFF  # uint32 max
 TRUNCATE_SIZE_MIN = 64
 TRUNCATE_SIZE_MAX = 9216
 
 
 def validate_sample_rate(ctx, param, value):
     if value != 0 and (value < SAMPLE_RATE_MIN or value > SAMPLE_RATE_MAX):
-        raise click.BadParameter(f"must be 0 or in range {SAMPLE_RATE_MIN}..{SAMPLE_RATE_MAX}")
+        raise click.BadParameter(
+            f"must be 0 or in range {SAMPLE_RATE_MIN}..{SAMPLE_RATE_MAX} (uint32 max)")
     return value
 
 
@@ -3222,7 +3223,7 @@ def erspan(ctx):
 @click.argument('direction', metavar='[direction]', required=False)
 @click.option('--policer')
 @click.option('--sample_rate', type=int, default=0, callback=validate_sample_rate,
-              help="Sampling rate (1-in-N), 256..8388608. 0 disables sampling")
+              help="Sampling rate (1-in-N), 2..4294967295. 0 disables sampling")
 @click.option('--truncate_size', type=int, default=0, callback=validate_truncate_size,
               help="Truncation size in bytes, 64..9216. 0 disables truncation")
 def erspan_add(session_name, src_ip, dst_ip, dscp, ttl, gre_type, queue, policer, src_port, direction,

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9361,8 +9361,8 @@ While adding a new ERSPAN session, users need to configure the following fields 
 7) optional - Policer which will be used to control the rate at which frames are mirrored.
 8) optional - List of source ports which can have both Ethernet and LAG ports.
 9) optional - Direction - Mirror session direction when configured along with Source port. (Supported rx/tx/both. default direction is both)
-10) optional - Sample rate for sampled mirroring. N means mirror 1-in-N packets. When not specified, full mirroring is used. Valid range: 256..8388608.
-11) optional - Truncate size in bytes for mirrored packets. When not specified, no truncation is applied. Valid range: 64..9216.
+10) optional - Sample rate for sampled mirroring. N means mirror 1-in-N packets. When not specified (or set to 0), full mirroring is used. Valid values: 0 or 2..4294967295 (uint32 max).
+11) optional - Truncate size in bytes for mirrored packets. When not specified (or set to 0), no truncation is applied. Valid values: 0 or 64..9216.
 
 - Usage:
   ```

--- a/tests/config_mirror_session_test.py
+++ b/tests/config_mirror_session_test.py
@@ -810,7 +810,7 @@ def test_mirror_session_erspan_add_with_invalid_sample_rate():
             ["test_session", "1.1.1.1", "2.2.2.2", "8", "64",
              "--sample_rate", "-1"])
     assert result.exit_code != 0
-    assert 'must be 0 or in range 256..8388608' in result.output
+    assert 'must be 0 or in range 2..4294967295' in result.output
 
     # Verify invalid truncate_size (negative)
     result = runner.invoke(
@@ -824,45 +824,45 @@ def test_mirror_session_erspan_add_with_invalid_sample_rate():
 def test_mirror_session_erspan_add_sample_rate_boundary():
     runner = CliRunner()
 
-    # sample_rate=1 (in the 1-255 hole, should fail)
+    # sample_rate=1 (below minimum of 2, should fail)
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
             ["test_session", "1.1.1.1", "2.2.2.2", "8", "64",
              "--sample_rate", "1"])
     assert result.exit_code != 0
-    assert 'must be 0 or in range 256..8388608' in result.output
+    assert 'must be 0 or in range 2..4294967295' in result.output
 
-    # sample_rate=255 (upper boundary of hole, should fail)
-    result = runner.invoke(
-            config.config.commands["mirror_session"].commands["erspan"].commands["add"],
-            ["test_session", "1.1.1.1", "2.2.2.2", "8", "64",
-             "--sample_rate", "255"])
-    assert result.exit_code != 0
-    assert 'must be 0 or in range 256..8388608' in result.output
-
-    # sample_rate=256 (minimum valid, should pass)
+    # sample_rate=2 (minimum valid, should pass)
     with mock.patch('config.main.add_erspan') as _:
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["erspan"].commands["add"],
                 ["test_session", "1.1.1.1", "2.2.2.2", "8", "64",
-                 "--sample_rate", "256"])
+                 "--sample_rate", "2"])
         assert result.exit_code == 0
 
-    # sample_rate=8388608 (maximum valid, should pass)
+    # sample_rate=100 (in the valid range, should pass)
     with mock.patch('config.main.add_erspan') as _:
         result = runner.invoke(
                 config.config.commands["mirror_session"].commands["erspan"].commands["add"],
                 ["test_session", "1.1.1.1", "2.2.2.2", "8", "64",
-                 "--sample_rate", "8388608"])
+                 "--sample_rate", "100"])
         assert result.exit_code == 0
 
-    # sample_rate=8388609 (above maximum, should fail)
+    # sample_rate=4294967295 (maximum valid, should pass)
+    with mock.patch('config.main.add_erspan') as _:
+        result = runner.invoke(
+                config.config.commands["mirror_session"].commands["erspan"].commands["add"],
+                ["test_session", "1.1.1.1", "2.2.2.2", "8", "64",
+                 "--sample_rate", "4294967295"])
+        assert result.exit_code == 0
+
+    # sample_rate=4294967296 (above maximum, should fail)
     result = runner.invoke(
             config.config.commands["mirror_session"].commands["erspan"].commands["add"],
             ["test_session", "1.1.1.1", "2.2.2.2", "8", "64",
-             "--sample_rate", "8388609"])
+             "--sample_rate", "4294967296"])
     assert result.exit_code != 0
-    assert 'must be 0 or in range 256..8388608' in result.output
+    assert 'must be 0 or in range 2..4294967295' in result.output
 
 
 def test_mirror_session_erspan_add_truncate_size_boundary():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Aligned the ERSPAN mirror session `sample_rate` validation range with the YANG model ([sonic-buildimage #26756](https://github.com/sonic-net/sonic-buildimage/pull/26756)), which defines it as uint32 `2..max`.

#### How I did it
 - `config/main.py`: changed from `SAMPLE_RATE_MIN` 256 to 2, changed `SAMPLE_RATE_MAX` 8388608 to `0xFFFFFFFF` (uint32 max). 
 - `tests/config_mirror_session_test.py`: updated assertions and reworked the boundary test.
 - `doc/Command-Reference.md`: updated the valid range.
 
#### How to verify it
 pytest tests/config_mirror_session_test.py

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

