### PR TITLE
stp: Fix config_db table name and MSTP mode checks in STP interface commands

### DIFF
--- a/config/stp.py
+++ b/config/stp.py
@@ -241,6 +241,7 @@ def update_stp_vlan_parameter(ctx, db, param_type, new_value):
         if current_global_value == current_vlan_value:
             db.mod_entry('STP_VLAN', vlan, {param_type: new_value})
 
+
 def check_if_vlan_exist_in_db(db, ctx, vid):
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.get_entry('VLAN', vlan_name)
@@ -561,7 +562,6 @@ def stp_disable(_db, mode):
         disable_global_pvst(db)
     elif mode == "mst" and current_mode == "mst":
         disable_global_mst(db)
-
 
 
 # cmd: STP global root guard timeout
@@ -996,9 +996,7 @@ def check_if_interface_is_valid(ctx, db, interface_name):
     if interface_name_is_valid(db, interface_name) is False:
         ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
     for key in db.get_table('INTERFACE'):
-        if type(key) != tuple:
-            continue
-        if key[0] == interface_name:
+        if isinstance(key, tuple) and key[0] == interface_name:
             ctx.fail(" {} has ip address {} configured - It's not a L2 interface".format(interface_name, key[1]))
     if is_portchannel_member_port(db, interface_name):
         ctx.fail(" {} is a portchannel member port - STP can't be configured".format(interface_name))
@@ -1281,6 +1279,7 @@ def is_valid_vlan_interface_priority(ctx, priority):
     if priority not in range(STP_INTERFACE_MIN_PRIORITY, STP_INTERFACE_MAX_PRIORITY + 1):
         ctx.fail("STP per vlan port priority must be in range 0-240")
 
+
 # config spanning_tree vlan interface priority <Vlan> <interface_name> <value: 0-240>
 @spanning_tree_vlan_interface.command('priority')
 @click.argument('vid', metavar='<Vlan>', required=True, type=int)
@@ -1403,7 +1402,7 @@ def stp_interface_disable(_db, interface_name):
         if interface_name in stp_port_tbl:
             db.set_entry('STP_PORT', interface_name, {'enabled': 'false'})
             click.echo(f"STP disabled for {interface_name}")
-        else :
+        else:
             click.echo(f"No STP_PORT entry for {interface_name}")
 
 

--- a/config/stp.py
+++ b/config/stp.py
@@ -1391,7 +1391,6 @@ def stp_interface_disable(_db, interface_name):
     current_mode = stp_global_entry.get('mode', 'none')
     click.echo(f"Current STP mode: {current_mode}")
 
-    check_if_global_stp_enabled(db, ctx)
     check_if_interface_is_valid(ctx, db, interface_name)
 
     # Clear all entries for the interface except the disable attribute

--- a/config/stp.py
+++ b/config/stp.py
@@ -1335,7 +1335,7 @@ def stp_interface_enable(_db, interface_name):
     db = _db.cfgdb
 
     # Check and display the current STP mode
-    stp_global_entry = db.get_entry('STP_GLOBAL', 'GLOBAL')
+    stp_global_entry = db.get_entry('STP', 'GLOBAL')
     current_mode = stp_global_entry.get('mode', 'none')
     click.echo(f"Current STP mode: {current_mode}")
     if current_mode == "none":
@@ -1355,7 +1355,7 @@ def stp_interface_enable(_db, interface_name):
     }
 
     # Add mode-specific attributes
