### PR TITLE
Remove unused STATE_DB connection from wredstat get_counters()

### DIFF
--- a/scripts/wredstat
+++ b/scripts/wredstat
@@ -193,8 +193,6 @@ class Wredstat(object):
             fields = ["0","0","0","0","0","0"]
             fields[0] = get_queue_index(table_id)
             fields[1] = get_queue_type(table_id)
-            self.state_db = SonicV2Connector(use_unix_socket_path=False)
-            self.state_db.connect(self.state_db.STATE_DB)     
 
             for counter_name, pos in counter_bucket_dict.items():
                 full_table_id = COUNTER_TABLE_PREFIX + table_id


### PR DESCRIPTION
## Summary
- Remove per-queue `SonicV2Connector` + `STATE_DB` connect from `wredstat.get_counters()`.
- The connector was introduced in #2807 but never used: all WRED counter values are read from `COUNTERS_DB` via `self.db`.

## Problem
On multi-ASIC platforms, `wredstat -c` / show walks every queue and opened a new TCP Redis connection to `STATE_DB` per queue. With hundreds of VoQ ports and multiple namespaces this can exhaust ephemeral ports and fail with:

```
RuntimeError: Unable to connect to redis - Cannot assign requested address
```

## Note on portstat
PR #2807 also added legitimate `STATE_DB` reads in `portstat` (WRED capability flags via `self.db.get(STATE_DB, ...)` once per collect). That path is unchanged. `wredstat` does not perform those checks and does not need a separate connector per queue.

## Test plan
- [x] Existing `tests/wred_queue_counter_test.py` coverage unchanged (no `state_db` dependency)
- [ ] `wredstat` on multi-ASIC DUT: `wredstat -c` completes without Redis connection errors
- [ ] `wredstat` / `wredstat -j` output matches pre-change counter values


