### PR TITLE
[sonic-package-manager]: Unpin docker-image-py and use lowercase 'azure/sonic' in registry test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,7 @@ setup(
         'urllib3>=2',
         'click-log>=0.3.2',
         'docker>=4.4.4',
-        'docker-image-py==0.1.13',
+        'docker-image-py>=0.1.10',
         'filelock>=3.0.12',
         'enlighten>=1.8.0',
         'ijson>=3.2.3',

--- a/tests/sonic_package_manager/test_registry.py
+++ b/tests/sonic_package_manager/test_registry.py
@@ -9,7 +9,7 @@ def test_get_registry_for():
     resolver = RegistryResolver()
     registry = resolver.get_registry_for('debian')
     assert registry is resolver.DockerHubRegistry
-    registry = resolver.get_registry_for('Azure/sonic')
+    registry = resolver.get_registry_for('azure/sonic')
     assert registry is resolver.DockerHubRegistry
     registry = resolver.get_registry_for('registry-server:5000/docker')
     assert registry.url == 'https://registry-server:5000'


### PR DESCRIPTION
#### What I did

`docker-image-py` was pulled in unpinned (`docker-image-py>=0.1.10`). When **0.2.0** was released (2026-06-29) it changed `Reference.split_docker_domain()` to treat an uppercase first path component as a registry domain (Docker Hub repository names must be lowercase). This broke `tests/sonic_package_manager/test_registry.py::test_get_registry_for`, which resolved the reference `Azure/sonic`.

The key point is that `Azure/sonic` is **not a valid Docker Hub reference** in the first place — Docker Hub namespaces must be lowercase (`Azure/...` is rejected as an invalid namespace). So instead of pinning `docker-image-py` to `==0.1.13` (#4660) or reimplementing `split_docker_domain()`, this change simply fixes the test to use the valid lowercase reference `azure/sonic` and drops the pin (`>=0.1.10`), so registry resolution and the test are correct regardless of the installed `docker-image-py` version and the build can adopt 0.2.0. It pairs with sonic-net/sonic-buildimage#28144, which stops installing `python3-regex` via apt so 0.2.0's `regex>=2026.6.28` installs cleanly.

#### How I did it

- `setup.py`: `docker-image-py==0.1.13` → `docker-image-py>=0.1.10` (drop the pin added in #4660).
- `tests/sonic_package_manager/test_registry.py`: `resolver.get_registry_for('Azure/sonic')` → `resolver.get_registry_for('azure/sonic')`.

#### How to verify it

Run the package-manager registry test with `docker-image-py` 0.2.0 installed:

```
pytest tests/sonic_package_manager/test_registry.py::test_get_registry_for
```

It passes (CI green) — `azure/sonic` resolves to the `DockerHubRegistry` singleton regardless of the `docker-image-py` version.

#### Previous command output (if the output of a command-line utility has changed)

N/A - no user-facing command output changes.

#### New command output (if the output of a command-line utility has changed)

N/A - no user-facing command output changes.