### PR TITLE
[click]: Add resilient parsing for AbbreviationGroup

### DIFF
--- a/tests/abbreviation_group_test.py
+++ b/tests/abbreviation_group_test.py
@@ -1,0 +1,36 @@
+import click
+import pytest
+
+from utilities_common.cli import AbbreviationGroup
+
+
+@click.group(cls=AbbreviationGroup)
+def cli():
+    pass
+
+
+@cli.command(name="switch-hash")
+def switch_hash():
+    pass
+
+
+@cli.command(name="switchport")
+def switchport():
+    pass
+
+
+class TestAbbreviationGroup:
+    def test_ambiguous_prefix_returns_none_during_completion(self):
+        # During shell completion Click sets ctx.resilient_parsing and does not
+        # catch exceptions from get_command, so an ambiguous prefix must return
+        # None instead of raising (which would dump a traceback to the terminal).
+        ctx = click.Context(cli, resilient_parsing=True)
+        assert cli.get_command(ctx, "switch") is None
+
+    def test_ambiguous_prefix_fails_on_invocation(self):
+        # On a real invocation the ambiguous prefix must still fail with the
+        # "Too many matches" usage error.
+        ctx = click.Context(cli)
+        with pytest.raises(click.exceptions.UsageError) as exc_info:
+            cli.get_command(ctx, "switch")
+        assert "Too many matches" in str(exc_info.value)

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -56,6 +56,12 @@ class AbbreviationGroup(click.Group):
             else:
                 return click.Group.get_command(self, ctx, shortest)
 
+            # During shell completion Click sets ctx.resilient_parsing and does not
+            # catch exceptions raised from get_command. Raising here would dump a
+            # traceback into the user's terminal, so degrade gracefully instead.
+            if ctx.resilient_parsing:
+                return None
+
             ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

## The bug

The `config` command uses a custom Click group, `AbbreviationGroup`, that supports abbreviated subcommand names via prefix matching:

`sonic-buildimage/src/sonic-utilities/utilities_common/cli.py`
```python
    def get_command(self, ctx, cmd_name):
        # Try to get builtin commands as normal
        rv = click.Group.get_command(self, ctx, cmd_name)
        if rv is not None:
            return rv
        ...
        matches = []
        shortest = None
        for x in self.list_commands(ctx):
            if x.lower().startswith(cmd_name.lower()):
                matches.append(x)
                ...
        if not matches:
            return None
        elif len(matches) == 1:
            return click.Group.get_command(self, ctx, matches[0])
        else:
            for x in matches:
                if not x.startswith(shortest):
                    break
            else:
                return click.Group.get_command(self, ctx, shortest)

            ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
```

`switch` is an ambiguous prefix — it matches `switch-fast-linkup`, `switch-hash`, `switch-trimming`, and `switchport`. The shortest match is `switchport`, but not all matches start with `switchport`, so the `for/else` falls through to `ctx.fail(...)`, which raises `click.exceptions.UsageError`.

## Why the trailing space matters

The two Tab presses take completely different code paths inside Click:

- **`config switch` + Tab** (cursor right after the word): Click treats `switch` as the **incomplete** token. It just filters the list of subcommand names by that prefix and prints the candidates. `get_command("switch")` is never called, so nothing fails — that's why we see the nice list of 4 completions.

- **`config switch ` + Tab** (extra space): now `switch` is a **complete** argument and the incomplete token is `""`. To figure out which subcommand's arguments to complete next, Click's `_resolve_context` walks the arg list and calls `command.resolve_command(ctx, ["switch"])` → `get_command(ctx, "switch")`. That triggers the ambiguous-prefix path and hits `ctx.fail()`.

The real defect is that `ctx.fail()` raises an exception **during shell completion**. Click's completion resolver doesn't catch exceptions from `get_command`, so instead of silently returning "no completions," the whole traceback gets dumped into the terminal.

## Why it only appears now

During completion, Click sets `ctx.resilient_parsing = True` precisely so that resolution logic degrades gracefully instead of erroring. `AbbreviationGroup.get_command` ignores that flag. (We are also on a newer Click / Python 3.13, where completion resolution is stricter — older versions were more forgiving, which is likely why we hadn't seen this before.)

## The fix

Guard the failure so it returns `None` during completion instead of raising:

```python
        else:
            for x in matches:
                if not x.startswith(shortest):
                    break
            else:
                return click.Group.get_command(self, ctx, shortest)

            if ctx.resilient_parsing:
                return None

            ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
```

With that, tab-completion on an ambiguous prefix just yields no completion (or the caller can list children) instead of crashing, while actually *running* `config switch` still gives the proper "Too many matches" usage error.

#### What I did
* Fixed traceback dumping into the terminal on command autocompletion

#### How I did it
* Added a guard for `AbbreviationGroup` autocompletion

#### How to verify it
1. Run UTs

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# config switch Traceback (most recent call last):
  File "/usr/local/bin/config", line 8, in <module>
    sys.exit(config())
             ~~~~~~^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1077, in main
    self._main_shell_completion(extra, prog_name, complete_var)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1156, in _main_shell_completion
    rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
  File "/usr/lib/python3/dist-packages/click/shell_completion.py", line 49, in shell_complete
    echo(comp.complete())
         ~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/click/shell_completion.py", line 293, in complete
    completions = self.get_completions(args, incomplete)
  File "/usr/lib/python3/dist-packages/click/shell_completion.py", line 273, in get_completions
    ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
  File "/usr/lib/python3/dist-packages/click/shell_completion.py", line 525, in _resolve_context
    name, cmd, args = command.resolve_command(ctx, args)
                      ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1738, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/usr/local/lib/python3.13/dist-packages/utilities_common/cli.py", line 59, in get_command
    ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 691, in fail
    raise UsageError(message, self)
click.exceptions.UsageError: Too many matches: switch-fast-linkup, switch-hash, switch-trimming, switchport

Usage: config [OPTIONS] COMMAND [ARGS]...
Try 'config -h' for help.

Error: Too many matches: switch-fast-linkup, switch-hash, switch-trimming, switchport
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# config switch
switch-fast-linkup
switch-hash
switch-trimming
switchport
...
```

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```