### PR TITLE
config: support link-local IPv6 on VLAN subinterfaces

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -7120,6 +7120,50 @@ def disable():
 # 'config interface ipv6 enable use-link-local-only <interface-name>'
 #
 
+def _get_ipv6_ll_intf_type(interface_name):
+    """Map an interface name (full or shortname) to the CONFIG_DB table used
+    for ipv6_use_link_local_only.
+    """
+    table_name = get_interface_table_name(interface_name)
+    if table_name in ("INTERFACE", "PORTCHANNEL_INTERFACE",
+                      "VLAN_INTERFACE", "VLAN_SUB_INTERFACE"):
+        return table_name
+    return ""
+
+
+def _validate_ipv6_ll_interface(ctx, db, interface_name, interface_type):
+    """Shared validation for ipv6 link-local enable/disable commands."""
+    if not interface_type:
+        ctx.fail("'interface_name' is not valid. Valid names "
+                 "[Ethernet/Eth/PortChannel/Po/Vlan/Sub-interface]")
+
+    if interface_type == "VLAN_INTERFACE":
+        if not clicommon.is_valid_vlan_interface(db, interface_name):
+            ctx.fail("Interface name %s is invalid."
+                     " Please enter a valid interface name!!"
+                     % (interface_name))
+    else:
+        if interface_name_is_valid(db, interface_name) is False:
+            ctx.fail("Interface name %s is invalid."
+                     " Please enter a valid interface name!!"
+                     % (interface_name))
+
+    is_sub_intf = VLAN_SUB_INTERFACE_SEPARATOR in interface_name
+    if not is_sub_intf:
+        portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
+        if interface_is_in_portchannel(portchannel_member_table,
+                                       interface_name):
+            ctx.fail("{} is configured as a member of portchannel."
+                     " Cannot configure the IPv6 link local mode!"
+                     .format(interface_name))
+
+        vlan_member_table = db.get_table('VLAN_MEMBER')
+        if interface_is_in_vlan(vlan_member_table, interface_name):
+            ctx.fail("{} is configured as a member of vlan."
+                     " Cannot configure the IPv6 link local mode!"
+                     .format(interface_name))
+
+
 @enable.command('use-link-local-only')
 @click.pass_context
 @click.argument('interface_name', metavar='<interface_name>', required=True)
@@ -7132,43 +7176,8 @@ def enable_use_link_local_only(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    is_sub_intf = VLAN_SUB_INTERFACE_SEPARATOR in interface_name
-
-    if is_sub_intf and (interface_name.startswith("Ethernet") or interface_name.startswith("PortChannel")):
-        interface_type = "VLAN_SUB_INTERFACE"
-    elif interface_name.startswith("Ethernet"):
-        interface_type = "INTERFACE"
-    elif interface_name.startswith("PortChannel"):
-        interface_type = "PORTCHANNEL_INTERFACE"
-    elif interface_name.startswith("Vlan"):
-        interface_type = "VLAN_INTERFACE"
-    else:
-        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Sub-interface]")
-
-    if interface_type == "VLAN_SUB_INTERFACE":
-        if interface_name_is_valid(db, interface_name) is False:
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
-    elif (interface_type == "INTERFACE") or (interface_type == "PORTCHANNEL_INTERFACE"):
-        if interface_name_is_valid(db, interface_name) is False:
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
-    elif interface_type == "VLAN_INTERFACE":
-        if not clicommon.is_valid_vlan_interface(db, interface_name):
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
-
-    if not is_sub_intf:
-        portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
-
-        if interface_is_in_portchannel(portchannel_member_table, interface_name):
-            ctx.fail("{} is configured as a member of portchannel."
-                     " Cannot configure the IPv6 link local mode!"
-                     .format(interface_name))
-
-        vlan_member_table = db.get_table('VLAN_MEMBER')
-
-        if interface_is_in_vlan(vlan_member_table, interface_name):
-            ctx.fail("{} is configured as a member of vlan."
-                     " Cannot configure the IPv6 link local mode!"
-                     .format(interface_name))
+    interface_type = _get_ipv6_ll_intf_type(interface_name)
+    _validate_ipv6_ll_interface(ctx, db, interface_name, interface_type)
 
     interface_dict = db.get_table(interface_type)
     set_ipv6_link_local_only_on_interface(db, interface_dict, interface_type, interface_name, "enable")
