### PR TITLE
[GCU] Restart bgp container when routing-mode fields change

### DIFF
--- a/generic_config_updater/gcu_services_validator.conf.json
+++ b/generic_config_updater/gcu_services_validator.conf.json
@@ -57,6 +57,9 @@
         },
         "TELEMETRY": {
             "services_to_validate": [ "telemetry-service" ]
+        },
+        "DEVICE_METADATA": {
+            "services_to_validate": [ "bgp-routing-mode-service" ]
         }
     },
     "services": {
@@ -89,6 +92,9 @@
         },
         "telemetry-service": {
             "validate_commands": [ "generic_config_updater.services_validator.telemetry_validator" ]
+        },
+        "bgp-routing-mode-service": {
+            "validate_commands": [ "generic_config_updater.services_validator.frr_routing_mode_validator" ]
         }
     }
 }

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -184,6 +184,74 @@ def telemetry_validator(old_config, upd_config, keys):
     return True
 
 
+# These defaults must track the fallbacks in the bgp container's docker_init.sh
+# (missing docker_routing_config_mode -> "separated", missing
+# frr_mgmt_framework_config -> "false"); if that script's startup behavior ever
+# changes, update them here in lockstep. Kept as a module-level constant to make
+# clear these are frozen invariants, not an incidental per-call dict.
+#
+# NOTE: do not "reconcile" these against sonic-device_metadata.yang, which
+# declares default "unified" for docker_routing_config_mode. That YANG default
+# does NOT reflect runtime: docker_init.sh renders supervisord.conf via
+# frr_vars.j2, which emits "" for an absent field, and docker_init.sh's -z check
+# then maps that empty value to "separated". The startup fallback, not the YANG
+# model, is what this validator must match.
+_FRR_ROUTING_MODE_DEFAULTS = {"docker_routing_config_mode": "separated",
+                              "frr_mgmt_framework_config": "false"}
+
+
+def frr_routing_mode_validator(old_config, upd_config, keys):
+    # The routing daemon selection (frrcfgd vs bgpcfgd) and the set of rendered
+    # FRR config files are decided when the bgp container starts: docker_init.sh
+    # renders supervisord.conf from DEVICE_METADATA, and supervisord reads that
+    # config only once at startup. Writing the new DEVICE_METADATA into CONFIG_DB
+    # (as a config-replace / apply-patch does) therefore has no effect on its own
+    # -- the previously-selected daemon keeps running and the new BGP_* tables are
+    # never translated to FRR. Restarting the bgp container re-runs docker_init.sh,
+    # which re-renders supervisord.conf from the now-updated CONFIG_DB and launches
+    # the correct daemon set. Only these two startup-only fields need the restart.
+    #
+    # Absent values are normalized to their startup defaults (docker_init.sh treats
+    # a missing docker_routing_config_mode as "separated" and a missing
+    # frr_mgmt_framework_config as "false") so that adding or removing a field is
+    # compared against the behavior it actually replaces. See
+    # _FRR_ROUTING_MODE_DEFAULTS.
+    #
+    # Scope: supervisord.conf.j2 also gates staticroutebfd on DEVICE_METADATA
+    # switch_type -- the same startup-only class of field -- but that is
+    # deliberately out of scope here because switch_type is platform identity
+    # that never changes at runtime, so no config-time restart is warranted.
+    old_meta = old_config.get("DEVICE_METADATA", {}).get("localhost", {})
+    upd_meta = upd_config.get("DEVICE_METADATA", {}).get("localhost", {})
+
+    # Pre-scan both fields so a single commit that changes both is logged in
+    # full (one restart still covers both). A per-field early return would log
+    # only the first-matched field and hide the other's change from the audit
+    # trail.
+    changed = {field: (old_meta.get(field, default), upd_meta.get(field, default))
+               for field, default in _FRR_ROUTING_MODE_DEFAULTS.items()
+               if old_meta.get(field, default) != upd_meta.get(field, default)}
+    if changed:
+        changes_str = ", ".join(
+            f"{field}: {old!r} -> {new!r}" for field, (old, new) in changed.items())
+        logger.log(
+            logger.LOG_PRIORITY_NOTICE,
+            f"frr_routing_mode_validator: routing-mode fields changed ({changes_str}), "
+            f"restart bgp service",
+            print_to_console
+        )
+        # Best-effort pre-clear of StartLimitBurst; rc ignored because
+        # _service_restart() retries with its own reset-failed.
+        #
+        # Single-asic assumption: the bgp unit is plain "bgp". On a multi-asic
+        # platform the per-asic units are "bgp@<N>" and there is no plain "bgp"
+        # unit, so this would need per-asic handling. Every validator in this
+        # file shares that single-asic assumption today.
+        command_wrapper("systemctl reset-failed bgp")
+        return _service_restart("bgp")
+    return True
+
+
 def vlanintf_validator(old_config, upd_config, keys):
     old_vlan_intf = old_config.get("VLAN_INTERFACE", {})
     upd_vlan_intf = upd_config.get("VLAN_INTERFACE", {})

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -10,6 +10,7 @@ from generic_config_updater.services_validator import (
 )
 from generic_config_updater.services_validator import ntp_validator
 from generic_config_updater.services_validator import gnmi_validator, telemetry_validator
