### PR TITLE
pddf fanutil improvments

### DIFF
--- a/pddf_fanutil/main.py
+++ b/pddf_fanutil/main.py
@@ -129,7 +129,7 @@ def direction(index):
 @cli.command()
 @click.option('-i', '--index', default=-1, type=int, help="Index of FAN (1-based)")
 def getspeed(index):
-    """Display FAN speed in RPM"""
+    """Display FAN speed in RPM and duty cycle percentage"""
     fan_list = []
     if (index < 0):
         fan_list = platform_chassis.get_all_fans()
@@ -138,13 +138,14 @@ def getspeed(index):
         fan_list = platform_chassis.get_fan(index-1)
         default_index = index-1
 
-    header = ['FAN', 'SPEED (RPM)']
+    header = ['FAN', 'SPEED (RPM)', 'DUTY CYCLE (%)']
     speed_table = []
 
     for idx, fan in enumerate(fan_list, default_index):
         fan_name = helper.try_get(fan.get_name, "Fan {}".format(idx+1))
         rpm = helper.try_get(fan.get_speed_rpm, 'N/A')
-        speed_table.append([fan_name, rpm])
+        pct = helper.try_get(fan.get_speed, 'N/A')
+        speed_table.append([fan_name, rpm, pct])
 
     if speed_table:
         click.echo(tabulate(speed_table, header, tablefmt="simple"))
@@ -160,7 +161,10 @@ def setspeed(speed):
         raise click.Abort()
 
     fan_list = platform_chassis.get_all_fans()
+    any_present = False
     for idx, fan in enumerate(fan_list):
+        if fan.get_presence():
+            any_present = True
         try:
             status = fan.set_speed(speed)
         except NotImplementedError:
@@ -171,7 +175,9 @@ def setspeed(speed):
             click.echo("Failed")
             sys.exit(1)
 
-    click.echo("Successful")
+    click.echo("Set fan speed to {}%".format(speed))
+    if not any_present:
+        click.echo("Warning: No fans detected.")
 
 
 @cli.group()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Improved fan pddf CLI output pddf_fanutil getspeed also shows duty cycle.

#### How I did it
Reporting the percentage that the fans are set to with show speed

#### How to verify it
Run sudo pddf_fanutil getspeed and confirm it shows the duty cycle set.

#### Previous command output (if the output of a command-line utility has changed)
sudo pddf_fanutil getspeed would not show DUTY Cycle. This could be confusing as setspeed uses duty cycle.


#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sudo pddf_fanutil getspeed
FAN           SPEED (RPM)    DUTY CYCLE (%)
----------  -------------  ----------------
Fantray1_1           6093                30
Fantray1_2           5199                30
Fantray2_1           6093                30
Fantray2_2           5227                30
Fantray3_1           6112                30
Fantray3_2           5270                30
Fantray4_1           6093                30
Fantray4_2           5213                30
Fantray5_1            233                30
Fantray5_2              0                30
Fantray6_1            233                30
Fantray6_2              0                30
Fantray7_1           6132                30
Fantray7_2           5213                30
Fantray8_1            233                30
Fantray8_2              0                30


```