### PR TITLE
[hft] Add aggregator CLI support

### DIFF
--- a/config/hft.py
+++ b/config/hft.py
@@ -14,10 +14,10 @@ GROUP_TYPE_CHOICES = ("PORT", "BUFFER_POOL", "INGRESS_PRIORITY_GROUP", "QUEUE")
 
 PROFILE_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_PROFILE"
 GROUP_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_GROUP"
-HARMONIZER_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_HARMONIZER"
+AGGREGATOR_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR"
 PROFILE_TABLE_PATH = f"/{PROFILE_TABLE_NAME}"
 GROUP_TABLE_PATH = f"/{GROUP_TABLE_NAME}"
-HARMONIZER_TABLE_PATH = f"/{HARMONIZER_TABLE_NAME}"
+AGGREGATOR_TABLE_PATH = f"/{AGGREGATOR_TABLE_NAME}"
 STREAM_STATE_FIELD = "stream_state"
 
 
@@ -44,22 +44,22 @@ def hft_disable(ctx, profile_name):
     _process_payload(ctx, payload)
 
 
-@hft.command('bind-harmonizer', short_help="Bind a harmonizer to an HFT profile")
+@hft.command('bind-aggregator', short_help="Bind an aggregator to an HFT profile")
 @click.argument('profile_name')
-@click.argument('harmonizer_name')
+@click.argument('aggregator_name')
 @click.pass_context
-def hft_bind_harmonizer(ctx, profile_name, harmonizer_name):
-    """Bind an existing harmonizer to an HFT profile."""
-    payload = _build_profile_field_patch(profile_name, "harmonizer", harmonizer_name)
+def hft_bind_aggregator(ctx, profile_name, aggregator_name):
+    """Bind an existing aggregator to an HFT profile."""
+    payload = _build_profile_field_patch(profile_name, "aggregator", aggregator_name)
     _process_payload(ctx, payload)
 
 
-@hft.command('unbind-harmonizer', short_help="Unbind the harmonizer from an HFT profile")
+@hft.command('unbind-aggregator', short_help="Unbind the aggregator from an HFT profile")
 @click.argument('profile_name')
 @click.pass_context
-def hft_unbind_harmonizer(ctx, profile_name):
-    """Remove the harmonizer binding from an HFT profile."""
-    payload = _build_profile_field_remove_patch(profile_name, "harmonizer")
+def hft_unbind_aggregator(ctx, profile_name):
+    """Remove the aggregator binding from an HFT profile."""
+    payload = _build_profile_field_remove_patch(profile_name, "aggregator")
     _process_payload(ctx, payload)
 
 
@@ -76,10 +76,10 @@ def hft_add():
 @click.option('--poll_interval', 'poll_interval', default=DEFAULT_POLL_INTERVAL_USEC,
               type=click.IntRange(min=0), show_default=True,
               help='Polling interval in microseconds.')
-@click.option('--harmonizer', 'harmonizer', default=None,
-              help='Optional harmonizer name to apply to this profile.')
+@click.option('--aggregator', 'aggregator', default=None,
+              help='Optional aggregator name to apply to this profile.')
 @click.pass_context
-def hft_add_profile(ctx, profile_name, stream_state, poll_interval, harmonizer):
+def hft_add_profile(ctx, profile_name, stream_state, poll_interval, aggregator):
     """Create a profile entry for HFT."""
     if _has_existing_profile(ctx):
         click.echo(
@@ -92,8 +92,8 @@ def hft_add_profile(ctx, profile_name, stream_state, poll_interval, harmonizer):
         "stream_state": stream_state,
         "poll_interval": str(poll_interval),
     }
-    if harmonizer:
-        attributes["harmonizer"] = harmonizer
+    if aggregator:
+        attributes["aggregator"] = aggregator
 
     profile_payload = _build_profile_patch(
         op="add",
@@ -126,17 +126,17 @@ def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
     _process_payload(ctx, group_payload)
 
 
-@hft_add.command('harmonizer', short_help="Add an HFT harmonizer")
-@click.argument('harmonizer_name')
+@hft_add.command('aggregator', short_help="Add an HFT aggregator")
+@click.argument('aggregator_name')
 @click.option('--reporting_rate', 'reporting_rate', default=None,
-              type=click.IntRange(min=0), help='Reporting interval after harmonization in microseconds.')
+              type=click.IntRange(min=0), help='Reporting interval after aggregation in microseconds.')
 @click.option('--rollover_counters', 'rollover_counters', default=None,
               help='Comma-separated list of GROUP|COUNTER entries requiring rollover correction.')
 @click.option('--heatmap_counters', 'heatmap_counters', default=None,
               help='Comma-separated list of GROUP|COUNTER entries treated as heatmap data.')
 @click.pass_context
-def hft_add_harmonizer(ctx, harmonizer_name, reporting_rate, rollover_counters, heatmap_counters):
-    """Create a harmonizer definition for HFT."""
+def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters, heatmap_counters):
+    """Create an aggregator definition for HFT."""
     attributes = {}
     if reporting_rate is not None:
         attributes["reporting_rate"] = str(reporting_rate)
@@ -145,12 +145,12 @@ def hft_add_harmonizer(ctx, harmonizer_name, reporting_rate, rollover_counters, 
     if heatmap_counters is not None:
         attributes["heatmap_counters"] = _split_csv_items(heatmap_counters)
 
-    harmonizer_payload = _build_harmonizer_patch(
+    aggregator_payload = _build_aggregator_patch(
         op="add",
-        harmonizer_name=harmonizer_name,
+        aggregator_name=aggregator_name,
         attributes=attributes
     )
-    _process_payload(ctx, harmonizer_payload)
+    _process_payload(ctx, aggregator_payload)
 
 
 @hft.group('del', short_help="Remove HFT resources")
@@ -179,28 +179,28 @@ def hft_delete_group(ctx, profile_name, group_type):
     _process_payload(ctx, group_payload)
 
 
-@hft_delete.command('harmonizer', short_help="Delete an HFT harmonizer")
-@click.argument('harmonizer_name')
+@hft_delete.command('aggregator', short_help="Delete an HFT aggregator")
+@click.argument('aggregator_name')
 @click.pass_context
-def hft_delete_harmonizer(ctx, harmonizer_name):
-    """Remove an existing HFT harmonizer."""
-    profile_users = _get_harmonizer_users(ctx, harmonizer_name)
+def hft_delete_aggregator(ctx, aggregator_name):
+    """Remove an existing HFT aggregator."""
+    profile_users = _get_aggregator_users(ctx, aggregator_name)
     if profile_users:
         click.echo(
-            "Cannot delete harmonizer '{}'; it is still referenced by HFT profile(s): {}".format(
-                harmonizer_name,
+            "Cannot delete aggregator '{}'; it is still referenced by HFT profile(s): {}".format(
+                aggregator_name,
                 ', '.join(profile_users)
             )
         )
         ctx.exit(1)
 
-    if not _has_table_entry(ctx, HARMONIZER_TABLE_NAME, harmonizer_name):
-        click.echo("Harmonizer '{}' does not exist.".format(harmonizer_name))
+    if not _has_table_entry(ctx, AGGREGATOR_TABLE_NAME, aggregator_name):
+        click.echo("Aggregator '{}' does not exist.".format(aggregator_name))
         ctx.exit(1)
 
-    remove_entire_table = _is_last_entry(ctx, HARMONIZER_TABLE_NAME)
-    harmonizer_payload = _build_harmonizer_remove_patch(harmonizer_name, remove_entire_table)
-    _process_payload(ctx, harmonizer_payload)
+    remove_entire_table = _is_last_entry(ctx, AGGREGATOR_TABLE_NAME)
+    aggregator_payload = _build_aggregator_remove_patch(aggregator_name, remove_entire_table)
+    _process_payload(ctx, aggregator_payload)
 
 
 def _process_payload(ctx, payload):
@@ -266,11 +266,11 @@ def _build_group_patch(op, profile_name, group_type, attributes):
     ]
 
 
-def _build_harmonizer_patch(op, harmonizer_name, attributes):
-    """Construct a JSON Patch entry targeting the harmonizer table."""
+def _build_aggregator_patch(op, aggregator_name, attributes):
+    """Construct a JSON Patch entry targeting the aggregator table."""
     return [
-        _build_patch_entry(op, HARMONIZER_TABLE_PATH, {
-            harmonizer_name: attributes
+        _build_patch_entry(op, AGGREGATOR_TABLE_PATH, {
+            aggregator_name: attributes
         })
     ]
 
@@ -322,11 +322,11 @@ def _build_group_remove_patch(profile_name, group_type, remove_entire_table):
     ]
 
 
-def _build_harmonizer_remove_patch(harmonizer_name, remove_entire_table):
-    """Create a remove operation for a harmonizer or the entire table if requested."""
+def _build_aggregator_remove_patch(aggregator_name, remove_entire_table):
+    """Create a remove operation for an aggregator or the entire table if requested."""
     if remove_entire_table:
-        return [_build_remove_entry(HARMONIZER_TABLE_PATH)]
-    return [_build_remove_entry(_join_pointer(HARMONIZER_TABLE_PATH, harmonizer_name))]
+        return [_build_remove_entry(AGGREGATOR_TABLE_PATH)]
+    return [_build_remove_entry(_join_pointer(AGGREGATOR_TABLE_PATH, aggregator_name))]
 
 
 def _build_patch_entry(op, path, value):
@@ -407,8 +407,8 @@ def _has_table_entry(ctx, table_name, entry_name):
     return entry_name in entries
 
 
-def _get_harmonizer_users(ctx, harmonizer_name):
-    """Return profile names that reference the given harmonizer."""
+def _get_aggregator_users(ctx, aggregator_name):
+    """Return profile names that reference the given aggregator."""
     cfgdb = _get_cfgdb(ctx)
     if cfgdb is None:
         return []
@@ -419,6 +419,6 @@ def _get_harmonizer_users(ctx, harmonizer_name):
 
     users = []
     for profile_name, attributes in profiles.items():
-        if isinstance(attributes, dict) and attributes.get('harmonizer') == harmonizer_name:
+        if isinstance(attributes, dict) and attributes.get('aggregator') == aggregator_name:
             users.append(profile_name)
     return sorted(users)

--- a/config/hft.py
+++ b/config/hft.py
@@ -14,8 +14,10 @@ GROUP_TYPE_CHOICES = ("PORT", "BUFFER_POOL", "INGRESS_PRIORITY_GROUP", "QUEUE")
 
 PROFILE_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_PROFILE"
 GROUP_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_GROUP"
+HARMONIZER_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_HARMONIZER"
 PROFILE_TABLE_PATH = f"/{PROFILE_TABLE_NAME}"
 GROUP_TABLE_PATH = f"/{GROUP_TABLE_NAME}"
+HARMONIZER_TABLE_PATH = f"/{HARMONIZER_TABLE_NAME}"
 STREAM_STATE_FIELD = "stream_state"
 
 
@@ -42,6 +44,25 @@ def hft_disable(ctx, profile_name):
     _process_payload(ctx, payload)
 
 
+@hft.command('bind-harmonizer', short_help="Bind a harmonizer to an HFT profile")
+@click.argument('profile_name')
+@click.argument('harmonizer_name')
+@click.pass_context
+def hft_bind_harmonizer(ctx, profile_name, harmonizer_name):
+    """Bind an existing harmonizer to an HFT profile."""
+    payload = _build_profile_field_patch(profile_name, "harmonizer", harmonizer_name)
+    _process_payload(ctx, payload)
+
+
+@hft.command('unbind-harmonizer', short_help="Unbind the harmonizer from an HFT profile")
+@click.argument('profile_name')
+@click.pass_context
+def hft_unbind_harmonizer(ctx, profile_name):
+    """Remove the harmonizer binding from an HFT profile."""
+    payload = _build_profile_field_remove_patch(profile_name, "harmonizer")
+    _process_payload(ctx, payload)
+
+
 @hft.group('add', short_help="Add HFT resources")
 def hft_add():
     """Group of add operations for HFT."""
@@ -55,8 +76,10 @@ def hft_add():
 @click.option('--poll_interval', 'poll_interval', default=DEFAULT_POLL_INTERVAL_USEC,
               type=click.IntRange(min=0), show_default=True,
               help='Polling interval in microseconds.')
+@click.option('--harmonizer', 'harmonizer', default=None,
+              help='Optional harmonizer name to apply to this profile.')
 @click.pass_context
-def hft_add_profile(ctx, profile_name, stream_state, poll_interval):
+def hft_add_profile(ctx, profile_name, stream_state, poll_interval, harmonizer):
     """Create a profile entry for HFT."""
     if _has_existing_profile(ctx):
         click.echo(
@@ -65,13 +88,17 @@ def hft_add_profile(ctx, profile_name, stream_state, poll_interval):
         )
         ctx.exit(1)
 
+    attributes = {
+        "stream_state": stream_state,
+        "poll_interval": str(poll_interval),
+    }
+    if harmonizer:
+        attributes["harmonizer"] = harmonizer
+
     profile_payload = _build_profile_patch(
         op="add",
         profile_name=profile_name,
-        attributes={
-            "stream_state": stream_state,
-            "poll_interval": str(poll_interval),
-        }
+        attributes=attributes
     )
     _process_payload(ctx, profile_payload)
 
@@ -99,6 +126,33 @@ def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
     _process_payload(ctx, group_payload)
 
 
+@hft_add.command('harmonizer', short_help="Add an HFT harmonizer")
+@click.argument('harmonizer_name')
+@click.option('--reporting_rate', 'reporting_rate', default=None,
+              type=click.IntRange(min=0), help='Reporting interval after harmonization in microseconds.')
+@click.option('--rollover_counters', 'rollover_counters', default=None,
+              help='Comma-separated list of GROUP|COUNTER entries requiring rollover correction.')
+@click.option('--heatmap_counters', 'heatmap_counters', default=None,
+              help='Comma-separated list of GROUP|COUNTER entries treated as heatmap data.')
+@click.pass_context
+def hft_add_harmonizer(ctx, harmonizer_name, reporting_rate, rollover_counters, heatmap_counters):
+    """Create a harmonizer definition for HFT."""
+    attributes = {}
+    if reporting_rate is not None:
+        attributes["reporting_rate"] = str(reporting_rate)
+    if rollover_counters is not None:
+        attributes["rollover_counters"] = _split_csv_items(rollover_counters)
+    if heatmap_counters is not None:
+        attributes["heatmap_counters"] = _split_csv_items(heatmap_counters)
+
+    harmonizer_payload = _build_harmonizer_patch(
+        op="add",
+        harmonizer_name=harmonizer_name,
+        attributes=attributes
+    )
+    _process_payload(ctx, harmonizer_payload)
+
+
 @hft.group('del', short_help="Remove HFT resources")
 def hft_delete():
     """Group of delete operations for HFT."""
@@ -123,6 +177,26 @@ def hft_delete_group(ctx, profile_name, group_type):
     remove_entire_table = _is_last_entry(ctx, GROUP_TABLE_NAME)
     group_payload = _build_group_remove_patch(profile_name, group_type, remove_entire_table)
     _process_payload(ctx, group_payload)
+
+
+@hft_delete.command('harmonizer', short_help="Delete an HFT harmonizer")
+@click.argument('harmonizer_name')
+@click.pass_context
+def hft_delete_harmonizer(ctx, harmonizer_name):
+    """Remove an existing HFT harmonizer."""
+    profile_users = _get_harmonizer_users(ctx, harmonizer_name)
+    if profile_users:
+        click.echo(
+            "Cannot delete harmonizer '{}'; it is still referenced by HFT profile(s): {}".format(
+                harmonizer_name,
+                ', '.join(profile_users)
+            )
+        )
+        ctx.exit(1)
+
+    remove_entire_table = _is_last_entry(ctx, HARMONIZER_TABLE_NAME)
+    harmonizer_payload = _build_harmonizer_remove_patch(harmonizer_name, remove_entire_table)
+    _process_payload(ctx, harmonizer_payload)
 
 
 def _process_payload(ctx, payload):
@@ -188,19 +262,42 @@ def _build_group_patch(op, profile_name, group_type, attributes):
     ]
 
 
+def _build_harmonizer_patch(op, harmonizer_name, attributes):
+    """Construct a JSON Patch entry targeting the harmonizer table."""
+    return [
+        _build_patch_entry(op, HARMONIZER_TABLE_PATH, {
+            harmonizer_name: attributes
+        })
+    ]
+
+
 def _build_stream_state_patch(profile_name, state):
     """Construct a JSON Patch entry to update a profile stream state."""
+    return _build_profile_field_patch(profile_name, STREAM_STATE_FIELD, state)
+
+
+def _build_profile_field_patch(profile_name, field_name, value):
+    """Construct a JSON Patch entry to update a profile field."""
     path = _join_pointer(
         _join_pointer(PROFILE_TABLE_PATH, profile_name),
-        STREAM_STATE_FIELD
+        field_name
     )
     return [
         {
             "op": "add",
             "path": path,
-            "value": state,
+            "value": value,
         }
     ]
+
+
+def _build_profile_field_remove_patch(profile_name, field_name):
+    """Construct a JSON Patch entry to remove a profile field."""
+    path = _join_pointer(
+        _join_pointer(PROFILE_TABLE_PATH, profile_name),
+        field_name
+    )
+    return [_build_remove_entry(path)]
 
 
 def _build_profile_remove_patch(profile_name, remove_entire_table):
@@ -219,6 +316,13 @@ def _build_group_remove_patch(profile_name, group_type, remove_entire_table):
             _join_pointer(GROUP_TABLE_PATH, _compose_group_key(profile_name, group_type))
         )
     ]
+
+
+def _build_harmonizer_remove_patch(harmonizer_name, remove_entire_table):
+    """Create a remove operation for a harmonizer or the entire table if requested."""
+    if remove_entire_table:
+        return [_build_remove_entry(HARMONIZER_TABLE_PATH)]
+    return [_build_remove_entry(_join_pointer(HARMONIZER_TABLE_PATH, harmonizer_name))]
 
 
 def _build_patch_entry(op, path, value):
@@ -285,3 +389,20 @@ def _has_existing_profile(ctx):
     except Exception:
         return False
     return bool(entries)
+
+
+def _get_harmonizer_users(ctx, harmonizer_name):
+    """Return profile names that reference the given harmonizer."""
+    cfgdb = _get_cfgdb(ctx)
+    if cfgdb is None:
+        return []
+    try:
+        profiles = cfgdb.get_table(PROFILE_TABLE_NAME) or {}
+    except Exception:
+        return []
+
+    users = []
+    for profile_name, attributes in profiles.items():
+        if isinstance(attributes, dict) and attributes.get('harmonizer') == harmonizer_name:
+            users.append(profile_name)
+    return sorted(users)

--- a/config/hft.py
+++ b/config/hft.py
@@ -194,6 +194,10 @@ def hft_delete_harmonizer(ctx, harmonizer_name):
         )
         ctx.exit(1)
 
+    if not _has_table_entry(ctx, HARMONIZER_TABLE_NAME, harmonizer_name):
+        click.echo("Harmonizer '{}' does not exist.".format(harmonizer_name))
+        ctx.exit(1)
+
     remove_entire_table = _is_last_entry(ctx, HARMONIZER_TABLE_NAME)
     harmonizer_payload = _build_harmonizer_remove_patch(harmonizer_name, remove_entire_table)
     _process_payload(ctx, harmonizer_payload)
@@ -389,6 +393,18 @@ def _has_existing_profile(ctx):
     except Exception:
         return False
     return bool(entries)
+
+
+def _has_table_entry(ctx, table_name, entry_name):
+    """Return True if the CFG table contains the requested entry."""
+    cfgdb = _get_cfgdb(ctx)
+    if cfgdb is None:
+        return False
+    try:
+        entries = cfgdb.get_table(table_name) or {}
+    except Exception:
+        return False
+    return entry_name in entries
 
 
 def _get_harmonizer_users(ctx, harmonizer_name):

--- a/config/hft.py
+++ b/config/hft.py
@@ -118,6 +118,7 @@ def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
         op="add",
         profile_name=profile_name,
         group_type=group_type,
+        table_exists=_has_table(ctx, GROUP_TABLE_NAME),
         attributes={
             "object_names": _split_csv_items(object_names),
             "object_counters": _split_csv_items(object_counters),
@@ -129,25 +130,56 @@ def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
 @hft_add.command('aggregator', short_help="Add an HFT aggregator")
 @click.argument('aggregator_name')
 @click.option('--reporting_rate', 'reporting_rate', default=None,
-              type=click.IntRange(min=0), help='Reporting interval after aggregation in microseconds.')
+              type=click.IntRange(min=1, max=2**32 - 1),
+              help='Reporting interval after aggregation in microseconds.')
 @click.option('--rollover_counters', 'rollover_counters', default=None,
               help='Comma-separated list of GROUP|COUNTER entries requiring rollover correction.')
+@click.option('--heatmap_interval', 'heatmap_interval', default=None,
+              type=click.IntRange(min=1, max=2**32 - 1),
+              help='Independent heatmap interval in microseconds.')
 @click.option('--heatmap_counters', 'heatmap_counters', default=None,
               help='Comma-separated list of GROUP|COUNTER entries treated as heatmap data.')
