### PR TITLE
skip migrate_copp_table during warm-reboot for cisco-8000 platform

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -1477,7 +1477,8 @@ class DBMigrator():
         # vendors, probably Broadcom. This change can be checked with any specific vendor and if this works fine the platform
         # condition can be modified and extend. If no vendor has an issue with not clearing copp tables the condition can be
         # removed together with calling to migrate_copp_table function.
-        if self.asic_type != "mellanox":
+        warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
+        if self.asic_type != "mellanox" and not (self.asic_type == "cisco-8000" and warmreboot_state == 'true'):
             self.migrate_copp_table()
         if self.asic_type == "broadcom" and 'Force10-S6100' in str(self.hwsku):
             self.migrate_mgmt_ports_on_s6100()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
skip migrate_copp_table during warm-reboot for cisco-8000 platform

#### How I did it
add check for cisco-8000 platform

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

