### PR TITLE
[fdbshow]: Fix 'show mac' hang on multi-ASIC when no namespace is specified

### DIFF
--- a/scripts/fdbshow
+++ b/scripts/fdbshow
@@ -304,11 +304,27 @@ def main():
     display_only_local = args.local
 
     try:
-        fdb = FdbShow(namespace=args.namespace)
-        if not fdb.validate_params(args.vlan, args.port, args.address, args.type):
-           sys.exit(1)
+        # On multi-ASIC platforms the FDB is maintained per ASIC namespace.
+        if args.namespace is not None:
+            ns_list = [args.namespace]
+        else:
+            ns_list = multi_asic.get_namespace_list()
 
-        fdb.display(args.vlan, args.port, args.address, args.type, args.count)
+        displayed = False
+        for ns in ns_list:
+            namespace = None if ns in (None, multi_asic.DEFAULT_NAMESPACE) else ns
+            fdb = FdbShow(namespace=namespace)
+            if not fdb.validate_params(args.vlan, args.port, args.address, args.type):
+                # -p port may exist on only some ASICs; fail only if none matched.
+                continue
+
+            if len(ns_list) > 1:
+                print("Namespace: {}".format(ns))
+            fdb.display(args.vlan, args.port, args.address, args.type, args.count)
+            displayed = True
+
+        if not displayed:
+            sys.exit(1)
     except Exception as e:
         print(str(e))
         sys.exit(1)

--- a/tests/fdbshow_input/fdbshow_masic_test_vectors.py
+++ b/tests/fdbshow_input/fdbshow_masic_test_vectors.py
@@ -5,10 +5,27 @@ show_mac_masic_asic0_output = """\
 Total number of entries 1
 """
 
+show_mac_masic_all_output = """\
+Namespace: asic0
+  No.    Vlan  MacAddress         Port       Type
+-----  ------  -----------------  ---------  -------
+    1       2  11:22:33:44:55:66  Ethernet0  Dynamic
+Total number of entries 1
+Namespace: asic1
+No.    Vlan    MacAddress    Port    Type
+-----  ------  ------------  ------  ------
+Total number of entries 0
+"""
+
 test_data = {
     "show_mac_masic_asic0": {
         "cmd": "mac",
         "args": "-n asic0",
         "expected_output": show_mac_masic_asic0_output,
-    }
+    },
+    "show_mac_masic_all": {
+        "cmd": "mac",
+        "args": [],
+        "expected_output": show_mac_masic_all_output,
+    },
 }

--- a/tests/multi_asic_fdbshow_test.py
+++ b/tests/multi_asic_fdbshow_test.py
@@ -3,7 +3,11 @@ import sys
 
 from click.testing import CliRunner
 
-from tests.fdbshow_input.fdbshow_masic_test_vectors import show_mac_masic_asic0_output, test_data
+from tests.fdbshow_input.fdbshow_masic_test_vectors import (
+    show_mac_masic_asic0_output,
+    show_mac_masic_all_output,
+    test_data,
+)
 from tests.utils import get_result_and_return_code
 
 test_path = os.path.dirname(os.path.abspath(__file__))
@@ -31,6 +35,20 @@ class TestFdbshowMultiAsic(object):
         assert result == show_mac_masic_asic0_output
 
         self.command_executor(test_data["show_mac_masic_asic0"])
+
+    def test_show_mac_masic_all_namespaces(self):
+        # Without -n the FDB of every ASIC namespace is shown. This must not
+        # hang on the host connection (regression: show mac blocked forever on
+        # multi-ASIC because the host COUNTERS_DB has no COUNTERS_PORT_NAME_MAP).
+        return_code, result = get_result_and_return_code([
+            'fdbshow'
+        ])
+        print("return_code: {}".format(return_code))
+        print("result: {}".format(result))
+        assert return_code == 0
+        assert result == show_mac_masic_all_output
+
+        self.command_executor(test_data["show_mac_masic_all"])
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
#### What I did
Fix `show mac` (and the underlying `fdbshow` script) hanging indefinitely on multi-ASIC platforms when no namespace is specified.

On multi-ASIC the FDB and port maps live in each ASIC namespace; the global/host instance has no `COUNTERS_PORT_NAME_MAP`. `fdbshow` without `-n` connected to the host (`SonicV2Connector(host="127.0.0.1")`), so `port_util.get_interface_oid_map(db, blocking=True)` blocked forever waiting for a map that never appears there. `fdbshow -n asicN` worked because the per-ASIC COUNTERS_DB has the map.

#### How I did it
In `fdbshow` `main()`, when no `-n` is given, iterate the ASIC namespaces (`multi_asic.get_namespace_list()`) instead of querying the host — the same approach `nbrshow` already uses. On single-ASIC this resolves to the default namespace, so behavior is unchanged. On multi-ASIC each ASIC's FDB is shown under a `Namespace: <ns>` header. `-n asicN` and all filters (`-p/-v/-a/-t/-c`) are unaffected. Added a unit test for the default (no `-n`) multi-ASIC path.

#### How to verify it
- Unit tests: `pytest tests/fdbshow_test.py tests/multi_asic_fdbshow_test.py`
- On a multi-ASIC platform, `show mac` with no `-n` now returns each ASIC's FDB instead of hanging. `show mac -n asic0` and single-ASIC output are unchanged.

#### Previous command output (if the output of a command-line utility has changed)
On a multi-ASIC platform:
```
admin@sonic:~$ show mac
<hangs indefinitely, never returns>
```

#### New command output (if the output of a command-line utility has changed)
On a multi-ASIC platform:
```
admin@sonic:~$ show mac
Namespace: asic0
  No.    Vlan  MacAddress         Port       Type
-----  ------  -----------------  ---------  -------
    1       2  11:22:33:44:55:66  Ethernet0  Dynamic
Total number of entries 1
Namespace: asic1
No.    Vlan    MacAddress    Port    Type
-----  ------  ------------  ------  ------
Total number of entries 0
```