+@click.option('--heatmap_bucket_boundaries', 'heatmap_bucket_boundaries', default=None,
+              help='Comma-separated inclusive upper bounds shared by all heatmap counters.')
 @click.pass_context
-def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters, heatmap_counters):
+def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
+                       heatmap_interval, heatmap_counters, heatmap_bucket_boundaries):
     """Create an aggregator definition for HFT."""
+    heatmap_counters = (
+        None if heatmap_counters is None else _split_csv_items(heatmap_counters)
+    )
+    heatmap_bucket_boundaries = _parse_heatmap_bucket_boundaries(
+        heatmap_bucket_boundaries
+    )
+    heatmap_fields = (
+        heatmap_interval is not None,
+        bool(heatmap_counters),
+        bool(heatmap_bucket_boundaries),
+    )
+    if any(heatmap_fields) and not all(heatmap_fields):
+        raise click.UsageError(
+            '--heatmap_interval, --heatmap_counters, and --heatmap_bucket_boundaries '
+            'must be configured together.'
+        )
+
     attributes = {}
     if reporting_rate is not None:
         attributes["reporting_rate"] = str(reporting_rate)
     if rollover_counters is not None:
         attributes["rollover_counters"] = _split_csv_items(rollover_counters)
+    if heatmap_interval is not None:
+        attributes["heatmap_interval"] = str(heatmap_interval)
     if heatmap_counters is not None:
-        attributes["heatmap_counters"] = _split_csv_items(heatmap_counters)
+        attributes["heatmap_counters"] = heatmap_counters
+    if heatmap_bucket_boundaries is not None:
+        attributes["heatmap_bucket_boundaries"] = [
+            str(boundary) for boundary in heatmap_bucket_boundaries
+        ]
 
     aggregator_payload = _build_aggregator_patch(
         op="add",
         aggregator_name=aggregator_name,
+        table_exists=_has_table(ctx, AGGREGATOR_TABLE_NAME),
         attributes=attributes
     )
     _process_payload(ctx, aggregator_payload)
@@ -248,6 +280,32 @@ def _split_csv_items(value):
     return [item.strip() for item in value.split(',') if item.strip()]
 
 
+def _parse_heatmap_bucket_boundaries(value):
+    """Parse strictly increasing uint64 heatmap bucket upper bounds."""
+    if value is None:
+        return None
+
+    try:
+        boundaries = [int(item) for item in _split_csv_items(value)]
+    except ValueError as error:
+        raise click.BadParameter(
+            'must be a comma-separated list of uint64 values',
+            param_hint='--heatmap_bucket_boundaries'
+        ) from error
+
+    if any(boundary < 0 or boundary > 2**53 for boundary in boundaries):
+        raise click.BadParameter(
+            'values must be between 0 and 2^53 for exact OTLP encoding',
+            param_hint='--heatmap_bucket_boundaries'
+        )
+    if any(left >= right for left, right in zip(boundaries, boundaries[1:])):
+        raise click.BadParameter(
+            'values must be strictly increasing',
+            param_hint='--heatmap_bucket_boundaries'
+        )
+    return boundaries
+
+
 def _build_profile_patch(op, profile_name, attributes):
     """Construct a JSON Patch entry targeting the profile table."""
     return [
@@ -257,17 +315,30 @@ def _build_profile_patch(op, profile_name, attributes):
     ]
 
 
-def _build_group_patch(op, profile_name, group_type, attributes):
+def _build_group_patch(op, profile_name, group_type, attributes, table_exists=False):
     """Construct a JSON Patch entry targeting the group table."""
+    group_key = _compose_group_key(profile_name, group_type)
+    if table_exists:
+        return [
+            _build_patch_entry(op, _join_pointer(GROUP_TABLE_PATH, group_key), attributes)
+        ]
     return [
         _build_patch_entry(op, GROUP_TABLE_PATH, {
-            _compose_group_key(profile_name, group_type): attributes
+            group_key: attributes
         })
     ]
 
 
-def _build_aggregator_patch(op, aggregator_name, attributes):
+def _build_aggregator_patch(op, aggregator_name, attributes, table_exists=False):
     """Construct a JSON Patch entry targeting the aggregator table."""
