### PR TITLE
[clear] Add 'sonic-clear pfcwdstats' to clear PFC watchdog counters

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -208,6 +208,14 @@ def pfccounters():
     command = ["pfcstat", "-c"]
     run_command(command)
 
+
+@cli.command()
+def pfcwdstats():
+    """Clear PFC Watchdog stats counters"""
+    command = ["pfcwdstat", "-c"]
+    run_command(command)
+
+
 @cli.command()
 def dropcounters():
     """Clear drop counters"""

--- a/scripts/pfcwdstat
+++ b/scripts/pfcwdstat
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+"""
+pfcwdstat - PFC Watchdog statistics tool
+
+Usage:
+    pfcwdstat -c      Clear PFCWD stats
+"""
+
+import argparse
+import sys
+from swsscommon.swsscommon import SonicV2Connector
+
+PFC_WD_STATS_FIELDS = [
+    'PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED',
+    'PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED',
+    'PFC_WD_QUEUE_STATS_TX_PACKETS',
+    'PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS',
+    'PFC_WD_QUEUE_STATS_RX_PACKETS',
+    'PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS',
+    'PFC_WD_QUEUE_STATS_TX_PACKETS_LAST',
+    'PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS_LAST',
+    'PFC_WD_QUEUE_STATS_RX_PACKETS_LAST',
+    'PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS_LAST',
+]
+
+def clear_stats():
+    """Zero out PFCWD stats in COUNTERS_DB.
+
+    Enumerates all queues via COUNTERS_QUEUE_NAME_MAP — the same source
+    'show pfcwd stats' uses — so stale stats from queues that are no longer
+    actively monitored (PFC_WD_TABLE entries gone, STATUS=N/A) are also cleared.
+
+    Queues with an active storm (PFC_WD_STATUS == 'stormed') are skipped.
+    """
+    db = SonicV2Connector()
+    db.connect(db.COUNTERS_DB)
+
+    queue_name_map = db.get_all(db.COUNTERS_DB, 'COUNTERS_QUEUE_NAME_MAP')
+    if not queue_name_map:
+        print("No PFC Watchdog stats found.")
+        return
+
+    cleared = False
+    skipped = []
+    for queue_name, queue_oid in queue_name_map.items():
+        counter_key = 'COUNTERS:' + queue_oid
+        stats = db.get_all(db.COUNTERS_DB, counter_key)
+        if not stats:
+            continue
+        if not any(f in stats for f in PFC_WD_STATS_FIELDS):
+            continue
+        if stats.get('PFC_WD_STATUS') == 'stormed':
+            skipped.append(queue_name)
+            continue
+        for field in PFC_WD_STATS_FIELDS:
+            db.set(db.COUNTERS_DB, counter_key, field, '0')
+        cleared = True
+
+    if cleared:
+        print("PFC Watchdog counters cleared.")
+    elif not skipped:
+        print("No PFC Watchdog stats found.")
+
+    if skipped:
+        print("Skipped queue(s) with an active storm (not cleared): {}".format(
+            ', '.join(sorted(skipped))))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='PFC Watchdog statistics tool'
+    )
+    parser.add_argument('-c', '--clear', action='store_true',
+                        help='Clear PFCWD stats')
+    args = parser.parse_args()
+
+    if args.clear:
+        clear_stats()
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ setup(
         'scripts/portconfig',
         'scripts/portstat',
         'scripts/pfcstat',
+        'scripts/pfcwdstat',
         'scripts/psushow',
         'scripts/queuestat',
         'scripts/reboot',

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -102,6 +102,13 @@ class TestClear(object):
         run_command.assert_called_with(['fdbclear'])
 
     @patch('clear.main.run_command')
+    def test_clear_pfcwdstats(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['pfcwdstats'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['pfcwdstat', '-c'])
+
+    @patch('clear.main.run_command')
     def test_clear_srv6counters(self, run_command):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands['srv6counters'])

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -1027,3 +1027,166 @@ class TestMultiAsicPfcwdShow(object):
         importlib.reload(mock_tables.mock_single_asic)
         import pfcwd.main
         importlib.reload(pfcwd.main)
+
+
+class TestPfcwdstatClear(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        scripts_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'scripts'
+        )
+        import importlib.util
+        from importlib.machinery import SourceFileLoader
+        script_path = os.path.join(scripts_path, "pfcwdstat")
+        loader = SourceFileLoader("pfcwdstat", script_path)
+        spec = importlib.util.spec_from_loader("pfcwdstat", loader, origin=script_path)
+        cls.pfcwdstat = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.pfcwdstat)
+        sys.modules['pfcwdstat'] = cls.pfcwdstat
+
+    def _make_mock_db(self, queue_name_map=None, counters=None):
+        mock_db = MagicMock()
+        mock_db.COUNTERS_DB = 'COUNTERS_DB'
+
+        def get_all(db_id, key):
+            if key == 'COUNTERS_QUEUE_NAME_MAP':
+                return queue_name_map
+            return (counters or {}).get(key)
+
+        mock_db.get_all.side_effect = get_all
+        return mock_db
+
+    def _pfc_wd_counters(self, value='100', status='operational'):
+        """Return a COUNTERS hash with all PFC_WD stats fields set to value."""
+        fields = {f: value for f in self.pfcwdstat.PFC_WD_STATS_FIELDS}
+        fields['PFC_WD_STATUS'] = status
+        return fields
+
+    @patch('pfcwdstat.SonicV2Connector')
+    def test_clear_single_queue(self, mock_connector):
+        oid = 'oid:0x100'
+        mock_db = self._make_mock_db(
+            queue_name_map={'Ethernet0:3': oid},
+            counters={'COUNTERS:' + oid: self._pfc_wd_counters()},
+        )
+        mock_connector.return_value = mock_db
+
+        self.pfcwdstat.clear_stats()
+
+        assert mock_db.set.call_count == len(self.pfcwdstat.PFC_WD_STATS_FIELDS)
+        assert all(c[0][1] == 'COUNTERS:' + oid for c in mock_db.set.call_args_list)
+        assert all(c[0][3] == '0' for c in mock_db.set.call_args_list)
+
+    @patch('pfcwdstat.SonicV2Connector')
+    def test_clear_multiple_queues(self, mock_connector):
+        oid_map = {
+            'Ethernet0:3': 'oid:0x100',
+            'Ethernet0:4': 'oid:0x200',
+            'Ethernet4:3': 'oid:0x300',
+        }
+        counters = {
+            'COUNTERS:' + oid: self._pfc_wd_counters()
+            for oid in oid_map.values()
+        }
+        mock_db = self._make_mock_db(queue_name_map=oid_map, counters=counters)
+        mock_connector.return_value = mock_db
+
+        self.pfcwdstat.clear_stats()
+
+        num_fields = len(self.pfcwdstat.PFC_WD_STATS_FIELDS)
+        assert mock_db.set.call_count == num_fields * 3
+        counter_keys = {c[0][1] for c in mock_db.set.call_args_list}
+        assert counter_keys == {
+            'COUNTERS:oid:0x100',
+            'COUNTERS:oid:0x200',
+            'COUNTERS:oid:0x300',
+        }
+
+    @patch('pfcwdstat.SonicV2Connector')
+    def test_clear_no_entries(self, mock_connector):
+        mock_db = self._make_mock_db(queue_name_map=None)
+        mock_connector.return_value = mock_db
+
+        self.pfcwdstat.clear_stats()
+
+        mock_db.set.assert_not_called()
+
+    @patch('pfcwdstat.SonicV2Connector')
+    def test_clear_skips_queue_without_pfc_wd_stats(self, mock_connector):
+        """Queues that have no PFC_WD_QUEUE_STATS_* fields are not touched."""
+        oid = 'oid:0x100'
+        mock_db = self._make_mock_db(
+            queue_name_map={'Ethernet0:3': oid},
+            counters={'COUNTERS:' + oid: {'SAI_QUEUE_STAT_PACKETS': '500'}},
+        )
+        mock_connector.return_value = mock_db
+
+        self.pfcwdstat.clear_stats()
+
+        mock_db.set.assert_not_called()
+
+    @patch('pfcwdstat.SonicV2Connector')
+    def test_clear_stale_stats_no_pfc_wd_table(self, mock_connector):
+        """Stats from inactive queues (PFC_WD_TABLE gone, STATUS=N/A) are cleared.
+
+        An implementation that enumerates queues via PFC_WD_TABLE|* would bail
+        with 'No PFC Watchdog stats found.' when pfcwd is no longer active,
+        leaving residual stats that 'show pfcwd stats' continues to render.
+        """
+        oid = 'oid:0x15000000000032'
+        # No PFC_WD_STATUS field — mirrors the inactive/stale state
+        stale_counters = {f: '100' for f in self.pfcwdstat.PFC_WD_STATS_FIELDS}
+        mock_db = self._make_mock_db(
+            queue_name_map={'Ethernet32:4': oid},
+            counters={'COUNTERS:' + oid: stale_counters},
+        )
+        mock_connector.return_value = mock_db
+
+        self.pfcwdstat.clear_stats()
+
+        assert mock_db.set.call_count == len(self.pfcwdstat.PFC_WD_STATS_FIELDS)
+        assert all(c[0][1] == 'COUNTERS:' + oid for c in mock_db.set.call_args_list)
+        assert all(c[0][3] == '0' for c in mock_db.set.call_args_list)
+
+    @patch('pfcwdstat.SonicV2Connector')
+    def test_clear_skips_active_storm_queue(self, mock_connector):
+        """A queue with an active storm (PFC_WD_STATUS == 'stormed') is not
+        cleared, so the in-flight DEADLOCK_DETECTED/RESTORED pair is not split
+        (which would otherwise leave RESTORED > DETECTED once the storm ends)."""
+        oid = 'oid:0x100'
+        mock_db = self._make_mock_db(
+            queue_name_map={'Ethernet384:3': oid},
+            counters={'COUNTERS:' + oid: self._pfc_wd_counters(status='stormed')},
+        )
+        mock_connector.return_value = mock_db
+
+        self.pfcwdstat.clear_stats()
+
+        mock_db.set.assert_not_called()
+
+    @patch('pfcwdstat.SonicV2Connector')
+    def test_clear_mixed_storm_and_idle(self, mock_connector):
+        """Stormed queues are skipped while non-stormed queues are still cleared
+        in the same invocation."""
+        stormed_oid = 'oid:0x100'
+        idle_oid = 'oid:0x200'
+        mock_db = self._make_mock_db(
+            queue_name_map={'Ethernet0:3': stormed_oid, 'Ethernet4:3': idle_oid},
+            counters={
+                'COUNTERS:' + stormed_oid: self._pfc_wd_counters(status='stormed'),
+                'COUNTERS:' + idle_oid: self._pfc_wd_counters(status='operational'),
+            },
+        )
+        mock_connector.return_value = mock_db
+
+        self.pfcwdstat.clear_stats()
+
+        # Only the non-stormed (idle) queue is zeroed.
+        assert mock_db.set.call_count == len(self.pfcwdstat.PFC_WD_STATS_FIELDS)
+        assert all(c[0][1] == 'COUNTERS:' + idle_oid for c in mock_db.set.call_args_list)
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")


