### PR TITLE
Fix route_check.py: intersection retry and snapshot reorder

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -742,20 +742,45 @@ def is_feature_bgp_enabled(namespace):
 
 def check_frr_pending_routes(namespace):
     """
-    Check FRR routes for offload flag presence by executing "show ip route json"
-    Returns a list of routes that have no offload flag.
+    Check FRR routes for offload flag presence by executing "show ip route json".
+    Returns lists of routes that are persistently non-offloaded across all retry
+    iterations (intersection logic).
+
+    Intersection approach: only routes that appear as stuck in *every* poll
+    are returned for mitigation.  A route that clears between iterations is
+    converging normally and should not be mitigated.
     """
+    acc_miss = []
+    acc_fail = []
 
-    missed_rt = []
-    failed_rt = []
-    retries = FRR_CHECK_RETRIES
-    for i in range(retries):
-        missed_rt, failed_rt = get_frr_routes_parallel(namespace)
+    for i in range(FRR_CHECK_RETRIES):
+        curr_miss, curr_fail = get_frr_routes_parallel(namespace)
 
-        if not missed_rt and not failed_rt:
+        if i == 0:
+            acc_miss = curr_miss
+            acc_fail = curr_fail
+        else:
+            curr_miss_set = {entry['prefix'] for entry in curr_miss}
+            curr_fail_set = set(curr_fail)
+            acc_miss = [entry for entry in acc_miss if entry['prefix'] in curr_miss_set]
+            acc_fail = [prefix for prefix in acc_fail if prefix in curr_fail_set]
+
+        if not acc_miss and not acc_fail:
             break
 
-        time.sleep(FRR_WAIT_TIME)
+        if i < FRR_CHECK_RETRIES - 1:
+            time.sleep(FRR_WAIT_TIME)
+
+    missed_rt = acc_miss
+    failed_rt = acc_fail
+
+    excluded_miss = {entry['prefix'] for entry in curr_miss} - {entry['prefix'] for entry in acc_miss}
+    excluded_fail = set(curr_fail) - set(acc_fail)
+    if excluded_miss or excluded_fail:
+        print_message(syslog.LOG_DEBUG,
+                      f"Routes pending in final poll but excluded by intersection "
+                      f"(not mitigated): missed={excluded_miss} failed={excluded_fail}")
+
     print_message(syslog.LOG_DEBUG, f"FRR missed routes: {missed_rt}")
     print_message(syslog.LOG_DEBUG, f"FRR failed routes: {failed_rt}")
     return missed_rt, failed_rt
@@ -897,6 +922,8 @@ def check_routes_for_namespace(namespace):
     rt_frr_miss = []
     rt_frr_failed = []
 
+    rt_frr_miss, rt_frr_failed = check_frr_pending_routes(namespace)
+
     selector, subs, rt_asic = get_asicdb_routes(namespace)
 
     rt_appl = get_appdb_routes(namespace)
@@ -953,8 +980,6 @@ def check_routes_for_namespace(namespace):
 
     if rt_asic_miss:
         results["Unaccounted_ROUTE_ENTRY_TABLE_entries"] = rt_asic_miss
-
-    rt_frr_miss, rt_frr_failed = check_frr_pending_routes(namespace)
 
     if rt_frr_miss:
         results["missed_FRR_routes"] = rt_frr_miss

--- a/tests/check_frr_pending_routes_test.py
+++ b/tests/check_frr_pending_routes_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Tests for intersection-based retry logic in check_frr_pending_routes().
+"""
+
+import sys
+from unittest.mock import patch
+
+sys.path.append("scripts")
+import route_check  # noqa: E402
+
+
+def _miss(*prefixes, protocol='bgp'):
+    return [{'prefix': p, 'protocol': protocol} for p in prefixes]
+
+
+class TestCheckFrrPendingRoutes:
+    def setup_method(self):
+        route_check.UNIT_TESTING = 1
+        route_check.FRR_WAIT_TIME = 0
+
+    def test_clears_on_first_poll_no_mitigation(self):
+        with patch.object(route_check, "get_frr_routes_parallel",
+                          return_value=([], [])) as mock_poll:
+            missed, failed = route_check.check_frr_pending_routes(None)
+        assert missed == []
+        assert failed == []
+        assert mock_poll.call_count == 1
+
+    def test_all_stuck_every_poll_all_mitigated(self):
+        always_stuck = (_miss("10.0.0.0/24", "10.1.0.0/24"), [])
+        with patch.object(route_check, "get_frr_routes_parallel",
+                          return_value=always_stuck):
+            missed, failed = route_check.check_frr_pending_routes(None)
+        assert {e['prefix'] for e in missed} == {"10.0.0.0/24", "10.1.0.0/24"}
+        assert failed == []
+
+    def test_converging_route_not_mitigated(self):
+        side_effects = [
+            (_miss("10.0.0.0/24", "10.1.0.0/24"), []),
+            (_miss("10.0.0.0/24"), []),
+            (_miss("10.0.0.0/24"), []),
+        ]
+        with patch.object(route_check, "get_frr_routes_parallel",
+                          side_effect=side_effects):
+            missed, failed = route_check.check_frr_pending_routes(None)
+        assert missed == _miss("10.0.0.0/24")
+        assert failed == []
+
+    def test_all_converge_mid_retry(self):
+        side_effects = [
+            (_miss("10.0.0.0/24"), []),
+            ([], []),
+        ]
+        with patch.object(route_check, "get_frr_routes_parallel",
+                          side_effect=side_effects) as mock_poll:
+            missed, failed = route_check.check_frr_pending_routes(None)
+        assert missed == []
+        assert failed == []
+        assert mock_poll.call_count == 2
+
+    def test_failed_routes_intersection(self):
+        side_effects = [
+            ([], ["10.0.0.0/24", "10.1.0.0/24"]),
+            ([], ["10.0.0.0/24"]),
+            ([], ["10.0.0.0/24"]),
+        ]
+        with patch.object(route_check, "get_frr_routes_parallel",
+                          side_effect=side_effects):
+            missed, failed = route_check.check_frr_pending_routes(None)
+        assert missed == []
+        assert failed == ["10.0.0.0/24"]


### PR DESCRIPTION
## Summary

Split from #4576 per [@deepak-singhal0408's review](https://github.com/sonic-net/sonic-utilities/pull/4576#issuecomment-2976544324) — **Bucket B (correctness, land after Bucket A)**.

Depends on #4649 (dict-format bugfix). Includes two improvements:

1. **Intersection-based retry** in `check_frr_pending_routes()`: only routes stuck in *every* poll window are mitigated, preventing premature mitigation of converging routes.
2. **Snapshot reorder**: move ASIC/APPL DB snapshot to after FRR polling completes so `rt_appl_miss` / `rt_asic_miss` are temporally aligned with FRR results when the mitigation cross-check fires.

Keeps the ijson JSON parser (no text-streaming change).

## Test plan

- [ ] `tests/check_frr_pending_routes_test.py` — intersection accumulator cases
- [ ] CI unit tests pass
- [ ] Routes that converge between retry iterations are not mitigated
- [ ] Routes finishing ASIC programming during the FRR retry window do not suppress mitigation