### PR TITLE
Fix empty leaf-list regression in GCU sorter

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1355,6 +1355,7 @@ class BulkLeafListMoveGenerator:
             if isinstance(current_val, list) and isinstance(target_val, list):
                 # Only handle leaf-lists (lists of scalars)
                 if (current_val != target_val and
+                        target_val and
                         self._is_leaf_list(current_val) and
                         self._is_leaf_list(target_val)):
                     yield JsonMoveGroup(

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2494,11 +2494,11 @@ class TestBulkLeafListMoveGenerator(unittest.TestCase):
             ex_ops=[])
 
     def test_generate__leaf_list_all_items_removed__single_replace_move(self):
-        """Removing all items from a leaf-list should produce one REPLACE with empty list."""
+        """Removing all items from a leaf-list should not bulk-replace with an empty list."""
         self.verify(
             current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
             target={"ACL_TABLE": {"EVERFLOW": {"ports": [], "type": "MIRROR"}}},
-            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports", "value": []}])
+            ex_ops=[])
 
     def test_generate__multiple_tables_with_leaf_lists__multiple_moves(self):
         """Multiple differing leaf-lists should each get a REPLACE move."""
@@ -3728,6 +3728,39 @@ class TestPatchSorter(unittest.TestCase):
 
             if notfound_substrings:
                 self.fail(f"Did not find the substrings {notfound_substrings} in the error: '{error}'")
+
+    def test_patch_sorter__remove_last_bgp_allowed_prefix__does_not_replace_with_empty_list(self):
+        current_config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "deployment": "DEPLOYMENT_ID",
+                    "id": 0,
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc00:f0::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch([
+            {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+        ])
+        sorter = self.create_patch_sorter(current_config)
+
+        actual_changes = sorter.sort(patch)
+        expected_changes = [
+            JsonChange(jsonpatch.JsonPatch([
+                {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+            ]))
+        ]
+
+        self.assertEqual(expected_changes, actual_changes)
+
+        target_config = patch.apply(current_config)
+        simulated_config = current_config
+        for change in actual_changes:
+            simulated_config = change.apply(simulated_config)
+            is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
+            self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
+        self.assertEqual(target_config, simulated_config)
 
     def test_sort__does_not_remove_tables_without_yang_unintentionally_if_generated_change_replaces_whole_config(self):
         # Arrange


### PR DESCRIPTION
## Summary
Prevent BulkLeafListMoveGenerator from emitting a bulk `REPLACE ... []` for empty target leaf-lists, which could serialize to `""` in CONFIG_DB.

## Regression coverage
- Added a unit test to ensure empty target leaf-lists do not produce a bulk move.
- Added a sorter regression for removing the last BGP allowed prefix and verifying the patch sorts to a remove-only flow.
- Kept the non-empty leaf-list bulk-replace path covered.

## Tracking
- Fixes sonic-buildimage issue #27818