### PR TITLE
improve performance for show vlan brief in large-scale config

### DIFF
--- a/show/vlan.py
+++ b/show/vlan.py
@@ -12,83 +12,131 @@ def vlan():
     pass
 
 
+# Attribute name used to stash per-invocation indexes on the ``db``
+# object so all built-in column getters (and the plugin-extension
+# callers that share the same ``ctx``) can reuse them. ``brief()`` is
+# responsible for clearing this attribute before and after each render
+# so stale data from a previous invocation can never be observed when
+# the same ``Db`` instance is shared (e.g. by CliRunner-based tests or
+# by tools that invoke the command multiple times after mutating
+# VLAN_MEMBER / VLAN_INTERFACE / SONIC_CLI_IFACE_MODE).
+_BRIEF_CACHE_ATTR = '_vlan_brief_cache'
+
+
+def _get_brief_cache(ctx):
+    """Build (lazily, once per ``brief`` invocation) and return indexes
+    used by the built-in "show vlan brief" column getters.
+
+    Without this cache each getter rescans VLAN_INTERFACE / VLAN_MEMBER
+    for every VLAN, and ``get_vlan_ports`` re-constructs an
+    ``InterfaceAliasConverter`` (which reloads the PORT table) per VLAN.
+    With ~800 VLANs that becomes O(V^2) plus 800 PORT-table reads.
+
+    The cache is stashed on the ``db`` object purely as a convenient
+    place that every getter can reach via ``ctx``. ``brief()`` clears
+    the attribute before populating ``vlan_cfg`` and again after the
+    render completes, so the lifetime of the cache is exactly one
+    invocation -- it never carries indexes from an earlier ``brief()``
+    call into a later one, even when callers share the same ``Db``.
+    """
+    cfg, db = ctx
+    cache = getattr(db, _BRIEF_CACHE_ATTR, None)
+    if cache is not None:
+        return cache
+
+    _, vlan_ip_data, vlan_ports_data = cfg
+
+    # Index VLAN_INTERFACE once: (vlan, prefix) entries provide IP
+    # addresses; (vlan,) entries carry per-VLAN attributes like
+    # proxy_arp.
+    ip_by_vlan = {}
+    proxy_arp_by_vlan = {}
+    for key, value in vlan_ip_data.items():
+        if clicommon.is_ip_prefix_in_key(key):
+            ifname, address = key
+            ip_by_vlan.setdefault(ifname, []).append(address)
+        else:
+            proxy_arp_by_vlan[key] = value.get('proxy_arp', 'disabled')
+
+    # Index VLAN_MEMBER once, in natsorted port order. Both the Ports
+    # column and the Port Tagging column iterate in this single order so
+    # the two columns line up row-for-row.
+    ports_by_vlan = {}
+    tagging_by_vlan = {}
+    for key in natsorted(list(vlan_ports_data.keys())):
+        vlan_key, port = key
+        ports_by_vlan.setdefault(vlan_key, []).append(port)
+        tagging_by_vlan.setdefault(vlan_key, []).append(
+            vlan_ports_data[key].get('tagging_mode', ''))
+
+    naming_mode = clicommon.get_interface_naming_mode()
+    # Only build the alias converter (which reads the PORT table) when
+    # we will actually use it.
+    iface_alias_converter = (clicommon.InterfaceAliasConverter(db)
+                             if naming_mode == 'alias' else None)
+
+    cache = {
+        'ip_by_vlan': ip_by_vlan,
+        'proxy_arp_by_vlan': proxy_arp_by_vlan,
+        'ports_by_vlan': ports_by_vlan,
+        'tagging_by_vlan': tagging_by_vlan,
+        'naming_mode': naming_mode,
+        'iface_alias_converter': iface_alias_converter,
+    }
+    setattr(db, _BRIEF_CACHE_ATTR, cache)
+    return cache
+
+
+def _clear_brief_cache(db):
+    """Drop any per-invocation index cache attached to ``db``.
+
+    Called by ``brief()`` to scope the cache to a single render.
+    """
+    try:
+        delattr(db, _BRIEF_CACHE_ATTR)
+    except AttributeError:
+        pass
+
+
 def get_vlan_id(ctx, vlan):
     vlan_prefix, vid = vlan.split('Vlan')
     return vid
 
 
 def get_vlan_ip_address(ctx, vlan):
