### PR TITLE
[generic_config_updater]: Fix emptying a leaf-list writing an invalid value to CONFIG_DB

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -114,7 +114,7 @@ class PatchApplier:
 
         # Generate target config
         self.logger.log_notice(f"{scope}: simulating the target full config after applying the patch.")
-        target_config = self.patch_wrapper.simulate_patch(patch, old_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, old_config)
 
         # Validate all JsonPatch operations on specified fields
         self.logger.log_notice(f"{scope}: validating all JsonPatch operations are permitted on the specified fields")

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -405,6 +405,36 @@ class DryRunConfigWrapper(ConfigWrapper):
             self.imitated_config_db = super().get_config_db_as_json()
 
 
+def remove_empty_leaf_lists(config):
+    """Drop leaf-list fields whose value is an empty list.
+
+    Expects ConfigDB shaped json, i.e. table -> key -> field. At that shape a
+    list valued field is always a leaf-list, so every empty list found here is
+    an empty leaf-list. Do not call this with SonicYang shaped json, where a
+    list is a yang list of entries rather than a leaf-list.
+
+    ConfigDB has no representation for an empty leaf-list. set_entry serializes
+    [] to an empty string, which is then read back as [''], so a config that asks
+    for [] can never be satisfied. The canonical way to express "this leaf-list
+    has no items" is for the field to be absent.
+
+    Normalizing the simulated target keeps the patch sorter, the change applier
+    and the final verification in agreement: the sorter emits a field-level
+    remove instead of a replace-with-empty-list that ConfigDB cannot store.
+    """
+    for entries in config.values():
+        if not isinstance(entries, dict):
+            continue
+        for fields in entries.values():
+            if not isinstance(fields, dict):
+                continue
+            empty_leaf_lists = [field for field, value in fields.items()
+                                if isinstance(value, list) and len(value) == 0]
+            for field in empty_leaf_lists:
+                del fields[field]
+    return config
+
+
 class PatchWrapper:
     def __init__(self, config_wrapper=None, scope=multi_asic.DEFAULT_NAMESPACE):
         self.scope = scope
@@ -438,12 +468,21 @@ class PatchWrapper:
     def simulate_patch(self, patch, jsonconfig):
         return patch.apply(jsonconfig)
 
+    def simulate_config_db_patch(self, patch, config_db):
+        """Simulate a patch against ConfigDB shaped json.
+
+        Use this instead of simulate_patch whenever the result is meant to be a
+        ConfigDB target, so that empty leaf-lists are normalized to absent
+        fields, which is the only way ConfigDB can express them.
+        """
+        return remove_empty_leaf_lists(self.simulate_patch(patch, config_db))
+
     def convert_config_db_patch_to_sonic_yang_patch(self, patch):
         if not(self.validate_config_db_patch_has_yang_models(patch)):
             raise ValueError(f"Given patch is not valid")
 
         current_config_db = self.config_wrapper.get_config_db_as_json()
-        target_config_db = self.simulate_patch(patch, current_config_db)
+        target_config_db = self.simulate_config_db_patch(patch, current_config_db)
 
         current_yang = self.config_wrapper.convert_config_db_to_sonic_yang(current_config_db)
         target_yang = self.config_wrapper.convert_config_db_to_sonic_yang(target_config_db)

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1354,7 +1354,12 @@ class BulkLeafListMoveGenerator:
 
             if isinstance(current_val, list) and isinstance(target_val, list):
                 # Only handle leaf-lists (lists of scalars)
