### PR TITLE
[show]: Restore disabled default for show suppress-fib-pending CLI

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2811,7 +2811,7 @@ def suppress_pending_fib(db):
     for ns in namespace_list:
         config_db = db.cfgdb_clients[ns]
         field_values = config_db.get_entry('DEVICE_METADATA', 'localhost')
-        state = field_values.get('suppress-fib-pending', 'enabled').title()
+        state = field_values.get('suppress-fib-pending', 'disabled').title()
 
         if masic:
             click.echo("{}: {}".format(ns, state))

--- a/tests/suppress_pending_fib_test.py
+++ b/tests/suppress_pending_fib_test.py
@@ -8,6 +8,18 @@ from utilities_common.db import Db
 
 
 class TestSuppressFibPending:
+    def test_show_suppress_fib_pending_default_disabled(self):
+        runner = CliRunner()
+        db = Db()
+        entry = db.cfgdb.get_entry('DEVICE_METADATA', 'localhost')
+        if 'suppress-fib-pending' in entry:
+            del entry['suppress-fib-pending']
+            db.cfgdb.set_entry('DEVICE_METADATA', 'localhost', entry)
+
+        result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
+        assert result.exit_code == 0
+        assert result.output == 'Disabled\n'
+
     def test_synchronous_mode(self):
         runner = CliRunner()
 
@@ -66,6 +78,20 @@ class TestSuppressFibPendingMultiAsic(object):
         from .mock_tables import mock_multi_asic
         importlib.reload(mock_multi_asic)
         dbconnector.load_namespace_config()
+
+    def test_show_suppress_fib_pending_default_disabled_all_asics(self):
+        runner = CliRunner()
+        db = Db()
+        for ns in ['asic0', 'asic1']:
+            cfgdb = db.cfgdb_clients[ns]
+            entry = cfgdb.get_entry('DEVICE_METADATA', 'localhost')
+            if 'suppress-fib-pending' in entry:
+                del entry['suppress-fib-pending']
+                cfgdb.set_entry('DEVICE_METADATA', 'localhost', entry)
+
+        result = runner.invoke(show.cli.commands['suppress-fib-pending'], obj=db)
+        assert result.exit_code == 0
+        assert result.output == 'asic0: Disabled\nasic1: Disabled\n'
 
     def test_config_suppress_fib_pending_all_asics(self):
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- Restore `show suppress-fib-pending` default display for an absent CONFIG_DB key from **Enabled** back to **Disabled**.
- Regresses a typo introduced in sonic-net/sonic-utilities#3948 when multi-ASIC show output was added; the original CLI (#2495 / #3477) used `'disabled'`.
- Add unit tests for the absent-key case on single-ASIC and multi-ASIC.

## Problem

#3948 changed:

```python
field_values.get('suppress-fib-pending', 'enabled')
```

Previously (and per sonic-buildimage#19022) the default is **disabled** when the key is absent. Orchagent and fpmsyncd only enable suppression when the key is explicitly `enabled`, so `show` was reporting **Enabled** on DUTs where the dataplane runs with suppression off.

Verified on lab pizza box and multi-ASIC LC/RP: absent key → show reported Enabled, CONFIG_DB empty.
## Test plan

- [x] Unit tests added in `tests/suppress_pending_fib_test.py` for absent key on single-ASIC and multi-ASIC
- [ ] CI on sonic-utilities

Related: sonic-mgmt#22916