-    cfg, _ = ctx
-    _, vlan_ip_data, _ = cfg
-    ip_address = ""
-    for key in vlan_ip_data:
-        if not clicommon.is_ip_prefix_in_key(key):
-            continue
-        ifname, address = key
-        if vlan == ifname:
-            ip_address += "\n{}".format(address)
-
-    return ip_address
+    cache = _get_brief_cache(ctx)
+    addrs = cache['ip_by_vlan'].get(vlan)
+    if not addrs:
+        return ""
+    # Preserve the original formatting (leading newline before the first
+    # address) so existing output / tests are unchanged.
+    return "".join("\n{}".format(a) for a in addrs)
 
 
 def get_vlan_ports(ctx, vlan):
-    cfg, db = ctx
-    _, _, vlan_ports_data = cfg
-    vlan_ports = []
-    iface_alias_converter = clicommon.InterfaceAliasConverter(db)
-    # Here natsorting is important in relation to another
-    # column which prints port tagging mode.
-    # If we sort both in the same way using same keys
-    # we will result in right order in both columns.
-    # This should be fixed by cli code autogeneration tool
-    # and we won't need this specific approach with
-    # VlanBrief.COLUMNS anymore.
-    for key in natsorted(list(vlan_ports_data.keys())):
-        ports_key, ports_value = key
-        if vlan != ports_key:
-            continue
+    cache = _get_brief_cache(ctx)
+    ports = cache['ports_by_vlan'].get(vlan)
+    if not ports:
+        return ''
 
-        if clicommon.get_interface_naming_mode() == "alias":
-            ports_value = iface_alias_converter.name_to_alias(ports_value)
+    if cache['naming_mode'] == "alias":
+        iface_alias_converter = cache['iface_alias_converter']
+        ports = [iface_alias_converter.name_to_alias(p) for p in ports]
 
-        vlan_ports.append(ports_value)
-
-    return '\n'.join(vlan_ports)
+    return '\n'.join(ports)
 
 
 def get_vlan_ports_tagging(ctx, vlan):
-    cfg, db = ctx
-    _, _, vlan_ports_data = cfg
-    vlan_ports_tagging = []
-    # Here natsorting is important in relation to another
-    # column which prints vlan ports.
-    # If we sort both in the same way using same keys
-    # we will result in right order in both columns.
-    # This should be fixed by cli code autogeneration tool
-    # and we won't need this specific approach with
-    # VlanBrief.COLUMNS anymore.
-    for key in natsorted(list(vlan_ports_data.keys())):
-        ports_key, ports_value = key
-        if vlan != ports_key:
-            continue
-
-        tagging_value = vlan_ports_data[key]["tagging_mode"]
-        vlan_ports_tagging.append(tagging_value)
-
-    return '\n'.join(vlan_ports_tagging)
+    cache = _get_brief_cache(ctx)
+    tagging = cache['tagging_by_vlan'].get(vlan)
+    if not tagging:
+        return ''
+    return '\n'.join(tagging)
 
 
 def get_proxy_arp(ctx, vlan):
-    cfg, _ = ctx
-    _, vlan_ip_data, _ = cfg
-    proxy_arp = "disabled"
-    for key in vlan_ip_data:
-        if clicommon.is_ip_prefix_in_key(key):
-            continue
-        if vlan == key:
-            proxy_arp = vlan_ip_data[key].get("proxy_arp", "disabled")
-
-    return proxy_arp
+    cache = _get_brief_cache(ctx)
+    return cache['proxy_arp_by_vlan'].get(vlan, "disabled")
 
 
 class VlanBrief:
@@ -131,12 +179,22 @@ def brief(verbose, namespace):
         vlan_ports_data = db.cfgdb.get_table('VLAN_MEMBER')
         vlan_cfg = (vlan_data, vlan_ip_data, vlan_ports_data)
 