@@ -7189,43 +7198,8 @@ def disable_use_link_local_only(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    is_sub_intf = VLAN_SUB_INTERFACE_SEPARATOR in interface_name
-
-    interface_type = ""
-    if is_sub_intf and (interface_name.startswith("Ethernet") or interface_name.startswith("PortChannel")):
-        interface_type = "VLAN_SUB_INTERFACE"
-    elif interface_name.startswith("Ethernet"):
-        interface_type = "INTERFACE"
-    elif interface_name.startswith("PortChannel"):
-        interface_type = "PORTCHANNEL_INTERFACE"
-    elif interface_name.startswith("Vlan"):
-        interface_type = "VLAN_INTERFACE"
-    else:
-        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Sub-interface]")
-
-    if interface_type == "VLAN_SUB_INTERFACE":
-        if interface_name_is_valid(db, interface_name) is False:
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
-    elif (interface_type == "INTERFACE") or (interface_type == "PORTCHANNEL_INTERFACE"):
-        if interface_name_is_valid(db, interface_name) is False:
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
-    elif interface_type == "VLAN_INTERFACE":
-        if not clicommon.is_valid_vlan_interface(db, interface_name):
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
-
-    if not is_sub_intf:
-        portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
-
-        if interface_is_in_portchannel(portchannel_member_table, interface_name):
-            ctx.fail("{} is configured as a member of portchannel."
-                     " Cannot configure the IPv6 link local mode!"
-                     .format(interface_name))
-
-        vlan_member_table = db.get_table('VLAN_MEMBER')
-        if interface_is_in_vlan(vlan_member_table, interface_name):
-            ctx.fail("{} is configured as a member of vlan."
-                     " Cannot configure the IPv6 link local mode!"
-                     .format(interface_name))
+    interface_type = _get_ipv6_ll_intf_type(interface_name)
+    _validate_ipv6_ll_interface(ctx, db, interface_name, interface_type)
 
     interface_dict = db.get_table(interface_type)
     set_ipv6_link_local_only_on_interface(db, interface_dict, interface_type, interface_name, "disable")

--- a/config/main.py
+++ b/config/main.py
@@ -7132,34 +7132,43 @@ def enable_use_link_local_only(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
-    if interface_name.startswith("Ethernet"):
+    is_sub_intf = VLAN_SUB_INTERFACE_SEPARATOR in interface_name
+
+    if is_sub_intf and (interface_name.startswith("Ethernet") or interface_name.startswith("PortChannel")):
+        interface_type = "VLAN_SUB_INTERFACE"
+    elif interface_name.startswith("Ethernet"):
         interface_type = "INTERFACE"
     elif interface_name.startswith("PortChannel"):
         interface_type = "PORTCHANNEL_INTERFACE"
     elif interface_name.startswith("Vlan"):
         interface_type = "VLAN_INTERFACE"
     else:
-        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
+        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Sub-interface]")
 
-    if (interface_type == "INTERFACE" ) or (interface_type == "PORTCHANNEL_INTERFACE"):
+    if interface_type == "VLAN_SUB_INTERFACE":
         if interface_name_is_valid(db, interface_name) is False:
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
-
-    if (interface_type == "VLAN_INTERFACE"):
+            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
+    elif (interface_type == "INTERFACE") or (interface_type == "PORTCHANNEL_INTERFACE"):
+        if interface_name_is_valid(db, interface_name) is False:
+            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
+    elif interface_type == "VLAN_INTERFACE":
         if not clicommon.is_valid_vlan_interface(db, interface_name):
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
+            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
 
-    portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
+    if not is_sub_intf:
+        portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
 
-    if interface_is_in_portchannel(portchannel_member_table, interface_name):
-        ctx.fail("{} is configured as a member of portchannel. Cannot configure the IPv6 link local mode!"
-                .format(interface_name))
+        if interface_is_in_portchannel(portchannel_member_table, interface_name):
+            ctx.fail("{} is configured as a member of portchannel."
+                     " Cannot configure the IPv6 link local mode!"
+                     .format(interface_name))
 
-    vlan_member_table = db.get_table('VLAN_MEMBER')
+        vlan_member_table = db.get_table('VLAN_MEMBER')
 
-    if interface_is_in_vlan(vlan_member_table, interface_name):
-        ctx.fail("{} is configured as a member of vlan. Cannot configure the IPv6 link local mode!"
-                .format(interface_name))
+        if interface_is_in_vlan(vlan_member_table, interface_name):
+            ctx.fail("{} is configured as a member of vlan."
+                     " Cannot configure the IPv6 link local mode!"
+                     .format(interface_name))
 
     interface_dict = db.get_table(interface_type)
     set_ipv6_link_local_only_on_interface(db, interface_dict, interface_type, interface_name, "enable")
