### PR TITLE
[hft] Target per-key path in JSON Patch ops to avoid wiping the table

### DIFF
--- a/config/hft.py
+++ b/config/hft.py
@@ -171,20 +171,34 @@ def _split_csv_items(value):
 
 
 def _build_profile_patch(op, profile_name, attributes):
-    """Construct a JSON Patch entry targeting the profile table."""
+    """Construct a JSON Patch entry targeting a single profile row.
+
+    The patch must target the per-key path (e.g. /HIGH_FREQUENCY_TELEMETRY_PROFILE/foo)
+    rather than the table-level path (/HIGH_FREQUENCY_TELEMETRY_PROFILE), because per
+    RFC 6902 an "add" at an existing object member replaces that member's value -
+    which at the table level would wipe every other row.
+    """
     return [
-        _build_patch_entry(op, PROFILE_TABLE_PATH, {
-            profile_name: attributes
-        })
+        _build_patch_entry(
+            op,
+            _join_pointer(PROFILE_TABLE_PATH, profile_name),
+            attributes,
+        )
     ]
 
 
 def _build_group_patch(op, profile_name, group_type, attributes):
-    """Construct a JSON Patch entry targeting the group table."""
+    """Construct a JSON Patch entry targeting a single group row.
+
+    See _build_profile_patch for why this targets the per-key path rather than
+    the table path.
+    """
     return [
-        _build_patch_entry(op, GROUP_TABLE_PATH, {
-            _compose_group_key(profile_name, group_type): attributes
-        })
+        _build_patch_entry(
+            op,
+            _join_pointer(GROUP_TABLE_PATH, _compose_group_key(profile_name, group_type)),
+            attributes,
+        )
     ]
 
 

--- a/config/hft.py
+++ b/config/hft.py
@@ -18,6 +18,10 @@ PROFILE_TABLE_PATH = f"/{PROFILE_TABLE_NAME}"
 GROUP_TABLE_PATH = f"/{GROUP_TABLE_NAME}"
 STREAM_STATE_FIELD = "stream_state"
 
+STATE_SESSION_TABLE_NAME = "HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE"
+STREAM_STATUS_FIELD = "stream_status"
+STREAM_STATUS_ENABLED = "enabled"
+
 
 @click.group(name='hft', short_help="Manage high frequency telemetry")
 def hft():
@@ -87,6 +91,7 @@ def hft_add_profile(ctx, profile_name, stream_state, poll_interval):
 @click.pass_context
 def hft_add_group(ctx, profile_name, group_type, object_names, object_counters):
     """Create a group definition under an HFT profile."""
