### PR TITLE
Fix empty leaf-list regression in GCU sorter

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -9,8 +9,10 @@ import yang as ly
 import copy
 import re
 import os
+import hashlib
 from sonic_py_common import logger, multi_asic
 from enum import Enum
+from functools import cmp_to_key
 
 YANG_DIR = "/usr/local/yang-models"
 SYSLOG_IDENTIFIER = "GenericConfigUpdater"
@@ -76,10 +78,15 @@ def get_config_db_as_text(scope=None):
 
 
 class ConfigWrapper:
-    def __init__(self, yang_dir=YANG_DIR, scope=multi_asic.DEFAULT_NAMESPACE):
+    def __init__(self, yang_dir=YANG_DIR, scope=multi_asic.DEFAULT_NAMESPACE, namespace=None):
+        if namespace is not None and scope == multi_asic.DEFAULT_NAMESPACE:
+            scope = namespace
         self.scope = scope
         self.yang_dir = YANG_DIR
         self.sonic_yang_with_loaded_models = None
+        self._validate_config_cache = {}
+        self._currently_loaded_hash = None
+        self._loaded_sy = None
 
     def get_config_db_as_json(self):
         return get_config_db_as_json(self.scope)
@@ -138,6 +145,12 @@ class ConfigWrapper:
             return False, ex
 
     def validate_config_db_config(self, config_db_as_json):
+        _cache_key = hashlib.md5(
+            json.dumps(config_db_as_json, sort_keys=True).encode()
+        ).hexdigest()
+        if _cache_key in self._validate_config_cache:
+            return self._validate_config_cache[_cache_key]
+
         sy = self.create_sonic_yang_with_loaded_models()
 
         # TODO: Move these validators to YANG models
@@ -145,20 +158,28 @@ class ConfigWrapper:
                                         self.validate_lanes]
 
         try:
-            tmp_config_db_as_json = copy.deepcopy(config_db_as_json)
-
-            sy.loadData(tmp_config_db_as_json)
+            sy.loadData(config_db_as_json)
+            self._currently_loaded_hash = _cache_key
+            self._loaded_sy = sy
 
             sy.validate_data_tree()
 
             for supplemental_yang_validator in supplemental_yang_validators:
                 success, error = supplemental_yang_validator(config_db_as_json)
                 if not success:
-                    return success, error
+                    result = (success, error)
+                    self._validate_config_cache[_cache_key] = result
+                    return result
         except sonic_yang.SonicYangException as ex:
-            return False, ex
+            self._currently_loaded_hash = None
+            self._loaded_sy = None
+            result = (False, ex)
+            self._validate_config_cache[_cache_key] = result
+            return result
 
