### PR TITLE
config: add 'config mac add/del' for static FDB entries

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -10825,5 +10825,72 @@ def del_vnet_route(db, vnet_name, prefix):
         click.echo("All routes deleted for the VNET {}.".format(vnet_name))
 
 
+#
+# 'mac' group ('config mac ...')
+#
+
+@config.group(cls=clicommon.AbbreviationGroup)
+def mac():
+    """Static FDB (MAC) configuration tasks"""
+    pass
+
+
+def is_static_mac_valid(mac):
+    """Return True if mac is a well-formed unicast (non-zero, non-broadcast) MAC address."""
+    if not re.match('^' + '[:-]'.join(['([0-9a-fA-F]{2})'] * 6) + '$', mac):
+        return False
+    octets = re.split('[:-]', mac.lower())
+    # reject the all-zero and broadcast (all-ff) addresses
+    # (note: builtins all()/any() are shadowed by a 'config ... all' command here)
+    if octets == ['00'] * 6 or octets == ['ff'] * 6:
+        return False
+    # reject multicast addresses (group bit set in the first octet)
+    if int(octets[0], 16) & 1:
+        return False
+    return True
+
+
+@mac.command('add')
+@click.argument('mac', metavar='<mac-address as xx:xx:xx:xx:xx:xx>', required=True)
+@click.argument('vlan', metavar='<vlan-id>', required=True, type=click.IntRange(1, 4094))
+@click.argument('interface_name', metavar='<interface-name>', required=True)
+@clicommon.pass_db
+def mac_add(db, mac, vlan, interface_name):
+    """Add a static MAC entry to a VLAN"""
+    ctx = click.get_current_context()
+
+    if not is_static_mac_valid(mac):
+        ctx.fail("{} is not a valid unicast MAC address".format(mac))
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(db.cfgdb, interface_name)
+        if interface_name is None:
+            ctx.fail("Invalid interface alias")
+
+    if interface_name_is_valid(db.cfgdb, interface_name) is False:
+        ctx.fail("Interface name {} is invalid".format(interface_name))
+
+    vlan_name = 'Vlan{}'.format(vlan)
+    if vlan_name not in db.cfgdb.get_table('VLAN'):
+        ctx.fail("{} does not exist".format(vlan_name))
+
+    db.cfgdb.set_entry('FDB', (vlan_name, mac), {'port': interface_name})
+
+
+@mac.command('del')
+@click.argument('mac', metavar='<mac-address as xx:xx:xx:xx:xx:xx>', required=True)
+@click.argument('vlan', metavar='<vlan-id>', required=True, type=click.IntRange(1, 4094))
+@clicommon.pass_db
+def mac_del(db, mac, vlan):
+    """Delete a static MAC entry from a VLAN"""
+    ctx = click.get_current_context()
+
+    if not is_static_mac_valid(mac):
+        ctx.fail("{} is not a valid unicast MAC address".format(mac))
+
+    vlan_name = 'Vlan{}'.format(vlan)
+    db.cfgdb.set_entry('FDB', (vlan_name, mac), None)
+
+
 if __name__ == '__main__':
     config()

--- a/config/main.py
+++ b/config/main.py
@@ -10878,5 +10878,72 @@ def del_vnet_route(db, vnet_name, prefix):
         click.echo("All routes deleted for the VNET {}.".format(vnet_name))
 
 
