### PR TITLE
[bgp] Fix show ipv6 bgp neighbors: case-insensitive CONFIG_DB neighbor key lookup

### DIFF
--- a/tests/bgp_neigh_present_case_test.py
+++ b/tests/bgp_neigh_present_case_test.py
@@ -1,0 +1,73 @@
+import mock
+import pytest
+
+import utilities_common.bgp_util as bgp_util
+
+
+def test_canonical_neigh_ip_ipv6_case_and_compression():
+    # Uppercase / expanded IPv6 forms must canonicalize to the same value as
+    # the lowercase / compressed form a caller typically passes in.
+    canon = bgp_util._canonical_neigh_ip
+    assert canon("FC00::71") == canon("fc00::71")
+    assert canon("FC00:0000::0071") == canon("fc00::71")
+    # IPv4 is returned as-is (already canonical) and unaffected.
+    assert canon("10.0.0.1") == "10.0.0.1"
+    # Non-IP values (e.g. VRF names) pass through unchanged.
+    assert canon("Vrf-red") == "Vrf-red"
+
+
+class _FakeConfigDB(object):
+    """Minimal ConfigDBConnector stub keyed exactly like redis (case-sensitive)."""
+
+    def __init__(self, entries):
+        # entries: {table: {key: value_dict}}; key may be str or tuple
+        self._entries = entries
+
+    def get_keys(self, table):
+        return list(self._entries.get(table, {}).keys())
+
+    def get_entry(self, table, key):
+        return self._entries.get(table, {}).get(key, {})
+
+    def get_table(self, table):
+        return self._entries.get(table, {})
+
+
+@pytest.mark.parametrize("query", ["fc00::71", "FC00::71", "fc00:0000::0071"])
+def test_is_bgp_neigh_present_ipv6_uppercase_key(query):
+    # CONFIG_DB stores the v6 neighbor key uppercase (as minigraph renders it).
+    entries = {
+        bgp_util.multi_asic.BGP_NEIGH_CFG_DB_TABLE: {
+            "FC00::71": {"asn": "65100"},
+        },
+        bgp_util.multi_asic.BGP_INTERNAL_NEIGH_CFG_DB_TABLE: {},
+        "BGP_PEER_RANGE": {},
+    }
+    fake = _FakeConfigDB(entries)
+    with mock.patch.object(bgp_util.multi_asic, "connect_config_db_for_ns", return_value=fake):
+        assert bgp_util.is_bgp_neigh_present(query) is True
+
+
+def test_is_bgp_neigh_present_absent_returns_false():
+    entries = {
+        bgp_util.multi_asic.BGP_NEIGH_CFG_DB_TABLE: {"FC00::71": {"asn": "65100"}},
+        bgp_util.multi_asic.BGP_INTERNAL_NEIGH_CFG_DB_TABLE: {},
+        "BGP_PEER_RANGE": {},
+    }
+    fake = _FakeConfigDB(entries)
+    with mock.patch.object(bgp_util.multi_asic, "connect_config_db_for_ns", return_value=fake):
+        assert bgp_util.is_bgp_neigh_present("fc00::99") is False
+
+
+def test_is_bgp_neigh_present_unified_mode_vrf_key_ipv6_case():
+    # Unified routing config mode stores keys as (vrf, neighbor_ip) tuples.
+    entries = {
+        bgp_util.multi_asic.BGP_NEIGH_CFG_DB_TABLE: {
+            ("default", "FC00::71"): {"asn": "65100"},
+        },
+        bgp_util.multi_asic.BGP_INTERNAL_NEIGH_CFG_DB_TABLE: {},
+        "BGP_PEER_RANGE": {},
+    }
+    fake = _FakeConfigDB(entries)
+    with mock.patch.object(bgp_util.multi_asic, "connect_config_db_for_ns", return_value=fake):
+        assert bgp_util.is_bgp_neigh_present("fc00::71", vrf_name="all") is True

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -23,8 +23,25 @@ def get_namespace_for_bgp_neighbor(neighbor_ip, vrf_name=constants.DEFAULT_VRF):
                  ' Bgp neighbor {} not configured'.format(neighbor_ip))
 
 
+def _canonical_neigh_ip(value):
+    # CONFIG_DB BGP_NEIGHBOR keys for IPv6 neighbors are rendered by
+    # sonic-cfggen/minigraph in a form (e.g. uppercase hextets like
+    # 'FC00::71') that may not match the address string a caller passes in
+    # (e.g. lowercase 'fc00::71' typed on the CLI). Redis keys are
+    # case-sensitive, so an exact-string comparison misses. Canonicalize any
+    # IP to its normalized compressed form so IPv6 case/compression
+    # differences do not cause false negatives. Non-IP values (or VRF-only
+    # keys) are returned unchanged.
+    try:
+        return ipaddress.ip_address(value).compressed
+    except ValueError:
+        return value
+
+
 def is_bgp_neigh_present(neighbor_ip, namespace=multi_asic.DEFAULT_NAMESPACE, vrf_name=constants.DEFAULT_VRF):
     config_db = multi_asic.connect_config_db_for_ns(namespace)
