### PR TITLE
Add CLI knob to expose and configure LACP mode per port channel

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2915,8 +2915,10 @@ def portchannel(db, ctx, namespace):
 @click.option('--fast-rate', default='false',
               type=click.Choice(['true', 'false'],
                                 case_sensitive=False))
+@click.option('--lacp-mode', default='couple',
+              type=click.Choice(['couple', 'independent'], case_sensitive=False))
 @click.pass_context
-def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
+def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate, lacp_mode):
     """Add port channel"""
 
     fvs = {
@@ -2924,6 +2926,7 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
         'mtu': '9100',
         'lacp_key': 'auto',
         'fast_rate': fast_rate.lower(),
+        'lacp_mode': lacp_mode.lower(),
     }
 
     if min_links != 0:

--- a/tests/portchannel_test.py
+++ b/tests/portchannel_test.py
@@ -156,6 +156,48 @@ class TestPortChannel(object):
         assert result.exit_code != 0
         assert 'Invalid value for \'--fast-rate\'' in result.output
 
+    @pytest.mark.parametrize("lacp_mode", ["couple", "independent", "COUPLE", "Independent"])
+    def test_add_portchannel_with_lacp_mode_adhoc_validation(self, lacp_mode):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # add a portchannel with lacp mode
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"],
+                               ["PortChannel0005", "--lacp-mode", lacp_mode], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry('PORTCHANNEL', 'PortChannel0005')['lacp_mode'] == lacp_mode.lower()
+
+    def test_add_portchannel_default_lacp_mode(self):
+        config.ADHOC_VALIDATION = True
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # add a portchannel without specifying lacp mode, should default to 'couple'
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"], ["PortChannel0005"], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry('PORTCHANNEL', 'PortChannel0005')['lacp_mode'] == 'couple'
+
+    @pytest.mark.parametrize("lacp_mode", ["coupled", "indep"])
+    def test_add_portchannel_with_invalid_lacp_mode(self, lacp_mode):
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        # add a portchannel with an invalid lacp mode
+        result = runner.invoke(config.config.commands["portchannel"].commands["add"],
+                               ["PortChannel0005", "--lacp-mode", lacp_mode], obj=obj)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert 'Invalid value for \'--lacp-mode\'' in result.output
+
     def test_add_portchannel_member_with_invalid_name(self):
         runner = CliRunner()
         db = Db()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Expose and configure the LACP mode (independent | couple) per port channel via CLI. This complements the corresponding YANG model change in sonic-buildimage that adds the `lacp_mode` attribute to the PORTCHANNEL table.
PR - https://github.com/sonic-net/sonic-buildimage/pull/28286

#### How I did it

- Added a `--lacp-mode` option to `config portchannel add` (`config/main.py`), accepting `couple` or `independent` (case-insensitive), defaulting to `couple`, and writing `lacp_mode` into the PORTCHANNEL CONFIG_DB entry.
- Added unit tests in `tests/portchannel_test.py` covering valid values, the default value, and invalid value rejection.

#### How to verify it

YANG breadth test:
```
------------------- Test 952: Configure valid value for PortChannel lacp_mode.---------------------
INFO     YANG-TEST:test_yang_model.py:235 Configure valid value for PortChannel lacp_mode. Passed
------------------- Test 953: INCORRECT PORTCHANNEL LACP_MODE IN PORT_CHANNEL TABLE.---------------------
ERROR    YANG-TEST:test_yang_model.py:28  Exception >failed to parse data tree: Unsatisfied pattern - "off" does not conform to "independent|couple".: Data path: /sonic-portchannel:sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name='PortChannel0001']/lacp_mode (line 1)< in /sonic/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py:183
INFO     YANG-TEST:test_yang_model.py:187 failed to parse data tree: Unsatisfied pattern - "off" does not conform to "independent|couple".: Data path: /sonic-portchannel:sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name='PortChannel0001']/lacp_mode (line 1)
INFO     YANG-TEST:test_yang_model.py:235 INCORRECT PORTCHANNEL LACP_MODE IN PORT_CHANNEL TABLE. Passed
```
DUT test:
```
:~$ sudo config portchannel add PortChannel101 --lacp-mode off
Usage: config portchannel add [OPTIONS] <portchannel_name>
Try 'config portchannel add -h' for help.

Error: Invalid value for '--lacp-mode': 'off' is not one of 'couple', 'independent'.
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
