### PR TITLE
[202605] Add ssd health pre-check for warm-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -746,37 +746,8 @@ function check_pfc_storm_active()
     fi
 }
 
-function check_db_integrity()
+function check_ssd_health()
 {
-    if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" || "$REBOOT_TYPE" = "express-reboot" || "$REBOOT_TYPE" = "fast-reboot" ]]; then
-        CHECK_DB_INTEGRITY=0
-        /usr/local/bin/check_db_integrity.py || CHECK_DB_INTEGRITY=$?
-        if [[ CHECK_DB_INTEGRITY -ne 0 ]]; then
-            if [[ x"${IGNORE_DB_CHECK}" == x"yes" ]]; then
-                debug "Ignoring Database integrity checks..."
-            else
-                error "Failed to validate DB's integrity. Exit code: ${CHECK_DB_INTEGRITY}. \
-                    Use '-d' option to force ignore this check."
-                exit ${EXIT_DB_INTEGRITY_FAILURE}
-            fi
-        fi
-    fi
-}
-
-function reboot_pre_check()
-{
-    execute_in_namespaces asic check_pfc_storm_active
-    check_docker_exec
-    # Make sure that the file system is normal: read-write able
-    filename="/host/test-$(date +%Y%m%d-%H%M%S)"
-    if [[ ! -f ${filename} ]]; then
-        touch ${filename}
-    fi
-    rm ${filename}
-
-    execute_in_namespaces asic check_db_integrity
-
-    # Check SSD health
     if [ -x "${SSD_UTIL}" ]; then
         debug "Checking ssd health before ${REBOOT_TYPE}..."
         health_line=$(${SSD_UTIL} | grep -E "Health\s*:\s*[0-9]+\.?[0-9]*%" || true)
@@ -798,6 +769,38 @@ function reboot_pre_check()
             fi
         fi
     fi
+}
+
+function check_db_integrity()
+{
+    if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" || "$REBOOT_TYPE" = "express-reboot" || "$REBOOT_TYPE" = "fast-reboot" ]]; then
+        CHECK_DB_INTEGRITY=0
+        /usr/local/bin/check_db_integrity.py || CHECK_DB_INTEGRITY=$?
+        if [[ CHECK_DB_INTEGRITY -ne 0 ]]; then
+            if [[ x"${IGNORE_DB_CHECK}" == x"yes" ]]; then
+                debug "Ignoring Database integrity checks..."
+            else
+                error "Failed to validate DB's integrity. Exit code: ${CHECK_DB_INTEGRITY}. \
+                    Use '-d' option to force ignore this check."
+                exit ${EXIT_DB_INTEGRITY_FAILURE}
+            fi
+        fi
+    fi
+}
+
+function reboot_pre_check()
+{
+    execute_in_namespaces asic check_pfc_storm_active
+    check_ssd_health
+    check_docker_exec
+    # Make sure that the file system is normal: read-write able
+    filename="/host/test-$(date +%Y%m%d-%H%M%S)"
+    if [[ ! -f ${filename} ]]; then
+        touch ${filename}
+    fi
+    rm ${filename}
+
+    execute_in_namespaces asic check_db_integrity
 
     # Make sure /host has enough space for warm reboot temp files
     avail=$(df -k /host | tail -1 | awk '{ print $4 }')

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -25,6 +25,7 @@ DEVPATH="/usr/share/sonic/device"
 PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 PLATFORM_PLUGIN="${REBOOT_TYPE}_plugin"
 LOG_SSD_HEALTH="/usr/local/bin/log_ssd_health"
+SSD_UTIL="/usr/local/bin/ssdutil"
 PLATFORM_FWUTIL_AU_REBOOT_HANDLE="platform_fw_au_reboot_handle"
 PLATFORM_REBOOT_PRE_CHECK="platform_reboot_pre_check"
 SSD_FW_UPDATE="ssd-fw-upgrade"
@@ -50,6 +51,7 @@ EXIT_TEAMD_RETRY_COUNT_FAILURE=23
 EXIT_NO_MIRROR_SESSION_ACLS=24
 EXIT_PFC_STORM_DETECTED=25
 EXIT_LEFTOVER_CPA_TUNNEL=30
+EXIT_SSD_HEALTH_FAILURE=40
 
 [ -f /usr/share/sonic/device/$PLATFORM/asic.conf ] && . /usr/share/sonic/device/$PLATFORM/asic.conf
 NUM_ASIC=${NUM_ASIC:-1}
@@ -773,6 +775,29 @@ function reboot_pre_check()
     rm ${filename}
 
     execute_in_namespaces asic check_db_integrity
+
+    # Check SSD health
+    if [ -x "${SSD_UTIL}" ]; then
+        debug "Checking ssd health before ${REBOOT_TYPE}..."
+        health_line=$(${SSD_UTIL} | grep -E "Health\s*:\s*[0-9]+\.?[0-9]*%" || true)
+
+        if [ -z "$health_line" ]; then
+            debug "Warning: Health line not found in ${SSD_UTIL} output."
+        else
+            # Extract the numeric value X from "Health       : X%"
+            health_value=$(echo "$health_line" | sed -n 's/[^0-9]*\([0-9]\+\).*/\1/p')
+
+            # Check if health_value is a valid number
+            if [ -z "$health_value" ]; then
+                debug "Warning: Could not find health percentage."
+            elif [ "$health_value" -gt 0 ]; then
+                debug "SSD Health is $health_value% — OK."
+            else
+                error "Warning: Health is $health_value% — Possible drive failure!"
+                exit "${EXIT_SSD_HEALTH_FAILURE}"
+            fi
+        fi
+    fi
 
     # Make sure /host has enough space for warm reboot temp files
     avail=$(df -k /host | tail -1 | awk '{ print $4 }')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Check SSD health using ssdutil before warm-reboot
Fixes: https://github.com/sonic-net/sonic-utilities/issues/4694
Backport of https://github.com/sonic-net/sonic-utilities/pull/4086 to 202605

#### How I did it
Check the health of SSD based on the output of ssdutil. Stop warm-reboot early if the health number is 0.

#### How to verify it
The check will be skipped if the command ssdutil returned with error
The added lines can correctly parse the output of ssdutil in the format of "Health    :  X%" or "Health    :  X.Y%" 
The check will block fast-reboot/warm-reboot if the extracted health number is 0

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