+    if table_exists:
+        return [
+            _build_patch_entry(
+                op,
+                _join_pointer(AGGREGATOR_TABLE_PATH, aggregator_name),
+                attributes
+            )
+        ]
     return [
         _build_patch_entry(op, AGGREGATOR_TABLE_PATH, {
             aggregator_name: attributes
@@ -393,6 +464,17 @@ def _has_existing_profile(ctx):
     except Exception:
         return False
     return bool(entries)
+
+
+def _has_table(ctx, table_name):
+    """Return True when the CFG table contains at least one entry."""
+    cfgdb = _get_cfgdb(ctx)
+    if cfgdb is None:
+        return False
+    try:
+        return bool(cfgdb.get_table(table_name))
+    except Exception:
+        return False
 
 
 def _has_table_entry(ctx, table_name, entry_name):

--- a/config/hft.py
+++ b/config/hft.py
@@ -10,14 +10,17 @@ TEMP_FILE_SUFFIX = ".json"
 DEFAULT_STREAM_STATE = "disabled"
 STREAM_STATE_CHOICES = ("enabled", "disabled")
 DEFAULT_POLL_INTERVAL_USEC = 10000  # microseconds
+DEFAULT_HEATMAP_BUCKET_COUNT = 256
 GROUP_TYPE_CHOICES = ("PORT", "BUFFER_POOL", "INGRESS_PRIORITY_GROUP", "QUEUE")
 
 PROFILE_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_PROFILE"
 GROUP_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_GROUP"
 AGGREGATOR_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR"
+AGGREGATOR_HISTOGRAM_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM"
 PROFILE_TABLE_PATH = f"/{PROFILE_TABLE_NAME}"
 GROUP_TABLE_PATH = f"/{GROUP_TABLE_NAME}"
 AGGREGATOR_TABLE_PATH = f"/{AGGREGATOR_TABLE_NAME}"
+AGGREGATOR_HISTOGRAM_TABLE_PATH = f"/{AGGREGATOR_HISTOGRAM_TABLE_NAME}"
 STREAM_STATE_FIELD = "stream_state"
 
 
@@ -50,6 +53,7 @@ def hft_disable(ctx, profile_name):
 @click.pass_context
 def hft_bind_aggregator(ctx, profile_name, aggregator_name):
     """Bind an existing aggregator to an HFT profile."""
+    _validate_aggregator_name(aggregator_name)
     payload = _build_profile_field_patch(profile_name, "aggregator", aggregator_name)
     _process_payload(ctx, payload)
 
@@ -81,6 +85,8 @@ def hft_add():
 @click.pass_context
 def hft_add_profile(ctx, profile_name, stream_state, poll_interval, aggregator):
     """Create a profile entry for HFT."""
+    if aggregator is not None:
+        _validate_aggregator_name(aggregator, '--aggregator')
     if _has_existing_profile(ctx):
         click.echo(
             "A profile already exists; this version supports only one profile. "
@@ -139,27 +145,30 @@ def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
               help='Independent heatmap interval in microseconds.')
 @click.option('--heatmap_counters', 'heatmap_counters', default=None,
               help='Comma-separated list of GROUP|COUNTER entries treated as heatmap data.')
-@click.option('--heatmap_bucket_boundaries', 'heatmap_bucket_boundaries', default=None,
-              help='Comma-separated inclusive upper bounds shared by all heatmap counters.')
+@click.option('--heatmap_default_bucket_count', 'heatmap_default_bucket_count', default=None,
+              type=click.IntRange(min=4, max=512),
+              help='Default bucket count for heatmap counters (defaults to 256 when enabled).')
 @click.pass_context
 def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
-                       heatmap_interval, heatmap_counters, heatmap_bucket_boundaries):
+                       heatmap_interval, heatmap_counters, heatmap_default_bucket_count):
     """Create an aggregator definition for HFT."""
+    _validate_aggregator_name(aggregator_name)
     heatmap_counters = (
         None if heatmap_counters is None else _split_csv_items(heatmap_counters)
     )
-    heatmap_bucket_boundaries = _parse_heatmap_bucket_boundaries(
-        heatmap_bucket_boundaries
-    )
-    heatmap_fields = (
-        heatmap_interval is not None,
-        bool(heatmap_counters),
-        bool(heatmap_bucket_boundaries),
-    )
-    if any(heatmap_fields) and not all(heatmap_fields):
+    if heatmap_counters is not None and not heatmap_counters:
+        raise click.BadParameter(
+            'must contain at least one GROUP|COUNTER entry',
+            param_hint='--heatmap_counters'
+        )
+    if (heatmap_interval is None) != (heatmap_counters is None):
         raise click.UsageError(
-            '--heatmap_interval, --heatmap_counters, and --heatmap_bucket_boundaries '
-            'must be configured together.'
+            '--heatmap_interval and nonempty --heatmap_counters must be configured together.'
+        )
+    if heatmap_default_bucket_count is not None and heatmap_interval is None:
+        raise click.UsageError(
+            '--heatmap_default_bucket_count requires --heatmap_interval and '
+            'nonempty --heatmap_counters.'
         )
 
     attributes = {}
@@ -169,12 +178,10 @@ def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
         attributes["rollover_counters"] = _split_csv_items(rollover_counters)
     if heatmap_interval is not None:
         attributes["heatmap_interval"] = str(heatmap_interval)
-    if heatmap_counters is not None:
         attributes["heatmap_counters"] = heatmap_counters
-    if heatmap_bucket_boundaries is not None:
-        attributes["heatmap_bucket_boundaries"] = [
-            str(boundary) for boundary in heatmap_bucket_boundaries
-        ]
+        attributes["heatmap_default_bucket_count"] = str(
+            heatmap_default_bucket_count or DEFAULT_HEATMAP_BUCKET_COUNT
+        )
 
     aggregator_payload = _build_aggregator_patch(
         op="add",
@@ -183,6 +190,29 @@ def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
         attributes=attributes
     )
     _process_payload(ctx, aggregator_payload)
+
+
+@hft_add.command('histogram', short_help="Add per-counter HFT histogram bounds")
+@click.argument('aggregator_name')
+@click.option('--counter', 'counter', required=True,
+              help='Heatmap counter selector in GROUP|COUNTER form.')
+@click.option('--explicit_bounds', 'explicit_bounds', required=True,
+              help='Comma-separated explicit histogram bounds.')
+@click.pass_context
+def hft_add_histogram(ctx, aggregator_name, counter, explicit_bounds):
+    """Create explicit histogram bounds for one aggregator counter."""
+    _validate_aggregator_name(aggregator_name)
+    group_type, counter_name = _parse_counter_selector(counter, '--counter')
+    bounds = _parse_explicit_bounds(explicit_bounds)
+    histogram_payload = _build_histogram_patch(
+        op="add",
+        aggregator_name=aggregator_name,
+        group_type=group_type,
+        counter_name=counter_name,
+        table_exists=_has_table(ctx, AGGREGATOR_HISTOGRAM_TABLE_NAME),
+        attributes={"explicit_bounds": [str(boundary) for boundary in bounds]}
+    )
+    _process_payload(ctx, histogram_payload)
 
 
 @hft.group('del', short_help="Remove HFT resources")
@@ -216,6 +246,7 @@ def hft_delete_group(ctx, profile_name, group_type):
 @click.pass_context
 def hft_delete_aggregator(ctx, aggregator_name):
     """Remove an existing HFT aggregator."""
+    _validate_aggregator_name(aggregator_name)
     profile_users = _get_aggregator_users(ctx, aggregator_name)
     if profile_users:
         click.echo(
@@ -231,8 +262,42 @@ def hft_delete_aggregator(ctx, aggregator_name):
         ctx.exit(1)
 
     remove_entire_table = _is_last_entry(ctx, AGGREGATOR_TABLE_NAME)
-    aggregator_payload = _build_aggregator_remove_patch(aggregator_name, remove_entire_table)
+    aggregator_payload = _build_histogram_children_remove_patch(ctx, aggregator_name)
+    aggregator_payload.extend(
+        _build_aggregator_remove_patch(aggregator_name, remove_entire_table)
+    )
     _process_payload(ctx, aggregator_payload)
+
+
+@hft_delete.command('histogram', short_help="Delete per-counter HFT histogram bounds")
+@click.argument('aggregator_name')
+@click.argument('counter')
+@click.pass_context
+def hft_delete_histogram(ctx, aggregator_name, counter):
+    """Remove explicit histogram bounds for one aggregator counter."""
+    _validate_aggregator_name(aggregator_name)
+    group_type, counter_name = _parse_counter_selector(counter, 'counter')
+    histogram_key = _compose_histogram_key(
+        aggregator_name,
+        group_type,
+        counter_name
+    )
+    histogram_keys = _get_normalized_table_keys(
+        ctx,
+        AGGREGATOR_HISTOGRAM_TABLE_NAME
+    )
+    if histogram_key not in histogram_keys:
+        click.echo("Histogram '{}' does not exist.".format(histogram_key))
+        ctx.exit(1)
+
+    remove_entire_table = len(histogram_keys) == 1
+    histogram_payload = _build_histogram_remove_patch(
+        aggregator_name,
+        group_type,
+        counter_name,
+        remove_entire_table
+    )
+    _process_payload(ctx, histogram_payload)
 
 
 def _process_payload(ctx, payload):
@@ -280,30 +345,75 @@ def _split_csv_items(value):
     return [item.strip() for item in value.split(',') if item.strip()]
 
 
-def _parse_heatmap_bucket_boundaries(value):
-    """Parse strictly increasing uint64 heatmap bucket upper bounds."""
-    if value is None:
-        return None
+def _validate_aggregator_name(aggregator_name, param_hint='aggregator_name'):
+    """Reject names that cannot be represented in a histogram composite key."""
+    if aggregator_name != aggregator_name.strip():
+        raise click.BadParameter(
+            'must not have leading or trailing whitespace',
+            param_hint=param_hint
+        )
+    if '|' in aggregator_name:
+        raise click.BadParameter(
+            "must not contain '|'",
+            param_hint=param_hint
+        )
+
+
+def _parse_counter_selector(value, param_hint):
+    """Parse a GROUP|COUNTER selector without validating the SAI counter name."""
+    parts = value.split('|') if value is not None else []
+    if len(parts) != 2:
+        raise click.BadParameter(
+            'must use GROUP|COUNTER format',
+            param_hint=param_hint
+        )
+
+    group_type, counter_name = (part.strip() for part in parts)
+    if group_type not in GROUP_TYPE_CHOICES:
+        raise click.BadParameter(
+            'GROUP must be one of {}'.format(', '.join(GROUP_TYPE_CHOICES)),
+            param_hint=param_hint
+        )
+    if not counter_name:
+        raise click.BadParameter(
+            'COUNTER must be nonempty',
+            param_hint=param_hint
+        )
+    return group_type, counter_name
+
+
+def _parse_explicit_bounds(value):
+    """Parse 1..511 strictly increasing decimal bounds in the exact OTLP range."""
+    items = [item.strip() for item in value.split(',')]
+    if not 1 <= len(items) <= 511:
+        raise click.BadParameter(
+            'must contain between 1 and 511 values',
+            param_hint='--explicit_bounds'
+        )
+    if any(not item or not item.isascii() or not item.isdigit() for item in items):
+        raise click.BadParameter(
+            'must be a comma-separated list of uint64 decimal values',
+            param_hint='--explicit_bounds'
+        )
 
     try:
-        boundaries = [int(item) for item in _split_csv_items(value)]
+        bounds = [int(item, 10) for item in items]
     except ValueError as error:
         raise click.BadParameter(
-            'must be a comma-separated list of uint64 values',
-            param_hint='--heatmap_bucket_boundaries'
+            'must be a comma-separated list of uint64 decimal values',
+            param_hint='--explicit_bounds'
         ) from error
-
-    if any(boundary < 0 or boundary > 2**53 for boundary in boundaries):
+    if any(boundary > 2**53 for boundary in bounds):
         raise click.BadParameter(
             'values must be between 0 and 2^53 for exact OTLP encoding',
-            param_hint='--heatmap_bucket_boundaries'
+            param_hint='--explicit_bounds'
         )
-    if any(left >= right for left, right in zip(boundaries, boundaries[1:])):
+    if any(left >= right for left, right in zip(bounds, bounds[1:])):
         raise click.BadParameter(
             'values must be strictly increasing',
-            param_hint='--heatmap_bucket_boundaries'
+            param_hint='--explicit_bounds'
         )
-    return boundaries
+    return bounds
 
 
 def _build_profile_patch(op, profile_name, attributes):
@@ -342,6 +452,25 @@ def _build_aggregator_patch(op, aggregator_name, attributes, table_exists=False)
     return [
         _build_patch_entry(op, AGGREGATOR_TABLE_PATH, {
             aggregator_name: attributes
+        })
+    ]
+
+
+def _build_histogram_patch(op, aggregator_name, group_type, counter_name,
+                           attributes, table_exists=False):
+    """Construct a JSON Patch entry targeting the aggregator histogram table."""
+    histogram_key = _compose_histogram_key(aggregator_name, group_type, counter_name)
+    if table_exists:
+        return [
+            _build_patch_entry(
+                op,
+                _join_pointer(AGGREGATOR_HISTOGRAM_TABLE_PATH, histogram_key),
+                attributes
+            )
+        ]
+    return [
+        _build_patch_entry(op, AGGREGATOR_HISTOGRAM_TABLE_PATH, {
+            histogram_key: attributes
         })
     ]
 
@@ -400,6 +529,39 @@ def _build_aggregator_remove_patch(aggregator_name, remove_entire_table):
     return [_build_remove_entry(_join_pointer(AGGREGATOR_TABLE_PATH, aggregator_name))]
 
 
+def _build_histogram_remove_patch(aggregator_name, group_type, counter_name,
+                                  remove_entire_table):
+    """Create a remove operation for a histogram entry or its entire table."""
+    if remove_entire_table:
+        return [_build_remove_entry(AGGREGATOR_HISTOGRAM_TABLE_PATH)]
+    histogram_key = _compose_histogram_key(aggregator_name, group_type, counter_name)
+    return [
+        _build_remove_entry(
+            _join_pointer(AGGREGATOR_HISTOGRAM_TABLE_PATH, histogram_key)
+        )
+    ]
+
+
+def _build_histogram_children_remove_patch(ctx, aggregator_name):
+    """Remove all histogram rows owned by an aggregator."""
+    prefix = f"{aggregator_name}|"
+    all_histogram_keys = _get_normalized_table_keys(
+        ctx,
+        AGGREGATOR_HISTOGRAM_TABLE_NAME
+    )
+    histogram_keys = sorted(
+        key for key in all_histogram_keys if key.startswith(prefix)
+    )
+    if not histogram_keys:
+        return []
+    if len(histogram_keys) == len(all_histogram_keys):
+        return [_build_remove_entry(AGGREGATOR_HISTOGRAM_TABLE_PATH)]
+    return [
+        _build_remove_entry(_join_pointer(AGGREGATOR_HISTOGRAM_TABLE_PATH, key))
+        for key in histogram_keys
+    ]
+
+
 def _build_patch_entry(op, path, value):
     """Wrap a JSON Patch add/replace entry."""
     return {
@@ -420,6 +582,18 @@ def _build_remove_entry(path):
 def _compose_group_key(profile_name, group_type):
     """Compose the key used by the HFT group table."""
     return f"{profile_name}|{group_type}"
+
+
+def _compose_histogram_key(aggregator_name, group_type, counter_name):
+    """Compose the key used by the aggregator histogram table."""
+    return f"{aggregator_name}|{group_type}|{counter_name}"
+
+
+def _stringify_composite_key(key):
+    """Normalize Config DB tuple and string composite keys."""
+    if isinstance(key, (tuple, list)):
+        return '|'.join(str(component) for component in key)
+    return str(key)
 
 
 def _join_pointer(base_path, key):
@@ -475,6 +649,18 @@ def _has_table(ctx, table_name):
         return bool(cfgdb.get_table(table_name))
     except Exception:
         return False
+
+
+def _get_normalized_table_keys(ctx, table_name):
+    """Return Config DB table keys normalized to pipe-delimited strings."""
+    cfgdb = _get_cfgdb(ctx)
+    if cfgdb is None:
+        return []
+    try:
+        entries = cfgdb.get_table(table_name) or {}
+    except Exception:
+        return []
+    return [_stringify_composite_key(key) for key in entries]
 
 
 def _has_table_entry(ctx, table_name, entry_name):

--- a/config/hft.py
+++ b/config/hft.py
@@ -17,10 +17,12 @@ PROFILE_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_PROFILE"
 GROUP_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_GROUP"
 AGGREGATOR_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR"
 AGGREGATOR_HISTOGRAM_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM"
+AGGREGATOR_ROLLOVER_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER"
 PROFILE_TABLE_PATH = f"/{PROFILE_TABLE_NAME}"
 GROUP_TABLE_PATH = f"/{GROUP_TABLE_NAME}"
 AGGREGATOR_TABLE_PATH = f"/{AGGREGATOR_TABLE_NAME}"
 AGGREGATOR_HISTOGRAM_TABLE_PATH = f"/{AGGREGATOR_HISTOGRAM_TABLE_NAME}"
+AGGREGATOR_ROLLOVER_TABLE_PATH = f"/{AGGREGATOR_ROLLOVER_TABLE_NAME}"
 STREAM_STATE_FIELD = "stream_state"
 
 
@@ -215,6 +217,29 @@ def hft_add_histogram(ctx, aggregator_name, counter, explicit_bounds):
     _process_payload(ctx, histogram_payload)
 
 
+@hft_add.command('rollover', short_help="Add an HFT rollover counter bit width")
+@click.argument('aggregator_name')
+@click.option('--counter', 'counter', required=True,
+              help='Rollover counter selector in GROUP|COUNTER form.')
+@click.option('--bit_width', 'bit_width', required=True,
+              type=click.IntRange(min=1, max=63),
+              help='Counter bit width used for rollover correction.')
+@click.pass_context
+def hft_add_rollover(ctx, aggregator_name, counter, bit_width):
+    """Create a bit-width override for one aggregator rollover counter."""
+    _validate_aggregator_name(aggregator_name)
+    group_type, counter_name = _parse_counter_selector(counter, '--counter')
+    rollover_payload = _build_rollover_patch(
+        op="add",
+        aggregator_name=aggregator_name,
+        group_type=group_type,
+        counter_name=counter_name,
+        table_exists=_has_table(ctx, AGGREGATOR_ROLLOVER_TABLE_NAME),
+        attributes={"bit_width": str(bit_width)}
+    )
+    _process_payload(ctx, rollover_payload)
+
+
 @hft.group('del', short_help="Remove HFT resources")
 def hft_delete():
     """Group of delete operations for HFT."""
@@ -262,7 +287,19 @@ def hft_delete_aggregator(ctx, aggregator_name):
         ctx.exit(1)
 
     remove_entire_table = _is_last_entry(ctx, AGGREGATOR_TABLE_NAME)
-    aggregator_payload = _build_histogram_children_remove_patch(ctx, aggregator_name)
+    aggregator_payload = []
+    for table_name, table_path in (
+        (AGGREGATOR_HISTOGRAM_TABLE_NAME, AGGREGATOR_HISTOGRAM_TABLE_PATH),
+        (AGGREGATOR_ROLLOVER_TABLE_NAME, AGGREGATOR_ROLLOVER_TABLE_PATH),
+    ):
+        aggregator_payload.extend(
+            _build_counter_children_remove_patch(
+                ctx,
+                aggregator_name,
+                table_name,
+                table_path
+            )
+        )
     aggregator_payload.extend(
         _build_aggregator_remove_patch(aggregator_name, remove_entire_table)
     )
@@ -298,6 +335,37 @@ def hft_delete_histogram(ctx, aggregator_name, counter):
         remove_entire_table
     )
     _process_payload(ctx, histogram_payload)
+
+
+@hft_delete.command('rollover', short_help="Delete an HFT rollover counter bit width")
+@click.argument('aggregator_name')
+@click.argument('counter')
+@click.pass_context
+def hft_delete_rollover(ctx, aggregator_name, counter):
+    """Remove a bit-width override for one aggregator rollover counter."""
+    _validate_aggregator_name(aggregator_name)
+    group_type, counter_name = _parse_counter_selector(counter, 'counter')
+    rollover_key = _compose_rollover_key(
+        aggregator_name,
+        group_type,
+        counter_name
+    )
+    rollover_keys = _get_normalized_table_keys(
+        ctx,
+        AGGREGATOR_ROLLOVER_TABLE_NAME
+    )
+    if rollover_key not in rollover_keys:
+        click.echo("Rollover '{}' does not exist.".format(rollover_key))
+        ctx.exit(1)
+
+    remove_entire_table = len(rollover_keys) == 1
+    rollover_payload = _build_rollover_remove_patch(
+        aggregator_name,
+        group_type,
+        counter_name,
+        remove_entire_table
+    )
+    _process_payload(ctx, rollover_payload)
 
 
 def _process_payload(ctx, payload):
@@ -346,12 +414,14 @@ def _split_csv_items(value):
 
 
 def _validate_aggregator_name(aggregator_name, param_hint='aggregator_name'):
-    """Reject names that cannot be represented in a histogram composite key."""
+    """Reject names that cannot be represented in a child composite key."""
     if aggregator_name != aggregator_name.strip():
         raise click.BadParameter(
             'must not have leading or trailing whitespace',
             param_hint=param_hint
         )
+    if not aggregator_name:
+        raise click.BadParameter('must be nonempty', param_hint=param_hint)
     if '|' in aggregator_name:
         raise click.BadParameter(
             "must not contain '|'",
@@ -475,6 +545,25 @@ def _build_histogram_patch(op, aggregator_name, group_type, counter_name,
     ]
 
 
+def _build_rollover_patch(op, aggregator_name, group_type, counter_name,
+                          attributes, table_exists=False):
+    """Construct a JSON Patch entry targeting the aggregator rollover table."""
+    rollover_key = _compose_rollover_key(aggregator_name, group_type, counter_name)
+    if table_exists:
+        return [
+            _build_patch_entry(
+                op,
+                _join_pointer(AGGREGATOR_ROLLOVER_TABLE_PATH, rollover_key),
+                attributes
+            )
+        ]
+    return [
+        _build_patch_entry(op, AGGREGATOR_ROLLOVER_TABLE_PATH, {
+            rollover_key: attributes
+        })
+    ]
+
+
 def _build_stream_state_patch(profile_name, state):
     """Construct a JSON Patch entry to update a profile stream state."""
     return _build_profile_field_patch(profile_name, STREAM_STATE_FIELD, state)
@@ -542,23 +631,33 @@ def _build_histogram_remove_patch(aggregator_name, group_type, counter_name,
     ]
 
 
-def _build_histogram_children_remove_patch(ctx, aggregator_name):
-    """Remove all histogram rows owned by an aggregator."""
-    prefix = f"{aggregator_name}|"
-    all_histogram_keys = _get_normalized_table_keys(
-        ctx,
-        AGGREGATOR_HISTOGRAM_TABLE_NAME
-    )
-    histogram_keys = sorted(
-        key for key in all_histogram_keys if key.startswith(prefix)
-    )
-    if not histogram_keys:
-        return []
-    if len(histogram_keys) == len(all_histogram_keys):
-        return [_build_remove_entry(AGGREGATOR_HISTOGRAM_TABLE_PATH)]
+def _build_rollover_remove_patch(aggregator_name, group_type, counter_name,
+                                 remove_entire_table):
+    """Create a remove operation for a rollover entry or its entire table."""
+    if remove_entire_table:
+        return [_build_remove_entry(AGGREGATOR_ROLLOVER_TABLE_PATH)]
+    rollover_key = _compose_rollover_key(aggregator_name, group_type, counter_name)
     return [
-        _build_remove_entry(_join_pointer(AGGREGATOR_HISTOGRAM_TABLE_PATH, key))
-        for key in histogram_keys
+        _build_remove_entry(
+            _join_pointer(AGGREGATOR_ROLLOVER_TABLE_PATH, rollover_key)
+        )
+    ]
+
+
+def _build_counter_children_remove_patch(ctx, aggregator_name, table_name, table_path):
+    """Remove all rows in one counter child table owned by an aggregator."""
+    prefix = f"{aggregator_name}|"
+    all_child_keys = _get_normalized_table_keys(ctx, table_name)
+    child_keys = sorted(
+        key for key in all_child_keys if key.startswith(prefix)
+    )
+    if not child_keys:
+        return []
+    if len(child_keys) == len(all_child_keys):
+        return [_build_remove_entry(table_path)]
+    return [
+        _build_remove_entry(_join_pointer(table_path, key))
+        for key in child_keys
     ]
 
 
@@ -586,6 +685,11 @@ def _compose_group_key(profile_name, group_type):
 
 def _compose_histogram_key(aggregator_name, group_type, counter_name):
     """Compose the key used by the aggregator histogram table."""
+    return f"{aggregator_name}|{group_type}|{counter_name}"
+
+
+def _compose_rollover_key(aggregator_name, group_type, counter_name):
+    """Compose the key used by the aggregator rollover table."""
     return f"{aggregator_name}|{group_type}|{counter_name}"
 
 

--- a/config/hft.py
+++ b/config/hft.py
@@ -155,6 +155,11 @@ def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
                        heatmap_interval, heatmap_counters, heatmap_default_bucket_count):
     """Create an aggregator definition for HFT."""
     _validate_aggregator_name(aggregator_name)
+    aggregator_entries = _get_table_or_fail(ctx, AGGREGATOR_TABLE_NAME)
+    if aggregator_name in {_stringify_composite_key(key) for key in aggregator_entries}:
+        raise click.ClickException(
+            "Aggregator '{}' already exists.".format(aggregator_name)
+        )
     heatmap_counters = (
         None if heatmap_counters is None else _split_csv_items(heatmap_counters)
     )
@@ -188,7 +193,7 @@ def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
     aggregator_payload = _build_aggregator_patch(
         op="add",
         aggregator_name=aggregator_name,
-        table_exists=_has_table(ctx, AGGREGATOR_TABLE_NAME),
+        table_exists=bool(aggregator_entries),
         attributes=attributes
     )
     _process_payload(ctx, aggregator_payload)
@@ -730,6 +735,19 @@ def _get_cfgdb(ctx):
     if db is None:
         return None
     return getattr(db, 'cfgdb', None)
+
+
+def _get_table_or_fail(ctx, table_name):
+    """Read a Config DB table or fail before constructing a mutation."""
+    cfgdb = _get_cfgdb(ctx)
+    if cfgdb is None:
+        return {}
+    try:
+        return cfgdb.get_table(table_name) or {}
+    except Exception as error:
+        raise click.ClickException(
+            "Failed to read Config DB table '{}': {}".format(table_name, error)
+        ) from error
 
 
 def _has_existing_profile(ctx):

--- a/config/hft.py
+++ b/config/hft.py
@@ -10,7 +10,6 @@ TEMP_FILE_SUFFIX = ".json"
 DEFAULT_STREAM_STATE = "disabled"
 STREAM_STATE_CHOICES = ("enabled", "disabled")
 DEFAULT_POLL_INTERVAL_USEC = 10000  # microseconds
-DEFAULT_HEATMAP_BUCKET_COUNT = 256
 GROUP_TYPE_CHOICES = ("PORT", "BUFFER_POOL", "INGRESS_PRIORITY_GROUP", "QUEUE")
 
 PROFILE_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_PROFILE"
@@ -80,7 +79,7 @@ def hft_add():
               type=click.Choice(STREAM_STATE_CHOICES), show_default=True,
               help='Desired stream state for this profile.')
 @click.option('--poll_interval', 'poll_interval', default=DEFAULT_POLL_INTERVAL_USEC,
-              type=click.IntRange(min=0), show_default=True,
+              type=click.IntRange(min=1, max=2**32 - 1), show_default=True,
               help='Polling interval in microseconds.')
 @click.option('--aggregator', 'aggregator', default=None,
               help='Optional aggregator name to apply to this profile.')
@@ -89,7 +88,7 @@ def hft_add_profile(ctx, profile_name, stream_state, poll_interval, aggregator):
     """Create a profile entry for HFT."""
     if aggregator is not None:
         _validate_aggregator_name(aggregator, '--aggregator')
-    if _has_existing_profile(ctx):
+    if _get_table_or_fail(ctx, PROFILE_TABLE_NAME):
         click.echo(
             "A profile already exists; this version supports only one profile. "
             "Delete the existing profile before adding another."
@@ -122,11 +121,12 @@ def hft_add_profile(ctx, profile_name, stream_state, poll_interval, aggregator):
 @click.pass_context
 def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
     """Create a group definition under an HFT profile."""
+    group_entries = _get_table_or_fail(ctx, GROUP_TABLE_NAME)
     group_payload = _build_group_patch(
         op="add",
         profile_name=profile_name,
         group_type=group_type,
-        table_exists=_has_table(ctx, GROUP_TABLE_NAME),
+        table_exists=bool(group_entries),
         attributes={
             "object_names": _split_csv_items(object_names),
             "object_counters": _split_csv_items(object_counters),
@@ -147,12 +147,9 @@ def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
               help='Independent heatmap interval in microseconds.')
 @click.option('--heatmap_counters', 'heatmap_counters', default=None,
               help='Comma-separated list of GROUP|COUNTER entries treated as heatmap data.')
-@click.option('--heatmap_default_bucket_count', 'heatmap_default_bucket_count', default=None,
-              type=click.IntRange(min=4, max=512),
-              help='Default bucket count for heatmap counters (defaults to 256 when enabled).')
 @click.pass_context
 def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
-                       heatmap_interval, heatmap_counters, heatmap_default_bucket_count):
+                       heatmap_interval, heatmap_counters):
     """Create an aggregator definition for HFT."""
     _validate_aggregator_name(aggregator_name)
     aggregator_entries = _get_table_or_fail(ctx, AGGREGATOR_TABLE_NAME)
@@ -172,11 +169,6 @@ def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
         raise click.UsageError(
             '--heatmap_interval and nonempty --heatmap_counters must be configured together.'
         )
-    if heatmap_default_bucket_count is not None and heatmap_interval is None:
-        raise click.UsageError(
-            '--heatmap_default_bucket_count requires --heatmap_interval and '
-            'nonempty --heatmap_counters.'
-        )
 
     attributes = {}
     if reporting_rate is not None:
@@ -186,9 +178,6 @@ def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
     if heatmap_interval is not None:
         attributes["heatmap_interval"] = str(heatmap_interval)
         attributes["heatmap_counters"] = heatmap_counters
-        attributes["heatmap_default_bucket_count"] = str(
-            heatmap_default_bucket_count or DEFAULT_HEATMAP_BUCKET_COUNT
-        )
 
     aggregator_payload = _build_aggregator_patch(
         op="add",
@@ -204,19 +193,21 @@ def hft_add_aggregator(ctx, aggregator_name, reporting_rate, rollover_counters,
 @click.option('--counter', 'counter', required=True,
               help='Heatmap counter selector in GROUP|COUNTER form.')
 @click.option('--explicit_bounds', 'explicit_bounds', required=True,
-              help='Comma-separated explicit histogram bounds.')
+              help='Comma-separated histogram upper bounds in raw counter units: '
+                   '1..511 strictly increasing values, each in 0..2^53 inclusive.')
 @click.pass_context
 def hft_add_histogram(ctx, aggregator_name, counter, explicit_bounds):
     """Create explicit histogram bounds for one aggregator counter."""
     _validate_aggregator_name(aggregator_name)
     group_type, counter_name = _parse_counter_selector(counter, '--counter')
     bounds = _parse_explicit_bounds(explicit_bounds)
+    histogram_entries = _get_table_or_fail(ctx, AGGREGATOR_HISTOGRAM_TABLE_NAME)
     histogram_payload = _build_histogram_patch(
         op="add",
         aggregator_name=aggregator_name,
         group_type=group_type,
         counter_name=counter_name,
-        table_exists=_has_table(ctx, AGGREGATOR_HISTOGRAM_TABLE_NAME),
+        table_exists=bool(histogram_entries),
         attributes={"explicit_bounds": [str(boundary) for boundary in bounds]}
     )
     _process_payload(ctx, histogram_payload)
@@ -234,12 +225,13 @@ def hft_add_rollover(ctx, aggregator_name, counter, bit_width):
     """Create a bit-width override for one aggregator rollover counter."""
     _validate_aggregator_name(aggregator_name)
     group_type, counter_name = _parse_counter_selector(counter, '--counter')
+    rollover_entries = _get_table_or_fail(ctx, AGGREGATOR_ROLLOVER_TABLE_NAME)
     rollover_payload = _build_rollover_patch(
         op="add",
         aggregator_name=aggregator_name,
         group_type=group_type,
         counter_name=counter_name,
-        table_exists=_has_table(ctx, AGGREGATOR_ROLLOVER_TABLE_NAME),
+        table_exists=bool(rollover_entries),
         attributes={"bit_width": str(bit_width)}
     )
     _process_payload(ctx, rollover_payload)
@@ -748,29 +740,6 @@ def _get_table_or_fail(ctx, table_name):
         raise click.ClickException(
             "Failed to read Config DB table '{}': {}".format(table_name, error)
         ) from error
-
-
-def _has_existing_profile(ctx):
-    """Return True when at least one HFT profile already exists."""
-    cfgdb = _get_cfgdb(ctx)
-    if cfgdb is None:
-        return False
-    try:
-        entries = cfgdb.get_table(PROFILE_TABLE_NAME) or {}
-    except Exception:
-        return False
-    return bool(entries)
-
-
-def _has_table(ctx, table_name):
-    """Return True when the CFG table contains at least one entry."""
-    cfgdb = _get_cfgdb(ctx)
-    if cfgdb is None:
-        return False
-    try:
-        return bool(cfgdb.get_table(table_name))
-    except Exception:
-        return False
 
 
 def _get_normalized_table_keys(ctx, table_name):

--- a/show/hft.py
+++ b/show/hft.py
@@ -11,13 +11,13 @@ import utilities_common.cli as clicommon
 
 PROFILE_TABLE = 'HIGH_FREQUENCY_TELEMETRY_PROFILE'
 GROUP_TABLE = 'HIGH_FREQUENCY_TELEMETRY_GROUP'
-HARMONIZER_TABLE = 'HIGH_FREQUENCY_TELEMETRY_HARMONIZER'
+AGGREGATOR_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
 DEFAULT_CELL_PLACEHOLDER = '-'
 TABLE_HEADER = [
     'Profile',
     'Stream State',
     'Poll Interval (usec)',
-    'Harmonizer',
+    'Aggregator',
     'Group Type',
     'Object Names',
     'Object Counters',
@@ -71,9 +71,9 @@ def hft_counters(stats_interval, max_stats_per_report, log_level, log_format):
 def _display_hft(db):
     profile_table = db.cfgdb.get_table(PROFILE_TABLE) or {}
     group_table = db.cfgdb.get_table(GROUP_TABLE) or {}
-    harmonizer_table = db.cfgdb.get_table(HARMONIZER_TABLE) or {}
+    aggregator_table = db.cfgdb.get_table(AGGREGATOR_TABLE) or {}
 
-    rows = _build_rows(profile_table, group_table, harmonizer_table)
+    rows = _build_rows(profile_table, group_table, aggregator_table)
     if not rows:
         click.echo("No high frequency telemetry configuration present.")
         return
@@ -81,10 +81,10 @@ def _display_hft(db):
     click.echo(tabulate(rows, TABLE_HEADER, tablefmt='grid'))
 
 
-def _build_rows(profile_table, group_table, harmonizer_table=None):
+def _build_rows(profile_table, group_table, aggregator_table=None):
     group_index = _index_groups(group_table)
-    harmonizer_table = harmonizer_table or {}
-    used_harmonizers = set()
+    aggregator_table = aggregator_table or {}
+    used_aggregators = set()
     rows = []
 
     for profile_name in natsorted(profile_table.keys()):
@@ -92,11 +92,11 @@ def _build_rows(profile_table, group_table, harmonizer_table=None):
         stream_state = profile_entry.get('stream_state', DEFAULT_CELL_PLACEHOLDER)
         poll_interval_raw = profile_entry.get('poll_interval', DEFAULT_CELL_PLACEHOLDER)
         poll_interval = _format_poll_interval(poll_interval_raw)
-        harmonizer_name = profile_entry.get('harmonizer', DEFAULT_CELL_PLACEHOLDER)
-        if harmonizer_name != DEFAULT_CELL_PLACEHOLDER:
-            used_harmonizers.add(harmonizer_name)
-        harmonizer = harmonizer_table.get(harmonizer_name, {}) if harmonizer_name != DEFAULT_CELL_PLACEHOLDER else {}
-        reporting_rate, rollover_counters, heatmap_counters = _format_harmonizer(harmonizer)
+        aggregator_name = profile_entry.get('aggregator', DEFAULT_CELL_PLACEHOLDER)
+        if aggregator_name != DEFAULT_CELL_PLACEHOLDER:
+            used_aggregators.add(aggregator_name)
+        aggregator = aggregator_table.get(aggregator_name, {}) if aggregator_name != DEFAULT_CELL_PLACEHOLDER else {}
+        reporting_rate, rollover_counters, heatmap_counters = _format_aggregator(aggregator)
         groups = group_index.get(profile_name)
 
         if not groups:
@@ -104,7 +104,7 @@ def _build_rows(profile_table, group_table, harmonizer_table=None):
                 profile_name,
                 stream_state,
                 poll_interval,
-                harmonizer_name,
+                aggregator_name,
                 DEFAULT_CELL_PLACEHOLDER,
                 DEFAULT_CELL_PLACEHOLDER,
                 DEFAULT_CELL_PLACEHOLDER,
@@ -119,7 +119,7 @@ def _build_rows(profile_table, group_table, harmonizer_table=None):
                 profile_name if idx == 0 else '',
                 stream_state if idx == 0 else '',
                 poll_interval if idx == 0 else '',
-                harmonizer_name if idx == 0 else '',
+                aggregator_name if idx == 0 else '',
                 group['type'],
                 group['names'],
                 group['counters'],
@@ -128,15 +128,15 @@ def _build_rows(profile_table, group_table, harmonizer_table=None):
                 heatmap_counters if idx == 0 else ''
             ])
 
-    for harmonizer_name in natsorted(set(harmonizer_table.keys()) - used_harmonizers):
-        reporting_rate, rollover_counters, heatmap_counters = _format_harmonizer(
-            harmonizer_table.get(harmonizer_name, {})
+    for aggregator_name in natsorted(set(aggregator_table.keys()) - used_aggregators):
+        reporting_rate, rollover_counters, heatmap_counters = _format_aggregator(
+            aggregator_table.get(aggregator_name, {})
         )
         rows.append([
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,
-            harmonizer_name,
+            aggregator_name,
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,
@@ -148,10 +148,10 @@ def _build_rows(profile_table, group_table, harmonizer_table=None):
     return rows
 
 
-def _format_harmonizer(harmonizer):
-    reporting_rate = _format_poll_interval(harmonizer.get('reporting_rate', DEFAULT_CELL_PLACEHOLDER))
-    rollover_counters = _format_list(harmonizer.get('rollover_counters')) or DEFAULT_CELL_PLACEHOLDER
-    heatmap_counters = _format_list(harmonizer.get('heatmap_counters')) or DEFAULT_CELL_PLACEHOLDER
+def _format_aggregator(aggregator):
+    reporting_rate = _format_poll_interval(aggregator.get('reporting_rate', DEFAULT_CELL_PLACEHOLDER))
+    rollover_counters = _format_list(aggregator.get('rollover_counters')) or DEFAULT_CELL_PLACEHOLDER
+    heatmap_counters = _format_list(aggregator.get('heatmap_counters')) or DEFAULT_CELL_PLACEHOLDER
     return reporting_rate, rollover_counters, heatmap_counters
 
 

--- a/show/hft.py
+++ b/show/hft.py
@@ -11,14 +11,19 @@ import utilities_common.cli as clicommon
 
 PROFILE_TABLE = 'HIGH_FREQUENCY_TELEMETRY_PROFILE'
 GROUP_TABLE = 'HIGH_FREQUENCY_TELEMETRY_GROUP'
+HARMONIZER_TABLE = 'HIGH_FREQUENCY_TELEMETRY_HARMONIZER'
 DEFAULT_CELL_PLACEHOLDER = '-'
 TABLE_HEADER = [
     'Profile',
     'Stream State',
     'Poll Interval (usec)',
+    'Harmonizer',
     'Group Type',
     'Object Names',
-    'Object Counters'
+    'Object Counters',
+    'Reporting Rate (usec)',
+    'Rollover Counters',
+    'Heatmap Counters'
 ]
 
 
@@ -66,8 +71,9 @@ def hft_counters(stats_interval, max_stats_per_report, log_level, log_format):
 def _display_hft(db):
     profile_table = db.cfgdb.get_table(PROFILE_TABLE) or {}
     group_table = db.cfgdb.get_table(GROUP_TABLE) or {}
+    harmonizer_table = db.cfgdb.get_table(HARMONIZER_TABLE) or {}
 
-    rows = _build_rows(profile_table, group_table)
+    rows = _build_rows(profile_table, group_table, harmonizer_table)
     if not rows:
         click.echo("No high frequency telemetry configuration present.")
         return
@@ -75,8 +81,10 @@ def _display_hft(db):
     click.echo(tabulate(rows, TABLE_HEADER, tablefmt='grid'))
 
 
-def _build_rows(profile_table, group_table):
+def _build_rows(profile_table, group_table, harmonizer_table=None):
     group_index = _index_groups(group_table)
+    harmonizer_table = harmonizer_table or {}
+    used_harmonizers = set()
     rows = []
 
     for profile_name in natsorted(profile_table.keys()):
@@ -84,6 +92,11 @@ def _build_rows(profile_table, group_table):
         stream_state = profile_entry.get('stream_state', DEFAULT_CELL_PLACEHOLDER)
         poll_interval_raw = profile_entry.get('poll_interval', DEFAULT_CELL_PLACEHOLDER)
         poll_interval = _format_poll_interval(poll_interval_raw)
+        harmonizer_name = profile_entry.get('harmonizer', DEFAULT_CELL_PLACEHOLDER)
+        if harmonizer_name != DEFAULT_CELL_PLACEHOLDER:
+            used_harmonizers.add(harmonizer_name)
+        harmonizer = harmonizer_table.get(harmonizer_name, {}) if harmonizer_name != DEFAULT_CELL_PLACEHOLDER else {}
+        reporting_rate, rollover_counters, heatmap_counters = _format_harmonizer(harmonizer)
         groups = group_index.get(profile_name)
 
         if not groups:
@@ -91,9 +104,13 @@ def _build_rows(profile_table, group_table):
                 profile_name,
                 stream_state,
                 poll_interval,
+                harmonizer_name,
                 DEFAULT_CELL_PLACEHOLDER,
                 DEFAULT_CELL_PLACEHOLDER,
-                DEFAULT_CELL_PLACEHOLDER
+                DEFAULT_CELL_PLACEHOLDER,
+                reporting_rate,
+                rollover_counters,
+                heatmap_counters
             ])
             continue
 
@@ -102,12 +119,38 @@ def _build_rows(profile_table, group_table):
                 profile_name if idx == 0 else '',
                 stream_state if idx == 0 else '',
                 poll_interval if idx == 0 else '',
+                harmonizer_name if idx == 0 else '',
                 group['type'],
                 group['names'],
-                group['counters']
+                group['counters'],
+                reporting_rate if idx == 0 else '',
+                rollover_counters if idx == 0 else '',
+                heatmap_counters if idx == 0 else ''
             ])
 
