### PR TITLE
[acl_loader] Only inject IP_TYPE when the ACL table type supports it

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -78,6 +78,7 @@ class AclLoader(object):
     CFG_ACL_RULE = "ACL_RULE"
     APPL_ACL_RULE = "ACL_RULE_TABLE"
     STATE_ACL_RULE = "ACL_RULE_TABLE"
+    ACL_TABLE_TYPE = "ACL_TABLE_TYPE"
     ACL_TABLE_TYPE_MIRROR = "MIRROR"
     ACL_TABLE_TYPE_CTRLPLANE = "CTRLPLANE"
     CFG_MIRROR_SESSION_TABLE = "MIRROR_SESSION"
@@ -121,6 +122,7 @@ class AclLoader(object):
         self.mirror_stage = None
         self.current_table = None
         self.tables_db_info = {}
+        self.table_types_db_info = {}
         self.rules_db_info = {}
         self.rules_info = {}
         self.tables_state_info = None
@@ -177,6 +179,9 @@ class AclLoader(object):
         Read ACL_TABLE table from configuration database
         :return:
         """
+        # Read custom ACL table type definitions so rule conversion can honor
+        # the match fields each table type actually supports.
+        self.table_types_db_info = self.configdb.get_table(self.ACL_TABLE_TYPE)
         # get the acl table info from host config_db
         host_acl_table = self.configdb.get_table(self.ACL_TABLE)
         # For multi asic get only the control plane acls from the host config_db
@@ -447,6 +452,24 @@ class AclLoader(object):
         :return: True if table type is IPv6 else False
         """
         return self.tables_db_info[tname]["type"].upper() in ("L3V6", "MIRRORV6")
+
+    def is_match_field_supported(self, tname, match_field):
+        """
+        Check whether the table's type supports a given match field.
+        Custom table types (ACL_TABLE_TYPE) only support the matches they
+        declare; built-in types are not enumerated here, so assume supported.
+        :param tname: ACL table name
+        :param match_field: match field name, e.g. "IP_TYPE"
+        :return: True if supported (or table type is built-in), False otherwise
+        """
+        table_type = self.tables_db_info[tname].get("type")
+        if not table_type or table_type not in self.table_types_db_info:
+            # Built-in table type: preserve legacy behavior
+            return True
+        matches = self.table_types_db_info[table_type].get("MATCHES", [])
+        if isinstance(matches, str):
+            matches = matches.split(",")
+        return match_field.upper() in [m.upper() for m in matches]
 
     def is_table_control_plane(self, tname):
         """
@@ -795,10 +818,13 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_transport(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
 
-        if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props:
+        if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props \
+                and self.is_match_field_supported(table_name, "IP_TYPE"):
             # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
             # we could match on non-IP packets if the bits at the same offset match
             # https://github.com/sonic-net/sonic-mgmt/issues/23960
+            # Skip injection for custom table types whose MATCHES omit IP_TYPE,
+            # otherwise orchagent rejects the whole rule (sonic-buildimage #28028).
             rule_props["IP_TYPE"] = "IP"
 
         self.validate_rule_fields(rule_props)

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -159,6 +159,20 @@ class TestAclLoader(object):
             'ICMPV6_TYPE': 1
         }
 
+    def test_iptype_match_field_support_for_custom_table(self, acl_loader):
+        # Built-in table types are not enumerated, so IP_TYPE injection is preserved
+        acl_loader.tables_db_info["DATAACL"] = {"type": "L3"}
+        assert acl_loader.is_match_field_supported("DATAACL", "IP_TYPE")
+        # Custom table type whose MATCHES omit IP_TYPE must report it unsupported
+        # (MATCHES may be a list or a comma-separated string, as in CONFIG_DB)
+        acl_loader.table_types_db_info["CUSTOM_NOIP"] = {"MATCHES": ["SRC_IP", "IP_PROTOCOL"]}
+        acl_loader.tables_db_info["CUSTOM_NOIP_TBL"] = {"type": "CUSTOM_NOIP"}
+        assert not acl_loader.is_match_field_supported("CUSTOM_NOIP_TBL", "IP_TYPE")
+        # Custom table type that declares IP_TYPE supports it
+        acl_loader.table_types_db_info["CUSTOM_IP"] = {"MATCHES": "SRC_IP,IP_TYPE,IP_PROTOCOL"}
+        acl_loader.tables_db_info["CUSTOM_IP_TBL"] = {"type": "CUSTOM_IP"}
+        assert acl_loader.is_match_field_supported("CUSTOM_IP_TBL", "IP_TYPE")
+
     def test_rule_without_ethertype_inv4v6(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/illegal_v4v6_rule_no_ethertype.json'))


### PR DESCRIPTION
#### Why I did it
Fixes sonic-net/sonic-buildimage#28028.

`acl-loader` (`convert_rule_to_db_schema`) unconditionally injects an `IP_TYPE=IP` qualifier into any rule that contains `IP_PROTOCOL`. For a custom `ACL_TABLE_TYPE` whose `MATCHES` does **not** include `IP_TYPE`, orchagent then rejects the rule:

```
validateAclRuleMatch: Match SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE in rule RULE_1 is not supported by table <TABLE>
doAclRuleTask: Failed to create ACL rule. Rule configuration is invalid
```

so the rule never installs. This regressed the community test `acl/test_acl.py` on the `MULTI_BINDING_INGRESS_IPV4_TEST` custom table type. The unconditional injection was introduced in #4462.

#### How I did it
Read the `ACL_TABLE_TYPE` table and add `is_match_field_supported()`. Only inject `IP_TYPE` when the rule's table type actually supports that match field. Built-in table types are not enumerated, so their behavior is unchanged (legacy `IP_TYPE` injection preserved).

#### How to verify it
- **Unit tests:** `pytest tests/acl_loader_test.py` — added a case for custom table types; full suite passes (31 passed).
- **Hardware (Broadcom, SONiC 202511):** custom `ACL_TABLE_TYPE` whose `MATCHES` omits `IP_TYPE`, bound to a port, plus an `IP_PROTOCOL` rule loaded via `acl-loader`.
  - **Before:** `validateAclRuleMatch ... IP_TYPE ... not supported` → rule rejected (not installed).
  - **After:** rule installs (`Active`), matching on `IP_PROTOCOL` with no `IP_TYPE`.
  - **Regression:** a built-in `L3` table + `IP_PROTOCOL` rule still gets `IP_TYPE` and installs (`Active`).