+                # An empty target leaf-list is deliberately excluded: a bulk
+                # REPLACE with [] serializes to an empty string in CONFIG_DB,
+                # which is an invalid state. Those transitions are left to the
+                # granular removal generators, which remove the field instead.
                 if (current_val != target_val and
+                        len(target_val) > 0 and
                         self._is_leaf_list(current_val) and
                         self._is_leaf_list(target_val)):
                     yield JsonMoveGroup(
@@ -2406,7 +2411,7 @@ class StrictPatchSorter:
         if not(self.patch_wrapper.validate_config_db_patch_has_yang_models(patch)):
             raise ValueError(f"Given patch is not valid because it has changes to tables without YANG models")
 
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         # Validate target config
         self.logger.log_info("Validating target config according to YANG models.")
@@ -2596,7 +2601,7 @@ class NonStrictPatchSorter:
 
     def sort(self, patch, algorithm=Algorithm.DFS, trace_io: Optional[IO] = None):
         current_config = self.config_wrapper.get_config_db_as_json()
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         # Splitting current/target config based on YANG covered vs non-YANG covered configs
         self.logger.log_info("Splitting current/target config based on YANG covered vs non-YANG covered configs.")
@@ -2658,7 +2663,7 @@ class PatchSorter:
 
     def sort(self, patch, algorithm=Algorithm.DFS, preloaded_current_config=None, trace_io: Optional[IO] = None):
         current_config = preloaded_current_config if preloaded_current_config else self.config_wrapper.get_config_db_as_json()
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         diff = Diff(copy.deepcopy(current_config), target_config)
 

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -40,7 +40,7 @@ class TestPatchApplier(unittest.TestCase):
 
         # Assert
         patch_applier.config_wrapper.get_config_db_as_json.assert_has_calls([call(), call()])
-        patch_applier.patch_wrapper.simulate_patch.assert_has_calls(
+        patch_applier.patch_wrapper.simulate_config_db_patch.assert_has_calls(
             [call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, Files.CONFIG_DB_AS_JSON)])
         patch_applier.patchsorter.sort.assert_has_calls([call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, trace_io=None)])
         patch_applier.changeapplier.apply.assert_called()
@@ -59,7 +59,7 @@ class TestPatchApplier(unittest.TestCase):
             create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): empty_tables})
 
         patch_wrapper = Mock()
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(Files.MULTI_OPERATION_CONFIG_DB_PATCH), str(Files.CONFIG_DB_AS_JSON)):
                     Files.CONFIG_DB_AFTER_MULTI_PATCH})

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -658,6 +658,64 @@ class TestPatchWrapper(unittest.TestCase):
         # Assert
         self.assertDictEqual(expected, actual)
 
+    def test_simulate_config_db_patch__empties_leaf_list__field_is_dropped(self):
+        # Arrange
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc01:20::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}])
+        # ConfigDB cannot store an empty leaf-list, the field has to be absent
+        expected = {"BGP_ALLOWED_PREFIXES": {"DEPLOYMENT_ID|0": {"prefixes_v6": ["fc01:20::/64"]}}}
+
+        # Act
+        actual = patch_wrapper.simulate_config_db_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
+    def test_simulate_config_db_patch__leaf_list_still_has_items__field_is_kept(self):
+        # Arrange
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "prefixes_v4": ["10.20.0.0/16", "10.30.0.0/16"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}])
+        expected = {"BGP_ALLOWED_PREFIXES": {"DEPLOYMENT_ID|0": {"prefixes_v4": ["10.30.0.0/16"]}}}
+
+        # Act
+        actual = patch_wrapper.simulate_config_db_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
+    def test_simulate_patch__sonic_yang_config__empty_yang_list_is_kept(self):
+        # Arrange
+        # simulate_patch must stay shape agnostic. In SonicYang json a list holds yang list
+        # entries, not leaf-list items, so it must not be treated as an empty leaf-list.
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {"sonic-vlan:sonic-vlan": {"VLAN": {"VLAN_LIST": [{"name": "Vlan1000"}]}}}
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST/0"}])
+        expected = {"sonic-vlan:sonic-vlan": {"VLAN": {"VLAN_LIST": []}}}
+
+        # Act
+        actual = patch_wrapper.simulate_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
     def test_generate_patch__diff__non_empty_patch(self):
         # Arrange
         patch_wrapper = gu_common.PatchWrapper()