-        return True, None
+        result = (True, None)
+        self._validate_config_cache[_cache_key] = result
+        return result
 
     def validate_field_operation(self, old_config, target_config):
         """
@@ -339,7 +360,8 @@ class PatchWrapper:
 
     def validate_config_db_patch_has_yang_models(self, patch):
         config_db = {}
-        for operation in patch:
+        normalized_patch = self._normalize_scope_paths_in_patch(patch)
+        for operation in normalized_patch:
             tokens = self.path_addressing.get_path_tokens(operation[OperationWrapper.PATH_KEYWORD])
             if len(tokens) == 0: # Modifying whole config_db
                 tables_dict = {table_name: {} for table_name in operation['value']}
@@ -362,7 +384,30 @@ class PatchWrapper:
         return jsonpatch.make_patch(current, target)
 
     def simulate_patch(self, patch, jsonconfig):
-        return patch.apply(jsonconfig)
+        normalized_patch = self._normalize_scope_paths_in_patch(patch)
+        return normalized_patch.apply(jsonconfig)
+
+    def _normalize_scope_paths_in_patch(self, patch):
+        normalized_operations = []
+        for operation in patch:
+            normalized_operation = copy.deepcopy(operation)
+            if OperationWrapper.PATH_KEYWORD in normalized_operation:
+                normalized_operation[OperationWrapper.PATH_KEYWORD] = \
+                    self._strip_scope_prefix(normalized_operation[OperationWrapper.PATH_KEYWORD])
+            if "from" in normalized_operation:
+                normalized_operation["from"] = self._strip_scope_prefix(normalized_operation["from"])
+            normalized_operations.append(normalized_operation)
+        return jsonpatch.JsonPatch(normalized_operations)
+
+    def _strip_scope_prefix(self, path):
+        tokens = self.path_addressing.get_path_tokens(path)
+        if not tokens:
+            return path
+
+        first = tokens[0]
+        if first == HOST_NAMESPACE or (first.startswith("asic") and first[4:].isnumeric()):
+            return self.path_addressing.create_path(tokens[1:])
+        return path
 
     def convert_config_db_patch_to_sonic_yang_patch(self, patch):
         if not(self.validate_config_db_patch_has_yang_models(patch)):
@@ -519,10 +564,59 @@ class PathAddressing:
 
         return f"{PathAddressing.XPATH_SEPARATOR}{PathAddressing.XPATH_SEPARATOR.join(str(t) for t in tokens)}"
 
+    def configdb_sort_cmp(self, a, b):
+        cmp = a["backlinks"] - b["backlinks"]
+        if cmp != 0:
+            return cmp
+
+        cmp = b["musts"] - a["musts"]
+        if cmp != 0:
+            return cmp
+
+        return a["nsep"] - b["nsep"]
+
+    def configdb_sorted_keys_by_backlinks(self, configdb_path: str, configdb: dict, reverse: bool = False,
+                                          configdb_relative: bool = False, sy=None):
+        if sy is None and self.config_wrapper is not None:
+            sy = self._create_sonic_yang_with_loaded_models()
+
+        ptr = configdb
+        tokens = self.get_path_tokens(configdb_path)
+        if not configdb_relative:
+            for token in tokens:
+                ptr = ptr[token]
+
+        if self.config_wrapper is None:
+            return [key for key in ptr]
+
+        keys = []
+        for key in ptr:
+            tokens.append(key)
+            path = self.create_path(tokens)
+            try:
+                xpath = sy.configdb_path_to_xpath(path, schema_xpath=True)
+                keys.append({
+                    "key": key,
+                    "backlinks": len(sy.find_schema_dependencies(xpath, match_ancestors=True)),
+                    "musts": sy.find_schema_must_count(xpath, match_ancestors=True),
+                    "nsep": str(key).count("|")
+                })
+            except Exception:
+                keys.append({
+                    "key": key,
+                    "backlinks": 0,
+                    "musts": 0,
+                    "nsep": 0
+                })
+            tokens.pop()
+
+        keys = sorted(keys, key=cmp_to_key(self.configdb_sort_cmp), reverse=reverse)
+        return [d["key"] for d in keys]
+
     def _create_sonic_yang_with_loaded_models(self):
         return self.config_wrapper.create_sonic_yang_with_loaded_models()
 
-    def find_ref_paths(self, path, config):
+    def find_ref_paths(self, path, config, reload_config=True):
         """
         Finds the paths referencing any line under the given 'path' within the given 'config'.
         Example:
