### PR TITLE
log_ssd_health: detect storage device from /host

### DIFF
--- a/scripts/log_ssd_health
+++ b/scripts/log_ssd_health
@@ -1,7 +1,37 @@
-#! /bin/bash
+#!/bin/bash
 
-timeout --foreground 30 smartctl -xa /dev/sda > /tmp/smartctl
+get_storage_device() {
+    local src disk
+
+    src=$(findmnt -rn -o SOURCE /host 2>/dev/null) || return 1
+    src=$(readlink -f "$src" 2>/dev/null) || return 1
+
+    [ -b "$src" ] || return 1
+
+    disk=$(lsblk -no PKNAME "$src" 2>/dev/null)
+
+    if [ -n "$disk" ]; then
+        echo "/dev/$disk"
+    else
+        echo "$src"
+    fi
+}
+
+SSD_DEVICE=$(get_storage_device)
+
+if [ -z "$SSD_DEVICE" ]; then
+    logger "log_ssd_health: unable to determine storage device from /host"
+    exit 0
+fi
+
+case "$SSD_DEVICE" in
+    /dev/mmcblk*)
+        logger "log_ssd_health: $SSD_DEVICE is eMMC; smartctl is not supported"
+        exit 0
+        ;;
+esac
+
+timeout --foreground 30 smartctl -xa "$SSD_DEVICE" > /tmp/smartctl
 if [ -f /tmp/smartctl ];then
     logger -f /tmp/smartctl
 fi
-


### PR DESCRIPTION
Determine the underlying storage device dynamically instead of assuming /dev/sda. Skip eMMC devices where smartctl is unsupported, and log a message when the storage device cannot be resolved.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Updated scripts/log_ssd_health to determine the underlying storage device dynamically instead of assuming /dev/sda.

The script now skips eMMC devices because smartctl is not supported for them, and logs a message if the storage device cannot be resolved from /host.

#### How I did it

Added a helper to resolve the source device mounted at /host, follow it to the real block device, and use lsblk to find the parent disk when the source is a partition.

The resolved device is then used for the smartctl -xa call. If the resolved device is an eMMC device, the script logs that smartctl is unsupported and exits without error.

#### How to verify it

Run the script on systems with different storage layouts:

sudo scripts/log_ssd_health

Verify that:

grep log_ssd_health /var/log/syslog

Expected behavior:

