### PR TITLE
[GCU] Add Arista-7280DR3AM-36 (j2c+) to PFC_WD GCU validator hwsku map

### DIFF
--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -39,7 +39,7 @@
                 "td2": [ "Force10-S6000", "Force10-S6000-Q24S32", "Arista-7050-QX32", "Arista-7050-QX-32S", "Nexus-3164", "Arista-7050QX32S-Q32" ],
                 "td3": [ "Arista-7050CX3-32C-C32", "Arista-7050CX3-32S-C32", "Arista-7050CX3-32S-D48C8", "Arista-7050CX3-32S-C28S4", "Arista-7050CX3-32C-C28S4" ],
                 "td4": [ "Nokia-IXR7220-D4-36D" ],
-                "j2c+": [ "Nokia-IXR7250E-36x100G", "Nokia-IXR7250E-36x400G", "Nokia-IXR7250-X3B", "Arista-7800R3A-36DM2-D36" ],
+                "j2c+": [ "Nokia-IXR7250E-36x100G", "Nokia-IXR7250E-36x400G", "Nokia-IXR7250-X3B", "Arista-7800R3A-36DM2-D36", "Arista-7280DR3AM-36" ],
                 "q2c+": [ "Nokia-IXR7250-X1B" ],
                 "jr2": [ "Arista-7800R3-48CQ2-C48", "Arista-7800R3-48CQM2-C48", "Arista-7808R3A-FM" ],
                 "q3d": [ "Arista-7280R4-32QF-32DF-64O", "Arista-7280R4K-32QF-32DF-64O" ]


### PR DESCRIPTION
#### What I did

Registered the `Arista-7280DR3AM-36` (Broadcom Jericho2c+ / `j2c+`) hwsku in the `rdma_config_update_validator` hwsku map so that GCU updates to the `PFC_WD` table are validated and allowed on this platform.

The hwsku was missing from the map, so `get_asic_name()` resolved to `unknown` and every `PFC_WD` apply-patch was rejected, failing `generic_config_updater/test_pfcwd_status.py` on this platform.

#### How I did it

Added `"Arista-7280DR3AM-36"` to the `j2c+` list under `helper_data.rdma_config_update_validator.broadcom_asics` in `generic_config_updater/gcu_field_operation_validators.conf.json`.

#### How to verify it

Run `generic_config_updater/test_pfcwd_status.py` on an `Arista-7280DR3AM-36` testbed. Before the change the PFC_WD apply-patch is rejected; after the change the validator permits the modification and the test passes.
Related ADO: [38572985](https://msazure.visualstudio.com/One/_workitems/edit/38572985)

#### Previous command output (if the output of a command-line utility has changed)


#### New command output (if the output of a command-line utility has changed)