@@ -560,22 +654,39 @@ class PathAddressing:
             /ACL_TABLE/EVERFLOW6/ports/1
         """
         # TODO: Also fetch references by must statement (check similar statements)
-        return self._find_leafref_paths(path, config)
+        return self._find_leafref_paths(path, config, reload_config=reload_config)
 
-    def _find_leafref_paths(self, path, config):
-        sy = self._create_sonic_yang_with_loaded_models()
+    def _find_leafref_paths(self, path, config, reload_config=True):
+        if reload_config:
+            _config_hash = hashlib.md5(
+                json.dumps(config, sort_keys=True).encode()
+            ).hexdigest()
+            already_loaded = (
+                self.config_wrapper is not None and
+                self.config_wrapper._currently_loaded_hash == _config_hash and
+                self.config_wrapper._loaded_sy is not None
+            )
+            if not already_loaded:
+                sy = self._create_sonic_yang_with_loaded_models()
+                sy.loadData(config)
+                if self.config_wrapper is not None:
+                    self.config_wrapper._currently_loaded_hash = _config_hash
+                    self.config_wrapper._loaded_sy = sy
+            else:
+                sy = self.config_wrapper._loaded_sy
+        else:
+            sy = self._create_sonic_yang_with_loaded_models()
+            sy.loadData(config)
 
-        tmp_config = copy.deepcopy(config)
-
-        sy.loadData(tmp_config)
-
-        xpath = self.convert_path_to_xpath(path, config, sy)
-
-        leaf_xpaths = self._get_inner_leaf_xpaths(xpath, sy)
+        if not isinstance(path, list):
+            path = [path]
 
         ref_xpaths = []
-        for xpath in leaf_xpaths:
-            ref_xpaths.extend(sy.find_data_dependencies(xpath))
+        for inner_path in path:
+            xpath = self.convert_path_to_xpath(inner_path, config, sy)
+            leaf_xpaths = self._get_inner_leaf_xpaths(xpath, sy)
+            for leaf_xpath in leaf_xpaths:
+                ref_xpaths.extend(sy.find_data_dependencies(leaf_xpath))
 
         ref_paths = []
         ref_paths_set = set()

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -616,7 +616,8 @@ class RemoveCreateOnlyDependencyMoveValidator:
 
             simulated_config = move.apply(current_config) # Config after applying just this move
 
-            for member_name in current_members:
+            for member_name in self.path_addressing.configdb_sorted_keys_by_backlinks(
+                    f"/{table_to_check}", current_members, reverse=False, configdb_relative=True):
                 if member_name not in target_members:
                     continue
 
@@ -850,12 +851,12 @@ class NoDependencyMoveValidator:
         simulated_config = move.apply(diff.current_config)
         deleted_paths, added_paths = self._get_paths(diff.current_config, simulated_config, [])
 
-        # For deleted paths, we check the current config has no dependencies between nodes under the removed path
-        if not self._validate_paths_config(deleted_paths, diff.current_config):
-            return False
-
         # For added paths, we check the simulated config has no dependencies between nodes under the added path
         if not self._validate_paths_config(added_paths, simulated_config):
+            return False
+
+        # For deleted paths, we check the current config has no dependencies between nodes under the removed path
+        if not self._validate_paths_config(deleted_paths, diff.current_config):
             return False
 
         return True
@@ -935,10 +936,7 @@ class NoDependencyMoveValidator:
         return True
 
     def _find_ref_paths(self, paths, config):
-        refs = []
-        for path in paths:
-            refs.extend(self.path_addressing.find_ref_paths(path, config))
-        return refs
+        return self.path_addressing.find_ref_paths(paths, config)
 
 class NoEmptyTableMoveValidator:
     """
@@ -1041,19 +1039,59 @@ class TableLevelMoveGenerator:
     if they are in target but not current configs.
     """
 
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
     def generate(self, diff):
         # Removing tables in current but not target
-        for tokens in self._get_non_existing_tables_tokens(diff.current_config, diff.target_config):
+        for tokens in self._get_non_existing_tables_tokens(diff.current_config, diff.target_config, reverse=False):
             yield JsonMove(diff, OperationType.REMOVE, tokens)
 
         # Adding tables in target but not current
-        for tokens in self._get_non_existing_tables_tokens(diff.target_config, diff.current_config):
+        for tokens in self._get_non_existing_tables_tokens(diff.target_config, diff.current_config, reverse=True):
             yield JsonMove(diff, OperationType.ADD, tokens, tokens)
 
-    def _get_non_existing_tables_tokens(self, config1, config2):
-        for table in config1:
+    def _get_non_existing_tables_tokens(self, config1, config2, reverse):
+        for table in self.path_addressing.configdb_sorted_keys_by_backlinks("/", config1, reverse=reverse):
             if not(table in config2):
                 yield [table]
+
+class BulkLeafListMoveGenerator:
+    """
+    A class that generates bulk REPLACE moves for leaf-lists (lists of primitive
+    values) that differ between current and target configs.
+    """
+    def generate(self, diff):
+        for move in self._traverse(diff, diff.current_config, diff.target_config, []):
+            yield move
+
+    def _traverse(self, diff, current_ptr, target_ptr, tokens):
+        if not isinstance(current_ptr, dict) or not isinstance(target_ptr, dict):
+            return
+
+        for key in current_ptr:
+            if key not in target_ptr:
+                continue
+
+            current_val = current_ptr[key]
+            target_val = target_ptr[key]
+            tokens.append(key)
+
+            if isinstance(current_val, list) and isinstance(target_val, list):
+                if (current_val != target_val and
+                        target_val and
+                        self._is_leaf_list(current_val) and
+                        self._is_leaf_list(target_val)):
+                    yield JsonMove(diff, OperationType.REPLACE, list(tokens), list(tokens))
+            elif isinstance(current_val, dict) and isinstance(target_val, dict):
+                for move in self._traverse(diff, current_val, target_val, tokens):
+                    yield move
+
+            tokens.pop()
+
+    @staticmethod
+    def _is_leaf_list(lst):
+        return all(isinstance(item, (str, int, float, bool)) for item in lst)
 
 class KeyLevelMoveGenerator:
     """