--- a/tests/generic_config_updater/multiasic_generic_updater_test.py
+++ b/tests/generic_config_updater/multiasic_generic_updater_test.py
@@ -16,7 +16,7 @@ class TestMultiAsicPatchApplier(unittest.TestCase):
 
     @patch('generic_config_updater.gu_common.ConfigWrapper.get_empty_tables', return_value=[])
     @patch('generic_config_updater.gu_common.ConfigWrapper.get_config_db_as_json')
-    @patch('generic_config_updater.gu_common.PatchWrapper.simulate_patch')
+    @patch('generic_config_updater.gu_common.PatchWrapper.simulate_config_db_patch')
     @patch('generic_config_updater.generic_updater.ChangeApplier')
     def test_apply_patch_specific_namespace(self, mock_ChangeApplier, mock_simulate_patch, mock_get_config, mock_get_empty_tables):
         scope = "asic0"

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2493,12 +2493,12 @@ class TestBulkLeafListMoveGenerator(unittest.TestCase):
             target={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR", "ports": ["Ethernet0"]}}},
             ex_ops=[])
 
-    def test_generate__leaf_list_all_items_removed__single_replace_move(self):
-        """Removing all items from a leaf-list should produce one REPLACE with empty list."""
+    def test_generate__leaf_list_all_items_removed__no_bulk_replace_move(self):
+        """Removing all items from a leaf-list should not bulk-replace with an empty list."""
         self.verify(
             current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
             target={"ACL_TABLE": {"EVERFLOW": {"ports": [], "type": "MIRROR"}}},
-            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports", "value": []}])
+            ex_ops=[])
 
     def test_generate__multiple_tables_with_leaf_lists__multiple_moves(self):
         """Multiple differing leaf-lists should each get a REPLACE move."""
@@ -3729,6 +3729,42 @@ class TestPatchSorter(unittest.TestCase):
             if notfound_substrings:
                 self.fail(f"Did not find the substrings {notfound_substrings} in the error: '{error}'")
 
+    def test_patch_sorter__remove_last_bgp_allowed_prefix__removes_field_instead_of_emptying_it(self):
+        current_config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "deployment": "DEPLOYMENT_ID",
+                    "id": 0,
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc00:f0::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch([
+            {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+        ])
+        sorter = self.create_patch_sorter(current_config)
+
+        actual_changes = sorter.sort(patch)
+        # Removing the only item has to drop the whole field. ConfigDB cannot store an
+        # empty leaf-list, it would be written as "" and read back as [""].
+        expected_changes = [
+            JsonChange(jsonpatch.JsonPatch([
+                {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4"}
+            ]))
+        ]
+
+        self.assertEqual(expected_changes, actual_changes)
+
+        target_config = PatchWrapper().simulate_config_db_patch(patch, current_config)
+        self.assertNotIn("prefixes_v4", target_config["BGP_ALLOWED_PREFIXES"]["DEPLOYMENT_ID|0"])
+        simulated_config = current_config
+        for change in actual_changes:
+            simulated_config = change.apply(simulated_config)
+            is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
+            self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
+        self.assertEqual(target_config, simulated_config)
+
     def test_sort__does_not_remove_tables_without_yang_unintentionally_if_generated_change_replaces_whole_config(self):
         # Arrange
         current_config = Files.CONFIG_DB_AS_JSON # has a table without yang named 'TABLE_WITHOUT_YANG'
@@ -4002,7 +4038,7 @@ class TestNonStrictPatchSorter(unittest.TestCase):
         config_wrapper.get_config_db_as_json.side_effect = \
             [any_current_config]
 
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(patch), str(any_current_config)):
                     any_target_config})
@@ -4095,7 +4131,7 @@ class TestStrictPatchSorter(unittest.TestCase):
         config_wrapper.get_config_db_as_json.side_effect = \
             [any_current_config, any_target_config]
 
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(patch), str(any_current_config)):
                     any_target_config})


### PR DESCRIPTION
#### What I did

