### PR TITLE
[clear] Add --voq option to sonic-clear queue wredcounters

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -347,9 +347,12 @@ def queue():
 
 
 @queue.command()
-def wredcounters():
+@click.option('--voq', is_flag=True, help="Clear VOQ counters")
+def wredcounters(voq):
     """Clear queue wredcounters"""
     command = ['wredstat', '-c']
+    if voq:
+        command += ['-V']
     run_command(command)
 
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -11804,6 +11804,11 @@ Optionally, you can specify an interface name in order to display only that part
   admin@sonic:~$ sonic-clear queue wredcounters
   ```
 
+  To clear VOQ wred counters, use the `--voq` option:
+  ```
+  admin@sonic:~$ sonic-clear queue wredcounters --voq
+  ```
+
 
 #### Buffer Pool
 

--- a/tests/wred_queue_counter_test.py
+++ b/tests/wred_queue_counter_test.py
@@ -1762,6 +1762,15 @@ class TestWredQueue(object):
         assert result.exit_code == 0
         assert (wredstat_clear_str in result.output)
 
+    def test_clear_voq_wredstats(self):
+        wredstat_clear_str = "Clear and update saved counters"
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands["queue"].commands["wredcounters"], ["--voq"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert (wredstat_clear_str in result.output)
+
     def test_queue_counters_after_clear(self):
         runner = CliRunner()
         result = runner.invoke(


### PR DESCRIPTION
## What
Add a `--voq` option to `sonic-clear queue wredcounters` so users
can reset the per-VOQ WRED counters that were made accessible via
`show queue wredcounters --voq`.

## Why
`wredstat` already supports `-c -V` for clearing per-VOQ WRED
counters (mirroring the existing display option), but the
`sonic-clear queue wredcounters` CLI wrapper only invoked `wredstat
-c` and had no way to reach the VOQ path. So on VOQ-chassis
platforms users had no CLI-level way to clear the newly-visible VOQ
WRED counters without running `sonic-clear counters` (which resets
everything).

The show/clear pair should be symmetric — this brings the clear
side into line with the show side.

Companion to https://github.com/sonic-net/sonic-swss/pull/4545
(merged), which added WRED flex counter registration on VOQ OIDs on
VOQ-chassis platforms.

## How
- **clear/main.py**: add `@click.option('--voq', is_flag=True, ...)`
  to the `wredcounters()` sub-command, and pass `-V` through to
  `wredstat` when set.
- **tests/wred_queue_counter_test.py**: add
  `test_clear_voq_wredstats()`, mirroring the existing
  `test_clear_wredstats` pattern.
- **doc/Command-Reference.md**: document the new `--voq` option
  under the existing `sonic-clear queue wredcounters` section.

## How to verify
- On a VOQ-chassis platform with WRED counterpoll enabled, drive
  drops so `show queue wredcounters --voq` shows non-zero values,
  then run `sonic-clear queue wredcounters --voq`. The VOQ rows'
  drop counters reset to 0 while egress-queue counters are
  untouched. `show queue wredcounters` (no flag) continues to
  behave as today.
- Unit test `tests/wred_queue_counter_test.py::TestWredQueue::test_clear_voq_wredstats`.

## Refs
- https://github.com/sonic-net/sonic-swss/issues/4544
- https://github.com/sonic-net/sonic-swss/pull/4545 (merged)

## Which release branch to backport/forwardport
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511