### PR TITLE
[techsupport] Add interface link-training status to generate_dump

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2800,18 +2800,14 @@ main() {
 
     # Generic L3 summary (incl. management interfaces) - keep on all platforms.
     save_cmd "show ip interface -d all" "ip.interface" &
-<<<<<<< HEAD
     if ! $IS_SWITCH_BMC; then
         # Front-panel interface/transceiver collectors - none on a Switch-BMC.
         save_cmd "show interface status -d all" "interface.status" &
         save_cmd "show interface transceiver presence" "interface.xcvrs.presence" &
         save_cmd "show interface transceiver eeprom --dom" "interface.xcvrs.eeprom" &
         save_cmd "sfputil show eeprom-hexdump" "interface.xcvrs.eeprom.raw" &
+        save_cmd "show interface link-training status" "interface.link_training.status" &
     fi
-=======
-    save_cmd "sfputil show eeprom-hexdump" "interface.xcvrs.eeprom.raw" &
-    save_cmd "show interface link-training status" "interface.link_training.status" &
->>>>>>> dc9fb8ec (NOS-5780: Add output for show interface link-training status to generate_dump (#775))
     save_gearbox_data &
     wait
 

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2800,6 +2800,7 @@ main() {
 
     # Generic L3 summary (incl. management interfaces) - keep on all platforms.
     save_cmd "show ip interface -d all" "ip.interface" &
+<<<<<<< HEAD
     if ! $IS_SWITCH_BMC; then
         # Front-panel interface/transceiver collectors - none on a Switch-BMC.
         save_cmd "show interface status -d all" "interface.status" &
@@ -2807,6 +2808,10 @@ main() {
         save_cmd "show interface transceiver eeprom --dom" "interface.xcvrs.eeprom" &
         save_cmd "sfputil show eeprom-hexdump" "interface.xcvrs.eeprom.raw" &
     fi
+=======
+    save_cmd "sfputil show eeprom-hexdump" "interface.xcvrs.eeprom.raw" &
+    save_cmd "show interface link-training status" "interface.link_training.status" &
+>>>>>>> dc9fb8ec (NOS-5780: Add output for show interface link-training status to generate_dump (#775))
     save_gearbox_data &
     wait
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Currently, link training states are not available in the tech support bundle to debug issues such as link flaps or links not coming up. The output for show interface link-training needs to be added to the techsupport bundle so that the link status information would be available in the future to debug link issues.
#### How I did it
Added a line in generate dump to save the output of "show interface link training status" to a dump file.
#### How to verify it
- On a switch: running`show interface link-training status` and then running `generate_dump` shows that the var/dump/sonic_dump_XXXXXX/ interface.link_training.status file exists and the contents of the file match the output of `show interface link-training status`

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

