### PR TITLE
[console] Add new commands for Console Logging feature in CONSOLE_PORT

### DIFF
--- a/config/console.py
+++ b/config/console.py
@@ -1,5 +1,6 @@
 import click
 import string
+import re
 import utilities_common.cli as clicommon
 from .validated_config_db_connector import ValidatedConfigDBConnector
 from jsonpatch import JsonPatchConflict
@@ -308,6 +309,140 @@ def update_console_escape_char(db, linenum, escape):
             ctx.fail("Invalid ConfigDB. Error: {}".format(e))
     else:
         ctx.fail("Trying to update console port setting, which is not present.")
+
+
+#
+# 'console logging' group ('config console logging ...')
+#
+LOGROTATE_SIZE_PATTERN = re.compile(r'^[0-9]+[kKmMgG]?$')
+DEFAULT_LOG_FILE_TEMPLATE = "/var/log/console-{}.log"
+DEFAULT_LOGROTATE_SIZE = "1M"
+DEFAULT_LOGROTATE_COUNT = "20"
+
+
+def default_log_file(linenum):
+    return DEFAULT_LOG_FILE_TEMPLATE.format(linenum)
+
+
+def apply_default_logging_config(data, linenum):
+    """Fill in default log file and logrotate settings when not configured."""
+    if not data.get('log_file'):
+        data['log_file'] = default_log_file(linenum)
+    if not data.get('logrotate_size'):
+        data['logrotate_size'] = DEFAULT_LOGROTATE_SIZE
+    if not data.get('logrotate_count'):
+        data['logrotate_count'] = DEFAULT_LOGROTATE_COUNT
+
+
+def parse_logrotate_args(ctx, logrotate_keyword, size, count):
+    """Resolve logrotate size/count from optional CLI arguments."""
+    if logrotate_keyword is None:
+        return DEFAULT_LOGROTATE_SIZE, DEFAULT_LOGROTATE_COUNT
+
+    if logrotate_keyword != 'logrotate':
+        ctx.fail("Expected 'logrotate' keyword.")
+
+    if size is None or count is None:
+        ctx.fail("Both <size> and <count> are required when 'logrotate' is specified.")
+
+    if not LOGROTATE_SIZE_PATTERN.match(size):
+        ctx.fail("Invalid logrotate size '{}'. Use a value like 10M or 100k.".format(size))
+
+    return size, str(count)
+
+
+@console.group('logging')
+@click.argument('linenum', metavar='<line_number>', required=True, type=click.IntRange(0, 65535))
+def console_logging(linenum):
+    """Console I/O logging configuration"""
+    pass
+
+
+@console_logging.command('enable')
+@clicommon.pass_db
+def enable_console_logging(db):
+    """Enable console I/O logging for a console line"""
+    linenum = click.get_current_context().parent.params['linenum']
+    _set_console_logging_state(linenum, db, "yes")
+
+
+@console_logging.command('disable')
+@clicommon.pass_db
+def disable_console_logging(db):
+    """Disable console I/O logging for a console line"""
+    linenum = click.get_current_context().parent.params['linenum']
+    _set_console_logging_state(linenum, db, "no")
+
+
+@console_logging.command('filename')
+@clicommon.pass_db
+@click.argument('filename', metavar='<file_name>', required=True)
+@click.argument('logrotate_keyword', metavar='logrotate', required=False)
+@click.argument('size', metavar='<size>', required=False)
+@click.argument('count', metavar='<count>', required=False, type=click.IntRange(1, 100))
+def set_console_logging_filename(db, filename, logrotate_keyword, size, count):
+    """Configure console log file and optional logrotate settings"""
+    ctx = click.get_current_context()
+    logrotate_size, logrotate_count = parse_logrotate_args(ctx, logrotate_keyword, size, count)
+
+    linenum = ctx.parent.params['linenum']
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
+
+    table = "CONSOLE_PORT"
+    data = config_db.get_entry(table, linenum)
+    if not data:
+        ctx.fail("Trying to update console port setting, which is not present.")
+
+    size_key = 'logrotate_size'
+    count_key = 'logrotate_count'
+    file_key = 'log_file'
+
+    if (data.get(file_key) == filename and
+            data.get(size_key) == logrotate_size and
+            data.get(count_key) == logrotate_count):
+        return
+
+    data[file_key] = filename
+    data[size_key] = logrotate_size
+    data[count_key] = logrotate_count
+    try:
+        config_db.mod_entry(table, linenum, data)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+
+
+def _set_console_logging_state(linenum, db, enabled_value):
+    ctx = click.get_current_context()
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
+
+    table = "CONSOLE_PORT"
+    enabled_key = 'logging_enabled'
+
+    data = config_db.get_entry(table, linenum)
+    if not data:
+        ctx.fail("Trying to update console port setting, which is not present.")
+
+    if enabled_value == "yes":
+        old_log_file = data.get('log_file')
+        old_size = data.get('logrotate_size')
+        old_count = data.get('logrotate_count')
+        apply_default_logging_config(data, linenum)
+        defaults_changed = (
+            data.get('log_file') != old_log_file or
+            data.get('logrotate_size') != old_size or
+            data.get('logrotate_count') != old_count
+        )
+    else:
+        defaults_changed = False
+
+    if data.get(enabled_key) == enabled_value and not defaults_changed:
+        return
+
+    data[enabled_key] = enabled_value
+    try:
+        config_db.mod_entry(table, linenum, data)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
 
 
 def isExistingSameDevice(config_db, deviceName, table):

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -21,6 +21,7 @@ from jsonpatch import JsonPatchConflict
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 CONSOLE_MOCK_DIR = SCRIPT_DIR + "/console_mock"
+CONSOLE_LOGGING_CMD = config.config.commands["console"].commands["logging"]
 
 
 class TestConfigConsoleCommands(object):