@@ -1070,9 +1108,12 @@ class KeyLevelMoveGenerator:
     This class will generate moves to remove keys if they are in current, but not target. It also add keys
     if they are in target but not current configs.
     """
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
     def generate(self, diff):
         # Removing keys in current but not target
-        for tokens in self._get_non_existing_keys_tokens(diff.current_config, diff.target_config):
+        for tokens in self._get_non_existing_keys_tokens(diff.current_config, diff.target_config, reverse=False):
             table = tokens[0]
             # if table has a single key, delete the whole table because empty tables are not allowed in ConfigDB
             if len(diff.current_config[table]) == 1:
@@ -1081,12 +1122,12 @@ class KeyLevelMoveGenerator:
                 yield JsonMove(diff, OperationType.REMOVE, tokens)
 
         # Adding keys in target but not current
-        for tokens in self._get_non_existing_keys_tokens(diff.target_config, diff.current_config):
+        for tokens in self._get_non_existing_keys_tokens(diff.target_config, diff.current_config, reverse=True):
             yield JsonMove(diff, OperationType.ADD, tokens, tokens)
 
-    def _get_non_existing_keys_tokens(self, config1, config2):
-        for table in config1:
-            for key in config1[table]:
+    def _get_non_existing_keys_tokens(self, config1, config2, reverse):
+        for table in self.path_addressing.configdb_sorted_keys_by_backlinks("/", config1, reverse=reverse):
+            for key in self.path_addressing.configdb_sorted_keys_by_backlinks("/" + table, config1, reverse=reverse):
                 if not(table in config2) or not (key in config2[table]):
                     yield [table, key]
 
@@ -1194,7 +1235,10 @@ class SingleRunLowLevelMoveGenerator:
             return
 
         if isinstance(current_ptr, dict) or isinstance(target_ptr, dict):
-            for key in current_ptr:
+            current_path = self.path_addressing.create_path(current_tokens)
+            target_path = self.path_addressing.create_path(target_tokens)
+
+            for key in self._sorted_keys(current_path, current_ptr, reverse=False):
                 current_tokens.append(key)
                 if key in target_ptr:
                     target_tokens.append(key)
@@ -1207,7 +1251,7 @@ class SingleRunLowLevelMoveGenerator:
 
                 current_tokens.pop()
 
-            for key in target_ptr:
+            for key in self._sorted_keys(target_path, target_ptr, reverse=True):
                 if key in current_ptr:
                     continue # Already tried in the previous loop
 
@@ -1289,7 +1333,7 @@ class SingleRunLowLevelMoveGenerator:
                 yield JsonMove(self.diff, OperationType.REMOVE, current_tokens)
                 return
 
-            for key in ptr:
+            for key in self._sorted_keys(self.path_addressing.create_path(current_tokens), ptr, reverse=False):
                 current_tokens.append(key)
                 for move in self._traverse_current(ptr[key], current_tokens):
                     yield move
@@ -1326,7 +1370,7 @@ class SingleRunLowLevelMoveGenerator:
                 yield JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens)
                 return
 
-            for key in ptr:
+            for key in self._sorted_keys(self.path_addressing.create_path(target_tokens), ptr, reverse=True):
                 current_tokens.append(key)
                 target_tokens.append(key)
                 for move in self._traverse_target(ptr[key], current_tokens, target_tokens):
@@ -1368,6 +1412,14 @@ class SingleRunLowLevelMoveGenerator:
             counts[item] = counts.get(item, 0) + 1
 
         return counts
+
+    def _sorted_keys(self, path, ptr, reverse):
+        try:
+            return self.path_addressing.configdb_sorted_keys_by_backlinks(
+                path, ptr, reverse=reverse, configdb_relative=True
+            )
+        except Exception:
+            return list(ptr.keys())
 
 class RequiredValueMoveExtender:
     """
