### PR TITLE
[cSONiC] Make show CLI work in docker-sonic-vs neighbors (no nested docker/rvtysh)

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import sys
 import re
@@ -91,6 +92,15 @@ COMMAND_TIMEOUT = 300
 # bash oneliner. To be revisited once routing-stack info is tracked somewhere.
 def get_routing_stack():
     result = 'frr'
+
+    # The bash one-liner below relies on a nested "bgp" docker container, which
+    # only exists on a real SONiC device. On single-container images such as
+    # docker-sonic-vs (used as cSONiC neighbors in the KVM testbed) there is no
+    # nested docker, so the command would emit "sudo: docker: command not found"
+    # on every show invocation. Skip it and keep the default ('frr') in that case.
+    if shutil.which('docker') is None:
+        return result
+
     command = "sudo docker ps --format '{{.Image}}\t{{.Names}}' | awk '$2 ~ /^bgp([0-9]+)?$/' | cut -d'-' -f3 | cut -d':' -f1 | head -n 1"  # noqa: E501
 
     try:

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -1679,3 +1679,69 @@ class TestShowSwitchCounters(object):
     @patch("utilities_common.cli.run_command")
     def test_switch_stats_period(self, mock_run_command, command, options, expected):
         self.verify_stats(mock_run_command, command, options, expected)
+
+
+class TestCsonicNeighborEnv(object):
+    """Tests for cSONiC (docker-sonic-vs) single-container neighbor environments
+    where the nested 'bgp' docker container and the 'rvtysh' wrapper do not
+    exist. See sonic-utilities issue #4632.
+    """
+
+    def setup_method(self):
+        print('SETUP')
+
+    def test_get_routing_stack_no_docker_skips_oneliner(self):
+        # When the 'docker' binary is absent (docker-sonic-vs neighbor), the
+        # docker ps one-liner must NOT run, and the default 'frr' is returned.
+        with mock.patch('show.main.shutil.which', return_value=None), \
+                mock.patch('show.main.subprocess.check_output',
+                           side_effect=AssertionError("docker oneliner should not run")) \
+                as mock_check_output:
+            assert show.get_routing_stack() == 'frr'
+            mock_check_output.assert_not_called()
+
+    def test_get_routing_stack_with_docker_runs_oneliner(self):
+        # When 'docker' is present (real SONiC), the one-liner runs and its
+        # output determines the routing stack.
+        with mock.patch('show.main.shutil.which', return_value='/usr/bin/docker'), \
+                mock.patch('show.main.subprocess.check_output',
+                           return_value='quagga\n') as mock_check_output:
+            assert show.get_routing_stack() == 'quagga'
+            mock_check_output.assert_called_once()
+
+    def test_run_bgp_show_command_falls_back_to_vtysh(self):
+        # When 'rvtysh' is absent (docker-sonic-vs neighbor), run_bgp_show_command
+        # must fall back to the plain 'vtysh' binary instead of 'rvtysh'.
+        captured = {}
+
+        def fake_run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd, exit_on_fail):
+            captured['shell'] = vtysh_shell_cmd
+            return "{}"
+
+        def fake_which(cmd):
+            # rvtysh missing, vtysh present
+            return None if cmd == constants.RVTYSH_COMMAND else '/usr/bin/vtysh'
+
+        with mock.patch('utilities_common.bgp_util.shutil.which', side_effect=fake_which), \
+                mock.patch('utilities_common.bgp_util.run_bgp_command',
+                           side_effect=fake_run_bgp_command):
+            bgp_util.run_bgp_show_command("show ip bgp summary json")
+            assert captured['shell'] == constants.VTYSH_COMMAND
+
+    def test_run_bgp_show_command_uses_rvtysh_when_present(self):
+        # When 'rvtysh' is present (real SONiC), it is used as before.
+        captured = {}
+
+        def fake_run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd, exit_on_fail):
+            captured['shell'] = vtysh_shell_cmd
+            return "{}"
+
+        with mock.patch('utilities_common.bgp_util.shutil.which',
+                        return_value='/usr/bin/rvtysh'), \
+                mock.patch('utilities_common.bgp_util.run_bgp_command',
+                           side_effect=fake_run_bgp_command):
+            bgp_util.run_bgp_show_command("show ip bgp summary json")
+            assert captured['shell'] == constants.RVTYSH_COMMAND
+
+    def teardown_method(self):
+        print('TEAR DOWN')

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -1,6 +1,7 @@
 import ipaddress
 import json
 import re
+import shutil
 import sys
 
 import click
