### PR TITLE
[config][chassis_modules] Fix KeyError on CHASSIS_MODULE entry without admin_status

### DIFF
--- a/config/chassis_modules.py
+++ b/config/chassis_modules.py
@@ -57,16 +57,15 @@ def ensure_statedb_connected(db):
 def get_config_module_state(db, chassis_module_name):
     config_db = db.cfgdb
     fvs = config_db.get_entry('CHASSIS_MODULE', chassis_module_name)
-    if not fvs:
-        if is_smartswitch():
-            return 'down'
-        elif is_bmc() and chassis_module_name.startswith("SWITCH-HOST"):
-            # On BMC, SWITCH-HOST default is 'down' to keep it powered off on boot
-            return 'down'
-        else:
-            return 'up'
-    else:
-        return fvs['admin_status']
+    admin_status = fvs.get('admin_status') if fvs else None
+    if admin_status:
+        return admin_status
+    if is_smartswitch():
+        return 'down'
+    if is_bmc() and chassis_module_name.startswith("SWITCH-HOST"):
+        # On BMC, SWITCH-HOST default is 'down' to keep it powered off on boot
+        return 'down'
+    return 'up'
 
 #
 # Name: check_config_module_state_with_timeout


### PR DESCRIPTION
#### What I did

Fixed a `KeyError: 'admin_status'` in `get_config_module_state()` (`config/chassis_modules.py`). The function applied the smartswitch/BMC/default fallback for `admin_status` only when the `CHASSIS_MODULE` entry was absent; its `else` branch did an unguarded `return fvs['admin_status']` and raised `KeyError` when the entry existed but carried no `admin_status` field.

That is a legitimate state. The `config chassis modules shutdown-timeout` and `config chassis modules power-on-delay` subcommands create a `CHASSIS_MODULE` entry that holds only `graceful_shutdown_timeout` / `power_on_delay`, and `startup`/`shutdown` use `mod_entry` to preserve those fields. As a result `config chassis module startup|shutdown` aborted with `KeyError: 'admin_status'` on such an entry.

#### How I did it

Read `admin_status` with `fvs.get('admin_status')` and apply the existing default (`is_smartswitch()` / `is_bmc()` SWITCH-HOST → `'down'`, otherwise `'up'`) whenever `admin_status` is unset — the present-but-field-less case as well as the entry-absent case. When `admin_status` is present its value is returned unchanged, so behavior is identical to before for every entry that carries the field.

#### How to verify it

1. Create a `CHASSIS_MODULE` entry that has no `admin_status` field, e.g. `config chassis modules shutdown-timeout <module> <seconds>` (or `config chassis modules power-on-delay <module> <seconds>`), which writes only `graceful_shutdown_timeout` / `power_on_delay`.
2. Run `config chassis module startup <module>` (or `shutdown`). Before this change the command aborts with `KeyError: 'admin_status'`; after it, the command applies the platform default and proceeds.
3. Regression: confirm an entry that does carry `admin_status` still returns that stored value unchanged, and that the no-entry case still returns the smartswitch / BMC-SWITCH-HOST / default value as before.

#### Previous command output (if the output of a command-line utility has changed)

```
# config chassis module shutdown LINE-CARD0
Traceback (most recent call last):
  ...
  File ".../config/chassis_modules.py", line 69, in get_config_module_state
    return fvs['admin_status']
KeyError: 'admin_status'
```

#### New command output (if the output of a command-line utility has changed)

```
# config chassis module shutdown LINE-CARD0
(command completes; the module transition is applied without error)
```
