### PR TITLE
[GCU] test: add PORTCHANNEL learn_mode validation case

### DIFF
--- a/tests/generic_config_updater/files/config_db_with_portchannel_learn_mode.json
+++ b/tests/generic_config_updater/files/config_db_with_portchannel_learn_mode.json
@@ -1,0 +1,9 @@
+{
+    "PORTCHANNEL": {
+        "PortChannel0001": {
+            "admin_status": "up",
+            "mtu": "9100",
+            "learn_mode": "disable"
+        }
+    }
+}

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -221,6 +221,18 @@ class TestConfigWrapper(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertIsNotNone(error)
 
+    def test_validate_config_db_config__portchannel_learn_mode__returns_true(self):
+        # Arrange
+        config_wrapper = gu_common.ConfigWrapper()
+        expected = True
+
+        # Act
+        actual, error = config_wrapper.validate_config_db_config(Files.CONFIG_DB_WITH_PORTCHANNEL_LEARN_MODE)
+
+        # Assert
+        self.assertEqual(expected, actual)
+        self.assertIsNone(error)
+
     def test_validate_config_db_config__same_config_called_twice__loadData_called_once(self):
         """Cache hit: second call with same config must not call loadData again."""
         config_wrapper = gu_common.ConfigWrapper()


### PR DESCRIPTION
#### What I did

Add a GenericConfigUpdater unit test (and fixture) covering a `PORTCHANNEL` config that sets `learn_mode`, so a config carrying the leaf is exercised against the YANG models via `ConfigWrapper.validate_config_db_config`.

`learn_mode` is a valid CONFIG_DB `PORTCHANNEL` field (teammgr reads it from the LAG table and portsorch maps it to the SAI bridge-port FDB learning mode), but there was no GCU coverage for it.

> Depends on the `learn_mode` leaf added to `sonic-portchannel` in sonic-net/sonic-buildimage#28472. Until that merges and `sonic-yang-models` is republished, the model does not know `learn_mode` and this test fails, so this PR is a **Draft** until the dependency lands.

#### How I did it

- Added fixture `tests/generic_config_updater/files/config_db_with_portchannel_learn_mode.json` with a PortChannel that sets `learn_mode`.
- Added `test_validate_config_db_config__portchannel_learn_mode__returns_true` in `tests/generic_config_updater/gu_common_test.py`, mirroring the existing valid/invalid `validate_config_db_config` tests.

#### How to verify it

```
pytest tests/generic_config_updater/gu_common_test.py -k portchannel_learn_mode
```

With a `sonic-yang-models` that includes the `learn_mode` leaf, `ConfigWrapper.validate_config_db_config` returns `(True, None)` for the fixture. I verified by running that exact code path against a model with the leaf added: the fixture validates `(True, None)`, and an invalid enum value is rejected `(False, <error>)`. Against the current model (no leaf) it fails with `All Keys are not parsed in PORTCHANNEL ... 'learn_mode'`, which is the dependency noted above.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A