@@ -698,6 +699,181 @@ class TestConfigConsoleCommands(object):
         result = runner.invoke(config.config.commands["console"].commands["flow_control"], ["enable", "1"], obj=db)
         print(result.exit_code)
         print(sys.stderr, result.output)
+        assert "Invalid ConfigDB. Error" in result.output
+
+    def test_update_console_logging_non_exists(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "enable"],
+            obj=db,
+        )
+        assert result.exit_code != 0
+        assert "Trying to update console port setting, which is not present." in result.output
+
+    def test_update_console_logging_filename_success(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {"baud_rate": "9600"})
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "filename", "/var/log/console1.log", "logrotate", "10M", "5"],
+            obj=db,
+        )
+        assert result.exit_code == 0
+
+        entry = db.cfgdb.get_entry("CONSOLE_PORT", "1")
+        assert entry.get("log_file") == "/var/log/console1.log"
+        assert entry.get("logrotate_size") == "10M"
+        assert entry.get("logrotate_count") == "5"
+        assert entry.get("baud_rate") == "9600"
+
+    def test_update_console_logging_filename_defaults(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {"baud_rate": "9600"})
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "filename", "/var/log/console1.log"],
+            obj=db,
+        )
+        assert result.exit_code == 0
+
+        entry = db.cfgdb.get_entry("CONSOLE_PORT", "1")
+        assert entry.get("log_file") == "/var/log/console1.log"
+        assert entry.get("logrotate_size") == "1M"
+        assert entry.get("logrotate_count") == "20"
+
+    def test_update_console_logging_filename_invalid_size(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {"baud_rate": "9600"})
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "filename", "/var/log/console1.log", "logrotate", "big", "5"],
+            obj=db,
+        )
+        assert result.exit_code != 0
+        assert "Invalid logrotate size" in result.output
+
+    def test_update_console_logging_filename_invalid_keyword(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {"baud_rate": "9600"})
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "filename", "/var/log/console1.log", "rotate", "10M", "5"],
+            obj=db,
+        )
+        assert result.exit_code != 0
+        assert "Expected 'logrotate' keyword." in result.output
+
+    def test_update_console_logging_enable_applies_defaults(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {"baud_rate": "9600"})
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "enable"],
+            obj=db,
+        )
+        assert result.exit_code == 0
+
+        entry = db.cfgdb.get_entry("CONSOLE_PORT", "1")
+        assert entry.get("logging_enabled") == "yes"
+        assert entry.get("log_file") == "/var/log/console-1.log"
+        assert entry.get("logrotate_size") == "1M"
+        assert entry.get("logrotate_count") == "20"
+
+    def test_update_console_logging_enable_success(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {
+            "baud_rate": "9600",
+            "log_file": "/var/log/console1.log",
+            "logrotate_size": "10M",
+            "logrotate_count": "5",
+        })
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "enable"],
+            obj=db,
+        )
+        assert result.exit_code == 0
+
+        entry = db.cfgdb.get_entry("CONSOLE_PORT", "1")
+        assert entry.get("logging_enabled") == "yes"
+        assert entry.get("log_file") == "/var/log/console1.log"
+
+    def test_update_console_logging_disable_success(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {
+            "baud_rate": "9600",
+            "logging_enabled": "yes",
+            "log_file": "/var/log/console1.log",
+            "logrotate_size": "10M",
+            "logrotate_count": "5",
+        })
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "disable"],
+            obj=db,
+        )
+        assert result.exit_code == 0
+
+        entry = db.cfgdb.get_entry("CONSOLE_PORT", "1")
+        assert entry.get("logging_enabled") == "no"
+        assert entry.get("log_file") == "/var/log/console1.log"
+
+    def test_update_console_logging_enable_no_change(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {
+            "baud_rate": "9600",
+            "logging_enabled": "yes",
+            "log_file": "/var/log/console1.log",
+            "logrotate_size": "10M",
+            "logrotate_count": "5",
+        })
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "enable"],
+            obj=db,
+        )
+        assert result.exit_code == 0
+
+        entry = db.cfgdb.get_entry("CONSOLE_PORT", "1")
+        assert entry.get("logging_enabled") == "yes"
+
+    @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
+    @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_mod_entry",
+           mock.Mock(side_effect=ValueError))
+    def test_update_console_logging_enable_yang_validation(self):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {
+            "baud_rate": "9600",
+            "log_file": "/var/log/console1.log",
+            "logrotate_size": "10M",
+            "logrotate_count": "5",
+        })
+
+        result = runner.invoke(
+            CONSOLE_LOGGING_CMD,
+            ["1", "enable"],
+            obj=db,
+        )
         assert "Invalid ConfigDB. Error" in result.output
 
     def test_console_full_workflow_integration(self):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add new commands to enable, disable console logging. optional command to modify the filename, logrotate parameters for the filename.

Related PR from other sub modules:
https://github.com/sonic-net/sonic-buildimage/pull/28411
https://github.com/sonic-net/sonic-host-services/pull/409

#### How I did it
Add new commands: config console logging <line> {enable/disable}. 
optional command: config console logging <line> filename <path> [--logrotate-size SIZE] [--logrotate-count COUNT]
If filename,logrorate parameters are not configured, default values (/var/log/console-<line>.log, 10M size, 10 count) will be used.

#### How to verify it
Manually tested on physical testbed.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