+from generic_config_updater.services_validator import frr_routing_mode_validator
 
 # Mimics subprocess.run call
 #
@@ -372,6 +373,102 @@ test_telemetry_data = [
     ]
 
 
+RESTART_BGP = "systemctl reset-failed bgp,systemctl restart bgp"
+
+test_frr_routing_mode_data = [
+        # Both empty — no restart
+        {"old": {}, "upd": {}, "cmd": ""},
+        # DEVICE_METADATA present but neither startup field changed — no restart
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"hostname": "sonic"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {"hostname": "switch"}}},
+            "cmd": ""
+        },
+        # frr_mgmt_framework_config flipped false -> true — restart bgp
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"frr_mgmt_framework_config": "false"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {"frr_mgmt_framework_config": "true"}}},
+            "cmd": RESTART_BGP
+        },
+        # frr_mgmt_framework_config added where none existed (default "false") -> "true" — restart bgp
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {"frr_mgmt_framework_config": "true"}}},
+            "cmd": RESTART_BGP
+        },
+        # frr_mgmt_framework_config added but equals the default "false" — no restart
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {"frr_mgmt_framework_config": "false"}}},
+            "cmd": ""
+        },
+        # frr_mgmt_framework_config removed (was "true", default "false") — restart bgp
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"frr_mgmt_framework_config": "true"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {}}},
+            "cmd": RESTART_BGP
+        },
+        # docker_routing_config_mode separated -> unified — restart bgp
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"docker_routing_config_mode": "separated"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {"docker_routing_config_mode": "unified"}}},
+            "cmd": RESTART_BGP
+        },
+        # docker_routing_config_mode added where none existed (default "separated") — no restart
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {"docker_routing_config_mode": "separated"}}},
+            "cmd": ""
+        },
+        # docker_routing_config_mode removed (was "unified", default "separated") — restart bgp
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"docker_routing_config_mode": "unified"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {}}},
+            "cmd": RESTART_BGP
+        },
+        # docker_routing_config_mode unchanged, unrelated field changed — no restart
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {
+                "docker_routing_config_mode": "unified", "buffer_model": "traditional"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {
+                "docker_routing_config_mode": "unified", "buffer_model": "dynamic"}}},
+            "cmd": ""
+        },
+        # Both startup fields change together — single restart
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {
+                "docker_routing_config_mode": "separated", "frr_mgmt_framework_config": "false"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {
+                "docker_routing_config_mode": "unified", "frr_mgmt_framework_config": "true"}}},
+            "cmd": RESTART_BGP
+        },
+        # DEVICE_METADATA table entirely absent from upd, old had non-default field — restart bgp
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"frr_mgmt_framework_config": "true"}}},
+            "upd": {},
+            "cmd": RESTART_BGP
+        },
+        # DEVICE_METADATA table absent from old, added in upd with non-default field — restart bgp
+        {
+            "old": {},
+            "upd": {"DEVICE_METADATA": {"localhost": {"docker_routing_config_mode": "unified"}}},
+            "cmd": RESTART_BGP
+        },
+        # frr_mgmt_framework_config removed while at its default ("false") — no restart
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"frr_mgmt_framework_config": "false"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {}}},
+            "cmd": ""
+        },
+        # docker_routing_config_mode removed while at its default ("separated") — no restart
+        {
+            "old": {"DEVICE_METADATA": {"localhost": {"docker_routing_config_mode": "separated"}}},
+            "upd": {"DEVICE_METADATA": {"localhost": {}}},
+            "cmd": ""
+        },
+    ]
+
+
 class TestServiceValidator(unittest.TestCase):
 
     @patch("generic_config_updater.services_validator.subprocess.run")
