### PR TITLE
Fix empty leaf-list regression in GCU sorter

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1055,6 +1055,42 @@ class TableLevelMoveGenerator:
             if not(table in config2):
                 yield [table]
 
+class BulkLeafListMoveGenerator:
+    """
+    Generate a single bulk replace for leaf-lists when the target list is not empty.
+    Empty target leaf-lists are left to the existing granular path so they are
+    removed rather than rewritten as [].
+    """
+    def generate(self, diff):
+        for move in self._traverse(diff.current_config, diff.target_config, diff, []):
+            yield move
+
+    def _traverse(self, current_ptr, target_ptr, diff, tokens):
+        if not isinstance(current_ptr, dict) or not isinstance(target_ptr, dict):
+            return
+
+        for key in current_ptr:
+            if key not in target_ptr:
+                continue
+
+            current_val = current_ptr[key]
+            target_val = target_ptr[key]
+            tokens.append(key)
+
+            if isinstance(current_val, list) and isinstance(target_val, list):
+                if (current_val != target_val and target_val and
+                        self._is_leaf_list(current_val) and self._is_leaf_list(target_val)):
+                    yield JsonMove(diff, OperationType.REPLACE, list(tokens), list(tokens))
+            elif isinstance(current_val, dict) and isinstance(target_val, dict):
+                for move in self._traverse(current_val, target_val, diff, tokens):
+                    yield move
+
+            tokens.pop()
+
+    @staticmethod
+    def _is_leaf_list(lst):
+        return all(isinstance(item, (str, int, float, bool)) for item in lst)
+
 class KeyLevelMoveGenerator:
     """
     A class that key level moves. The item name at the root level of ConfigDB is called 'Table', the item
@@ -1639,7 +1675,8 @@ class SortAlgorithmFactory:
         move_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
                            LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
-        move_non_extendable_generators = [KeyLevelMoveGenerator()]
+        move_non_extendable_generators = [BulkLeafListMoveGenerator(),
+                                          KeyLevelMoveGenerator()]
         move_extenders = [RequiredValueMoveExtender(self.path_addressing, self.operation_wrapper),
                           UpperLevelMoveExtender(),
                           DeleteInsteadOfReplaceMoveExtender(),

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2118,6 +2118,33 @@ class TestTableLevelMoveGenerator(unittest.TestCase):
         moves_ops = [list(move.patch)[0] for move in moves]
         self.assertCountEqual(ops, moves_ops)
 
+class TestBulkLeafListMoveGenerator(unittest.TestCase):
+    def setUp(self):
+        self.generator = ps.BulkLeafListMoveGenerator()
+
+    def test_generate__empty_target_leaf_list__no_bulk_move(self):
+        diff = ps.Diff(
+            current_config={"VLAN": {"Vlan1000": {"dhcp_servers": ["192.0.0.1"]}}},
+            target_config={"VLAN": {"Vlan1000": {"dhcp_servers": []}}},
+        )
+
+        moves = list(self.generator.generate(diff))
+
+        self.assertEqual([], moves)
+
+    def test_generate__different_non_empty_leaf_list__bulk_replace_move(self):
+        diff = ps.Diff(
+            current_config={"VLAN": {"Vlan1000": {"dhcp_servers": ["192.0.0.1"]}}},
+            target_config={"VLAN": {"Vlan1000": {"dhcp_servers": ["192.0.0.2"]}}},
+        )
+
+        moves = list(self.generator.generate(diff))
+
+        self.assertEqual(
+            [{"op": "replace", "path": "/VLAN/Vlan1000/dhcp_servers", "value": ["192.0.0.2"]}],
+            [list(move.patch)[0] for move in moves],
+        )
+
 class TestKeyLevelMoveGenerator(unittest.TestCase):
     def setUp(self):
         self.generator = ps.KeyLevelMoveGenerator()
@@ -3371,6 +3398,39 @@ class TestPatchSorter(unittest.TestCase):
 
             if notfound_substrings:
                 self.fail(f"Did not find the substrings {notfound_substrings} in the error: '{error}'")
+
+    def test_patch_sorter__remove_last_bgp_allowed_prefix__does_not_replace_with_empty_list(self):
+        current_config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "deployment": "DEPLOYMENT_ID",
+                    "id": 0,
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc00:f0::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch([
+            {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+        ])
+        sorter = self.create_patch_sorter(current_config)
+
+        actual_changes = sorter.sort(patch)
+        expected_changes = [
+            JsonChange(jsonpatch.JsonPatch([
+                {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+            ]))
+        ]
+
+        self.assertEqual(expected_changes, actual_changes)
+
+        target_config = patch.apply(current_config)
+        simulated_config = current_config
+        for change in actual_changes:
+            simulated_config = change.apply(simulated_config)
+            is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
+            self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
+        self.assertEqual(target_config, simulated_config)
 
     def test_sort__does_not_remove_tables_without_yang_unintentionally_if_generated_change_replaces_whole_config(self):
         # Arrange


### PR DESCRIPTION
## Summary
Prevent BulkLeafListMoveGenerator from emitting a bulk `REPLACE ... []` for empty target leaf-lists, which could serialize to `""` in CONFIG_DB.

## Regression coverage
- Added a unit test to ensure empty target leaf-lists do not produce a bulk move.
- Added a sorter regression for removing the last BGP allowed prefix and verifying the patch sorts to a remove-only flow.
- Kept the non-empty leaf-list bulk-replace path covered.

## Tracking
- Fixes sonic-buildimage issue #27818