@@ -7180,34 +7189,43 @@ def disable_use_link_local_only(ctx, interface_name):
         if interface_name is None:
             ctx.fail("'interface_name' is None!")
 
+    is_sub_intf = VLAN_SUB_INTERFACE_SEPARATOR in interface_name
+
     interface_type = ""
-    if interface_name.startswith("Ethernet"):
+    if is_sub_intf and (interface_name.startswith("Ethernet") or interface_name.startswith("PortChannel")):
+        interface_type = "VLAN_SUB_INTERFACE"
+    elif interface_name.startswith("Ethernet"):
         interface_type = "INTERFACE"
     elif interface_name.startswith("PortChannel"):
         interface_type = "PORTCHANNEL_INTERFACE"
     elif interface_name.startswith("Vlan"):
         interface_type = "VLAN_INTERFACE"
     else:
-        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan]")
+        ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Sub-interface]")
 
-    if (interface_type == "INTERFACE" ) or (interface_type == "PORTCHANNEL_INTERFACE"):
+    if interface_type == "VLAN_SUB_INTERFACE":
         if interface_name_is_valid(db, interface_name) is False:
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
-
-    if (interface_type == "VLAN_INTERFACE"):
+            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
+    elif (interface_type == "INTERFACE") or (interface_type == "PORTCHANNEL_INTERFACE"):
+        if interface_name_is_valid(db, interface_name) is False:
+            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
+    elif interface_type == "VLAN_INTERFACE":
         if not clicommon.is_valid_vlan_interface(db, interface_name):
-            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" %(interface_name))
+            ctx.fail("Interface name %s is invalid. Please enter a valid interface name!!" % (interface_name))
 
-    portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
+    if not is_sub_intf:
+        portchannel_member_table = db.get_table('PORTCHANNEL_MEMBER')
 
-    if interface_is_in_portchannel(portchannel_member_table, interface_name):
-        ctx.fail("{} is configured as a member of portchannel. Cannot configure the IPv6 link local mode!"
-                .format(interface_name))
+        if interface_is_in_portchannel(portchannel_member_table, interface_name):
+            ctx.fail("{} is configured as a member of portchannel."
+                     " Cannot configure the IPv6 link local mode!"
+                     .format(interface_name))
 
-    vlan_member_table = db.get_table('VLAN_MEMBER')
-    if interface_is_in_vlan(vlan_member_table, interface_name):
-        ctx.fail("{} is configured as a member of vlan. Cannot configure the IPv6 link local mode!"
-                .format(interface_name))
+        vlan_member_table = db.get_table('VLAN_MEMBER')
+        if interface_is_in_vlan(vlan_member_table, interface_name):
+            ctx.fail("{} is configured as a member of vlan."
+                     " Cannot configure the IPv6 link local mode!"
+                     .format(interface_name))
 
     interface_dict = db.get_table(interface_type)
     set_ipv6_link_local_only_on_interface(db, interface_dict, interface_type, interface_name, "disable")

--- a/show/main.py
+++ b/show/main.py
@@ -1636,6 +1636,18 @@ def link_local_mode(namespace, verbose):
                     else:
                         body.append([port, 'Disabled'])
 
+        sub_intf_dict = config_db.get_table('VLAN_SUB_INTERFACE')
+        for sub_intf in sub_intf_dict.keys():
+            if not isinstance(sub_intf, tuple):
+                value = sub_intf_dict[sub_intf]
+                if 'ipv6_use_link_local_only' in value:
+                    if value['ipv6_use_link_local_only'] == 'enable':
+                        body.append([sub_intf, 'Enabled'])
+                    else:
+                        body.append([sub_intf, 'Disabled'])
+                else:
+                    body.append([sub_intf, 'Disabled'])
+
     click.echo(tabulate(body, header, tablefmt="grid"))
 
 #

--- a/tests/ipv6_link_local_test.py
+++ b/tests/ipv6_link_local_test.py
@@ -256,6 +256,42 @@ class TestIPv6LinkLocal(object):
         assert result.exit_code == 0
         assert result.output == ''
 