-        for vlan in natsorted(vlan_data):
-            row = []
-            for column in VlanBrief.COLUMNS:
-                column_name, getter = column
-                row.append(getter((vlan_cfg, db), vlan))
-            body.append(row)
+        # Force the per-invocation index cache to be rebuilt from the
+        # freshly fetched ``vlan_cfg`` above, and make sure nothing leaks
+        # out of this call. Without this, a caller that reuses the same
+        # ``Db`` across multiple ``brief`` invocations (CliRunner-based
+        # tests, dump tools, etc.) could see indexes built from VLAN data
+        # that was current at the time of the first call.
+        _clear_brief_cache(db)
+        try:
+            for vlan in natsorted(vlan_data):
+                row = []
+                for column in VlanBrief.COLUMNS:
+                    column_name, getter = column
+                    row.append(getter((vlan_cfg, db), vlan))
+                body.append(row)
+        finally:
+            _clear_brief_cache(db)
 
         click.echo(tabulate(body, header, tablefmt="grid"))
 

--- a/show/vlan.py
+++ b/show/vlan.py
@@ -38,13 +38,23 @@ def _get_brief_cache(ctx):
     render completes, so the lifetime of the cache is exactly one
     invocation -- it never carries indexes from an earlier ``brief()``
     call into a later one, even when callers share the same ``Db``.
