### PR TITLE
add cpo els cli show

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1385,6 +1385,138 @@ Ethernet0: SFP EEPROM detected
                 VccLowWarning  : 3.15Volts
 ```
 
+- Example (Decode and display information stored on the EEPROM of CPO connected to Ethernet0):
+```
+admin@sonic:~$ show interfaces transceiver eeprom -d Ethernet0
+Ethernet0: SFP EEPROM detected
+        Active Firmware: N/A
+        Active application selected code assigned to host lane 1: 6
+        Active application selected code assigned to host lane 2: 6
+        Active application selected code assigned to host lane 3: 6
+        Active application selected code assigned to host lane 4: 6
+        Active application selected code assigned to host lane 5: 6
+        Active application selected code assigned to host lane 6: 6
+        Active application selected code assigned to host lane 7: 6
+        Active application selected code assigned to host lane 8: 6
+        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400G-FR4/400GBASE-FR4 (Cl 151) - Media Assign (0x11)
+                                   200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - 200GBASE-FR4 (Cl 122) - Media Assign (0x11)
+                                   Bailly-Reserved-2 - Host Assign (0x11) - Bailly-Reserved-LC-2 - Media Assign (0x11)
+                                   CAUI-4 C2M (Annex 83E) with RS(528,514) FEC - Host Assign (0x11) - 100G CWDM4 MSA Spec - Media Assign (0x11)
+                                   Bailly-Reserved-1 - Host Assign (0x1) - Bailly-Reserved-LC-1 - Media Assign (0x1)
+                                   800GAUI-8 L C2M (Annex 120G) - Host Assign (0x1) - Bailly-800G-2xFR4 - Media Assign (0x1)
+        CMIS Rev: 5.2
+        Connector: LC
+        ELS Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
+        ELS Laser Count: 8
+        ELS Maximum Power Consumption: 12.0
+        ELS Revision: 0.1
+        ELS Vendor Date Code(YYYY-MM-DD Lot): 2024-06-28
+        ELS Vendor Name: BROADCOM
+        ELS Vendor OUI: ec-01-e2
+        ELS Vendor PN: ARLM-96F8DMZ
+        ELS Vendor Rev: A0
+        ELS Vendor SN: FD2424VG006
+        Encoding: N/A
+        Extended Identifier: Power Class 8 (20.0W Max)
+        Extended RateSelect Compliance: N/A
+        Host Lane Count: 8
+        Identifier: CPO Bailly
+        Inactive Firmware: N/A
+        Length Cable Assembly(m): 0.0
+        Media Interface Technology: Others
+        Media Lane Count: 8
+        Module Hardware Rev: 0.0
+        Nominal Bit Rate(100Mbs): N/A
+        RLM Laser Lpower Mode Control: 0
+        RLM Laser Wavelength Grid: CWDM4
+        Specification compliance: sm_media_interface
+        Vendor Date Code(YYYY-MM-DD Lot): 2024-09-14
+        Vendor Name: BROADCOM
+        Vendor OUI: 38-ba-b0
+        Vendor PN: BCM789096FBB0KLG
+        Vendor Rev: A0
+        Vendor SN: SB243500200
+        is_replaceable: False
+        type_abbrv_name: QSFP-DD
+        vdm_supported: False
+        ChannelMonitorValues:
+                RX1Power: 1.757dBm
+                RX2Power: 1.898dBm
+                RX3Power: 2.279dBm
+                RX4Power: 2.458dBm
+                RX5Power: 0.9dBm
+                RX6Power: 1.475dBm
+                RX7Power: 1.678dBm
+                RX8Power: 1.159dBm
+                TX1Bias: 79.6mA
+                TX1Power: 1.952dBm
+                TX2Bias: 57.22mA
+                TX2Power: 1.994dBm
+                TX3Bias: 68.8mA
+                TX3Power: 1.879dBm
+                TX4Bias: 63.024mA
+                TX4Power: 2.101dBm
+                TX5Bias: 79.6mA
+                TX5Power: 1.939dBm
+                TX6Bias: 57.22mA
+                TX6Power: 1.927dBm
+                TX7Bias: 68.8mA
+                TX7Power: 1.874dBm
+                TX8Bias: 63.024mA
+                TX8Power: 2.037dBm
+        ChannelThresholdValues:
+                RxPowerHighAlarm  : 6.0dBm
+                RxPowerHighWarning: 4.003dBm
+                RxPowerLowAlarm   : -11.203dBm
+                RxPowerLowWarning : -8.202dBm
+                TxBiasHighAlarm   : 137.5mA
+                TxBiasHighWarning : 132.5mA
+                TxBiasLowAlarm    : 5.0mA
+                TxBiasLowWarning  : 7.5mA
+                TxPowerHighAlarm  : 6.0dBm
+                TxPowerHighWarning: 4.0dBm
+                TxPowerLowAlarm   : -7.201dBm
+                TxPowerLowWarning : -4.201dBm
+        ModuleMonitorValues:
+                Temperature: 81.363C
+                Vcc: 3.311Volts
+        ModuleThresholdValues:
+                TempHighAlarm  : 90.0C
+                TempHighWarning: 85.0C
+                TempLowAlarm   : 15.0C
+                TempLowWarning : 20.0C
+                VccHighAlarm   : 3.465Volts
+                VccHighWarning : 3.399Volts
+                VccLowAlarm    : 3.135Volts
+                VccLowWarning  : 3.201Volts
+        ELSMonitorValues:
+                RLM0_Laser4_current: 252.38 mA
+                RLM0_Laser4_power: 72.290 mW 18.591 dBm
+                RLM0_Laser5_current: 275.49 mA
+                RLM0_Laser5_power: 76.700 mW 18.848 dBm
+                RLM0_Laser6_current: 228.96 mA
+                RLM0_Laser6_power: 66.600 mW 18.235 dBm
+                RLM0_Laser7_current: 318.41 mA
+                RLM0_Laser7_power: 88.060 mW 19.448 dBm
+                ELS Temperature: 25.027C
+                ELS Vcc: 3.365Volts
+        ELSThresholdValues:
+                ELS TempHighAlarm: 0.0C
+                ELS TempHighWarning: 0.0C
+                ELS TempLowAlarm: 0.0C
+                ELS TempLowWarning: 0.0C
+                ELS TxBiasHighAlarm: 0.0mA
+                ELS TxBiasHighWarning: 0.0mA
+                ELS TxPowerHighAlarm: 0.0mW
+                ELS TxPowerHighWarning: 0.0mW
+                ELS TxPowerLowAlarm: 0.0mW
+                ELS TxPowerLowWarning: 0.0mW
+                ELS VccHighAlarm: 0.0Volts
+                ELS VccHighWarning: 0.0Volts
+                ELS VccLowAlarm: 0.0Volts
+                ELS VccLowWarning: 0.0Volts
+```
+
 - Example (Decode and display information stored on the EEPROM of SFP transceiver connected to Ethernet16):
   ```
   admin@sonic:~$ show interfaces transceiver info Ethernet16
@@ -1425,6 +1557,62 @@ Ethernet0: SFP EEPROM detected
           Vendor PN: DP04QSDD-E20-00E
           Vendor Rev: 01
           Vendor SN: 210753986
