### PR TITLE
Prevent crash and show N/A for incomplete fan rows in fanshow

### DIFF
--- a/scripts/fanshow
+++ b/scripts/fanshow
@@ -48,32 +48,40 @@ class FanShow(object):
         table = []
         for key in natsorted(keys):
             key_list = key.split('|')
-            if len(key_list) != 2: # error data in DB, log it and ignore
+            if len(key_list) != 2:
                 print('Warn: Invalid key in table FAN_INFO: {}'.format(key))
                 continue
 
             name = key_list[1]
             data_dict = self.db.get_all(self.db.STATE_DB, key)
-            try:
-                speed = float(data_dict[SPEED_FIELD_NAME])
-                if speed > 100:
-                    speed = '{}RPM'.format(int(speed))
-                else:
-                    speed = '{}%'.format(data_dict[SPEED_FIELD_NAME])
-            except ValueError as e:
-                speed = data_dict[SPEED_FIELD_NAME]
 
-            presence = data_dict[PRESENCE_FIELD_NAME].lower()
-            presence = 'Present' if presence == 'true' else 'Not Present'
-            status = data_dict[STATUS_FIELD_NAME]
+            drawer = data_dict.get(DRAWER_FIELD_NAME, 'N/A')
+            led = data_dict.get(LED_STATUS_FIELD_NAME, 'N/A')
+            timestamp = data_dict.get(TIMESTAMP_FIELD_NAME, 'N/A')
+
+            presence_raw = data_dict.get(PRESENCE_FIELD_NAME, 'N/A').lower()
+            presence = 'Present' if presence_raw == 'true' else 'Not Present'
+
+            speed_raw = data_dict.get(SPEED_FIELD_NAME)
+            try:
+                speed = float(speed_raw)
+                speed_is_in_rpm = speed > 100
+                if speed_is_in_rpm:
+                    speed_str = '{}RPM'.format(int(speed))
+                else:
+                    speed_str = '{}%'.format(speed_raw)
+            except (ValueError, TypeError):
+                speed_str = "N/A"
+
+            status = data_dict.get(STATUS_FIELD_NAME, 'N/A')
             status_lower = status.lower()
             if status_lower == 'true':
                 status = 'OK'
             elif status_lower == 'false':
                 status = 'Not OK'
 
-            table.append((data_dict[DRAWER_FIELD_NAME], data_dict[LED_STATUS_FIELD_NAME], name, speed, data_dict[DIRECTION_FIELD_NAME], presence, status,
-                          data_dict[TIMESTAMP_FIELD_NAME]))
+            direction = data_dict.get(DIRECTION_FIELD_NAME, 'N/A')
+            table.append((drawer, led, name, speed_str, direction, presence, status, timestamp))
         if table:
             print(tabulate(table, header, tablefmt='simple', stralign='right'))
         else:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Improved error handling of show plat fan.

#### How I did it

STATE_DB FAN_INFO rows missing a field caused a KeyError and crashed `show platform fan` entirely. Use dict.get() with an 'N/A' default for drawer, LED, timestamp, direction, and status, and catch TypeError alongside ValueError when a missing/non-numeric speed value is parsed.

#### How to verify it
Before this change, a FAN_INFO row missing any field (e.g. status, led_status, timestamp) caused show platform fan to raise an uncaught KeyError and abort with no output at all.

1. Delete a field from an existing fan entry in STATE_DB (db 6) and confirm the command still completes and shows N/A for that field instead of crashing: 
  redis-cli -n 6 hdel "FAN_INFO|Fantray1_1" status
  show platform fan

2. Run show platform fan against a fully-populated FAN_INFO table and confirm the output is unchanged from before this change.

3. pytest tests/fan_test.py passes.
  
#### Previous command output (if the output of a command-line utility has changed)
Crashing

#### New command output (if the output of a command-line utility has changed)
'N/A' for missing values