@@ -1639,7 +1691,8 @@ class SortAlgorithmFactory:
         move_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
                            LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
-        move_non_extendable_generators = [KeyLevelMoveGenerator()]
+        move_non_extendable_generators = [BulkLeafListMoveGenerator(),
+                                          KeyLevelMoveGenerator(self.path_addressing)]
         move_extenders = [RequiredValueMoveExtender(self.path_addressing, self.operation_wrapper),
                           UpperLevelMoveExtender(),
                           DeleteInsteadOfReplaceMoveExtender(),

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2118,6 +2118,33 @@ class TestTableLevelMoveGenerator(unittest.TestCase):
         moves_ops = [list(move.patch)[0] for move in moves]
         self.assertCountEqual(ops, moves_ops)
 
+class TestBulkLeafListMoveGenerator(unittest.TestCase):
+    def setUp(self):
+        self.generator = ps.BulkLeafListMoveGenerator()
+
+    def test_generate__empty_target_leaf_list__no_bulk_move(self):
+        diff = ps.Diff(
+            current_config={"VLAN": {"Vlan1000": {"dhcp_servers": ["192.0.0.1"]}}},
+            target_config={"VLAN": {"Vlan1000": {"dhcp_servers": []}}},
+        )
+
+        moves = list(self.generator.generate(diff))
+
+        self.assertEqual([], moves)
+
+    def test_generate__different_non_empty_leaf_list__bulk_replace_move(self):
+        diff = ps.Diff(
+            current_config={"VLAN": {"Vlan1000": {"dhcp_servers": ["192.0.0.1"]}}},
+            target_config={"VLAN": {"Vlan1000": {"dhcp_servers": ["192.0.0.2"]}}},
+        )
+
+        moves = list(self.generator.generate(diff))
+
+        self.assertEqual(
+            [{"op": "replace", "path": "/VLAN/Vlan1000/dhcp_servers", "value": ["192.0.0.2"]}],
+            [list(move.patch)[0] for move in moves],
+        )
+
 class TestKeyLevelMoveGenerator(unittest.TestCase):
     def setUp(self):
         self.generator = ps.KeyLevelMoveGenerator()
@@ -3371,6 +3398,39 @@ class TestPatchSorter(unittest.TestCase):
 
             if notfound_substrings:
                 self.fail(f"Did not find the substrings {notfound_substrings} in the error: '{error}'")
+
+    def test_patch_sorter__remove_last_bgp_allowed_prefix__does_not_replace_with_empty_list(self):
+        current_config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "deployment": "DEPLOYMENT_ID",
+                    "id": 0,
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc00:f0::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch([
+            {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+        ])
+        sorter = self.create_patch_sorter(current_config)
+
+        actual_changes = sorter.sort(patch)
+        expected_changes = [
+            JsonChange(jsonpatch.JsonPatch([
+                {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+            ]))
+        ]
+
+        self.assertEqual(expected_changes, actual_changes)
+
+        target_config = patch.apply(current_config)
+        simulated_config = current_config
+        for change in actual_changes:
+            simulated_config = change.apply(simulated_config)
+            is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
+            self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
+        self.assertEqual(target_config, simulated_config)
 
     def test_sort__does_not_remove_tables_without_yang_unintentionally_if_generated_change_replaces_whole_config(self):
         # Arrange


### PR DESCRIPTION
## Summary
Prevent BulkLeafListMoveGenerator from emitting a bulk `REPLACE ... []` for empty target leaf-lists, which could serialize to `""` in CONFIG_DB.

## Regression coverage
- Added a unit test to ensure empty target leaf-lists do not produce a bulk move.
- Added a sorter regression for removing the last BGP allowed prefix and verifying the patch sorts to a remove-only flow.
- Kept the non-empty leaf-list bulk-replace path covered.

## Tracking
- Fixes sonic-buildimage issue #27818