@@ -262,7 +263,15 @@ def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE,
 
 
 def run_bgp_show_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, exit_on_fail=True):
-    output = run_bgp_command(vtysh_cmd, bgp_namespace, constants.RVTYSH_COMMAND, exit_on_fail)
+    # RVTYSH is a routing-stack-aware wrapper that execs into the nested "bgp"
+    # docker container on a real SONiC device. On single-container images such
+    # as docker-sonic-vs (cSONiC neighbors in the KVM testbed) the wrapper does
+    # not exist, so fall back to the plain vtysh binary to avoid failing with
+    # "sudo: rvtysh: command not found".
+    vtysh_shell_cmd = constants.RVTYSH_COMMAND
+    if shutil.which(vtysh_shell_cmd) is None:
+        vtysh_shell_cmd = constants.VTYSH_COMMAND
+    output = run_bgp_command(vtysh_cmd, bgp_namespace, vtysh_shell_cmd, exit_on_fail)
     # handle the the alias mode in the following code
     if output is not None:
         if clicommon.get_interface_naming_mode() == "alias" and re.search("show ip|ipv6 route", vtysh_cmd):


### PR DESCRIPTION
#### Why I did it

In `docker-sonic-vs` containers used as **cSONiC neighbors** in the sonic-mgmt KVM testbed, FRR runs inside the same container — there is **no nested `bgp` docker container** and **no `rvtysh` wrapper**. Two `sonic-utilities` code paths assume the real-SONiC layout, so every relevant `show` command either leaks an error to stderr or fails outright:

1. `show/main.py::get_routing_stack()` runs a `sudo docker ps ...` one-liner at **module import time** (`routing_stack = get_routing_stack()` global). It therefore executes on *every* `show` invocation — even `show ... --help` — printing:
   ```
   sudo: docker: command not found
   ```
   The `try/except` does default to `'frr'`, so the value is correct, but the stderr leak is unconditional. The function's own `# To be enhanced` comment already flags this one-liner as undesirable.

2. `utilities_common/bgp_util.py::run_bgp_show_command()` uses `RVTYSH_COMMAND = 'rvtysh'`, the routing-stack-aware wrapper that `docker exec`s into the `bgp` container on real SONiC. In `docker-sonic-vs` the wrapper does not exist, so commands fail with:
   ```
   sudo: rvtysh: command not found
   ```

In a cSONiC neighbor only the plain `vtysh` binary exists (`command -v rvtysh` → not found; `command -v vtysh` → `/usr/bin/vtysh`).

Resolves sonic-net/sonic-utilities#4632. This is the `sonic-utilities` counterpart to the cSONiC neighbor-environment gaps tracked in sonic-mgmt (e.g. #22647, #22648).

#### How I did it

- `get_routing_stack()`: short-circuit and return the default `'frr'` when the `docker` binary is not present (`shutil.which('docker') is None`), so the bash one-liner never runs on single-container images and no stderr is leaked. Behavior on real SONiC (docker present) is unchanged.
- `run_bgp_show_command()`: select the vtysh wrapper at runtime — use `rvtysh` when it is present in `PATH` (real SONiC), otherwise fall back to the plain `vtysh` binary (docker-sonic-vs). No change to the argv/return contract.
- Added unit tests in `tests/show_test.py` (`TestCsonicNeighborEnv`) covering both docker-present/absent paths of `get_routing_stack()` and both rvtysh-present/absent paths of `run_bgp_show_command()`.

#### How to verify it

Run the new unit tests:
```
pytest tests/show_test.py -k TestCsonicNeighborEnv
```

Manual verification on a live cSONiC neighbor (`docker-sonic-vs`) — before vs after this change:

Before:
```
# show ip --help        -> "sudo: docker: command not found" (leaked on stderr)
# show ip route         -> "sudo: rvtysh: command not found"
# show ip bgp summary   -> error / no output
```

After (verified):
```
# show ip --help        -> clean, no stderr leak
# show ip route         -> full FRR routing table
# show ip bgp summary   -> full IPv4 Unicast BGP summary (4 neighbors, real PfxRcd)
```

#### Which release branch to backport (provide reason below if selected)

<!-- Maintainers: consider 202xxx if cSONiC testbeds are used on those branches. -->

#### Description for the changelog

Make the `show` CLI work in `docker-sonic-vs` (cSONiC) neighbor containers: skip the `docker ps` routing-stack probe when docker is absent, and fall back from `rvtysh` to `vtysh` when the `rvtysh` wrapper is not present.
