### PR TITLE
Fix KeyError in 'show bmp tables' when BMP is not or partially configured

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2705,10 +2705,10 @@ def tables(db):
     bmp_body = []
     click.echo("BMP tables: ")
     bmp_keys = db.cfgdb.get_table('BMP')
-    if bmp_keys['table']:
-        bmp_body.append(['bgp_neighbor_table', bmp_keys['table']['bgp_neighbor_table']])
-        bmp_body.append(['bgp_rib_in_table', bmp_keys['table']['bgp_rib_in_table']])
-        bmp_body.append(['bgp_rib_out_table', bmp_keys['table']['bgp_rib_out_table']])
+    table_config = bmp_keys.get('table', {})
+    bmp_body.append(['bgp_neighbor_table', table_config.get('bgp_neighbor_table', 'false')])
+    bmp_body.append(['bgp_rib_in_table', table_config.get('bgp_rib_in_table', 'false')])
+    bmp_body.append(['bgp_rib_out_table', table_config.get('bgp_rib_out_table', 'false')])
     click.echo(tabulate(bmp_body, bmp_headers))
 
 

--- a/tests/show_bmp_test.py
+++ b/tests/show_bmp_test.py
@@ -171,6 +171,47 @@ bgp_rib_out_table   true
         resultB = expected_output.strip().replace(' ', '').replace('\n', '')
         assert resultA == resultB
 
+    def test_tables_no_bmp_config(self):
+        """Test show bmp tables when BMP is not configured at all"""
+        runner = CliRunner()
+        db = Db()
+        # Do not set any BMP config - simulates fresh system with no BMP configured
+
+        expected_output = """\
+BMP tables:
+Table_Name          Enabled
+------------------  ---------
+bgp_neighbor_table  false
+bgp_rib_in_table    false
+bgp_rib_out_table   false
+"""
+        result = runner.invoke(show.cli.commands['bmp'].commands['tables'], [], obj=db)
+        assert result.exit_code == 0
+        resultA = result.output.strip().replace(' ', '').replace('\n', '')
+        resultB = expected_output.strip().replace(' ', '').replace('\n', '')
+        assert resultA == resultB
+
+    def test_tables_partial_bmp_config(self):
+        """Test show bmp tables when only some BMP tables are configured"""
+        runner = CliRunner()
+        db = Db()
+        # Only configure one table - simulates partial config scenario
+        db.cfgdb.mod_entry("BMP", "table", {'bgp_neighbor_table': 'true'})
+
+        expected_output = """\
+BMP tables:
+Table_Name          Enabled
+------------------  ---------
+bgp_neighbor_table  true
+bgp_rib_in_table    false
+bgp_rib_out_table   false
+"""
+        result = runner.invoke(show.cli.commands['bmp'].commands['tables'], [], obj=db)
+        assert result.exit_code == 0
+        resultA = result.output.strip().replace(' ', '').replace('\n', '')
+        resultB = expected_output.strip().replace(' ', '').replace('\n', '')
+        assert resultA == resultB
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")


### PR DESCRIPTION
#### What I did
Fix KeyError exception in `show bmp tables` command when BMP feature is not configured or only partially configured.

#### How I did it
- Use `bmp_keys.get('table', {})` to safely handle missing 'table' key
- Use `table_config.get()` with 'false' default for each table field
- Always display all three table statuses with defaults when not configured

#### How to verify it
1. On a device without BMP configured, run `show bmp tables` - should display all tables as 'false' instead of crashing
2. Enable only one BMP table and run `show bmp tables` - should show mixed values without crashing

#### Previous command output (failing)
```
$ show bmp tables
BMP tables: 
Traceback (most recent call last):
  ...
KeyError: 'table'
```

#### New command output (fixed)
```
$ show bmp tables
BMP tables: 
Table_Name          Enabled
------------------  ---------
bgp_neighbor_table  false
bgp_rib_in_table    false
bgp_rib_out_table   false
```