### PR TITLE
Add show switch capabilities CLI command

### DIFF
--- a/show/switch.py
+++ b/show/switch.py
@@ -1,7 +1,16 @@
+import json
+
 import click
+import tabulate
 
 import utilities_common.cli as clicommon
-from utilities_common import multi_asic
+from utilities_common import constants
+import utilities_common.multi_asic as multi_asic_util
+from sonic_py_common import multi_asic
+from utilities_common.switch_hash import (
+    STATE_SWITCH_CAPABILITY,
+    SW_CAP_KEY,
+)
 
 
 #
@@ -18,6 +27,80 @@ def switch():
     pass
 
 
+def _switch_capability_db_key():
+    return "{}|{}".format(STATE_SWITCH_CAPABILITY, SW_CAP_KEY)
+
+
+def _format_switch_capabilities_body(entry):
+    body = []
+    for key in sorted(entry.keys()):
+        body.append([key, entry[key]])
+    return body
+
+
+def _print_switch_capabilities_namespace(ctx, state_db, ns, namespace_option, json_fmt, idx):
+    entry = state_db.get_all(state_db.STATE_DB, _switch_capability_db_key())
+
+    if not entry:
+        if not multi_asic.is_multi_asic() or namespace_option:
+            ctx.fail("No data is present in STATE DB")
+        return False
+
+    if multi_asic.is_multi_asic() and not namespace_option:
+        if idx > 0:
+            click.echo()
+        if ns != constants.DEFAULT_NAMESPACE:
+            click.echo("Namespace {}:".format(ns))
+
+    if json_fmt:
+        click.echo(json.dumps(entry, indent=4))
+    else:
+        header = ["Capability", "Value"]
+        body = _format_switch_capabilities_body(entry)
+        click.echo(tabulate.tabulate(body, header, tablefmt="grid"))
+
+    return True
+
+
+@switch.command(
+    name="capabilities"
+)
+@multi_asic_util.multi_asic_click_option_namespace
+@click.option(
+    "-j", "--json", "json_fmt",
+    help="Display in JSON format",
+    is_flag=True,
+    default=False
+)
+@clicommon.pass_db
+@click.pass_context
+def capabilities(ctx, db, namespace, json_fmt):
+    """ Show switch capabilities """
+
+    ns_list = multi_asic.get_namespace_list(namespace)
+    json_output = {}
+    found = False
+
+    for idx, ns in enumerate(ns_list):
+        state_db = db.db_clients.get(ns, db.db)
+
+        if json_fmt and len(ns_list) > 1:
+            entry = state_db.get_all(state_db.STATE_DB, _switch_capability_db_key())
+            if not entry:
+                continue
+            found = True
+            json_output[ns if ns else "host"] = entry
+            continue
+
+        if _print_switch_capabilities_namespace(ctx, state_db, ns, namespace, json_fmt, idx):
+            found = True
+
+    if not found:
+        ctx.fail("No data is present in STATE DB")
+    if json_fmt and len(ns_list) > 1:
+        click.echo(json.dumps(json_output, indent=4))
+
+
 @switch.group(
     name="counters",
     cls=clicommon.AliasedGroup,
@@ -30,7 +113,7 @@ def switch():
     default=0,
     show_default=True
 )
-@multi_asic.multi_asic_click_options
+@multi_asic_util.multi_asic_click_options
 @click.option(
     "-j", "--json", "json_fmt",
     help="Display in JSON format",
@@ -74,7 +157,7 @@ def counters(ctx, period, display, namespace, json_fmt, verbose):
     default=0,
     show_default=True
 )
-@multi_asic.multi_asic_click_options
+@multi_asic_util.multi_asic_click_options
 @click.option(
     "-j", "--json", "json_fmt",
     help="Display in JSON format",
@@ -114,7 +197,7 @@ def all_stats(period, display, namespace, json_fmt, verbose):
     default=0,
     show_default=True
 )
-@multi_asic.multi_asic_click_options
+@multi_asic_util.multi_asic_click_options
 @click.option(
     "-j", "--json", "json_fmt",
     help="Display in JSON format",
@@ -154,7 +237,7 @@ def trim_stats(period, display, namespace, json_fmt, verbose):
     default=0,
     show_default=True
 )
