### PR TITLE
[chassis] Record operator for user-initiated DPU reboot/shutdown

### DIFF
--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -3,6 +3,8 @@
 import click
 import time
 import re
+import os
+import getpass
 import subprocess
 import utilities_common.cli as clicommon
 from utilities_common.chassis import is_smartswitch, is_bmc, get_all_dpus
@@ -11,6 +13,20 @@ from datetime import timedelta
 
 TIMEOUT_SECS = 10
 TRANSITION_TIMEOUT = timedelta(seconds=240)  # 4 minutes
+MODULE_REBOOT_CAUSE_DIR = "/host/reboot-cause/module"
+
+
+def persist_dpu_reboot_user(module_name):
+    """Record the operator who shut down a DPU so chassisd can populate the DPU
+    reboot-cause 'user' field."""
+    try:
+        reboot_user = os.environ.get("SUDO_USER") or getpass.getuser()
+        dpu_dir = os.path.join(MODULE_REBOOT_CAUSE_DIR, module_name.lower())
+        os.makedirs(dpu_dir, exist_ok=True)
+        with open(os.path.join(dpu_dir, "prev_reboot_user.txt"), "w") as f:
+            f.write(reboot_user)
+    except Exception as e:
+        click.echo(f"Warning: failed to record reboot user for {module_name}: {e}")
 
 
 class StateDBHelper:
@@ -166,6 +182,7 @@ def shutdown_chassis_module(db, chassis_module_name):
             return
 
         click.echo(f"Shutting down chassis module {chassis_module_name}")
+        persist_dpu_reboot_user(chassis_module_name)
         fvs = {
             'admin_status': 'down',
         }

--- a/scripts/reboot_smartswitch_helper
+++ b/scripts/reboot_smartswitch_helper
@@ -3,6 +3,7 @@
 declare -r GNMI_PORT=8080 # Default GNMI port
 declare -r MODULE_REBOOT_DPU="DPU"
 declare -r MODULE_REBOOT_SMARTSWITCH="SMARTSWITCH"
+declare -r MODULE_REBOOT_CAUSE_DIR="/host/reboot-cause/module"
 
 declare -r EXIT_DPU_DOWN=2
 
@@ -10,6 +11,21 @@ declare -r EXIT_DPU_DOWN=2
 function log_message() {
     local message=$1
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $message" >&2
+}
+
+# Function to persist the user who issued a DPU reboot so chassisd can attribute
+# the DPU reboot-cause record to the operator. chassisd reads and removes this
+# marker in persist_dpu_reboot_cause.
+function persist_dpu_reboot_user() {
+    local DPU_NAME=$1
+    local REBOOT_USER=${2:-$(logname 2>/dev/null || whoami)}
+    local dpu_dir="${MODULE_REBOOT_CAUSE_DIR}/${DPU_NAME,,}"
+
+    if ! mkdir -p "${dpu_dir}" 2>/dev/null; then
+        log_message "ERROR: Failed to create ${dpu_dir} to persist reboot user"
+        return
+    fi
+    echo "${REBOOT_USER}" > "${dpu_dir}/prev_reboot_user.txt"
 }
 
 # Function to check if running on smart switch
@@ -229,6 +245,10 @@ function reboot_dpu()
             return ${EXIT_ERROR}
         fi
     fi
+
+    # Persist the operator who issued the reboot so chassisd can record it in
+    # the DPU reboot-cause "user" field (mirrors the NPU reboot-cause flow).
+    persist_dpu_reboot_user "${DPU_NAME}" "${REBOOT_USER:-}"
 
     # Send reboot command to DPU
     gnmi_reboot_dpu "${DPU_NAME}"

--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -453,6 +453,7 @@ class TestChassisModules(object):
     def test_shutdown_smartswitch_module(self):
         with mock.patch("config.chassis_modules.is_smartswitch", return_value=True), \
              mock.patch("config.chassis_modules.get_config_module_state", return_value='up'), \
+             mock.patch("config.chassis_modules.persist_dpu_reboot_user") as mock_persist, \
              mock.patch("config.chassis_modules.ModuleHelper.get_module_state_transition", return_value=False):
 
             runner = CliRunner()
