### PR TITLE
Make show techsupport --flow-dump require integer arg for flow limit.

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -58,6 +58,7 @@ IS_SUPERVISOR=false
 IS_SWITCH_BMC=false
 
 ENABLE_FLOW_DUMP=false
+FLOW_DUMP_MAX_FLOWS=
 
 # lock dirs/files
 LOCKDIR="/tmp/techsupport-lock"
@@ -2649,7 +2650,11 @@ start_dpu_flow_dump() {
     local path_file stderr_file
     path_file=$(mktemp /tmp/ts_dpu_flow_dump_path.XXXXXX)
     stderr_file=$(mktemp /tmp/ts_dpu_flow_dump_err.XXXXXX)
-    sonic-dpu-flow-dump.py --no-flow-state --file-only > "$path_file" 2>"$stderr_file"
+    local flow_dump_cmd=(sonic-dpu-flow-dump.py --no-flow-state --file-only)
+    if [[ -n "${FLOW_DUMP_MAX_FLOWS}" ]]; then
+        flow_dump_cmd+=(--max-flows "${FLOW_DUMP_MAX_FLOWS}")
+    fi
+    "${flow_dump_cmd[@]}" > "$path_file" 2>"$stderr_file"
     local rc=$?
     if [[ "$rc" -eq 0 ]] && [[ -f "$path_file" ]]; then
         echo "DPU flow dump collection successful (rc=${rc})."
@@ -3138,12 +3143,13 @@ OPTIONS
         Redirect any intermediate errors to STDERR
     -d
         Collect the output of debug dump cli
-    -f
-        On DPU platforms, also collect a DPU flow dump
+    -f MAX_FLOWS
+        On DPU platforms, also collect a DPU flow dump with the given
+        maximum number of flows
 EOF
 }
 
-while getopts ":xnvhzas:t:r:df" opt; do
+while getopts ":xnvhzas:t:r:df:" opt; do
     case $opt in
         x)
             # enable bash debugging
@@ -3195,7 +3201,12 @@ while getopts ":xnvhzas:t:r:df" opt; do
             DEBUG_DUMP=true
             ;;
         f)
+            if ! [[ ${OPTARG} =~ ^[0-9]+$ ]]; then
+                echo "Invalid max flows value: ${OPTARG}, Please enter a numeric value."
+                exit $EXT_GENERAL
+            fi
             ENABLE_FLOW_DUMP=true
+            FLOW_DUMP_MAX_FLOWS="${OPTARG}"
             ;;
         /?)
             echo "Invalid option: -$OPTARG" >&2

--- a/show/main.py
+++ b/show/main.py
@@ -1798,7 +1798,8 @@ def users(verbose):
 @click.option('--silent', is_flag=True, help="Run techsupport in silent mode")
 @click.option('--debug-dump', is_flag=True, help="Collect Debug Dump Output")
 @click.option('--redirect-stderr', '-r', is_flag=True, help="Redirect an intermediate errors to STDERR")
-@click.option('--flow-dump', is_flag=True, help="Collect DPU flow dump (Only valid on DPU platforms)")
+@click.option('--flow-dump', required=False, type=click.IntRange(min=1),
+              help="Collect DPU flow dump with maximum number of flows (Only valid on DPU platforms)")
 def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
                 silent, debug_dump, redirect_stderr, flow_dump):
     """Gather information for troubleshooting"""
@@ -1822,8 +1823,8 @@ def techsupport(since, global_timeout, cmd_timeout, verbose, allow_process_stop,
     if debug_dump:
         cmd += ["-d"]
 
-    if flow_dump:
-        cmd += ["-f"]
+    if flow_dump is not None:
+        cmd += ["-f", str(flow_dump)]
 
     cmd += ['-t', str(cmd_timeout)]
     if redirect_stderr:

--- a/tests/techsupport_test.py
+++ b/tests/techsupport_test.py
@@ -15,8 +15,8 @@ EXPECTED_BASE_COMMAND = ['sudo']
             (['--allow-process-stop'], ['generate_dump', '-v', '-a', '-t', '5']),
             (['--silent'], ['generate_dump', '-t', '5']),
             (['--debug-dump', '--redirect-stderr'], ['generate_dump', '-v', '-d', '-t', '5', '-r']),
-            (['--flow-dump'], ['generate_dump', '-v', '-f', '-t', '5']),
-            (['--debug-dump', '--flow-dump'], ['generate_dump', '-v', '-d', '-f', '-t', '5']),
+            (['--flow-dump', '100'], ['generate_dump', '-v', '-f', '100', '-t', '5']),
+            (['--debug-dump', '--flow-dump', '500'], ['generate_dump', '-v', '-d', '-f', '500', '-t', '5']),
         ]
 )
 def test_techsupport(run_command, cli_arguments, expected):


### PR DESCRIPTION
#### Why I did it
`show techsupport --flow-dump` previously relied on a default limit of 1000 flows in `sonic-dpu-flow-dump.py`. Operators need to specify the maximum flow count explicitly when collecting DPU flow dumps during techsupport.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Change `--flow-dump` from a flag to an integer argument in `show/main.py`.
- Update `generate_dump -f MAX_FLOWS` to validate numeric input and pass `--max-flows` to `sonic-dpu-flow-dump.py`.
- Update `tests/techsupport_test.py` for the new CLI argument form.

#### How to verify it
```bash
pytest tests/techsupport_test.py -k techsupport
show techsupport --flow-dump 100   # on DPU platform
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Tested branch (Please provide the tested image version)
- [x] master (202605–202611)

#### Description for the changelog
Make show techsupport --flow-dump require integer arg for flow limit.