-    if current_mode == 'mstp':
+    if current_mode == 'mst':
         fvs.update({
             'edge_port': 'false',
             'link_type': 'auto',
@@ -1387,7 +1387,7 @@ def stp_interface_disable(_db, interface_name):
     db = _db.cfgdb
 
     # Check and display the current STP mode
-    stp_global_entry = db.get_entry('STP_GLOBAL', 'GLOBAL')
+    stp_global_entry = db.get_entry('STP', 'GLOBAL')
     current_mode = stp_global_entry.get('mode', 'none')
     click.echo(f"Current STP mode: {current_mode}")
 
@@ -1395,11 +1395,17 @@ def stp_interface_disable(_db, interface_name):
     check_if_interface_is_valid(ctx, db, interface_name)
 
     # Clear all entries for the interface except the disable attribute
-    if current_mode in ['mstp', 'pvst']:
+    if current_mode in ['mst', 'pvst']:
         db.set_entry('STP_PORT', interface_name, {'enabled': 'false'})
         click.echo(f"STP mode {current_mode} is disabled for {interface_name}")
     else:
-        click.echo("No STP mode selected. Please select a mode first.")
+        # Allow clearing stp port setting even when STP is disabled globally
+        stp_port_tbl = db.get_table('STP_PORT')
+        if interface_name in stp_port_tbl:
+            db.set_entry('STP_PORT', interface_name, {'enabled': 'false'})
+            click.echo(f"STP disabled for {interface_name}")
+        else :
+            click.echo(f"No STP_PORT entry for {interface_name}")
 
 
 # config spanning_tree interface edge_port {enable|disable} <ifname>

--- a/tests/stp_test.py
+++ b/tests/stp_test.py
@@ -2372,3 +2372,476 @@ class TestStpInterfaceBpduGuardEnable:
 
         assert result.exit_code != 0
         assert "Invalid interface" in result.output
+
+
+class TestStpConfigCoverage:
+    """Broad coverage of config/stp.py command branches (pvst/mst/none/invalid modes)."""
+
+    # Valid L2 access ports (VLAN1000 members, no IP, not PortChannel members)
+    L2_PORT = "Ethernet4"       # has STP_PORT enabled=true in mock config
+    L2_PORT_NO_STP = "Ethernet8"  # VLAN member but no STP_PORT entry
+
+    def setup_method(self):
+        self.runner = CliRunner()
+        self.db = Db()
+        self.st = config.config.commands["spanning-tree"]
+        # Ensure a VLAN with STP enabled exists and matches valid timer relationship
+        self.db.cfgdb.set_entry('STP_VLAN', 'Vlan1000', {
+            'enabled': 'true', 'forward_delay': '15',
+            'hello_time': '2', 'max_age': '20', 'priority': '32768'})
+
+    def _set_mode(self, mode):
+        if mode is None:
+            self.db.cfgdb.set_entry('STP', 'GLOBAL', {'mode': 'none'})
+        else:
+            self.db.cfgdb.set_entry('STP', 'GLOBAL', {
+                'mode': mode, 'forward_delay': '15', 'hello_time': '2',
+                'max_age': '20', 'priority': '32768', 'rootguard_timeout': '30'})
+
+    def _invoke(self, cmd, args):
+        return self.runner.invoke(cmd, args, obj=self.db)
+
+    # ---------- global enable / disable ----------
+    def test_enable_pvst_fresh(self):
+        self._set_mode(None)
+        r = self._invoke(self.st.commands["enable"], ["pvst"])
+        assert r.exit_code == 0
+
+    def test_enable_mst_fresh(self):
+        self._set_mode(None)
+        r = self._invoke(self.st.commands["enable"], ["mst"])
+        assert r.exit_code == 0
+
+    def test_enable_pvst_already_configured(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["enable"], ["pvst"])
+        assert r.exit_code != 0
+
+    def test_enable_mst_already_configured(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["enable"], ["mst"])
+        assert r.exit_code != 0
+
+    def test_enable_mst_when_pvst_configured(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["enable"], ["mst"])
+        assert r.exit_code != 0
+
+    def test_enable_pvst_when_mst_configured(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["enable"], ["pvst"])
+        assert r.exit_code != 0
+
+    def test_disable_pvst(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["disable"], ["pvst"])
+        assert r.exit_code == 0
+
+    def test_disable_mst(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["disable"], ["mst"])
+        assert r.exit_code == 0
+
+    def test_disable_not_configured(self):
+        self._set_mode(None)
+        r = self._invoke(self.st.commands["disable"], ["pvst"])
+        assert r.exit_code != 0
+
+    def test_disable_wrong_mode(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["disable"], ["mst"])
+        assert r.exit_code != 0
+
+    # ---------- root_guard_timeout ----------
+    def test_root_guard_timeout_pvst_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["root_guard_timeout"], ["30"])
+        assert r.exit_code == 0
+
+    def test_root_guard_timeout_pvst_invalid(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["root_guard_timeout"], ["3"])
+        assert r.exit_code != 0
+
+    def test_root_guard_timeout_mst_fail(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["root_guard_timeout"], ["30"])
+        assert r.exit_code != 0
+
+    def test_root_guard_timeout_invalid_mode(self):
+        self._set_mode("rstp")
+        r = self._invoke(self.st.commands["root_guard_timeout"], ["30"])
+        assert r.exit_code != 0
+
+    # ---------- forward_delay ----------
+    def test_forward_delay_pvst_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["forward_delay"], ["15"])
+        assert r.exit_code == 0
+
+    def test_forward_delay_mst_ok(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["forward_delay"], ["15"])
+        assert r.exit_code == 0
+
+    def test_forward_delay_invalid_value(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["forward_delay"], ["100"])
+        assert r.exit_code != 0
+
+    def test_forward_delay_invalid_mode(self):
+        self._set_mode("rstp")
+        r = self._invoke(self.st.commands["forward_delay"], ["15"])
+        assert r.exit_code != 0
+
+    # ---------- hello ----------
+    def test_hello_pvst_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["hello"], ["2"])
+        assert r.exit_code == 0
+
+    def test_hello_mst_ok(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["hello"], ["2"])
+        assert r.exit_code == 0
+
+    def test_hello_invalid_mode(self):
+        self._set_mode("rstp")
+        r = self._invoke(self.st.commands["hello"], ["2"])
+        assert r.exit_code != 0
+
+    # ---------- max_age ----------
+    def test_max_age_pvst_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["max_age"], ["20"])
+        assert r.exit_code == 0
+
+    def test_max_age_mst_ok(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["max_age"], ["20"])
+        assert r.exit_code == 0
+
+    def test_max_age_invalid_mode(self):
+        self._set_mode("rstp")
+        r = self._invoke(self.st.commands["max_age"], ["20"])
+        assert r.exit_code != 0
+
+    # ---------- max_hops ----------
+    def test_max_hops_pvst_fail(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["max_hops"], ["20"])
+        assert r.exit_code != 0
+
+    def test_max_hops_mst_ok(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["max_hops"], ["20"])
+        assert r.exit_code == 0
+
+    def test_max_hops_mst_invalid(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["max_hops"], ["50"])
+        assert r.exit_code != 0
+
+    def test_max_hops_invalid_mode(self):
+        self._set_mode("rstp")
+        r = self._invoke(self.st.commands["max_hops"], ["20"])
+        assert r.exit_code != 0
+
+    # ---------- global priority ----------
+    def test_priority_pvst_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["priority"], ["4096"])
+        assert r.exit_code == 0
+
+    def test_priority_mst_fail(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["priority"], ["4096"])
+        assert r.exit_code != 0
+
+    def test_priority_invalid_mode(self):
+        self._set_mode("rstp")
+        r = self._invoke(self.st.commands["priority"], ["4096"])
+        assert r.exit_code != 0
+
+    # ---------- mst region-name / revision ----------
+    def test_region_name_mst_ok(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["mst"].commands["region-name"], ["region1"])
+        assert r.exit_code == 0
+
+    def test_region_name_pvst_fail(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["mst"].commands["region-name"], ["region1"])
+        assert r.exit_code != 0
+
+    def test_region_name_too_long(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["mst"].commands["region-name"], ["x" * 40])
+        assert r.exit_code != 0
+
+    def test_revision_mst_ok(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["mst"].commands["revision"], ["100"])
+        assert r.exit_code == 0
+
+    def test_revision_pvst_fail(self):
+        self._set_mode("pvst")
+        r = self._invoke(self.st.commands["mst"].commands["revision"], ["100"])
+        assert r.exit_code != 0
+
+    def test_revision_out_of_range(self):
+        self._set_mode("mst")
+        r = self._invoke(self.st.commands["mst"].commands["revision"], ["70000"])
+        assert r.exit_code != 0
+
+    # ---------- vlan commands (pvst) ----------
+    def _vlan(self):
+        return self.st.commands["vlan"]
+
+    def test_vlan_enable_pvst_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._vlan().commands["enable"], ["3000"])
+        assert r.exit_code == 0
+
+    def test_vlan_enable_mst_fail(self):
+        self._set_mode("mst")
+        r = self._invoke(self._vlan().commands["enable"], ["3000"])
+        assert r.exit_code != 0
+
+    def test_vlan_disable_pvst_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._vlan().commands["disable"], ["1000"])
+        assert r.exit_code == 0
+
+    def test_vlan_disable_mst_fail(self):
+        self._set_mode("mst")
+        r = self._invoke(self._vlan().commands["disable"], ["1000"])
+        assert r.exit_code != 0
+
+    def test_vlan_forward_delay_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._vlan().commands["forward_delay"], ["1000", "15"])
+        assert r.exit_code == 0
+
+    def test_vlan_forward_delay_mst_fail(self):
+        self._set_mode("mst")
+        r = self._invoke(self._vlan().commands["forward_delay"], ["1000", "15"])
+        assert r.exit_code != 0
+
+    def test_vlan_hello_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._vlan().commands["hello"], ["1000", "2"])
+        assert r.exit_code == 0
+
+    def test_vlan_max_age_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._vlan().commands["max_age"], ["1000", "20"])
+        assert r.exit_code == 0
+
+    def test_vlan_priority_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._vlan().commands["priority"], ["1000", "4096"])
+        assert r.exit_code == 0
+
+    # ---------- vlan interface commands ----------
+    def test_vlan_interface_priority_ok(self):
+        self._set_mode("pvst")
+        cmd = self._vlan().commands["interface"].commands["priority"]
+        r = self._invoke(cmd, ["1000", self.L2_PORT, "128"])
+        assert r.exit_code == 0
+
+    def test_vlan_interface_cost_ok(self):
+        self._set_mode("pvst")
+        cmd = self._vlan().commands["interface"].commands["cost"]
+        r = self._invoke(cmd, ["1000", self.L2_PORT, "200"])
+        assert r.exit_code == 0
+
+    # ---------- interface commands ----------
+    def _intf(self):
+        return self.st.commands["interface"]
+
+    def test_interface_cost_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["cost"], [self.L2_PORT, "200"])
+        assert r.exit_code == 0
+
+    def test_interface_cost_mst_ok(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["cost"], [self.L2_PORT, "200"])
+        assert r.exit_code == 0
+
+    def test_interface_priority_ok(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["priority"], [self.L2_PORT, "128"])
+        assert r.exit_code == 0
+
+    def test_interface_portfast_enable_pvst(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["portfast"].commands["enable"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_portfast_enable_mst_fail(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["portfast"].commands["enable"], [self.L2_PORT])
+        assert r.exit_code != 0
+
+    def test_interface_portfast_disable_pvst(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["portfast"].commands["disable"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_uplink_fast_enable_pvst(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["uplink_fast"].commands["enable"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_uplink_fast_enable_mst_fail(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["uplink_fast"].commands["enable"], [self.L2_PORT])
+        assert r.exit_code != 0
+
+    def test_interface_uplink_fast_disable_pvst(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["uplink_fast"].commands["disable"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_link_type_p2p(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["link_type"].commands["point-to-point"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_link_type_shared(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["link_type"].commands["shared"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_link_type_auto_mst(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["link_type"].commands["auto"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_link_type_auto_pvst_fail(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["link_type"].commands["auto"], [self.L2_PORT])
+        assert r.exit_code != 0
+
+    def test_interface_link_type_set_pvst(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["link-type"].commands["set"], ["P2P", self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_link_type_set_mst(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["link-type"].commands["set"], ["Auto", self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_enable_pvst(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["enable"], [self.L2_PORT_NO_STP])
+        assert r.exit_code == 0
+
+    def test_interface_enable_mst(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["enable"], ["Ethernet12"])
+        assert r.exit_code == 0
+
+    def test_interface_enable_none_fail(self):
+        self._set_mode(None)
+        r = self._invoke(self._intf().commands["enable"], [self.L2_PORT_NO_STP])
+        assert r.exit_code != 0
+
+    def test_interface_edge_port_flag_enable_mst(self):
+        self._set_mode("mst")
+        r = self._invoke(self._intf().commands["edge_port"], ["enable", self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_edge_port_flag_pvst_fail(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["edge_port"], ["enable", self.L2_PORT])
+        assert r.exit_code != 0
+
+    def test_interface_bpdu_guard_enable(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["bpdu-guard"].commands["enable"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_bpdu_guard_enable_shutdown(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["bpdu-guard"].commands["enable"], ["-s", self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_bpdu_guard_disable(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["bpdu-guard"].commands["disable"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    def test_interface_root_guard_enable(self):
+        self._set_mode("pvst")
+        r = self._invoke(self._intf().commands["root_guard"].commands["enable"], [self.L2_PORT])
+        assert r.exit_code == 0
+
+    # ---------- mst instance commands ----------
+    def _mst_inst(self):
+        return self.st.commands["mst"].commands["instance"]
+
+    def test_mst_instance_interface_priority_ok(self):
+        self._set_mode("mst")
+        cmd = self._mst_inst().commands["interface"].commands["priority"]
+        r = self._invoke(cmd, ["1", self.L2_PORT, "128"])
+        assert r.exit_code == 0
+
+    def test_mst_instance_interface_priority_bad_range(self):
+        self._set_mode("mst")
+        cmd = self._mst_inst().commands["interface"].commands["priority"]
+        r = self._invoke(cmd, ["999", self.L2_PORT, "128"])
+        assert r.exit_code != 0
+
+    def test_mst_instance_interface_cost_ok(self):
+        self._set_mode("mst")
+        cmd = self._mst_inst().commands["interface"].commands["cost"]
+        r = self._invoke(cmd, ["1", self.L2_PORT, "200"])
+        assert r.exit_code == 0
+
+    def test_mst_instance_interface_cost_pvst_fail(self):
+        self._set_mode("pvst")
+        cmd = self._mst_inst().commands["interface"].commands["cost"]
+        r = self._invoke(cmd, ["1", self.L2_PORT, "200"])
+        assert r.exit_code != 0
+
+    def test_mst_instance_priority_ok(self):
+        self._set_mode("mst")
+        self.db.cfgdb.set_entry('STP_MST_INST', 'MST_INSTANCE|1', {'bridge_priority': '32768'})
+        cmd = self._mst_inst().commands["priority"]
+        r = self._invoke(cmd, ["1", "4096"])
+        assert r.exit_code == 0
+
+    def test_mst_instance_priority_no_instance(self):
+        self._set_mode("mst")
+        cmd = self._mst_inst().commands["priority"]
+        r = self._invoke(cmd, ["5", "4096"])
+        assert r.exit_code != 0
+
+    def test_mst_instance_vlan_add_instance0_fail(self):
+        self._set_mode("mst")
+        cmd = self._mst_inst().commands["vlan"].commands["add"]
+        r = self._invoke(cmd, ["0", "1000"])
+        assert r.exit_code != 0
+
+    def test_mst_instance_vlan_del_instance0_fail(self):
+        self._set_mode("mst")
+        cmd = self._mst_inst().commands["vlan"].commands["del"]
+        r = self._invoke(cmd, ["0", "1000"])
+        assert r.exit_code != 0
+
+    def test_mst_instance_vlan_del_bad_range(self):
+        self._set_mode("mst")
+        cmd = self._mst_inst().commands["vlan"].commands["del"]
+        r = self._invoke(cmd, ["999", "1000"])
+        assert r.exit_code != 0
+
+    def test_mst_instance_vlan_add_ok(self):
+        self._set_mode("mst")
+        self.db.cfgdb.set_entry('STP_MST_INST', 'MST_INSTANCE|1', {'bridge_priority': '32768'})
+        cmd = self._mst_inst().commands["vlan"].commands["add"]
+        r = self._invoke(cmd, ["1", "1000"])
+        assert r.exit_code == 0

--- a/tests/stp_test.py
+++ b/tests/stp_test.py
@@ -1222,7 +1222,7 @@ class TestStpInterfaceDisable:
     @patch('config.stp.check_if_global_stp_enabled')
     @patch('config.stp.check_if_interface_is_valid')
     def test_disable_interface_mstp(self, mock_check_valid, mock_check_global):
-        self.cfgdb.get_entry.return_value = {'mode': 'mstp'}
+        self.cfgdb.get_entry.return_value = {'mode': 'mst'}
 
         result = self.runner.invoke(
             config.config.commands["spanning-tree"]
@@ -1234,8 +1234,8 @@ class TestStpInterfaceDisable:
 
         assert result.exit_code == 0
         self.cfgdb.set_entry.assert_called_with("STP_PORT", "Ethernet0", {"enabled": "false"})
-        assert "Current STP mode: mstp" in result.output
-        assert "STP mode mstp is disabled for Ethernet0" in result.output
+        assert "Current STP mode: mst" in result.output
+        assert "STP mode mst is disabled for Ethernet0" in result.output
 
     @patch('config.stp.check_if_global_stp_enabled')
     @patch('config.stp.check_if_interface_is_valid')

--- a/tests/stp_test.py
+++ b/tests/stp_test.py
@@ -1270,7 +1270,7 @@ class TestStpInterfaceDisable:
 
         assert result.exit_code == 0
         assert "Current STP mode: none" in result.output
-        assert "No STP mode selected" in result.output
+        assert "No STP_PORT entry for Ethernet9" in result.output
 
 
 class TestMstpInterfaceedge_port:


### PR DESCRIPTION
## Summary
- Fix STP interface enable/disable to use the correct `STP` config_db table
  instead of `STP_GLOBAL`.
- Fix MSTP mode check to use config_db value `mst` instead of `mstp`.
- Disable STP on an interface when STP is globally disabled, not only when
  per-interface STP is turned off.

## Motivation
PVST configuration fails because `stp_interface_enable()` and
`stp_interface_disable()` read/write the wrong config_db table and use an
incorrect MSTP mode string. Together these prevent STP from being applied
correctly on interfaces.

## Changes
- `stp_interface_enable()` / `stp_interface_disable()`:
  - Use `STP` table instead of `STP_GLOBAL`
  - Compare STP mode against `mst` (not `mstp`) to match config_db
- `stp_interface_disable()`:
  - Also disable STP on the interface when global STP mode is disabled

## Verification
- `pytest tests/stp_test.py -vv`
- Configure PVST on a 3 node setup with these changes. The test was done with sonic-vs image on a GNS3 deployment and also on Marvell Prestera switches. The test ensured that PVST configuration flowed to the STP daemon and PVST protocol converged.