+    def test_config_enable_disable_ipv6_link_local_on_shortname_sub_interface(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        enable_cmd = (config.config.commands["interface"]
+                      .commands["ipv6"].commands["enable"]
+                      .commands["use-link-local-only"])
+        disable_cmd = (config.config.commands["interface"]
+                       .commands["ipv6"].commands["disable"]
+                       .commands["use-link-local-only"])
+
+        result = runner.invoke(enable_cmd, ["Eth36.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+        result = runner.invoke(disable_cmd, ["Eth36.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+        result = runner.invoke(enable_cmd, ["Po0001.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+        result = runner.invoke(disable_cmd, ["Po0001.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
     def test_config_enable_ipv6_link_local_on_nonexistent_sub_interface(self):
         runner = CliRunner()
         db = Db()
@@ -271,6 +307,42 @@ class TestIPv6LinkLocal(object):
         assert result.exit_code != 0
         assert ('invalid' in result.output.lower()
                 or 'Invalid' in result.output)
+
+    def test_config_enable_ipv6_link_local_on_nonexistent_shortname(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        enable_cmd = (config.config.commands["interface"]
+                      .commands["ipv6"].commands["enable"]
+                      .commands["use-link-local-only"])
+
+        result = runner.invoke(enable_cmd, ["Eth99.99"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'invalid' in result.output.lower()
+
+    def test_config_enable_ipv6_link_local_on_bogus_prefix(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        enable_cmd = (config.config.commands["interface"]
+                      .commands["ipv6"].commands["enable"]
+                      .commands["use-link-local-only"])
+
+        result = runner.invoke(enable_cmd, ["Et36.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'not valid' in result.output
+
+        result = runner.invoke(enable_cmd, ["Foo0.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'not valid' in result.output
 
     def test_show_ipv6_link_local_mode_includes_sub_interfaces(self):
         runner = CliRunner()

--- a/tests/ipv6_link_local_test.py
+++ b/tests/ipv6_link_local_test.py
@@ -92,6 +92,14 @@ show_ipv6_link_local_mode_output="""\
 +------------------+----------+
 | Vlan4000         | Disabled |
 +------------------+----------+
+| Vlan1111         | Disabled |
++------------------+----------+
+| Ethernet0.10     | Disabled |
++------------------+----------+
+| Eth36.10         | Disabled |
++------------------+----------+
+| Po0001.10        | Disabled |
++------------------+----------+
 """
 
 class TestIPv6LinkLocal(object):
@@ -223,6 +231,56 @@ class TestIPv6LinkLocal(object):
         print(result.output)
         assert result.exit_code == 0
         assert result.output == ''
+
+    def test_config_enable_disable_ipv6_link_local_on_sub_interface(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        enable_cmd = (config.config.commands["interface"]
+                      .commands["ipv6"].commands["enable"]
+                      .commands["use-link-local-only"])
+        disable_cmd = (config.config.commands["interface"]
+                       .commands["ipv6"].commands["disable"]
+                       .commands["use-link-local-only"])
+
+        result = runner.invoke(enable_cmd, ["Ethernet0.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+        result = runner.invoke(disable_cmd, ["Ethernet0.10"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == ''
+
+    def test_config_enable_ipv6_link_local_on_nonexistent_sub_interface(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        enable_cmd = (config.config.commands["interface"]
+                      .commands["ipv6"].commands["enable"]
+                      .commands["use-link-local-only"])
+
+        result = runner.invoke(enable_cmd, ["Ethernet0.999"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert ('invalid' in result.output.lower()
+                or 'Invalid' in result.output)
+
+    def test_show_ipv6_link_local_mode_includes_sub_interfaces(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        show_cmd = show.cli.commands["ipv6"].commands["link-local-mode"]
+        result = runner.invoke(show_cmd, [], obj=obj)
+        print(result.output)
+        assert 'Ethernet0.10' in result.output
 
     def test_vlan_member_add_on_link_local_interface(self):
         runner = CliRunner()


### PR DESCRIPTION
## Summary

Add CLI support for IPv6 link-local-only mode on VLAN subinterfaces, including canonical and short subinterface names.

## Why

The configuration and show commands should expose the same link-local-only behavior for VLAN subinterfaces that operators use on routed interfaces. The CLI also needs to validate subinterface names consistently across long and short forms.

## Changes

- Extend `config interface ipv6` handling for VLAN subinterfaces.
- Display link-local-only mode for VLAN subinterfaces in `show ipv6 interfaces`.
- Add command tests for VLAN subinterface configuration and validation.

## Related

- Design proposal: https://github.com/sonic-net/SONiC/pull/2414

## Validation

- `git diff --check upstream/master..HEAD`
- `PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache-sonic-utils python3 -m py_compile config/main.py show/main.py tests/ipv6_link_local_test.py`
- Reviewed the diff for unintended references.
