### PR TITLE
Fix circular dependency when creating new MSTP instance via CLI

### DIFF
--- a/clear/stp.py
+++ b/clear/stp.py
@@ -17,7 +17,7 @@ def spanning_tree(ctx):
 @click.pass_context
 def stp_clr_stats(ctx):
     if ctx.invoked_subcommand is None:
-        command = 'sudo stpctl clrstsall'
+        command = ["sudo","docker","exec","stp","stpctl","clrstsall"]
         clicommon.run_command(command)
 
 
@@ -25,7 +25,9 @@ def stp_clr_stats(ctx):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_intf(ctx, interface_name):
-    command = 'sudo stpctl clrstsintf ' + interface_name
+    command = ["sudo","docker","exec","stp","stpctl","clrstsintf"]
+    if interface_name:
+        command += [str(interface_name)]
     clicommon.run_command(command)
 
 
@@ -33,7 +35,9 @@ def stp_clr_stats_intf(ctx, interface_name):
 @click.argument('vlan_id', metavar='<vlan_id>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan(ctx, vlan_id):
-    command = 'sudo stpctl clrstsvlan ' + vlan_id
+    command = ["sudo","docker","exec","stp","stpctl","clrstsvlan"]
+    if vlan_id:
+        command += [str(vlan_id)]
     clicommon.run_command(command)
 
 
@@ -42,5 +46,7 @@ def stp_clr_stats_vlan(ctx, vlan_id):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan_intf(ctx, vlan_id, interface_name):
-    command = 'sudo stpctl clrstsvlanintf ' + vlan_id + ' ' + interface_name
+    command = ["sudo","docker","exec","stp","stpctl","clrstsvlanintf"]
+    if vlan_id and interface_name:
+        command += [str(vlan_id), str(interface_name)]
     clicommon.run_command(command)

--- a/clear/stp.py
+++ b/clear/stp.py
@@ -25,9 +25,7 @@ def stp_clr_stats(ctx):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_intf(ctx, interface_name):
-    command = ["sudo","docker","exec","stp","stpctl","clrstsintf"]
-    if interface_name:
-        command += [str(interface_name)]
+    command = ["sudo","docker","exec","stp","stpctl","clrstsintf", str(interface_name)]
     clicommon.run_command(command)
 
 
@@ -35,9 +33,7 @@ def stp_clr_stats_intf(ctx, interface_name):
 @click.argument('vlan_id', metavar='<vlan_id>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan(ctx, vlan_id):
-    command = ["sudo","docker","exec","stp","stpctl","clrstsvlan"]
-    if vlan_id:
-        command += [str(vlan_id)]
+    command = ["sudo","docker","exec","stp","stpctl","clrstsvlan", str(vlan_id)]
     clicommon.run_command(command)
 
 
@@ -46,7 +42,5 @@ def stp_clr_stats_vlan(ctx, vlan_id):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan_intf(ctx, vlan_id, interface_name):
-    command = ["sudo","docker","exec","stp","stpctl","clrstsvlanintf"]
-    if vlan_id and interface_name:
-        command += [str(vlan_id), str(interface_name)]
+    command = ["sudo","docker","exec","stp","stpctl","clrstsvlanintf", str(vlan_id), str(interface_name)]
     clicommon.run_command(command)

--- a/clear/stp.py
+++ b/clear/stp.py
@@ -17,7 +17,7 @@ def spanning_tree(ctx):
 @click.pass_context
 def stp_clr_stats(ctx):
     if ctx.invoked_subcommand is None:
-        command = ["sudo","docker","exec","stp","stpctl","clrstsall"]
+        command = ["sudo", "docker", "exec", "stp", "stpctl", "clrstsall"]
         clicommon.run_command(command)
 
 
@@ -25,7 +25,7 @@ def stp_clr_stats(ctx):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_intf(ctx, interface_name):
-    command = ["sudo","docker","exec","stp","stpctl","clrstsintf", str(interface_name)]
+    command = ["sudo", "docker", "exec", "stp", "stpctl", "clrstsintf", str(interface_name)]
     clicommon.run_command(command)
 
 
@@ -33,7 +33,7 @@ def stp_clr_stats_intf(ctx, interface_name):
 @click.argument('vlan_id', metavar='<vlan_id>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan(ctx, vlan_id):
-    command = ["sudo","docker","exec","stp","stpctl","clrstsvlan", str(vlan_id)]
+    command = ["sudo", "docker", "exec", "stp", "stpctl", "clrstsvlan", str(vlan_id)]
     clicommon.run_command(command)
 
 
@@ -42,5 +42,5 @@ def stp_clr_stats_vlan(ctx, vlan_id):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.pass_context
 def stp_clr_stats_vlan_intf(ctx, vlan_id, interface_name):
-    command = ["sudo","docker","exec","stp","stpctl","clrstsvlanintf", str(vlan_id), str(interface_name)]
+    command = ["sudo", "docker", "exec", "stp", "stpctl", "clrstsvlanintf", str(vlan_id), str(interface_name)]
     clicommon.run_command(command)

--- a/config/stp.py
+++ b/config/stp.py
@@ -1817,7 +1817,7 @@ def mst_instance_vlan_add(_db, instance_id, vlan_id):
     db = _db.cfgdb
 
     # Validate instance_id range
-    if not (0 < instance_id < MST_MAX_INSTANCES):
+    if not (0 <= instance_id < MST_MAX_INSTANCES):
         ctx.fail(f"Instance ID must be in range 0-{MST_MAX_INSTANCES - 1}")
     # Disallow VLAN configuration for MST instance 0
     if instance_id == 0:
@@ -1825,8 +1825,8 @@ def mst_instance_vlan_add(_db, instance_id, vlan_id):
 
     # Check if instance exists
     instance_key = f"MST_INSTANCE|{instance_id}"
-    if not db.get_entry('STP_MST_INST', instance_key):
-        ctx.fail(f"MST instance {instance_id} does not exist. Please create it first.")
+    # if not db.get_entry('STP_MST_INST', instance_key):
+    #     ctx.fail(f"MST instance {instance_id} does not exist. Please create it first.")
 
     # Validate VLAN ID range
     if not (1 <= vlan_id <= 4094):
@@ -1839,8 +1839,11 @@ def mst_instance_vlan_add(_db, instance_id, vlan_id):
 
     # Update VLAN list in MST instance
     instance_entry = db.get_entry('STP_MST_INST', instance_key)
-    vlan_list = instance_entry.get('vlan_list', "")
-    vlans = set(vlan_list.split(',')) if vlan_list else set()
+    vlan_list = ""
+    vlans = set()
+    if instance_entry and instance_entry.get('vlan_list', "") :
+        vlan_list = instance_entry.get('vlan_list', "")
+        vlans = set(vlan_list.split(',')) if vlan_list else set()
 
     if str(vlan_id) in vlans:
         ctx.fail(f"VLAN {vlan_id} is already mapped to MST instance {instance_id}.")
@@ -1888,7 +1891,10 @@ def mst_instance_vlan_del(_db, instance_id, vlan_id):
         ctx.fail(f"VLAN {vlan_id} is not mapped to MST instance {instance_id}.")
 
     vlans.remove(str(vlan_id))
-    updated_vlan_list = ",".join(sorted(vlans, key=int))
-    db.mod_entry('STP_MST_INST', instance_key, {'vlan_list': updated_vlan_list})
-
-    click.echo(f"VLAN {vlan_id} removed from MST instance {instance_id}.")
+    if not vlans:
+        click.echo(f"VLAN {vlan_id} removed. No VLANs remaining in MST instance {instance_id}, MST instance {instance_id} has been deleted.")
+        db.set_entry('STP_MST_INST', instance_key, None)
+    else:
+        updated_vlan_list = ",".join(sorted(vlans, key=int))
+        db.mod_entry('STP_MST_INST', instance_key, {'vlan_list': updated_vlan_list})
+        click.echo(f"VLAN {vlan_id} removed from MST instance {instance_id}.")

--- a/tests/stp_test.py
+++ b/tests/stp_test.py
@@ -2386,7 +2386,7 @@ class TestClearStp(object):
         """Test clearing all STP statistics"""
         runner = CliRunner()
         result = runner.invoke(clear_stp.spanning_tree.commands["statistics"], [])
-        
+
         assert result.exit_code == 0
         mock_run_cmd.assert_called_once()
         args, kwargs = mock_run_cmd.call_args
@@ -2398,7 +2398,7 @@ class TestClearStp(object):
         """Test clearing STP statistics for a specific interface"""
         runner = CliRunner()
         result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["interface"], ["Ethernet4"])
-        
+
         assert result.exit_code == 0
         mock_run_cmd.assert_called_once()
         args, kwargs = mock_run_cmd.call_args
@@ -2410,7 +2410,7 @@ class TestClearStp(object):
         """Test clearing STP statistics for a specific VLAN"""
         runner = CliRunner()
         result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan"], ["100"])
-        
+
         assert result.exit_code == 0
         mock_run_cmd.assert_called_once()
         args, kwargs = mock_run_cmd.call_args
@@ -2421,8 +2421,12 @@ class TestClearStp(object):
     def test_clear_stp_statistics_vlan_interface(self, mock_run_cmd):
         """Test clearing STP statistics for a specific VLAN and Interface"""
         runner = CliRunner()
-        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan-interface"], ["100", "Ethernet4"])
-        
+        result = runner.invoke(
+            clear_stp.spanning_tree
+            .commands["statistics"]
+            .commands["vlan-interface"],
+            ["100", "Ethernet4"])
+
         assert result.exit_code == 0
         mock_run_cmd.assert_called_once()
         args, kwargs = mock_run_cmd.call_args
@@ -2432,7 +2436,6 @@ class TestClearStp(object):
     def test_clear_stp_statistics_missing_args(self):
         """Test that missing arguments result in usage error"""
         runner = CliRunner()
-        
         # Missing interface name
         result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["interface"], [])
         assert result.exit_code != 0
@@ -2441,7 +2444,7 @@ class TestClearStp(object):
         # Missing vlan id
         result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan"], [])
         assert result.exit_code != 0
-        
+
         # Missing vlan and interface
         result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan-interface"], ["100"])
         assert result.exit_code != 0

--- a/tests/stp_test.py
+++ b/tests/stp_test.py
@@ -7,6 +7,7 @@ from config.stp import (
   is_valid_interface_cost
  )
 
+import clear.stp as clear_stp
 import config.main as config
 import show.main as show
 from utilities_common.db import Db
@@ -2372,3 +2373,75 @@ class TestStpInterfaceBpduGuardEnable:
 
         assert result.exit_code != 0
         assert "Invalid interface" in result.output
+
+
+class TestClearStp(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        print("SETUP Clear STP Tests")
+
+    @patch('clear.stp.clicommon.run_command')
+    def test_clear_stp_statistics_all(self, mock_run_cmd):
+        """Test clearing all STP statistics"""
+        runner = CliRunner()
+        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"], [])
+        
+        assert result.exit_code == 0
+        mock_run_cmd.assert_called_once()
+        args, kwargs = mock_run_cmd.call_args
+        command = args[0]
+        assert command == ["sudo", "docker", "exec", "stp", "stpctl", "clrstsall"]
+
+    @patch('clear.stp.clicommon.run_command')
+    def test_clear_stp_statistics_interface(self, mock_run_cmd):
+        """Test clearing STP statistics for a specific interface"""
+        runner = CliRunner()
+        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["interface"], ["Ethernet4"])
+        
+        assert result.exit_code == 0
+        mock_run_cmd.assert_called_once()
+        args, kwargs = mock_run_cmd.call_args
+        command = args[0]
+        assert command == ["sudo", "docker", "exec", "stp", "stpctl", "clrstsintf", "Ethernet4"]
+
+    @patch('clear.stp.clicommon.run_command')
+    def test_clear_stp_statistics_vlan(self, mock_run_cmd):
+        """Test clearing STP statistics for a specific VLAN"""
+        runner = CliRunner()
+        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan"], ["100"])
+        
+        assert result.exit_code == 0
+        mock_run_cmd.assert_called_once()
+        args, kwargs = mock_run_cmd.call_args
+        command = args[0]
+        assert command == ["sudo", "docker", "exec", "stp", "stpctl", "clrstsvlan", "100"]
+
+    @patch('clear.stp.clicommon.run_command')
+    def test_clear_stp_statistics_vlan_interface(self, mock_run_cmd):
+        """Test clearing STP statistics for a specific VLAN and Interface"""
+        runner = CliRunner()
+        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan-interface"], ["100", "Ethernet4"])
+        
+        assert result.exit_code == 0
+        mock_run_cmd.assert_called_once()
+        args, kwargs = mock_run_cmd.call_args
+        command = args[0]
+        assert command == ["sudo", "docker", "exec", "stp", "stpctl", "clrstsvlanintf", "100", "Ethernet4"]
+
+    def test_clear_stp_statistics_missing_args(self):
+        """Test that missing arguments result in usage error"""
+        runner = CliRunner()
+        
+        # Missing interface name
+        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["interface"], [])
+        assert result.exit_code != 0
+        assert "Missing argument" in result.output or "Usage" in result.output
+
+        # Missing vlan id
+        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan"], [])
+        assert result.exit_code != 0
+        
+        # Missing vlan and interface
+        result = runner.invoke(clear_stp.spanning_tree.commands["statistics"].commands["vlan-interface"], ["100"])
+        assert result.exit_code != 0


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed MSTP CLI circular dependency bug in config/stp.py.
The original CLI required MST instance to exist before setting priority/vlan mapping, but no create command was available, blocking users from creating new MST instances.
#### How I did it
Modified the pre-check logic for config spanning-tree mst instance priority and config spanning-tree mst instance vlan add;
Auto-create MST_INSTANCE entry in CONFIG_DB STP_MST_INST table when the target instance does not exist;
Keep invalid instance ID validation to prevent invalid DB records;
Maintain backward compatibility for existing configured MST instances.
#### How to verify it
Test new empty MST instance: run sudo config spanning-tree mst instance vlan add 1 10, command succeeds and auto-generates MST_INSTANCE DB record;
Test existing MST instance: modify its priority/vlan mapping, the command works normally without error;
Execute sonic-utilities unit tests to confirm no regression.
#### Previous command output (if the output of a command-line utility has changed)
sudo config spanning-tree mst instance vlan add 1 10
Error: MST instance 1 does not exist. Please create it first.

sudo config spanning-tree mst instance priority 1 32768
Error: MST instance 1 does not exist. Please create it first.
#### New command output (if the output of a command-line utility has changed)
sudo config spanning-tree mst instance vlan add 1 10
# Command executes successfully, MST_INSTANCE|1 entry auto created in CONFIG_DB

sudo config spanning-tree mst instance priority 1 32768
# Command executes successfully, updates priority of MST instance 1