+    for harmonizer_name in natsorted(set(harmonizer_table.keys()) - used_harmonizers):
+        reporting_rate, rollover_counters, heatmap_counters = _format_harmonizer(harmonizer_table.get(harmonizer_name, {}))
+        rows.append([
+            DEFAULT_CELL_PLACEHOLDER,
+            DEFAULT_CELL_PLACEHOLDER,
+            DEFAULT_CELL_PLACEHOLDER,
+            harmonizer_name,
+            DEFAULT_CELL_PLACEHOLDER,
+            DEFAULT_CELL_PLACEHOLDER,
+            DEFAULT_CELL_PLACEHOLDER,
+            reporting_rate,
+            rollover_counters,
+            heatmap_counters
+        ])
+
     return rows
+
+
+def _format_harmonizer(harmonizer):
+    reporting_rate = _format_poll_interval(harmonizer.get('reporting_rate', DEFAULT_CELL_PLACEHOLDER))
+    rollover_counters = _format_list(harmonizer.get('rollover_counters')) or DEFAULT_CELL_PLACEHOLDER
+    heatmap_counters = _format_list(harmonizer.get('heatmap_counters')) or DEFAULT_CELL_PLACEHOLDER
+    return reporting_rate, rollover_counters, heatmap_counters
 
 
 def _index_groups(group_table):

--- a/show/hft.py
+++ b/show/hft.py
@@ -129,7 +129,9 @@ def _build_rows(profile_table, group_table, harmonizer_table=None):
             ])
 
     for harmonizer_name in natsorted(set(harmonizer_table.keys()) - used_harmonizers):
-        reporting_rate, rollover_counters, heatmap_counters = _format_harmonizer(harmonizer_table.get(harmonizer_name, {}))
+        reporting_rate, rollover_counters, heatmap_counters = _format_harmonizer(
+            harmonizer_table.get(harmonizer_name, {})
+        )
         rows.append([
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,

--- a/show/hft.py
+++ b/show/hft.py
@@ -14,7 +14,6 @@ GROUP_TABLE = 'HIGH_FREQUENCY_TELEMETRY_GROUP'
 AGGREGATOR_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
 AGGREGATOR_HISTOGRAM_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM'
 AGGREGATOR_ROLLOVER_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER'
-DEFAULT_HEATMAP_BUCKET_COUNT = 256
 DEFAULT_ROLLOVER_BIT_WIDTH = 32
 DEFAULT_CELL_PLACEHOLDER = '-'
 TABLE_HEADER = [
@@ -30,7 +29,6 @@ TABLE_HEADER = [
     'Rollover Bit Widths',
     'Heatmap Interval (usec)',
     'Heatmap Counters',
-    'Heatmap Default Buckets',
     'Per-counter Explicit Bounds'
 ]
 
@@ -122,7 +120,7 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
             rollover_index.get(aggregator_name, {})
         )
         reporting_rate, rollover_counters, rollover_bit_widths, heatmap_interval, \
-            heatmap_counters, heatmap_default_buckets, explicit_bounds = aggregator_fields
+            heatmap_counters, explicit_bounds = aggregator_fields
         groups = group_index.get(profile_name)
 
         if not groups:
@@ -139,7 +137,6 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
                 rollover_bit_widths,
                 heatmap_interval,
                 heatmap_counters,
-                heatmap_default_buckets,
                 explicit_bounds
             ])
             continue
@@ -158,7 +155,6 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
                 rollover_bit_widths if idx == 0 else '',
                 heatmap_interval if idx == 0 else '',
                 heatmap_counters if idx == 0 else '',
-                heatmap_default_buckets if idx == 0 else '',
                 explicit_bounds if idx == 0 else ''
             ])
 
@@ -169,7 +165,7 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
             rollover_index.get(aggregator_name, {})
         )
         reporting_rate, rollover_counters, rollover_bit_widths, heatmap_interval, \
-            heatmap_counters, heatmap_default_buckets, explicit_bounds = aggregator_fields
+            heatmap_counters, explicit_bounds = aggregator_fields
         rows.append([
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,
@@ -183,7 +179,6 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
             rollover_bit_widths,
             heatmap_interval,
             heatmap_counters,
-            heatmap_default_buckets,
             explicit_bounds
         ])
 
@@ -206,12 +201,6 @@ def _format_aggregator(aggregator, histograms=None, rollover_overrides=None):
         aggregator.get('heatmap_interval', DEFAULT_CELL_PLACEHOLDER)
     )
     heatmap_counters = _format_list(aggregator.get('heatmap_counters')) or DEFAULT_CELL_PLACEHOLDER
-    default_bucket_count = aggregator.get('heatmap_default_bucket_count')
-    if (default_bucket_count is None and
-            heatmap_interval != DEFAULT_CELL_PLACEHOLDER and
-            heatmap_counters != DEFAULT_CELL_PLACEHOLDER):
-        default_bucket_count = DEFAULT_HEATMAP_BUCKET_COUNT
-    heatmap_default_buckets = _format_poll_interval(default_bucket_count)
     explicit_bounds = '\n'.join(histograms or []) or DEFAULT_CELL_PLACEHOLDER
     return (
         reporting_rate,
@@ -219,7 +208,6 @@ def _format_aggregator(aggregator, histograms=None, rollover_overrides=None):
         rollover_bit_widths,
         heatmap_interval,
         heatmap_counters,
-        heatmap_default_buckets,
         explicit_bounds
     )
 

--- a/show/hft.py
+++ b/show/hft.py
@@ -23,7 +23,9 @@ TABLE_HEADER = [
     'Object Counters',
     'Reporting Rate (usec)',
     'Rollover Counters',
-    'Heatmap Counters'
+    'Heatmap Interval (usec)',
+    'Heatmap Counters',
+    'Heatmap Bucket Boundaries'
 ]
 
 
@@ -95,8 +97,14 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
         aggregator_name = profile_entry.get('aggregator', DEFAULT_CELL_PLACEHOLDER)
         if aggregator_name != DEFAULT_CELL_PLACEHOLDER:
             used_aggregators.add(aggregator_name)
-        aggregator = aggregator_table.get(aggregator_name, {}) if aggregator_name != DEFAULT_CELL_PLACEHOLDER else {}
-        reporting_rate, rollover_counters, heatmap_counters = _format_aggregator(aggregator)
+        aggregator = (
+            aggregator_table.get(aggregator_name, {})
+            if aggregator_name != DEFAULT_CELL_PLACEHOLDER else {}
+        )
+        aggregator_fields = _format_aggregator(aggregator)
+        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, heatmap_buckets = (
+            aggregator_fields
+        )
         groups = group_index.get(profile_name)
 
         if not groups:
@@ -110,7 +118,9 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
                 DEFAULT_CELL_PLACEHOLDER,
                 reporting_rate,
                 rollover_counters,
-                heatmap_counters
+                heatmap_interval,
+                heatmap_counters,
+                heatmap_buckets
             ])
             continue
 
@@ -125,12 +135,17 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
                 group['counters'],
                 reporting_rate if idx == 0 else '',
                 rollover_counters if idx == 0 else '',
-                heatmap_counters if idx == 0 else ''
+                heatmap_interval if idx == 0 else '',
+                heatmap_counters if idx == 0 else '',
+                heatmap_buckets if idx == 0 else ''
             ])
 
     for aggregator_name in natsorted(set(aggregator_table.keys()) - used_aggregators):
-        reporting_rate, rollover_counters, heatmap_counters = _format_aggregator(
+        aggregator_fields = _format_aggregator(
             aggregator_table.get(aggregator_name, {})
+        )
+        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, heatmap_buckets = (
+            aggregator_fields
         )
         rows.append([
             DEFAULT_CELL_PLACEHOLDER,
@@ -142,7 +157,9 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
             DEFAULT_CELL_PLACEHOLDER,
             reporting_rate,
             rollover_counters,
-            heatmap_counters
+            heatmap_interval,
+            heatmap_counters,
+            heatmap_buckets
         ])
 
     return rows
@@ -151,8 +168,12 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
 def _format_aggregator(aggregator):
     reporting_rate = _format_poll_interval(aggregator.get('reporting_rate', DEFAULT_CELL_PLACEHOLDER))
     rollover_counters = _format_list(aggregator.get('rollover_counters')) or DEFAULT_CELL_PLACEHOLDER
+    heatmap_interval = _format_poll_interval(
+        aggregator.get('heatmap_interval', DEFAULT_CELL_PLACEHOLDER)
+    )
     heatmap_counters = _format_list(aggregator.get('heatmap_counters')) or DEFAULT_CELL_PLACEHOLDER
-    return reporting_rate, rollover_counters, heatmap_counters
+    heatmap_buckets = _format_list(aggregator.get('heatmap_bucket_boundaries')) or DEFAULT_CELL_PLACEHOLDER
+    return reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, heatmap_buckets
 
 
 def _index_groups(group_table):

--- a/show/hft.py
+++ b/show/hft.py
@@ -12,6 +12,8 @@ import utilities_common.cli as clicommon
 PROFILE_TABLE = 'HIGH_FREQUENCY_TELEMETRY_PROFILE'
 GROUP_TABLE = 'HIGH_FREQUENCY_TELEMETRY_GROUP'
 AGGREGATOR_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
+AGGREGATOR_HISTOGRAM_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM'
+DEFAULT_HEATMAP_BUCKET_COUNT = 256
 DEFAULT_CELL_PLACEHOLDER = '-'
 TABLE_HEADER = [
     'Profile',
@@ -25,7 +27,8 @@ TABLE_HEADER = [
     'Rollover Counters',
     'Heatmap Interval (usec)',
     'Heatmap Counters',
-    'Heatmap Bucket Boundaries'
+    'Heatmap Default Buckets',
+    'Per-counter Explicit Bounds'
 ]
 
 
@@ -74,8 +77,9 @@ def _display_hft(db):
     profile_table = db.cfgdb.get_table(PROFILE_TABLE) or {}
     group_table = db.cfgdb.get_table(GROUP_TABLE) or {}
     aggregator_table = db.cfgdb.get_table(AGGREGATOR_TABLE) or {}
+    histogram_table = db.cfgdb.get_table(AGGREGATOR_HISTOGRAM_TABLE) or {}
 
-    rows = _build_rows(profile_table, group_table, aggregator_table)
+    rows = _build_rows(profile_table, group_table, aggregator_table, histogram_table)
     if not rows:
         click.echo("No high frequency telemetry configuration present.")
         return
@@ -83,9 +87,10 @@ def _display_hft(db):
     click.echo(tabulate(rows, TABLE_HEADER, tablefmt='grid'))
 
 
-def _build_rows(profile_table, group_table, aggregator_table=None):
+def _build_rows(profile_table, group_table, aggregator_table=None, histogram_table=None):
     group_index = _index_groups(group_table)
     aggregator_table = aggregator_table or {}
+    histogram_index = _index_histograms(histogram_table or {})
     used_aggregators = set()
     rows = []
 
@@ -101,10 +106,12 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
             aggregator_table.get(aggregator_name, {})
             if aggregator_name != DEFAULT_CELL_PLACEHOLDER else {}
         )
-        aggregator_fields = _format_aggregator(aggregator)
-        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, heatmap_buckets = (
-            aggregator_fields
+        aggregator_fields = _format_aggregator(
+            aggregator,
+            histogram_index.get(aggregator_name, [])
         )
+        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, \
+            heatmap_default_buckets, explicit_bounds = aggregator_fields
         groups = group_index.get(profile_name)
 
         if not groups:
@@ -120,7 +127,8 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
                 rollover_counters,
                 heatmap_interval,
                 heatmap_counters,
-                heatmap_buckets
+                heatmap_default_buckets,
+                explicit_bounds
             ])
             continue
 
@@ -137,16 +145,17 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
                 rollover_counters if idx == 0 else '',
                 heatmap_interval if idx == 0 else '',
                 heatmap_counters if idx == 0 else '',
-                heatmap_buckets if idx == 0 else ''
+                heatmap_default_buckets if idx == 0 else '',
+                explicit_bounds if idx == 0 else ''
             ])
 
     for aggregator_name in natsorted(set(aggregator_table.keys()) - used_aggregators):
         aggregator_fields = _format_aggregator(
-            aggregator_table.get(aggregator_name, {})
+            aggregator_table.get(aggregator_name, {}),
+            histogram_index.get(aggregator_name, [])
         )
-        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, heatmap_buckets = (
-            aggregator_fields
-        )
+        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, \
+            heatmap_default_buckets, explicit_bounds = aggregator_fields
         rows.append([
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,
@@ -159,21 +168,54 @@ def _build_rows(profile_table, group_table, aggregator_table=None):
             rollover_counters,
             heatmap_interval,
             heatmap_counters,
-            heatmap_buckets
+            heatmap_default_buckets,
+            explicit_bounds
         ])
 
     return rows
 
 
-def _format_aggregator(aggregator):
+def _format_aggregator(aggregator, histograms=None):
     reporting_rate = _format_poll_interval(aggregator.get('reporting_rate', DEFAULT_CELL_PLACEHOLDER))
     rollover_counters = _format_list(aggregator.get('rollover_counters')) or DEFAULT_CELL_PLACEHOLDER
     heatmap_interval = _format_poll_interval(
         aggregator.get('heatmap_interval', DEFAULT_CELL_PLACEHOLDER)
     )
     heatmap_counters = _format_list(aggregator.get('heatmap_counters')) or DEFAULT_CELL_PLACEHOLDER
-    heatmap_buckets = _format_list(aggregator.get('heatmap_bucket_boundaries')) or DEFAULT_CELL_PLACEHOLDER
-    return reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, heatmap_buckets
+    default_bucket_count = aggregator.get('heatmap_default_bucket_count')
+    if (default_bucket_count is None and
+            heatmap_interval != DEFAULT_CELL_PLACEHOLDER and
+            heatmap_counters != DEFAULT_CELL_PLACEHOLDER):
+        default_bucket_count = DEFAULT_HEATMAP_BUCKET_COUNT
+    heatmap_default_buckets = _format_poll_interval(default_bucket_count)
+    explicit_bounds = '\n'.join(histograms or []) or DEFAULT_CELL_PLACEHOLDER
+    return (
+        reporting_rate,
+        rollover_counters,
+        heatmap_interval,
+        heatmap_counters,
+        heatmap_default_buckets,
+        explicit_bounds
+    )
+
+
+def _index_histograms(histogram_table):
+    index = {}
+    for composite_key, attributes in histogram_table.items():
+        aggregator_name, group_type, counter_name = _split_histogram_key(composite_key)
+        if not aggregator_name or not group_type or not counter_name:
+            continue
+
+        bounds = ','.join(_ensure_list((attributes or {}).get('explicit_bounds')))
+        if not bounds:
+            continue
+        index.setdefault(aggregator_name, []).append(
+            '{}|{}: {}'.format(group_type, counter_name, bounds)
+        )
+
+    for histograms in index.values():
+        histograms.sort()
+    return index
 
 
 def _index_groups(group_table):
@@ -210,6 +252,21 @@ def _split_group_key(key):
             return parts[0], parts[1]
 
     return None, None
+
+
+def _split_histogram_key(key):
+    if not key:
+        return None, None, None
+
+    if isinstance(key, (tuple, list)) and len(key) == 3:
+        return key[0], key[1], key[2]
+
+    if isinstance(key, str):
+        parts = key.split('|')
+        if len(parts) == 3:
+            return parts[0], parts[1], parts[2]
+
+    return None, None, None
 
 
 def _format_list(value):

--- a/show/hft.py
+++ b/show/hft.py
@@ -13,7 +13,9 @@ PROFILE_TABLE = 'HIGH_FREQUENCY_TELEMETRY_PROFILE'
 GROUP_TABLE = 'HIGH_FREQUENCY_TELEMETRY_GROUP'
 AGGREGATOR_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
 AGGREGATOR_HISTOGRAM_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM'
+AGGREGATOR_ROLLOVER_TABLE = 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER'
 DEFAULT_HEATMAP_BUCKET_COUNT = 256