### PR DESCRIPTION
#### What I did

There is currently no CLI to clear PFC watchdog statistics. Clearing them is needed when troubleshooting PFC storms — stale counts from a prior event make it hard to tell whether a storm is currently ongoing. `show pfcwd stats` displays the counters, but there is no corresponding clear command. This PR adds `sonic-clear pfcwdstats`.

Addresses the PFC-watchdog-counter-clear item in #4595.

#### How I did it

- `scripts/pfcwdstat`: new tool that zeroes the `PFC_WD_QUEUE_STATS_*` fields in `COUNTERS_DB`, following the standard counter-clear pattern (`pfcstat -c`, `queuestat -c`, …). It enumerates queues via `COUNTERS_QUEUE_NAME_MAP` — the same source `show pfcwd stats` uses — so stale stats from queues that are no longer actively monitored (`STATUS=N/A`) are also cleared.
- Queues with an active storm (`PFC_WD_STATUS == 'stormed'`) are skipped, so the in-flight `DEADLOCK_DETECTED`/`DEADLOCK_RESTORED` pair is not split (which would otherwise leave `RESTORED > DETECTED` once the storm ends).
- `clear/main.py`: adds `sonic-clear pfcwdstats`, invoking `pfcwdstat -c`.
- `setup.py`: installs `scripts/pfcwdstat`.
- Unit tests for the clear command and the `pfcwdstat` clear logic (including the stale-stats and active-storm cases).

#### How to verify it

```
pytest tests/pfcwd_test.py::TestPfcwdstatClear tests/clear_test.py -k pfcwd
```

Manually: `show pfcwd stats` to see counts, `sonic-clear pfcwdstats` to clear them; an actively storming queue is left untouched (and reported as skipped) until the storm ends.

#### Previous command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ show pfcwd stats
        QUEUE       STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
-------------  -----------  -------------------------  ------------  ------------  -----------------  -----------------
Ethernet192:3  operational                        1/1           0/0           0/0                0/0                0/0
```

#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sonic-clear pfcwdstats
PFC Watchdog counters cleared.

admin@sonic:~$ show pfcwd stats
  QUEUE    STATUS    STORM DETECTED/RESTORED    TX OK/DROP    RX OK/DROP    TX LAST OK/DROP    RX LAST OK/DROP
-------  --------  -------------------------  ------------  ------------  -----------------  -----------------
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