+    _reject_if_stream_active(profile_name)
     group_payload = _build_group_patch(
         op="add",
         profile_name=profile_name,
@@ -120,6 +125,7 @@ def hft_delete_profile(ctx, profile_name):
 @click.pass_context
 def hft_delete_group(ctx, profile_name, group_type):
     """Remove a group definition from an HFT profile."""
+    _reject_if_stream_active(profile_name)
     remove_entire_table = _is_last_entry(ctx, GROUP_TABLE_NAME)
     group_payload = _build_group_remove_patch(profile_name, group_type, remove_entire_table)
     _process_payload(ctx, group_payload)
@@ -299,3 +305,51 @@ def _has_existing_profile(ctx):
     except Exception:
         return False
     return bool(entries)
+
+
+def _get_state_db(namespace=None):
+    """Connect to STATE_DB for the given namespace. `namespace=None` maps
+    to the localhost/default DB.
+    """
+    from swsscommon.swsscommon import SonicV2Connector
+    state_db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+    state_db.connect(state_db.STATE_DB, False)
+    return state_db
+
+
+def _active_session_groups(state_db, profile_name):
+    """Return sorted group names for `profile_name` whose STATE_DB entry
+    reports `stream_status == "enabled"`. Missing entries are treated as
+    inactive.
+    """
+    pattern = f"{STATE_SESSION_TABLE_NAME}|{profile_name}|*"
+    try:
+        keys = state_db.keys(state_db.STATE_DB, pattern) or []
+    except Exception:
+        return []
+    active = []
+    for key in keys:
+        entry = state_db.get_all(state_db.STATE_DB, key) or {}
+        if entry.get(STREAM_STATUS_FIELD) == STREAM_STATUS_ENABLED:
+            # STATE_DB key: HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE|profile|group
+            active.append(key.split("|", 2)[-1])
+    return sorted(active)
+
+
+def _reject_if_stream_active(profile_name, namespace=None):
+    """Refuse the group mutation while any of the profile's runtime streams
+    is still active. CONFIG_DB.stream_state alone is not sufficient - it can
+    be 'disabled' while orchagent is still tearing down the runtime stream.
+    STATE_DB reflects the operational state written after the SAI transition
+    completes.
+    """
+    state_db = _get_state_db(namespace=namespace)
+    active = _active_session_groups(state_db, profile_name)
+    if not active:
+        return
+    raise click.ClickException(
+        f"Profile '{profile_name}' has active runtime streams for group(s): "
+        f"{', '.join(active)}. Run `config hft disable {profile_name}` and "
+        f"wait until STATE_DB {STATE_SESSION_TABLE_NAME}|{profile_name}|* "
+        f"reports {STREAM_STATUS_FIELD}=disabled before modifying groups."
+    )

--- a/config/hft.py
+++ b/config/hft.py
@@ -320,13 +320,11 @@ def _get_state_db(namespace=None):
 def _active_session_groups(state_db, profile_name):
     """Return sorted group names for `profile_name` whose STATE_DB entry
     reports `stream_status == "enabled"`. Missing entries are treated as
-    inactive.
+    inactive. Propagates any underlying STATE_DB error so callers can
+    decide the failure policy.
     """
     pattern = f"{STATE_SESSION_TABLE_NAME}|{profile_name}|*"
-    try:
-        keys = state_db.keys(state_db.STATE_DB, pattern) or []
-    except Exception:
-        return []
+    keys = state_db.keys(state_db.STATE_DB, pattern) or []
     active = []
     for key in keys:
         entry = state_db.get_all(state_db.STATE_DB, key) or {}
@@ -342,9 +340,19 @@ def _reject_if_stream_active(profile_name, namespace=None):
     be 'disabled' while orchagent is still tearing down the runtime stream.
     STATE_DB reflects the operational state written after the SAI transition
     completes.
+
+    Fails closed: if STATE_DB cannot be reached or queried, the mutation is
+    refused rather than silently permitted, so we never mutate group config
+    against a stream whose state we cannot verify.
     """
-    state_db = _get_state_db(namespace=namespace)
-    active = _active_session_groups(state_db, profile_name)
+    try:
+        state_db = _get_state_db(namespace=namespace)
+        active = _active_session_groups(state_db, profile_name)
+    except Exception as exc:  # noqa: BLE001 - fail-closed on any STATE_DB error
+        raise click.ClickException(
+            "Unable to determine HFT runtime stream state; refusing group "
+            "mutation. Ensure STATE_DB is reachable, then retry."
+        ) from exc
     if not active:
         return
     raise click.ClickException(

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -22,12 +22,10 @@ class TestConfigHftCli:
         _, payload = mock_process.call_args[0]
         expected_payload = [{
             'op': 'add',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_PROFILE/profileA',
             'value': {
-                'profileA': {
-                    'stream_state': 'disabled',
-                    'poll_interval': '10000'
-                }
+                'stream_state': 'disabled',
+                'poll_interval': '10000'
             }
         }]
         assert payload == expected_payload
@@ -48,12 +46,10 @@ class TestConfigHftCli:
         _, payload = mock_process.call_args[0]
         expected_payload = [{
             'op': 'add',
-            'path': '/HIGH_FREQUENCY_TELEMETRY_GROUP',
+            'path': '/HIGH_FREQUENCY_TELEMETRY_GROUP/profileA|PORT',
             'value': {
-                'profileA|PORT': {
-                    'object_names': ['Ethernet0', 'Ethernet4'],
-                    'object_counters': ['COUNTER_A', 'COUNTER_B']
-                }
+                'object_names': ['Ethernet0', 'Ethernet4'],
+                'object_counters': ['COUNTER_A', 'COUNTER_B']
             }
         }]
         assert payload == expected_payload

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -98,6 +98,79 @@ class TestConfigHftCli:
         }]
         assert payload == expected_payload
 
+    def test_add_group_rejected_while_stream_active(self):
+        with patch('config.hft._get_state_db', return_value=object()), \
+                patch('config.hft._active_session_groups', return_value=['PORT']), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'group', 'profileA',
+                    '--group_type', 'BUFFER_POOL',
+                    '--object_names', 'egress_lossless_pool',
+                    '--object_counters', 'COUNTER_A'
+                ]
+            )
+
+        assert result.exit_code != 0
+        assert 'active runtime streams' in result.output
+        assert 'config hft disable profileA' in result.output
+        mock_process.assert_not_called()
+
+    def test_delete_group_rejected_while_stream_active(self):
+        with patch('config.hft._get_state_db', return_value=object()), \
+                patch('config.hft._active_session_groups', return_value=['PORT']), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                ['del', 'group', 'profileA', 'PORT']
+            )
+
+        assert result.exit_code != 0
+        assert 'active runtime streams' in result.output
+        mock_process.assert_not_called()
+
+    def test_add_group_succeeds_when_stream_inactive(self):
+        with patch('config.hft._get_state_db', return_value=object()), \
+                patch('config.hft._active_session_groups', return_value=[]), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'group', 'profileA',
+                    '--group_type', 'PORT',
+                    '--object_names', 'Ethernet0',
+                    '--object_counters', 'COUNTER_A'
+                ]
+            )
+
+        assert result.exit_code == 0
+        mock_process.assert_called_once()
+
+    def test_add_group_rejected_when_sibling_group_active_in_mixed(self):
+        """MIXED-mode scenario: adding BUFFER_POOL is rejected because a
+        sibling group (PORT / QUEUE) is still streaming against the shared
+        tel_type/report resources.
+        """
+        with patch('config.hft._get_state_db', return_value=object()), \
+                patch('config.hft._active_session_groups',
+                      return_value=['PORT', 'QUEUE']), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'group', 'profileA',
+                    '--group_type', 'BUFFER_POOL',
+                    '--object_names', 'egress_lossless_pool',
+                    '--object_counters', 'COUNTER_A'
+                ]
+            )
+
+        assert result.exit_code != 0
+        assert 'PORT' in result.output
+        assert 'QUEUE' in result.output
+        mock_process.assert_not_called()
+
 
 def test_is_last_entry_true_and_false():
     class MockCfgDb:
@@ -119,6 +192,35 @@ def test_is_last_entry_true_and_false():
 
     tables = {'HIGH_FREQUENCY_TELEMETRY_PROFILE': {'p1': {}, 'p2': {}}}
     assert config_hft._is_last_entry(MockCtx(tables), 'HIGH_FREQUENCY_TELEMETRY_PROFILE') is False
+
+
+def test_active_session_groups_filters_by_stream_status():
+    """_active_session_groups must include only sessions whose
+    stream_status field is exactly 'enabled', excluding disabled and
+    missing values, and only under the requested profile.
+    """
+    entries = {
+        'HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE|profileA|PORT': {'stream_status': 'enabled'},
+        'HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE|profileA|QUEUE': {'stream_status': 'disabled'},
+        'HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE|profileA|IPG': {},  # no field
+        'HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE|profileB|PORT': {'stream_status': 'enabled'},
+    }
+
+    class MockStateDb:
+        STATE_DB = 6
+
+        def keys(self, db, pattern):
+            # Interpret glob-style pattern with a single trailing '*'.
+            assert pattern.endswith('*')
+            prefix = pattern[:-1]
+            return [k for k in entries.keys() if k.startswith(prefix)]
+
+        def get_all(self, db, key):
+            return entries.get(key)
+
+    assert config_hft._active_session_groups(MockStateDb(), 'profileA') == ['PORT']
+    assert config_hft._active_session_groups(MockStateDb(), 'profileB') == ['PORT']
+    assert config_hft._active_session_groups(MockStateDb(), 'unknown') == []
 
 
 def test_materialize_payload_creates_file():

--- a/tests/config_hft_test.py
+++ b/tests/config_hft_test.py
@@ -31,7 +31,11 @@ class TestConfigHftCli:
         assert payload == expected_payload
 
     def test_add_group_splits_comma_separated_lists(self):
-        with patch('config.hft._process_payload') as mock_process:
+        # Stub the runtime guard so this payload-shape assertion doesn't
+        # depend on swsscommon or the host STATE_DB. The guard has its
+        # own dedicated tests below.
+        with patch('config.hft._reject_if_stream_active'), \
+                patch('config.hft._process_payload') as mock_process:
             result = self.runner.invoke(
                 config_hft.hft,
                 [
@@ -146,6 +150,27 @@ class TestConfigHftCli:
 
         assert result.exit_code == 0
         mock_process.assert_called_once()
+
+    def test_add_group_rejected_when_state_db_query_fails(self):
+        """Fail closed: if STATE_DB cannot be queried, refuse the
+        mutation rather than silently permitting it.
+        """
+        with patch('config.hft._get_state_db',
+                   side_effect=RuntimeError("state_db unreachable")), \
+                patch('config.hft._process_payload') as mock_process:
+            result = self.runner.invoke(
+                config_hft.hft,
+                [
+                    'add', 'group', 'profileA',
+                    '--group_type', 'PORT',
+                    '--object_names', 'Ethernet0',
+                    '--object_counters', 'COUNTER_A'
+                ]
+            )
+
+        assert result.exit_code != 0
+        assert 'Unable to determine HFT runtime stream state' in result.output
+        mock_process.assert_not_called()
 
     def test_add_group_rejected_when_sibling_group_active_in_mixed(self):
         """MIXED-mode scenario: adding BUFFER_POOL is rejected because a


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix `config hft add profile` / `config hft add group` so the emitted
JSON Patch no longer wipes pre-existing rows in
`HIGH_FREQUENCY_TELEMETRY_PROFILE` /
`HIGH_FREQUENCY_TELEMETRY_GROUP`.

#### How I did it
Changed _build_profile_patch and _build_group_patch in
config/hft.py to target the row's per-key path
(/HIGH_FREQUENCY_TELEMETRY_PROFILE/<name> or
/HIGH_FREQUENCY_TELEMETRY_GROUP/<profile>|<group>) with the row's
attributes as the value, instead of the table-level path with a
single-entry value dict. This matches what _build_stream_state_patch
and the _build_*_remove_patch helpers in the same file already do.

Updated the two CLI unit tests in tests/config_hft_test.py that
asserted the old patch shape.

No CLI surface or CONFIG_DB schema change.

#### How to verify it
- pytest tests/config_hft_test.py — both updated assertions pass.
- Manual smoke against a running SONiC switch:

config hft add profile P --poll_interval 10000
config hft add group P --group_type PORT  --object_names Ethernet0
config hft add group P --group_type QUEUE --object_names Ethernet0
sonic-cfggen -d -v 'HIGH_FREQUENCY_TELEMETRY_GROUP'

- After the fix both P|PORT and P|QUEUE are present; before the fix
only P|QUEUE remained.

#### Previous command output (if the output of a command-line utility has changed)
N/A - no user-facing CLI output change.

#### New command output (if the output of a command-line utility has changed)
N/A - no user-facing CLI output change.