+DEFAULT_ROLLOVER_BIT_WIDTH = 32
 DEFAULT_CELL_PLACEHOLDER = '-'
 TABLE_HEADER = [
     'Profile',
@@ -25,6 +27,7 @@ TABLE_HEADER = [
     'Object Counters',
     'Reporting Rate (usec)',
     'Rollover Counters',
+    'Rollover Bit Widths',
     'Heatmap Interval (usec)',
     'Heatmap Counters',
     'Heatmap Default Buckets',
@@ -78,8 +81,15 @@ def _display_hft(db):
     group_table = db.cfgdb.get_table(GROUP_TABLE) or {}
     aggregator_table = db.cfgdb.get_table(AGGREGATOR_TABLE) or {}
     histogram_table = db.cfgdb.get_table(AGGREGATOR_HISTOGRAM_TABLE) or {}
+    rollover_table = db.cfgdb.get_table(AGGREGATOR_ROLLOVER_TABLE) or {}
 
-    rows = _build_rows(profile_table, group_table, aggregator_table, histogram_table)
+    rows = _build_rows(
+        profile_table,
+        group_table,
+        aggregator_table,
+        histogram_table,
+        rollover_table
+    )
     if not rows:
         click.echo("No high frequency telemetry configuration present.")
         return
@@ -87,10 +97,12 @@ def _display_hft(db):
     click.echo(tabulate(rows, TABLE_HEADER, tablefmt='grid'))
 
 
-def _build_rows(profile_table, group_table, aggregator_table=None, histogram_table=None):
+def _build_rows(profile_table, group_table, aggregator_table=None, histogram_table=None,
+                rollover_table=None):
     group_index = _index_groups(group_table)
     aggregator_table = aggregator_table or {}
     histogram_index = _index_histograms(histogram_table or {})
+    rollover_index = _index_rollovers(rollover_table or {})
     used_aggregators = set()
     rows = []
 
@@ -99,19 +111,18 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
         stream_state = profile_entry.get('stream_state', DEFAULT_CELL_PLACEHOLDER)
         poll_interval_raw = profile_entry.get('poll_interval', DEFAULT_CELL_PLACEHOLDER)
         poll_interval = _format_poll_interval(poll_interval_raw)
-        aggregator_name = profile_entry.get('aggregator', DEFAULT_CELL_PLACEHOLDER)
-        if aggregator_name != DEFAULT_CELL_PLACEHOLDER:
+        aggregator_name = profile_entry.get('aggregator')
+        aggregator_display = aggregator_name or DEFAULT_CELL_PLACEHOLDER
+        if aggregator_name is not None:
             used_aggregators.add(aggregator_name)
-        aggregator = (
-            aggregator_table.get(aggregator_name, {})
-            if aggregator_name != DEFAULT_CELL_PLACEHOLDER else {}
-        )
+        aggregator = aggregator_table.get(aggregator_name, {}) if aggregator_name is not None else {}
         aggregator_fields = _format_aggregator(
             aggregator,
-            histogram_index.get(aggregator_name, [])
+            histogram_index.get(aggregator_name, []),
+            rollover_index.get(aggregator_name, {})
         )
-        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, \
-            heatmap_default_buckets, explicit_bounds = aggregator_fields
+        reporting_rate, rollover_counters, rollover_bit_widths, heatmap_interval, \
+            heatmap_counters, heatmap_default_buckets, explicit_bounds = aggregator_fields
         groups = group_index.get(profile_name)
 
         if not groups:
@@ -119,12 +130,13 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
                 profile_name,
                 stream_state,
                 poll_interval,
-                aggregator_name,
+                aggregator_display,
                 DEFAULT_CELL_PLACEHOLDER,
                 DEFAULT_CELL_PLACEHOLDER,
                 DEFAULT_CELL_PLACEHOLDER,
                 reporting_rate,
                 rollover_counters,
+                rollover_bit_widths,
                 heatmap_interval,
                 heatmap_counters,
                 heatmap_default_buckets,
@@ -137,12 +149,13 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
                 profile_name if idx == 0 else '',
                 stream_state if idx == 0 else '',
                 poll_interval if idx == 0 else '',
-                aggregator_name if idx == 0 else '',
+                aggregator_display if idx == 0 else '',
                 group['type'],
                 group['names'],
                 group['counters'],
                 reporting_rate if idx == 0 else '',
                 rollover_counters if idx == 0 else '',
+                rollover_bit_widths if idx == 0 else '',
                 heatmap_interval if idx == 0 else '',
                 heatmap_counters if idx == 0 else '',
                 heatmap_default_buckets if idx == 0 else '',
@@ -152,10 +165,11 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
     for aggregator_name in natsorted(set(aggregator_table.keys()) - used_aggregators):
         aggregator_fields = _format_aggregator(
             aggregator_table.get(aggregator_name, {}),
-            histogram_index.get(aggregator_name, [])
+            histogram_index.get(aggregator_name, []),
+            rollover_index.get(aggregator_name, {})
         )
-        reporting_rate, rollover_counters, heatmap_interval, heatmap_counters, \
-            heatmap_default_buckets, explicit_bounds = aggregator_fields
+        reporting_rate, rollover_counters, rollover_bit_widths, heatmap_interval, \
+            heatmap_counters, heatmap_default_buckets, explicit_bounds = aggregator_fields
         rows.append([
             DEFAULT_CELL_PLACEHOLDER,
             DEFAULT_CELL_PLACEHOLDER,
@@ -166,6 +180,7 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
             DEFAULT_CELL_PLACEHOLDER,
             reporting_rate,
             rollover_counters,
+            rollover_bit_widths,
             heatmap_interval,
             heatmap_counters,
             heatmap_default_buckets,
@@ -175,9 +190,18 @@ def _build_rows(profile_table, group_table, aggregator_table=None, histogram_tab
     return rows
 
 
-def _format_aggregator(aggregator, histograms=None):
+def _format_aggregator(aggregator, histograms=None, rollover_overrides=None):
     reporting_rate = _format_poll_interval(aggregator.get('reporting_rate', DEFAULT_CELL_PLACEHOLDER))
-    rollover_counters = _format_list(aggregator.get('rollover_counters')) or DEFAULT_CELL_PLACEHOLDER
+    rollover_selectors = _ensure_list(aggregator.get('rollover_counters'))
+    rollover_counters = '\n'.join(rollover_selectors) or DEFAULT_CELL_PLACEHOLDER
+    rollover_overrides = rollover_overrides or {}
+    rollover_bit_widths = '\n'.join(
+        '{}: {}'.format(
+            selector,
+            rollover_overrides.get(selector, '{} (default)'.format(DEFAULT_ROLLOVER_BIT_WIDTH))
+        )
+        for selector in rollover_selectors
+    ) or DEFAULT_CELL_PLACEHOLDER
     heatmap_interval = _format_poll_interval(
         aggregator.get('heatmap_interval', DEFAULT_CELL_PLACEHOLDER)
     )
@@ -192,6 +216,7 @@ def _format_aggregator(aggregator, histograms=None):
     return (
         reporting_rate,
         rollover_counters,
+        rollover_bit_widths,
         heatmap_interval,
         heatmap_counters,
         heatmap_default_buckets,
@@ -215,6 +240,20 @@ def _index_histograms(histogram_table):
 
     for histograms in index.values():
         histograms.sort()
+    return index
+
+
+def _index_rollovers(rollover_table):
+    index = {}
+    for composite_key, attributes in rollover_table.items():
+        aggregator_name, group_type, counter_name = _split_counter_child_key(composite_key)
+        if not aggregator_name or not group_type or not counter_name:
+            continue
+        if not isinstance(attributes, dict) or attributes.get('bit_width') is None:
+            continue
+
+        selector = '{}|{}'.format(group_type, counter_name)
+        index.setdefault(aggregator_name, {})[selector] = str(attributes['bit_width'])
     return index
 
 
@@ -255,6 +294,10 @@ def _split_group_key(key):
 
 
 def _split_histogram_key(key):
+    return _split_counter_child_key(key)
+
+
+def _split_counter_child_key(key):
     if not key:
         return None, None, None
 

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -15,7 +15,7 @@ class TestConfigHftCli:
         with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['add', 'profile', 'profileA', '--harmonizer', 'hm0']
+                ['add', 'profile', 'profileA', '--aggregator', 'ag0']
             )
 
         assert result.exit_code == 0
@@ -27,18 +27,18 @@ class TestConfigHftCli:
                 'profileA': {
                     'stream_state': 'disabled',
                     'poll_interval': '10000',
-                    'harmonizer': 'hm0'
+                    'aggregator': 'ag0'
                 }
             }
         }]
         assert payload == expected_payload
 
-    def test_add_harmonizer_splits_comma_separated_lists(self):
+    def test_add_aggregator_splits_comma_separated_lists(self):
         with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
-                    'add', 'harmonizer', 'hm0',
+                    'add', 'aggregator', 'ag0',
                     '--reporting_rate', '1000',
                     '--rollover_counters', 'PORT|IF_IN_UCAST_PKTS, QUEUE|DROPPED_PACKETS',
                     '--heatmap_counters', 'PORT|IF_OUT_ERRORS, QUEUE|WRED_ECN_MARKED_PACKETS'
@@ -49,9 +49,9 @@ class TestConfigHftCli:
         _, payload = mock_process.call_args[0]
         expected_payload = [{
             'op': 'add',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_HARMONIZER',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR',
             'value': {
-                'hm0': {
+                'ag0': {
                     'reporting_rate': '1000',
                     'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
                     'heatmap_counters': ['PORT|IF_OUT_ERRORS', 'QUEUE|WRED_ECN_MARKED_PACKETS']
@@ -102,34 +102,34 @@ class TestConfigHftCli:
         }]
         assert payload == expected_payload
 
-    def test_bind_harmonizer_sets_profile_harmonizer_patch(self):
+    def test_bind_aggregator_sets_profile_aggregator_patch(self):
         with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['bind-harmonizer', 'profileA', 'hm0']
+                ['bind-aggregator', 'profileA', 'ag0']
             )
 
         assert result.exit_code == 0
         _, payload = mock_process.call_args[0]
         expected_payload = [{
             'op': 'add',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE/profileA/harmonizer',
-            'value': 'hm0'
+            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE/profileA/aggregator',
+            'value': 'ag0'
         }]
         assert payload == expected_payload
 
-    def test_unbind_harmonizer_removes_profile_harmonizer_patch(self):
+    def test_unbind_aggregator_removes_profile_aggregator_patch(self):
         with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['unbind-harmonizer', 'profileA']
+                ['unbind-aggregator', 'profileA']
             )
 
         assert result.exit_code == 0
         _, payload = mock_process.call_args[0]
         expected_payload = [{
             'op': 'remove',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE/profileA/harmonizer'
+            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE/profileA/aggregator'
         }]
         assert payload == expected_payload
 
@@ -161,66 +161,66 @@ class TestConfigHftCli:
         }]
         assert payload == expected_payload
 
-    def test_delete_harmonizer_removes_entry(self):
+    def test_delete_aggregator_removes_entry(self):
         with patch('config.hft._is_last_entry', return_value=False), \
-                patch('config.hft._get_harmonizer_users', return_value=[]), \
+                patch('config.hft._get_aggregator_users', return_value=[]), \
                 patch('config.hft._has_table_entry', return_value=True), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['del', 'harmonizer', 'hm0']
+                ['del', 'aggregator', 'ag0']
             )
 
         assert result.exit_code == 0
         _, payload = mock_process.call_args[0]
         expected_payload = [{
             'op': 'remove',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_HARMONIZER/hm0'
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/ag0'
         }]
         assert payload == expected_payload
 
-    def test_delete_harmonizer_removes_entire_table_when_last_entry(self):
+    def test_delete_aggregator_removes_entire_table_when_last_entry(self):
         with patch('config.hft._is_last_entry', return_value=True), \
-                patch('config.hft._get_harmonizer_users', return_value=[]), \
+                patch('config.hft._get_aggregator_users', return_value=[]), \
                 patch('config.hft._has_table_entry', return_value=True), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['del', 'harmonizer', 'hm0']
+                ['del', 'aggregator', 'ag0']
             )
 
         assert result.exit_code == 0
         _, payload = mock_process.call_args[0]
         expected_payload = [{
             'op': 'remove',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_HARMONIZER'
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
         }]
         assert payload == expected_payload
 
-    def test_delete_harmonizer_rejected_when_profile_still_references_it(self):
-        with patch('config.hft._get_harmonizer_users', return_value=['profileA']), \
+    def test_delete_aggregator_rejected_when_profile_still_references_it(self):
+        with patch('config.hft._get_aggregator_users', return_value=['profileA']), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['del', 'harmonizer', 'hm0']
+                ['del', 'aggregator', 'ag0']
             )
 
         assert result.exit_code == 1
-        assert "Cannot delete harmonizer 'hm0'" in result.output
+        assert "Cannot delete aggregator 'ag0'" in result.output
         assert 'profileA' in result.output
         mock_process.assert_not_called()
 
-    def test_delete_harmonizer_rejected_when_harmonizer_does_not_exist(self):
-        with patch('config.hft._get_harmonizer_users', return_value=[]), \
+    def test_delete_aggregator_rejected_when_aggregator_does_not_exist(self):
+        with patch('config.hft._get_aggregator_users', return_value=[]), \
                 patch('config.hft._has_table_entry', return_value=False), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['del', 'harmonizer', 'missing']
+                ['del', 'aggregator', 'missing']
             )
 
         assert result.exit_code == 1
-        assert "Harmonizer 'missing' does not exist." in result.output
+        assert "Aggregator 'missing' does not exist." in result.output
         mock_process.assert_not_called()
 
 
@@ -246,7 +246,7 @@ def test_is_last_entry_true_and_false():
     assert config_hft._is_last_entry(MockCtx(tables), 'HIGH_FREQUENCY_TELEMETRY_PROFILE') is False
 
 
-def test_harmonizer_table_helpers():
+def test_aggregator_table_helpers():
     class MockCfgDb:
         def __init__(self, tables):
             self.tables = tables
@@ -262,23 +262,23 @@ def test_harmonizer_table_helpers():
             return self
 
     tables = {
-        'HIGH_FREQUENCY_TELEMETRY_HARMONIZER': {
-            'hm0': {},
-            'hm1': {}
+        'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR': {
+            'ag0': {},
+            'ag1': {}
         },
         'HIGH_FREQUENCY_TELEMETRY_PROFILE': {
-            'profileB': {'harmonizer': 'hm0'},
-            'profileA': {'harmonizer': 'hm0'},
-            'profileC': {'harmonizer': 'hm1'},
+            'profileB': {'aggregator': 'ag0'},
+            'profileA': {'aggregator': 'ag0'},
+            'profileC': {'aggregator': 'ag1'},
             'profileD': {}
         }
     }
     ctx = MockCtx(tables)
 
-    assert config_hft._has_table_entry(ctx, 'HIGH_FREQUENCY_TELEMETRY_HARMONIZER', 'hm0') is True
-    assert config_hft._has_table_entry(ctx, 'HIGH_FREQUENCY_TELEMETRY_HARMONIZER', 'missing') is False
-    assert config_hft._get_harmonizer_users(ctx, 'hm0') == ['profileA', 'profileB']
-    assert config_hft._get_harmonizer_users(ctx, 'missing') == []
+    assert config_hft._has_table_entry(ctx, 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR', 'ag0') is True
+    assert config_hft._has_table_entry(ctx, 'HIGH_FREQUENCY_TELEMETRY_AGGREGATOR', 'missing') is False
+    assert config_hft._get_aggregator_users(ctx, 'ag0') == ['profileA', 'profileB']
+    assert config_hft._get_aggregator_users(ctx, 'missing') == []
 
 
 def test_materialize_payload_creates_file():

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -179,6 +179,24 @@ class TestConfigHftCli:
         }]
         assert payload == expected_payload
 
+    def test_delete_harmonizer_removes_entire_table_when_last_entry(self):
+        with patch('config.hft._is_last_entry', return_value=True), \
+                patch('config.hft._get_harmonizer_users', return_value=[]), \
+                patch('config.hft._has_table_entry', return_value=True), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'harmonizer', 'hm0']
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        expected_payload = [{
+            'op': 'remove',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_HARMONIZER'
+        }]
+        assert payload == expected_payload
+
     def test_delete_harmonizer_rejected_when_profile_still_references_it(self):
         with patch('config.hft._get_harmonizer_users', return_value=['profileA']), \
                 patch('config.hft._process_payload') as mock_process:
@@ -226,6 +244,41 @@ def test_is_last_entry_true_and_false():
 
     tables = {'HIGH_FREQUENCY_TELEMETRY_PROFILE': {'p1': {}, 'p2': {}}}
     assert config_hft._is_last_entry(MockCtx(tables), 'HIGH_FREQUENCY_TELEMETRY_PROFILE') is False
+
+
+def test_harmonizer_table_helpers():
+    class MockCfgDb:
+        def __init__(self, tables):
+            self.tables = tables
+
+        def get_table(self, name):
+            return self.tables.get(name, {})
+
+    class MockCtx:
+        def __init__(self, tables):
+            self.obj = type('Obj', (), {'cfgdb': MockCfgDb(tables)})
+
+        def find_root(self):
+            return self
+
+    tables = {
+        'HIGH_FREQUENCY_TELEMETRY_HARMONIZER': {
+            'hm0': {},
+            'hm1': {}
+        },
+        'HIGH_FREQUENCY_TELEMETRY_PROFILE': {
+            'profileB': {'harmonizer': 'hm0'},
+            'profileA': {'harmonizer': 'hm0'},
+            'profileC': {'harmonizer': 'hm1'},
+            'profileD': {}
+        }
+    }
+    ctx = MockCtx(tables)
+
+    assert config_hft._has_table_entry(ctx, 'HIGH_FREQUENCY_TELEMETRY_HARMONIZER', 'hm0') is True
+    assert config_hft._has_table_entry(ctx, 'HIGH_FREQUENCY_TELEMETRY_HARMONIZER', 'missing') is False
+    assert config_hft._get_harmonizer_users(ctx, 'hm0') == ['profileA', 'profileB']
+    assert config_hft._get_harmonizer_users(ctx, 'missing') == []
 
 
 def test_materialize_payload_creates_file():

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -164,6 +164,7 @@ class TestConfigHftCli:
     def test_delete_harmonizer_removes_entry(self):
         with patch('config.hft._is_last_entry', return_value=False), \
                 patch('config.hft._get_harmonizer_users', return_value=[]), \
+                patch('config.hft._has_table_entry', return_value=True), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -189,6 +190,19 @@ class TestConfigHftCli:
         assert result.exit_code == 1
         assert "Cannot delete harmonizer 'hm0'" in result.output
         assert 'profileA' in result.output
+        mock_process.assert_not_called()
+
+    def test_delete_harmonizer_rejected_when_harmonizer_does_not_exist(self):
+        with patch('config.hft._get_harmonizer_users', return_value=[]), \
+                patch('config.hft._has_table_entry', return_value=False), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'harmonizer', 'missing']
+            )
+
+        assert result.exit_code == 1
+        assert "Harmonizer 'missing' does not exist." in result.output
         mock_process.assert_not_called()
 
 

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -15,7 +15,7 @@ class TestConfigHftCli:
         with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
-                ['add', 'profile', 'profileA']
+                ['add', 'profile', 'profileA', '--harmonizer', 'hm0']
             )
 
         assert result.exit_code == 0
@@ -26,7 +26,35 @@ class TestConfigHftCli:
             'value': {
                 'profileA': {
                     'stream_state': 'disabled',
-                    'poll_interval': '10000'
+                    'poll_interval': '10000',
+                    'harmonizer': 'hm0'
+                }
+            }
+        }]
+        assert payload == expected_payload
+
+    def test_add_harmonizer_splits_comma_separated_lists(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'harmonizer', 'hm0',
+                    '--reporting_rate', '1000',
+                    '--rollover_counters', 'PORT|IF_IN_UCAST_PKTS, QUEUE|DROPPED_PACKETS',
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS, QUEUE|WRED_ECN_MARKED_PACKETS'
+                ]
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        expected_payload = [{
+            'op': 'add',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_HARMONIZER',
+            'value': {
+                'hm0': {
+                    'reporting_rate': '1000',
+                    'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
+                    'heatmap_counters': ['PORT|IF_OUT_ERRORS', 'QUEUE|WRED_ECN_MARKED_PACKETS']
                 }
             }
         }]
@@ -74,6 +102,37 @@ class TestConfigHftCli:
         }]
         assert payload == expected_payload
 
+    def test_bind_harmonizer_sets_profile_harmonizer_patch(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['bind-harmonizer', 'profileA', 'hm0']
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        expected_payload = [{
+            'op': 'add',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE/profileA/harmonizer',
+            'value': 'hm0'
+        }]
+        assert payload == expected_payload
+
+    def test_unbind_harmonizer_removes_profile_harmonizer_patch(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['unbind-harmonizer', 'profileA']
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        expected_payload = [{
+            'op': 'remove',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE/profileA/harmonizer'
+        }]
+        assert payload == expected_payload
+
     def test_add_profile_rejected_when_profile_already_exists(self):
         with patch('config.hft._has_existing_profile', return_value=True), \
                 patch('config.hft._process_payload') as mock_process:
@@ -101,6 +160,36 @@ class TestConfigHftCli:
             'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE'
         }]
         assert payload == expected_payload
