### PR TITLE
[watermarkstat] Handle missing ALL queue map

### DIFF
--- a/scripts/watermarkstat
+++ b/scripts/watermarkstat
@@ -244,12 +244,15 @@ class Watermarkstat(object):
                 header_idx_set.add(element_idx)
 
         if len(header_idx_set) == 0:
-            if counter_type != 'q_shared_multi':
-                print("Object map is empty!", file=sys.stderr)
-                sys.exit(1)
-            else:
+            if counter_type == 'q_shared_multi':
                 print("Object map from the COUNTERS_DB is empty because the multicast queues are not configured in the CONFIG_DB!")
                 sys.exit(0)
+            elif counter_type == 'q_shared_all':
+                print("Object map from the COUNTERS_DB is empty because queue type ALL is not configured in the CONFIG_DB!")
+                sys.exit(0)
+            else:
+                print("Object map is empty!", file=sys.stderr)
+                sys.exit(1)
 
         header_idx_list = list(header_idx_set)
         header_idx_list.sort()

--- a/tests/watermarkstat_test.py
+++ b/tests/watermarkstat_test.py
@@ -4,12 +4,15 @@ import pytest
 import show.main as show
 from click.testing import CliRunner
 from wm_input.wm_test_vectors import testData
+from .utils import load_source
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
+
+watermarkstat = load_source('watermarkstat', os.path.join(scripts_path, 'watermarkstat'))
 
 
 @pytest.fixture(scope="function")
@@ -100,6 +103,25 @@ class TestWatermarkstat(object):
 
     def test_show_headroom_pool_persistent_wm(self):
         self.executor(testData['show_hdrm_pool_pwm'])
+
+    def test_empty_all_queue_map(self, capsys):
+        wm_stat = watermarkstat.Watermarkstat.__new__(watermarkstat.Watermarkstat)
+        wm_type = {
+            "obj_map": {
+                "Ethernet0": {},
+                "Ethernet4": {},
+            },
+            "header_prefix": "ALL",
+        }
+
+        with pytest.raises(SystemExit) as exc_info:
+            wm_stat.build_header(wm_type, "q_shared_all")
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out == ("Object map from the COUNTERS_DB is empty because "
+                                "queue type ALL is not configured in the CONFIG_DB!\n")
+        assert captured.err == ""
 
     def executor(self, testcase):
         runner = CliRunner()

--- a/tests/watermarkstat_test.py
+++ b/tests/watermarkstat_test.py
@@ -4,12 +4,15 @@ import pytest
 import show.main as show
 from click.testing import CliRunner
 from wm_input.wm_test_vectors import testData
+from .utils import load_source
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, test_path)
 sys.path.insert(0, modules_path)
+
+watermarkstat = load_source('watermarkstat', os.path.join(scripts_path, 'watermarkstat'))
 
 
 @pytest.fixture(scope="function")
@@ -100,6 +103,43 @@ class TestWatermarkstat(object):
 
     def test_show_headroom_pool_persistent_wm(self):
         self.executor(testData['show_hdrm_pool_pwm'])
+
+    def test_empty_all_queue_map(self, capsys):
+        wm_stat = watermarkstat.Watermarkstat.__new__(watermarkstat.Watermarkstat)
+        wm_type = {
+            "obj_map": {
+                "Ethernet0": {},
+                "Ethernet4": {},
+            },
+            "header_prefix": "ALL",
+        }
+
+        with pytest.raises(SystemExit) as exc_info:
+            wm_stat.build_header(wm_type, "q_shared_all")
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out == ("Object map from the COUNTERS_DB is empty because "
+                                "queue type ALL is not configured in the CONFIG_DB!\n")
+        assert captured.err == ""
+
+    def test_empty_object_map(self, capsys):
+        wm_stat = watermarkstat.Watermarkstat.__new__(watermarkstat.Watermarkstat)
+        wm_type = {
+            "obj_map": {
+                "Ethernet0": {},
+                "Ethernet4": {},
+            },
+            "header_prefix": "PG",
+        }
+
+        with pytest.raises(SystemExit) as exc_info:
+            wm_stat.build_header(wm_type, "pg_shared")
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == "Object map is empty!\n"
 
     def executor(self, testcase):
         runner = CliRunner()


### PR DESCRIPTION
#### What I did

Made `show queue watermark all` and `show queue persistent-watermark all` handle platforms that do not expose `SAI_QUEUE_TYPE_ALL` queue objects without returning a fatal error.

Fixes #4594.

#### How I did it

* Added an explicit successful empty-map path for `q_shared_all`.
* Preserved the existing `q_shared_multi` message and exit behavior.
* Preserved the existing failure behavior for all other empty object maps.
* Added a focused unit test that verifies the exit status, stdout, and stderr.
* Did not change CLI syntax or normal non-empty object-map behavior.

#### How to verify it

Local checks completed:

* `git diff --check`
* `python3 -m py_compile scripts/watermarkstat tests/watermarkstat_test.py`

The full pytest test file was not run locally because the WSL environment does not contain pytest and the required SONiC-specific dependencies.

In a SONiC utilities test environment, run:

```bash
python3 -m pytest -o addopts='' tests/watermarkstat_test.py -k 'empty_all_queue_map or multicast_wm_neg' -q
python3 -m pytest -o addopts='' tests/watermarkstat_test.py -q
```

#### Previous command output (if the output of a command-line utility has changed)

```text
Object map is empty!
```

The command printed the message to stderr and exited with status 1.

#### New command output (if the output of a command-line utility has changed)

```text
Object map from the COUNTERS_DB is empty because queue type ALL is not configured in the CONFIG_DB!
```

The command prints the message to stdout and exits with status 0.