+#
+# 'mac' group ('config mac ...')
+#
+
+@config.group(cls=clicommon.AbbreviationGroup)
+def mac():
+    """Static FDB (MAC) configuration tasks"""
+    pass
+
+
+def is_static_mac_valid(mac):
+    """Return True if mac is a well-formed unicast (non-zero, non-broadcast) MAC address."""
+    if not re.match('^' + '[:-]'.join(['([0-9a-fA-F]{2})'] * 6) + '$', mac):
+        return False
+    octets = re.split('[:-]', mac.lower())
+    # reject the all-zero and broadcast (all-ff) addresses
+    # (note: builtins all()/any() are shadowed by a 'config ... all' command here)
+    if octets == ['00'] * 6 or octets == ['ff'] * 6:
+        return False
+    # reject multicast addresses (group bit set in the first octet)
+    if int(octets[0], 16) & 1:
+        return False
+    return True
+
+
+@mac.command('add')
+@click.argument('mac', metavar='<mac-address as xx:xx:xx:xx:xx:xx>', required=True)
+@click.argument('vlan', metavar='<vlan-id>', required=True, type=click.IntRange(1, 4094))
+@click.argument('interface_name', metavar='<interface-name>', required=True)
+@clicommon.pass_db
+def mac_add(db, mac, vlan, interface_name):
+    """Add a static MAC entry to a VLAN"""
+    ctx = click.get_current_context()
+
+    if not is_static_mac_valid(mac):
+        ctx.fail("{} is not a valid unicast MAC address".format(mac))
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(db.cfgdb, interface_name)
+        if interface_name is None:
+            ctx.fail("Invalid interface alias")
+
+    if interface_name_is_valid(db.cfgdb, interface_name) is False:
+        ctx.fail("Interface name {} is invalid".format(interface_name))
+
+    vlan_name = 'Vlan{}'.format(vlan)
+    if vlan_name not in db.cfgdb.get_table('VLAN'):
+        ctx.fail("{} does not exist".format(vlan_name))
+
+    db.cfgdb.set_entry('FDB', (vlan_name, mac), {'port': interface_name})
+
+
+@mac.command('del')
+@click.argument('mac', metavar='<mac-address as xx:xx:xx:xx:xx:xx>', required=True)
+@click.argument('vlan', metavar='<vlan-id>', required=True, type=click.IntRange(1, 4094))
+@clicommon.pass_db
+def mac_del(db, mac, vlan):
+    """Delete a static MAC entry from a VLAN"""
+    ctx = click.get_current_context()
+
+    if not is_static_mac_valid(mac):
+        ctx.fail("{} is not a valid unicast MAC address".format(mac))
+
+    vlan_name = 'Vlan{}'.format(vlan)
+    db.cfgdb.set_entry('FDB', (vlan_name, mac), None)
+
+
 if __name__ == '__main__':
     config()

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -227,6 +227,7 @@
     * [VLAN show commands](#vlan-show-commands)
     * [VLAN Config commands](#vlan-config-commands)
   * [FDB](#fdb)
+    * [FDB config commands](#fdb-config-commands)
     * [FDB show commands](#fdb-show-commands)
 * [VxLAN & Vnet](#vxlan--vnet)
   * [VxLAN](#vxlan)
@@ -14705,6 +14706,38 @@ This command is used to enable or disable proxy ARP for a VLAN interface
 Go Back To [Beginning of the document](#) or [Beginning of this section](#vlan--FDB)
 
 ### FDB
+
+#### FDB config commands
+
+**config mac add**
+
+This command adds a static MAC (FDB) entry: frames destined to `<mac-address>` on VLAN
+`<vlan-id>` are forwarded to the given interface. The entry is written to the CONFIG_DB
+`FDB` table and programmed as a static FDB entry.
+
+- Usage:
+  ```
+  config mac add <mac-address> <vlan-id> <interface-name>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config mac add 00:11:22:33:44:55 1000 Ethernet192
+  ```
+
+**config mac del**
+
+This command deletes a previously configured static MAC (FDB) entry.
+
+- Usage:
+  ```
+  config mac del <mac-address> <vlan-id>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config mac del 00:11:22:33:44:55 1000
+  ```
 
 #### FDB show commands
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -230,6 +230,7 @@
     * [VLAN show commands](#vlan-show-commands)
     * [VLAN Config commands](#vlan-config-commands)
   * [FDB](#fdb)
+    * [FDB config commands](#fdb-config-commands)
     * [FDB show commands](#fdb-show-commands)
 * [VxLAN & Vnet](#vxlan--vnet)
   * [VxLAN](#vxlan)
@@ -14805,6 +14806,38 @@ This command is used to enable or disable proxy ARP for a VLAN interface
 Go Back To [Beginning of the document](#) or [Beginning of this section](#vlan--FDB)
 
 ### FDB
+
+#### FDB config commands
+
+**config mac add**
+
+This command adds a static MAC (FDB) entry: frames destined to `<mac-address>` on VLAN
+`<vlan-id>` are forwarded to the given interface. The entry is written to the CONFIG_DB
+`FDB` table and programmed as a static FDB entry.
+
+- Usage:
+  ```
+  config mac add <mac-address> <vlan-id> <interface-name>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config mac add 00:11:22:33:44:55 1000 Ethernet192
+  ```
+
+**config mac del**
+
+This command deletes a previously configured static MAC (FDB) entry.
+
+- Usage:
+  ```
+  config mac del <mac-address> <vlan-id>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config mac del 00:11:22:33:44:55 1000
+  ```
 
 #### FDB show commands
 

--- a/tests/config_mac_test.py
+++ b/tests/config_mac_test.py
@@ -1,0 +1,74 @@
+from click.testing import CliRunner
+
+import config.main as config
+from utilities_common.db import Db
+
+
+class TestConfigMac(object):
+    def test_config_mac_add(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["mac"].commands["add"],
+                               ["00:11:22:33:44:55", "1000", "Ethernet4"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry("FDB", ("Vlan1000", "00:11:22:33:44:55")) == {"port": "Ethernet4"}
+
+    def test_config_mac_add_invalid_mac(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["mac"].commands["add"],
+                               ["invalid-mac", "1000", "Ethernet4"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "not a valid unicast MAC address" in result.output
+
+    def test_config_mac_add_multicast_mac(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["mac"].commands["add"],
+                               ["01:00:5e:00:00:01", "1000", "Ethernet4"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "not a valid unicast MAC address" in result.output
+
+    def test_config_mac_add_nonexistent_vlan(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["mac"].commands["add"],
+                               ["00:11:22:33:44:55", "999", "Ethernet4"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "Vlan999 does not exist" in result.output
+
+    def test_config_mac_add_invalid_interface(self):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(config.config.commands["mac"].commands["add"],
+                               ["00:11:22:33:44:55", "1000", "Ethernet999"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code != 0
+        assert "is invalid" in result.output
+
+    def test_config_mac_del(self):
+        runner = CliRunner()
+        db = Db()
+
+        runner.invoke(config.config.commands["mac"].commands["add"],
+                      ["00:11:22:33:44:55", "1000", "Ethernet4"], obj=db)
+        result = runner.invoke(config.config.commands["mac"].commands["del"],
+                               ["00:11:22:33:44:55", "1000"], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry("FDB", ("Vlan1000", "00:11:22:33:44:55")) == {}


### PR DESCRIPTION
#### What I did

Added a `config mac` command group for static MAC (FDB) entries via CONFIG_DB:
`config mac add <mac> <vlan> <interface>` and `config mac del <mac> <vlan>`. Both write the
CONFIG_DB `FDB` table (consumed by `vlanmgr`, modeled by `sonic-fdb.yang`). Part of
config-driven static L2 forwarding — HLD sonic-net/SONiC#2468.

#### How I did it

Added the `mac` click group + `add`/`del` subcommands with MAC/VLAN/interface validation;
they set/clear the `FDB` table entry `(Vlan, mac) → {port}` in CONFIG_DB.

#### How to verify it

Unit tests `tests/config_mac_test.py` (add/del + validation). Hardware: `config mac add/del`
→ CONFIG_DB `FDB` → APPL `FDB_TABLE` → ASIC `SAI_FDB_ENTRY_TYPE_STATIC`; the target MAC is
forwarded to the configured port.

#### Previous command output (if the output of a command-line utility has changed)

N/A — new command.

#### New command output (if the output of a command-line utility has changed)

    admin@sonic:~$ sudo config mac add 00:11:22:33:44:55 100 Ethernet72
    admin@sonic:~$ sudo config mac del 00:11:22:33:44:55 100
