### PR TITLE
acl-loader: Skip adding `IP_TYPE` on ACLs that don't support it

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -72,6 +72,7 @@ class AclLoader(object):
 
     ACL_TABLE = "ACL_TABLE"
     ACL_RULE = "ACL_RULE"
+    ACL_TABLE_TYPE = "ACL_TABLE_TYPE"
     CFG_ACL_TABLE = "ACL_TABLE"
     APPL_ACL_TABLE = "ACL_TABLE_TABLE"
     STATE_ACL_TABLE = "ACL_TABLE_TABLE"
@@ -121,6 +122,7 @@ class AclLoader(object):
         self.mirror_stage = None
         self.current_table = None
         self.tables_db_info = {}
+        self.tables_type_info = {}
         self.rules_db_info = {}
         self.rules_info = {}
         self.tables_state_info = None
@@ -202,6 +204,17 @@ class AclLoader(object):
                     else:
                         self.tables_db_info[table]['ports'] += entry.get(
                             'ports', [])
+
+        # Update user defined acl table types
+        host_acl_table_type = self.configdb.get_table(self.ACL_TABLE_TYPE)
+        if self.per_npu_configdb:
+            for ns, config_db in self.per_npu_configdb.items():
+                acl_table_type = config_db.get_table(self.ACL_TABLE_TYPE)
+                for table_type, entry in acl_table_type.items():
+                    if table not in self.tables_type_info:
+                        self.tables_type_info[table_type] = entry
+        else:
+            self.tables_type_info.update(host_acl_table_type)
 
         if self.per_npu_configdb:
             # Note: Ability to read table information from APPL_DB is not yet supported for masic devices
@@ -455,6 +468,16 @@ class AclLoader(object):
         :return: True if table type is ACL_TABLE_TYPE_CTRLPLANE else False
         """
         return self.tables_db_info[tname]['type'].upper() == self.ACL_TABLE_TYPE_CTRLPLANE
+
+    def acl_table_has_match(self, tname, match):
+        """
+        """
+        table_type = self.tables_db_info[tname]["type"]
+        # Predefined table types aren't defined in the tables_type_info
+        if table_type not in self.tables_type_info:
+            return True
+        else:
+            return match in self.tables_type_info[table_type]["MATCHES"]
 
     @staticmethod
     def parse_acl_json(filename):
@@ -795,7 +818,7 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_transport(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
 
-        if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props:
+        if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props and self.acl_table_has_match(table_name, "IP_TYPE"):
             # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
             # we could match on non-IP packets if the bits at the same offset match
             # https://github.com/sonic-net/sonic-mgmt/issues/23960

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -818,7 +818,8 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_transport(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
 
-        if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props and self.acl_table_has_match(table_name, "IP_TYPE"):
+        if ("IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props
+            and self.acl_table_has_match(table_name, "IP_TYPE")):
             # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
             # we could match on non-IP packets if the bits at the same offset match
             # https://github.com/sonic-net/sonic-mgmt/issues/23960

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -206,15 +206,17 @@ class AclLoader(object):
                             'ports', [])
 
         # Update user defined acl table types
-        host_acl_table_type = self.configdb.get_table(self.ACL_TABLE_TYPE)
         if self.per_npu_configdb:
+            # On multi-asic the acl table type should be defined in both the global namespace
+            # and the asic namespaces but using the asic namespace definition to be consistent
+            # with the way tables_db_info is populated.
             for ns, config_db in self.per_npu_configdb.items():
                 acl_table_type = config_db.get_table(self.ACL_TABLE_TYPE)
                 for table_type, entry in acl_table_type.items():
-                    if table not in self.tables_type_info:
+                    if table_type not in self.tables_type_info:
                         self.tables_type_info[table_type] = entry
         else:
-            self.tables_type_info.update(host_acl_table_type)
+            self.tables_type_info.update(self.configdb.get_table(self.ACL_TABLE_TYPE))
 
         if self.per_npu_configdb:
             # Note: Ability to read table information from APPL_DB is not yet supported for masic devices
@@ -471,6 +473,12 @@ class AclLoader(object):
 
     def acl_table_has_match(self, tname, match):
         """