Fixes [sonic-net/sonic-buildimage#27818](https://github.com/sonic-net/sonic-buildimage/issues/27818).

Emptying a leaf-list through `config apply-patch` left an invalid value in CONFIG_DB and made the patch application fail. Removing the last item of `BGP_ALLOWED_PREFIXES|DEPLOYMENT_ID|0` `prefixes_v4` wrote `prefixes_v4@ = ""`, and the command reported `after applying patch to config, there are still some parts not updated`. Every later patch touching that field then failed YANG validation with `"" does not conform`.

#### How I did it

CONFIG_DB has no representation for an empty leaf-list. `set_entry` serializes `[]` to an empty string, which is read back as `[""]`, so a target config that asks for `[]` can never be satisfied and the final `verify_same_json` in `PatchApplier.apply` always mismatches. The canonical way to express "this leaf-list has no items" is for the field to be absent.

The target config is always derived through `PatchWrapper`, so a ConfigDB specific simulation entry point was added there, and empty leaf-lists are dropped in it:

```python
def simulate_config_db_patch(self, patch, config_db):
    return remove_empty_leaf_lists(self.simulate_patch(patch, config_db))
```

This is used everywhere the result is meant to be a ConfigDB target: `PatchApplier.apply`, all three sorters (`StrictPatchSorter.sort`, `NonStrictPatchSorter.sort`, `PatchSorter.sort`) and `convert_config_db_patch_to_sonic_yang_patch`. The sorter then produces a field level `remove` instead of a `replace` with an empty list, the change applier writes the entry without the field, and the readback matches the target.

`simulate_patch` itself stays shape agnostic, so the `--format SONICYANG` path is unaffected. In SonicYang json a list holds yang list entries rather than leaf-list items, so ConfigDB canonicalization must not be applied there.

The guard in `BulkLeafListMoveGenerator` is kept as defence in depth, so that generator never emits a bulk `replace` with an empty list.

> Note on scope: this only reproduces on images whose `sonic_yang` uses the libyang3 python bindings (`import libyang as ly`). That holds for master and for 202605, so both are affected. On branches still on libyang 1.0.73 (`import yang as ly`) the empty list is rejected during validation before the sorter runs, so the bad value never reaches CONFIG_DB.

#### How to verify it

Verified end to end on `docker-sonic-vs` built from master (`db028339e`) using the reproduction steps from the issue.

Before, step 2 emits a `replace` with an empty list, `apply-patch` fails, and CONFIG_DB is left corrupted:

```
=== STEP 2: remove the LAST prefixes_v4 item (empties the leaf-list) ===
apply-patch failed for localhost: localhost: after applying patch to config, there are still some parts not updated
Error: Failed to apply patch on the following scopes:
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier:   * [{"op": "replace", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4", "value": []}]

=== STEP 3: CONFIG_DB state ===
{'prefixes_v4@': '', 'prefixes_v6@': 'fc01:20::/64'}
```

After, step 2 emits a field level `remove`, the patch applies, and the field is gone:

```
=== STEP 2: remove the LAST prefixes_v4 item (empties the leaf-list) ===
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier:   * [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4"}]
Patch applied successfully.

=== STEP 3: CONFIG_DB state ===
{'prefixes_v6@': 'fc01:20::/64'}
```

Re-adding the leaf-list afterwards works, so the config is fully recoverable:

```
=== re-add via add ===
Patch applied successfully.
{'prefixes_v6@': 'fc01:20::/64', 'prefixes_v4@': '10.40.0.0/16'}
```

Edge case where the leaf-list is the only field in the entry also applies cleanly, the entry is kept as `NULL: NULL`, which is the normal ConfigDB representation of an entry with no fields.

Unit tests, run in the same container against `tests/generic_config_updater/`:

| | result |
| --- | --- |
| master baseline | 554 passed, 81 subtests passed |
| this PR | 558 passed, 81 subtests passed |

Five tests are added and one pre-existing test is updated, so the net delta is four.

The updated one is `test_generate__leaf_list_all_items_removed__single_replace_move` from #4478. It asserted that emptying a leaf-list produces a single bulk `replace` with an empty list, which is exactly the value CONFIG_DB cannot store, so that assertion has to be reversed. It is renamed to `test_generate__leaf_list_all_items_removed__no_bulk_replace_move` and now expects no bulk move, leaving the transition to the granular removal generators. The batching optimisation from #4478 is untouched for every non-empty leaf-list, which is still covered by `test_generate__leaf_list_items_removed__single_replace_move` and `test_generate__leaf_list_items_added__single_replace_move`.

#### Which release branch to backport

<!--
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
-->

- [x] 202605

Updated following @dgsudharsan's request. 202605 ships the libyang3 based `sonic_yang`, so it is affected and the fix is needed there. Reproduction and fix are both confirmed on a real 202605 image, see **Test result**.

The cherry-pick applies without conflict, but #4423 (`33c1c482`) should be picked first. It is a one line change to `_traverse_current_list` that 202605 never received, and without it the test added here fails. Details in **Test result**.

#### Tested branch (Please provide the tested image version)

- [x] master, `docker-sonic-vs` at `db028339e`
- [x] 202605, `docker-sonic-vs` at `0b2faef94`

#### Test result

master: PASS. `docker-sonic-vs` at `db028339e`. Issue reproduction end to end plus `tests/generic_config_updater/` at 558 passed against a 554 passed baseline, as described in **How to verify it**.

202605: PASS, with #4423 as a prerequisite.

Image is `docker-sonic-vs` built from 202605, reporting `branch: '202605'`, `commit_id: '0b2faef94'`. That image has `BulkLeafListMoveGenerator` from #4478 and the libyang3 binding (`sonic_yang.py:3:import libyang as ly`) and does not have this fix, so it is exposed.

Stock 202605, bug present:

```
=== STEP 2: remove the LAST prefixes_v4 item (empties the leaf-list) ===
apply-patch failed for localhost: localhost: after applying patch to config, there are still some parts not updated
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier:   * [{"op": "replace", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4", "value": []}]

=== STEP 3: CONFIG_DB state ===
{'prefixes_v4@': '', 'prefixes_v6@': 'fc01:20::/64'}
```

202605 with this PR cherry-picked, bug fixed:

```
=== STEP 2: remove the LAST prefixes_v4 item (empties the leaf-list) ===
Patch Applier: The localhost patch was converted into 2 changes:
Patch Applier:   * [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}]
Patch Applier:   * [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4"}]
Patch applied successfully.

=== STEP 3: CONFIG_DB state ===
{'prefixes_v6@': 'fc01:20::/64'}
```

CONFIG_DB ends correct, but the sorter takes two changes instead of one, because 202605 is missing #4423 which relaxed `_traverse_current_list` from `len(ptr) == 0` to `len(ptr) <= 1`. That difference is visible to the test added here, `test_patch_sorter__remove_last_bgp_allowed_prefix__removes_field_instead_of_emptying_it`, which asserts the single change form.

`tests/generic_config_updater/` run in the same 202605 container:

| 202605 tree | result |
| --- | --- |
| baseline, nothing picked | 549 passed, 81 subtests passed |
| this PR only | 552 passed, 81 subtests passed, 1 failed |
| #4423 + this PR | 553 passed, 81 subtests passed, 0 failed |

With #4423 picked first, 202605 matches master exactly, a single field level `remove`:

```
=== STEP 2: remove the LAST prefixes_v4 item (empties the leaf-list) ===
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier:   * [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4"}]
Patch applied successfully.

=== STEP 3: CONFIG_DB state ===
{'prefixes_v6@': 'fc01:20::/64'}
```

#4423 is already included in 202511 and has a cherry-pick PR created for msft-202601, but it was never taken to 202605, so picking it there is a gap fix in its own right. Both cherry-picks apply without conflict.

#### Description for the changelog

Fix `config apply-patch` leaving an invalid empty value in CONFIG_DB when a patch empties a leaf-list.


