### PR TITLE
Fix migrate_sonic_packages() resolv.conf injection for relative symlinks

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -387,13 +387,20 @@ def migrate_sonic_packages(bootloader, binary_image_version):
             # Inject host DNS into chroot for sonic-package-manager to resolve hostnames.
             chroot_resolv = os.path.join(new_image_mount, RESOLV_CONF_FILE)
             if os.path.islink(chroot_resolv):
-                # Symlink: populate the target inside the chroot so the symlink resolves.
-                # Cannot cp over the symlink because the absolute target path escapes
-                # the overlay mount to the host filesystem ("are the same file" error).
+                # Symlink: populate its target inside the chroot ("cp" over the link
+                # would write through it, outside the overlay mount).
                 resolv_target = os.readlink(chroot_resolv)
+                if not os.path.isabs(resolv_target):
+                    # Relative target resolves against the symlink's directory
+                    resolv_target = os.path.join("/", os.path.dirname(RESOLV_CONF_FILE), resolv_target)
+                # Leading "/" makes normpath clamp ".." at the chroot root
+                resolv_target = os.path.normpath(resolv_target)
                 chroot_target = os.path.join(new_image_mount, resolv_target.lstrip("/"))
                 run_command_or_raise(["mkdir", "-p", os.path.dirname(chroot_target)])
-                run_command_or_raise(["cp", "-L", os.path.join("/", RESOLV_CONF_FILE), chroot_target])
+                # --remove-destination: if the target is itself a symlink, replace it
+                # instead of writing through it (could escape the mount again)
+                run_command_or_raise(["cp", "-L", "--remove-destination",
+                                      os.path.join("/", RESOLV_CONF_FILE), chroot_target])
             else:
                 # Regular file: overwrite with host DNS content.
                 run_command_or_raise(["cp", os.path.join("/", RESOLV_CONF_FILE), chroot_resolv])

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -13,11 +13,18 @@ def test_run_command():
         output = sonic_installer_common.run_command([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert e.value.code == 6
 
+
+@pytest.mark.parametrize("resolv_conf_symlink_target", [
+    "/run/resolvconf/resolv.conf",       # absolute symlink
+    "../run/resolvconf/resolv.conf",     # relative symlink (resolvconf package default)
+    "../../run/resolvconf/resolv.conf",  # excess ".." clamps at the chroot root
+    None,                                # regular file
+])
 @patch("sonic_installer.main.SWAPAllocator")
 @patch("sonic_installer.main.get_bootloader")
 @patch("sonic_installer.main.run_command_or_raise")
 @patch("sonic_installer.main.run_command")
-def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
+def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs, resolv_conf_symlink_target):
     """ This test covers the execution of "sonic-installer install" command. """
 
     sonic_image_filename = "sonic.bin"
@@ -34,8 +41,11 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
     fs.create_dir(os.path.join(mounted_image_folder, "usr/lib/docker/docker.sh"))
     fs.create_file("/var/run/docker.pid", contents="15")
     fs.create_file("/proc/15/cmdline", contents="\x00".join(["dockerd"] + dockerd_opts))
-    # Simulate new image: /etc/resolv.conf is a dangling symlink (target doesn't exist in squashfs)
-    fs.create_symlink(f"{mounted_image_folder}/etc/resolv.conf", "/run/resolvconf/resolv.conf")
+    # New image /etc/resolv.conf: dangling symlink or regular file
+    if resolv_conf_symlink_target:
+        fs.create_symlink(f"{mounted_image_folder}/etc/resolv.conf", resolv_conf_symlink_target)
+    else:
+        fs.create_file(f"{mounted_image_folder}/etc/resolv.conf")
 
     # Expect fd:// to be replaced by unix://
     expected_dockerd_opts = [opt if opt != "fd://" else "unix://" for opt in dockerd_opts]
@@ -101,9 +111,20 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
              f"{mounted_image_folder}/var/lib/sonic-package-manager"]),
         call(["touch", f"{mounted_image_folder}/tmp/docker.sock"]),
         call(["mount", "--bind", "/var/run/docker.sock", f"{mounted_image_folder}/tmp/docker.sock"]),
-        # /etc/resolv.conf is a dangling symlink -> /run/resolvconf/resolv.conf, populate its target
-        call(["mkdir", "-p", f"{mounted_image_folder}/run/resolvconf"]),
-        call(["cp", "-L", "/etc/resolv.conf", f"{mounted_image_folder}/run/resolvconf/resolv.conf"]),
+    ]
+    if resolv_conf_symlink_target:
+        # Symlink target resolves to /run/resolvconf/resolv.conf inside the chroot
+        expected_call_list += [
+            call(["mkdir", "-p", f"{mounted_image_folder}/run/resolvconf"]),
+            call(["cp", "-L", "--remove-destination", "/etc/resolv.conf",
+                  f"{mounted_image_folder}/run/resolvconf/resolv.conf"]),
+        ]
+    else:
+        # Regular file overwritten in place
+        expected_call_list += [
+            call(["cp", "/etc/resolv.conf", f"{mounted_image_folder}/etc/resolv.conf"]),
+        ]
+    expected_call_list += [
         call(["chroot", mounted_image_folder, "sh", "-c", "command -v sonic-package-manager"]),
         call(["chroot", mounted_image_folder, "sonic-package-manager", "migrate", "/tmp/packages.json", "--dockerd-socket", "/tmp/docker.sock", "-y"], capture=False),
         call(["chroot", mounted_image_folder, "/usr/lib/docker/docker.sh", "stop"], raise_exception=False),


### PR DESCRIPTION
#### What I did

Fixed `sonic-installer install` failing in `migrate_sonic_packages()` with `Temporary failure in name resolution` when `sonic-package-manager migrate` has to fetch a package manifest from a container registry inside the new image's chroot.

#4365 made the DNS injection symlink-aware, but its path math only handles absolute symlink targets: `lstrip("/")` is a no-op on a relative target such as `../run/resolvconf/resolv.conf` (the form the Debian resolvconf package ships in the image), so `os.path.join()` produced a path whose `..` escaped the chroot mount. The host's DNS configuration was written to the host filesystem (`/tmp/run/...`) instead of into the chroot overlay, leaving the chroot with whatever stale `resolv.conf` the image's squashfs happened to carry from its build server — so package migration worked or failed depending on which build machine produced the image.

#### How I did it

- Resolve a relative symlink target against the symlink's own directory (`etc/`), per POSIX symlink semantics.
- `os.path.normpath()` on the anchored absolute path collapses `..` and clamps it at the chroot root, mirroring how the kernel resolves the link inside the chroot — the computed path can never escape the image mount.
- `cp -L --remove-destination`: if the computed target already exists as a symlink, replace it instead of writing through it.
- Absolute targets pass through unchanged (`normpath` is the identity on them), so the case #4365 fixed behaves exactly as before; the regular-file branch is untouched.

#### How to verify it

- `tests/test_sonic_installer.py`: `test_install` is parametrized over the new image's `/etc/resolv.conf` layouts — absolute symlink, relative symlink, a target with excess `..`, and a regular file. The relative-symlink case fails against the previous code; the expected command list is asserted with strict order/argv equality.
- Verified end to end on a Mellanox MSN4700: installing an image whose squashfs ships the relative symlink and stale, unreachable build-time nameservers previously failed at the `sonic-package-manager migrate` step with the DNS error above (and left a stray copy of the host's DNS configuration under `/tmp/run/` on the host). With this fix the same install completes: the host DNS lands inside the chroot overlay (`rw/run/resolvconf/resolv.conf`) and no stray host file is created.
