### PR TITLE
aaa: add --prompt/--prompt-key to hide secrets from CLI history

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -16,6 +16,11 @@ def is_secret(secret):
     return bool(re.match('^' + '[^ #,]*' + '$', secret))
 
 
+def prompt_secret(text='Enter passkey', confirm=True):
+    """Read a secret from a hidden interactive prompt so it never appears on the command line."""
+    return click.prompt(text, hide_input=True, confirmation_prompt=confirm)
+
+
 def add_table_kv(db, table, entry, key, val):
     config_db = ValidatedConfigDBConnector(db.cfgdb)
     config_db.connect()
@@ -243,13 +248,23 @@ default.add_command(authtype)
 
 @click.command()
 @click.argument('secret', metavar='<secret_string>', required=False)
+@click.option('-p', '--prompt', is_flag=True,
+              help='Enter the passkey interactively (hidden) instead of on the command line')
+@click.option('--confirm/--no-confirm', default=True, show_default=True,
+              help='Ask for the passkey a second time to confirm when using --prompt')
 @click.pass_context
 @clicommon.pass_db
-def passkey(db, ctx, secret):
+def passkey(db, ctx, secret, prompt, confirm):
     """Specify TACACS+ server global passkey <STRING>"""
     if ctx.obj == 'default':
         del_table_key(db, 'TACPLUS', 'global', 'passkey')
-    elif secret:
+        return
+    if prompt:
+        if secret:
+            click.echo('Cannot use both <secret_string> argument and --prompt')
+            return
+        secret = prompt_secret('Enter passkey', confirm)
+    if secret:
         add_table_kv(db, 'TACPLUS', 'global', 'passkey', secret)
     else:
         click.echo('Argument "secret" is required')
@@ -262,17 +277,27 @@ default.add_command(passkey)
 @click.argument('address', metavar='<ip_address>')
 @click.option('-t', '--timeout', help='Transmission timeout interval, default 5', type=int)
 @click.option('-k', '--key', help='Shared secret')
+@click.option('--prompt-key', is_flag=True,
+              help='Enter the shared secret interactively (hidden) instead of on the command line')
+@click.option('--confirm/--no-confirm', default=True, show_default=True,
+              help='Ask for the shared secret a second time to confirm when using --prompt-key')
 @click.option('-a', '--auth_type', help='Authentication type, default pap', type=click.Choice(["chap", "pap", "mschap", "login"]))
 @click.option('-o', '--port', help='TCP port range is 1 to 65535, default 49', type=click.IntRange(1, 65535), default=49)
 @click.option('-p', '--pri', help="Priority, default 1", type=click.IntRange(1, 64), default=1)
 @click.option('-m', '--use-mgmt-vrf', help="Management vrf, default is no vrf", is_flag=True)
 @clicommon.pass_db
-def add(db, address, timeout, key, auth_type, port, pri, use_mgmt_vrf):
+def add(db, address, timeout, key, prompt_key, confirm, auth_type, port, pri, use_mgmt_vrf):
     """Specify a TACACS+ server"""
     if ADHOC_VALIDATION:
         if not clicommon.is_ipaddress(address):
             click.echo('Invalid ip address') # TODO: MISSING CONSTRAINT IN YANG MODEL
             return
+
+    if prompt_key:
+        if key:
+            click.echo('Cannot use both --key and --prompt-key')
+            return
+        key = prompt_secret('Enter shared secret', confirm)
 
     config_db = ValidatedConfigDBConnector(db.cfgdb)
     config_db.connect()
@@ -386,13 +411,23 @@ default.add_command(authtype)
 
 @click.command()
 @click.argument('secret', metavar='<secret_string>', required=False)
+@click.option('-p', '--prompt', is_flag=True,
+              help='Enter the passkey interactively (hidden) instead of on the command line')
+@click.option('--confirm/--no-confirm', default=True, show_default=True,
+              help='Ask for the passkey a second time to confirm when using --prompt')
 @click.pass_context
 @clicommon.pass_db
-def passkey(db, ctx, secret):
+def passkey(db, ctx, secret, prompt, confirm):
     """Specify RADIUS server global passkey <STRING>"""
     if ctx.obj == 'default':
         del_table_key(db, 'RADIUS', 'global', 'passkey')
