### PR TITLE
route_check: fix 'string indices must be integers' crash in FRR route mitigation

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -417,9 +417,9 @@ def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
         if not route_entry.get('selected', False):
             return
         if not route_entry.get('offloaded', False):
-            missing_routes.append(prefix)
+            missing_routes.append({'prefix': prefix, 'protocol': route_entry.get('protocol')})
         if route_entry.get('failed', False):
-            failing_routes.append(prefix)
+            failing_routes.append({'prefix': prefix, 'protocol': route_entry.get('protocol')})
 
     try:
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=0) as proc:
@@ -948,10 +948,10 @@ def check_routes_for_namespace(namespace):
     rt_frr_miss, rt_frr_failed = check_frr_pending_routes(namespace)
 
     if rt_frr_miss:
-        results["missed_FRR_routes"] = rt_frr_miss
+        results["missed_FRR_routes"] = [entry['prefix'] for entry in rt_frr_miss]
 
     if rt_frr_failed:
-        results["failed_FRR_routes"] = rt_frr_failed
+        results["failed_FRR_routes"] = [entry['prefix'] for entry in rt_frr_failed]
 
     if results:
         if rt_frr_miss and not rt_appl_miss and not rt_asic_miss:
@@ -961,7 +961,7 @@ def check_routes_for_namespace(namespace):
                 mitigate_installed_not_offloaded_frr_routes(namespace, rt_frr_miss, rt_appl)
         if rt_frr_failed:
             print_message(syslog.LOG_ERR, "Some routes have failed state in FRR {} \
-                          : {}".format(namespace, rt_frr_failed))
+                          : {}".format(namespace, [entry['prefix'] for entry in rt_frr_failed]))
 
     return results, adds, deletes
 

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -291,9 +291,9 @@ class TestRouteCheck(object):
                 if not e.get('selected', False):
                     continue
                 if not e.get('offloaded', False):
-                    missed_route_list.append(r)
+                    missed_route_list.append({'prefix': r, 'protocol': e.get('protocol')})
                 if e.get('failed', False):
-                    failed_route_list.append(r)
+                    failed_route_list.append({'prefix': r, 'protocol': e.get('protocol')})
         return missed_route_list, failed_route_list  # Return tuple of (missed_routes, failed_routes)
 
     def assert_results(self, ct_data, ret, res):


### PR DESCRIPTION


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
ixed a `route_check.py` crash — `TypeError: string indices must be integers, not 'str'` — that occurs during FRR route mitigation when `SUPPRESS_FIB_PENDING` is enabled.

The `ijson` streaming refactor of `fetch_routes()` changed the data shape it produces: `process_route_entry()` started appending bare prefix **strings** to the missed/failed route lists. However, the downstream consumer `mitigate_installed_not_offloaded_frr_routes()` (and its unit test `test_mitigate_routes`) still expects **dicts** with `prefix` and `protocol` keys. When there are installed-but-not-offloaded FRR routes and FIB-suppress is enabled, `mitigate` indexes `entry['prefix']` on a `str`, raising `TypeError: string indices must be integers`. This makes `check_routes()` return `-1`, so `route_check.py` reports a failure even though routing is healthy.

This is not caught by CI because the unit tests mock `check_frr_pending_routes` to return strings and patch `mitigate_installed_not_offloaded_frr_routes` to a no-op, so the real string-vs-dict mismatch never executes.

Crash:
```
Traceback (most recent call last):
  File "/usr/local/bin/route_check.py", line ..., in check_routes_for_namespace
    mitigate_installed_not_offloaded_frr_routes(namespace, rt_frr_miss, rt_appl)
  File "/usr/local/bin/route_check.py", line ..., in mitigate_installed_not_offloaded_frr_routes
    for entry in [entry for entry in missed_frr_rt if entry['prefix'] in rt_appl]:
TypeError: string indices must be integers, not 'str'
```

#### How I did it

- `scripts/route_check.py`
  - `fetch_routes()` / `process_route_entry()`: collect `{'prefix': prefix, 'protocol': route_entry.get('protocol')}` dicts instead of bare prefix strings, so `mitigate` has the `protocol` it needs for the `FieldValuePairs` notification it sends to fpmsyncd.
  - `check_routes_for_namespace()`: extract the prefix when populating `results["missed_FRR_routes"]` / `results["failed_FRR_routes"]` and the failed-routes log message, so the reported/result format remains a list of prefix strings (no change to external output or existing test data).
  - `mitigate_installed_not_offloaded_frr_routes()` is unchanged — it now receives the dict shape it always expected.
- `tests/route_check_test.py`
  - Updated the `mock_fetch_routes` helper to return the same `{'prefix', 'protocol'}` dict shape as the real `fetch_routes`, keeping the mock consistent with production behavior.


#### How to verify it

1. Run the unit tests:
   ```
   python3 -m pytest tests/route_check_test.py
   ```
   All cases pass, including `test_mitigate_routes` (which exercises the dict contract directly).

2. On a device with `SUPPRESS_FIB_PENDING` enabled, create an installed-but-not-offloaded FRR route condition (e.g. a selected BGP route present in APPL_DB whose offload flag has not been set in zebra) and run:
   ```
   route_check.py
   ```
   Before the fix this aborts with `TypeError: string indices must be integers` and a non-zero return code; after the fix it mitigates the route (sends the `SWSS_RC_SUCCESS` response) and returns success.


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

**Backport:** this fix also needs to be ported to the **202605**