### PR TITLE
[ci]sonic-ubuntu-1c agent pool: migrate pre-commit from pip to uv to address S360 vulnerability

### DIFF
--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -5,7 +5,7 @@ steps:
 
 - script: |
     set -x
-    sudo pip install pre-commit
+    sudo uv pip install --system pre-commit
     pre-commit install-hooks
   displayName: 'Prepare pre-commit check'
 
@@ -20,7 +20,7 @@ steps:
     To run the pre-commit checks locally, you can follow below steps:\n\
       1. Ensure that default python is python3.\n\
       2. Ensure that the 'pre-commit' package is installed:\n\
-         sudo pip install pre-commit\n\
+         sudo uv pip install --system pre-commit\n\
       3. Go to repository root folder\n\
       4. Install the pre-commit hooks:\n\
          pre-commit install\n\


### PR DESCRIPTION
### Description of PR

Summary: Migrate the pre-commit static-analysis step off python3-pip to uv.

The CI agent pool **sonic-ubuntu-1c** (VMSS sonic-ubuntu-2ca, Ubuntu 22.04) is flagged by S360 for pip vulnerabilities **USN-8344-1** and **USN-8344-3** (`python3-pip`). The agent is being redeployed without python3-pip. `pre-commit-check.yml` runs directly on that host (no container), so `sudo pip install pre-commit` would break. uv is already installed on the agent and is a drop-in replacement.

### Type of change
- [x] Refactor / cleanup

### Approach
#### What is the motivation for this PR?
Remove python3-pip dependency from sonic-ubuntu-1c to clear S360 USN-8344-1/-3.
##### Work item tracking
- Microsoft ADO **(number only)**: 6035751, 6035790
#### How did you do it?
Replaced `sudo pip install pre-commit` with `sudo uv pip install --system pre-commit` in .azure-pipelines/pre-commit-check.yml (and the local-instructions text).
#### How did you verify/test it?
Static Analysis stage runs pre-commit successfully via uv.
