### PR TITLE
snmp: add --prompt-* options to hide community and user passwords from CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4519,12 +4519,10 @@ def add_community(db, community, string_type, prompt_community):
     """ Add snmp community string"""
     if prompt_community:
         if community:
-            click.echo('Cannot use both <snmp_community> argument and --prompt-community')
-            sys.exit(1)
+            raise click.UsageError('Cannot use both <snmp_community> argument and --prompt-community')
         community = _prompt_secret('SNMP community string')
     elif not community:
-        click.echo('Error: Missing argument \'<snmp_community>\'')
-        sys.exit(1)
+        raise click.UsageError('Missing argument \'<snmp_community>\'')
     string_type = string_type.upper()
     if ADHOC_VALIDATION:
         if not is_valid_community_type(string_type):
@@ -4591,12 +4589,10 @@ def replace_community(db, current_community, new_community, prompt_new):
     """ Replace snmp community string"""
     if prompt_new:
         if new_community:
-            click.echo('Cannot use both <new_community_string> argument and --prompt-new')
-            sys.exit(1)
+            raise click.UsageError('Cannot use both <new_community_string> argument and --prompt-new')
         new_community = _prompt_secret('New SNMP community string')
     elif not new_community:
-        click.echo('Error: Missing argument \'<new_community_string>\'')
-        sys.exit(1)
+        raise click.UsageError('Missing argument \'<new_community_string>\'')
     snmp_communities = db.cfgdb.get_table("SNMP_COMMUNITY")
     if not current_community in snmp_communities:
         click.echo("Current SNMP community {} is not configured".format(current_community))
@@ -4893,13 +4889,11 @@ def add_user(db, user, user_type, user_permission_type, user_auth_type, user_aut
         sys.exit(SnmpUserError.RoRwCheckFailure)
     if prompt_auth_password:
         if user_auth_password:
-            click.echo('Cannot use both <auth_password> argument and --prompt-auth-password')
-            sys.exit(SnmpUserError.AuthPasswordMissing)
+            raise click.UsageError('Cannot use both <auth_password> argument and --prompt-auth-password')
         user_auth_password = _prompt_secret('Auth password')
     if prompt_encrypt_password:
         if user_encrypt_password:
-            click.echo('Cannot use both <encrypt_password> argument and --prompt-encrypt-password')
-            sys.exit(SnmpUserError.EncryptPasswordMissingFailure)
+            raise click.UsageError('Cannot use both <encrypt_password> argument and --prompt-encrypt-password')
         user_encrypt_password = _prompt_secret('Encrypt password')
     if user_type == "noAuthNoPriv":
         if user_auth_type:

--- a/config/main.py
+++ b/config/main.py
@@ -4407,6 +4407,11 @@ def community(db):
     pass
 
 
+def _prompt_secret(prompt_text):
+    """Read a secret interactively with echo suppressed so it never appears on the command line."""
+    return click.prompt(prompt_text, hide_input=True)
+
+
 def is_valid_community_type(commstr_type):
     commstr_types = ['RO', 'RW']
     if commstr_type not in commstr_types:
@@ -4505,11 +4510,21 @@ def snmp_user_secret_check(snmp_secret):
 
 
 @community.command('add')
-@click.argument('community', metavar='<snmp_community>', required=True)
+@click.argument('community', metavar='<snmp_community>', required=False)
 @click.argument('string_type', metavar='<RO|RW>', required=True)
+@click.option('--prompt-community', is_flag=True,
+              help='Enter the community string interactively (hidden) instead of on the command line')
 @clicommon.pass_db
-def add_community(db, community, string_type):
+def add_community(db, community, string_type, prompt_community):
     """ Add snmp community string"""
+    if prompt_community:
+        if community:
+            click.echo('Cannot use both <snmp_community> argument and --prompt-community')
+            sys.exit(1)
+        community = _prompt_secret('SNMP community string')
+    elif not community:
+        click.echo('Error: Missing argument \'<snmp_community>\'')
+        sys.exit(1)
     string_type = string_type.upper()
     if ADHOC_VALIDATION:
         if not is_valid_community_type(string_type):
@@ -4568,10 +4583,20 @@ def del_community(db, community):
 
 @community.command('replace')
 @click.argument('current_community', metavar='<current_community_string>', required=True)
-@click.argument('new_community', metavar='<new_community_string>', required=True)
+@click.argument('new_community', metavar='<new_community_string>', required=False)
+@click.option('--prompt-new', is_flag=True,
+              help='Enter the new community string interactively (hidden) instead of on the command line')
 @clicommon.pass_db
-def replace_community(db, current_community, new_community):
+def replace_community(db, current_community, new_community, prompt_new):
     """ Replace snmp community string"""
+    if prompt_new:
+        if new_community:
+            click.echo('Cannot use both <new_community_string> argument and --prompt-new')
+            sys.exit(1)
+        new_community = _prompt_secret('New SNMP community string')
+    elif not new_community:
+        click.echo('Error: Missing argument \'<new_community_string>\'')
+        sys.exit(1)
     snmp_communities = db.cfgdb.get_table("SNMP_COMMUNITY")
     if not current_community in snmp_communities:
         click.echo("Current SNMP community {} is not configured".format(current_community))
@@ -4848,9 +4873,13 @@ def user(db):
 @click.argument('user_auth_password', metavar='<auth_password>', required=False)
 @click.argument('user_encrypt_type', metavar='<DES|AES>', required=False)
 @click.argument('user_encrypt_password', metavar='<encrypt_password>', required=False)
+@click.option('--prompt-auth-password', is_flag=True,
+              help='Enter the auth password interactively (hidden) instead of on the command line')
+@click.option('--prompt-encrypt-password', is_flag=True,
+              help='Enter the encrypt password interactively (hidden) instead of on the command line')
 @clicommon.pass_db
 def add_user(db, user, user_type, user_permission_type, user_auth_type, user_auth_password, user_encrypt_type,
-             user_encrypt_password):
+             user_encrypt_password, prompt_auth_password, prompt_encrypt_password):
     """ Add snmp user"""
     if not snmp_username_check(user):
         sys.exit(SnmpUserError.NameCheckFailure)