+
+    As a second line of defence (for external callers that invoke the
+    getters directly on a reused ``Db`` without going through
+    ``brief()``), the cache records the identity of the ``vlan_ip_data``
+    and ``vlan_ports_data`` objects it was built from and is rebuilt
+    automatically when a different ``vlan_cfg`` is observed. The source
+    objects are kept referenced (rather than comparing raw ``id()``
+    values) so their identity can never be recycled by a freed object.
     """
     cfg, db = ctx
-    cache = getattr(db, _BRIEF_CACHE_ATTR, None)
-    if cache is not None:
-        return cache
-
     _, vlan_ip_data, vlan_ports_data = cfg
+
+    cache = getattr(db, _BRIEF_CACHE_ATTR, None)
+    if cache is not None and \
+            cache['_source'][0] is vlan_ip_data and \
+            cache['_source'][1] is vlan_ports_data:
+        return cache
 
     # Index VLAN_INTERFACE once: (vlan, prefix) entries provide IP
     # addresses; (vlan,) entries carry per-VLAN attributes like
@@ -76,6 +86,13 @@ def _get_brief_cache(ctx):
                              if naming_mode == 'alias' else None)
 
     cache = {
+        # Identity guard: the exact (vlan_ip_data, vlan_ports_data)
+        # objects this cache was built from. Retrieval compares against
+        # these with ``is`` (an O(1) identity check) and rebuilds on any
+        # mismatch, so a reused ``Db`` can never expose indexes from
+        # stale config. Keeping the references here also prevents their
+        # identity from being recycled by a later, freed object.
+        '_source': (vlan_ip_data, vlan_ports_data),
         'ip_by_vlan': ip_by_vlan,
         'proxy_arp_by_vlan': proxy_arp_by_vlan,
         'ports_by_vlan': ports_by_vlan,

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -1956,6 +1956,57 @@ class TestVlanBriefCache:
         assert "Vlan1000" not in cache_after["ip_by_vlan"]
         assert cache_before is not cache_after
 
+    def test_cache_rebuilds_when_vlan_ip_data_identity_changes(self):
+        """Identity guard: reusing the same db (cache still attached) with a
+        *different* vlan_ip_data object -- without an explicit
+        _clear_brief_cache -- must rebuild rather than return stale indexes.
+        Covers the ``_source[0] is vlan_ip_data`` arm of the guard."""
+        from show.vlan import _get_brief_cache
+
+        ctx, db = self._make_ctx_shared_db(
+            vlan_ip_data={("Vlan1000", "10.0.0.1/24"): {}},
+            vlan_ports_data={("Vlan1000", "Ethernet4"): {"tagging_mode": "untagged"}},
+        )
+        cache_before = _get_brief_cache(ctx)
+        assert "Vlan1000" in cache_before["ip_by_vlan"]
+
+        # Same db, new vlan_ip_data object -> _source[0] mismatch -> rebuild.
+        new_ip_data = {("Vlan2000", "10.0.2.1/24"): {}}
+        _, _, old_ports = ctx[0]
+        ctx2 = (({}, new_ip_data, old_ports), db)
+
+        cache_after = _get_brief_cache(ctx2)
+        assert cache_after is not cache_before
+        assert "Vlan2000" in cache_after["ip_by_vlan"]
+        assert "Vlan1000" not in cache_after["ip_by_vlan"]
+        assert cache_after["_source"][0] is new_ip_data
+
+    def test_cache_rebuilds_when_vlan_ports_data_identity_changes(self):
+        """Identity guard: a matching vlan_ip_data but a *different*
+        vlan_ports_data object must still trigger a rebuild. Covers the
+        second (short-circuited) ``_source[1] is vlan_ports_data`` arm."""
+        from show.vlan import _get_brief_cache
+
+        shared_ip_data = {("Vlan1000", "10.0.0.1/24"): {}}
+        ctx, db = self._make_ctx_shared_db(
+            vlan_ip_data=shared_ip_data,
+            vlan_ports_data={("Vlan1000", "Ethernet4"): {"tagging_mode": "untagged"}},
+        )
+        cache_before = _get_brief_cache(ctx)
+        assert "Vlan1000" in cache_before["ports_by_vlan"]
+
+        # Same vlan_ip_data object, new vlan_ports_data object ->
+        # _source[0] matches but _source[1] mismatches -> rebuild.
+        new_ports_data = {("Vlan3000", "Ethernet8"): {"tagging_mode": "tagged"}}
+        ctx2 = (({}, shared_ip_data, new_ports_data), db)
+
+        cache_after = _get_brief_cache(ctx2)
+        assert cache_after is not cache_before
+        assert "Vlan3000" in cache_after["ports_by_vlan"]
+        assert "Vlan1000" not in cache_after["ports_by_vlan"]
+        assert cache_after["_source"][0] is shared_ip_data
+        assert cache_after["_source"][1] is new_ports_data
+
     # ------------------------------------------------------------------
     # Integration tests: brief() command
     # ------------------------------------------------------------------

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -1875,7 +1875,6 @@ class TestVlanBriefCache:
         """tagging_by_vlan must have the same order as ports_by_vlan so the
         two columns line up row-for-row in the table."""
         from show.vlan import _get_brief_cache
-        from natsort import natsorted
 
         members = {
             ("Vlan1000", "Ethernet12"): {"tagging_mode": "untagged"},

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -1764,3 +1764,292 @@ class TestVlan(object):
             assert result.exit_code != 0
 
         config.vlan.clicommon.run_command = origin_run_command_func
+
+
+class TestVlanBriefCache:
+    """Unit and integration tests for the per-invocation index cache
+    introduced in show/vlan.py (_get_brief_cache / _clear_brief_cache).
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_ctx(self, vlan_ip_data=None, vlan_ports_data=None):
+        """Return a (vlan_cfg, FakeDb) tuple usable by _get_brief_cache
+        without touching ConfigDb or the filesystem."""
+
+        class FakeDb:
+            pass
+
+        vlan_ip_data = vlan_ip_data or {}
+        vlan_ports_data = vlan_ports_data or {}
+        vlan_cfg = ({}, vlan_ip_data, vlan_ports_data)
+        return (vlan_cfg, FakeDb()), FakeDb.__new__(FakeDb)
+
+    def _make_ctx_shared_db(self, vlan_ip_data=None, vlan_ports_data=None):
+        """Like _make_ctx but returns (ctx, the_db_object) where the db
+        object IS the one embedded in ctx (so callers can inspect attrs)."""
+
+        class FakeDb:
+            pass
+
+        db = FakeDb()
+        vlan_ip_data = vlan_ip_data or {}
+        vlan_ports_data = vlan_ports_data or {}
+        vlan_cfg = ({}, vlan_ip_data, vlan_ports_data)
+        ctx = (vlan_cfg, db)
+        return ctx, db
+
+    # ------------------------------------------------------------------
+    # Unit tests: _get_brief_cache indexing
+    # ------------------------------------------------------------------
+
+    def test_cache_returns_same_object_on_repeated_calls(self):
+        """Within the same ctx the cache dict must be reused, not rebuilt."""
+        from show.vlan import _get_brief_cache
+
+        ctx, db = self._make_ctx_shared_db(
+            vlan_ip_data={
+                ("Vlan1000", "192.168.0.1/21"): {},
+                "Vlan2000": {"proxy_arp": "enabled"},
+            },
+            vlan_ports_data={
+                ("Vlan1000", "Ethernet4"): {"tagging_mode": "untagged"},
+            },
+        )
+
+        cache1 = _get_brief_cache(ctx)
+        cache2 = _get_brief_cache(ctx)
+        assert cache1 is cache2
+
+    def test_cache_ip_by_vlan_contains_only_prefix_keys(self):
+        """ip_by_vlan must include only (vlan, prefix) entries, not plain
+        vlan-name entries."""
+        from show.vlan import _get_brief_cache
+
+        ctx, _ = self._make_ctx_shared_db(
+            vlan_ip_data={
+                ("Vlan1000", "10.0.0.1/24"): {},
+                ("Vlan1000", "10.0.1.1/24"): {},
+                ("Vlan2000", "10.0.2.1/24"): {},
+                "Vlan1000": {"proxy_arp": "enabled"},   # plain key → proxy_arp
+            },
+        )
+
+        cache = _get_brief_cache(ctx)
+        assert set(cache["ip_by_vlan"].keys()) == {"Vlan1000", "Vlan2000"}
+        assert "10.0.0.1/24" in cache["ip_by_vlan"]["Vlan1000"]
+        assert "10.0.1.1/24" in cache["ip_by_vlan"]["Vlan1000"]
+        assert cache["ip_by_vlan"]["Vlan2000"] == ["10.0.2.1/24"]
+
+    def test_cache_proxy_arp_defaults_to_disabled(self):
+        """Vlan entries without a proxy_arp field must default to 'disabled'."""
+        from show.vlan import _get_brief_cache
+
+        ctx, _ = self._make_ctx_shared_db(
+            vlan_ip_data={
+                "Vlan1000": {"proxy_arp": "enabled"},
+                "Vlan2000": {},                          # no proxy_arp key
+            },
+        )
+
+        cache = _get_brief_cache(ctx)
+        assert cache["proxy_arp_by_vlan"]["Vlan1000"] == "enabled"
+        assert cache["proxy_arp_by_vlan"]["Vlan2000"] == "disabled"
+
+    def test_cache_ports_in_natsorted_order(self):
+        """ports_by_vlan must list ports in natsorted order."""
+        from show.vlan import _get_brief_cache
+        from natsort import natsorted
+
+        ports = ["Ethernet12", "Ethernet4", "Ethernet100", "Ethernet8"]
+        ctx, _ = self._make_ctx_shared_db(
+            vlan_ports_data={("Vlan1000", p): {"tagging_mode": "untagged"} for p in ports},
+        )
+
+        cache = _get_brief_cache(ctx)
+        assert cache["ports_by_vlan"]["Vlan1000"] == natsorted(ports)
+
+    def test_cache_tagging_aligned_with_ports(self):
+        """tagging_by_vlan must have the same order as ports_by_vlan so the
+        two columns line up row-for-row in the table."""
+        from show.vlan import _get_brief_cache
+        from natsort import natsorted
+
+        members = {
+            ("Vlan1000", "Ethernet12"): {"tagging_mode": "untagged"},
+            ("Vlan1000", "Ethernet4"): {"tagging_mode": "tagged"},
+            ("Vlan1000", "Ethernet8"): {"tagging_mode": "untagged"},
+        }
+        ctx, _ = self._make_ctx_shared_db(vlan_ports_data=members)
+
+        cache = _get_brief_cache(ctx)
+        ports = cache["ports_by_vlan"]["Vlan1000"]
+        tags = cache["tagging_by_vlan"]["Vlan1000"]
+        assert len(ports) == len(tags)
+        # Verify alignment: each port maps to the right tagging mode
+        for port, tag in zip(ports, tags):
+            expected = members[("Vlan1000", port)]["tagging_mode"]
+            assert tag == expected, f"Tagging mismatch for {port}: got {tag!r}, expected {expected!r}"
+
+    def test_cache_no_alias_converter_in_default_mode(self):
+        """In 'default' naming mode the alias converter must be None
+        (no PORT-table read needed)."""
+        from show.vlan import _get_brief_cache
+        import os
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = 'default'
+        try:
+            ctx, _ = self._make_ctx_shared_db()
+            cache = _get_brief_cache(ctx)
+            assert cache['iface_alias_converter'] is None
+            assert cache['naming_mode'] == 'default'
+        finally:
+            os.environ['SONIC_CLI_IFACE_MODE'] = 'default'
+
+    # ------------------------------------------------------------------
+    # Unit tests: _clear_brief_cache
+    # ------------------------------------------------------------------
+
+    def test_clear_removes_cache_attribute(self):
+        """_clear_brief_cache must delete the stashed attribute."""
+        from show.vlan import _get_brief_cache, _clear_brief_cache, _BRIEF_CACHE_ATTR
+
+        ctx, db = self._make_ctx_shared_db()
+        _get_brief_cache(ctx)
+
+        assert hasattr(db, _BRIEF_CACHE_ATTR)
+        _clear_brief_cache(db)
+        assert not hasattr(db, _BRIEF_CACHE_ATTR)
+
+    def test_clear_is_idempotent_when_no_cache(self):
+        """_clear_brief_cache must not raise when called on an object
+        that has no cache attribute."""
+        from show.vlan import _clear_brief_cache
+
+        class FakeDb:
+            pass
+
+        _clear_brief_cache(FakeDb())   # must not raise
+
+    def test_clear_allows_rebuild_with_fresh_data(self):
+        """After _clear_brief_cache the next _get_brief_cache call must
+        rebuild indexes from the current vlan_ip_data in ctx."""
+        from show.vlan import _get_brief_cache, _clear_brief_cache
+
+        ctx, db = self._make_ctx_shared_db(
+            vlan_ip_data={("Vlan1000", "10.0.0.1/24"): {}},
+        )
+
+        cache_before = _get_brief_cache(ctx)
+        assert "Vlan1000" in cache_before["ip_by_vlan"]
+
+        _clear_brief_cache(db)
+
+        # Replace vlan_ip_data in ctx with different data
+        new_ip_data = {("Vlan2000", "10.0.2.1/24"): {}}
+        new_cfg = ({}, new_ip_data, {})
+        ctx2 = (new_cfg, db)
+
+        cache_after = _get_brief_cache(ctx2)
+        assert "Vlan2000" in cache_after["ip_by_vlan"]
+        assert "Vlan1000" not in cache_after["ip_by_vlan"]
+        assert cache_before is not cache_after
+
+    # ------------------------------------------------------------------
+    # Integration tests: brief() command
+    # ------------------------------------------------------------------
+
+    def test_brief_calls_clear_cache_in_finally_on_exception(self):
+        """If a column getter raises, brief()'s finally block must still
+        invoke _clear_brief_cache so the cache is not left dangling."""
+        import show.vlan as vlan_show
+
+        runner = CliRunner()
+        db = Db()
+
+        original_cols = vlan_show.VlanBrief.COLUMNS[:]
+
+        def _failing_getter(ctx, vlan):
+            raise RuntimeError("simulated getter failure")
+
+        vlan_show.VlanBrief.COLUMNS = [
+            ("VLAN ID", vlan_show.get_vlan_id),
+            ("Bad", _failing_getter),
+        ]
+        try:
+            with mock.patch.object(
+                vlan_show, '_clear_brief_cache',
+                wraps=vlan_show._clear_brief_cache,
+            ) as mock_clear:
+                result = runner.invoke(
+                    show.cli.commands["vlan"].commands["brief"], [], obj=db
+                )
+            # The exception must propagate (exit_code != 0)
+            assert result.exit_code != 0
+            # _clear_brief_cache must have been called at least once (the
+            # finally-block call is guaranteed regardless of exceptions).
+            assert mock_clear.call_count >= 1
+        finally:
+            vlan_show.VlanBrief.COLUMNS = original_cols
+
+    def test_brief_second_invocation_reflects_added_vlan(self, mock_restart_dhcp_relay_service):
+        """Mutating the DB between two brief() calls on the same Db object
+        must be visible in the second call -- stale cache must not bleed
+        across invocations."""
+        from sonic_py_common import multi_asic as _sonic_multi_asic
+
+        runner = CliRunner()
+        db = Db()
+
+        # Patch DB connections so brief() uses db.cfgdb throughout.
+        with mock.patch.object(_sonic_multi_asic, 'connect_config_db_for_ns',
+                               return_value=db.cfgdb), \
+             mock.patch.object(_sonic_multi_asic, 'connect_to_all_dbs_for_ns',
+                               return_value=db.db):
+
+            # First call: baseline -- Vlan1001 must not exist yet.
+            # Use '|      1001 |' (the tabulate cell format) to avoid matching
+            # 'PortChannel1001' which also contains the substring '1001'.
+            result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [])
+            assert result.exit_code == 0
+            assert "|      1001 |" not in result.output
+
+            # Mutate: add a new VLAN
+            result = runner.invoke(
+                config.config.commands["vlan"].commands["add"], ["1001"], obj=db
+            )
+            assert result.exit_code == 0
+
+            # Second call: new VLAN must appear
+            result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [])
+            assert result.exit_code == 0
+            assert "|      1001 |" in result.output
+
+    def test_brief_second_invocation_reflects_removed_member(self):
+        """Removing a VLAN member between two brief() calls must be
+        visible in the second call -- no stale ports from the first call."""
+        from sonic_py_common import multi_asic as _sonic_multi_asic
+
+        runner = CliRunner()
+        db = Db()
+
+        # Patch DB connections so brief() uses db.cfgdb throughout.
+        with mock.patch.object(_sonic_multi_asic, 'connect_config_db_for_ns',
+                               return_value=db.cfgdb), \
+             mock.patch.object(_sonic_multi_asic, 'connect_to_all_dbs_for_ns',
+                               return_value=db.db):
+
+            # First call: Ethernet4 is a member of Vlan1000
+            result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [])
+            assert result.exit_code == 0
+            assert "Ethernet4" in result.output
+
+            # Mutate: remove Ethernet4 from Vlan1000 directly in the DB
+            db.cfgdb.set_entry("VLAN_MEMBER", ("Vlan1000", "Ethernet4"), None)
+
+            # Second call: output must differ from baseline (Ethernet4 removed)
+            result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [])
+            assert result.exit_code == 0
+            assert result.output != show_vlan_brief_output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Improve the performance of "show vlan brief" in large-scale testbed