+
+    neighbor_ip_canon = _canonical_neigh_ip(neighbor_ip)
 
     tables = [
         multi_asic.BGP_NEIGH_CFG_DB_TABLE,
@@ -32,9 +49,21 @@ def is_bgp_neigh_present(neighbor_ip, namespace=multi_asic.DEFAULT_NAMESPACE, vr
     ]
 
     for table in tables:
-        # Check for the neighbor_ip format (no VRF prefix = default VRF)
+        # Fast path: exact-key lookup (O(1)). Covers IPv4 and any query that
+        # already matches the stored key form (the common case).
         if vrf_name in ('all', constants.DEFAULT_VRF) and config_db.get_entry(table, neighbor_ip):
             return True
+
+        # Fallback (only when the exact match missed): scan keys comparing the
+        # canonical IP form, so an IPv6 case/compression mismatch between the
+        # query and the stored key (e.g. uppercase 'FC00::71' vs 'fc00::71')
+        # is still resolved.
+        if vrf_name in ('all', constants.DEFAULT_VRF):
+            for key in config_db.get_keys(table):
+                if isinstance(key, tuple):
+                    continue
+                if _canonical_neigh_ip(key) == neighbor_ip_canon and config_db.get_entry(table, key):
+                    return True
 
         # Check for any string|neighbor_ip format. This is needed
         # when unified routing config mode is enabled, as in that case
@@ -42,7 +71,8 @@ def is_bgp_neigh_present(neighbor_ip, namespace=multi_asic.DEFAULT_NAMESPACE, vr
         keys = config_db.get_keys(table)
         for key in keys:
             if (
-                    isinstance(key, tuple) and len(key) == 2 and key[1] == neighbor_ip and
+                    isinstance(key, tuple) and len(key) == 2 and
+                    _canonical_neigh_ip(key[1]) == neighbor_ip_canon and
                     (vrf_name == 'all' or key[0] == vrf_name) and config_db.get_entry(table, key)
             ):
                 return True

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -54,12 +54,17 @@ def is_bgp_neigh_present(neighbor_ip, namespace=multi_asic.DEFAULT_NAMESPACE, vr
         if vrf_name in ('all', constants.DEFAULT_VRF) and config_db.get_entry(table, neighbor_ip):
             return True
 
+        # Fetch the key list once and reuse it for both the canonical-IP
+        # fallback scan and the unified-mode tuple scan below, to avoid a
+        # duplicate Redis get_keys() call per table (and per namespace).
+        keys = config_db.get_keys(table)
+
         # Fallback (only when the exact match missed): scan keys comparing the
         # canonical IP form, so an IPv6 case/compression mismatch between the
         # query and the stored key (e.g. uppercase 'FC00::71' vs 'fc00::71')
         # is still resolved.
         if vrf_name in ('all', constants.DEFAULT_VRF):
-            for key in config_db.get_keys(table):
+            for key in keys:
                 if isinstance(key, tuple):
                     continue
                 if _canonical_neigh_ip(key) == neighbor_ip_canon and config_db.get_entry(table, key):
@@ -68,7 +73,6 @@ def is_bgp_neigh_present(neighbor_ip, namespace=multi_asic.DEFAULT_NAMESPACE, vr
         # Check for any string|neighbor_ip format. This is needed
         # when unified routing config mode is enabled, as in that case
         # vrfname|neighbor_ip is the key instead of just neighbor_ip
-        keys = config_db.get_keys(table)
         for key in keys:
             if (
                     isinstance(key, tuple) and len(key) == 2 and


### PR DESCRIPTION
#### What I did

Fix `show ipv6 bgp neighbors <ip>` failing for a validly-configured IPv6 BGP neighbor when the neighbor IP is queried in lowercase.

`is_bgp_neigh_present()` looked up the `BGP_NEIGHBOR` CONFIG_DB key with an **exact string** comparison against the caller-supplied neighbor IP. IPv6 neighbor keys are rendered by minigraph/sonic-cfggen in a form (e.g. uppercase hextets `FC00::71`) that need not match the string a caller passes in (lowercase `fc00::71` typed on the CLI). Redis keys are case-sensitive, so the exact match missed and `get_namespace_for_bgp_neighbor()` raised `Bgp neighbor <ip> not configured` -> `ctx.fail` -> exit 2, even though the neighbor was configured and BGP established.

The IPv4 path (`bgp_frr_v4.py`) does not perform this CONFIG_DB pre-check, which is why only IPv6 is affected.

#### How I did it

Added a small `_canonical_neigh_ip()` helper that normalizes any IP via `ipaddress.ip_address(x).compressed`, and compare the canonical forms of both the query and the stored key in `is_bgp_neigh_present()` (both the plain-key and the unified-mode `vrf|neighbor` tuple-key paths). IPv6 case/compression differences no longer cause false negatives. IPv4 addresses and non-IP values (VRF-only keys) pass through unchanged.

#### How to verify it

Reproduce (verified live on a docker-sonic-vs neighbor):

```
show ipv6 bgp neighbors fc00::71   # before: Error: Bgp neighbor fc00::71 not configured (exit 2); after: emits neighbor output
show ipv6 bgp neighbors FC00::71   # already worked
```

Added `tests/bgp_neigh_present_case_test.py` covering canonicalization, uppercase-stored-key match for lowercase/uppercase/expanded queries, absent-neighbor False, and unified-mode `(vrf, neighbor)` tuple keys.

Fixes #4682
