### PR TITLE
[setup]: Pin docker-image-py to 0.1.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,7 @@ setup(
         'urllib3>=2',
         'click-log>=0.3.2',
         'docker>=4.4.4',
-        'docker-image-py>=0.1.10',
+        'docker-image-py==0.1.13',
         'filelock>=3.0.12',
         'enlighten>=1.8.0',
         'ijson>=3.2.3',


### PR DESCRIPTION
#### What I did

`docker-image-py` was unpinned (`>=0.1.10`). The 0.2.0 release (2026-06-29) breaks
`sonic-utilities`: its `split_docker_domain()` mis-parses `Azure/sonic` (failing
`test_get_registry_for` and corrupting registry paths), and it requires
`regex>=2026.6.28`, which breaks the wheel install against the apt `regex`
(`uninstall-no-record-file`). Pin to `==0.1.13` to keep the pre-0.2.0 behavior.

Minimal alternative to #4655 (which makes the code 0.2.0-compatible instead) —
merge only one.

#### How I did it

- `setup.py`: `'docker-image-py>=0.1.10'` -> `'docker-image-py==0.1.13'`.

#### How to verify it

```
pytest tests/sonic_package_manager/test_registry.py -v
```
passes; pip resolves `docker-image-py` to 0.1.13 (not 0.2.0).

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A