### PR TITLE
C-CMIS page 35h CLI PM Fields

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -292,7 +292,12 @@ ZR_PM_INFO_MAP = {
     'SOP ROC': ['krad/s', 'soproc'],
     'Pre-FEC BER': ['N/A', 'prefec_ber'],
     'Post-FEC BER': ['N/A', 'uncorr_frames'],
-    'EVM': ['%', 'evm']
+    'EVM': ['%', 'evm'],
+    'Clock Recovery Loop': ['%', 'clockrec'],
+    'LG-SOPMD': ['ps^2', 'lg_sopmd'],
+    'SNR Margin': ['dB', 'snr_margin'],
+    'Q-Factor': ['dB', 'qfactor'],
+    'Q-Margin': ['dB', 'qmargin']
 }
 
 ZR_PM_NOT_APPLICABLE_STR = 'Transceiver performance monitoring not applicable'

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -334,8 +334,6 @@ test_qsfp_dd_pm_output = (
     "       -18.0        -15.0        True\n"
     "    CD-short link        ps/nm   0.0       0.0       0.0       1000.0       500.0        False  "
     "       -1000.0      -500.0       False\n"
-    "    CD-long link         ps/nm   N/A       N/A       N/A       400000.0     200000.0     N/A    "
-    "       -400000.0    -200000.0    N/A\n"
     "    PDL                  dB      0.5       0.6       0.6       4.0          4.0          False  "
     "       0.0          0.0          False\n"
     "    OSNR                 dB      36.5      36.5      36.5      99.0         99.0         False  "

--- a/tests/sfp_test.py
+++ b/tests/sfp_test.py
@@ -316,28 +316,57 @@ Ethernet40: SFP EEPROM detected
         Vendor SN: INKAO2900002A
 """
 
-test_qsfp_dd_pm_output = """\
-Ethernet44:
-    Parameter        Unit    Min       Avg       Max       Threshold    Threshold    Threshold     Threshold    Threshold    Threshold
-                                                           High         High         Crossing      Low          Low          Crossing
-                                                           Alarm        Warning      Alert-High    Alarm        Warning      Alert-Low
-    ---------------  ------  --------  --------  --------  -----------  -----------  ------------  -----------  -----------  -----------
-    Tx Power         dBm     -8.22     -8.23     -8.24     -5.0         -6.0         False         -16.99       -16.003      False
-    Rx Total Power   dBm     -10.61    -10.62    -10.62    2.0          0.0          False         -21.0        -18.0        False
-    Rx Signal Power  dBm     -40.0     0.0       40.0      13.0         10.0         True          -18.0        -15.0        True
-    CD-short link    ps/nm   0.0       0.0       0.0       1000.0       500.0        False         -1000.0      -500.0       False
-    PDL              dB      0.5       0.6       0.6       4.0          4.0          False         0.0          0.0          False
-    OSNR             dB      36.5      36.5      36.5      99.0         99.0         False         0.0          0.0          False
-    eSNR             dB      30.5      30.5      30.5      99.0         99.0         False         0.0          0.0          False
-    CFO              MHz     54.0      70.0      121.0     3800.0       3800.0       False         -3800.0      -3800.0      False
-    DGD              ps      5.37      5.56      5.81      7.0          7.0          False         0.0          0.0          False
-    SOPMD            ps^2    0.0       0.0       0.0       655.35       655.35       False         0.0          0.0          False
-    SOP ROC          krad/s  1.0       1.0       2.0       N/A          N/A          N/A           N/A          N/A          N/A
-    Pre-FEC BER      N/A     4.58E-04  4.66E-04  5.76E-04  1.25E-02     1.10E-02     False         0.0          0.0\
-          False
-    Post-FEC BER     N/A     0.0       0.0       0.0       1000.0       1.0          False         0.0          0.0          False
-    EVM              %       100.0     100.0     100.0     N/A          N/A          N/A           N/A          N/A          N/A
-"""
+test_qsfp_dd_pm_output = (
+    "Ethernet44:\n"
+    "    Parameter            Unit    Min       Avg       Max       Threshold    Threshold    "
+    "Threshold     Threshold    Threshold    Threshold\n"
+    "                                                               High         High         "
+    "Crossing      Low          Low          Crossing\n"
+    "                                                               Alarm        Warning      "
+    "Alert-High    Alarm        Warning      Alert-Low\n"
+    "    -------------------  ------  --------  --------  --------  -----------  -----------  "
+    "------------  -----------  -----------  -----------\n"
+    "    Tx Power             dBm     -8.22     -8.23     -8.24     -5.0         -6.0         False  "
+    "       -16.99       -16.003      False\n"
+    "    Rx Total Power       dBm     -10.61    -10.62    -10.62    2.0          0.0          False  "
+    "       -21.0        -18.0        False\n"
+    "    Rx Signal Power      dBm     -40.0     0.0       40.0      13.0         10.0         True   "
+    "       -18.0        -15.0        True\n"
+    "    CD-short link        ps/nm   0.0       0.0       0.0       1000.0       500.0        False  "
+    "       -1000.0      -500.0       False\n"
+    "    CD-long link         ps/nm   N/A       N/A       N/A       400000.0     200000.0     N/A    "
+    "       -400000.0    -200000.0    N/A\n"
+    "    PDL                  dB      0.5       0.6       0.6       4.0          4.0          False  "
+    "       0.0          0.0          False\n"
+    "    OSNR                 dB      36.5      36.5      36.5      99.0         99.0         False  "
+    "       0.0          0.0          False\n"
+    "    eSNR                 dB      30.5      30.5      30.5      99.0         99.0         False  "
+    "       0.0          0.0          False\n"
+    "    CFO                  MHz     54.0      70.0      121.0     3800.0       3800.0       False  "
+    "       -3800.0      -3800.0      False\n"
+    "    DGD                  ps      5.37      5.56      5.81      7.0          7.0          False  "
+    "       0.0          0.0          False\n"
+    "    SOPMD                ps^2    0.0       0.0       0.0       655.35       655.35       False  "
+    "       0.0          0.0          False\n"
+    "    SOP ROC              krad/s  1.0       1.0       2.0       N/A          N/A          N/A    "
+    "       N/A          N/A          N/A\n"
+    "    Pre-FEC BER          N/A     4.58E-04  4.66E-04  5.76E-04  1.25E-02     1.10E-02     False  "
+    "       0.0          0.0          False\n"
+    "    Post-FEC BER         N/A     0.0       0.0       0.0       1000.0       1.0          False  "
+    "       0.0          0.0          False\n"
+    "    EVM                  %       100.0     100.0     100.0     N/A          N/A          N/A    "
+    "       N/A          N/A          N/A\n"
+    "    Clock Recovery Loop  %       N/A       N/A       N/A       N/A          N/A          N/A    "
+    "       N/A          N/A          N/A\n"
+    "    LG-SOPMD             ps^2    N/A       N/A       N/A       N/A          N/A          N/A    "
+    "       N/A          N/A          N/A\n"
+    "    SNR Margin           dB      N/A       N/A       N/A       N/A          N/A          N/A    "
+    "       N/A          N/A          N/A\n"
+    "    Q-Factor             dB      N/A       N/A       N/A       N/A          N/A          N/A    "
+    "       N/A          N/A          N/A\n"
+    "    Q-Margin             dB      N/A       N/A       N/A       N/A          N/A          N/A    "
+    "       N/A          N/A          N/A\n"
+)
 
 test_qsfp_status_output = """\
 Ethernet4:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added new [C-CMIS 1.4](https://www.oiforum.com/wp-content/uploads/OIF-C-CMIS-01.4.pdf) PM fields from page 35h that are missing from the PM CLI support.

#### How I did it
Added the fields to the `ZR_PM_INFO_MAP` used for the pm command.

#### How to verify it
- Run `tests/sfp_test.py` and ensure pm tests pass.
- On a DUT with a transceiver that supports C-CMIS and at least one of the new pm fields (Clock Recovery Loop, LG-SOPMD, SNR Margin, Q-Factor, Q-Margin), run `show interface transceiver pm <IFNAME>` and look for the the field on the table.
