### PR TITLE
[202605] [sonic-package-manager]: Use lowercase 'azure/sonic' in registry reso…

### DIFF
--- a/tests/sonic_package_manager/test_registry.py
+++ b/tests/sonic_package_manager/test_registry.py
@@ -9,7 +9,7 @@ def test_get_registry_for():
     resolver = RegistryResolver()
     registry = resolver.get_registry_for('debian')
     assert registry is resolver.DockerHubRegistry
-    registry = resolver.get_registry_for('Azure/sonic')
+    registry = resolver.get_registry_for('azure/sonic')
     assert registry is resolver.DockerHubRegistry
     registry = resolver.get_registry_for('registry-server:5000/docker')
     assert registry.url == 'https://registry-server:5000'


### PR DESCRIPTION
#### What I did

On 202605, `test_get_registry_for` uses the invalid reference `Azure/sonic`, which fails under `docker-image-py` 0.2.0 (it treats the uppercase first path component as a registry domain). Fix the test to use the valid lowercase `azure/sonic` so it passes regardless of the `docker-image-py` version. (Test-only portion of #4655.)

#### How I did it

- `tests/sonic_package_manager/test_registry.py`: `resolver.get_registry_for('Azure/sonic')` → `resolver.get_registry_for('azure/sonic')`.

#### How to verify it

Run the package-manager registry test with `docker-image-py` 0.2.0 installed:

```
pytest tests/sonic_package_manager/test_registry.py::test_get_registry_for
```

It passes — `azure/sonic` resolves to the `DockerHubRegistry` singleton regardless of the `docker-image-py` version.

#### Previous command output (if the output of a command-line utility has changed)

N/A - no user-facing command output changes.

#### New command output (if the output of a command-line utility has changed)

N/A - no user-facing command output changes.
