### PR TITLE
[sonic-installer] Enroll image db certificate before Secure Boot verification

### DIFF
--- a/scripts/secure_boot_enroll_db.sh
+++ b/scripts/secure_boot_enroll_db.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Enroll the UEFI Secure Boot db certificate bundled inside a SONiC installer image
+# (boot/DB.auth) into the running system's UEFI db variable.
+#
+# This must run BEFORE the image's CMS signature is verified (verify_image_sign.sh reads the
+# verification certificate from the UEFI db via "efi-readvar -v db"). When an image is signed
+# with a rotated db key, the new db certificate is not yet present in the firmware, so the
+# verification would fail. Enrolling the bundled, pre-signed db update here lets the new image
+# be verified and trusted without a manual key-enrollment step.
+#
+# Security: DB.auth is a TIME_BASED_AUTHENTICATED_WRITE update that was signed (by the KEK) at
+# build time. UEFI firmware validates that signature against the already-enrolled KEK before
+# applying the update, so a db certificate can only be added when it is authorized by a trusted
+# KEK. An image carrying a db certificate signed by an untrusted KEK is rejected by firmware,
+# the db is left unchanged, and the subsequent CMS verification still fails. This therefore
+# does not bypass the secure-upgrade trust model; it implements KEK-authorized db key rotation.
+#
+# On any failure this logs the cause and exits non-zero; the calling script (sonic_installer)
+# ignores the exit status, so a failure here still never blocks an install.
+
+set -euo pipefail
+
+image_file="${1:-}"
+DB_GUID="d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+EFIVARS_DIR="/sys/firmware/efi/efivars"
+DB_VAR="${EFIVARS_DIR}/db-${DB_GUID}"
+
+log() {
+    echo "secure_boot_enroll_db: $*"
+}
+
+if [ -z "$image_file" ] || [ ! -f "$image_file" ]; then
+    log "ERROR: image file '${image_file}' not found"
+    exit 1
+fi
+
+if [ ! -d "$EFIVARS_DIR" ]; then
+    log "ERROR: efivars not available at $EFIVARS_DIR, cannot enroll db certificate"
+    exit 1
+fi
+if ! mountpoint -q "$EFIVARS_DIR" 2>/dev/null; then
+    if ! mount -t efivarfs efivarfs "$EFIVARS_DIR" 2>/dev/null; then
+        log "ERROR: failed to mount efivarfs at $EFIVARS_DIR, cannot enroll db certificate"
+        exit 1
+    fi
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+FS_ZIP="${TMP_DIR}/fs.zip"
+DB_AUTH="${TMP_DIR}/DB.auth"
+
+# The .bin is a self-extracting archive: a shell header up to the "exit_marker" line, followed
+# by a tar of the installer/ directory (which contains fs.zip), then an optional appended CMS
+# signature. Strip the header, then pull installer/fs.zip out of the tar; --occurrence=1 makes
+# tar stop after the first match so the trailing signature is ignored.
+SHARCH_SIZE=$(sed '/^exit_marker$/q' "$image_file" | wc -c)
+tail -c +$((SHARCH_SIZE + 1)) "$image_file" | tar --occurrence=1 -xO installer/fs.zip 2>/dev/null > "$FS_ZIP" || true
+if [ ! -s "$FS_ZIP" ]; then
+    log "image does not contain installer/fs.zip, no db certificate to enroll"
+    exit 0
+fi
+
+unzip -p "$FS_ZIP" boot/DB.auth 2>/dev/null > "$DB_AUTH" || true
+if [ ! -s "$DB_AUTH" ]; then
+    log "image does not bundle boot/DB.auth, no db certificate to enroll"
+    exit 0
+fi
+
+# Persist the db certificate shipped with the image under /host/db-auth using a unique,
+# content-based name, so certificates from successive installations accumulate instead of
+# overwriting each other. The file name is the certificate's sha256, so a matching name implies
+# identical content; a name clash with differing content would be a hash collision and is
+# treated as an error rather than silently trusting the wrong certificate.
+DB_AUTH_DIR=/host/db-auth
+if ! mkdir -p "$DB_AUTH_DIR"; then
+    log "ERROR: failed to create $DB_AUTH_DIR"
+    exit 1
+fi
+
+db_hash=$(sha256sum "$DB_AUTH" | cut -d' ' -f1)
+db_dest="$DB_AUTH_DIR/DB-${db_hash}.auth"
+
+if [ -e "$db_dest" ]; then
+    if cmp -s "$DB_AUTH" "$db_dest"; then
+        log "DB.auth already present at $db_dest, not copying"
+    else
+        log "ERROR: $db_dest already exists with different content (sha256 collision)"
+        exit 1
+    fi
+elif cp "$DB_AUTH" "$db_dest"; then
+    log "copied DB.auth to $db_dest"
+else
+    log "ERROR: failed to copy DB.auth to $db_dest"
+    exit 1
+fi
+
+# Clear the immutable (i) attribute the kernel sets on existing Secure Boot variables so the
+# variable can be written. efi-updatevar does not clear this flag itself, so it is done here.
+clear_db_immutable() {
+    [ -e "$DB_VAR" ] || return 0
+    chattr -i "$DB_VAR" 2>/dev/null || true
+}
+
+# Enroll via efi-updatevar (efitools); append (-a) so existing db entries are preserved.
+# efitools is installed in the SONiC image; if it is absent there is no supported way to
+# apply a signed authenticated variable update here, so enrollment fails.
+if ! command -v efi-updatevar >/dev/null 2>&1; then
+    log "ERROR: efi-updatevar not found, cannot enroll db certificate"
+    exit 1
+fi
+
+log "enrolling bundled db certificate into UEFI db"
+clear_db_immutable
+if ! efi-updatevar -a -f "$DB_AUTH" db; then
+    log "ERROR: failed to enroll db certificate (db immutable, or its update is not authorized by an enrolled KEK)"
+    exit 1
+fi
+log "db certificate enrolled"
+exit 0