@@ -4862,6 +4891,16 @@ def add_user(db, user, user_type, user_permission_type, user_auth_type, user_aut
     user_permission_type = user_permission_type.upper()
     if not is_valid_community_type(user_permission_type):
         sys.exit(SnmpUserError.RoRwCheckFailure)
+    if prompt_auth_password:
+        if user_auth_password:
+            click.echo('Cannot use both <auth_password> argument and --prompt-auth-password')
+            sys.exit(SnmpUserError.AuthPasswordMissing)
+        user_auth_password = _prompt_secret('Auth password')
+    if prompt_encrypt_password:
+        if user_encrypt_password:
+            click.echo('Cannot use both <encrypt_password> argument and --prompt-encrypt-password')
+            sys.exit(SnmpUserError.EncryptPasswordMissingFailure)
+        user_encrypt_password = _prompt_secret('Encrypt password')
     if user_type == "noAuthNoPriv":
         if user_auth_type:
             click.echo("User auth type not used with 'noAuthNoPriv'.  Please use 'AuthNoPriv' or 'Priv' instead")

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -873,13 +873,19 @@ class TestSNMPConfigCommands(object):
     # ---------------------------------------------------------------------------
 
     def test_config_snmp_community_add_prompt_community(self):
-        """community add --prompt-community reads from stdin instead of positional arg."""
+        """community add --prompt-community reads community string from stdin.
+
+        Because click assigns positional args left-to-right and <snmp_community>
+        is the first (optional) positional, callers must pass an empty string as
+        a placeholder so that <RO|RW> (second, required) is still supplied while
+        the community value itself comes from the interactive prompt.
+        """
         db = Db()
         runner = CliRunner()
         with mock.patch('utilities_common.cli.run_command'):
             result = runner.invoke(
                 config.config.commands["snmp"].commands["community"].commands["add"],
-                ["--prompt-community", "RO"],
+                ["", "RO", "--prompt-community"],
                 input="PromptedCommunity\n",
                 obj=db,
             )
@@ -932,13 +938,18 @@ class TestSNMPConfigCommands(object):
         assert "Cannot use both" in result.output
 
     def test_config_snmp_user_add_prompt_auth_password(self):
-        """user add --prompt-auth-password reads auth password from stdin."""
+        """user add --prompt-auth-password reads auth password from stdin.
+
+        Pass an empty string in the <auth_password> positional slot so that
+        click satisfies the subsequent optional arguments while the code sees
+        auth_password as falsy and reads from the interactive prompt instead.
+        """
         db = Db()
         runner = CliRunner()
         with mock.patch('utilities_common.cli.run_command'):
             result = runner.invoke(
                 config.config.commands["snmp"].commands["user"].commands["add"],
-                ["testuser", "Priv", "RO", "MD5", "--prompt-auth-password", "DES", "user_encrypt_pass"],
+                ["testuser", "Priv", "RO", "MD5", "", "--prompt-auth-password", "DES", "user_encrypt_pass"],
                 input="promptedAuthPass\n",
                 obj=db,
             )

--- a/tests/config_snmp_test.py
+++ b/tests/config_snmp_test.py
@@ -868,6 +868,121 @@ class TestSNMPConfigCommands(object):
         assert ('10.1.0.32', '', '') in db.cfgdb.get_keys('SNMP_AGENT_ADDRESS_CONFIG')
         assert db.cfgdb.get_entry("SNMP_AGENT_ADDRESS_CONFIG", "10.1.0.32||") == {}
 
+    # ---------------------------------------------------------------------------
+    # Tests for --prompt-* options (hide secrets from CLI history)
+    # ---------------------------------------------------------------------------
+
+    def test_config_snmp_community_add_prompt_community(self):
+        """community add --prompt-community reads from stdin instead of positional arg."""
+        db = Db()
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command'):
+            result = runner.invoke(
+                config.config.commands["snmp"].commands["community"].commands["add"],
+                ["--prompt-community", "RO"],
+                input="PromptedCommunity\n",
+                obj=db,
+            )
+        assert result.exit_code == 0, result.output
+        assert db.cfgdb.get_entry("SNMP_COMMUNITY", "PromptedCommunity") == {"TYPE": "RO"}
+
+    def test_config_snmp_community_add_prompt_and_arg_conflict(self):
+        """community add with both positional arg and --prompt-community is an error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["snmp"].commands["community"].commands["add"],
+            ["Everest", "--prompt-community", "RO"],
+            input="PromptedCommunity\n",
+        )
+        assert result.exit_code != 0
+        assert "Cannot use both" in result.output
+
+    def test_config_snmp_community_add_missing_arg_and_no_prompt(self):
+        """community add with no arg and no --prompt-community is an error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["snmp"].commands["community"].commands["add"],
+            ["RO"],
+        )
+        assert result.exit_code != 0
+
+    def test_config_snmp_community_replace_prompt_new(self):
+        """community replace --prompt-new reads new community from stdin."""
+        db = Db()
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command'):
+            result = runner.invoke(
+                config.config.commands["snmp"].commands["community"].commands["replace"],
+                ["Rainer", "--prompt-new"],
+                input="PromptedNew\n",
+                obj=db,
+            )
+        assert result.exit_code == 0, result.output
+        assert db.cfgdb.get_entry("SNMP_COMMUNITY", "PromptedNew") == {"TYPE": "RW"}
+
+    def test_config_snmp_community_replace_prompt_and_arg_conflict(self):
+        """community replace with both positional new_community and --prompt-new is an error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["snmp"].commands["community"].commands["replace"],
+            ["Rainer", "NewCom", "--prompt-new"],
+            input="PromptedNew\n",
+        )
+        assert result.exit_code != 0
+        assert "Cannot use both" in result.output
+
+    def test_config_snmp_user_add_prompt_auth_password(self):
+        """user add --prompt-auth-password reads auth password from stdin."""
+        db = Db()
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command'):
+            result = runner.invoke(
+                config.config.commands["snmp"].commands["user"].commands["add"],
+                ["testuser", "Priv", "RO", "MD5", "--prompt-auth-password", "DES", "user_encrypt_pass"],
+                input="promptedAuthPass\n",
+                obj=db,
+            )
+        assert result.exit_code == 0, result.output
+        entry = db.cfgdb.get_entry("SNMP_USER", "testuser")
+        assert entry.get("SNMP_USER_AUTH_PASSWORD") == "promptedAuthPass"
+
+    def test_config_snmp_user_add_prompt_encrypt_password(self):
+        """user add --prompt-encrypt-password reads encrypt password from stdin."""
+        db = Db()
+        runner = CliRunner()
+        with mock.patch('utilities_common.cli.run_command'):
+            result = runner.invoke(
+                config.config.commands["snmp"].commands["user"].commands["add"],
+                ["testuser2", "Priv", "RO", "MD5", "user_auth_pass", "DES", "--prompt-encrypt-password"],
+                input="promptedEncPass\n",
+                obj=db,
+            )
+        assert result.exit_code == 0, result.output
+        entry = db.cfgdb.get_entry("SNMP_USER", "testuser2")
+        assert entry.get("SNMP_USER_ENCRYPTION_PASSWORD") == "promptedEncPass"
+
+    def test_config_snmp_user_add_prompt_auth_and_arg_conflict(self):
+        """user add with both auth password arg and --prompt-auth-password is an error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["snmp"].commands["user"].commands["add"],
+            ["testuser", "Priv", "RO", "MD5", "user_auth_pass", "--prompt-auth-password", "DES", "enc_pass"],
+            input="promptedAuthPass\n",
+        )
+        assert result.exit_code != 0
+        assert "Cannot use both" in result.output
+
+    def test_config_snmp_user_add_prompt_encrypt_and_arg_conflict(self):
+        """user add with both encrypt password arg and --prompt-encrypt-password is an error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["snmp"].commands["user"].commands["add"],
+            ["testuser", "Priv", "RO", "MD5", "auth_pass", "DES", "enc_pass", "--prompt-encrypt-password"],
+            input="promptedEncPass\n",
+        )
+        assert result.exit_code != 0
+        assert "Cannot use both" in result.output
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")


### PR DESCRIPTION
#### What I did

Added opt-in `--prompt-*` flags to SNMP community and user add commands so secrets (community strings, auth/encrypt passwords) can be entered interactively with echo suppressed instead of being passed as plaintext command-line arguments.

Passing secrets on the command line makes them visible in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs.

#### How I did it

- Added `_prompt_secret()` helper using `click.prompt(hide_input=True)`
- `config snmp community add`: added `--prompt-community` flag; positional argument made optional for use with the flag
- `config snmp community replace`: added `--prompt-new` flag for the new community string
- `config snmp user add`: added `--prompt-auth-password` and `--prompt-encrypt-password` flags
- All existing positional arguments retained for backward compatibility

#### How to verify it

```
# Interactive hidden prompt (secret not visible in ps or history):
config snmp community add --prompt-community RO
config snmp community replace old_community --prompt-new
config snmp user add myuser priv RO SHA --prompt-auth-password DES --prompt-encrypt-password

# Existing behavior unchanged (backward compatible):
config snmp community add mycommunity RO
config snmp user add myuser priv RO SHA myauthpass DES myencpass
```

#### Previous command output (if the output of a command-line utility has changed)

```
$ config snmp community add --help
Usage: config snmp community add [OPTIONS] <snmp_community> <RO|RW>

  Add snmp community string

Options:
  --help  Show this message and exit.
```

#### New command output (if the output of a command-line utility has changed)

```
$ config snmp community add --help
Usage: config snmp community add [OPTIONS] [<snmp_community>] <RO|RW>

  Add snmp community string

Options:
  --prompt-community  Enter the community string interactively (hidden)
                      instead of on the command line
  --help              Show this message and exit.
```