-    elif secret:
+        return
+    if prompt:
+        if secret:
+            click.echo('Cannot use both <secret_string> argument and --prompt')
+            return
+        secret = prompt_secret('Enter passkey', confirm)
+    if secret:
         if len(secret) > RADIUS_PASSKEY_MAX_LEN:
             click.echo('Maximum of %d chars can be configured' % RADIUS_PASSKEY_MAX_LEN)
             return
@@ -510,14 +545,25 @@ radius.add_command(statistics)
 @click.option('-r', '--retransmit', help='Retransmit attempts, default 3', type=click.IntRange(1, 10))
 @click.option('-t', '--timeout', help='Transmission timeout interval, default 5', type=click.IntRange(1, 60))
 @click.option('-k', '--key', help='Shared secret')
+@click.option('--prompt-key', is_flag=True,
+              help='Enter the shared secret interactively (hidden) instead of on the command line')
+@click.option('--confirm/--no-confirm', default=True, show_default=True,
+              help='Ask for the shared secret a second time to confirm when using --prompt-key')
 @click.option('-a', '--auth_type', help='Authentication type, default pap', type=click.Choice(["chap", "pap", "mschapv2"]))
 @click.option('-o', '--auth-port', help='UDP port range is 1 to 65535, default 1812', type=click.IntRange(1, 65535), default=1812)
 @click.option('-p', '--pri', help="Priority, default 1", type=click.IntRange(1, 64), default=1)
 @click.option('-m', '--use-mgmt-vrf', help="Management vrf, default is no vrf", is_flag=True)
 @click.option('-s', '--source-interface', help='Source Interface')
 @clicommon.pass_db
-def add(db, address, retransmit, timeout, key, auth_type, auth_port, pri, use_mgmt_vrf, source_interface):
+def add(db, address, retransmit, timeout, key, prompt_key, confirm,
+        auth_type, auth_port, pri, use_mgmt_vrf, source_interface):
     """Specify a RADIUS server"""
+
+    if prompt_key:
+        if key:
+            click.echo('Cannot use both --key and --prompt-key')
+            return
+        key = prompt_secret('Enter shared secret', confirm)
 
     if ADHOC_VALIDATION:
         if key:

--- a/tests/aaa_test.py
+++ b/tests/aaa_test.py
@@ -507,3 +507,146 @@ class TestAaa(object):
         result = runner.invoke(config.config.commands["tacacs"].commands["add"], ["10.10.10.10"], obj=obj)
         print(result.exit_code)
         assert result.exit_code != 0