- On SATA/NVMe storage, smartctl runs against the detected underlying disk.
```
NVME:

2026 Jul  7 20:25:49.272090 ctn101 INFO systemd[1]: Starting fstrim.service - Discard unused blocks...
2026 Jul  7 20:25:49.346613 ctn101 NOTICE root: smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.12.41+deb13-sonic-amd64] (local build)
2026 Jul  7 20:25:49.346685 ctn101 NOTICE root: Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org
2026 Jul  7 20:25:49.346715 ctn101 NOTICE root:
2026 Jul  7 20:25:49.346745 ctn101 NOTICE root: === START OF INFORMATION SECTION ===
2026 Jul  7 20:25:49.346772 ctn101 NOTICE root: Model Number:                       ATP AF480GSTJA-AW2
2026 Jul  7 20:25:49.346799 ctn101 NOTICE root: Serial Number:                      24070070-000648
2026 Jul  7 20:25:49.346825 ctn101 NOTICE root: Firmware Version:                   42A4SB6D
2026 Jul  7 20:25:49.346850 ctn101 NOTICE root: PCI Vendor/Subsystem ID:            0x1db2
2026 Jul  7 20:25:49.346876 ctn101 NOTICE root: IEEE OUI Identifier:                0x141357
2026 Jul  7 20:25:49.346907 ctn101 NOTICE root: Controller ID:                      1
2026 Jul  7 20:25:49.346934 ctn101 NOTICE root: NVMe Version:                       1.3
2026 Jul  7 20:25:49.346959 ctn101 NOTICE root: Number of Namespaces:               1
2026 Jul  7 20:25:49.346984 ctn101 NOTICE root: Namespace 1 Size/Capacity:          480,103,981,056 [480 GB]
2026 Jul  7 20:25:49.347013 ctn101 NOTICE root: Namespace 1 Utilization:            19,536,654,336 [19.5 GB]
2026 Jul  7 20:25:49.347040 ctn101 NOTICE root: Namespace 1 Formatted LBA Size:     512
2026 Jul  7 20:25:49.347065 ctn101 NOTICE root: Namespace 1 IEEE EUI-64:            141357 7160017c90
2026 Jul  7 20:25:49.347090 ctn101 NOTICE root: Local Time is:                      Tue Jul  7 20:25:49 2026 UTC
2026 Jul  7 20:25:49.347115 ctn101 NOTICE root: Firmware Updates (0x14):            2 Slots, no Reset required
2026 Jul  7 20:25:49.347141 ctn101 NOTICE root: Optional Admin Commands (0x0017):   Security Format Frmw_DL Self_Test
2026 Jul  7 20:25:49.347167 ctn101 NOTICE root: Optional NVM Commands (0x005f):     Comp Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat Timestmp
2026 Jul  7 20:25:49.347192 ctn101 NOTICE root: Log Page Attributes (0x0b):         S/H_per_NS Cmd_Eff_Lg Telmtry_Lg
2026 Jul  7 20:25:49.347218 ctn101 NOTICE root: Maximum Data Transfer Size:         64 Pages
2026 Jul  7 20:25:49.347243 ctn101 NOTICE root: Warning  Comp. Temp. Threshold:     75 Celsius
2026 Jul  7 20:25:49.347268 ctn101 NOTICE root: Critical Comp. Temp. Threshold:     80 Celsius
2026 Jul  7 20:25:49.347293 ctn101 NOTICE root:
2026 Jul  7 20:25:49.347324 ctn101 NOTICE root: Supported Power States
2026 Jul  7 20:25:49.347354 ctn101 NOTICE root: St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
2026 Jul  7 20:25:49.347449 ctn101 NOTICE root:  0 +     9.00W       -        -    0  0  0  0        0       0
2026 Jul  7 20:25:49.347483 ctn101 NOTICE root:  1 +     4.60W       -        -    1  1  1  1        0       0
2026 Jul  7 20:25:49.347505 ctn101 NOTICE root:  2 +     3.80W       -        -    2  2  2  2        0       0
2026 Jul  7 20:25:49.347525 ctn101 NOTICE root:  3 -   0.0450W       -        -    3  3  3  3     2000    2000
2026 Jul  7 20:25:49.347546 ctn101 NOTICE root:  4 -   0.0040W       -        -    4  4  4  4    15000   15000
2026 Jul  7 20:25:49.347566 ctn101 NOTICE root:
2026 Jul  7 20:25:49.347586 ctn101 NOTICE root: Supported LBA Sizes (NSID 0x1)
2026 Jul  7 20:25:49.347605 ctn101 NOTICE root: Id Fmt  Data  Metadt  Rel_Perf
2026 Jul  7 20:25:49.347625 ctn101 NOTICE root:  0 +     512       0         0
2026 Jul  7 20:25:49.347644 ctn101 NOTICE root:
2026 Jul  7 20:25:49.347663 ctn101 NOTICE root: === START OF SMART DATA SECTION ===
2026 Jul  7 20:25:49.347682 ctn101 NOTICE root: SMART overall-health self-assessment test result: PASSED
2026 Jul  7 20:25:49.347707 ctn101 NOTICE root:
2026 Jul  7 20:25:49.347727 ctn101 NOTICE root: SMART/Health Information (NVMe Log 0x02)
2026 Jul  7 20:25:49.347746 ctn101 NOTICE root: Critical Warning:                   0x00
2026 Jul  7 20:25:49.347765 ctn101 NOTICE root: Temperature:                        52 Celsius
2026 Jul  7 20:25:49.347784 ctn101 NOTICE root: Available Spare:                    100%
2026 Jul  7 20:25:49.347804 ctn101 NOTICE root: Available Spare Threshold:          10%
2026 Jul  7 20:25:49.347823 ctn101 NOTICE root: Percentage Used:                    6%
2026 Jul  7 20:25:49.347842 ctn101 NOTICE root: Data Units Read:                    178,860,895 [91.5 TB]
2026 Jul  7 20:25:49.347863 ctn101 NOTICE root: Data Units Written:                 35,497,777 [18.1 TB]
2026 Jul  7 20:25:49.347882 ctn101 NOTICE root: Host Read Commands:                 830,259,554
2026 Jul  7 20:25:49.347902 ctn101 NOTICE root: Host Write Commands:                269,623,058
2026 Jul  7 20:25:49.347925 ctn101 NOTICE root: Controller Busy Time:               5,154
2026 Jul  7 20:25:49.347944 ctn101 NOTICE root: Power Cycles:                       7,972
2026 Jul  7 20:25:49.347964 ctn101 NOTICE root: Power On Hours:                     5,122
2026 Jul  7 20:25:49.347983 ctn101 NOTICE root: Unsafe Shutdowns:                   4,622
2026 Jul  7 20:25:49.348002 ctn101 NOTICE root: Media and Data Integrity Errors:    0
2026 Jul  7 20:25:49.348021 ctn101 NOTICE root: Error Information Log Entries:      0
2026 Jul  7 20:25:49.348040 ctn101 NOTICE root: Warning  Comp. Temperature Time:    3
2026 Jul  7 20:25:49.348059 ctn101 NOTICE root: Critical Comp. Temperature Time:    0
2026 Jul  7 20:25:49.348078 ctn101 NOTICE root: Temperature Sensor 1:               55 Celsius
2026 Jul  7 20:25:49.348097 ctn101 NOTICE root: Temperature Sensor 2:               52 Celsius
2026 Jul  7 20:25:49.348119 ctn101 NOTICE root: Temperature Sensor 3:               58 Celsius
2026 Jul  7 20:25:49.348139 ctn101 NOTICE root: Temperature Sensor 4:               52 Celsius
2026 Jul  7 20:25:49.348158 ctn101 NOTICE root: Temperature Sensor 5:               52 Celsius
2026 Jul  7 20:25:49.348178 ctn101 NOTICE root: Temperature Sensor 6:               41 Celsius
2026 Jul  7 20:25:49.348197 ctn101 NOTICE root:
2026 Jul  7 20:25:49.348217 ctn101 NOTICE root: Error Information (NVMe Log 0x01, 16 of 256 entries)
2026 Jul  7 20:25:49.348237 ctn101 NOTICE root: No Errors Logged
2026 Jul  7 20:25:49.348255 ctn101 NOTICE root:
2026 Jul  7 20:25:49.348274 ctn101 NOTICE root: Read Self-test Log failed: Invalid Field in Command (0x002)
2026 Jul  7 20:25:49.348297 ctn101 NOTICE root:
```
- On eMMC storage, the script logs that smartctl is unsupported and exits cleanly.
```
eMMC:
2026 Jul  7 20:26:57.096369 pkzm504 NOTICE root: log_ssd_health: /dev/mmcblk0 is eMMC; smartctl is not supported
```
- If /host cannot be resolved to a block device, the script logs an error message and exits cleanly.

#### Previous command output (if the output of a command-line utility has changed)

No command-line utility output changed. Previously, the script always ran:

smartctl -xa /dev/sda

#### New command output (if the output of a command-line utility has changed)

No command-line utility output changed. The script now runs smartctl against the detected storage device, or logs and exits when the device is unsupported or cannot be resolved.