@@ -467,11 +468,29 @@ class TestChassisModules(object):
             assert result.exit_code == 0
             assert "Shutting down chassis module DPU0" in result.output
 
+            # The operator who shut down the DPU must be recorded so chassisd can
+            # populate the DPU reboot-cause "user" field.
+            mock_persist.assert_called_once_with("DPU0")
+
             # Check CONFIG_DB for admin_status
             cfg_fvs = db.cfgdb.get_entry("CHASSIS_MODULE", "DPU0")
             admin_status = cfg_fvs.get("admin_status")
             print(f"admin_status: {admin_status}")
             assert admin_status == "down"
+
+    def test_persist_dpu_reboot_user(self):
+        """persist_dpu_reboot_user records the operator (SUDO_USER/login) to the
+        per-DPU prev_reboot_user.txt marker that chassisd reads to populate the
+        DPU reboot-cause 'user' field."""
+        m = mock.mock_open()
+        with mock.patch("config.chassis_modules.os.makedirs") as mock_makedirs, \
+             mock.patch("builtins.open", m), \
+             mock.patch.dict("os.environ", {"SUDO_USER": "admin"}):
+            config.chassis_modules.persist_dpu_reboot_user("DPU0")
+
+        mock_makedirs.assert_called_once_with("/host/reboot-cause/module/dpu0", exist_ok=True)
+        m.assert_called_once_with("/host/reboot-cause/module/dpu0/prev_reboot_user.txt", "w")
+        m().write.assert_called_once_with("admin")
 
     def test_shutdown_smartswitch_transition_in_progress(self):
         with mock.patch("config.chassis_modules.is_smartswitch", return_value=True), \


### PR DESCRIPTION
#### What I did

Capture the operator who triggers a **user-initiated** DPU down event so the
DPU reboot-cause history (written by `chassisd`) can attribute it, mirroring
the NPU reboot-cause `user` field. Covers both DPU down paths:

- **Reboot** — `reboot_smartswitch_helper`
- **Shutdown** — `config chassis modules shutdown <DPU>`

Companion consumer PR in sonic-platform-daemons (chassisd reads the marker and
populates the `user` field): https://github.com/sonic-net/sonic-platform-daemons/pull/841

Addresses sonic-net/sonic-buildimage#28149.

#### How I did it

Both producers write the operator to
`/host/reboot-cause/module/<dpu>/prev_reboot_user.txt` before the DPU goes
down; chassisd reads and clears this one-shot marker.

- `scripts/reboot_smartswitch_helper`: write `REBOOT_USER` (exported by the
  sourcing `reboot` script via `logname`, falling back to `whoami`) in
  `reboot_dpu()`, so both the single-DPU (`-d`) and all-DPU SmartSwitch paths
  are covered.
- `config/chassis_modules.py`: `persist_dpu_reboot_user()` writes the operator
  (`SUDO_USER`, falling back to `getpass.getuser()`) and is called in
  `shutdown_chassis_module()` for the SmartSwitch DPU branch. It is
  **best-effort** — a marker-write failure logs a warning and never blocks the
  shutdown. Hardware/auto reboots write no marker, so chassisd reports `N/A`.

#### How to verify it

Unit tests:
- `tests/chassis_modules_test.py::test_persist_dpu_reboot_user` — writes the
  marker with `SUDO_USER`.
- `test_shutdown_smartswitch_module` — asserts `persist_dpu_reboot_user("DPU0")`
  is invoked on shutdown.

Manual (SmartSwitch DUT):
1. `config chassis modules shutdown DPU0` (or `reboot -d DPU0`).
2. `cat /host/reboot-cause/module/dpu0/prev_reboot_user.txt` → operator name.
3. After chassisd persists the reboot cause:
   `redis-cli -h redis_chassis.server -p 6380 -n 13 HGETALL "REBOOT_CAUSE|DPU0|<name>"`
   and `show reboot-cause history DPU0` → `User` column shows the operator.

#### Previous command output (if the output of a command-line utility has changed)

No CLI output change. `config chassis modules shutdown DPU0` still prints
`Shutting down chassis module DPU0`. The captured operator surfaces only in
`show reboot-cause history <DPU>` once chassisd persists the record.

#### New command output (if the output of a command-line utility has changed)

N/A — no command output changed; only the recorded reboot-cause `user` field.
