### PR TITLE
[202605] Abort config reload if warm-boot or fast-reboot is still in progress

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2196,6 +2196,24 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
 
     #Stop services before config push
     if not no_service_restart:
+        try:
+            _db = swsscommon.DBConnector('STATE_DB', 0)
+            boot_type = None
+            # fast-reboot sets both FAST_RESTART_ENABLE_TABLE and WARM_RESTART_ENABLE_TABLE;
+            # check fast first so the label is correct when both flags are set.
+            if swsscommon.RestartWaiter.isFastBootInProgress(_db):
+                boot_type = 'fast-reboot'
+            elif swsscommon.RestartWaiter.isWarmBootInProgress(_db):
+                boot_type = 'warm-boot'
+            if boot_type:
+                click.echo(f"A {boot_type} is still in progress. Please wait for finalization to complete.")
+                sys.exit(CONFIG_RELOAD_NOT_READY)
+        except SystemExit:
+            raise
+        except Exception:
+            pass
+
+    if not no_service_restart:
         log.log_notice("'reload' stopping services...")
         _stop_services()
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -754,6 +754,90 @@ class TestConfigReload(object):
             assert "\n".join([line.rstrip() for line in result.output.split('\n')][:2]) == \
                 reload_config_with_sys_info_command_output.format(config.SYSTEM_RELOAD_LOCK)
 
