### PR TITLE
[clear] Add 'sonic-clear buffer_pool watermark' commands

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -512,6 +512,48 @@ def persistent_watermark(namespace):
         command += ['-n', str(namespace)]
     run_command(command)
 
+
+@cli.group(name='buffer_pool')
+def buffer_pool():
+    """Clear buffer_pool WM"""
+    pass
+
+
+@buffer_pool.command('watermark')
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def wm_buffer_pool(namespace):
+    """Clear user WM for buffer pools."""
+    command = ['watermarkstat', '-c', '-t', 'buffer_pool']
+    if namespace:
+        command += ['-n', str(namespace)]
+    run_command(command)
+    click.echo("Buffer pool watermark counters cleared.")
+
+
+@buffer_pool.command('persistent-watermark')
+@click.option('--namespace',
+              '-n',
+              'namespace',
+              default=None,
+              type=str,
+              show_default=True,
+              help='Namespace name or all',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def pwm_buffer_pool(namespace):
+    """Clear persistent WM for buffer pools."""
+    command = ['watermarkstat', '-c', '-p', '-t', 'buffer_pool']
+    if namespace:
+        command += ['-n', str(namespace)]
+    run_command(command)
+    click.echo("Buffer pool persistent watermark counters cleared.")
+
 #
 # 'arp' command ####
 #

--- a/clear/main.py
+++ b/clear/main.py
@@ -534,7 +534,6 @@ def wm_buffer_pool(namespace):
     if namespace:
         command += ['-n', str(namespace)]
     run_command(command)
-    click.echo("Buffer pool watermark counters cleared.")
 
 
 @buffer_pool.command('persistent-watermark')
@@ -552,7 +551,6 @@ def pwm_buffer_pool(namespace):
     if namespace:
         command += ['-n', str(namespace)]
     run_command(command)
-    click.echo("Buffer pool persistent watermark counters cleared.")
 
 #
 # 'arp' command ####

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -11482,6 +11482,14 @@ This command displays the user persistent-watermark for all the buffer pools
              lossy_pool     2464
   ```
 
+- NOTE: "user watermark" and "persistent watermark" can be cleared by user:
+
+  ```
+  admin@sonic:~$ sonic-clear buffer_pool watermark
+
+  admin@sonic:~$ sonic-clear buffer_pool persistent-watermark
+  ```
+
 
 
 ### QoS config commands

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -109,6 +109,24 @@ class TestClear(object):
         run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'buffer_pool'])
 
     @patch('clear.main.run_command')
+    @patch('clear.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    @patch('utilities_common.multi_asic.multi_asic_namespace_validation_callback', MagicMock(return_value='asic0'))
+    def test_clear_buffer_pool_wm_with_namespace(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['buffer_pool'].commands['watermark'], ['-n', 'asic0'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['watermarkstat', '-c', '-t', 'buffer_pool', '-n', 'asic0'])
+
+    @patch('clear.main.run_command')
+    @patch('clear.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    @patch('utilities_common.multi_asic.multi_asic_namespace_validation_callback', MagicMock(return_value='asic0'))
+    def test_clear_buffer_pool_pst_wm_with_namespace(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['buffer_pool'].commands['persistent-watermark'], ['-n', 'asic0'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'buffer_pool', '-n', 'asic0'])
+
+    @patch('clear.main.run_command')
     def test_clear_fdb(self, run_command):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands['fdb'].commands['all'])

--- a/tests/clear_test.py
+++ b/tests/clear_test.py
@@ -95,6 +95,20 @@ class TestClear(object):
         run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'headroom_pool'])
 
     @patch('clear.main.run_command')
+    def test_clear_buffer_pool_wm(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['buffer_pool'].commands['watermark'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['watermarkstat', '-c', '-t', 'buffer_pool'])
+
+    @patch('clear.main.run_command')
+    def test_clear_buffer_pool_pst_wm(self, run_command):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands['buffer_pool'].commands['persistent-watermark'])
+        assert result.exit_code == 0
+        run_command.assert_called_with(['watermarkstat', '-c', '-p', '-t', 'buffer_pool'])
+
+    @patch('clear.main.run_command')
     def test_clear_fdb(self, run_command):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands['fdb'].commands['all'])


### PR DESCRIPTION
#### What I did

There is no CLI to clear the buffer pool watermarks shown by `show buffer_pool watermark` / `show buffer_pool persistent-watermark`. The neighbouring `sonic-clear headroom-pool` group already exists, and the backend (`watermarkstat -c -t buffer_pool`) is already implemented — only the `sonic-clear` wrapper was missing. This PR adds it.

Addresses the buffer_pool-watermark-clear item in #4595.

#### How I did it

Added a `buffer_pool` clear group to `clear/main.py`, mirroring the existing `headroom-pool` group:

- `sonic-clear buffer_pool watermark` → `watermarkstat -c -t buffer_pool`
- `sonic-clear buffer_pool persistent-watermark` → `watermarkstat -c -p -t buffer_pool`

Both support the `-n/--namespace` option like the other watermark clears. Added unit tests for both.

#### How to verify it

```
pytest tests/clear_test.py -k buffer_pool
```

Manually: `show buffer_pool watermark` to see occupancy, then `sonic-clear buffer_pool watermark`; the watermark resets.

#### Previous command output (if the output of a command-line utility has changed)

New command — `sonic-clear buffer_pool watermark` / `persistent-watermark` did not exist before this PR.

#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sonic-clear buffer_pool watermark
admin@sonic:~$ sonic-clear buffer_pool persistent-watermark
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605


---

#### Tested on 202605 branch

Validated on a Broadcom DNX (Q3D) VOQ chassis running a 202605-based image.

- **Image version:** `SONiC.202605.Nexthop.152445-e5b6d3c8c7`
- **Platform / HwSKU:** `x86_64-nexthop_5010-r0` / `NH-5010-F-O64` (broadcom, Q3D)
- **Branch:** 202605 (this change is present on the branch under test; the cherry-pick of this PR onto `202605` applies cleanly with no conflicts)

Run as the non-root `admin` user:

```
admin@sonic:~$ show version | head -3

SONiC Software Version: SONiC.202605.Nexthop.152445-e5b6d3c8c7
SONiC OS Version: 13

admin@sonic:~$ sonic-clear buffer_pool --help
Usage: sonic-clear buffer_pool [OPTIONS] COMMAND [ARGS]...

  Clear buffer_pool WM

Options:
  -h, -?, --help  Show this message and exit.

Commands:
  persistent-watermark  Clear persistent WM for buffer pools.
  watermark             Clear user WM for buffer pools.

admin@sonic:~$ show buffer_pool watermark
Shared pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool    13712

admin@sonic:~$ sonic-clear buffer_pool watermark

admin@sonic:~$ show buffer_pool watermark
Shared pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool        0

admin@sonic:~$ show buffer_pool persistent-watermark
Shared pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool    13712

admin@sonic:~$ sonic-clear buffer_pool persistent-watermark

admin@sonic:~$ show buffer_pool persistent-watermark
Shared pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
ingress_lossless_pool        0
```

Both clears take effect (`13712` -> `0`), confirming the watermark is actually reset rather than the command merely returning success.

Unit tests covering these commands also pass on the 202605 branch:

```
PASSED tests/clear_test.py::TestClear::test_clear_buffer_pool_wm
PASSED tests/clear_test.py::TestClear::test_clear_buffer_pool_pst_wm
```

**Nature of the change:** new feature — adds two `sonic-clear` subcommands; no existing command behaviour is modified.
