### PR TITLE
[acl_loader] Fix multi-ASIC policer display

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -272,8 +272,8 @@ class AclLoader(object):
         :return:
         """
 
-        # Policer configuration can be ASIC-specific, so merge entries from
-        # every front ASIC namespace.
+        # Merge ASIC-specific policers from every front namespace, preserving
+        # the first namespace's value for duplicate names to retain existing behavior.
         if self.per_npu_configdb:
             self.policers_db_info = {}
             for namespace_configdb in self.per_npu_configdb.values():

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -272,11 +272,14 @@ class AclLoader(object):
         :return:
         """
 
-        # For multi-npu platforms we will read from any one of front asic namespace
-        # config db as the information should be same across all config db
+        # Policer configuration can be ASIC-specific, so merge entries from
+        # every front ASIC namespace.
         if self.per_npu_configdb:
-            namespace_configdb = list(self.per_npu_configdb.values())[0]
-            self.policers_db_info = namespace_configdb.get_table(self.POLICER)
+            self.policers_db_info = {}
+            for namespace_configdb in self.per_npu_configdb.values():
+                for policer_name, policer_config in namespace_configdb.get_table(self.POLICER).items():
+                    if policer_name not in self.policers_db_info:
+                        self.policers_db_info[policer_name] = policer_config
         else:
             self.policers_db_info = self.configdb.get_table(self.POLICER)
 

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -365,6 +365,35 @@ class TestMasicAclLoader(object):
         assert len(acl_loader.per_npu_configdb) == 2
         assert len(acl_loader.per_npu_statedb) == 2
 
+    def test_read_policers_from_all_namespaces(self):
+        acl_loader = object.__new__(AclLoader)
+        asic0_configdb = mock.MagicMock()
+        asic1_configdb = mock.MagicMock()
+        asic0_configdb.get_table.return_value = {
+            "policer_asic0": {
+                "meter_type": "bytes",
+                "mode": "sr_tcm",
+                "cir": "10000000",
+                "cbs": "10000000",
+            }
+        }
+        asic1_configdb.get_table.return_value = {
+            "policer_asic1": {
+                "meter_type": "bytes",
+                "mode": "sr_tcm",
+                "cir": "12500000",
+                "cbs": "12500000",
+            }
+        }
+        acl_loader.per_npu_configdb = {
+            "asic0": asic0_configdb,
+            "asic1": asic1_configdb,
+        }
+
+        acl_loader.read_policers_info()
+
+        assert set(acl_loader.policers_db_info) == {"policer_asic0", "policer_asic1"}
+
     def test_incremental_update(self, acl_loader):
         acl_loader.rules_info = {}
         acl_loader.tables_db_info['NTP_ACL'] = {

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -369,21 +369,37 @@ class TestMasicAclLoader(object):
         acl_loader = object.__new__(AclLoader)
         asic0_configdb = mock.MagicMock()
         asic1_configdb = mock.MagicMock()
+        asic0_policer = {
+            "meter_type": "bytes",
+            "mode": "sr_tcm",
+            "cir": "10000000",
+            "cbs": "10000000",
+        }
+        asic1_policer = {
+            "meter_type": "bytes",
+            "mode": "sr_tcm",
+            "cir": "12500000",
+            "cbs": "12500000",
+        }
+        asic0_shared_policer = {
+            "meter_type": "packets",
+            "mode": "sr_tcm",
+            "cir": "100",
+            "cbs": "100",
+        }
+        asic1_shared_policer = {
+            "meter_type": "packets",
+            "mode": "sr_tcm",
+            "cir": "200",
+            "cbs": "200",
+        }
         asic0_configdb.get_table.return_value = {
-            "policer_asic0": {
-                "meter_type": "bytes",
-                "mode": "sr_tcm",
-                "cir": "10000000",
-                "cbs": "10000000",
-            }
+            "policer_asic0": asic0_policer,
+            "policer_shared": asic0_shared_policer,
         }
         asic1_configdb.get_table.return_value = {
-            "policer_asic1": {
-                "meter_type": "bytes",
-                "mode": "sr_tcm",
-                "cir": "12500000",
-                "cbs": "12500000",
-            }
+            "policer_asic1": asic1_policer,
+            "policer_shared": asic1_shared_policer,
         }
         acl_loader.per_npu_configdb = {
             "asic0": asic0_configdb,
@@ -392,7 +408,11 @@ class TestMasicAclLoader(object):
 
         acl_loader.read_policers_info()
 
-        assert set(acl_loader.policers_db_info) == {"policer_asic0", "policer_asic1"}
+        assert acl_loader.policers_db_info == {
+            "policer_asic0": asic0_policer,
+            "policer_shared": asic0_shared_policer,
+            "policer_asic1": asic1_policer,
+        }
 
     def test_incremental_update(self, acl_loader):
         acl_loader.rules_info = {}


### PR DESCRIPTION
#### What I did

Fixed `show policer` so ASIC-specific policers are visible on multi-ASIC platforms instead of reading only the first front ASIC namespace.

#### How I did it

Merged policer entries from every front ASIC namespace while preserving the existing first-namespace value when duplicate policer names are present. Added a unit test covering distinct policers stored in ASIC0 and ASIC1.

#### How to verify it

Run the ACL loader unit tests:

```
python3 -m pytest -q tests/acl_loader_test.py
```

On a multi-ASIC DUT, create a policer only in ASIC1 and verify it is displayed:

```
sudo sonic-db-cli -n asic1 CONFIG_DB hgetall "POLICER|policer_dscp"
sudo ip netns exec asic1 show policer policer_dscp
```

#### Previous command output (if the output of a command-line utility has changed)

```
Name    Type    Mode    CIR    CBS
------  ------  ------  -----  -----
```

#### New command output (if the output of a command-line utility has changed)

```
Name          Type    Mode         CIR       CBS
------------  ------  ------  --------  --------
policer_dscp  bytes   sr_tcm  12500000  12500000
```