+        Check if the ACL table supports matching on a given qualifier.
+        Non-user defined ACL table types will always return true here as we assume they
+        support all qualifiers
+        :param tname: ACL table name
+        :param match: ACL qualifier to query support for
+        :return: True if qualifier is supported or table type is not user defined
         """
         table_type = self.tables_db_info[tname]["type"]
         # Predefined table types aren't defined in the tables_type_info

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -819,7 +819,7 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
 
         if ("IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props
-            and self.acl_table_has_match(table_name, "IP_TYPE")):
+                and self.acl_table_has_match(table_name, "IP_TYPE")):
             # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
             # we could match on non-IP packets if the bits at the same offset match
             # https://github.com/sonic-net/sonic-mgmt/issues/23960

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -373,7 +373,7 @@
 								},
 								"ip": {
 									"config": {
-										"protocol": "0"
+										"protocol": "1"
 									}
 								}
 							}

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -359,6 +359,38 @@
 						"name": "bmc_acl_northbound_v6"
 					}
 				},
+				"acl_noiptype": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "0",
+										"source-ip-address": "172.17.0.200/30"
+									}
+								},
+								"input_interface": {
+									"interface_ref": {
+										"config": {
+											"interface": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45"
+										}
+									}
+								}
+							}
+						}
+					},
+					"config": {
+						"name": "acl_noiptype"
+					}
+				},
 				"DATAACLV4V6": {
 					"acl-entries": {
 						"acl-entry": {

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -373,15 +373,7 @@
 								},
 								"ip": {
 									"config": {
-										"protocol": "0",
-										"source-ip-address": "172.17.0.200/30"
-									}
-								},
-								"input_interface": {
-									"interface_ref": {
-										"config": {
-											"interface": "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45"
-										}
+										"protocol": "0"
 									}
 								}
 							}

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -236,7 +236,7 @@ class TestAclLoader(object):
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
         assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")]
         assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")] == {
-            "IP_PROTOCOL": 0,
+            "IP_PROTOCOL": 1,
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9999"
         }

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -231,6 +231,17 @@ class TestAclLoader(object):
             "PRIORITY": "9998"
         }
 
+    def test_noiptype_custom_acl_table_type(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")]
+        assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")] == {
+            "IP_PROTOCOL": 0,
+            "SRC_IP": "172.17.0.200/30",
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9999"
+        }
+
     def test_ingress_default_deny_rule(self, acl_loader):
         acl_loader.set_mirror_stage("ingress")
         acl_loader.get_session_name = mock.MagicMock(return_value="everflow_session_mock")

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -22,7 +22,7 @@ class TestAclLoader(object):
 
     def test_valid(self):
         yang_acl = AclLoader.parse_acl_json(os.path.join(test_path, 'acl_input/acl1.json'))
-        assert len(yang_acl.acl.acl_sets.acl_set) == 9
+        assert len(yang_acl.acl.acl_sets.acl_set) == 10
 
     def test_invalid(self):
         with pytest.raises(AclLoaderException):
@@ -237,7 +237,6 @@ class TestAclLoader(object):
         assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")]
         assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")] == {
             "IP_PROTOCOL": 0,
-            "SRC_IP": "172.17.0.200/30",
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9999"
         }

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -90,7 +90,7 @@ RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 16
+Total number of ACL Tables: 17
 Total number of ACL Rules: 21
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -588,6 +588,12 @@
         "stage": "ingress",
         "type": "BMCDATAV6"
     },
+    "ACL_TABLE|ACL_NOIPTYPE": {
+        "policy_desc": "ACL_NOIPTYPE",
+        "ports@": "Ethernet8,Ethernet0,Ethernet17,Ethernet16,Ethernet37,Ethernet4,Ethernet13,Ethernet45,Ethernet19,Ethernet24,Ethernet31,Ethernet30,Ethernet39,Ethernet40,Ethernet27,Ethernet43,Ethernet7,Ethernet3,Ethernet20,Ethernet6,Ethernet12,Ethernet34,Ethernet26,Ethernet11,Ethernet42,Ethernet5,Ethernet32,Ethernet36,Ethernet15,Ethernet33,Ethernet35,Ethernet9,Ethernet29,Ethernet21,Ethernet18,Ethernet38,Ethernet23,Ethernet41,Ethernet14,Ethernet2,Ethernet28,Ethernet22,Ethernet10,Ethernet25,Ethernet44,Ethernet1",
+        "stage": "ingress",
+        "type": "NOIPTYPE"
+    },
     "ACL_TABLE|DATAACL": {
         "policy_desc": "DATAACL",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
@@ -668,6 +674,11 @@
         "ACTIONS": "PACKET_ACTION,COUNTER",
         "BIND_POINTS": "PORT",
         "MATCHES": "SRC_IPV6,DST_IPV6,ETHER_TYPE,IP_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
+    },
+    "ACL_TABLE_TYPE|NOIPTYPE": {
+        "ACTIONS": "PACKET_ACTION,COUNTER",
+        "BIND_POINTS": "PORT",
+        "MATCHES": "SRC_IP,DST_IP,ETHER_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
     },
     "PBH_TABLE|pbh_table1": {
         "description": "NVGRE",


### PR DESCRIPTION
In https://github.com/sonic-net/sonic-utilities/pull/4462 functionality was added to include a IP_TYPE qualifier on rules with IP_PROTOCOL.
This broke custom ACL types that don't support the IP_TYPE qualifier.
https://github.com/sonic-net/sonic-buildimage/issues/28028
This change will avoid adding IP_TYPE on those custom ACL types.

#### What I did
Skip adding `IP_TYPE` qualifier automatically on custom ACL types that don't support `IP_TYPE` qualifier

#### How I did it
In `acl-loader` check if `IP_TYPE` is in the `MATCHES` attribute of `ACL_TABLE_TYPE` before adding the `IP_TYPE` qualifier.

#### How to verify it
I executed the same steps described in
https://github.com/sonic-net/sonic-buildimage/issues/28028

Before this change I'd see the `IP_TYPE` added to the `RULE_1` entry in CONFIG_DB:
```
# sonic-db-cli CONFIG_DB hgetall "ACL_RULE|TEST_NOIPTYPE|RULE_1"
{'IP_PROTOCOL': '6', 'IP_TYPE': 'IP', 'PACKET_ACTION': 'FORWARD', 'PRIORITY': '9999', 'SRC_IP': '20.0.0.2/32'}
root@ctn106:~# show acl rule
Table          Rule    Priority    Action    Match                Status
-------------  ------  ----------  --------  -------------------  --------
TEST_NOIPTYPE  RULE_1  9999        FORWARD   IP_PROTOCOL: 6       Inactive
                                             IP_TYPE: IP
                                             SRC_IP: 20.0.0.2/32
```
And the error syslog in orchagent:
```
2026 Jun 29 18:22:34.681995 ctn106 ERR swss#orchagent: :- validateAclRuleMatch: Match SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE in rule RULE_1 is not supported by table TEST_NOIPTYPE             2026 Jun 29 18:22:34.681995 ctn106 ERR swss#orchagent: :- doAclRuleTask: Unknown or invalid rule attribute 'IP_TYPE : IP'
2026 Jun 29 18:22:34.682107 ctn106 ERR swss#orchagent: :- doAclRuleTask: Failed to create ACL rule. Rule configuration is invalid
```

After this change I see the `IP_TYPE` isn't added to the `RULE_1` entry in CONFIG_DB:
```
root@ctn106:~# sonic-db-cli CONFIG_DB hgetall "ACL_RULE|TEST_NOIPTYPE|RULE_1"
{'IP_PROTOCOL': '6', 'PACKET_ACTION': 'FORWARD', 'PRIORITY': '9999', 'SRC_IP': '20.0.0.2/32'}
root@ctn106:~# show acl rule
Table          Rule    Priority    Action    Match                Status
-------------  ------  ----------  --------  -------------------  --------
TEST_NOIPTYPE  RULE_1  9999        FORWARD   IP_PROTOCOL: 6       Active
                                             SRC_IP: 20.0.0.2/32
```
And the rule is successfully added:
```
2026 Jun 29 18:56:24.439088 ctn106 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_1 in table TEST_NOIPTYPE
```

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
N/A

#### Casts
* 202511
* 202605