### PR TITLE
Remove root privilege check in clear_pg_counters

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -289,9 +289,6 @@ def drop():
 @drop.command('counters')
 def clear_pg_counters():
     """Clear priority-group dropped packets counter """
-
-    if os.geteuid() != 0 and os.environ.get("UTILITIES_UNIT_TESTING", "0") != "2":
-        sys.exit("Root privileges are required for this operation")
     command = ['pg-drop', '-c', 'clear']
     run_command(command)
 


### PR DESCRIPTION
#### What I did
Fixes https://github.com/sonic-net/sonic-utilities/issues/4144

Remove the root-privilege check from `sonic-clear priority-group drop counters` (`clear_pg_counters`) so the `admin` (non-root) user can clear PG drop counters — matching `show priority-group drop counters`, which already runs unprivileged.

**Why this is correct and safe:**
- PG drop counters are cleared through a **per-user cache**: `pg-drop -c clear` writes the clear checkpoint under `UserCache().get_directory()` — a per-UID directory (`<uid>/pg_drop_stats`). No root and no shared/privileged write is involved.
- The root check was **actively harmful**: `admin` was rejected, and running the command via `sudo` cleared **root's** cache, so the admin's subsequent `show priority-group drop counters` (which reads the admin cache) never reflected the clear. That is exactly the bug in #4144.
- **No security impact:** because the cache is per-user, a user only ever clears their own view; root/monitoring keep a separate cache and are unaffected — this cannot be used to hide drops from monitoring.
- **Consistent with the correct peer:** `sonic-clear dropcounters` (the same per-user drop-counter clear pattern) already has no root check. The watermark clears (`clear_wm_*` / `clear_pwm_*`) keep their root check because they are a different mechanism, so they are intentionally left unchanged.

> Note: This replaces #4145, which became un-reopenable after its head branch was accidentally force-pushed. This PR carries the identical single-file change, now DCO signed-off.

#### How I did it
Removed the `os.geteuid() != 0` root-privilege check in `clear_pg_counters()` (`clear/main.py`). The underlying `pg-drop -c clear` already works for any user via the per-user cache.

#### How to verify it
As the `admin` (non-root) user:
```
show priority-group drop counters            # note current values
sonic-clear priority-group drop counters     # succeeds (previously failed for admin)
show priority-group drop counters            # values reflect the clear (admin's own cache)
```

#### Previous command output (if the output of a command-line utility has changed)
```
admin@dut:~$ sonic-clear priority-group drop counters
Root privileges are required for this operation
```

#### New command output (if the output of a command-line utility has changed)
`sonic-clear priority-group drop counters` now returns success for the `admin` user (no "Root privileges are required" error), and the subsequent `show priority-group drop counters` reflects the cleared baseline.