+
+    def test_delete_harmonizer_removes_entry(self):
+        with patch('config.hft._is_last_entry', return_value=False), \
+                patch('config.hft._get_harmonizer_users', return_value=[]), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'harmonizer', 'hm0']
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        expected_payload = [{
+            'op': 'remove',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_HARMONIZER/hm0'
+        }]
+        assert payload == expected_payload
+
+    def test_delete_harmonizer_rejected_when_profile_still_references_it(self):
+        with patch('config.hft._get_harmonizer_users', return_value=['profileA']), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'harmonizer', 'hm0']
+            )
+
+        assert result.exit_code == 1
+        assert "Cannot delete harmonizer 'hm0'" in result.output
+        assert 'profileA' in result.output
+        mock_process.assert_not_called()
 
 
 def test_is_last_entry_true_and_false():

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -7,6 +7,14 @@ from unittest.mock import patch
 import config.hft as config_hft
 
 
+def _make_cli_obj(tables):
+    class MockCfgDb:
+        def get_table(self, name):
+            return tables.get(name, {})
+
+    return type('Obj', (), {'cfgdb': MockCfgDb()})
+
+
 class TestConfigHftCli:
     def setup_method(self):
         self.runner = CliRunner()
@@ -44,7 +52,7 @@ class TestConfigHftCli:
                     '--rollover_counters', 'PORT|IF_IN_UCAST_PKTS, QUEUE|DROPPED_PACKETS',
                     '--heatmap_interval', '1000000',
                     '--heatmap_counters', 'PORT|IF_OUT_ERRORS, QUEUE|WRED_ECN_MARKED_PACKETS',
-                    '--heatmap_bucket_boundaries', '0, 1024, 4096'
+                    '--heatmap_default_bucket_count', '64'
                 ]
             )
 
@@ -59,11 +67,49 @@ class TestConfigHftCli:
                     'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
                     'heatmap_interval': '1000000',
                     'heatmap_counters': ['PORT|IF_OUT_ERRORS', 'QUEUE|WRED_ECN_MARKED_PACKETS'],
-                    'heatmap_bucket_boundaries': ['0', '1024', '4096']
+                    'heatmap_default_bucket_count': '64'
                 }
             }
         }]
         assert payload == expected_payload
+
+    def test_aggregator_entry_paths_reject_name_with_separator(self):
+        commands = (
+            ['add', 'aggregator', 'ag|0'],
+            ['add', 'profile', 'profileA', '--aggregator', 'ag|0'],
+            ['bind-aggregator', 'profileA', 'ag|0'],
+            ['del', 'aggregator', 'ag|0'],
+            ['del', 'histogram', 'ag|0', 'PORT|IF_OUT_OCTETS'],
+        )
+        for command in commands:
+            with patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(config_hft.hft, command)
+
+            assert result.exit_code == 2
+            assert "must not contain '|'" in result.output
+            mock_process.assert_not_called()
+
+    def test_aggregator_entry_paths_reject_surrounding_whitespace(self):
+        for aggregator_name in (' ag0', 'ag0 '):
+            commands = (
+                ['add', 'aggregator', aggregator_name],
+                ['add', 'profile', 'profileA', '--aggregator', aggregator_name],
+                ['bind-aggregator', 'profileA', aggregator_name],
+                ['del', 'aggregator', aggregator_name],
+                [
+                    'add', 'histogram', aggregator_name,
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--explicit_bounds', '0,1'
+                ],
+                ['del', 'histogram', aggregator_name, 'PORT|IF_OUT_OCTETS'],
+            )
+            for command in commands:
+                with patch('config.hft._process_payload') as mock_process:
+                    result = self.runner.invoke(config_hft.hft, command)
+
+                assert result.exit_code == 2
+                assert 'must not have leading or trailing whitespace' in result.output
+                mock_process.assert_not_called()
 
     def test_add_aggregator_accepts_each_optional_method_independently(self):
         commands = [
@@ -75,8 +121,7 @@ class TestConfigHftCli:
             [
                 'add', 'aggregator', 'heatmap',
                 '--heatmap_interval', '1000000',
-                '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
-                '--heatmap_bucket_boundaries', '0,1024'
+                '--heatmap_counters', 'PORT|IF_OUT_ERRORS'
             ]
         ]
 
@@ -87,8 +132,9 @@ class TestConfigHftCli:
             assert result.exit_code == 0
             mock_process.assert_called_once()
 
-    def test_add_aggregator_rejects_heatmap_without_bucket_boundaries(self):
-        with patch('config.hft._process_payload') as mock_process:
+    def test_add_aggregator_defaults_heatmap_bucket_count(self):
+        with patch('config.hft._has_table', return_value=False), \
+                patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
@@ -98,9 +144,19 @@ class TestConfigHftCli:
                 ]
             )
 
-        assert result.exit_code == 2
-        assert 'must be configured together' in result.output
-        mock_process.assert_not_called()
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'add',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR',
+            'value': {
+                'ag0': {
+                    'heatmap_interval': '1000000',
+                    'heatmap_counters': ['PORT|IF_OUT_ERRORS'],
+                    'heatmap_default_bucket_count': '256'
+                }
+            }
+        }]
 
     def test_add_aggregator_rejects_heatmap_without_interval(self):
         with patch('config.hft._process_payload') as mock_process:
@@ -108,14 +164,84 @@ class TestConfigHftCli:
                 config_hft.hft,
                 [
                     'add', 'aggregator', 'ag0',
-                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
-                    '--heatmap_bucket_boundaries', '0,1024'
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS'
                 ]
             )
 
         assert result.exit_code == 2
         assert 'must be configured together' in result.output
         mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_heatmap_without_counters(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['add', 'aggregator', 'ag0', '--heatmap_interval', '1000000']
+            )
+
+        assert result.exit_code == 2
+        assert 'must be configured together' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_empty_heatmap_counters(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'aggregator', 'ag0',
+                    '--heatmap_interval', '1000000',
+                    '--heatmap_counters', ' , '
+                ]
+            )
+
+        assert result.exit_code == 2
+        assert 'at least one' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_bucket_count_without_heatmap(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['add', 'aggregator', 'ag0', '--heatmap_default_bucket_count', '32']
+            )
+
+        assert result.exit_code == 2
+        assert 'requires --heatmap_interval' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_bucket_count_outside_range(self):
+        for value in ('3', '513'):
+            with patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    [
+                        'add', 'aggregator', 'ag0',
+                        '--heatmap_interval', '1000000',
+                        '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
+                        '--heatmap_default_bucket_count', value
+                    ]
+                )
+
+            assert result.exit_code == 2
+            mock_process.assert_not_called()
+
+    def test_add_aggregator_accepts_bucket_count_range_limits(self):
+        for value in ('4', '512'):
+            with patch('config.hft._has_table', return_value=False), \
+                    patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    [
+                        'add', 'aggregator', 'ag0',
+                        '--heatmap_interval', '1000000',
+                        '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
+                        '--heatmap_default_bucket_count', value
+                    ]
+                )
+
+            assert result.exit_code == 0
+            _, payload = mock_process.call_args[0]
+            assert payload[0]['value']['ag0']['heatmap_default_bucket_count'] == value
 
     def test_add_aggregator_rejects_intervals_above_uint32(self):
         for option in ('--reporting_rate', '--heatmap_interval'):
@@ -128,37 +254,134 @@ class TestConfigHftCli:
             assert result.exit_code == 2
             mock_process.assert_not_called()
 
-    def test_add_aggregator_rejects_unordered_bucket_boundaries(self):
+    def test_add_histogram_creates_table_with_composite_key(self):
+        with patch('config.hft._has_table', return_value=False), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'histogram', 'ag0',
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--explicit_bounds', '0, 1250000, 2500000'
+                ]
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'add',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM',
+            'value': {
+                'ag0|PORT|IF_OUT_OCTETS': {
+                    'explicit_bounds': ['0', '1250000', '2500000']
+                }
+            }
+        }]
+
+    def test_add_histogram_preserves_existing_table_entries(self):
+        with patch('config.hft._has_table', return_value=True), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'histogram', 'ag1',
+                    '--counter', 'QUEUE|BYTES',
+                    '--explicit_bounds', '1'
+                ]
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'add',
+            'path': (
+                '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM/'
+                'ag1|QUEUE|BYTES'
+            ),
+            'value': {'explicit_bounds': ['1']}
+        }]
+
+    def test_add_histogram_rejects_malformed_selector(self):
+        selectors = (
+            'PORT',
+            'PORT|',
+            '|IF_OUT_OCTETS',
+            'NOT_A_GROUP|IF_OUT_OCTETS',
+            'PORT|IF_OUT_OCTETS|EXTRA',
+        )
+        for selector in selectors:
+            with patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    [
+                        'add', 'histogram', 'ag0',
+                        '--counter', selector,
+                        '--explicit_bounds', '0,1'
+                    ]
+                )
+
+            assert result.exit_code == 2
+            mock_process.assert_not_called()
+
+    def test_add_histogram_rejects_aggregator_name_with_separator(self):
         with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
-                    'add', 'aggregator', 'ag0',
-                    '--heatmap_interval', '1000000',
-                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
-                    '--heatmap_bucket_boundaries', '0,4096,1024'
+                    'add', 'histogram', 'ag|0',
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--explicit_bounds', '0,1'
                 ]
             )
 
         assert result.exit_code == 2
-        assert 'strictly increasing' in result.output
+        assert "must not contain '|'" in result.output
         mock_process.assert_not_called()
 
-    def test_add_aggregator_rejects_bucket_boundary_above_exact_otel_range(self):
-        with patch('config.hft._process_payload') as mock_process:
+    def test_add_histogram_rejects_invalid_explicit_bounds(self):
+        invalid_bounds = (
+            '',
+            '0,,1',
+            '-1,1',
+            '+1,2',
+            '1.0,2',
+            '0,2,2',
+            '0,2,1',
+            str(2**53 + 1),
+            ','.join(str(value) for value in range(512)),
+        )
+        for bounds in invalid_bounds:
+            with patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    [
+                        'add', 'histogram', 'ag0',
+                        '--counter', 'PORT|IF_OUT_OCTETS',
+                        '--explicit_bounds', bounds
+                    ]
+                )
+
+            assert result.exit_code == 2
+            mock_process.assert_not_called()
+
+    def test_add_histogram_accepts_bounds_limits(self):
+        bounds = ','.join([*(str(value) for value in range(510)), str(2**53)])
+        with patch('config.hft._has_table', return_value=False), \
+                patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
-                    'add', 'aggregator', 'ag0',
-                    '--heatmap_interval', '1000000',
-                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
-                    '--heatmap_bucket_boundaries', str(2**53 + 1)
+                    'add', 'histogram', 'ag0',
+                    '--counter', 'PORT|UNKNOWN_COUNTER_FOR_YANG',
+                    '--explicit_bounds', bounds
                 ]
             )
 
-        assert result.exit_code == 2
-        assert 'exact OTLP encoding' in result.output
-        mock_process.assert_not_called()
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload[0]['value']['ag0|PORT|UNKNOWN_COUNTER_FOR_YANG'][
+            'explicit_bounds'
+        ][-1] == str(2**53)
 
     def test_add_group_splits_comma_separated_lists(self):
         with patch('config.hft._has_table', return_value=False), \
@@ -337,6 +560,188 @@ class TestConfigHftCli:
             'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
         }]
         assert payload == expected_payload
+
+    def test_delete_histogram_rejects_missing_entry_in_empty_table(self):
+        obj = _make_cli_obj({})
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'histogram', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 1
+        assert "Histogram 'ag0|PORT|IF_OUT_OCTETS' does not exist." in result.output
+        mock_process.assert_not_called()
+
+    def test_delete_histogram_rejects_missing_entry_with_one_unrelated_row(self):
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: {
+                'ag1|PORT|IF_IN_OCTETS': {}
+            }
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'histogram', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 1
+        assert "Histogram 'ag0|PORT|IF_OUT_OCTETS' does not exist." in result.output
+        mock_process.assert_not_called()
+
+    def test_delete_histogram_removes_exact_tuple_key(self):
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: {
+                ('ag0', 'PORT', 'IF_OUT_OCTETS'): {},
+                'ag1|QUEUE|BYTES': {}
+            }
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'histogram', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'remove',
+            'path': (
+                '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM/'
+                'ag0|PORT|IF_OUT_OCTETS'
+            )
+        }]
+
+    def test_delete_histogram_removes_exact_list_key(self):
+        class ListKeyTable:
+            def __iter__(self):
+                return iter([
+                    ['ag0', 'PORT', 'IF_OUT_OCTETS'],
+                    'ag1|QUEUE|BYTES'
+                ])
+
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: ListKeyTable()
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'histogram', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'remove',
+            'path': (
+                '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM/'
+                'ag0|PORT|IF_OUT_OCTETS'
+            )
+        }]
+
+    def test_delete_histogram_removes_table_for_exact_sole_string_key(self):
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: {
+                'ag0|PORT|IF_OUT_OCTETS': {}
+            }
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'histogram', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'remove',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM'
+        }]
+
+    def test_delete_aggregator_cascades_histograms_before_parent(self):
+        class MockCfgDb:
+            def get_table(self, name):
+                return {
+                    config_hft.PROFILE_TABLE_NAME: {},
+                    config_hft.AGGREGATOR_TABLE_NAME: {
+                        'ag0': {},
+                        'ag1': {}
+                    },
+                    config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: {
+                        'ag0|QUEUE|BYTES': {},
+                        ('ag0', 'PORT', 'IF_OUT_OCTETS'): {},
+                        'ag1|PORT|IF_IN_OCTETS': {}
+                    }
+                }.get(name, {})
+
+        obj = type('Obj', (), {'cfgdb': MockCfgDb()})
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'aggregator', 'ag0'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [
+            {
+                'op': 'remove',
+                'path': (
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM/'
+                    'ag0|PORT|IF_OUT_OCTETS'
+                )
+            },
+            {
+                'op': 'remove',
+                'path': (
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM/'
+                    'ag0|QUEUE|BYTES'
+                )
+            },
+            {
+                'op': 'remove',
+                'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/ag0'
+            }
+        ]
+
+    def test_delete_last_aggregator_cascades_entire_histogram_table(self):
+        class MockCfgDb:
+            def get_table(self, name):
+                return {
+                    config_hft.PROFILE_TABLE_NAME: {},
+                    config_hft.AGGREGATOR_TABLE_NAME: {'ag0': {}},
+                    config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: {
+                        'ag0|PORT|IF_OUT_OCTETS': {},
+                        'ag0|QUEUE|BYTES': {}
+                    }
+                }.get(name, {})
+
+        obj = type('Obj', (), {'cfgdb': MockCfgDb()})
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'aggregator', 'ag0'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [
+            {
+                'op': 'remove',
+                'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM'
+            },
+            {
+                'op': 'remove',
+                'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
+            }
+        ]
 
     def test_delete_aggregator_rejected_when_profile_still_references_it(self):
         with patch('config.hft._get_aggregator_users', return_value=['profileA']), \

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+import pytest
 from click.testing import CliRunner
 from unittest.mock import patch
 
@@ -80,6 +81,12 @@ class TestConfigHftCli:
             ['bind-aggregator', 'profileA', 'ag|0'],
             ['del', 'aggregator', 'ag|0'],
             ['del', 'histogram', 'ag|0', 'PORT|IF_OUT_OCTETS'],
+            [
+                'add', 'rollover', 'ag|0',
+                '--counter', 'PORT|IF_OUT_OCTETS',
+                '--bit_width', '32'
+            ],
+            ['del', 'rollover', 'ag|0', 'PORT|IF_OUT_OCTETS'],
         )
         for command in commands:
             with patch('config.hft._process_payload') as mock_process:
@@ -102,6 +109,12 @@ class TestConfigHftCli:
                     '--explicit_bounds', '0,1'
                 ],
                 ['del', 'histogram', aggregator_name, 'PORT|IF_OUT_OCTETS'],
+                [
+                    'add', 'rollover', aggregator_name,
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--bit_width', '32'
+                ],
+                ['del', 'rollover', aggregator_name, 'PORT|IF_OUT_OCTETS'],
             )
             for command in commands:
                 with patch('config.hft._process_payload') as mock_process:
@@ -383,6 +396,122 @@ class TestConfigHftCli:
             'explicit_bounds'
         ][-1] == str(2**53)
 
+    def test_add_rollover_creates_table_with_composite_key(self):
+        with patch('config.hft._has_table', return_value=False), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'rollover', 'ag0',
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--bit_width', '32'
+                ]
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'add',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER',
+            'value': {
+                'ag0|PORT|IF_OUT_OCTETS': {'bit_width': '32'}
+            }
+        }]
+
+    def test_add_rollover_preserves_existing_table_entries(self):
+        with patch('config.hft._has_table', return_value=True), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'rollover', 'ag1',
+                    '--counter', 'QUEUE|BYTES',
+                    '--bit_width', '63'
+                ]
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'add',
+            'path': (
+                '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER/'
+                'ag1|QUEUE|BYTES'
+            ),
+            'value': {'bit_width': '63'}
+        }]
+
+    def test_add_rollover_accepts_bit_width_range_limits(self):
+        for bit_width in ('1', '63'):
+            with patch('config.hft._has_table', return_value=False), \
+                    patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    [
+                        'add', 'rollover', 'ag0',
+                        '--counter', 'PORT|UNKNOWN_COUNTER_FOR_YANG',
+                        '--bit_width', bit_width
+                    ]
+                )
+
+            assert result.exit_code == 0
+            _, payload = mock_process.call_args[0]
+            assert payload[0]['value']['ag0|PORT|UNKNOWN_COUNTER_FOR_YANG'] == {
+                'bit_width': bit_width
+            }
+
+    def test_add_rollover_rejects_bit_width_outside_range(self):
+        for bit_width in ('0', '64'):
+            with patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    [
+                        'add', 'rollover', 'ag0',
+                        '--counter', 'PORT|IF_OUT_OCTETS',
+                        '--bit_width', bit_width
+                    ]
+                )
+
+            assert result.exit_code == 2
+            mock_process.assert_not_called()
+
+    def test_add_rollover_rejects_malformed_selector(self):
+        selectors = (
+            'PORT',
+            'PORT|',
+            '|IF_OUT_OCTETS',
+            'NOT_A_GROUP|IF_OUT_OCTETS',
+            'PORT|IF_OUT_OCTETS|EXTRA',
+        )
+        for selector in selectors:
+            with patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    [
+                        'add', 'rollover', 'ag0',
+                        '--counter', selector,
+                        '--bit_width', '32'
+                    ]
+                )
+
+            assert result.exit_code == 2
+            mock_process.assert_not_called()
+
+    def test_add_rollover_rejects_empty_aggregator_name(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'rollover', '',
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--bit_width', '32'
+                ]
+            )
+
+        assert result.exit_code == 2
+        assert 'must be nonempty' in result.output
+        mock_process.assert_not_called()
+
     def test_add_group_splits_comma_separated_lists(self):
         with patch('config.hft._has_table', return_value=False), \
                 patch('config.hft._process_payload') as mock_process:
@@ -663,6 +792,108 @@ class TestConfigHftCli:
             'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM'
         }]
 
+    def test_delete_rollover_rejects_missing_entry_in_empty_table(self):
+        obj = _make_cli_obj({})
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'rollover', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 1
+        assert "Rollover 'ag0|PORT|IF_OUT_OCTETS' does not exist." in result.output
+        mock_process.assert_not_called()
+
+    def test_delete_rollover_does_not_remove_unrelated_sole_row(self):
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_ROLLOVER_TABLE_NAME: {
+                'ag1|PORT|IF_IN_OCTETS': {'bit_width': '32'}
+            }
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'rollover', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 1
+        assert "Rollover 'ag0|PORT|IF_OUT_OCTETS' does not exist." in result.output
+        mock_process.assert_not_called()
+
+    def test_delete_rollover_removes_exact_tuple_key(self):
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_ROLLOVER_TABLE_NAME: {
+                ('ag0', 'PORT', 'IF_OUT_OCTETS'): {'bit_width': '32'},
+                'ag1|QUEUE|BYTES': {'bit_width': '16'}
+            }
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'rollover', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'remove',
+            'path': (
+                '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER/'
+                'ag0|PORT|IF_OUT_OCTETS'
+            )
+        }]
+
+    def test_delete_rollover_removes_exact_list_key(self):
+        class ListKeyTable:
+            def __iter__(self):
+                return iter([
+                    ['ag0', 'PORT', 'IF_OUT_OCTETS'],
+                    'ag1|QUEUE|BYTES'
+                ])
+
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_ROLLOVER_TABLE_NAME: ListKeyTable()
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'rollover', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'remove',
+            'path': (
+                '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER/'
+                'ag0|PORT|IF_OUT_OCTETS'
+            )
+        }]
+
+    def test_delete_rollover_removes_table_for_exact_sole_string_key(self):
+        obj = _make_cli_obj({
+            config_hft.AGGREGATOR_ROLLOVER_TABLE_NAME: {
+                'ag0|PORT|IF_OUT_OCTETS': {'bit_width': '32'}
+            }
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'rollover', 'ag0', 'PORT|IF_OUT_OCTETS'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'remove',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER'
+        }]
+
     def test_delete_aggregator_cascades_histograms_before_parent(self):
         class MockCfgDb:
             def get_table(self, name):
