### PR TITLE
portstat: fix IP receive counter label

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -6623,7 +6623,7 @@ The "detailed" subcommand is used to display more detailed interface counters. A
     Jabbers Received............................... N/A
     Fragments Received............................. N/A
     Undersize Received............................. 0
-    Overruns Received.............................. 0
+    IP Packets Received............................ 0
 
     Packets Transmitted 64 Octets.................. 0
     Packets Transmitted 65-127 Octets.............. 0

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -272,7 +272,7 @@ Broadcast Packets Received..................... 0
 Jabbers Received............................... 0
 Fragments Received............................. 0
 Undersize Received............................. 0
-Overruns Received.............................. 0
+IP Packets Received............................ 0
 
 Packets Transmitted 64 Octets.................. 0
 Packets Transmitted 65-127 Octets.............. 0

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -26,7 +26,7 @@ NStats = namedtuple("NStats", "rx_ok, rx_err, rx_drop, rx_ovr, tx_ok,\
                     tx_64, tx_65_127, tx_128_255, tx_256_511, tx_512_1023, tx_1024_1518,\
                     tx_1519_2047, tx_2048_4095, tx_4096_9216, tx_9217_16383,\
                     tx_uca, tx_mca, tx_bca, tx_all,\
-                    rx_jbr, rx_frag, rx_usize, rx_ovrrun,\
+                    rx_jbr, rx_frag, rx_usize, rx_ip_recv,\
                     fec_corr, fec_uncorr, fec_symbol_err,\
                     wred_grn_drp_pkt, wred_ylw_drp_pkt, wred_red_drp_pkt, wred_tot_drp_pkt,\
                     trim, trim_sent, trim_drop, fec_bin0, fec_bin1, fec_bin2, fec_bin3,\
@@ -493,8 +493,8 @@ class Portstat(object):
                                                                                       old_cntr['rx_frag'])))
             print("Undersize Received............................. {}".format(ns_diff(cntr['rx_usize'],
                                                                                       old_cntr['rx_usize'])))
-            print("Overruns Received.............................. {}".format(ns_diff(cntr["rx_ovrrun"],
-                                                                                      old_cntr["rx_ovrrun"])))
+            print("IP Packets Received............................ {}".format(ns_diff(cntr["rx_ip_recv"],
+                                                                                      old_cntr["rx_ip_recv"])))
 
             print("")
             print("Packets Transmitted 64 Octets.................. {}".format(ns_diff(cntr['tx_64'],


### PR DESCRIPTION
Summary:
Fixes the detailed interface counters output so SAI_PORT_STAT_IP_IN_RECEIVES is no longer mislabeled as "Overruns Received".

The counter represents received IP packets, not an overrun/error counter. This PR:
- Renames the internal NStats field from rx_ovrrun to rx_ip_recv while preserving field order.
- Updates the detailed output label to "IP Packets Received".
- Updates the portstat test expectation.
- Updates the command reference example output.

Issue:
Fixes #4568

Testing:
- Ran: git diff --check
- Ran: grep -R "Overruns Received\|rx_ovrrun" -n utilities_common tests doc | cat
- Ran: python3 -m py_compile utilities_common/portstat.py
- Not run: python3 -m pytest tests/portstat_test.py -k "detailed" -q, local environment is missing pytest.