### PR TITLE
Preserve IPv6 connected routes during fast-reboot

### DIFF
--- a/scripts/fast-reboot-filter-routes.py
+++ b/scripts/fast-reboot-filter-routes.py
@@ -21,6 +21,14 @@ def get_connected_routes():
         for route in route_info.keys():
             connected_routes.append(route)
 
+    cmd = ['sudo', 'vtysh', '-c', "show ipv6 route connected json"]
+    output, ret = clicommon.run_command(cmd, return_cmd=True)
+    if ret != 0:
+        raise RuntimeError("Failed to execute {}: {}".format(" ".join(cmd), output.rstrip('\n')))
+    if output is not None:
+        route_info = json.loads(output)
+        connected_routes.extend(route_info)
+
     return connected_routes
 
 def get_route(db, route):

--- a/scripts/fast-reboot-filter-routes.py
+++ b/scripts/fast-reboot-filter-routes.py
@@ -16,9 +16,11 @@ ROUTE_IDX = 1
 def get_connected_routes(namespace):
     if namespace:
         ns_name = multi_asic.get_asic_id_from_name(namespace)
-        cmd = ['sudo', 'vtysh', '-n', ns_name, '-c', "show ip route connected json"]
+        vtysh_cmd = ['sudo', 'vtysh', '-n', ns_name]
     else:
-        cmd = ['sudo', 'vtysh', '-c', "show ip route connected json"]
+        vtysh_cmd = ['sudo', 'vtysh']
+
+    cmd = vtysh_cmd + ['-c', "show ip route connected json"]
     connected_routes = []
     output, ret = clicommon.run_command(cmd, return_cmd=True)
     if ret != 0:
@@ -27,6 +29,14 @@ def get_connected_routes(namespace):
         route_info = json.loads(output)
         for route in route_info.keys():
             connected_routes.append(route)
+
+    cmd = vtysh_cmd + ['-c', "show ipv6 route connected json"]
+    output, ret = clicommon.run_command(cmd, return_cmd=True)
+    if ret != 0:
+        raise RuntimeError("Failed to execute {}: {}".format(" ".join(cmd), output.rstrip('\n')))
+    if output is not None:
+        route_info = json.loads(output)
+        connected_routes.extend(route_info)
 
     return connected_routes
 

--- a/tests/fast_reboot_filter_routes_test.py
+++ b/tests/fast_reboot_filter_routes_test.py
@@ -10,10 +10,13 @@ class TestFastRebootFilterRoutes(object):
 
     @patch('utilities_common.cli.run_command')
     def test_get_connected_routes(self, mock_run_command):
-        mock_run_command.return_value = ('{"1.1.0.0/16": {}}', 0)
+        mock_run_command.side_effect = [('{"1.1.0.0/16": {}}', 0), ('{"2001:db8:1::/64": {}}', 0)]
         output = fast_reboot_filter_routes.get_connected_routes()
-        mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', "show ip route connected json"], return_cmd=True)
-        assert output == ['1.1.0.0/16']
+        mock_run_command.assert_has_calls([
+            mock.call(['sudo', 'vtysh', '-c', "show ip route connected json"], return_cmd=True),
+            mock.call(['sudo', 'vtysh', '-c', "show ipv6 route connected json"], return_cmd=True)
+        ])
+        assert output == ['1.1.0.0/16', '2001:db8:1::/64']
 
     @patch('utilities_common.cli.run_command')
     def test_get_connected_routes_command_failed(self, mock_run_command):
@@ -21,6 +24,13 @@ class TestFastRebootFilterRoutes(object):
         with pytest.raises(Exception):
             fast_reboot_filter_routes.get_connected_routes()
         mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', "show ip route connected json"], return_cmd=True)
+
+    @patch('utilities_common.cli.run_command')
+    def test_get_connected_routes_ipv6_command_failed(self, mock_run_command):
+        mock_run_command.side_effect = [('{"1.1.0.0/16": {}}', 0), ('', 1)]
+        with pytest.raises(Exception):
+            fast_reboot_filter_routes.get_connected_routes()
+        mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', "show ipv6 route connected json"], return_cmd=True)
 
     def teardown_method(self):
         print("TEAR DOWN")