+  ```
+
+- Example (Decode and display information stored on the EEPROM of CPO connected to Ethernet0):
+  ```
+admin@sonic:~$ show interfaces transceiver info Ethernet0
+Ethernet0: SFP EEPROM detected
+        Active Firmware: N/A
+        Active application selected code assigned to host lane 1: 6
+        Active application selected code assigned to host lane 2: 6
+        Active application selected code assigned to host lane 3: 6
+        Active application selected code assigned to host lane 4: 6
+        Active application selected code assigned to host lane 5: 6
+        Active application selected code assigned to host lane 6: 6
+        Active application selected code assigned to host lane 7: 6
+        Active application selected code assigned to host lane 8: 6
+        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400G-FR4/400GBASE-FR4 (Cl 151) - Media Assign (0x11)
+                                   200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - 200GBASE-FR4 (Cl 122) - Media Assign (0x11)
+                                   Bailly-Reserved-2 - Host Assign (0x11) - Bailly-Reserved-LC-2 - Media Assign (0x11)
+                                   CAUI-4 C2M (Annex 83E) with RS(528,514) FEC - Host Assign (0x11) - 100G CWDM4 MSA Spec - Media Assign (0x11)
+                                   Bailly-Reserved-1 - Host Assign (0x1) - Bailly-Reserved-LC-1 - Media Assign (0x1)
+                                   800GAUI-8 L C2M (Annex 120G) - Host Assign (0x1) - Bailly-800G-2xFR4 - Media Assign (0x1)
+        CMIS Rev: 5.2
+        Connector: LC
+        ELS Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
+        ELS Laser Count: 8
+        ELS Maximum Power Consumption: 12.0
+        ELS Revision: 0.1
+        ELS Vendor Date Code(YYYY-MM-DD Lot): 2024-06-28
+        ELS Vendor Name: BROADCOM
+        ELS Vendor OUI: ec-01-e2
+        ELS Vendor PN: ARLM-96F8DMZ
+        ELS Vendor Rev: A0
+        ELS Vendor SN: FD2424VG006
+        Encoding: N/A
+        Extended Identifier: Power Class 8 (20.0W Max)
+        Extended RateSelect Compliance: N/A
+        Host Lane Count: 8
+        Identifier: CPO Bailly
+        Inactive Firmware: N/A
+        Length Cable Assembly(m): 0.0
+        Media Interface Technology: Others
+        Media Lane Count: 8
+        Module Hardware Rev: 0.0
+        Nominal Bit Rate(100Mbs): N/A
+        RLM Laser Lpower Mode Control: 0
+        RLM Laser Wavelength Grid: CWDM4
+        Specification compliance: sm_media_interface
+        Vendor Date Code(YYYY-MM-DD Lot): 2024-09-14
+        Vendor Name: BROADCOM
+        Vendor OUI: 38-ba-b0
+        Vendor PN: BCM789096FBB0KLG
+        Vendor Rev: A0
+        Vendor SN: SB243500200
+        is_replaceable: False
+        type_abbrv_name: QSFP-DD
+        vdm_supported: False
   ```
 
 - Example (Display status of low-power mode of SFP transceiver connected to Ethernet100):
@@ -1757,6 +1945,221 @@ Ethernet0: SFP EEPROM detected
           Rxtotpower high warning flag: False
           Rxtotpower low warning flag: False
           Rxtotpower low alarm flag: False
+  ```
+
+- Example (Display status info of CPO connected to Ethernet0):
+  ```
+admin@sonic:~$ show interfaces transceiver status Ethernet0
+Ethernet0: 
+        CMIS State (SW): READY
+        Tx fault flag on media lane 1: False
+        Tx fault flag on media lane 2: False
+        Tx fault flag on media lane 3: False
+        Tx fault flag on media lane 4: False
+        Tx fault flag on media lane 5: False
+        Tx fault flag on media lane 6: False
+        Tx fault flag on media lane 7: False
+        Tx fault flag on media lane 8: False
+        Rx loss of signal flag on media lane 1: False
+        Rx loss of signal flag on media lane 2: False
+        Rx loss of signal flag on media lane 3: False
+        Rx loss of signal flag on media lane 4: False
+        Rx loss of signal flag on media lane 5: False
+        Rx loss of signal flag on media lane 6: False
+        Rx loss of signal flag on media lane 7: False
+        Rx loss of signal flag on media lane 8: False
+        TX disable status on lane 1: False
+        TX disable status on lane 2: False
+        TX disable status on lane 3: False
+        TX disable status on lane 4: False
+        TX disable status on lane 5: False
+        TX disable status on lane 6: False
+        TX disable status on lane 7: False
+        TX disable status on lane 8: False
+        Disabled TX channels: 0
+        Current module state: ModuleReady
+        Reason of entering the module fault state: No Fault detected
+        Datapath firmware fault: False
+        Module firmware fault: False
+        Module state changed: False
+        Data path state indicator on host lane 1: DataPathActivated
+        Data path state indicator on host lane 2: DataPathActivated
+        Data path state indicator on host lane 3: DataPathActivated
+        Data path state indicator on host lane 4: DataPathActivated
+        Data path state indicator on host lane 5: DataPathActivated
+        Data path state indicator on host lane 6: DataPathActivated
+        Data path state indicator on host lane 7: DataPathActivated
+        Data path state indicator on host lane 8: DataPathActivated
+        Tx output status on media lane 1: True
+        Tx output status on media lane 2: True
+        Tx output status on media lane 3: True
+        Tx output status on media lane 4: True
+        Tx output status on media lane 5: True
+        Tx output status on media lane 6: True
+        Tx output status on media lane 7: True
+        Tx output status on media lane 8: True
+        Rx output status on host lane 1: True
+        Rx output status on host lane 2: True
+        Rx output status on host lane 3: True
+        Rx output status on host lane 4: True
+        Rx output status on host lane 5: True
+        Rx output status on host lane 6: True
+        Rx output status on host lane 7: True
+        Rx output status on host lane 8: True
+        Tx loss of signal flag on host lane 1: False
+        Tx loss of signal flag on host lane 2: False
+        Tx loss of signal flag on host lane 3: False
+        Tx loss of signal flag on host lane 4: False
+        Tx loss of signal flag on host lane 5: False
+        Tx loss of signal flag on host lane 6: False
+        Tx loss of signal flag on host lane 7: False
+        Tx loss of signal flag on host lane 8: False
+        Tx clock and data recovery loss of lock on host lane 1: N/A
+        Tx clock and data recovery loss of lock on host lane 2: N/A
+        Tx clock and data recovery loss of lock on host lane 3: N/A
+        Tx clock and data recovery loss of lock on host lane 4: N/A
+        Tx clock and data recovery loss of lock on host lane 5: N/A
+        Tx clock and data recovery loss of lock on host lane 6: N/A
+        Tx clock and data recovery loss of lock on host lane 7: N/A
+        Tx clock and data recovery loss of lock on host lane 8: N/A
+        Rx clock and data recovery loss of lock on media lane 1: N/A
+        Rx clock and data recovery loss of lock on media lane 2: N/A
+        Rx clock and data recovery loss of lock on media lane 3: N/A
+        Rx clock and data recovery loss of lock on media lane 4: N/A
+        Rx clock and data recovery loss of lock on media lane 5: N/A
+        Rx clock and data recovery loss of lock on media lane 6: N/A
+        Rx clock and data recovery loss of lock on media lane 7: N/A
+        Rx clock and data recovery loss of lock on media lane 8: N/A
+        Configuration status for the data path of host line 1: ConfigSuccess
+        Configuration status for the data path of host line 2: ConfigSuccess
+        Configuration status for the data path of host line 3: ConfigSuccess
+        Configuration status for the data path of host line 4: ConfigSuccess
+        Configuration status for the data path of host line 5: ConfigSuccess
+        Configuration status for the data path of host line 6: ConfigSuccess
+        Configuration status for the data path of host line 7: ConfigSuccess
+        Configuration status for the data path of host line 8: ConfigSuccess
+        Data path configuration updated on host lane 1: True
+        Data path configuration updated on host lane 2: True
+        Data path configuration updated on host lane 3: True
+        Data path configuration updated on host lane 4: True
+        Data path configuration updated on host lane 5: True
+        Data path configuration updated on host lane 6: True
+        Data path configuration updated on host lane 7: True
+        Data path configuration updated on host lane 8: True
+        Temperature high alarm flag: False
+        Temperature high warning flag: False
+        Temperature low warning flag: False
+        Temperature low alarm flag: False
+        Vcc high alarm flag: False
+        Vcc high warning flag: False
+        Vcc low warning flag: False
+        Vcc low alarm flag: False
+        Tx power high alarm flag on lane 1: False
+        Tx power high alarm flag on lane 2: False
+        Tx power high alarm flag on lane 3: False
+        Tx power high alarm flag on lane 4: False
+        Tx power high alarm flag on lane 5: False
+        Tx power high alarm flag on lane 6: False
+        Tx power high alarm flag on lane 7: False
+        Tx power high alarm flag on lane 8: False
+        Tx power high warning flag on lane 1: False
+        Tx power high warning flag on lane 2: False
+        Tx power high warning flag on lane 3: False
+        Tx power high warning flag on lane 4: False
+        Tx power high warning flag on lane 5: False
+        Tx power high warning flag on lane 6: False
+        Tx power high warning flag on lane 7: False
+        Tx power high warning flag on lane 8: False
+        Tx power low warning flag on lane 1: False
+        Tx power low warning flag on lane 2: False
+        Tx power low warning flag on lane 3: False
+        Tx power low warning flag on lane 4: False
+        Tx power low warning flag on lane 5: False
+        Tx power low warning flag on lane 6: False
+        Tx power low warning flag on lane 7: False
+        Tx power low warning flag on lane 8: False
+        Tx power low alarm flag on lane 1: False
+        Tx power low alarm flag on lane 2: False
+        Tx power low alarm flag on lane 3: False
+        Tx power low alarm flag on lane 4: False
+        Tx power low alarm flag on lane 5: False
+        Tx power low alarm flag on lane 6: False
+        Tx power low alarm flag on lane 7: False
+        Tx power low alarm flag on lane 8: False
+        Rx power high alarm flag on lane 1: False
+        Rx power high alarm flag on lane 2: False
+        Rx power high alarm flag on lane 3: False
+        Rx power high alarm flag on lane 4: False
+        Rx power high alarm flag on lane 5: False
+        Rx power high alarm flag on lane 6: False
+        Rx power high alarm flag on lane 7: False
+        Rx power high alarm flag on lane 8: False
+        Rx power high warning flag on lane 1: False
+        Rx power high warning flag on lane 2: False
+        Rx power high warning flag on lane 3: False
+        Rx power high warning flag on lane 4: False
+        Rx power high warning flag on lane 5: False
+        Rx power high warning flag on lane 6: False
+        Rx power high warning flag on lane 7: False
+        Rx power high warning flag on lane 8: False
+        Rx power low warning flag on lane 1: False
+        Rx power low warning flag on lane 2: False
+        Rx power low warning flag on lane 3: False
+        Rx power low warning flag on lane 4: False
+        Rx power low warning flag on lane 5: False
+        Rx power low warning flag on lane 6: False
+        Rx power low warning flag on lane 7: False
+        Rx power low warning flag on lane 8: False
+        Rx power low alarm flag on lane 1: False
+        Rx power low alarm flag on lane 2: False
+        Rx power low alarm flag on lane 3: False
+        Rx power low alarm flag on lane 4: False
+        Rx power low alarm flag on lane 5: False
+        Rx power low alarm flag on lane 6: False
+        Rx power low alarm flag on lane 7: False
+        Rx power low alarm flag on lane 8: False
+        Tx bias high alarm flag on lane 1: False
+        Tx bias high alarm flag on lane 2: False
+        Tx bias high alarm flag on lane 3: False
+        Tx bias high alarm flag on lane 4: False
+        Tx bias high alarm flag on lane 5: False
+        Tx bias high alarm flag on lane 6: False
+        Tx bias high alarm flag on lane 7: False
+        Tx bias high alarm flag on lane 8: False
+        Tx bias high warning flag on lane 1: False
+        Tx bias high warning flag on lane 2: False
+        Tx bias high warning flag on lane 3: False
+        Tx bias high warning flag on lane 4: False
+        Tx bias high warning flag on lane 5: False
+        Tx bias high warning flag on lane 6: False
+        Tx bias high warning flag on lane 7: False
+        Tx bias high warning flag on lane 8: False
+        Tx bias low warning flag on lane 1: False
+        Tx bias low warning flag on lane 2: False
+        Tx bias low warning flag on lane 3: False
+        Tx bias low warning flag on lane 4: False
+        Tx bias low warning flag on lane 5: False
+        Tx bias low warning flag on lane 6: False
+        Tx bias low warning flag on lane 7: False
+        Tx bias low warning flag on lane 8: False
+        Tx bias low alarm flag on lane 1: False
+        Tx bias low alarm flag on lane 2: False
+        Tx bias low alarm flag on lane 3: False
+        Tx bias low alarm flag on lane 4: False
+        Tx bias low alarm flag on lane 5: False
+        Tx bias low alarm flag on lane 6: False
+        Tx bias low alarm flag on lane 7: False
+        Tx bias low alarm flag on lane 8: False
+        ELS temperature high alarm flag: False
+        ELS temperature low alarm flag: False
+        ELS temperature high warning flag: False
+        ELS temperature low warning flag: False
+        ELS Vcc high alarm flag: False
+        ELS Vcc low alarm flag: False
+        ELS Vcc high warning flag: False
+        ELS Vcc low warning flag: False
+        ELS module state: High power mode
+        ELS interrupt status: Interrupt event cleared
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#basic-show-commands)

--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -147,6 +147,28 @@ DOM_MODULE_MONITOR_MAP = {
     'tx_config_power': 'Requested Tx Power'
 }
 
+ELS_DOM_MONITOR_MAP = {
+    'els_temperature': 'ELS Temperature',
+    'els_voltage': 'ELS Vcc',
+}
+
+ELS_THRESHOLD_MAP = {
+    'els_temphighalarm': 'ELS TempHighAlarm',
+    'els_templowalarm': 'ELS TempLowAlarm',
+    'els_temphighwarning': 'ELS TempHighWarning',
+    'els_templowwarning': 'ELS TempLowWarning',
+    'els_vcchighalarm': 'ELS VccHighAlarm',
+    'els_vcclowalarm': 'ELS VccLowAlarm',
+    'els_vcchighwarning': 'ELS VccHighWarning',
+    'els_vcclowwarning': 'ELS VccLowWarning',
+    'els_txpowerhighalarm': 'ELS TxPowerHighAlarm',
+    'els_txpowerlowalarm': 'ELS TxPowerLowAlarm',
+    'els_txpowerhighwarning': 'ELS TxPowerHighWarning',
+    'els_txpowerlowwarning': 'ELS TxPowerLowWarning',
+    'els_txbiashighalarm': 'ELS TxBiasHighAlarm',
+    'els_txbiashighwarning': 'ELS TxBiasHighWarning'
+}
+
 DOM_CHANNEL_THRESHOLD_UNIT_MAP = {
     'txpowerhighalarm':   'dBm',
     'txpowerlowalarm':    'dBm',
@@ -171,6 +193,28 @@ DOM_MODULE_THRESHOLD_UNIT_MAP = {
     'vcclowalarm':     'Volts',
     'vcchighwarning':  'Volts',
     'vcclowwarning':   'Volts'
+}
+
+ELS_DOM_MONITOR_UNIT_MAP = {
+    'els_temperature': 'C',
+    'els_voltage': 'Volts',
+}
+
+ELS_THRESHOLD_UNIT_MAP = {
+    'els_temphighalarm': 'C',
+    'els_templowalarm': 'C',
+    'els_temphighwarning': 'C',
+    'els_templowwarning': 'C',
+    'els_vcchighalarm': 'Volts',
+    'els_vcclowalarm': 'Volts',
+    'els_vcchighwarning': 'Volts',
+    'els_vcclowwarning': 'Volts',
+    'els_txpowerhighalarm': 'mW',
+    'els_txpowerlowalarm': 'mW',
+    'els_txpowerhighwarning': 'mW',
+    'els_txpowerlowwarning': 'mW',
+    'els_txbiashighalarm': 'mA',
+    'els_txbiashighwarning': 'mA'
 }
 
 DOM_VALUE_UNIT_MAP = {
@@ -430,6 +474,31 @@ class SFPShow(object):
                 DOM_MODULE_THRESHOLD_UNIT_MAP,
                 module_threshold_align)
             output_dom += output_module_threshold
+
+            # This is specific for CPO DOM value parsing.
+            is_cpo = sfp_type.startswith('CPO')
+            if is_cpo:
+                laser_keys = [key for key in dom_info_dict if key.startswith('RLM') and 'Laser' in key]
+                dom_monitor_map = ELS_DOM_MONITOR_MAP.copy()
+                dom_monitor_map.update({key: key for key in laser_keys})
+                dom_monitor_unit_map = ELS_DOM_MONITOR_UNIT_MAP.copy()
+                dom_monitor_unit_map.update({key: '' for key in laser_keys})  # laser monitor values include units
+                output_dom += (indent + 'ELSMonitorValues:\n')
+                sorted_key_table = natsorted(dom_monitor_map)
+                output_monitor = self.format_dict_value_to_string(
+                    sorted_key_table, dom_info_dict,
+                    dom_monitor_map,
+                    dom_monitor_unit_map)
+                output_dom += output_monitor
+
+                # Threshold
+                output_dom += (indent + 'ELSThresholdValues:\n')
+                sorted_key_table = natsorted(ELS_THRESHOLD_MAP)
+                output_threshold = self.format_dict_value_to_string(
+                    sorted_key_table, dom_info_dict,
+                    ELS_THRESHOLD_MAP,
+                    ELS_THRESHOLD_UNIT_MAP)
+                output_dom += output_threshold
 
         else:
             output_dom += (indent + 'MonitorData:\n')

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -111,7 +111,19 @@ QSFP_DD_DATA_MAP = {
     'supported_max_tx_power': 'Supported Max TX Power',
     'supported_min_tx_power': 'Supported Min TX Power',
     'supported_max_laser_freq': 'Supported Max Laser Frequency',
-    'supported_min_laser_freq': 'Supported Min Laser Frequency'
+    'supported_min_laser_freq': 'Supported Min Laser Frequency',
+    'els_identifier': 'ELS Identifier',
+    'els_revision': 'ELS Revision',
+    'els_laser_count': 'ELS Laser Count',
+    'els_vendor_name': 'ELS Vendor Name',
+    'els_vendor_oui': 'ELS Vendor OUI',
+    'els_vendor_pn': 'ELS Vendor PN',
+    'els_vendor_rev': 'ELS Vendor Rev',
+    'els_vendor_sn': 'ELS Vendor SN',
+    'els_date_code': 'ELS Vendor Date Code(YYYY-MM-DD Lot)',
+    'els_max_power': 'ELS Maximum Power Consumption',
+    'rlm_laser_lpmode_control': 'RLM Laser Lpower Mode Control',
+    'rlm_laser_wavelength_grid': 'RLM Laser Wavelength Grid',
 }
 
 SFP_DOM_CHANNEL_MONITOR_MAP = {
@@ -204,6 +216,28 @@ DOM_MODULE_MONITOR_MAP = {
     'voltage': 'Vcc'
 }
 
+ELS_DOM_MONITOR_MAP = {
+    'els_temperature': 'ELS Temperature',
+    'els_voltage': 'ELS Vcc',
+}
+
+ELS_THRESHOLD_MAP = {
+    'els_temphighalarm': 'ELS TempHighAlarm',
+    'els_templowalarm': 'ELS TempLowAlarm',
+    'els_temphighwarning': 'ELS TempHighWarning',
+    'els_templowwarning': 'ELS TempLowWarning',
+    'els_vcchighalarm': 'ELS VccHighAlarm',
+    'els_vcclowalarm': 'ELS VccLowAlarm',
+    'els_vcchighwarning': 'ELS VccHighWarning',
+    'els_vcclowwarning': 'ELS VccLowWarning',
+    'els_txpowerhighalarm': 'ELS TxPowerHighAlarm',
+    'els_txpowerlowalarm': 'ELS TxPowerLowAlarm',
+    'els_txpowerhighwarning': 'ELS TxPowerHighWarning',
+    'els_txpowerlowwarning': 'ELS TxPowerLowWarning',
+    'els_txbiashighalarm': 'ELS TxBiasHighAlarm',
+    'els_txbiashighwarning': 'ELS TxBiasHighWarning'
+}
+
 DOM_CHANNEL_THRESHOLD_UNIT_MAP = {
     'txpowerhighalarm':   'dBm',
     'txpowerlowalarm':    'dBm',
@@ -228,6 +262,28 @@ DOM_MODULE_THRESHOLD_UNIT_MAP = {
     'vcclowalarm':     'Volts',
     'vcchighwarning':  'Volts',
     'vcclowwarning':   'Volts'
+}
+
+ELS_DOM_MONITOR_UNIT_MAP = {
+    'els_temperature': 'C',
+    'els_voltage': 'Volts',
+}
+
+ELS_THRESHOLD_UNIT_MAP = {
+    'els_temphighalarm': 'C',
+    'els_templowalarm': 'C',
+    'els_temphighwarning': 'C',
+    'els_templowwarning': 'C',
+    'els_vcchighalarm': 'Volts',
+    'els_vcclowalarm': 'Volts',
+    'els_vcchighwarning': 'Volts',
+    'els_vcclowwarning': 'Volts',
+    'els_txpowerhighalarm': 'mW',
+    'els_txpowerlowalarm': 'mW',
+    'els_txpowerhighwarning': 'mW',
+    'els_txpowerlowwarning': 'mW',
+    'els_txbiashighalarm': 'mA',
+    'els_txbiashighwarning': 'mA'
 }
 
 DOM_VALUE_UNIT_MAP = {
@@ -453,6 +509,30 @@ def convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict):
             module_threshold_align)
         output_dom += output_module_threshold
 
+        # This is specific for CPO DOM value parsing.
+        is_cpo = sfp_type.startswith('CPO')
+        if is_cpo:
+            laser_keys = [key for key in dom_info_dict if key.startswith('RLM') and 'Laser' in key]
+            dom_monitor_map = ELS_DOM_MONITOR_MAP.copy()
+            dom_monitor_map.update({key: key for key in laser_keys})
+            dom_monitor_unit_map = ELS_DOM_MONITOR_UNIT_MAP.copy()
+            dom_monitor_unit_map.update({key: '' for key in laser_keys})  # laser monitor values include units
+            output_dom += (indent + 'ELSMonitorValues:\n')
+            sorted_key_table = natsorted(dom_monitor_map)
+            output_els_monitor = format_dict_value_to_string(
+                sorted_key_table, dom_info_dict,
+                dom_monitor_map,
+                dom_monitor_unit_map)
+            output_dom += output_els_monitor
+
+            # Threshold
+            output_dom += (indent + 'ELSThresholdValues:\n')
+            sorted_key_table = natsorted(ELS_THRESHOLD_MAP)
+            output_els_threshold = format_dict_value_to_string(
+                sorted_key_table, dom_info_dict,
+                ELS_THRESHOLD_MAP,
+                ELS_THRESHOLD_UNIT_MAP)
+            output_dom += output_els_threshold
     else:
         output_dom += (indent + 'MonitorData:\n')
         sorted_key_table = natsorted(SFP_DOM_CHANNEL_MONITOR_MAP)

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -9,6 +9,7 @@ from utilities_common.platform_sfputil_helper import (
     logical_port_name_to_physical_port_list, is_sfp_present,
     get_first_subport, get_subport, get_sfp_object, get_value_from_db_by_field
 )
+from .utils import load_source
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -17,6 +18,7 @@ sys.path.insert(0, modules_path)
 
 import show.main as show
 import show as show_module
+sfpshow = load_source("sfpshow", os.path.join(scripts_path, "sfpshow"))
 
 ERROR_INVALID_PORT = 1
 EXIT_FAIL = -1
@@ -898,6 +900,50 @@ Ethernet4: Transceiver status info not applicable
 Ethernet64: Transceiver status info not applicable
 """
 
+test_els_dom_info_dict = {
+    'els_temperature': '16.16',
+    'els_voltage': '3.396',
+    'els_temphighalarm': '80.0',
+    'els_templowalarm': '-5.0',
+    'els_temphighwarning': '70.0',
+    'els_templowwarning': '0.0',
+    'els_vcchighalarm': '3.63',
+    'els_vcclowalarm': '2.97',
+    'els_vcchighwarning': '3.465',
+    'els_vcclowwarning': '3.135',
+    'els_txpowerhighalarm': '7.0',
+    'els_txpowerlowalarm': '-6.9',
+    'els_txpowerhighwarning': '4.0',
+    'els_txpowerlowwarning': '-2.9',
+    'els_txbiashighalarm': '162.5',
+    'els_txbiashighwarning': '156.248',
+}
+
+test_els_dom_output = """\
+        ChannelMonitorValues:
+        ChannelThresholdValues:
+        ModuleMonitorValues:
+        ModuleThresholdValues:
+        ELSMonitorValues:
+                ELS Temperature: 16.16C
+                ELS Vcc: 3.396Volts
+        ELSThresholdValues:
+                ELS TempHighAlarm: 80.0C
+                ELS TempHighWarning: 70.0C
+                ELS TempLowAlarm: -5.0C
+                ELS TempLowWarning: 0.0C
+                ELS TxBiasHighAlarm: 162.5mA
+                ELS TxBiasHighWarning: 156.248mA
+                ELS TxPowerHighAlarm: 7.0mW
+                ELS TxPowerHighWarning: 4.0mW
+                ELS TxPowerLowAlarm: -6.9mW
+                ELS TxPowerLowWarning: -2.9mW
+                ELS VccHighAlarm: 3.63Volts
+                ELS VccHighWarning: 3.465Volts
+                ELS VccLowAlarm: 2.97Volts
+                ELS VccLowWarning: 3.135Volts
+"""
+
 class TestSFP(object):
     @classmethod
     def setup_class(cls):
@@ -974,6 +1020,11 @@ Ethernet36  Present
         result = runner.invoke(show.cli.commands["interfaces"].commands["transceiver"].commands["info"])
         assert result.exit_code == 0
         assert "Ethernet24" not in result.output
+
+    def test_sfpshow_convert_dom_to_output_string_with_els(self):
+        sfp_show = sfpshow.SFPShow(None, None, dump_dom=True)
+        output = sfp_show.convert_dom_to_output_string("CPO", True, test_els_dom_info_dict)
+        assert output == test_els_dom_output
 
     def test_sfp_eeprom_with_dom(self):
         runner = CliRunner()

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -412,6 +412,52 @@ class TestSfputil(object):
                 Vcc: 3.2577Volts
         ModuleThresholdValues:
 '''
+        ),
+        (
+            'CPO',
+            True,
+            {
+                'els_temperature': '16.16',
+                'els_voltage': '3.396',
+                'els_temphighalarm': '80.0',
+                'els_templowalarm': '-5.0',
+                'els_temphighwarning': '70.0',
+                'els_templowwarning': '0.0',
+                'els_vcchighalarm': '3.63',
+                'els_vcclowalarm': '2.97',
+                'els_vcchighwarning': '3.465',
+                'els_vcclowwarning': '3.135',
+                'els_txpowerhighalarm': '7.0',
+                'els_txpowerlowalarm': '-6.9',
+                'els_txpowerhighwarning': '4.0',
+                'els_txpowerlowwarning': '-2.9',
+                'els_txbiashighalarm': '162.5',
+                'els_txbiashighwarning': '156.248',
+            },
+            '''\
+        ChannelMonitorValues:
+        ChannelThresholdValues:
+        ModuleMonitorValues:
+        ModuleThresholdValues:
+        ELSMonitorValues:
+                ELS Temperature: 16.16C
+                ELS Vcc: 3.396Volts
+        ELSThresholdValues:
+                ELS TempHighAlarm: 80.0C
+                ELS TempHighWarning: 70.0C
+                ELS TempLowAlarm: -5.0C
+                ELS TempLowWarning: 0.0C
+                ELS TxBiasHighAlarm: 162.5mA
+                ELS TxBiasHighWarning: 156.248mA
+                ELS TxPowerHighAlarm: 7.0mW
+                ELS TxPowerHighWarning: 4.0mW
+                ELS TxPowerLowAlarm: -6.9mW
+                ELS TxPowerLowWarning: -2.9mW
+                ELS VccHighAlarm: 3.63Volts
+                ELS VccHighWarning: 3.465Volts
+                ELS VccLowAlarm: 2.97Volts
+                ELS VccLowWarning: 3.135Volts
+'''
         )])
     def test_convert_dom_to_output_string(self, sfp_type, is_sfp_cmis, dom_info_dict, expected_output):
         output = sfputil.convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict)

--- a/utilities_common/sfp_helper.py
+++ b/utilities_common/sfp_helper.py
@@ -43,6 +43,24 @@ QSFP_CMIS_DELTA_DATA_MAP = {
     'e2_server_firmware': 'E2 Server Firmware'
 }
 
+ELSFP_DATA_MAP = {
+    'els_identifier': 'ELS Identifier',
+    'els_revision': 'ELS Revision',
+    'els_laser_count': 'ELS Laser Count',
+    'els_vendor_name': 'ELS Vendor Name',
+    'els_vendor_oui': 'ELS Vendor OUI',
+    'els_vendor_pn': 'ELS Vendor PN',
+    'els_vendor_rev': 'ELS Vendor Rev',
+    'els_vendor_sn': 'ELS Vendor SN',
+    'els_date_code': 'ELS Vendor Date Code(YYYY-MM-DD Lot)',
+    'els_max_power': 'ELS Maximum Power Consumption',
+}
+
+BAILLY_RLM_DATA_MAP = {
+    'rlm_laser_wavelength_grid': 'RLM Laser Wavelength Grid',
+    'rlm_laser_lpmode_control': 'RLM Laser Lpower Mode Control'
+}
+
 C_CMIS_DELTA_DATA_MAP = {
     'supported_max_tx_power': 'Supported Max TX Power',
     'supported_min_tx_power': 'Supported Min TX Power',
@@ -50,7 +68,7 @@ C_CMIS_DELTA_DATA_MAP = {
     'supported_min_laser_freq': 'Supported Min Laser Frequency',
 }
 
-CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP}
+CMIS_DATA_MAP = {**QSFP_DATA_MAP, **QSFP_CMIS_DELTA_DATA_MAP, **BAILLY_RLM_DATA_MAP, **ELSFP_DATA_MAP}
 C_CMIS_DATA_MAP = {**CMIS_DATA_MAP, **C_CMIS_DELTA_DATA_MAP}
 
 # Common fields for all types:
@@ -271,7 +289,17 @@ CMIS_STATUS_MAP = {
     'postfecberhighalarm_flag': 'Postfec ber high alarm flag',
     'postfecberhighwarning_flag': 'Postfec ber high warning flag',
     'postfecberlowwarning_flag': 'Postfec ber low warning flag',
-    'postfecberlowalarm_flag': 'Postfec ber low alarm flag'
+    'postfecberlowalarm_flag': 'Postfec ber low alarm flag',
+    'els_tempHAlarm': 'ELS temperature high alarm flag',
+    'els_tempLAlarm': 'ELS temperature low alarm flag',
+    'els_tempHWarn': 'ELS temperature high warning flag',
+    'els_tempLWarn': 'ELS temperature low warning flag',
+    'els_vccHAlarm': 'ELS Vcc high alarm flag',
+    'els_vccLAlarm': 'ELS Vcc low alarm flag',
+    'els_vccHWarn': 'ELS Vcc high warning flag',
+    'els_vccLWarn': 'ELS Vcc low warning flag',
+    'els_module_low_power_state': 'ELS module state',
+    'els_interrupt_status': 'ELS interrupt status'
 }
 
 CMIS_VDM_TO_LEGACY_STATUS_MAP = {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
add cpo els cli show
show interfaces transceiver eeprom -d
sfputil show eeprom -d


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605
- [x] 202608
#### How I did it
add cpo els key map

#### How to verify it
show interfaces transceiver eeprom -d
sfputil show eeprom -d
show interfaces transceiver status
#### Previous command output (if the output of a command-line utility has changed)
```
 root@sonic:/# show interfaces transceiver eeprom -d Ethernet0
 Ethernet0: SFP EEPROM detected
         Active Firmware: N/A
         Active application selected code assigned to host lane 1: 1
         Active application selected code assigned to host lane 2: 1
         Active application selected code assigned to host lane 3: 1
         Active application selected code assigned to host lane 4: 1
         Active application selected code assigned to host lane 5: 1
         Active application selected code assigned to host lane 6: 1
         Active application selected code assigned to host lane 7: 1
         Active application selected code assigned to host lane 8: 1
         Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400G-FR4/400GBASE-FR4 (Cl 151) - Media Assign (0x11)
                                    200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - 200GBASE-FR4 (Cl 122) - Media Assign (0x11)
                                    CAUI-4 C2M (Annex 83E) with RS(528,514) FEC - Host Assign (0x11) - 100G CWDM4 MSA Spec - Media Assign (0x11)
         CMIS Rev: 5.2
         Connector: LC
         Encoding: N/A
         Extended Identifier: Power Class 5 (8.0W Max)
         Extended RateSelect Compliance: N/A
         Host Lane Count: 4
         Identifier: CPO Bailly
         Inactive Firmware: N/A
         Length Cable Assembly(m): 0.0
         Media Interface Technology: Others
         Media Lane Count: 4
         Module Hardware Rev: 0.0
         Nominal Bit Rate(100Mbs): N/A
         Specification compliance: sm_media_interface
         Vendor Date Code(YYYY-MM-DD Lot): 20
         Vendor Name: BROADCOM
         Vendor OUI: ec-01-e2
         Vendor PN: BCM78909CPO
         Vendor Rev: A0
         Vendor SN: 
         is_replaceable: False
         type_abbrv_name: QSFP-DD
         vdm_supported: False
         ChannelMonitorValues:
                 RX1Power: -40.0dBm
                 RX2Power: -40.0dBm
                 RX3Power: -40.0dBm
                 RX4Power: -40.0dBm
                 RX5Power: -40.0dBm
                 RX6Power: -40.0dBm
                 RX7Power: -40.0dBm
                 RX8Power: -40.0dBm
                 TX1Bias: 0.004mA
                 TX1Power: -40.0dBm
                 TX2Bias: 0.004mA
                 TX2Power: -40.0dBm
                 TX3Bias: 0.004mA
                 TX3Power: -40.0dBm
                 TX4Bias: 0.004mA
                 TX4Power: -40.0dBm
                 TX5Bias: 0.004mA
                 TX5Power: -40.0dBm
                 TX6Bias: 0.004mA
                 TX6Power: -40.0dBm
                 TX7Bias: 0.004mA
                 TX7Power: -40.0dBm
                 TX8Bias: 0.004mA
                 TX8Power: -40.0dBm
         ChannelThresholdValues:
                 RxPowerHighAlarm  : 7.0dBm
                 RxPowerHighWarning: 4.0dBm
                 RxPowerLowAlarm   : -9.901dBm
                 RxPowerLowWarning : -5.901dBm
                 TxBiasHighAlarm   : 162.5mA
                 TxBiasHighWarning : 156.248mA
                 TxBiasLowAlarm    : 15.0mA
                 TxBiasLowWarning  : 20.0mA
                 TxPowerHighAlarm  : 7.0dBm
                 TxPowerHighWarning: 4.0dBm
                 TxPowerLowAlarm   : -6.899dBm
                 TxPowerLowWarning : -2.9dBm
         ModuleMonitorValues:
                 Temperature: 32.293C
                 Vcc: 3.298Volts
         ModuleThresholdValues:
                 TempHighAlarm  : 90.0C
                 TempHighWarning: 85.0C
                 TempLowAlarm   : -5.0C
                 TempLowWarning : 0.0C
                 VccHighAlarm   : 3.63Volts
                 VccHighWarning : 3.465Volts
                 VccLowAlarm    : 2.97Volts
                 VccLowWarning  : 3.135Volts

 root@sonic:/# show interfaces transceiver status Ethernet0
 Ethernet0: 
         CMIS State (SW): FAILED
         Tx fault flag on media lane 1: False
         Tx fault flag on media lane 2: False
         Tx fault flag on media lane 3: False
         Tx fault flag on media lane 4: False
         Tx fault flag on media lane 5: False
         Tx fault flag on media lane 6: False
         Tx fault flag on media lane 7: False
         Tx fault flag on media lane 8: False
         Rx loss of signal flag on media lane 1: True
         Rx loss of signal flag on media lane 2: True
         Rx loss of signal flag on media lane 3: True
         Rx loss of signal flag on media lane 4: True
         Rx loss of signal flag on media lane 5: True
         Rx loss of signal flag on media lane 6: True
         Rx loss of signal flag on media lane 7: True
         Rx loss of signal flag on media lane 8: True
         TX disable status on lane 1: True
         TX disable status on lane 2: True
         TX disable status on lane 3: True
         TX disable status on lane 4: True
         TX disable status on lane 5: True
         TX disable status on lane 6: True
         TX disable status on lane 7: True
         TX disable status on lane 8: True
         Disabled TX channels: 255
         Current module state: ModuleLowPwr
         Reason of entering the module fault state: No Fault detected
         Datapath firmware fault: False
         Module firmware fault: False
         Module state changed: False
         Data path state indicator on host lane 1: DataPathDeactivated
         Data path state indicator on host lane 2: DataPathDeactivated
         Data path state indicator on host lane 3: DataPathDeactivated
         Data path state indicator on host lane 4: DataPathDeactivated
         Data path state indicator on host lane 5: DataPathDeactivated
         Data path state indicator on host lane 6: DataPathDeactivated
         Data path state indicator on host lane 7: DataPathDeactivated
         Data path state indicator on host lane 8: DataPathDeactivated
         Tx output status on media lane 1: False
         Tx output status on media lane 2: False
         Tx output status on media lane 3: False
         Tx output status on media lane 4: False
         Tx output status on media lane 5: False
         Tx output status on media lane 6: False
         Tx output status on media lane 7: False
         Tx output status on media lane 8: False
         Rx output status on host lane 1: False
         Rx output status on host lane 2: False
         Rx output status on host lane 3: False
         Rx output status on host lane 4: False
         Rx output status on host lane 5: False
         Rx output status on host lane 6: False
         Rx output status on host lane 7: False
         Rx output status on host lane 8: False
         Tx loss of signal flag on host lane 1: False
         Tx loss of signal flag on host lane 2: False
         Tx loss of signal flag on host lane 3: False
         Tx loss of signal flag on host lane 4: False
         Tx loss of signal flag on host lane 5: False
         Tx loss of signal flag on host lane 6: False
         Tx loss of signal flag on host lane 7: False
         Tx loss of signal flag on host lane 8: False
         Tx clock and data recovery loss of lock on host lane 1: N/A
         Tx clock and data recovery loss of lock on host lane 2: N/A
         Tx clock and data recovery loss of lock on host lane 3: N/A
         Tx clock and data recovery loss of lock on host lane 4: N/A
         Tx clock and data recovery loss of lock on host lane 5: N/A
         Tx clock and data recovery loss of lock on host lane 6: N/A
         Tx clock and data recovery loss of lock on host lane 7: N/A
         Tx clock and data recovery loss of lock on host lane 8: N/A
         Rx clock and data recovery loss of lock on media lane 1: False
         Rx clock and data recovery loss of lock on media lane 2: False
         Rx clock and data recovery loss of lock on media lane 3: False
         Rx clock and data recovery loss of lock on media lane 4: False
         Rx clock and data recovery loss of lock on media lane 5: False
         Rx clock and data recovery loss of lock on media lane 6: False
         Rx clock and data recovery loss of lock on media lane 7: False
         Rx clock and data recovery loss of lock on media lane 8: False
         Configuration status for the data path of host line 1: ConfigUndefined
         Configuration status for the data path of host line 2: ConfigUndefined
         Configuration status for the data path of host line 3: ConfigUndefined
         Configuration status for the data path of host line 4: ConfigUndefined
         Configuration status for the data path of host line 5: ConfigUndefined
         Configuration status for the data path of host line 6: ConfigUndefined
         Configuration status for the data path of host line 7: ConfigUndefined
         Configuration status for the data path of host line 8: ConfigUndefined
         Data path configuration updated on host lane 1: True
         Data path configuration updated on host lane 2: True
         Data path configuration updated on host lane 3: True
         Data path configuration updated on host lane 4: True
         Data path configuration updated on host lane 5: True
         Data path configuration updated on host lane 6: True
         Data path configuration updated on host lane 7: True
         Data path configuration updated on host lane 8: True
         Temperature high alarm flag: False
         Temperature high warning flag: False
         Temperature low warning flag: False
         Temperature low alarm flag: False
         Vcc high alarm flag: False
         Vcc high warning flag: False
         Vcc low warning flag: False
         Vcc low alarm flag: False
         Tx power high alarm flag on lane 1: False
         Tx power high alarm flag on lane 2: False
         Tx power high alarm flag on lane 3: False
         Tx power high alarm flag on lane 4: False
         Tx power high alarm flag on lane 5: False
         Tx power high alarm flag on lane 6: False
         Tx power high alarm flag on lane 7: False
         Tx power high alarm flag on lane 8: False
         Tx power high warning flag on lane 1: False
         Tx power high warning flag on lane 2: False
         Tx power high warning flag on lane 3: False
         Tx power high warning flag on lane 4: False
         Tx power high warning flag on lane 5: False
         Tx power high warning flag on lane 6: False
         Tx power high warning flag on lane 7: False
         Tx power high warning flag on lane 8: False
         Tx power low warning flag on lane 1: False
         Tx power low warning flag on lane 2: False
         Tx power low warning flag on lane 3: False
         Tx power low warning flag on lane 4: False
         Tx power low warning flag on lane 5: False
         Tx power low warning flag on lane 6: False
         Tx power low warning flag on lane 7: False
         Tx power low warning flag on lane 8: False
         Tx power low alarm flag on lane 1: False
         Tx power low alarm flag on lane 2: False
         Tx power low alarm flag on lane 3: False
         Tx power low alarm flag on lane 4: False
         Tx power low alarm flag on lane 5: False
         Tx power low alarm flag on lane 6: False
         Tx power low alarm flag on lane 7: False
         Tx power low alarm flag on lane 8: False
         Rx power high alarm flag on lane 1: False
         Rx power high alarm flag on lane 2: False
         Rx power high alarm flag on lane 3: False
         Rx power high alarm flag on lane 4: False
         Rx power high alarm flag on lane 5: False
         Rx power high alarm flag on lane 6: False
         Rx power high alarm flag on lane 7: False
         Rx power high alarm flag on lane 8: False
         Rx power high warning flag on lane 1: False
         Rx power high warning flag on lane 2: False
         Rx power high warning flag on lane 3: False
         Rx power high warning flag on lane 4: False
         Rx power high warning flag on lane 5: False
         Rx power high warning flag on lane 6: False
         Rx power high warning flag on lane 7: False
         Rx power high warning flag on lane 8: False
         Rx power low warning flag on lane 1: False
         Rx power low warning flag on lane 2: False
         Rx power low warning flag on lane 3: False
         Rx power low warning flag on lane 4: False
         Rx power low warning flag on lane 5: False
         Rx power low warning flag on lane 6: False
         Rx power low warning flag on lane 7: False
         Rx power low warning flag on lane 8: False
         Rx power low alarm flag on lane 1: False
         Rx power low alarm flag on lane 2: False
         Rx power low alarm flag on lane 3: False
         Rx power low alarm flag on lane 4: False
         Rx power low alarm flag on lane 5: False
         Rx power low alarm flag on lane 6: False
         Rx power low alarm flag on lane 7: False
         Rx power low alarm flag on lane 8: False
         Tx bias high alarm flag on lane 1: False
         Tx bias high alarm flag on lane 2: False
         Tx bias high alarm flag on lane 3: False
         Tx bias high alarm flag on lane 4: False
         Tx bias high alarm flag on lane 5: False
         Tx bias high alarm flag on lane 6: False
         Tx bias high alarm flag on lane 7: False
         Tx bias high alarm flag on lane 8: False
         Tx bias high warning flag on lane 1: False
         Tx bias high warning flag on lane 2: False
         Tx bias high warning flag on lane 3: False
         Tx bias high warning flag on lane 4: False
         Tx bias high warning flag on lane 5: False
         Tx bias high warning flag on lane 6: False
         Tx bias high warning flag on lane 7: False
         Tx bias high warning flag on lane 8: False
         Tx bias low warning flag on lane 1: False
         Tx bias low warning flag on lane 2: False
         Tx bias low warning flag on lane 3: False
         Tx bias low warning flag on lane 4: False
         Tx bias low warning flag on lane 5: False
         Tx bias low warning flag on lane 6: False
         Tx bias low warning flag on lane 7: False
         Tx bias low warning flag on lane 8: False
         Tx bias low alarm flag on lane 1: False
         Tx bias low alarm flag on lane 2: False
         Tx bias low alarm flag on lane 3: False
         Tx bias low alarm flag on lane 4: False
         Tx bias low alarm flag on lane 5: False
         Tx bias low alarm flag on lane 6: False
         Tx bias low alarm flag on lane 7: False
         Tx bias low alarm flag on lane 8: False