+    def test_config_reload_blocked_during_warm_boot(self, get_cmd_module, setup_single_broadcom_asic):
+        """config reload must abort when a warm-boot is in progress (Redmine #5154490)."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = True
+        mock_swsscommon.RestartWaiter.isFastBootInProgress.return_value = False
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch('config.main._is_system_starting', return_value=False), \
+                mock.patch('config.main._swss_ready', return_value=True), \
+                mock.patch.object(config, 'config_file_yang_validation'):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y"])
+            assert result.exit_code != 0
+            assert "warm-boot" in result.output
+            assert "still in progress" in result.output
+
+    def test_config_reload_blocked_during_fast_boot(self, get_cmd_module, setup_single_broadcom_asic):
+        """config reload must abort when a fast-reboot is in progress.
+        fast-reboot sets both FAST_RESTART_ENABLE_TABLE and WARM_RESTART_ENABLE_TABLE;
+        isFastBootInProgress is checked first so the label is correct."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = True
+        mock_swsscommon.RestartWaiter.isFastBootInProgress.return_value = True
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch('config.main._is_system_starting', return_value=False), \
+                mock.patch('config.main._swss_ready', return_value=True), \
+                mock.patch.object(config, 'config_file_yang_validation'):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y"])
+            assert result.exit_code != 0
+            assert "fast-reboot" in result.output
+            assert "still in progress" in result.output
+
+    def test_config_reload_not_blocked_when_no_boot_in_progress(self, get_cmd_module, setup_single_broadcom_asic):
+        """Guard runs but does not block when no boot is in progress; both checks are invoked."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = False
+        mock_swsscommon.RestartWaiter.isFastBootInProgress.return_value = False
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch.object(config, 'config_file_yang_validation'), \
+                mock.patch('config.main._is_system_starting', return_value=False), \
+                mock.patch('config.main._swss_ready', return_value=True), \
+                mock.patch('config.main._stop_services'), \
+                mock.patch('config.main._restart_services'), \
+                mock.patch('config.main._reset_failed_services'), \
+                mock.patch("utilities_common.cli.run_command",
+                           mock.MagicMock(side_effect=mock_run_command_side_effect)):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y"])
+            assert result.exit_code == 0
+            assert "still in progress" not in result.output
+            mock_swsscommon.RestartWaiter.isFastBootInProgress.assert_called_once()
+            mock_swsscommon.RestartWaiter.isWarmBootInProgress.assert_called_once()
+
+    def test_config_reload_no_service_restart_skips_guard(self, get_cmd_module, setup_single_broadcom_asic):
+        """With -n (no_service_restart), guard is skipped — no syncd teardown, no risk."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = True
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch.object(config, 'config_file_yang_validation'), \
+                mock.patch("utilities_common.cli.run_command",
+                           mock.MagicMock(side_effect=mock_run_command_side_effect)):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y", "-n"])
+            assert result.exit_code == 0
+            assert "still in progress" not in result.output
+            mock_swsscommon.RestartWaiter.isFastBootInProgress.assert_not_called()
+            mock_swsscommon.RestartWaiter.isWarmBootInProgress.assert_not_called()
+
     def test_config_reload_stdin(self, get_cmd_module, setup_single_broadcom_asic):
         def mock_json_load(f):
             device_metadata = {


### PR DESCRIPTION
Cherry-pick of community PR #4711 (commit `cd4953c3`) into `202605`.

#### Why I did it

On SONiC, `config reload` can inherit a stale `WARM_RESTART_ENABLE_TABLE|system=true`
flag left by an unfinished warm-boot or fast-reboot finalization (e.g. BGP reconcile still
pending). `syncd.sh::check_warm_boot()` reads this flag and issues `syncd_request_shutdown --warm` without a preceding `--pre` (pre-shutdown).

logs
```
2026 Jul 17 23:06:49.042750 sonic NOTICE root: WARMBOOT_FINALIZER : Waiting for components to reconcile: bgp
2026 Jul 17 23:06:50.305408 sonic NOTICE teamd#teamsyncd: :- setWarmStartState: teamsyncd warm start state changed to reconciled
2026 Jul 17 23:06:51.222019 sonic NOTICE wjh-config[14724]: 'reload' executing with command: config reload -yf
2026 Jul 17 23:06:51.417474 sonic NOTICE admin: Warm boot flag: bgp true.
2026 Jul 17 23:06:52.036422 sonic NOTICE syncd#syncd_request_shutdown: :- send: requested WARM shutdown
2026 Jul 17 23:06:52.036761 sonic INFO syncd.sh[15207]: requested WARM shutdown
```

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Added a boot-in-progress guard in `config/main.py` (`reload()`) that uses`swsscommon.RestartWaiter` to detect if a warm-boot or fast-reboot is still finalizing. If so, `config reload` is aborted with a clear message before syncd is stopped.
- `isFastBootInProgress` is checked first — fast-reboot sets both `FAST_RESTART_ENABLE_TABLE` and `WARM_RESTART_ENABLE_TABLE`, so checking fast first ensures the correct label.
- Guard is skipped when `--no-service-restart` (`-n`) is passed since no syncd teardown occurs in that path.
- Added four inline tests in `tests/config_test.py`.

#### How to verify it
**Test 1 — Manual warm-boot flag**

1a. Flag set → BLOCKED

```
$ redis-cli -n 6 HSET "WARM_RESTART_ENABLE_TABLE|system" enable true
(integer) 0
$ sudo config reload -yf
Acquired lock on /etc/sonic/reload.lock
A warm-boot is still in progress. Please wait for finalization to complete.
Released lock on /etc/sonic/reload.lock
```

1b. Flag cleared → PASSES

```
$ redis-cli -n 6 HSET "WARM_RESTART_ENABLE_TABLE|system" enable false
(integer) 0
$ sudo config reload -yf -n
Acquired lock on /etc/sonic/reload.lock
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Released lock on /etc/sonic/reload.lock
```

---

**Test 2 — Manual fast-reboot flags (fast-reboot sets both warm+fast flags)**

2a. Both flags set → BLOCKED with correct `fast-reboot` label

```
$ redis-cli -n 6 HSET "WARM_RESTART_ENABLE_TABLE|system" enable true
(integer) 0
$ redis-cli -n 6 HSET "FAST_RESTART_ENABLE_TABLE|system" enable true
(integer) 0
$ sudo config reload -yf
Acquired lock on /etc/sonic/reload.lock
A fast-reboot is still in progress. Please wait for finalization to complete.
Released lock on /etc/sonic/reload.lock
```

2b. Flags cleared → PASSES

```
$ redis-cli -n 6 HSET "WARM_RESTART_ENABLE_TABLE|system" enable false
(integer) 0
$ redis-cli -n 6 HSET "FAST_RESTART_ENABLE_TABLE|system" enable false
(integer) 0
$ sudo config reload -yf -n
Acquired lock on /etc/sonic/reload.lock
Running command: /usr/local/bin/sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json --write-to-db
Running command: /usr/local/bin/db_migrator.py -o migrate
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Released lock on /etc/sonic/reload.lock
```

---

**Test 3 — Real warm-reboot**

```
$ sudo config bgp shutdown all # create latency during bgp reconciliation during warm reboot
$ sudo warm-reboot -f
Firmware is up to date.
Successfully copied 370kB to /host/warmboot
Stopping 'docker.service', but its triggering units are still active:
docker.socket
Watchdog armed for 180 seconds
0
client_loop: send disconnect: Broken pipe
[reconnect after ~60s]
$ sudo config reload -yf
Acquired lock on /etc/sonic/reload.lock
A warm-boot is still in progress. Please wait for finalization to complete.
Released lock on /etc/sonic/reload.lock
```

---

**Test 4 — Real fast-reboot**

```
$ sudo fast-reboot
Firmware is up to date.
Successfully copied 105kB to /host/warmboot
Stopping 'docker.service', but its triggering units are still active:
docker.socket
Watchdog armed for 180 seconds
0
client_loop: send disconnect: Broken pipe
[reconnect]
$ sudo config reload -yf
Acquired lock on /etc/sonic/reload.lock
A fast-reboot is still in progress. Please wait for finalization to complete.
Released lock on /etc/sonic/reload.lock
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411


#### Description for the changelog

[Mellanox] abort `config reload` if warm-boot or fast-reboot is still in progress

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

## Summary by CodeRabbit

* **Bug Fixes**
  * `config reload` now performs a readiness pre-check and blocks the operation when a warm-boot or fast-reboot is still in progress.
  * The command reports the detected boot type and indicates that reload can’t proceed yet.
  * Reload proceeds normally when no boot is in progress, and when service restart is explicitly disabled.

* **Tests**
  * Added test coverage for warm-boot/fast-reboot blocked scenarios, normal readiness, and the override behavior when restart is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `config reload` safety with a pre-stop readiness check that detects warm-boot or fast-reboot already in progress.
  * When a reboot is detected, `config reload` is blocked with a message indicating which boot is still in progress and exits as non-ready.
  * When service restart is disabled (`-n` / `--no_service_restart`), the reboot-in-progress guard is skipped and reload proceeds.

* **Tests**
  * Added new test coverage for warm-boot blocking, fast-reboot blocking, allowed reload when no reboot is in progress, and `-n` bypass behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->