### PR TITLE
Ecn acl marking

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -42,12 +42,12 @@ def deep_update(dst, src):
 class AclAction:
     """ namespace for ACL action keys """
 
-    PACKET = "PACKET_ACTION"
-    REDIRECT = "REDIRECT_ACTION"
-    MIRROR = "MIRROR_ACTION"
+    PACKET         = "PACKET_ACTION"
+    REDIRECT       = "REDIRECT_ACTION"
+    MIRROR         = "MIRROR_ACTION"
     MIRROR_INGRESS = "MIRROR_INGRESS_ACTION"
-    MIRROR_EGRESS = "MIRROR_EGRESS_ACTION"
-    ECN = "ECN_ACTION"
+    MIRROR_EGRESS  = "MIRROR_EGRESS_ACTION"
+    ECN            = "ECN_ACTION"
 
 
 class PacketAction:

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -47,7 +47,7 @@ class AclAction:
     MIRROR         = "MIRROR_ACTION"
     MIRROR_INGRESS = "MIRROR_INGRESS_ACTION"
     MIRROR_EGRESS  = "MIRROR_EGRESS_ACTION"
-    ECN            = "ECN_ACTION"
+    ECN            = "ECN_ACTION"  # noqa: E221
 
 
 class PacketAction:

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -47,6 +47,7 @@ class AclAction:
     MIRROR         = "MIRROR_ACTION"
     MIRROR_INGRESS = "MIRROR_INGRESS_ACTION"
     MIRROR_EGRESS  = "MIRROR_EGRESS_ACTION"
+    ECN            = "ECN_ACTION"
 
 
 class PacketAction:
@@ -1086,6 +1087,8 @@ class AclLoader(object):
                     action = "MIRROR INGRESS: {}".format(val.pop(key))
                 elif key == AclAction.MIRROR_EGRESS:
                     action = "MIRROR EGRESS: {}".format(val.pop(key))
+                elif key == AclAction.ECN:
+                    action = "ECN: {}".format(val.pop(key))
                 else:
                     continue
 

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -42,12 +42,12 @@ def deep_update(dst, src):
 class AclAction:
     """ namespace for ACL action keys """
 
-    PACKET         = "PACKET_ACTION"
-    REDIRECT       = "REDIRECT_ACTION"
-    MIRROR         = "MIRROR_ACTION"
+    PACKET = "PACKET_ACTION"
+    REDIRECT = "REDIRECT_ACTION"
+    MIRROR = "MIRROR_ACTION"
     MIRROR_INGRESS = "MIRROR_INGRESS_ACTION"
-    MIRROR_EGRESS  = "MIRROR_EGRESS_ACTION"
-    ECN            = "ECN_ACTION"
+    MIRROR_EGRESS = "MIRROR_EGRESS_ACTION"
+    ECN = "ECN_ACTION"
 
 
 class PacketAction:

--- a/tests/show_acl_test.py
+++ b/tests/show_acl_test.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from unittest import mock
 from click.testing import CliRunner
 
 import acl_loader.main as acl_loader_show
@@ -85,6 +86,33 @@ class TestShowACLSingleASIC(object):
         result_top = result.output.split('\n')[2]
         expected_output = "DATAACL_5  RULE_1        9999  FORWARD   IP_PROTOCOL: 126  Active"
         assert result_top == expected_output
+
+    def test_show_acl_rule_ecn(self, setup_teardown_single_asic):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        # Inject an ECN-marking rule directly (isolated from the shared mock
+        # tables) so the assertion is deterministic and cannot perturb other
+        # tests' tabulate column widths.
+        aclloader.get_rules_db_info = mock.MagicMock(return_value={
+            ("DATAACL", "RULE_ECN"): {
+                "PRIORITY": "9990",
+                "L4_SRC_PORT": "5000",
+                "ECN_ACTION": "3",
+            }
+        })
+        aclloader.acl_rule_status = {("DATAACL", "RULE_ECN"): {"status": "Active"}}
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['rule'],
+                               ['DATAACL', 'RULE_ECN'], obj=context)
+        assert result.exit_code == 0
+        # ECN_ACTION must be rendered under the Action column as "ECN: <value>";
+        # before the fix it leaked into the Match column as the raw "ECN_ACTION" key.
+        assert "ECN: 3" in result.output
+        assert "ECN_ACTION" not in result.output
+        # The non-action fields are still shown as matches.
+        assert "L4_SRC_PORT: 5000" in result.output
 
 
 class TestShowACLMultiASIC(object):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Make  `show acl rule`  display the ECN‑marking ACL action correctly.  `ECN_ACTION`  is now rendered as  `ECN: <value>`  under the Action column. Previously it was unrecognized and leaked into the Match column as the raw  `ECN_ACTION`  key.

#### How I did it
In  `acl_loader/main.py` :

• Registered  `ECN_ACTION`  as a known action ( `AclAction.ECN = "ECN_ACTION"` ).
• Handled it in  `AclRule.pop_action()`  so a rule with  `ECN_ACTION`  renders  `ECN: <val>`  under Action (and is no longer shown as a match).

Added a unit test  `tests/show_acl_test.py::test_show_acl_rule_ecn`  (mocks an ECN rule and asserts  `ECN: 3`  appears under Action and the raw  `ECN_ACTION`  key is not leaked). A follow‑up commit normalizes the  `AclAction   =`  alignment to satisfy pre‑commit flake8 (E221).

#### How to verify it
• Unit test:  `python3 -m pytest tests/show_acl_test.py -k test_show_acl_rule_ecn`  (passes).
• Manual: configure an ACL rule with  `ECN_ACTION`  and run  `show acl rule <table> <rule>`  — the action shows under Action as  `ECN: <val>` .

#### Previous command output (if the output of a command-line utility has changed)
```
Table    Rule      Priority    Action    Match              Status
-------  --------  ----------  --------  -----------------  --------
DATAACL  RULE_ECN  9990                  ECN_ACTION: 3      Active
                                         L4_SRC_PORT: 5000
```
#### New command output (if the output of a command-line utility has changed)
```
Table    Rule        Priority  Action    Match              Status
-------  --------  ----------  --------  -----------------  --------
DATAACL  RULE_ECN        9990  ECN: 3    L4_SRC_PORT: 5000  Active
```