--- a/scripts/verify_image_sign.sh
+++ b/scripts/verify_image_sign.sh
@@ -39,22 +39,26 @@ sig-list-to-certs $EFI_CERTS_DIR/db_efi $EFI_CERTS_DIR/db >/dev/null||
     echo "Error: convert sig list to certs: $?"
     clean_up 1
 }
-for file in $(ls $EFI_CERTS_DIR | grep "db-"); do
-    LOG=$(openssl  x509 -in $EFI_CERTS_DIR/$file -inform der -out $EFI_CERTS_DIR/cert.pem 2>&1)
-    if [ $? -ne 0 ]; then
-        logger "cms_validation: $LOG"
-    fi
-    # Verify detached signature
-    LOG=$(verify_image_sign_common $image_file $DATA_FILE $CMS_SIG_FILE)
-    VALIDATION_RES=$?
-    if [ $VALIDATION_RES -eq 0 ]; then
-        RESULT="CMS Verified OK using efi keys"
-        echo "verification ok:$RESULT"
-        # No need to continue.
-        # Exit without error if any success signature verification.
-        clean_up 0
-    fi
-done
+# Combine all db certificates into a single trust store. The CMS SignerInfo identifies the
+# signing certificate by issuer and serial number, so openssl selects the matching db entry
+# itself. Verifying once against the whole db set is equivalent to trying each certificate
+# individually, but performs a single verification instead of one per db entry. On a failing
+# image this avoids re-reading the payload once for every certificate enrolled in db, which is
+# what made verification of an unsigned/untrusted image scale with the size of db.
+LOG=$(find $EFI_CERTS_DIR -type f -name 'db-*' -execdir openssl x509 -in {} -inform der \; 2>&1 > $EFI_CERTS_DIR/cert.pem)
+if [ $? -ne 0 ]; then
+    logger "cms_validation: $LOG"
+fi
+
+# Verify the detached signature against the combined db trust store.
+LOG=$(verify_image_sign_common $image_file $DATA_FILE $CMS_SIG_FILE)
+VALIDATION_RES=$?
+if [ $VALIDATION_RES -eq 0 ]; then
+    RESULT="CMS Verified OK using efi keys"
+    echo "verification ok:$RESULT"
+    clean_up 0
+fi
+
 echo "Failure: CMS signature Verification Failed: $LOG"
 
 clean_up 1

