### PR TITLE
[multi_asic]: Fix namespace validation callback to reject -n only on single-asic

### DIFF
--- a/tests/multi_asic_util_test.py
+++ b/tests/multi_asic_util_test.py
@@ -1,0 +1,41 @@
+import click
+import mock
+
+from click.testing import CliRunner
+
+import utilities_common.multi_asic as multi_asic_util
+
+
+def _make_cmd():
+    """Build a throwaway command wired to the namespace validation callback."""
+    @click.command()
+    @click.option('-n', '--namespace', 'namespace', default=None,
+                  callback=multi_asic_util.multi_asic_namespace_validation_callback)
+    def cmd(namespace):
+        click.echo("ran namespace={}".format(namespace))
+    return cmd
+
+
+class TestMultiAsicNamespaceValidationCallback:
+    @mock.patch("utilities_common.multi_asic.multi_asic.is_multi_asic",
+                mock.Mock(return_value=False))
+    def test_single_asic_without_namespace_is_allowed(self):
+        # Click runs the callback even when -n is not supplied; the command
+        # must still run on single-asic instead of aborting.
+        result = CliRunner().invoke(_make_cmd(), [])
+        assert result.exit_code == 0
+        assert "ran namespace=None" in result.output
+
+    @mock.patch("utilities_common.multi_asic.multi_asic.is_multi_asic",
+                mock.Mock(return_value=False))
+    def test_single_asic_with_namespace_is_rejected(self):
+        result = CliRunner().invoke(_make_cmd(), ["-n", "asic0"])
+        assert result.exit_code != 0
+        assert "not available for single asic" in result.output
+
+    @mock.patch("utilities_common.multi_asic.multi_asic.is_multi_asic",
+                mock.Mock(return_value=True))
+    def test_multi_asic_with_namespace_is_allowed(self):
+        result = CliRunner().invoke(_make_cmd(), ["-n", "asic0"])
+        assert result.exit_code == 0
+        assert "ran namespace=asic0" in result.output

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -133,7 +133,17 @@ _multi_asic_click_options = [
 ]
 
 def multi_asic_namespace_validation_callback(ctx, param, value):
-    if not multi_asic.is_multi_asic:
+    # Click invokes option callbacks even when the option is left at its
+    # default (e.g. value is None or the default namespace), so only reject a
+    # namespace that was explicitly supplied on the command line. Otherwise
+    # every command using this callback would abort on single-asic devices
+    # even when -n/--namespace was not passed. Also note is_multi_asic must be
+    # called (not just referenced) for the check to work.
+    explicitly_set = (
+        ctx is not None
+        and ctx.get_parameter_source(param.name) == click.core.ParameterSource.COMMANDLINE
+    )
+    if explicitly_set and not multi_asic.is_multi_asic():
         click.echo("-n/--namespace is not available for single asic")
         ctx.abort()
     return value


### PR DESCRIPTION
#### What I did

Fixed a latent bug in `multi_asic_namespace_validation_callback`
(`utilities_common/multi_asic.py`), the option callback used by ~60
`show`/`config`/`sonic-clear` commands to validate `-n/--namespace`.

The callback tested `multi_asic.is_multi_asic` (a **function reference**,
always truthy) instead of calling `is_multi_asic()`, so the validation never
ran and `-n/--namespace` was silently accepted on single-asic platforms.

This was surfaced while reviewing sonic-net/sonic-utilities#4687 (a Copilot
review comment on the storm-control namespace test).

> **NOTE: opened as a draft.** This callback guards ~60 commands, and the
> default unit-test state is single-asic, so some existing tests that pass
> `-n` without forcing a multi-asic context (they previously relied on the
> callback never aborting) are expected to fail in CI. I will iterate on the
> CI results to fix that fallout. I could not run the full `tests/` suite
> locally (no `swsscommon`/`libyang` in my environment).

#### How I did it

Naively adding the missing `()` is **not** sufficient: Click invokes option
callbacks even when the option is left at its default, so `value` is `None`
when `-n` is not passed. An unconditional `if not multi_asic.is_multi_asic()`
would therefore abort **every** command using this callback on single-asic
even when `-n` was never supplied.

The fix guards on the Click parameter source so only a namespace that was
**explicitly** provided on the command line is rejected on single-asic:

```python
explicitly_set = (
    ctx is not None
    and ctx.get_parameter_source(param.name) == click.core.ParameterSource.COMMANDLINE
)
if explicitly_set and not multi_asic.is_multi_asic():
    click.echo("-n/--namespace is not available for single asic")
    ctx.abort()
```

Added `tests/multi_asic_util_test.py` covering the three behaviors:
- single-asic, no `-n` -> command runs (no regression)
- single-asic, `-n asic0` -> aborts with the error message
- multi-asic, `-n asic0` -> command runs

#### How to verify it

- Unit test: `python3 -m pytest tests/multi_asic_util_test.py -v`
- On a single-asic device: `show storm-control` (no `-n`) still works;
  `show storm-control -n asic0` is rejected with
  "-n/--namespace is not available for single asic".
- On a multi-asic device: `show storm-control -n asic0` works.

#### Previous command output (if the output of a command-line utility has changed)

```
# single-asic, before this fix (validation silently skipped)
$ show storm-control -n asic0
<storm-control table rendered even though -n is invalid on single-asic>
```

#### New command output (if the output of a command-line utility has changed)

```
# single-asic, after this fix
$ show storm-control -n asic0
-n/--namespace is not available for single asic
Aborted!

# single-asic, no -n (unchanged, still works)
$ show storm-control
<storm-control table>
```