+
+    # ------------------------------------------------------------------
+    # prompt_secret / --prompt / --prompt-key tests
+    # ------------------------------------------------------------------
+
+    def test_tacacs_passkey_prompt(self, get_cmd_module):
+        """--prompt reads secret interactively and stores it."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='hidden123') as mock_prompt:
+            result = runner.invoke(
+                config.config.commands['tacacs'].commands['passkey'],
+                ['--prompt', '--no-confirm'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            mock_prompt.assert_called_once_with('Enter passkey', False)
+
+        entry = db.cfgdb.get_entry('TACPLUS', 'global')
+        assert entry.get('passkey') == 'hidden123'
+
+    def test_tacacs_passkey_prompt_and_positional_conflict(self, get_cmd_module):
+        """Giving both <secret_string> and --prompt is an error."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='hidden123'):
+            result = runner.invoke(
+                config.config.commands['tacacs'].commands['passkey'],
+                ['mysecret', '--prompt'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            assert 'Cannot use both' in result.output
+
+    def test_tacacs_passkey_positional(self, get_cmd_module):
+        """Positional <secret_string> still works (backward compat)."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(
+            config.config.commands['tacacs'].commands['passkey'],
+            ['mykey'], obj=db)
+        print(result.output)
+        assert result.exit_code == 0
+
+        entry = db.cfgdb.get_entry('TACPLUS', 'global')
+        assert entry.get('passkey') == 'mykey'
+
+    def test_tacacs_add_prompt_key(self, get_cmd_module):
+        """--prompt-key reads shared secret interactively for tacacs add."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='tackey') as mock_prompt:
+            result = runner.invoke(
+                config.config.commands['tacacs'].commands['add'],
+                ['10.10.10.10', '--prompt-key', '--no-confirm'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            mock_prompt.assert_called_once_with('Enter shared secret', False)
+
+        entry = db.cfgdb.get_entry('TACPLUS_SERVER', '10.10.10.10')
+        assert entry.get('passkey') == 'tackey'
+
+    def test_tacacs_add_prompt_key_and_key_conflict(self, get_cmd_module):
+        """Giving both --key and --prompt-key is an error for tacacs add."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='tackey'):
+            result = runner.invoke(
+                config.config.commands['tacacs'].commands['add'],
+                ['10.10.10.10', '-k', 'explicit', '--prompt-key'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            assert 'Cannot use both' in result.output
+
+    def test_radius_passkey_prompt(self, get_cmd_module):
+        """--prompt reads global passkey interactively for radius."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='radpass') as mock_prompt:
+            result = runner.invoke(
+                config.config.commands['radius'].commands['passkey'],
+                ['--prompt', '--no-confirm'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            mock_prompt.assert_called_once_with('Enter passkey', False)
+
+        entry = db.cfgdb.get_entry('RADIUS', 'global')
+        assert entry.get('passkey') == 'radpass'
+
+    def test_radius_passkey_prompt_and_positional_conflict(self, get_cmd_module):
+        """Giving both <secret_string> and --prompt is an error for radius passkey."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='radpass'):
+            result = runner.invoke(
+                config.config.commands['radius'].commands['passkey'],
+                ['mysecret', '--prompt'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            assert 'Cannot use both' in result.output
+
+    def test_radius_add_prompt_key(self, get_cmd_module):
+        """--prompt-key reads shared secret interactively for radius add."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='radkey') as mock_prompt:
+            result = runner.invoke(
+                config.config.commands['radius'].commands['add'],
+                ['10.10.10.10', '--prompt-key', '--no-confirm'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            mock_prompt.assert_called_once_with('Enter shared secret', False)
+
+        entry = db.cfgdb.get_entry('RADIUS_SERVER', '10.10.10.10')
+        assert entry.get('passkey') == 'radkey'
+
+    def test_radius_add_prompt_key_and_key_conflict(self, get_cmd_module):
+        """Giving both --key and --prompt-key is an error for radius add."""
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        with patch('config.aaa.prompt_secret', return_value='radkey'):
+            result = runner.invoke(
+                config.config.commands['radius'].commands['add'],
+                ['10.10.10.10', '-k', 'explicit', '--prompt-key'], obj=db)
+            print(result.output)
+            assert result.exit_code == 0
+            assert 'Cannot use both' in result.output


### PR DESCRIPTION
#### What I did

Add interactive hidden prompt options to TACACS+ and RADIUS passkey and server-add commands so secrets are not exposed on the command line or in shell history.

#### How I did it

- Added `prompt_secret()` helper using `click.prompt(hide_input=True)`
- `tacacs passkey`: added `-p`/`--prompt` and `--confirm`/`--no-confirm` options
- `tacacs add`: added `--prompt-key` and `--confirm`/`--no-confirm` options
- `radius passkey`: added `-p`/`--prompt` and `--confirm`/`--no-confirm` options
- `radius add`: added `--prompt-key` and `--confirm`/`--no-confirm` options
- Positional `<secret_string>` argument retained for backward compatibility
- Mutual exclusion enforced: passing both the positional arg and the prompt flag is an error

#### How to verify it

```
# Set TACACS+ global passkey interactively (hidden, with confirmation)
sudo config tacacs passkey --prompt

# Set RADIUS server shared secret interactively (no confirmation)
sudo config radius add <ip> --prompt-key --no-confirm

# Verify backward compat still works
sudo config tacacs passkey mysecret
```

Unit tests added in `tests/aaa_test.py` covering:
- `--prompt` happy path (TACACS+ and RADIUS passkey)
- `--prompt-key` happy path (TACACS+ and RADIUS add)
- Conflict error when both positional arg and prompt flag are given
- Backward compat: positional `<secret_string>` still works