--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ setup(
         'scripts/storm_control.py',
         'scripts/verify_image_sign.sh',
         'scripts/verify_image_sign_common.sh',
+        'scripts/secure_boot_enroll_db.sh',
         'scripts/check_db_integrity.py',
         'scripts/sysreadyshow',
         'scripts/wredstat',

--- a/sonic_installer/bootloader/bootloader.py
+++ b/sonic_installer/bootloader/bootloader.py
@@ -79,6 +79,10 @@ class Bootloader(object):
         """verify image signature is valid"""
         raise NotImplementedError
 
+    def enroll_image_secure_boot_keys(self, image_path):
+        """enroll Secure Boot keys bundled in the image before signature verification"""
+        return True
+
     def is_secure_upgrade_image_verification_supported(self):
         return False
 

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -201,6 +201,21 @@ class GrubBootloader(OnieInstallerBootloader):
         click.echo(verification_result.stdout.decode())
         return verification_result.returncode == 0
 
+    def enroll_image_secure_boot_keys(self, image_path):
+        # Enroll the db certificate bundled in the image into the UEFI db before the image's
+        # signature is verified. verify_image_sign.sh reads the verification certificate from
+        # the UEFI db, so an image signed with a rotated (KEK-authorized) db key would not be
+        # trusted until its certificate is enrolled. This is best-effort: firmware still
+        # validates the db update against the enrolled KEK, so it does not weaken verification.
+        enroll_script_name = 'secure_boot_enroll_db.sh'
+        script_path = os.path.join('/usr', 'local', 'bin', enroll_script_name)
+        if not os.path.exists(script_path):
+            click.echo("Unable to find Secure Boot enrollment script in path " + script_path)
+            return False
+        enroll_result = subprocess.run([script_path, image_path], capture_output=True)
+        click.echo(enroll_result.stdout.decode())
+        return enroll_result.returncode == 0
+
     @classmethod
     def detect(cls):
         return os.path.isfile(os.path.join(HOST_PATH, 'grub/grub.cfg'))

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -595,6 +595,8 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
             raise click.Abort()
 
         if bootloader.is_secure_upgrade_image_verification_supported():
+            echo_and_log("Enrolling image {} Secure Boot db certificate...".format(binary_image_version))
+            bootloader.enroll_image_secure_boot_keys(image_path)
             echo_and_log("Verifying image {} signature...".format(binary_image_version))
             if not bootloader.verify_image_sign(image_path):
                 echo_and_log('Error: Failed verify image signature', LOG_ERR)

--- a/tests/installer_bootloader_grub_test.py
+++ b/tests/installer_bootloader_grub_test.py
@@ -130,3 +130,26 @@ def test_verify_image():
     assert not bootloader.is_secure_upgrade_image_verification_supported()
     # command should fail
     assert not bootloader.verify_image_sign(image)
+
+
+def test_enroll_image_secure_boot_keys_missing_script():
+
+    bootloader = grub.GrubBootloader()
+    image = f'{grub.IMAGE_PREFIX}expeliarmus-{grub.IMAGE_PREFIX}abcde'
+    with patch("sonic_installer.bootloader.grub.os.path.exists", return_value=False):
+        # When the enrollment script is absent, the method reports failure without raising.
+        assert not bootloader.enroll_image_secure_boot_keys(image)
+
+
+def test_enroll_image_secure_boot_keys_runs_script():
+
+    bootloader = grub.GrubBootloader()
+    image = f'{grub.IMAGE_PREFIX}expeliarmus-{grub.IMAGE_PREFIX}abcde'
+    completed = Mock()
+    completed.returncode = 0
+    completed.stdout = b'db certificate enrolled\n'
+    with patch("sonic_installer.bootloader.grub.os.path.exists", return_value=True), \
+            patch("sonic_installer.bootloader.grub.subprocess.run", return_value=completed) as mock_run:
+        assert bootloader.enroll_image_secure_boot_keys(image)
+        mock_run.assert_called_once_with(
+            ['/usr/local/bin/secure_boot_enroll_db.sh', image], capture_output=True)


### PR DESCRIPTION
#### What I did
Enroll the image's UEFI Secure Boot **db** certificate into the firmware db immediately before `sonic-installer` runs CMS signature verification, so an image signed by a rotated, KEK-authorized db key verifies on install.

- Microsoft ADO (number only): 38692567

#### How I did it
- Add `scripts/secure_boot_enroll_db.sh`, which extracts `boot/DB.auth` from the installer image and appends it to the UEFI db (`efi-updatevar -a`), persisting each shipped cert under `/host/db-auth/DB-<sha256>.auth`.
- Invoke it from the grub bootloader (`enroll_image_secure_boot_keys`) right before `verify_image_sign`; base `Bootloader` keeps a no-op default for other bootloaders.
- Best-effort; firmware still validates the db update against the enrolled KEK, so verification is not weakened.

#### How to verify it
`pytest tests/installer_bootloader_grub_test.py`. On a UEFI DUT, install an image signed by a rotated db key -> enrollment + verification pass; `/host/db-auth` receives `DB-<sha256>.auth`.