#### How I did it
Performance issues in "show vlan brief":

1. get_vlan_ports constructs InterfaceAliasConverter(db) per VLAN — that loads the entire PORT table and calls load_db_config() each time. With 800 VLANs that's 800 PORT-table reads.
2. natsorted(list(vlan_ports_data.keys())) runs twice per VLAN (in get_vlan_ports and get_vlan_ports_tagging).
3. get_vlan_ip_address and get_proxy_arp linearly scan all VLAN_INTERFACE keys per VLAN .
4. get_interface_naming_mode() is queried per VLAN.

**Fix** :
added _get_brief_cache(ctx) that precomputes ip_by_vlan, proxy_arp_by_vlan, ports_by_vlan (natsorted), tagging_by_vlan, naming mode, and the alias converter exactly once per command.

The cache is stashed on the db object (the same pattern the dhcp-relay plugin uses) — safe because click.make_pass_decorator(Db, ensure=True) creates a fresh Db per CLI invocation. InterfaceAliasConverter is only built when SONIC_CLI_IFACE_MODE=alias.

#### How to verify it
Verify it on Large scale setup.
It reduces the response time from **35s to 5s.**

[show-vlan-brief-improvement-ut.log](https://github.com/user-attachments/files/29060453/show-vlan-brief-improvement-ut.log)


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