@@ -555,3 +652,35 @@ class TestServiceValidator(unittest.TestCase):
 
             result = telemetry_validator(entry["old"], entry["upd"], None)
             assert result, "telemetry_validator failed: {}".format(str(entry))
+
+    @patch("generic_config_updater.services_validator.subprocess.run")
+    def test_frr_routing_mode_validator(self, mock_subprocess):
+        """Test frr_routing_mode_validator restarts the bgp container when the
+        startup-only DEVICE_METADATA fields docker_routing_config_mode or
+        frr_mgmt_framework_config change.
+
+        On a change the validator first issues `systemctl reset-failed bgp` (to
+        clear systemd's StartLimit counter) and only then `systemctl restart bgp`.
+        Both calls must appear in the expected order. Absent fields are compared
+        against their startup defaults, so adding/removing a field only restarts
+        when it actually changes the effective value.
+        """
+        global subprocess_calls, subprocess_call_index
+
+        mock_subprocess.side_effect = mock_subprocess_run
+
+        for entry in test_frr_routing_mode_data:
+            subprocess_calls = []
+            subprocess_call_index = 0
+
+            if entry["cmd"]:
+                for c in entry["cmd"].split(","):
+                    subprocess_calls.append({"cmd": c, "rc": 0})
+
+            result = frr_routing_mode_validator(entry["old"], entry["upd"], None)
+            assert result, "frr_routing_mode_validator failed: {}".format(str(entry))
+            # Ensure exactly the expected number of subprocess calls fired
+            # (0 when no restart is expected).
+            expected = len(entry["cmd"].split(",")) if entry["cmd"] else 0
+            self.assertEqual(subprocess_call_index, expected,
+                             "unexpected call count for: {}".format(str(entry)))


### PR DESCRIPTION
#### What I did

Fixed a case where switching the BGP routing mode via GCU (`config apply-patch` / `config replace`) writes the new `DEVICE_METADATA` into CONFIG_DB but leaves FRR unconfigured, so `show bgp neighbors` / `show bgp summary` come back empty until a full `config reload`.

Root cause: the frrcfgd-vs-bgpcfgd daemon selection and the set of rendered FRR config files are decided **when the bgp container starts**. `docker_init.sh` renders `supervisord.conf` from `DEVICE_METADATA`, and supervisord reads that config only once at startup (`supervisord.conf.j2`: `frr_mgmt_framework_config == "true"` selects `[program:frrcfgd]`, else `[program:bgpcfgd]`; `docker_routing_config_mode` gates `vtysh_b` and the rendered config-file set). A config-replace / apply-patch writes CONFIG_DB but never re-renders `supervisord.conf` or restarts the container, so the previously-selected daemon keeps running and the new `BGP_*` tables are never translated to FRR.

#### How I did it

Added a GCU services-validator keyed on `DEVICE_METADATA`:

- `gcu_services_validator.conf.json`: map `DEVICE_METADATA` → `bgp-routing-mode-service` → `frr_routing_mode_validator`.
- `services_validator.py`: `frr_routing_mode_validator` diffs the two startup-only fields (`docker_routing_config_mode`, `frr_mgmt_framework_config`) and, on change, `reset-failed` + restarts the `bgp` container. Restarting bgp re-runs `docker_init.sh`, which re-renders `supervisord.conf` from the now-updated CONFIG_DB and launches the correct daemon set — so a config-replace becomes self-sufficient for a routing-mode switch, no manual `config reload` needed. Absent fields are normalized to their startup defaults (`separated` / `false`) so adding/removing a field is compared against the behavior it actually replaces.

Both apply-patch and config-replace flow through `ChangeApplier.apply` → `_services_validate`, so both commit paths are covered.

#### How to verify it

1. `pytest tests/generic_config_updater/service_validator_test.py -k frr_routing_mode` — unit tests added for changed / unchanged / add / remove / both-change / table-absent cases.
2. On a device: with FRR-mode BGP configured, `config apply-patch` / `config replace` a `DEVICE_METADATA` patch that flips `frr_mgmt_framework_config` / `docker_routing_config_mode`; confirm the bgp container restarts and `show bgp summary` reflects the config without a manual `config reload`.

#### Previous command output (if the output of a command-line utility has changed)

N/A — no command-line output changes.

#### New command output (if the output of a command-line utility has changed)

N/A — no command-line output changes.
