### PR TITLE
Render CDB support field in sfputil CLI output

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -91,6 +91,7 @@ QSFP_DD_DATA_MAP = {
     'encoding': 'Encoding',
     'connector': 'Connector',
     'application_advertisement': 'Application Advertisement',
+    'cdb_supported': 'CDB Supported',
     'hardware_rev': 'Hardware Revision',
     'media_interface_code': 'Media Interface Code',
     'host_electrical_interface': 'Host Electrical Interface',

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -217,6 +217,7 @@ class TestSfputil(object):
                 'active_apsel_hostlane8': 1,
                 'media_interface_technology': 'C-band tunable laser',
                 'cmis_rev': '5.0',
+                'cdb_supported': True,
                 'supported_max_tx_power': 0,
                 'supported_min_tx_power': -20,
                 'supported_max_laser_freq': 196100,
@@ -233,6 +234,7 @@ class TestSfputil(object):
             "        Active App Selection Host Lane 8: 1\n"
             "        Application Advertisement: 400G CR8 - Host Assign (0x1) - Copper cable - Media Assign (0x2)\n"
             "                                   200GBASE-CR4 (Clause 136) - Host Assign (Unknown) - Unknown - Media Assign (Unknown)\n"
+            "        CDB Supported: True\n"
             "        CMIS Revision: 5.0\n"
             "        Connector: LC\n"
             "        Encoding: N/A\n"


### PR DESCRIPTION
#### What I did

Add a line to the `sfputil show eeprom` output that indicates whether the transceiver advertises CDB support.

#### How I did it

https://github.com/sonic-net/sonic-platform-common/pull/721 adds a field to `get_transceiver_info` that indicates whether the transceiver advertises CDB support.

This PR just renders that field in the CLI output.

#### How to verify it

Extended existing unit-test.

#### Previous command output (if the output of a command-line utility has changed)

```
~$ sudo sfputil show eeprom -p Ethernet144
Ethernet144: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 1
        Active App Selection Host Lane 6: 1
        Active App Selection Host Lane 7: 1
        Active App Selection Host Lane 8: 1
        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   800GAUI-8 L C2M (Annex 120G) - Host Assign (0x1) - 800GBASE-DR8 (Clause 124) - Media Assign (0x1)
        CMIS Revision: 5.2
        Connector: MPO 1x12
        Encoding: N/A
        Extended Identifier: Power Class 5 (8.5W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 4.0
        Host Lane Count: 4
        Identifier: OSFP 8X Pluggable Transceiver
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm DFB
        Media Lane Count: 4
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: sm_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2025-09-01
        Vendor Name: Amphenol
        Vendor OUI: 78-a7-14
        Vendor PN: OP13LD8-005D
        Vendor Rev: 10
        Vendor SN: 2508220085
        type_abbrv_name: OSFP-8X
        vdm_supported: False
```

#### New command output (if the output of a command-line utility has changed)

```
admin@gold220:~$ sudo sfputil show eeprom -p Ethernet144
Ethernet144: SFP EEPROM detected
        Active App Selection Host Lane 1: 1
        Active App Selection Host Lane 2: 1
        Active App Selection Host Lane 3: 1
        Active App Selection Host Lane 4: 1
        Active App Selection Host Lane 5: 1
        Active App Selection Host Lane 6: 1
        Active App Selection Host Lane 7: 1
        Active App Selection Host Lane 8: 1
        Application Advertisement: 400GAUI-4-L C2M (Annex 120G) - Host Assign (0x11) - 400GBASE-DR4 (Cl 124) - Media Assign (0x11)
                                   800GAUI-8 L C2M (Annex 120G) - Host Assign (0x1) - 800GBASE-DR8 (Clause 124) - Media Assign (0x1)
        CDB Supported: False
        CMIS Revision: 5.2
        Connector: MPO 1x12
        Encoding: N/A
        Extended Identifier: Power Class 5 (8.5W Max)
        Extended RateSelect Compliance: N/A
        Hardware Revision: 4.0
        Host Lane Count: 4
        Identifier: OSFP 8X Pluggable Transceiver
        Length Cable Assembly(m): 0.0
        Media Interface Technology: 1310 nm DFB
        Media Lane Count: 4
        Nominal Bit Rate(100Mbs): N/A
        Specification compliance: sm_media_interface
        Vendor Date Code(YYYY-MM-DD Lot): 2025-09-01
        Vendor Name: Amphenol
        Vendor OUI: 78-a7-14
        Vendor PN: OP13LD8-005D
        Vendor Rev: 10
        Vendor SN: 2508220085
        type_abbrv_name: OSFP-8X
        vdm_supported: False
```