--- a/tests/fast_reboot_filter_routes_test.py
+++ b/tests/fast_reboot_filter_routes_test.py
@@ -11,10 +11,13 @@ class TestFastRebootFilterRoutes(object):
 
     @patch('utilities_common.cli.run_command')
     def test_get_connected_routes(self, mock_run_command):
-        mock_run_command.return_value = ('{"1.1.0.0/16": {}}', 0)
+        mock_run_command.side_effect = [('{"1.1.0.0/16": {}}', 0), ('{"2001:db8:1::/64": {}}', 0)]
         output = fast_reboot_filter_routes.get_connected_routes(namespace="")
-        mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', "show ip route connected json"], return_cmd=True)
-        assert output == ['1.1.0.0/16']
+        mock_run_command.assert_has_calls([
+            mock.call(['sudo', 'vtysh', '-c', "show ip route connected json"], return_cmd=True),
+            mock.call(['sudo', 'vtysh', '-c', "show ipv6 route connected json"], return_cmd=True)
+        ])
+        assert output == ['1.1.0.0/16', '2001:db8:1::/64']
 
     @patch('utilities_common.cli.run_command')
     def test_get_connected_routes_command_failed(self, mock_run_command):
@@ -25,18 +28,28 @@ class TestFastRebootFilterRoutes(object):
 
     @patch('utilities_common.cli.run_command')
     def test_get_connected_routes_for_namespace(self, mock_run_command):
-        mock_run_command.return_value = ('{"2.2.0.0/16": {}}', 0)
+        mock_run_command.side_effect = [('{"2.2.0.0/16": {}}', 0), ('{"2001:db8:2::/64": {}}', 0)]
         with mock.patch.object(fast_reboot_filter_routes.multi_asic,
                                'get_asic_id_from_name',
                                return_value='0') as mock_get_asic_id:
             output = fast_reboot_filter_routes.get_connected_routes(namespace="asic0")
 
         mock_get_asic_id.assert_called_once_with("asic0")
-        mock_run_command.assert_called_with(
-            ['sudo', 'vtysh', '-n', '0', '-c', "show ip route connected json"],
-            return_cmd=True
-        )
-        assert output == ['2.2.0.0/16']
+        mock_run_command.assert_has_calls([
+            mock.call(['sudo', 'vtysh', '-n', '0', '-c', "show ip route connected json"],
+                      return_cmd=True),
+            mock.call(['sudo', 'vtysh', '-n', '0', '-c', "show ipv6 route connected json"],
+                      return_cmd=True)
+        ])
+        assert output == ['2.2.0.0/16', '2001:db8:2::/64']
+
+    @patch('utilities_common.cli.run_command')
+    def test_get_connected_routes_ipv6_command_failed(self, mock_run_command):
+        mock_run_command.side_effect = [('{"1.1.0.0/16": {}}', 0), ('', 1)]
+        with pytest.raises(Exception):
+            fast_reboot_filter_routes.get_connected_routes(namespace="")
+        mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', "show ipv6 route connected json"],
+                                            return_cmd=True)
 
     @patch('utilities_common.cli.run_command')
     def test_get_connected_routes_with_empty_output(self, mock_run_command):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Preserved IPv6 connected routes during fast reboot, matching the existing behavior for IPv4 connected routes.
This prevents IPv6 connected routes from being removed from APP_DB and delayed until fpmsyncd reconciliation.

Fixes this issue - [Bug: [fast-reboot] IPv6 connected routes are not preserved during fast-reboot and remain unavailable until route reconciliation](https://github.com/sonic-net/sonic-buildimage/issues/28603)

#### How I did it
Updated `fast-reboot-filter-routes.py` to collect connected routes from both address families:

1. show ip route connected json
2. show ipv6 route connected json

#### How to verify it

1. Configure IPv6 addresses on routed interfaces.
2. Confirm the connected routes exist:
    show ipv6 route connected
3. Run fast reboot with continuous IPv6 traffic.
4. Verify:
- IPv6 connected routes remain preserved in APP_DB.
- fpmsyncd does not report them as introducing new entry after the 120-second timer.
- Traffic loss remains within the fast-reboot limit.
- Existing IPv4 route-preservation behavior is unchanged.