```

#### New command output (if the output of a command-line utility has changed)
 root@sonic:/# show interfaces transceiver eeprom -d Ethernet0
 Ethernet0: SFP EEPROM detected
         Active Firmware: N/A
         Active application selected code assigned to host lane 1: 1
         Active application selected code assigned to host lane 2: 1
         Active application selected code assigned to host lane 3: 1
         Active application selected code assigned to host lane 4: 1
         Active application selected code assigned to host lane 5: 1
         Active application selected code assigned to host lane 6: 1
         Active application selected code assigned to host lane 7: 1
         Active application selected code assigned to host lane 8: 1
         Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400G-FR4/400GBASE-FR4 (Cl 151) - Media Assign (0x11)
                                    200GAUI-4 C2M (Annex 120E) - Host Assign (0x11) - 200GBASE-FR4 (Cl 122) - Media Assign (0x11)
                                    CAUI-4 C2M (Annex 83E) with RS(528,514) FEC - Host Assign (0x11) - 100G CWDM4 MSA Spec - Media Assign (0x11)
         CMIS Rev: 5.2
         Connector: LC
         **ELS Identifier: QSFP-DD Double Density 8X Pluggable Transceiver
         ELS Laser Count: 8
         ELS Maximum Power Consumption: 12.0
         ELS Revision: 0.1
         ELS Vendor Date Code(YYYY-MM-DD Lot): 2023-12-01
         ELS Vendor Name: BROADCOM
         ELS Vendor OUI: ec-01-e2
         ELS Vendor PN: ARLM-96F8DMZ
         ELS Vendor Rev: A0
         ELS Vendor SN: FD2342VG04W**
         Encoding: N/A
         Extended Identifier: Power Class 5 (8.0W Max)
         Extended RateSelect Compliance: N/A
         Host Lane Count: 4
         Identifier: CPO Bailly
         Inactive Firmware: N/A
         Length Cable Assembly(m): 0.0
         Media Interface Technology: Others
         Media Lane Count: 4
         Module Hardware Rev: 0.0
         Nominal Bit Rate(100Mbs): N/A
         **RLM Laser Lpower Mode Control: 0
         RLM Laser Wavelength Grid: CWDM4**
         Specification compliance: sm_media_interface
         Vendor Date Code(YYYY-MM-DD Lot): 20
         Vendor Name: BROADCOM
         Vendor OUI: ec-01-e2
         Vendor PN: BCM78909CPO
         Vendor Rev: A0
         Vendor SN: 
         is_replaceable: False
         type_abbrv_name: QSFP-DD
         vdm_supported: False
         ChannelMonitorValues:
                 RX1Power: -40.0dBm
                 RX2Power: -40.0dBm
                 RX3Power: -40.0dBm
                 RX4Power: -40.0dBm
                 RX5Power: -40.0dBm
                 RX6Power: -40.0dBm
                 RX7Power: -40.0dBm
                 RX8Power: -40.0dBm
                 TX1Bias: 0.004mA
                 TX1Power: -40.0dBm
                 TX2Bias: 0.004mA
                 TX2Power: -40.0dBm
                 TX3Bias: 0.004mA
                 TX3Power: -40.0dBm
                 TX4Bias: 0.004mA
                 TX4Power: -40.0dBm
                 TX5Bias: 0.004mA
                 TX5Power: -40.0dBm
                 TX6Bias: 0.004mA
                 TX6Power: -40.0dBm
                 TX7Bias: 0.004mA
                 TX7Power: -40.0dBm
                 TX8Bias: 0.004mA
                 TX8Power: -40.0dBm
         ChannelThresholdValues:
                 RxPowerHighAlarm  : 7.0dBm
                 RxPowerHighWarning: 4.0dBm
                 RxPowerLowAlarm   : -9.901dBm
                 RxPowerLowWarning : -5.901dBm
                 TxBiasHighAlarm   : 162.5mA
                 TxBiasHighWarning : 156.248mA
                 TxBiasLowAlarm    : 15.0mA
                 TxBiasLowWarning  : 20.0mA
                 TxPowerHighAlarm  : 7.0dBm
                 TxPowerHighWarning: 4.0dBm
                 TxPowerLowAlarm   : -6.899dBm
                 TxPowerLowWarning : -2.9dBm
         ModuleMonitorValues:
                 Temperature: 32.293C
                 Vcc: 3.298Volts
         ModuleThresholdValues:
                 TempHighAlarm  : 90.0C
                 TempHighWarning: 85.0C
                 TempLowAlarm   : -5.0C
                 TempLowWarning : 0.0C
                 VccHighAlarm   : 3.63Volts
                 VccHighWarning : 3.465Volts
                 VccLowAlarm    : 2.97Volts
                 VccLowWarning  : 3.135Volts
         **ELSMonitorValues:
                 RLM0_Laser4_current: 0.0 mA
                 RLM0_Laser4_power: 0.010 mW -20.000 dBm
                 RLM0_Laser5_current: 0.0 mA
                 RLM0_Laser5_power: 0.140 mW -8.539 dBm
                 RLM0_Laser6_current: 0.0 mA
                 RLM0_Laser6_power: 0.010 mW -20.000 dBm
                 RLM0_Laser7_current: 0.0 mA
                 RLM0_Laser7_power: 0.010 mW -20.000 dBm
                 ELS Temperature: 15.957C
                 ELS Vcc: 3.384Volts
         ELSThresholdValues:
                 ELS TempHighAlarm: 0.0C
                 ELS TempHighWarning: 0.0C
                 ELS TempLowAlarm: 0.0C
                 ELS TempLowWarning: 0.0C
                 ELS TxBiasHighAlarm: 0.0mA
                 ELS TxBiasHighWarning: 0.0mA
                 ELS TxPowerHighAlarm: 0.0mW
                 ELS TxPowerHighWarning: 0.0mW
                 ELS TxPowerLowAlarm: 0.0mW
                 ELS TxPowerLowWarning: 0.0mW
                 ELS VccHighAlarm: 0.0Volts
                 ELS VccHighWarning: 0.0Volts
                 ELS VccLowAlarm: 0.0Volts
                 ELS VccLowWarning: 0.0Volts**


 root@sonic:/# show interfaces transceiver status Ethernet0
... (Omit the original print output.)
         **ELS temperature high alarm flag: False
         ELS temperature low alarm flag: False
         ELS temperature high warning flag: False
         ELS temperature low warning flag: False
         ELS Vcc high alarm flag: False
         ELS Vcc low alarm flag: False
         ELS Vcc high warning flag: False
         ELS Vcc low warning flag: False
         ELS module state: Low power mode
         ELS interrupt status: Interrupt event occurred**