-@multi_asic.multi_asic_click_options
+@multi_asic_util.multi_asic_click_options
 @click.option(
     "-v", "--verbose",
     help="Enable verbose output",

--- a/tests/switch_capability_test.py
+++ b/tests/switch_capability_test.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import click
-import pytest
 import show.main as show
 from click.testing import CliRunner
 from unittest.mock import MagicMock, patch

--- a/tests/switch_capability_test.py
+++ b/tests/switch_capability_test.py
@@ -1,0 +1,113 @@
+import importlib
+import json
+import os
+import sys
+
+import click
+import pytest
+import show.main as show
+from click.testing import CliRunner
+from unittest.mock import MagicMock, patch
+
+from utilities_common.db import Db
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, test_path)
+
+SUCCESS = 0
+ERROR2 = 2
+
+
+class TestSwitchCapabilities:
+    @classmethod
+    def setup_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+        from .mock_tables import dbconnector
+
+        dbconnector.dedicated_dbs["STATE_DB"] = os.path.join(
+            test_path, "mock_tables", "asic0", "state_db"
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        from .mock_tables import dbconnector
+
+        dbconnector.dedicated_dbs.pop("STATE_DB", None)
+
+    def test_show_switch_capabilities(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["switch"],
+            ["capabilities"],
+            obj=Db(),
+        )
+        assert result.exit_code == SUCCESS
+        assert "Capability" in result.output
+        assert "ECMP_HASH_CAPABLE" in result.output
+        assert "MIRROR" in result.output
+
+    def test_show_switch_capabilities_json(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["switch"],
+            ["capabilities", "--json"],
+            obj=Db(),
+        )
+        assert result.exit_code == SUCCESS
+        data = json.loads(result.output)
+        assert data["ECMP_HASH_CAPABLE"] == "true"
+        assert data["MIRROR"] == "true"
+
+
+class TestSwitchCapabilitiesMultiAsic:
+    @classmethod
+    def setup_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+
+        import mock_tables.mock_multi_asic
+
+        importlib.reload(mock_tables.mock_multi_asic)
+        from mock_tables import dbconnector
+
+        dbconnector.dedicated_dbs.pop("STATE_DB", None)
+        dbconnector.load_namespace_config()
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ.pop("UTILITIES_UNIT_TESTING_TOPOLOGY", None)
+
+    @patch.object(click.Choice, "convert", MagicMock(return_value="asic0"))
+    def test_show_switch_capabilities_namespace(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["switch"],
+            ["capabilities", "-n", "asic0"],
+            obj=Db(),
+        )
+        assert result.exit_code == SUCCESS
+        assert "ECMP_HASH_CAPABLE" in result.output
+
+    def test_show_switch_capabilities_all_namespaces(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["switch"],
+            ["capabilities"],
+            obj=Db(),
+        )
+        assert result.exit_code == SUCCESS
+        assert "ECMP_HASH_CAPABLE" in result.output
+        assert "Namespace asic1:" in result.output
+
+    def test_show_switch_capabilities_all_namespaces_json(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["switch"],
+            ["capabilities", "--json"],
+            obj=Db(),
+        )
+        assert result.exit_code == SUCCESS
+        data = json.loads(result.output)
+        assert "asic0" in data
+        assert "asic1" in data
+        assert data["asic0"]["ECMP_HASH_CAPABLE"] == "true"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Enhancement: Add show switch capabilities CLI command
Orchagent queries the vendor SAI for different capabilities and updates the STATE_DB and many modules check these capabilities before configure/use those features. So adding this new cli command to show all the supported capabilities for better debugging.

#### How I did it
Add `show switch capabilities` to display all fields from
STATE_DB SWITCH_CAPABILITY|switch, including future capabilities
such as DEVICE_MODE. Supports --json output and multi-ASIC namespace
iteration via -n/--namespace.
Fix multi_asic imports in show/switch.py: use sonic_py_common.multi_asic
for runtime helpers and utilities_common.multi_asic for Click decorators.
Add unit tests for single-ASIC and multi-ASIC table/JSON output.
#### How to verify it
The following commands are verified multi asic planforms.
show switch capabilities              # all namespaces on multi-ASIC
show switch capabilities -n asic0/asic1     # specific namespace
show switch capabilities --json       # JSON output
show switch capabilities -n asic0/asic1 -j  # JSON for one namespace

The following commands are verified in single asic
show switch capabilities  
show switch capabilities --json 
#### Previous command output (if the output of a command-line utility has changed)
It was  not present.
#### New command output (if the output of a command-line utility has changed)

<img width="1682" height="1538" alt="image" src="https://github.com/user-attachments/assets/aafb0058-d05d-405b-bbb5-927a2e581a39" />
<img width="1772" height="798" alt="image" src="https://github.com/user-attachments/assets/d29528d7-9963-4128-9c71-af3b7c528e08" />