@@ -741,6 +972,97 @@ class TestConfigHftCli:
                 'op': 'remove',
                 'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR'
             }
+        ]
+
+    @pytest.mark.parametrize(
+        'histograms,rollovers,expected_children',
+        [
+            (
+                {},
+                {'ag0|PORT|IF_OUT_OCTETS': {}},
+                ['/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER']
+            ),
+            (
+                {},
+                {
+                    ('ag0', 'PORT', 'IF_OUT_OCTETS'): {},
+                    'ag1|QUEUE|BYTES': {}
+                },
+                [
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER/'
+                    'ag0|PORT|IF_OUT_OCTETS'
+                ]
+            ),
+            (
+                {'ag0|QUEUE|BYTES': {}},
+                {'ag0|PORT|IF_OUT_OCTETS': {}},
+                [
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM',
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER'
+                ]
+            ),
+            (
+                {'ag0|QUEUE|BYTES': {}},
+                {
+                    'ag0|PORT|IF_OUT_OCTETS': {},
+                    'ag1|QUEUE|BYTES': {}
+                },
+                [
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM',
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER/'
+                    'ag0|PORT|IF_OUT_OCTETS'
+                ]
+            ),
+            (
+                {
+                    'ag0|QUEUE|BYTES': {},
+                    'ag1|PORT|IF_IN_OCTETS': {}
+                },
+                {'ag0|PORT|IF_OUT_OCTETS': {}},
+                [
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM/'
+                    'ag0|QUEUE|BYTES',
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER'
+                ]
+            ),
+            (
+                {
+                    'ag0|QUEUE|BYTES': {},
+                    'ag1|PORT|IF_IN_OCTETS': {}
+                },
+                {
+                    'ag0|PORT|IF_OUT_OCTETS': {},
+                    'ag1|QUEUE|BYTES': {}
+                },
+                [
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM/'
+                    'ag0|QUEUE|BYTES',
+                    '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER/'
+                    'ag0|PORT|IF_OUT_OCTETS'
+                ]
+            ),
+        ]
+    )
+    def test_delete_aggregator_cascades_each_child_table_independently(
+            self, histograms, rollovers, expected_children):
+        obj = _make_cli_obj({
+            config_hft.PROFILE_TABLE_NAME: {},
+            config_hft.AGGREGATOR_TABLE_NAME: {'ag0': {}, 'ag1': {}},
+            config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: histograms,
+            config_hft.AGGREGATOR_ROLLOVER_TABLE_NAME: rollovers
+        })
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'aggregator', 'ag0'],
+                obj=obj
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert [entry['path'] for entry in payload] == [
+            *expected_children,
+            '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/ag0'
         ]
 
     def test_delete_aggregator_rejected_when_profile_still_references_it(self):

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -564,7 +564,7 @@ class TestConfigHftCli:
         }]
 
     def test_add_aggregator_preserves_existing_table_entries(self):
-        with patch('config.hft._has_table', return_value=True), \
+        with patch('config.hft._get_table_or_fail', return_value={'ag0': {}}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -578,6 +578,58 @@ class TestConfigHftCli:
             'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/ag1',
             'value': {'reporting_rate': '1000'}
         }]
+
+    def test_add_aggregator_rejects_existing_entry_before_patch(self):
+        class MockCfgDb:
+            def get_table(self, name):
+                return {
+                    config_hft.AGGREGATOR_TABLE_NAME: {
+                        'ag0': {
+                            'heatmap_interval': '1000000',
+                            'heatmap_counters': ['PORT|IF_OUT_OCTETS']
+                        }
+                    },
+                    config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME: {
+                        'ag0|PORT|IF_OUT_OCTETS': {'explicit_bounds': ['0', '1024']}
+                    },
+                    config_hft.AGGREGATOR_ROLLOVER_TABLE_NAME: {
+                        'ag0|PORT|IF_IN_OCTETS': {'bit_width': '48'}
+                    }
+                }.get(name, {})
+
+        obj = type('Obj', (), {'cfgdb': MockCfgDb()})
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'aggregator', 'ag0',
+                    '--heatmap_interval', '1000000',
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS'
+                ],
+                obj=obj
+            )
+
+        assert result.exit_code == 1
+        assert "Aggregator 'ag0' already exists." in result.output
+        mock_process.assert_not_called()
+
+    def test_add_aggregator_fails_closed_when_table_read_fails(self):
+        class MockCfgDb:
+            def get_table(self, _name):
+                raise RuntimeError('database unavailable')
+
+        obj = type('Obj', (), {'cfgdb': MockCfgDb()})
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['add', 'aggregator', 'ag0', '--reporting_rate', '1000'],
+                obj=obj
+            )
+
+        assert result.exit_code == 1
+        assert "Failed to read Config DB table" in result.output
+        assert 'database unavailable' in result.output
+        mock_process.assert_not_called()
 
     def test_enable_profile_sets_stream_state_patch(self):
         with patch('config.hft._process_payload') as mock_process:

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -34,14 +34,17 @@ class TestConfigHftCli:
         assert payload == expected_payload
 
     def test_add_aggregator_splits_comma_separated_lists(self):
-        with patch('config.hft._process_payload') as mock_process:
+        with patch('config.hft._has_table', return_value=False), \
+                patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
                     'add', 'aggregator', 'ag0',
                     '--reporting_rate', '1000',
                     '--rollover_counters', 'PORT|IF_IN_UCAST_PKTS, QUEUE|DROPPED_PACKETS',
-                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS, QUEUE|WRED_ECN_MARKED_PACKETS'
+                    '--heatmap_interval', '1000000',
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS, QUEUE|WRED_ECN_MARKED_PACKETS',
+                    '--heatmap_bucket_boundaries', '0, 1024, 4096'
                 ]
             )
 
@@ -54,14 +57,112 @@ class TestConfigHftCli:
                 'ag0': {
                     'reporting_rate': '1000',
                     'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
-                    'heatmap_counters': ['PORT|IF_OUT_ERRORS', 'QUEUE|WRED_ECN_MARKED_PACKETS']
+                    'heatmap_interval': '1000000',
+                    'heatmap_counters': ['PORT|IF_OUT_ERRORS', 'QUEUE|WRED_ECN_MARKED_PACKETS'],
+                    'heatmap_bucket_boundaries': ['0', '1024', '4096']
                 }
             }
         }]
         assert payload == expected_payload
 
-    def test_add_group_splits_comma_separated_lists(self):
+    def test_add_aggregator_accepts_each_optional_method_independently(self):
+        commands = [
+            ['add', 'aggregator', 'reporting', '--reporting_rate', '1000'],
+            [
+                'add', 'aggregator', 'rollover',
+                '--rollover_counters', 'PORT|IF_IN_UCAST_PKTS'
+            ],
+            [
+                'add', 'aggregator', 'heatmap',
+                '--heatmap_interval', '1000000',
+                '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
+                '--heatmap_bucket_boundaries', '0,1024'
+            ]
+        ]
+
+        for command in commands:
+            with patch('config.hft._has_table', return_value=False), \
+                    patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(config_hft.hft, command)
+            assert result.exit_code == 0
+            mock_process.assert_called_once()
+
+    def test_add_aggregator_rejects_heatmap_without_bucket_boundaries(self):
         with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'aggregator', 'ag0',
+                    '--heatmap_interval', '1000000',
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS'
+                ]
+            )
+
+        assert result.exit_code == 2
+        assert 'must be configured together' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_heatmap_without_interval(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'aggregator', 'ag0',
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
+                    '--heatmap_bucket_boundaries', '0,1024'
+                ]
+            )
+
+        assert result.exit_code == 2
+        assert 'must be configured together' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_intervals_above_uint32(self):
+        for option in ('--reporting_rate', '--heatmap_interval'):
+            with patch('config.hft._process_payload') as mock_process:
+                result = self.runner.invoke(
+                    config_hft.hft,
+                    ['add', 'aggregator', 'ag0', option, str(2**32)]
+                )
+
+            assert result.exit_code == 2
+            mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_unordered_bucket_boundaries(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'aggregator', 'ag0',
+                    '--heatmap_interval', '1000000',
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
+                    '--heatmap_bucket_boundaries', '0,4096,1024'
+                ]
+            )
+
+        assert result.exit_code == 2
+        assert 'strictly increasing' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_aggregator_rejects_bucket_boundary_above_exact_otel_range(self):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'aggregator', 'ag0',
+                    '--heatmap_interval', '1000000',
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
+                    '--heatmap_bucket_boundaries', str(2**53 + 1)
+                ]
+            )
+
+        assert result.exit_code == 2
+        assert 'exact OTLP encoding' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_group_splits_comma_separated_lists(self):
+        with patch('config.hft._has_table', return_value=False), \
+                patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
@@ -85,6 +186,46 @@ class TestConfigHftCli:
             }
         }]
         assert payload == expected_payload
+
+    def test_add_group_preserves_existing_table_entries(self):
+        with patch('config.hft._has_table', return_value=True), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'group', 'profileA',
+                    '--group_type', 'QUEUE',
+                    '--object_names', 'Ethernet0|0',
+                    '--object_counters', 'PACKETS'
+                ]
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'add',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_GROUP/profileA|QUEUE',
+            'value': {
+                'object_names': ['Ethernet0|0'],
+                'object_counters': ['PACKETS']
+            }
+        }]
+
+    def test_add_aggregator_preserves_existing_table_entries(self):
+        with patch('config.hft._has_table', return_value=True), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['add', 'aggregator', 'ag1', '--reporting_rate', '1000']
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload == [{
+            'op': 'add',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/ag1',
+            'value': {'reporting_rate': '1000'}
+        }]
 
     def test_enable_profile_sets_stream_state_patch(self):
         with patch('config.hft._process_payload') as mock_process:

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -42,9 +42,31 @@ class TestConfigHftCli:
         }]
         assert payload == expected_payload
 
+    @pytest.mark.parametrize('poll_interval', ('1', str(2**32 - 1)))
+    def test_add_profile_accepts_poll_interval_range_limits(self, poll_interval):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['add', 'profile', 'profileA', '--poll_interval', poll_interval]
+            )
+
+        assert result.exit_code == 0
+        _, payload = mock_process.call_args[0]
+        assert payload[0]['value']['profileA']['poll_interval'] == poll_interval
+
+    @pytest.mark.parametrize('poll_interval', ('0', str(2**32)))
+    def test_add_profile_rejects_poll_interval_outside_range(self, poll_interval):
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['add', 'profile', 'profileA', '--poll_interval', poll_interval]
+            )
+
+        assert result.exit_code == 2
+        mock_process.assert_not_called()
+
     def test_add_aggregator_splits_comma_separated_lists(self):
-        with patch('config.hft._has_table', return_value=False), \
-                patch('config.hft._process_payload') as mock_process:
+        with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
@@ -52,8 +74,7 @@ class TestConfigHftCli:
                     '--reporting_rate', '1000',
                     '--rollover_counters', 'PORT|IF_IN_UCAST_PKTS, QUEUE|DROPPED_PACKETS',
                     '--heatmap_interval', '1000000',
-                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS, QUEUE|WRED_ECN_MARKED_PACKETS',
-                    '--heatmap_default_bucket_count', '64'
+                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS, QUEUE|WRED_ECN_MARKED_PACKETS'
                 ]
             )
 
@@ -67,8 +88,7 @@ class TestConfigHftCli:
                     'reporting_rate': '1000',
                     'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
                     'heatmap_interval': '1000000',
-                    'heatmap_counters': ['PORT|IF_OUT_ERRORS', 'QUEUE|WRED_ECN_MARKED_PACKETS'],
-                    'heatmap_default_bucket_count': '64'
+                    'heatmap_counters': ['PORT|IF_OUT_ERRORS', 'QUEUE|WRED_ECN_MARKED_PACKETS']
                 }
             }
         }]
@@ -139,37 +159,10 @@ class TestConfigHftCli:
         ]
 
         for command in commands:
-            with patch('config.hft._has_table', return_value=False), \
-                    patch('config.hft._process_payload') as mock_process:
+            with patch('config.hft._process_payload') as mock_process:
                 result = self.runner.invoke(config_hft.hft, command)
             assert result.exit_code == 0
             mock_process.assert_called_once()
-
-    def test_add_aggregator_defaults_heatmap_bucket_count(self):
-        with patch('config.hft._has_table', return_value=False), \
-                patch('config.hft._process_payload') as mock_process:
-            result = self.runner.invoke(
-                config_hft.hft,
-                [
-                    'add', 'aggregator', 'ag0',
-                    '--heatmap_interval', '1000000',
-                    '--heatmap_counters', 'PORT|IF_OUT_ERRORS'
-                ]
-            )
-
-        assert result.exit_code == 0
-        _, payload = mock_process.call_args[0]
-        assert payload == [{
-            'op': 'add',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR',
-            'value': {
-                'ag0': {
-                    'heatmap_interval': '1000000',
-                    'heatmap_counters': ['PORT|IF_OUT_ERRORS'],
-                    'heatmap_default_bucket_count': '256'
-                }
-            }
-        }]
 
     def test_add_aggregator_rejects_heatmap_without_interval(self):
         with patch('config.hft._process_payload') as mock_process:
@@ -211,51 +204,6 @@ class TestConfigHftCli:
         assert 'at least one' in result.output
         mock_process.assert_not_called()
 
-    def test_add_aggregator_rejects_bucket_count_without_heatmap(self):
-        with patch('config.hft._process_payload') as mock_process:
-            result = self.runner.invoke(
-                config_hft.hft,
-                ['add', 'aggregator', 'ag0', '--heatmap_default_bucket_count', '32']
-            )
-
-        assert result.exit_code == 2
-        assert 'requires --heatmap_interval' in result.output
-        mock_process.assert_not_called()
-
-    def test_add_aggregator_rejects_bucket_count_outside_range(self):
-        for value in ('3', '513'):
-            with patch('config.hft._process_payload') as mock_process:
-                result = self.runner.invoke(
-                    config_hft.hft,
-                    [
-                        'add', 'aggregator', 'ag0',
-                        '--heatmap_interval', '1000000',
-                        '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
-                        '--heatmap_default_bucket_count', value
-                    ]
-                )
-
-            assert result.exit_code == 2
-            mock_process.assert_not_called()
-
-    def test_add_aggregator_accepts_bucket_count_range_limits(self):
-        for value in ('4', '512'):
-            with patch('config.hft._has_table', return_value=False), \
-                    patch('config.hft._process_payload') as mock_process:
-                result = self.runner.invoke(
-                    config_hft.hft,
-                    [
-                        'add', 'aggregator', 'ag0',
-                        '--heatmap_interval', '1000000',
-                        '--heatmap_counters', 'PORT|IF_OUT_ERRORS',
-                        '--heatmap_default_bucket_count', value
-                    ]
-                )
-
-            assert result.exit_code == 0
-            _, payload = mock_process.call_args[0]
-            assert payload[0]['value']['ag0']['heatmap_default_bucket_count'] == value
-
     def test_add_aggregator_rejects_intervals_above_uint32(self):
         for option in ('--reporting_rate', '--heatmap_interval'):
             with patch('config.hft._process_payload') as mock_process:
@@ -268,7 +216,7 @@ class TestConfigHftCli:
             mock_process.assert_not_called()
 
     def test_add_histogram_creates_table_with_composite_key(self):
-        with patch('config.hft._has_table', return_value=False), \
+        with patch('config.hft._get_table_or_fail', return_value={}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -292,7 +240,7 @@ class TestConfigHftCli:
         }]
 
     def test_add_histogram_preserves_existing_table_entries(self):
-        with patch('config.hft._has_table', return_value=True), \
+        with patch('config.hft._get_table_or_fail', return_value={'existing': {}}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -379,7 +327,7 @@ class TestConfigHftCli:
 
     def test_add_histogram_accepts_bounds_limits(self):
         bounds = ','.join([*(str(value) for value in range(510)), str(2**53)])
-        with patch('config.hft._has_table', return_value=False), \
+        with patch('config.hft._get_table_or_fail', return_value={}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -397,7 +345,7 @@ class TestConfigHftCli:
         ][-1] == str(2**53)
 
     def test_add_rollover_creates_table_with_composite_key(self):
-        with patch('config.hft._has_table', return_value=False), \
+        with patch('config.hft._get_table_or_fail', return_value={}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -419,7 +367,7 @@ class TestConfigHftCli:
         }]
 
     def test_add_rollover_preserves_existing_table_entries(self):
-        with patch('config.hft._has_table', return_value=True), \
+        with patch('config.hft._get_table_or_fail', return_value={'existing': {}}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -443,7 +391,7 @@ class TestConfigHftCli:
 
     def test_add_rollover_accepts_bit_width_range_limits(self):
         for bit_width in ('1', '63'):
-            with patch('config.hft._has_table', return_value=False), \
+            with patch('config.hft._get_table_or_fail', return_value={}), \
                     patch('config.hft._process_payload') as mock_process:
                 result = self.runner.invoke(
                     config_hft.hft,
@@ -513,7 +461,7 @@ class TestConfigHftCli:
         mock_process.assert_not_called()
 
     def test_add_group_splits_comma_separated_lists(self):
-        with patch('config.hft._has_table', return_value=False), \
+        with patch('config.hft._get_table_or_fail', return_value={}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -540,7 +488,7 @@ class TestConfigHftCli:
         assert payload == expected_payload
 
     def test_add_group_preserves_existing_table_entries(self):
-        with patch('config.hft._has_table', return_value=True), \
+        with patch('config.hft._get_table_or_fail', return_value={'existing': {}}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
@@ -631,6 +579,63 @@ class TestConfigHftCli:
         assert 'database unavailable' in result.output
         mock_process.assert_not_called()
 
+    @pytest.mark.parametrize(
+        'table_name,command',
+        (
+            (
+                config_hft.PROFILE_TABLE_NAME,
+                ['add', 'profile', 'profileA']
+            ),
+            (
+                config_hft.GROUP_TABLE_NAME,
+                [
+                    'add', 'group', 'profileA',
+                    '--group_type', 'PORT',
+                    '--object_names', 'Ethernet0',
+                    '--object_counters', 'IF_OUT_OCTETS'
+                ]
+            ),
+            (
+                config_hft.AGGREGATOR_HISTOGRAM_TABLE_NAME,
+                [
+                    'add', 'histogram', 'ag0',
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--explicit_bounds', '0,1'
+                ]
+            ),
+            (
+                config_hft.AGGREGATOR_ROLLOVER_TABLE_NAME,
+                [
+                    'add', 'rollover', 'ag0',
+                    '--counter', 'PORT|IF_OUT_OCTETS',
+                    '--bit_width', '32'
+                ]
+            ),
+        ),
+        ids=('profile', 'group', 'histogram', 'rollover')
+    )
+    def test_add_resource_fails_closed_when_table_read_fails(self, table_name, command):
+        class MockCfgDb:
+            def get_table(self, name):
+                assert name == table_name
+                raise RuntimeError('database unavailable')
+
+        obj = type('Obj', (), {'cfgdb': MockCfgDb()})
+        with patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                command,
+                obj=obj,
+                standalone_mode=False
+            )
+
+        assert result.exit_code == 1
+        assert isinstance(result.exception, config_hft.click.ClickException)
+        assert str(result.exception) == (
+            "Failed to read Config DB table '{}': database unavailable".format(table_name)
+        )
+        mock_process.assert_not_called()
+
     def test_enable_profile_sets_stream_state_patch(self):
         with patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
@@ -679,7 +684,7 @@ class TestConfigHftCli:
         assert payload == expected_payload
 
     def test_add_profile_rejected_when_profile_already_exists(self):
-        with patch('config.hft._has_existing_profile', return_value=True), \
+        with patch('config.hft._get_table_or_fail', return_value={'existing': {}}), \
                 patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,

--- a/tests/show_hft_test.py
+++ b/tests/show_hft_test.py
@@ -36,9 +36,9 @@ def test_build_rows_with_mixed_profiles_and_groups():
     ]
 
 
-def test_build_rows_with_harmonizer_config():
+def test_build_rows_with_aggregator_config():
     profile_table = {
-        'profileA': {'stream_state': 'enabled', 'poll_interval': '1000', 'harmonizer': 'hm0'}
+        'profileA': {'stream_state': 'enabled', 'poll_interval': '1000', 'aggregator': 'ag0'}
     }
     group_table = {
         'profileA|PORT': {
@@ -46,21 +46,21 @@ def test_build_rows_with_harmonizer_config():
             'object_counters': ['IF_IN_UCAST_PKTS']
         }
     }
-    harmonizer_table = {
-        'hm0': {
+    aggregator_table = {
+        'ag0': {
             'reporting_rate': '5000',
             'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
             'heatmap_counters': 'PORT|IF_OUT_ERRORS,QUEUE|WRED_ECN_MARKED_PACKETS'
         }
     }
 
-    rows = show_hft._build_rows(profile_table, group_table, harmonizer_table)
+    rows = show_hft._build_rows(profile_table, group_table, aggregator_table)
 
     assert rows == [[
         'profileA',
         'enabled',
         '1,000',
-        'hm0',
+        'ag0',
         'PORT',
         'Ethernet0',
         'IF_IN_UCAST_PKTS',
@@ -70,12 +70,12 @@ def test_build_rows_with_harmonizer_config():
     ]]
 
 
-def test_build_rows_includes_unbound_harmonizer_config():
+def test_build_rows_includes_unbound_aggregator_config():
     rows = show_hft._build_rows(
         {},
         {},
         {
-            'hm0': {
+            'ag0': {
                 'reporting_rate': '5000',
                 'rollover_counters': ['PORT|IF_IN_UCAST_PKTS'],
                 'heatmap_counters': []
@@ -87,7 +87,7 @@ def test_build_rows_includes_unbound_harmonizer_config():
         '-',
         '-',
         '-',
-        'hm0',
+        'ag0',
         '-',
         '-',
         '-',
@@ -167,7 +167,7 @@ def test_display_hft_outputs_table(capsys):
                         'object_counters': ['BYTES']
                     }
                 }
-            if name == show_hft.HARMONIZER_TABLE:
+            if name == show_hft.AGGREGATOR_TABLE:
                 return {}
             return {}
 

--- a/tests/show_hft_test.py
+++ b/tests/show_hft_test.py
@@ -29,11 +29,72 @@ def test_build_rows_with_mixed_profiles_and_groups():
     rows = show_hft._build_rows(profile_table, group_table)
 
     assert rows == [
-        ['profile2', 'disabled', '15', 'PORT', 'Ethernet0\nEthernet1', 'COUNTER0\nCOUNTER2'],
-        ['', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY'],
-        ['profile3', '-', '-', '-', '-', '-'],
-        ['profile10', 'enabled', '2,000', 'BUFFER_POOL', '-', '-']
+        ['profile2', 'disabled', '15', '-', 'PORT', 'Ethernet0\nEthernet1', 'COUNTER0\nCOUNTER2', '-', '-', '-'],
+        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', ''],
+        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
+        ['profile10', 'enabled', '2,000', '-', 'BUFFER_POOL', '-', '-', '-', '-', '-']
     ]
+
+
+def test_build_rows_with_harmonizer_config():
+    profile_table = {
+        'profileA': {'stream_state': 'enabled', 'poll_interval': '1000', 'harmonizer': 'hm0'}
+    }
+    group_table = {
+        'profileA|PORT': {
+            'object_names': ['Ethernet0'],
+            'object_counters': ['IF_IN_UCAST_PKTS']
+        }
+    }
+    harmonizer_table = {
+        'hm0': {
+            'reporting_rate': '5000',
+            'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
+            'heatmap_counters': 'PORT|IF_OUT_ERRORS,QUEUE|WRED_ECN_MARKED_PACKETS'
+        }
+    }
+
+    rows = show_hft._build_rows(profile_table, group_table, harmonizer_table)
+
+    assert rows == [[
+        'profileA',
+        'enabled',
+        '1,000',
+        'hm0',
+        'PORT',
+        'Ethernet0',
+        'IF_IN_UCAST_PKTS',
+        '5,000',
+        'PORT|IF_IN_UCAST_PKTS\nQUEUE|DROPPED_PACKETS',
+        'PORT|IF_OUT_ERRORS\nQUEUE|WRED_ECN_MARKED_PACKETS'
+    ]]
+
+
+def test_build_rows_includes_unbound_harmonizer_config():
+    rows = show_hft._build_rows(
+        {},
+        {},
+        {
+            'hm0': {
+                'reporting_rate': '5000',
+                'rollover_counters': ['PORT|IF_IN_UCAST_PKTS'],
+                'heatmap_counters': []
+            }
+        }
+    )
+
+    assert rows == [[
+        '-',
+        '-',
+        '-',
+        'hm0',
+        '-',
+        '-',
+        '-',
+        '5,000',
+        'PORT|IF_IN_UCAST_PKTS',
+        '-'
+    ]]
 
 
 def test_format_poll_interval_variants():
@@ -106,6 +167,8 @@ def test_display_hft_outputs_table(capsys):
                         'object_counters': ['BYTES']
                     }
                 }
+            if name == show_hft.HARMONIZER_TABLE:
+                return {}
             return {}
 
     class MockDb:

--- a/tests/show_hft_test.py
+++ b/tests/show_hft_test.py
@@ -31,13 +31,13 @@ def test_build_rows_with_mixed_profiles_and_groups():
     assert rows == [
         [
             'profile2', 'disabled', '15', '-', 'PORT', 'Ethernet0\nEthernet1',
-            'COUNTER0\nCOUNTER2', '-', '-', '-', '-', '-', '-'
+            'COUNTER0\nCOUNTER2', '-', '-', '-', '-', '-', '-', '-'
         ],
-        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', '', '', '', ''],
-        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
+        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', '', '', '', '', ''],
+        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
         [
             'profile10', 'enabled', '2,000', '-', 'BUFFER_POOL', '-', '-',
-            '-', '-', '-', '-', '-', '-'
+            '-', '-', '-', '-', '-', '-', '-'
         ]
     ]
 
@@ -73,7 +73,11 @@ def test_build_rows_with_aggregator_config():
         profile_table,
         group_table,
         aggregator_table,
-        histogram_table
+        histogram_table,
+        {
+            ('ag0', 'PORT', 'IF_IN_UCAST_PKTS'): {'bit_width': '40'},
+            'orphan|PORT|IF_OUT_OCTETS': {'bit_width': '24'}
+        }
     )
 
     assert rows == [[
@@ -86,6 +90,7 @@ def test_build_rows_with_aggregator_config():
         'IF_IN_UCAST_PKTS',
         '5,000',
         'PORT|IF_IN_UCAST_PKTS\nQUEUE|DROPPED_PACKETS',
+        'PORT|IF_IN_UCAST_PKTS: 40\nQUEUE|DROPPED_PACKETS: 32 (default)',
         '1,000,000',
         'PORT|IF_OUT_OCTETS\nQUEUE|WRED_ECN_MARKED_PACKETS',
         '256',
@@ -111,6 +116,9 @@ def test_build_rows_includes_unbound_aggregator_config():
             'ag0|PORT|IF_OUT_OCTETS': {
                 'explicit_bounds': ['0', '1000']
             }
+        },
+        {
+            'ag0|PORT|IF_IN_UCAST_PKTS': {'bit_width': 48}
         }
     )
 
@@ -124,11 +132,57 @@ def test_build_rows_includes_unbound_aggregator_config():
         '-',
         '5,000',
         'PORT|IF_IN_UCAST_PKTS',
+        'PORT|IF_IN_UCAST_PKTS: 48',
         '1,000,000',
         'PORT|IF_OUT_OCTETS',
         '128',
         'PORT|IF_OUT_OCTETS: 0,1000'
     ]]
+
+
+def test_build_rows_shows_default_rollover_width():
+    rows = show_hft._build_rows(
+        {'profileA': {'aggregator': 'ag0'}},
+        {},
+        {'ag0': {'rollover_counters': ['QUEUE|PACKETS']}},
+        {},
+        {}
+    )
+
+    assert rows[0][8:10] == [
+        'QUEUE|PACKETS',
+        'QUEUE|PACKETS: 32 (default)'
+    ]
+
+
+def test_build_rows_supports_dash_aggregator_name():
+    rows = show_hft._build_rows(
+        {'profileA': {'aggregator': '-'}},
+        {},
+        {'-': {'rollover_counters': ['QUEUE|PACKETS']}},
+        {},
+        {'-|QUEUE|PACKETS': {'bit_width': '24'}}
+    )
+
+    assert rows[0][3] == '-'
+    assert rows[0][9] == 'QUEUE|PACKETS: 24'
+
+
+def test_build_rows_ignores_unbound_rollover_child_rows():
+    rows = show_hft._build_rows(
+        {},
+        {},
+        {'ag0': {'rollover_counters': ['PORT|IF_IN_OCTETS']}},
+        {},
+        {
+            'ag0|PORT|IF_OUT_OCTETS': {'bit_width': '24'},
+            'missing|PORT|IF_IN_OCTETS': {'bit_width': '16'}
+        }
+    )
+
+    assert rows[0][9] == 'PORT|IF_IN_OCTETS: 32 (default)'
+    assert 'IF_OUT_OCTETS' not in rows[0][9]
+    assert all(row[3] != 'missing' for row in rows)
 
 
 def test_format_aggregator_only_defaults_buckets_for_configured_heatmap():
@@ -224,9 +278,11 @@ def test_display_hft_outputs_table(capsys):
     assert 'p1' in output
     assert 'Ethernet0' in output
     assert 'BYTES' in output
+    assert 'Rollover Bit Widths' in output
     assert 'Heatmap Default Buckets' in output
     assert 'Per-counter Explicit Bounds' in output
     assert show_hft.AGGREGATOR_HISTOGRAM_TABLE in requested_tables
+    assert show_hft.AGGREGATOR_ROLLOVER_TABLE in requested_tables
 
 
 def test_format_list_parses_json_array():

--- a/tests/show_hft_test.py
+++ b/tests/show_hft_test.py
@@ -31,13 +31,13 @@ def test_build_rows_with_mixed_profiles_and_groups():
     assert rows == [
         [
             'profile2', 'disabled', '15', '-', 'PORT', 'Ethernet0\nEthernet1',
-            'COUNTER0\nCOUNTER2', '-', '-', '-', '-', '-', '-', '-'
+            'COUNTER0\nCOUNTER2', '-', '-', '-', '-', '-', '-'
         ],
-        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', '', '', '', '', ''],
-        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
+        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', '', '', '', ''],
+        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
         [
             'profile10', 'enabled', '2,000', '-', 'BUFFER_POOL', '-', '-',
-            '-', '-', '-', '-', '-', '-', '-'
+            '-', '-', '-', '-', '-', '-'
         ]
     ]
 
@@ -93,7 +93,6 @@ def test_build_rows_with_aggregator_config():
         'PORT|IF_IN_UCAST_PKTS: 40\nQUEUE|DROPPED_PACKETS: 32 (default)',
         '1,000,000',
         'PORT|IF_OUT_OCTETS\nQUEUE|WRED_ECN_MARKED_PACKETS',
-        '256',
         'PORT|IF_OUT_OCTETS: 0,1250000,2500000\n'
         'QUEUE|WRED_ECN_MARKED_PACKETS: 0,64,128'
     ]]
@@ -108,8 +107,7 @@ def test_build_rows_includes_unbound_aggregator_config():
                 'reporting_rate': '5000',
                 'rollover_counters': ['PORT|IF_IN_UCAST_PKTS'],
                 'heatmap_interval': '1000000',
-                'heatmap_counters': ['PORT|IF_OUT_OCTETS'],
-                'heatmap_default_bucket_count': '128'
+                'heatmap_counters': ['PORT|IF_OUT_OCTETS']
             }
         },
         {
@@ -135,7 +133,6 @@ def test_build_rows_includes_unbound_aggregator_config():
         'PORT|IF_IN_UCAST_PKTS: 48',
         '1,000,000',
         'PORT|IF_OUT_OCTETS',
-        '128',
         'PORT|IF_OUT_OCTETS: 0,1000'
     ]]
 
@@ -183,14 +180,6 @@ def test_build_rows_ignores_unbound_rollover_child_rows():
     assert rows[0][9] == 'PORT|IF_IN_OCTETS: 32 (default)'
     assert 'IF_OUT_OCTETS' not in rows[0][9]
     assert all(row[3] != 'missing' for row in rows)
-
-
-def test_format_aggregator_only_defaults_buckets_for_configured_heatmap():
-    assert show_hft._format_aggregator({})[-2:] == ('-', '-')
-    assert show_hft._format_aggregator({
-        'heatmap_interval': '1000',
-        'heatmap_counters': ['PORT|IF_OUT_OCTETS']
-    })[-2:] == ('256', '-')
 
 
 def test_format_poll_interval_variants():
@@ -279,7 +268,6 @@ def test_display_hft_outputs_table(capsys):
     assert 'Ethernet0' in output
     assert 'BYTES' in output
     assert 'Rollover Bit Widths' in output
-    assert 'Heatmap Default Buckets' in output
     assert 'Per-counter Explicit Bounds' in output
     assert show_hft.AGGREGATOR_HISTOGRAM_TABLE in requested_tables
     assert show_hft.AGGREGATOR_ROLLOVER_TABLE in requested_tables

--- a/tests/show_hft_test.py
+++ b/tests/show_hft_test.py
@@ -31,11 +31,14 @@ def test_build_rows_with_mixed_profiles_and_groups():
     assert rows == [
         [
             'profile2', 'disabled', '15', '-', 'PORT', 'Ethernet0\nEthernet1',
-            'COUNTER0\nCOUNTER2', '-', '-', '-', '-', '-'
+            'COUNTER0\nCOUNTER2', '-', '-', '-', '-', '-', '-'
         ],
-        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', '', '', ''],
-        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
-        ['profile10', 'enabled', '2,000', '-', 'BUFFER_POOL', '-', '-', '-', '-', '-', '-', '-']
+        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', '', '', '', ''],
+        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
+        [
+            'profile10', 'enabled', '2,000', '-', 'BUFFER_POOL', '-', '-',
+            '-', '-', '-', '-', '-', '-'
+        ]
     ]
 
 
@@ -54,12 +57,24 @@ def test_build_rows_with_aggregator_config():
             'reporting_rate': '5000',
             'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
             'heatmap_interval': '1000000',
-            'heatmap_counters': 'PORT|IF_OUT_ERRORS,QUEUE|WRED_ECN_MARKED_PACKETS',
-            'heatmap_bucket_boundaries': [0, 1024, 4096]
+            'heatmap_counters': 'PORT|IF_OUT_OCTETS,QUEUE|WRED_ECN_MARKED_PACKETS'
+        }
+    }
+    histogram_table = {
+        'ag0|QUEUE|WRED_ECN_MARKED_PACKETS': {
+            'explicit_bounds': '["0", "64", "128"]'
+        },
+        ('ag0', 'PORT', 'IF_OUT_OCTETS'): {
+            'explicit_bounds': [0, 1250000, 2500000]
         }
     }
 
-    rows = show_hft._build_rows(profile_table, group_table, aggregator_table)
+    rows = show_hft._build_rows(
+        profile_table,
+        group_table,
+        aggregator_table,
+        histogram_table
+    )
 
     assert rows == [[
         'profileA',
@@ -72,8 +87,10 @@ def test_build_rows_with_aggregator_config():
         '5,000',
         'PORT|IF_IN_UCAST_PKTS\nQUEUE|DROPPED_PACKETS',
         '1,000,000',
-        'PORT|IF_OUT_ERRORS\nQUEUE|WRED_ECN_MARKED_PACKETS',
-        '0\n1024\n4096'
+        'PORT|IF_OUT_OCTETS\nQUEUE|WRED_ECN_MARKED_PACKETS',
+        '256',
+        'PORT|IF_OUT_OCTETS: 0,1250000,2500000\n'
+        'QUEUE|WRED_ECN_MARKED_PACKETS: 0,64,128'
     ]]
 
 
@@ -85,7 +102,14 @@ def test_build_rows_includes_unbound_aggregator_config():
             'ag0': {
                 'reporting_rate': '5000',
                 'rollover_counters': ['PORT|IF_IN_UCAST_PKTS'],
-                'heatmap_counters': []
+                'heatmap_interval': '1000000',
+                'heatmap_counters': ['PORT|IF_OUT_OCTETS'],
+                'heatmap_default_bucket_count': '128'
+            }
+        },
+        {
+            'ag0|PORT|IF_OUT_OCTETS': {
+                'explicit_bounds': ['0', '1000']
             }
         }
     )
@@ -100,10 +124,19 @@ def test_build_rows_includes_unbound_aggregator_config():
         '-',
         '5,000',
         'PORT|IF_IN_UCAST_PKTS',
-        '-',
-        '-',
-        '-'
+        '1,000,000',
+        'PORT|IF_OUT_OCTETS',
+        '128',
+        'PORT|IF_OUT_OCTETS: 0,1000'
     ]]
+
+
+def test_format_aggregator_only_defaults_buckets_for_configured_heatmap():
+    assert show_hft._format_aggregator({})[-2:] == ('-', '-')
+    assert show_hft._format_aggregator({
+        'heatmap_interval': '1000',
+        'heatmap_counters': ['PORT|IF_OUT_OCTETS']
+    })[-2:] == ('256', '-')
 
 
 def test_format_poll_interval_variants():
@@ -163,8 +196,11 @@ def test_execute_streaming_command_exits_on_unhandled_return_code(monkeypatch):
 
 
 def test_display_hft_outputs_table(capsys):
+    requested_tables = []
+
     class MockCfgDb:
         def get_table(self, name):
+            requested_tables.append(name)
             if name == show_hft.PROFILE_TABLE:
                 return {
                     'p1': {'stream_state': 'enabled', 'poll_interval': '1000'}
@@ -188,6 +224,9 @@ def test_display_hft_outputs_table(capsys):
     assert 'p1' in output
     assert 'Ethernet0' in output
     assert 'BYTES' in output
+    assert 'Heatmap Default Buckets' in output
+    assert 'Per-counter Explicit Bounds' in output
+    assert show_hft.AGGREGATOR_HISTOGRAM_TABLE in requested_tables
 
 
 def test_format_list_parses_json_array():

--- a/tests/show_hft_test.py
+++ b/tests/show_hft_test.py
@@ -29,10 +29,13 @@ def test_build_rows_with_mixed_profiles_and_groups():
     rows = show_hft._build_rows(profile_table, group_table)
 
     assert rows == [
-        ['profile2', 'disabled', '15', '-', 'PORT', 'Ethernet0\nEthernet1', 'COUNTER0\nCOUNTER2', '-', '-', '-'],
-        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', ''],
-        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
-        ['profile10', 'enabled', '2,000', '-', 'BUFFER_POOL', '-', '-', '-', '-', '-']
+        [
+            'profile2', 'disabled', '15', '-', 'PORT', 'Ethernet0\nEthernet1',
+            'COUNTER0\nCOUNTER2', '-', '-', '-', '-', '-'
+        ],
+        ['', '', '', '', 'QUEUE', '-', 'QUEUE_OCCUPANCY', '', '', '', '', ''],
+        ['profile3', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-'],
+        ['profile10', 'enabled', '2,000', '-', 'BUFFER_POOL', '-', '-', '-', '-', '-', '-', '-']
     ]
 
 
@@ -50,7 +53,9 @@ def test_build_rows_with_aggregator_config():
         'ag0': {
             'reporting_rate': '5000',
             'rollover_counters': ['PORT|IF_IN_UCAST_PKTS', 'QUEUE|DROPPED_PACKETS'],
-            'heatmap_counters': 'PORT|IF_OUT_ERRORS,QUEUE|WRED_ECN_MARKED_PACKETS'
+            'heatmap_interval': '1000000',
+            'heatmap_counters': 'PORT|IF_OUT_ERRORS,QUEUE|WRED_ECN_MARKED_PACKETS',
+            'heatmap_bucket_boundaries': [0, 1024, 4096]
         }
     }
 
@@ -66,7 +71,9 @@ def test_build_rows_with_aggregator_config():
         'IF_IN_UCAST_PKTS',
         '5,000',
         'PORT|IF_IN_UCAST_PKTS\nQUEUE|DROPPED_PACKETS',
-        'PORT|IF_OUT_ERRORS\nQUEUE|WRED_ECN_MARKED_PACKETS'
+        '1,000,000',
+        'PORT|IF_OUT_ERRORS\nQUEUE|WRED_ECN_MARKED_PACKETS',
+        '0\n1024\n4096'
     ]]
 
 
@@ -93,6 +100,8 @@ def test_build_rows_includes_unbound_aggregator_config():
         '-',
         '5,000',
         'PORT|IF_IN_UCAST_PKTS',
+        '-',
+        '-',
         '-'
     ]]
 


### PR DESCRIPTION
**What I did**

Added HFT aggregator configuration and display support to the `config` and `show` CLIs.

This PR adds:

- `config hft add aggregator <name>`.
- Optional `--reporting_rate` and `--rollover_counters` methods.
- Independent `--heatmap_interval`, `--heatmap_counters`, and `--heatmap_bucket_boundaries` options.
- Positive `uint32` validation for both intervals.
- Strictly increasing heatmap bounds in the exact OTLP range from 0 through `2^53`.
- All-or-none validation for the three heatmap options.
- Aggregator bind/unbind support on HFT profiles.
- Referenced-aggregator delete protection.
- `show hft` columns for reporting rate, rollover counters, heatmap interval, heatmap counters, and bucket boundaries.

The runtime contract executes methods as:

`rollover(raw samples) -> reporting -> heatmap`

Reporting and heatmap intervals are independent and use microseconds.

**Why I did it**

This exposes the schema defined by sonic-net/SONiC#2079 and sonic-net/sonic-buildimage#28009, including the independent heatmap duration required by sonic-net/sonic-swss#4691.

**How I verified it**

Ran targeted HFT CLI tests in a `sonic-slave-bookworm` environment:

`pytest --noconftest -q tests/config_hft_test.py tests/show_hft_test.py`

Result: 32 passed.

Also ran Python compile checks for all four modified Python files. Tests cover payload generation, independent methods, missing heatmap fields, interval overflow, unordered/out-of-range bounds, bind/unbind, delete protection, and show row formatting.

**Details if related**

Related PRs:

- sonic-net/SONiC#2079
- sonic-net/sonic-buildimage#28009
- sonic-net/sonic-swss#4691
