### PR TITLE
Add image-installation disk-space validation helper and auto-recover DPU disk space during reboot -d DPUx

### DIFF
--- a/scripts/reboot_smartswitch_helper
+++ b/scripts/reboot_smartswitch_helper
@@ -121,6 +121,30 @@ function get_module_state_transition_flag()
     fi
 }
 
+# Enforce the optional platform DPU storage policy before reboot.
+# A missing policy is a no-op, preserving behavior on other platforms.
+function ensure_dpu_reboot_disk_space()
+{
+    local DPU_NAME=$1
+
+    python3 - "$DPU_NAME" "$PLATFORM_JSON_PATH" <<'PYCODE'
+import sys
+
+from utilities_common.image_disk_space import (
+    ensure_remote_dpu_disk_space_for_operation,
+)
+
+dpu_name = sys.argv[1]
+platform_json_path = sys.argv[2] or None
+result = ensure_remote_dpu_disk_space_for_operation(
+    dpu_name=dpu_name,
+    operation="reboot",
+    platform_json_path=platform_json_path,
+)
+sys.exit(0 if result else 1)
+PYCODE
+}
+
 # Function to reboot DPU
 function reboot_dpu_platform()
 {
@@ -218,6 +242,14 @@ function reboot_dpu()
             log_message "INFO: ${DPU_NAME} is not online. Current status: $oper_status"
             return ${EXIT_DPU_DOWN}
         fi
+    fi
+
+    # Validate and, when configured, rotate DPU diagnostic files before
+    # entering the state transition or halting services.
+    ensure_dpu_reboot_disk_space "${DPU_NAME}"
+    if [ $? -ne 0 ]; then
+        log_message "ERROR: ${DPU_NAME} reboot aborted because the required disk space could not be recovered"
+        return ${EXIT_ERROR}
     fi
 
     if [[ "$REBOOT_TYPE" != $MODULE_REBOOT_SMARTSWITCH ]]; then

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -6,6 +6,9 @@ import subprocess
 import sys
 import time
 import utilities_common.cli as clicommon
+from utilities_common.image_disk_space import (
+    check_image_install_free_disk_space,
+)
 from urllib.request import urlopen, urlretrieve
 
 import click
@@ -580,6 +583,16 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
             echo_and_log('Error: Failed to set image as default', LOG_ERR)
             raise click.Abort()
     else:
+        # Validate that enough disk space is available before modifying the
+        # installed image state. The check is skipped when platform.json does
+        # not define min_free_disk_in_gb_for_image.
+        if not check_image_install_free_disk_space():
+            echo_and_log(
+                "Insufficient free disk space to install the image. Aborting...",
+                LOG_ERR,
+            )
+            raise click.Abort()
+
         # Verify not installing non-secure image in a secure running image
         if not force and not bootloader.verify_secureboot_image(image_path):
             echo_and_log("Image file '{}' is of a different type than running image.\n".format(url) +

--- a/tests/image_disk_space_test.py
+++ b/tests/image_disk_space_test.py
@@ -33,8 +33,6 @@ def write_platform_json(tmp_path, data):
         ),
     ],
 )
-
-
 def test_get_min_free_disk_from_platform_json(
     tmp_path, image_type, key, value
 ):
@@ -56,8 +54,6 @@ def test_get_min_free_disk_from_platform_json(
         image_disk_space.IMAGE_TYPE_DPU,
     ],
 )
-
-
 def test_get_min_free_disk_missing_key_returns_none(
     tmp_path, image_type
 ):
@@ -73,8 +69,6 @@ def test_get_min_free_disk_missing_key_returns_none(
 
 
 @pytest.mark.parametrize("bad_value", [0, -1, "bad", None])
-
-
 @pytest.mark.parametrize(
     "image_type,key",
     [
@@ -88,8 +82,6 @@ def test_get_min_free_disk_missing_key_returns_none(
         ),
     ],
 )
-
-
 def test_invalid_platform_json_value_returns_none(
     tmp_path,
     bad_value,
@@ -227,8 +219,6 @@ def test_is_running_on_dpu_exception(monkeypatch):
         (True, image_disk_space.IMAGE_TYPE_DPU),
     ],
 )
-
-
 def test_get_local_image_type(
     monkeypatch, running_on_dpu, expected_type
 ):
@@ -251,8 +241,6 @@ def test_get_local_image_type(
         (image_disk_space.IMAGE_TYPE_DPU, None, False),
     ],
 )
-
-
 def test_check_local_image_install_free_disk_space(
     monkeypatch,
     tmp_path,
@@ -405,8 +393,6 @@ def test_run_cmd_os_error(monkeypatch):
         ("Filesystem\n/dev/sda1\nAvail\n32212254720", 30 * GB),
     ],
 )
-
-
 def test_parse_df_available_bytes_success(output, expected):
     assert image_disk_space._parse_df_available_bytes(output) == expected
 
@@ -415,8 +401,6 @@ def test_parse_df_available_bytes_success(output, expected):
     "output",
     ["", "Avail", "Avail\nbad", "Avail\n-1", "Avail\n18.5"],
 )
-
-
 def test_parse_df_available_bytes_failure(output):
     assert image_disk_space._parse_df_available_bytes(output) is None
 
@@ -910,7 +894,10 @@ def test_list_remote_dir_files_parses_output(monkeypatch):
         assert cmd[0] == "ssh"
         assert cmd[1] == "DPU0"
         assert "find" in cmd[-1]
-        return 0, "1000.5 1073741824 /var/dump/a\n2000.0 2147483648 /var/dump/b"
+        return 0, (
+            "1000.5 1073741824 /var/dump/a\n"
+            "2000.0 2147483648 /var/dump/b"
+        )
 
     monkeypatch.setattr(image_disk_space, "_run_cmd", fake_run_cmd)
 

--- a/tests/image_disk_space_test.py
+++ b/tests/image_disk_space_test.py
@@ -1,0 +1,1157 @@
+# tests/image_disk_space_test.py
+
+import json
+import subprocess
+
+import pytest
+
+from utilities_common import image_disk_space
+
+
+GB = 1024 * 1024 * 1024
+
+
+def write_platform_json(tmp_path, data):
+    """Write platform data to a temporary platform.json file."""
+    path = tmp_path / "platform.json"
+    path.write_text(json.dumps(data))
+    return str(path)
+
+
+@pytest.mark.parametrize(
+    "image_type,key,value",
+    [
+        (
+            image_disk_space.IMAGE_TYPE_COMMON,
+            image_disk_space.SONIC_IMG_MIN_FREE_DISK_KEY,
+            16,
+        ),
+        (
+            image_disk_space.IMAGE_TYPE_DPU,
+            image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY,
+            14,
+        ),
+    ],
+)
+def test_get_min_free_disk_from_platform_json(
+    tmp_path, image_type, key, value
+):
+    path = write_platform_json(tmp_path, {key: value})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb(
+            image_type,
+            platform_json_path=path,
+        )
+        == value
+    )
+
+
+@pytest.mark.parametrize(
+    "image_type",
+    [
+        image_disk_space.IMAGE_TYPE_COMMON,
+        image_disk_space.IMAGE_TYPE_DPU,
+    ],
+)
+def test_get_min_free_disk_missing_key_returns_none(
+    tmp_path, image_type
+):
+    path = write_platform_json(tmp_path, {})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb(
+            image_type,
+            platform_json_path=path,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, "bad", None])
+@pytest.mark.parametrize(
+    "image_type,key",
+    [
+        (
+            image_disk_space.IMAGE_TYPE_COMMON,
+            image_disk_space.SONIC_IMG_MIN_FREE_DISK_KEY,
+        ),
+        (
+            image_disk_space.IMAGE_TYPE_DPU,
+            image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY,
+        ),
+    ],
+)
+def test_invalid_platform_json_value_returns_none(
+    tmp_path,
+    bad_value,
+    image_type,
+    key,
+):
+    path = write_platform_json(tmp_path, {key: bad_value})
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb(
+            image_type,
+            platform_json_path=path,
+        )
+        is None
+    )
+
+
+def test_missing_platform_json_returns_none():
+    assert (
+        image_disk_space.get_min_free_disk_in_gb(
+            image_disk_space.IMAGE_TYPE_COMMON,
+            platform_json_path="/bad/path/platform.json",
+        )
+        is None
+    )
+
+
+def test_invalid_platform_json_returns_none(tmp_path):
+    path = tmp_path / "platform.json"
+    path.write_text("{invalid-json")
+
+    assert (
+        image_disk_space.get_min_free_disk_in_gb(
+            image_disk_space.IMAGE_TYPE_DPU,
+            platform_json_path=str(path),
+        )
+        is None
+    )
+
+
+def test_get_min_free_disk_invalid_image_type():
+    with pytest.raises(ValueError):
+        image_disk_space.get_min_free_disk_in_gb("invalid")
+
+
+def test_get_free_disk_in_gb_success(monkeypatch):
+    class Usage:
+        free = 20 * GB
+
+    monkeypatch.setattr(
+        image_disk_space.os.path,
+        "exists",
+        lambda path: True,
+    )
+    monkeypatch.setattr(
+        image_disk_space.shutil,
+        "disk_usage",
+        lambda path: Usage,
+    )
+
+    assert image_disk_space.get_free_disk_in_gb("/host") == 20
+
+
+def test_get_free_disk_in_gb_missing_path(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space.os.path,
+        "exists",
+        lambda path: False,
+    )
+
+    assert image_disk_space.get_free_disk_in_gb("/missing") is None
+
+
+def test_get_free_disk_in_gb_disk_usage_failure(monkeypatch):
+    def raise_error(path):
+        raise OSError("disk usage failed")
+
+    monkeypatch.setattr(
+        image_disk_space.os.path,
+        "exists",
+        lambda path: True,
+    )
+    monkeypatch.setattr(
+        image_disk_space.shutil,
+        "disk_usage",
+        raise_error,
+    )
+
+    assert image_disk_space.get_free_disk_in_gb("/host") is None
+
+
+def test_is_running_on_dpu_true(monkeypatch):
+    class DeviceInfo:
+        @staticmethod
+        def is_dpu():
+            return True
+
+    monkeypatch.setattr(image_disk_space, "device_info", DeviceInfo)
+
+    assert image_disk_space.is_running_on_dpu()
+
+
+def test_is_running_on_dpu_false(monkeypatch):
+    class DeviceInfo:
+        @staticmethod
+        def is_dpu():
+            return False
+
+    monkeypatch.setattr(image_disk_space, "device_info", DeviceInfo)
+
+    assert not image_disk_space.is_running_on_dpu()
+
+
+def test_is_running_on_dpu_false_when_device_info_missing(monkeypatch):
+    monkeypatch.setattr(image_disk_space, "device_info", None)
+
+    assert not image_disk_space.is_running_on_dpu()
+
+
+def test_is_running_on_dpu_exception(monkeypatch):
+    class DeviceInfo:
+        @staticmethod
+        def is_dpu():
+            raise RuntimeError("failed")
+
+    monkeypatch.setattr(image_disk_space, "device_info", DeviceInfo)
+
+    assert not image_disk_space.is_running_on_dpu()
+
+
+@pytest.mark.parametrize(
+    "running_on_dpu,expected_type",
+    [
+        (False, image_disk_space.IMAGE_TYPE_COMMON),
+        (True, image_disk_space.IMAGE_TYPE_DPU),
+    ],
+)
+def test_get_local_image_type(
+    monkeypatch, running_on_dpu, expected_type
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: running_on_dpu,
+    )
+
+    assert image_disk_space.get_local_image_type() == expected_type
+
+
+@pytest.mark.parametrize(
+    "image_type,available_gb,expected",
+    [
+        (image_disk_space.IMAGE_TYPE_COMMON, 20, True),
+        (image_disk_space.IMAGE_TYPE_COMMON, 8, False),
+        (image_disk_space.IMAGE_TYPE_DPU, 20, True),
+        (image_disk_space.IMAGE_TYPE_DPU, 8, False),
+        (image_disk_space.IMAGE_TYPE_DPU, None, False),
+    ],
+)
+def test_check_local_image_install_free_disk_space(
+    monkeypatch,
+    tmp_path,
+    image_type,
+    available_gb,
+    expected,
+):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.SONIC_IMG_MIN_FREE_DISK_KEY: 12,
+            image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY: 12,
+        },
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        lambda disk_path: available_gb,
+    )
+
+    result = image_disk_space.check_local_image_install_free_disk_space(
+        image_type=image_type,
+        disk_path="/host",
+        platform_json_path=path,
+    )
+
+    assert result is expected
+
+
+def test_check_local_image_install_free_disk_space_auto_detects_common(
+    monkeypatch,
+):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_local_image_type",
+        lambda: image_disk_space.IMAGE_TYPE_COMMON,
+    )
+
+    def fake_get_threshold(image_type, platform_json_path):
+        captured["image_type"] = image_type
+        return 12
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_min_free_disk_in_gb",
+        fake_get_threshold,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        lambda disk_path: 20,
+    )
+
+    assert image_disk_space.check_local_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_COMMON
+
+
+def test_check_local_image_install_free_disk_space_auto_detects_dpu(
+    monkeypatch,
+):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_local_image_type",
+        lambda: image_disk_space.IMAGE_TYPE_DPU,
+    )
+
+    def fake_get_threshold(image_type, platform_json_path):
+        captured["image_type"] = image_type
+        return 12
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_min_free_disk_in_gb",
+        fake_get_threshold,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_free_disk_in_gb",
+        lambda disk_path: 20,
+    )
+
+    assert image_disk_space.check_local_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_DPU
+
+
+def test_check_local_image_install_free_disk_space_invalid_type():
+    assert not image_disk_space.check_local_image_install_free_disk_space(
+        image_type="invalid"
+    )
+
+
+def test_run_cmd_success(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "Avail\n20G\n",
+    )
+
+    rc, output = image_disk_space._run_cmd(["dummy"])
+
+    assert rc == 0
+    assert output == "Avail\n20G"
+
+
+def test_run_cmd_called_process_failure(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            1,
+            "cmd",
+            output="error",
+        )
+
+    monkeypatch.setattr(
+        image_disk_space.subprocess,
+        "check_output",
+        raise_error,
+    )
+
+    rc, output = image_disk_space._run_cmd(["dummy"])
+
+    assert rc == 1
+    assert output == "error"
+
+
+def test_run_cmd_os_error(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise OSError("command unavailable")
+
+    monkeypatch.setattr(
+        image_disk_space.subprocess,
+        "check_output",
+        raise_error,
+    )
+
+    rc, output = image_disk_space._run_cmd(["dummy"])
+
+    assert rc == 1
+    assert output == "command unavailable"
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("Avail\n18G", 18),
+        ("Avail\n18", 18),
+        ("Available\n  25G\n", 25),
+        ("Filesystem\n/dev/sda1\nAvail\n30G", 30),
+    ],
+)
+def test_parse_df_available_gb_success(output, expected):
+    assert image_disk_space._parse_df_available_gb(output) == expected
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "",
+        "Avail",
+        "Avail\nbad",
+        "Avail\n18GB",
+        "Avail\n18.5G",
+    ],
+)
+def test_parse_df_available_gb_failure(output):
+    assert image_disk_space._parse_df_available_gb(output) is None
+
+
+def test_get_remote_dpu_free_disk_in_gb_success(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (0, "Avail\n18G"),
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
+        == 18
+    )
+
+
+def test_get_remote_dpu_free_disk_in_gb_custom_ssh_options(
+    monkeypatch,
+):
+    captured = {}
+
+    def fake_run_cmd(cmd):
+        captured["cmd"] = cmd
+        return 0, "Avail\n18G"
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        fake_run_cmd,
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb(
+            "DPU0",
+            ssh_options=["-o", "ConnectTimeout=3"],
+        )
+        == 18
+    )
+    assert captured["cmd"] == [
+        "ssh",
+        "-o",
+        "ConnectTimeout=3",
+        "DPU0",
+        "df",
+        "-BG",
+        "--output=avail",
+        "/host",
+    ]
+
+
+def test_get_remote_dpu_free_disk_in_gb_command_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (1, "ssh failed"),
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
+        is None
+    )
+
+
+@pytest.mark.parametrize("output", ["", "Avail\nbad"])
+def test_get_remote_dpu_free_disk_in_gb_parse_failure(
+    monkeypatch, output
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (0, output),
+    )
+
+    assert (
+        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
+        is None
+    )
+
+
+def test_remote_dpu_check_rejected_when_running_on_dpu(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: True,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space("DPU0")
+    )
+
+
+def test_remote_dpu_check_requires_name(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space([])
+    )
+
+
+def test_remote_dpu_check_single_success(monkeypatch, tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY: 12},
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: 20,
+    )
+
+    assert (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            "DPU0",
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+def test_remote_dpu_check_multi_success(monkeypatch, tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY: 12},
+    )
+    free_space = {
+        "DPU0": 20,
+        "DPU1": 18,
+        "DPU2": 16,
+    }
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: (
+            free_space[dpu_name]
+        ),
+    )
+
+    assert (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0", "DPU1", "DPU2"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+@pytest.mark.parametrize("available_gb", [8, None])
+def test_remote_dpu_check_failure(
+    monkeypatch, tmp_path, available_gb
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY: 12},
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: available_gb,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+def test_remote_dpu_check_mixed_results_fail(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY: 12},
+    )
+    free_space = {
+        "DPU0": 20,
+        "DPU1": 8,
+        "DPU2": 18,
+    }
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options=None: (
+            free_space[dpu_name]
+        ),
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0", "DPU1", "DPU2"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+
+
+def test_remote_dpu_check_stops_on_first_failure(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_IMG_MIN_FREE_DISK_KEY: 12},
+    )
+    checked_dpus = []
+
+    def fake_get_remote_disk(
+        dpu_name,
+        disk_path,
+        ssh_options=None,
+    ):
+        checked_dpus.append(dpu_name)
+        return {
+            "DPU0": 20,
+            "DPU1": 8,
+            "DPU2": 20,
+        }[dpu_name]
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        fake_get_remote_disk,
+    )
+
+    assert not (
+        image_disk_space
+        .check_remote_dpu_image_install_free_disk_space(
+            ["DPU0", "DPU1", "DPU2"],
+            disk_path="/host",
+            platform_json_path=path,
+        )
+    )
+    assert checked_dpus == ["DPU0", "DPU1"]
+
+
+def test_smart_check_local_npu(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+
+    def fake_local_check(
+        image_type=None,
+        disk_path=image_disk_space.DEFAULT_DISK_PATH,
+        platform_json_path=None,
+    ):
+        captured["image_type"] = image_type
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "check_local_image_install_free_disk_space",
+        fake_local_check,
+    )
+
+    assert image_disk_space.check_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_COMMON
+
+
+def test_smart_check_local_dpu(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: True,
+    )
+
+    def fake_local_check(
+        image_type=None,
+        disk_path=image_disk_space.DEFAULT_DISK_PATH,
+        platform_json_path=None,
+    ):
+        captured["image_type"] = image_type
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "check_local_image_install_free_disk_space",
+        fake_local_check,
+    )
+
+    assert image_disk_space.check_image_install_free_disk_space()
+    assert captured["image_type"] == image_disk_space.IMAGE_TYPE_DPU
+
+
+def test_smart_check_remote_dpus_from_npu(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: False,
+    )
+
+    def fake_remote_check(
+        dpu_names,
+        disk_path=image_disk_space.DEFAULT_DISK_PATH,
+        platform_json_path=None,
+        ssh_options=None,
+    ):
+        captured["dpu_names"] = dpu_names
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "check_remote_dpu_image_install_free_disk_space",
+        fake_remote_check,
+    )
+
+    assert image_disk_space.check_image_install_free_disk_space(
+        dpu_names=["DPU0", "DPU1"]
+    )
+    assert captured["dpu_names"] == ["DPU0", "DPU1"]
+
+
+def test_smart_check_rejects_dpu_names_on_dpu(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "is_running_on_dpu",
+        lambda: True,
+    )
+
+    assert not image_disk_space.check_image_install_free_disk_space(
+        dpu_names=["DPU0"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# DPU reboot storage policy / retention (issue #28734)
+# ---------------------------------------------------------------------------
+
+
+DPU_STORAGE_POLICY = {
+    "reboot": {
+        "disk_path": "/",
+        "min_free_disk_in_gb": 4,
+    },
+    "retention": {
+        "paths": {
+            "/var/dump": {
+                "max_size_in_gb": 4,
+                "min_files_to_keep": 1,
+                "min_file_age_minutes": 10,
+            },
+        },
+    },
+}
+
+
+def test_get_dpu_storage_policy_present(tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_STORAGE_POLICY_KEY: DPU_STORAGE_POLICY},
+    )
+
+    assert (
+        image_disk_space.get_dpu_storage_policy(platform_json_path=path)
+        == DPU_STORAGE_POLICY
+    )
+
+
+def test_get_dpu_storage_policy_absent(tmp_path):
+    path = write_platform_json(tmp_path, {})
+
+    assert (
+        image_disk_space.get_dpu_storage_policy(platform_json_path=path)
+        is None
+    )
+
+
+def test_get_dpu_storage_policy_not_a_dict(tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_STORAGE_POLICY_KEY: "invalid"},
+    )
+
+    assert (
+        image_disk_space.get_dpu_storage_policy(platform_json_path=path)
+        is None
+    )
+
+
+def test_select_retention_files_under_max_keeps_all():
+    now = 1000.0
+    files = [
+        {"path": "/var/dump/a", "size": 1 * GB, "mtime": now - 3600},
+        {"path": "/var/dump/b", "size": 1 * GB, "mtime": now - 7200},
+    ]
+    path_policy = {
+        "max_size_in_gb": 4,
+        "min_files_to_keep": 1,
+        "min_file_age_minutes": 10,
+    }
+
+    assert image_disk_space.select_retention_files_to_delete(
+        files, path_policy, now=now
+    ) == []
+
+
+def test_select_retention_deletes_oldest_first_until_under_max():
+    now = 10000.0
+    files = [
+        {"path": "/var/dump/new", "size": 3 * GB, "mtime": now - 3600},
+        {"path": "/var/dump/old", "size": 3 * GB, "mtime": now - 7200},
+        {"path": "/var/dump/older", "size": 3 * GB, "mtime": now - 10800},
+    ]
+    path_policy = {
+        "max_size_in_gb": 4,
+        "min_files_to_keep": 1,
+        "min_file_age_minutes": 10,
+    }
+
+    # Total is 9GB, must drop to <= 4GB: remove the two oldest (older, old).
+    assert image_disk_space.select_retention_files_to_delete(
+        files, path_policy, now=now
+    ) == ["/var/dump/older", "/var/dump/old"]
+
+
+def test_select_retention_respects_min_files_to_keep():
+    now = 10000.0
+    files = [
+        {"path": "/var/dump/a", "size": 3 * GB, "mtime": now - 3600},
+        {"path": "/var/dump/b", "size": 3 * GB, "mtime": now - 7200},
+    ]
+    path_policy = {
+        "max_size_in_gb": 1,
+        "min_files_to_keep": 1,
+        "min_file_age_minutes": 10,
+    }
+
+    # Would need to delete both to get under 1GB, but must keep at least one.
+    assert image_disk_space.select_retention_files_to_delete(
+        files, path_policy, now=now
+    ) == ["/var/dump/b"]
+
+
+def test_select_retention_respects_min_file_age():
+    now = 10000.0
+    files = [
+        {"path": "/var/dump/recent", "size": 5 * GB, "mtime": now - 60},
+        {"path": "/var/dump/old", "size": 5 * GB, "mtime": now - 7200},
+    ]
+    path_policy = {
+        "max_size_in_gb": 1,
+        "min_files_to_keep": 0,
+        "min_file_age_minutes": 10,
+    }
+
+    # "recent" is younger than 10 minutes, so only "old" may be deleted.
+    assert image_disk_space.select_retention_files_to_delete(
+        files, path_policy, now=now
+    ) == ["/var/dump/old"]
+
+
+def test_select_retention_missing_max_size_is_noop():
+    now = 10000.0
+    files = [
+        {"path": "/var/dump/a", "size": 5 * GB, "mtime": now - 7200},
+    ]
+
+    assert image_disk_space.select_retention_files_to_delete(
+        files, {"min_files_to_keep": 0}, now=now
+    ) == []
+
+
+def test_list_remote_dir_files_parses_output(monkeypatch):
+    def fake_run_cmd(cmd):
+        assert cmd[0] == "ssh"
+        assert cmd[1] == "DPU0"
+        assert "find" in cmd[-1]
+        return 0, "1000.5 1073741824 /var/dump/a\n2000.0 2147483648 /var/dump/b"
+
+    monkeypatch.setattr(image_disk_space, "_run_cmd", fake_run_cmd)
+
+    files = image_disk_space._list_remote_dir_files(
+        "DPU0", "/var/dump", ["DPU0"]
+    )
+
+    assert files == [
+        {"path": "/var/dump/a", "size": 1073741824, "mtime": 1000.5},
+        {"path": "/var/dump/b", "size": 2147483648, "mtime": 2000.0},
+    ]
+
+
+def test_list_remote_dir_files_failure_returns_empty(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (1, "No such file or directory"),
+    )
+
+    assert image_disk_space._list_remote_dir_files(
+        "DPU0", "/var/dump", ["DPU0"]
+    ) == []
+
+
+def test_delete_remote_files_empty_is_noop(monkeypatch):
+    called = {"count": 0}
+
+    def fake_run_cmd(cmd):
+        called["count"] += 1
+        return 0, ""
+
+    monkeypatch.setattr(image_disk_space, "_run_cmd", fake_run_cmd)
+
+    assert image_disk_space._delete_remote_files("DPU0", [], ["DPU0"])
+    assert called["count"] == 0
+
+
+def test_delete_remote_files_builds_rm_command(monkeypatch):
+    captured = {}
+
+    def fake_run_cmd(cmd):
+        captured["cmd"] = cmd
+        return 0, ""
+
+    monkeypatch.setattr(image_disk_space, "_run_cmd", fake_run_cmd)
+
+    assert image_disk_space._delete_remote_files(
+        "DPU0", ["/var/dump/a", "/var/dump/b"], []
+    )
+    assert captured["cmd"] == [
+        "ssh",
+        "DPU0",
+        "rm -f -- /var/dump/a /var/dump/b",
+    ]
+
+
+def test_recover_remote_dpu_disk_space_lists_selects_deletes(monkeypatch):
+    deleted = {}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "_list_remote_dir_files",
+        lambda dpu_name, path, ssh_options: [
+            {"path": path + "/a", "size": 5 * GB, "mtime": 1},
+        ],
+    )
+
+    def fake_delete(dpu_name, file_paths, ssh_options):
+        deleted[dpu_name] = file_paths
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space, "_delete_remote_files", fake_delete
+    )
+
+    image_disk_space.recover_remote_dpu_disk_space(
+        "DPU0",
+        {
+            "paths": {
+                "/var/dump": {
+                    "max_size_in_gb": 1,
+                    "min_files_to_keep": 0,
+                    "min_file_age_minutes": 0,
+                }
+            }
+        },
+        ["DPU0"],
+    )
+
+    assert deleted == {"DPU0": ["/var/dump/a"]}
+
+
+def test_ensure_reboot_disk_space_no_policy_is_skipped(tmp_path):
+    path = write_platform_json(tmp_path, {})
+
+    assert image_disk_space.ensure_remote_dpu_reboot_disk_space(
+        "DPU0", platform_json_path=path
+    )
+
+
+def test_ensure_reboot_disk_space_no_reboot_section_is_skipped(tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_STORAGE_POLICY_KEY: {"retention": {}}},
+    )
+
+    assert image_disk_space.ensure_remote_dpu_reboot_disk_space(
+        "DPU0", platform_json_path=path
+    )
+
+
+def test_ensure_reboot_disk_space_sufficient_no_retention(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_STORAGE_POLICY_KEY: DPU_STORAGE_POLICY},
+    )
+    recovered = {"called": False}
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options: 10,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "recover_remote_dpu_disk_space",
+        lambda *args, **kwargs: recovered.__setitem__("called", True),
+    )
+
+    assert image_disk_space.ensure_remote_dpu_reboot_disk_space(
+        "DPU0", platform_json_path=path
+    )
+    assert recovered["called"] is False
+
+
+def test_ensure_reboot_disk_space_recovers_then_succeeds(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_STORAGE_POLICY_KEY: DPU_STORAGE_POLICY},
+    )
+    free_values = iter([2, 8])
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options: next(free_values),
+    )
+    recovered = {"called": False}
+    monkeypatch.setattr(
+        image_disk_space,
+        "recover_remote_dpu_disk_space",
+        lambda *args, **kwargs: recovered.__setitem__("called", True),
+    )
+
+    assert image_disk_space.ensure_remote_dpu_reboot_disk_space(
+        "DPU0", platform_json_path=path
+    )
+    assert recovered["called"] is True
+
+
+def test_ensure_reboot_disk_space_still_insufficient_fails(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_STORAGE_POLICY_KEY: DPU_STORAGE_POLICY},
+    )
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options: 2,
+    )
+    monkeypatch.setattr(
+        image_disk_space,
+        "recover_remote_dpu_disk_space",
+        lambda *args, **kwargs: None,
+    )
+
+    assert not image_disk_space.ensure_remote_dpu_reboot_disk_space(
+        "DPU0", platform_json_path=path
+    )
+
+
+def test_ensure_reboot_disk_space_undeterminable_fails(
+    monkeypatch, tmp_path
+):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.DPU_STORAGE_POLICY_KEY: {
+                "reboot": {"disk_path": "/", "min_free_disk_in_gb": 4}
+            }
+        },
+    )
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "get_remote_dpu_free_disk_in_gb",
+        lambda dpu_name, disk_path, ssh_options: None,
+    )
+
+    assert not image_disk_space.ensure_remote_dpu_reboot_disk_space(
+        "DPU0", platform_json_path=path
+    )
+
+
+def test_ensure_operation_delegates_to_reboot_check(monkeypatch):
+    captured = {}
+
+    def fake_reboot_check(dpu_name, platform_json_path=None, ssh_options=None):
+        captured["dpu_name"] = dpu_name
+        captured["platform_json_path"] = platform_json_path
+        return True
+
+    monkeypatch.setattr(
+        image_disk_space,
+        "ensure_remote_dpu_reboot_disk_space",
+        fake_reboot_check,
+    )
+
+    assert image_disk_space.ensure_remote_dpu_disk_space_for_operation(
+        "DPU0", "reboot", platform_json_path="/tmp/platform.json"
+    )
+    assert captured["dpu_name"] == "DPU0"
+    assert captured["platform_json_path"] == "/tmp/platform.json"

--- a/tests/image_disk_space_test.py
+++ b/tests/image_disk_space_test.py
@@ -33,6 +33,8 @@ def write_platform_json(tmp_path, data):
         ),
     ],
 )
+
+
 def test_get_min_free_disk_from_platform_json(
     tmp_path, image_type, key, value
 ):
@@ -54,6 +56,8 @@ def test_get_min_free_disk_from_platform_json(
         image_disk_space.IMAGE_TYPE_DPU,
     ],
 )
+
+
 def test_get_min_free_disk_missing_key_returns_none(
     tmp_path, image_type
 ):
@@ -69,6 +73,8 @@ def test_get_min_free_disk_missing_key_returns_none(
 
 
 @pytest.mark.parametrize("bad_value", [0, -1, "bad", None])
+
+
 @pytest.mark.parametrize(
     "image_type,key",
     [
@@ -82,6 +88,8 @@ def test_get_min_free_disk_missing_key_returns_none(
         ),
     ],
 )
+
+
 def test_invalid_platform_json_value_returns_none(
     tmp_path,
     bad_value,
@@ -219,6 +227,8 @@ def test_is_running_on_dpu_exception(monkeypatch):
         (True, image_disk_space.IMAGE_TYPE_DPU),
     ],
 )
+
+
 def test_get_local_image_type(
     monkeypatch, running_on_dpu, expected_type
 ):
@@ -241,6 +251,8 @@ def test_get_local_image_type(
         (image_disk_space.IMAGE_TYPE_DPU, None, False),
     ],
 )
+
+
 def test_check_local_image_install_free_disk_space(
     monkeypatch,
     tmp_path,
@@ -388,106 +400,81 @@ def test_run_cmd_os_error(monkeypatch):
 @pytest.mark.parametrize(
     "output,expected",
     [
-        ("Avail\n18G", 18),
-        ("Avail\n18", 18),
-        ("Available\n  25G\n", 25),
-        ("Filesystem\n/dev/sda1\nAvail\n30G", 30),
+        ("Avail\n19327352832", 18 * GB),
+        ("Available\n  26843545600\n", 25 * GB),
+        ("Filesystem\n/dev/sda1\nAvail\n32212254720", 30 * GB),
     ],
 )
-def test_parse_df_available_gb_success(output, expected):
-    assert image_disk_space._parse_df_available_gb(output) == expected
+
+
+def test_parse_df_available_bytes_success(output, expected):
+    assert image_disk_space._parse_df_available_bytes(output) == expected
 
 
 @pytest.mark.parametrize(
     "output",
-    [
-        "",
-        "Avail",
-        "Avail\nbad",
-        "Avail\n18GB",
-        "Avail\n18.5G",
-    ],
+    ["", "Avail", "Avail\nbad", "Avail\n-1", "Avail\n18.5"],
 )
-def test_parse_df_available_gb_failure(output):
-    assert image_disk_space._parse_df_available_gb(output) is None
+
+
+def test_parse_df_available_bytes_failure(output):
+    assert image_disk_space._parse_df_available_bytes(output) is None
 
 
 def test_get_remote_dpu_free_disk_in_gb_success(monkeypatch):
     monkeypatch.setattr(
         image_disk_space,
         "_run_cmd",
-        lambda cmd: (0, "Avail\n18G"),
+        lambda cmd: (0, "Avail\n19327352832"),
     )
+    assert image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0") == 18
 
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
-        == 18
+
+def test_get_remote_dpu_free_disk_in_gb_floors_partial_gib(monkeypatch):
+    monkeypatch.setattr(
+        image_disk_space,
+        "_run_cmd",
+        lambda cmd: (0, "Avail\n4294967295"),
     )
+    assert image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0") == 3
 
 
-def test_get_remote_dpu_free_disk_in_gb_custom_ssh_options(
-    monkeypatch,
-):
+def test_get_remote_dpu_free_disk_in_gb_custom_ssh_options(monkeypatch):
     captured = {}
 
     def fake_run_cmd(cmd):
         captured["cmd"] = cmd
-        return 0, "Avail\n18G"
+        return 0, "Avail\n19327352832"
 
-    monkeypatch.setattr(
-        image_disk_space,
-        "_run_cmd",
-        fake_run_cmd,
-    )
-
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb(
-            "DPU0",
-            ssh_options=["-o", "ConnectTimeout=3"],
-        )
-        == 18
-    )
+    monkeypatch.setattr(image_disk_space, "_run_cmd", fake_run_cmd)
+    assert image_disk_space.get_remote_dpu_free_disk_in_gb(
+        "DPU0", ssh_options=["-o", "ConnectTimeout=3"]
+    ) == 18
     assert captured["cmd"] == [
         "ssh",
         "-o",
         "ConnectTimeout=3",
         "DPU0",
         "df",
-        "-BG",
+        "-B1",
         "--output=avail",
         "/host",
     ]
 
 
-def test_get_remote_dpu_free_disk_in_gb_command_failure(
-    monkeypatch,
-):
+def test_get_remote_dpu_free_disk_in_gb_command_failure(monkeypatch):
     monkeypatch.setattr(
-        image_disk_space,
-        "_run_cmd",
-        lambda cmd: (1, "ssh failed"),
+        image_disk_space, "_run_cmd", lambda cmd: (1, "ssh failed")
     )
-
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
-        is None
-    )
+    assert image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0") is None
 
 
 @pytest.mark.parametrize("output", ["", "Avail\nbad"])
-def test_get_remote_dpu_free_disk_in_gb_parse_failure(
-    monkeypatch, output
-):
+def test_get_remote_dpu_free_disk_in_gb_parse_failure(monkeypatch, output):
     monkeypatch.setattr(
-        image_disk_space,
-        "_run_cmd",
-        lambda cmd: (0, output),
+        image_disk_space, "_run_cmd", lambda cmd: (0, output)
     )
-
-    assert (
-        image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0")
-        is None
-    )
+    assert image_disk_space.get_remote_dpu_free_disk_in_gb("DPU0") is None
 
 
 def test_remote_dpu_check_rejected_when_running_on_dpu(
@@ -1136,22 +1123,51 @@ def test_ensure_reboot_disk_space_undeterminable_fails(
     )
 
 
-def test_ensure_operation_delegates_to_reboot_check(monkeypatch):
+@pytest.mark.parametrize("bad_value", [0, -1, "4GB", None])
+def test_ensure_reboot_disk_space_invalid_threshold_fails(tmp_path, bad_value):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.DPU_STORAGE_POLICY_KEY: {
+                "reboot": {"min_free_disk_in_gb": bad_value}
+            }
+        },
+    )
+    assert not image_disk_space.ensure_remote_dpu_reboot_disk_space(
+        "DPU0", platform_json_path=path
+    )
+
+
+def test_ensure_operation_uses_requested_policy(monkeypatch, tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {
+            image_disk_space.DPU_STORAGE_POLICY_KEY: {
+                "reboot": {"disk_path": "/reboot", "min_free_disk_in_gb": 4},
+                "upgrade": {"disk_path": "/upgrade", "min_free_disk_in_gb": 9},
+            }
+        },
+    )
     captured = {}
 
-    def fake_reboot_check(dpu_name, platform_json_path=None, ssh_options=None):
-        captured["dpu_name"] = dpu_name
-        captured["platform_json_path"] = platform_json_path
-        return True
+    def fake_free(dpu_name, disk_path, ssh_options):
+        captured["disk_path"] = disk_path
+        return 10
 
     monkeypatch.setattr(
-        image_disk_space,
-        "ensure_remote_dpu_reboot_disk_space",
-        fake_reboot_check,
+        image_disk_space, "get_remote_dpu_free_disk_in_gb", fake_free
     )
-
     assert image_disk_space.ensure_remote_dpu_disk_space_for_operation(
-        "DPU0", "reboot", platform_json_path="/tmp/platform.json"
+        "DPU0", "upgrade", platform_json_path=path
     )
-    assert captured["dpu_name"] == "DPU0"
-    assert captured["platform_json_path"] == "/tmp/platform.json"
+    assert captured["disk_path"] == "/upgrade"
+
+
+def test_ensure_operation_invalid_section_fails(tmp_path):
+    path = write_platform_json(
+        tmp_path,
+        {image_disk_space.DPU_STORAGE_POLICY_KEY: {"reboot": "invalid"}},
+    )
+    assert not image_disk_space.ensure_remote_dpu_disk_space_for_operation(
+        "DPU0", "reboot", platform_json_path=path
+    )

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -13,11 +13,20 @@ def test_run_command():
         output = sonic_installer_common.run_command([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert e.value.code == 6
 
+
+@patch("sonic_installer.main.check_image_install_free_disk_space", return_value=True)
 @patch("sonic_installer.main.SWAPAllocator")
 @patch("sonic_installer.main.get_bootloader")
 @patch("sonic_installer.main.run_command_or_raise")
 @patch("sonic_installer.main.run_command")
-def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
+def test_install(
+    run_command,
+    run_command_or_raise,
+    get_bootloader,
+    swap,
+    _,
+    fs,
+):
     """ This test covers the execution of "sonic-installer install" command. """
 
     sonic_image_filename = "sonic.bin"
@@ -159,12 +168,21 @@ def test_runtime_exception(mock_popen):
     assert all(v in str(sre.value) for v in ['test.sh', 'Running', 'Failed']), "Invalid message"
 
 
+@patch("sonic_installer.main.check_image_install_free_disk_space", return_value=True)
 @patch("sonic_installer.main.SWAPAllocator")
 @patch("sonic_installer.main.get_bootloader")
 @patch("sonic_installer.main.run_command_or_raise")
 @patch("sonic_installer.main.run_command")
 @patch('shutil.rmtree')
-def test_install_failed(rmtree, run_command, run_command_or_raise, get_bootloader, swap, fs):
+def test_install_failed(
+    rmtree,
+    run_command,
+    run_command_or_raise,
+    get_bootloader,
+    swap,
+    _,
+    fs,
+):
     """ This test covers the "sonic-installer" install image failed handling. """
 
     sonic_image_filename = "sonic.bin"

--- a/utilities_common/image_disk_space.py
+++ b/utilities_common/image_disk_space.py
@@ -1,0 +1,746 @@
+# utilities_common/image_disk_space.py
+
+import json
+import logging
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import time
+from typing import Dict, List, Optional, Tuple, Union
+
+try:
+    from sonic_py_common import device_info
+except ImportError:
+    device_info = None
+
+
+# Minimum free disk (in GB) is read from platform.json. Common and DPU images
+# have independent thresholds and may be configured at the same time. When the
+# relevant key is absent the install check is skipped, so platforms that do not
+# opt in are unaffected.
+SONIC_IMG_MIN_FREE_DISK_KEY = "min_free_disk_in_gb_for_image"
+DPU_IMG_MIN_FREE_DISK_KEY = "min_free_disk_in_gb_for_dpu_image"
+
+# Optional DPU storage policy used by the smart-switch reboot flow. When
+# platform.json defines "dpu_storage_policy" the DPU free disk space is
+# validated before a reboot and, if a retention policy is configured, space is
+# recovered automatically. Platforms that do not define the policy keep their
+# existing behavior.
+DPU_STORAGE_POLICY_KEY = "dpu_storage_policy"
+
+DEFAULT_DISK_PATH = "/host"
+
+IMAGE_TYPE_COMMON = "common"
+IMAGE_TYPE_DPU = "dpu"
+
+DEFAULT_SSH_OPTIONS = [
+    "-o", "BatchMode=yes",
+    "-o", "ConnectTimeout=10",
+    "-o", "StrictHostKeyChecking=no",
+]
+
+
+def get_default_platform_json_path() -> Optional[str]:
+    """Return the platform.json path for the current platform."""
+    if device_info is None:
+        return None
+
+    try:
+        platform = device_info.get_platform()
+    except Exception as error:
+        logging.warning(
+            "Failed to determine platform: %s",
+            error,
+        )
+        return None
+
+    if not platform:
+        return None
+
+    return f"/usr/share/sonic/device/{platform}/platform.json"
+
+
+def _load_platform_json(
+    platform_json_path: Optional[str] = None,
+) -> Dict:
+    if platform_json_path is None:
+        platform_json_path = get_default_platform_json_path()
+
+    if platform_json_path is None:
+        logging.warning("Unable to determine platform.json path")
+        return {}
+
+    try:
+        with open(platform_json_path, "r") as platform_json_file:
+            return json.load(platform_json_file)
+    except (OSError, ValueError, TypeError) as error:
+        logging.warning(
+            "Failed to read platform.json %s: %s",
+            platform_json_path,
+            error,
+        )
+        return {}
+
+
+def _get_optional_positive_int(
+    data: Dict,
+    key: str,
+) -> Optional[int]:
+    """
+    Return a positive integer for key, or None when the key is absent or
+    invalid. A None result tells callers to skip the disk-space check.
+    """
+    value = data.get(key)
+    if value is None:
+        return None
+
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        logging.warning("Invalid value for %s: %r", key, value)
+        return None
+
+    if value <= 0:
+        logging.warning("Non-positive value for %s: %s", key, value)
+        return None
+
+    return value
+
+
+def get_min_free_disk_in_gb(
+    image_type: str,
+    platform_json_path: Optional[str] = None,
+) -> Optional[int]:
+    """
+    Return the configured minimum free disk space (in GB) for an image type,
+    or None when platform.json does not define the corresponding key (in which
+    case the install check is skipped).
+
+    image_type:
+        "common" - local/common image threshold
+        "dpu"    - DPU image threshold
+    """
+    platform_data = _load_platform_json(platform_json_path)
+
+    if image_type == IMAGE_TYPE_COMMON:
+        return _get_optional_positive_int(
+            platform_data, SONIC_IMG_MIN_FREE_DISK_KEY
+        )
+
+    if image_type == IMAGE_TYPE_DPU:
+        return _get_optional_positive_int(
+            platform_data, DPU_IMG_MIN_FREE_DISK_KEY
+        )
+
+    raise ValueError("Unsupported image type: {}".format(image_type))
+
+
+def get_free_disk_in_gb(
+    path: str = DEFAULT_DISK_PATH,
+) -> Optional[int]:
+    if not os.path.exists(path):
+        logging.warning("Disk path does not exist: %s", path)
+        return None
+
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError as error:
+        logging.warning(
+            "Failed to get disk usage for %s: %s",
+            path,
+            error,
+        )
+        return None
+
+    return usage.free // (1024 * 1024 * 1024)
+
+
+def is_running_on_dpu() -> bool:
+    """
+    Return True when this utility is running on a DPU.
+    """
+    try:
+        return bool(device_info and device_info.is_dpu())
+    except Exception as error:
+        logging.warning(
+            "Failed to determine whether the system is a DPU: %s",
+            error,
+        )
+        return False
+
+
+def get_local_image_type() -> str:
+    """
+    Determine which image threshold applies to the local system.
+    """
+    if is_running_on_dpu():
+        return IMAGE_TYPE_DPU
+
+    return IMAGE_TYPE_COMMON
+
+
+def check_local_image_install_free_disk_space(
+    image_type: Optional[str] = None,
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+) -> bool:
+    """
+    Check free disk space on the system where this function is running.
+
+    When image_type is omitted it is auto-detected (DPU vs. common). The check
+    is skipped (returns True) when platform.json does not configure the
+    corresponding threshold.
+    """
+    resolved_image_type = image_type or get_local_image_type()
+
+    try:
+        required_gb = get_min_free_disk_in_gb(
+            resolved_image_type,
+            platform_json_path,
+        )
+    except ValueError as error:
+        logging.error("%s", error)
+        return False
+
+    if required_gb is None:
+        logging.info(
+            "No min free disk configured for %s image; skipping install check",
+            resolved_image_type,
+        )
+        return True
+
+    available_gb = get_free_disk_in_gb(disk_path)
+
+    if available_gb is None:
+        logging.error(
+            "Unable to determine local free disk space: path=%s",
+            disk_path,
+        )
+        return False
+
+    if available_gb < required_gb:
+        logging.error(
+            "Insufficient local disk space: "
+            "image_type=%s available=%sGB required=%sGB path=%s",
+            resolved_image_type,
+            available_gb,
+            required_gb,
+            disk_path,
+        )
+        return False
+
+    return True
+
+
+def _run_cmd(cmd: List[str]) -> Tuple[int, str]:
+    try:
+        output = subprocess.check_output(
+            cmd,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+        return 0, output.strip()
+    except subprocess.CalledProcessError as error:
+        output = error.output or ""
+        return error.returncode, output.strip()
+    except OSError as error:
+        return 1, str(error)
+
+
+def _parse_df_available_gb(output: str) -> Optional[int]:
+    """
+    Parse output from:
+
+        df -BG --output=avail <path>
+
+    Expected output resembles:
+
+        Avail
+          18G
+    """
+    lines = [
+        line.strip()
+        for line in output.splitlines()
+        if line.strip()
+    ]
+
+    if len(lines) < 2:
+        return None
+
+    match = re.fullmatch(r"(\d+)G?", lines[-1])
+    if not match:
+        return None
+
+    return int(match.group(1))
+
+
+def get_remote_dpu_free_disk_in_gb(
+    dpu_name: str,
+    disk_path: str = DEFAULT_DISK_PATH,
+    ssh_options: Optional[List[str]] = None,
+) -> Optional[int]:
+    """
+    Get free disk space from a DPU reachable over SSH.
+    """
+    resolved_ssh_options = (
+        ssh_options
+        if ssh_options is not None
+        else DEFAULT_SSH_OPTIONS
+    )
+
+    command = [
+        "ssh",
+        *resolved_ssh_options,
+        dpu_name,
+        "df",
+        "-BG",
+        "--output=avail",
+        disk_path,
+    ]
+
+    return_code, output = _run_cmd(command)
+    if return_code != 0:
+        logging.warning(
+            "Failed to get free disk space from %s: %s",
+            dpu_name,
+            output,
+        )
+        return None
+
+    available_gb = _parse_df_available_gb(output)
+    if available_gb is None:
+        logging.warning(
+            "Failed to parse disk space from %s: %s",
+            dpu_name,
+            output,
+        )
+
+    return available_gb
+
+
+def check_remote_dpu_image_install_free_disk_space(
+    dpu_names: Union[str, List[str]],
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+    ssh_options: Optional[List[str]] = None,
+) -> bool:
+    """
+    Check one or more remote DPUs from an NPU.
+
+    The complete check fails if any DPU has insufficient disk space or
+    if the free disk space cannot be determined for any DPU.
+    """
+    if is_running_on_dpu():
+        logging.error(
+            "Remote DPU disk-space checks must be initiated from an NPU"
+        )
+        return False
+
+    if isinstance(dpu_names, str):
+        resolved_dpu_names = [dpu_names]
+    else:
+        resolved_dpu_names = dpu_names
+
+    if not resolved_dpu_names:
+        logging.error(
+            "Remote DPU disk-space check requires at least one DPU name"
+        )
+        return False
+
+    required_gb = get_min_free_disk_in_gb(
+        IMAGE_TYPE_DPU,
+        platform_json_path,
+    )
+
+    if required_gb is None:
+        logging.info(
+            "%s is not configured; skipping remote DPU check",
+            DPU_IMG_MIN_FREE_DISK_KEY,
+        )
+        return True
+
+    for dpu_name in resolved_dpu_names:
+        available_gb = get_remote_dpu_free_disk_in_gb(
+            dpu_name,
+            disk_path,
+            ssh_options,
+        )
+
+        if available_gb is None:
+            logging.error(
+                "Unable to determine free disk space for %s",
+                dpu_name,
+            )
+            return False
+
+        if available_gb < required_gb:
+            logging.error(
+                "Insufficient remote DPU disk space: "
+                "dpu=%s available=%sGB required=%sGB path=%s",
+                dpu_name,
+                available_gb,
+                required_gb,
+                disk_path,
+            )
+            return False
+
+    return True
+
+
+def check_image_install_free_disk_space(
+    dpu_names: Optional[Union[str, List[str]]] = None,
+    disk_path: str = DEFAULT_DISK_PATH,
+    platform_json_path: Optional[str] = None,
+    ssh_options: Optional[List[str]] = None,
+) -> bool:
+    """
+    Smart image-installation disk-space validation entry point.
+
+    Behavior:
+
+    Running on a DPU:
+        Checks the local DPU.
+
+    Running on a switch without dpu_names:
+        Checks the local system.
+
+    Running on a switch with dpu_names:
+        Checks the specified remote DPUs.
+    """
+    if is_running_on_dpu():
+        if dpu_names:
+            logging.error(
+                "dpu_names must not be supplied when running locally on a DPU"
+            )
+            return False
+
+        return check_local_image_install_free_disk_space(
+            image_type=IMAGE_TYPE_DPU,
+            disk_path=disk_path,
+            platform_json_path=platform_json_path,
+        )
+
+    if dpu_names:
+        return check_remote_dpu_image_install_free_disk_space(
+            dpu_names=dpu_names,
+            disk_path=disk_path,
+            platform_json_path=platform_json_path,
+            ssh_options=ssh_options,
+        )
+
+    return check_local_image_install_free_disk_space(
+        image_type=IMAGE_TYPE_COMMON,
+        disk_path=disk_path,
+        platform_json_path=platform_json_path,
+    )
+
+def get_dpu_storage_policy(
+    platform_json_path: Optional[str] = None,
+) -> Optional[Dict]:
+    """
+    Return the "dpu_storage_policy" object from platform.json, or None when it
+    is not defined. A None result tells callers to skip the reboot disk-space
+    check so platforms without the policy are unaffected.
+    """
+    platform_data = _load_platform_json(platform_json_path)
+    policy = platform_data.get(DPU_STORAGE_POLICY_KEY)
+    if isinstance(policy, dict):
+        return policy
+    return None
+
+
+def select_retention_files_to_delete(
+    files: List[Dict],
+    path_policy: Dict,
+    now: Optional[float] = None,
+) -> List[str]:
+    """
+    Decide which files to delete from a single retention path.
+
+    files:
+        list of {"path": str, "size": int (bytes), "mtime": float (epoch)}
+    path_policy:
+        {
+            "max_size_in_gb": int,       # target maximum total size for path
+            "min_files_to_keep": int,    # never delete below this many files
+            "min_file_age_minutes": int, # only delete files older than this
+        }
+
+    Oldest eligible files are removed first until the total size is at or below
+    max_size_in_gb, while always keeping at least min_files_to_keep files and
+    never deleting files younger than min_file_age_minutes.
+    """
+    max_size_in_gb = _get_optional_positive_int(path_policy, "max_size_in_gb")
+    if max_size_in_gb is None:
+        return []
+
+    if now is None:
+        now = time.time()
+
+    try:
+        min_files_to_keep = max(int(path_policy.get("min_files_to_keep", 0)), 0)
+    except (TypeError, ValueError):
+        min_files_to_keep = 0
+
+    try:
+        min_file_age_minutes = max(
+            int(path_policy.get("min_file_age_minutes", 0)), 0
+        )
+    except (TypeError, ValueError):
+        min_file_age_minutes = 0
+
+    age_cutoff = now - (min_file_age_minutes * 60)
+    max_size_bytes = max_size_in_gb * (1024 ** 3)
+
+    total_size = sum(int(entry.get("size", 0)) for entry in files)
+    remaining = len(files)
+
+    # Oldest files first.
+    ordered = sorted(files, key=lambda entry: entry.get("mtime", 0))
+
+    to_delete = []
+    for entry in ordered:
+        if total_size <= max_size_bytes:
+            break
+        if remaining <= min_files_to_keep:
+            break
+        if entry.get("mtime", 0) > age_cutoff:
+            # File is newer than the minimum age; do not delete it.
+            continue
+
+        to_delete.append(entry["path"])
+        total_size -= int(entry.get("size", 0))
+        remaining -= 1
+
+    return to_delete
+
+
+def _list_remote_dir_files(
+    dpu_name: str,
+    path: str,
+    ssh_options: List[str],
+) -> List[Dict]:
+    """
+    List regular files under a directory on a remote DPU.
+
+    Returns a list of {"path", "size", "mtime"} entries. A missing directory or
+    a listing failure yields an empty list.
+    """
+    remote_cmd = "find {} -type f -printf '%T@ %s %p\\n'".format(
+        shlex.quote(path)
+    )
+    return_code, output = _run_cmd(
+        ["ssh", *ssh_options, dpu_name, remote_cmd]
+    )
+    if return_code != 0:
+        logging.info(
+            "Unable to list %s on %s (it may not exist): %s",
+            path,
+            dpu_name,
+            output,
+        )
+        return []
+
+    files = []
+    for line in output.splitlines():
+        parts = line.strip().split(" ", 2)
+        if len(parts) != 3:
+            continue
+        mtime_str, size_str, file_path = parts
+        try:
+            files.append(
+                {
+                    "path": file_path,
+                    "size": int(size_str),
+                    "mtime": float(mtime_str),
+                }
+            )
+        except ValueError:
+            continue
+    return files
+
+
+def _delete_remote_files(
+    dpu_name: str,
+    file_paths: List[str],
+    ssh_options: List[str],
+) -> bool:
+    """Delete the given files on a remote DPU. Returns True on success."""
+    if not file_paths:
+        return True
+
+    quoted = " ".join(shlex.quote(file_path) for file_path in file_paths)
+    remote_cmd = "rm -f -- {}".format(quoted)
+    return_code, output = _run_cmd(
+        ["ssh", *ssh_options, dpu_name, remote_cmd]
+    )
+    if return_code != 0:
+        logging.warning(
+            "Failed to delete files on %s: %s",
+            dpu_name,
+            output,
+        )
+        return False
+    return True
+
+
+def recover_remote_dpu_disk_space(
+    dpu_name: str,
+    retention_policy: Dict,
+    ssh_options: List[str],
+) -> None:
+    """
+    Apply the retention policy on a remote DPU to free disk space.
+
+    Each configured path is trimmed independently; a failure for one path does
+    not prevent the remaining paths from being processed.
+    """
+    paths = retention_policy.get("paths")
+    if not isinstance(paths, dict):
+        return
+
+    for path, path_policy in paths.items():
+        if not isinstance(path_policy, dict):
+            continue
+
+        files = _list_remote_dir_files(dpu_name, path, ssh_options)
+        if not files:
+            continue
+
+        to_delete = select_retention_files_to_delete(files, path_policy)
+        if not to_delete:
+            continue
+
+        logging.info(
+            "Applying retention on %s:%s, removing %d file(s)",
+            dpu_name,
+            path,
+            len(to_delete),
+        )
+        _delete_remote_files(dpu_name, to_delete, ssh_options)
+
+
+def ensure_remote_dpu_reboot_disk_space(
+    dpu_name: str,
+    platform_json_path: Optional[str] = None,
+    ssh_options: Optional[List[str]] = None,
+) -> bool:
+    """
+    Validate that a remote DPU has enough free disk space before a reboot, and
+    attempt to recover space using the retention policy when it is short.
+
+    Governed by the optional "dpu_storage_policy" in platform.json:
+
+        "dpu_storage_policy": {
+            "reboot": {"disk_path": "/", "min_free_disk_in_gb": 4},
+            "retention": {"paths": {"/var/dump": {...}, "/var/core": {...}}}
+        }
+
+    Returns True when the policy is not configured (no-op) or when there is
+    sufficient free space (possibly after retention). Returns False when the
+    space remains insufficient or cannot be determined.
+    """
+    policy = get_dpu_storage_policy(platform_json_path)
+    if not policy:
+        logging.info(
+            "dpu_storage_policy is not configured; skipping reboot "
+            "disk-space check for %s",
+            dpu_name,
+        )
+        return True
+
+    reboot_policy = policy.get("reboot")
+    if not isinstance(reboot_policy, dict):
+        logging.info(
+            "dpu_storage_policy.reboot is not configured; skipping reboot "
+            "disk-space check for %s",
+            dpu_name,
+        )
+        return True
+
+    required_gb = _get_optional_positive_int(
+        reboot_policy, "min_free_disk_in_gb"
+    )
+    if required_gb is None:
+        logging.info(
+            "dpu_storage_policy.reboot.min_free_disk_in_gb is not configured; "
+            "skipping reboot disk-space check for %s",
+            dpu_name,
+        )
+        return True
+
+    disk_path = reboot_policy.get("disk_path", DEFAULT_DISK_PATH)
+    resolved_ssh_options = (
+        ssh_options if ssh_options is not None else DEFAULT_SSH_OPTIONS
+    )
+
+    available_gb = get_remote_dpu_free_disk_in_gb(
+        dpu_name, disk_path, resolved_ssh_options
+    )
+
+    if available_gb is not None and available_gb >= required_gb:
+        return True
+
+    retention_policy = policy.get("retention")
+    if isinstance(retention_policy, dict):
+        logging.info(
+            "Insufficient free disk on %s (available=%sGB required=%sGB); "
+            "applying retention policy",
+            dpu_name,
+            available_gb,
+            required_gb,
+        )
+        recover_remote_dpu_disk_space(
+            dpu_name, retention_policy, resolved_ssh_options
+        )
+        available_gb = get_remote_dpu_free_disk_in_gb(
+            dpu_name, disk_path, resolved_ssh_options
+        )
+
+    if available_gb is None:
+        logging.error(
+            "Unable to determine free disk space on %s",
+            dpu_name,
+        )
+        return False
+
+    if available_gb < required_gb:
+        logging.error(
+            "Insufficient free disk on %s after retention: "
+            "available=%sGB required=%sGB path=%s",
+            dpu_name,
+            available_gb,
+            required_gb,
+            disk_path,
+        )
+        return False
+
+    return True
+
+
+def ensure_remote_dpu_disk_space_for_operation(
+        dpu_name,
+        operation,
+        platform_json_path=None,
+        ssh_options=None):
+    """
+    Validate (and, when configured, recover) free disk space on a remote DPU
+    before an operation such as a reboot is performed against it.
+
+    Uses the platform "dpu_storage_policy" and returns True when there is
+    sufficient free space (or the policy is not configured), and False when the
+    space is insufficient or cannot be determined.
+    """
+    logging.info(
+        "Validating free disk space on %s before %s",
+        dpu_name,
+        operation,
+    )
+
+    return ensure_remote_dpu_reboot_disk_space(
+        dpu_name=dpu_name,
+        platform_json_path=platform_json_path,
+        ssh_options=ssh_options,
+    )

--- a/utilities_common/image_disk_space.py
+++ b/utilities_common/image_disk_space.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import re
 import shlex
 import shutil
 import subprocess
@@ -249,31 +248,18 @@ def _run_cmd(cmd: List[str]) -> Tuple[int, str]:
         return 1, str(error)
 
 
-def _parse_df_available_gb(output: str) -> Optional[int]:
-    """
-    Parse output from:
-
-        df -BG --output=avail <path>
-
-    Expected output resembles:
-
-        Avail
-          18G
-    """
-    lines = [
-        line.strip()
-        for line in output.splitlines()
-        if line.strip()
-    ]
-
+def _parse_df_available_bytes(output: str) -> Optional[int]:
+    """Parse the available-byte value from ``df -B1 --output=avail``."""
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
     if len(lines) < 2:
         return None
 
-    match = re.fullmatch(r"(\d+)G?", lines[-1])
-    if not match:
+    try:
+        available_bytes = int(lines[-1])
+    except ValueError:
         return None
 
-    return int(match.group(1))
+    return available_bytes if available_bytes >= 0 else None
 
 
 def get_remote_dpu_free_disk_in_gb(
@@ -281,21 +267,16 @@ def get_remote_dpu_free_disk_in_gb(
     disk_path: str = DEFAULT_DISK_PATH,
     ssh_options: Optional[List[str]] = None,
 ) -> Optional[int]:
-    """
-    Get free disk space from a DPU reachable over SSH.
-    """
+    """Get remote DPU free space, flooring exact bytes to whole GiB."""
     resolved_ssh_options = (
-        ssh_options
-        if ssh_options is not None
-        else DEFAULT_SSH_OPTIONS
+        ssh_options if ssh_options is not None else DEFAULT_SSH_OPTIONS
     )
-
     command = [
         "ssh",
         *resolved_ssh_options,
         dpu_name,
         "df",
-        "-BG",
+        "-B1",
         "--output=avail",
         disk_path,
     ]
@@ -309,15 +290,16 @@ def get_remote_dpu_free_disk_in_gb(
         )
         return None
 
-    available_gb = _parse_df_available_gb(output)
-    if available_gb is None:
+    available_bytes = _parse_df_available_bytes(output)
+    if available_bytes is None:
         logging.warning(
             "Failed to parse disk space from %s: %s",
             dpu_name,
             output,
         )
+        return None
 
-    return available_gb
+    return available_bytes // (1024 ** 3)
 
 
 def check_remote_dpu_image_install_free_disk_space(
@@ -435,6 +417,7 @@ def check_image_install_free_disk_space(
         disk_path=disk_path,
         platform_json_path=platform_json_path,
     )
+
 
 def get_dpu_storage_policy(
     platform_json_path: Optional[str] = None,
@@ -622,73 +605,77 @@ def recover_remote_dpu_disk_space(
         _delete_remote_files(dpu_name, to_delete, ssh_options)
 
 
-def ensure_remote_dpu_reboot_disk_space(
+def ensure_remote_dpu_disk_space_for_operation(
     dpu_name: str,
+    operation: str,
     platform_json_path: Optional[str] = None,
     ssh_options: Optional[List[str]] = None,
 ) -> bool:
-    """
-    Validate that a remote DPU has enough free disk space before a reboot, and
-    attempt to recover space using the retention policy when it is short.
-
-    Governed by the optional "dpu_storage_policy" in platform.json:
-
-        "dpu_storage_policy": {
-            "reboot": {"disk_path": "/", "min_free_disk_in_gb": 4},
-            "retention": {"paths": {"/var/dump": {...}, "/var/core": {...}}}
-        }
-
-    Returns True when the policy is not configured (no-op) or when there is
-    sufficient free space (possibly after retention). Returns False when the
-    space remains insufficient or cannot be determined.
-    """
+    """Validate and, when configured, recover DPU space for an operation."""
     policy = get_dpu_storage_policy(platform_json_path)
     if not policy:
         logging.info(
-            "dpu_storage_policy is not configured; skipping reboot "
-            "disk-space check for %s",
+            "dpu_storage_policy is not configured; skipping %s disk-space "
+            "check for %s",
+            operation,
             dpu_name,
         )
         return True
 
-    reboot_policy = policy.get("reboot")
-    if not isinstance(reboot_policy, dict):
+    operation_policy = policy.get(operation)
+    if operation_policy is None:
         logging.info(
-            "dpu_storage_policy.reboot is not configured; skipping reboot "
-            "disk-space check for %s",
+            "dpu_storage_policy.%s is not configured; skipping disk-space "
+            "check for %s",
+            operation,
+            dpu_name,
+        )
+        return True
+    if not isinstance(operation_policy, dict):
+        logging.error("dpu_storage_policy.%s must be an object", operation)
+        return False
+
+    threshold_key = "min_free_disk_in_gb"
+    if threshold_key not in operation_policy:
+        logging.info(
+            "dpu_storage_policy.%s.%s is not configured; skipping disk-space "
+            "check for %s",
+            operation,
+            threshold_key,
             dpu_name,
         )
         return True
 
-    required_gb = _get_optional_positive_int(
-        reboot_policy, "min_free_disk_in_gb"
-    )
+    required_gb = _get_optional_positive_int(operation_policy, threshold_key)
     if required_gb is None:
-        logging.info(
-            "dpu_storage_policy.reboot.min_free_disk_in_gb is not configured; "
-            "skipping reboot disk-space check for %s",
-            dpu_name,
+        logging.error(
+            "Invalid dpu_storage_policy.%s.%s",
+            operation,
+            threshold_key,
         )
-        return True
+        return False
 
-    disk_path = reboot_policy.get("disk_path", DEFAULT_DISK_PATH)
+    disk_path = operation_policy.get("disk_path", DEFAULT_DISK_PATH)
+    if not isinstance(disk_path, str) or not disk_path:
+        logging.error("Invalid dpu_storage_policy.%s.disk_path", operation)
+        return False
+
     resolved_ssh_options = (
         ssh_options if ssh_options is not None else DEFAULT_SSH_OPTIONS
     )
-
     available_gb = get_remote_dpu_free_disk_in_gb(
         dpu_name, disk_path, resolved_ssh_options
     )
-
     if available_gb is not None and available_gb >= required_gb:
         return True
 
     retention_policy = policy.get("retention")
     if isinstance(retention_policy, dict):
         logging.info(
-            "Insufficient free disk on %s (available=%sGB required=%sGB); "
-            "applying retention policy",
+            "Insufficient free disk on %s before %s "
+            "(available=%sGB required=%sGB); applying retention policy",
             dpu_name,
+            operation,
             available_gb,
             required_gb,
         )
@@ -700,47 +687,32 @@ def ensure_remote_dpu_reboot_disk_space(
         )
 
     if available_gb is None:
-        logging.error(
-            "Unable to determine free disk space on %s",
-            dpu_name,
-        )
+        logging.error("Unable to determine free disk space on %s", dpu_name)
         return False
-
     if available_gb < required_gb:
         logging.error(
             "Insufficient free disk on %s after retention: "
-            "available=%sGB required=%sGB path=%s",
+            "available=%sGB required=%sGB path=%s operation=%s",
             dpu_name,
             available_gb,
             required_gb,
             disk_path,
+            operation,
         )
         return False
 
     return True
 
 
-def ensure_remote_dpu_disk_space_for_operation(
-        dpu_name,
-        operation,
-        platform_json_path=None,
-        ssh_options=None):
-    """
-    Validate (and, when configured, recover) free disk space on a remote DPU
-    before an operation such as a reboot is performed against it.
-
-    Uses the platform "dpu_storage_policy" and returns True when there is
-    sufficient free space (or the policy is not configured), and False when the
-    space is insufficient or cannot be determined.
-    """
-    logging.info(
-        "Validating free disk space on %s before %s",
-        dpu_name,
-        operation,
-    )
-
-    return ensure_remote_dpu_reboot_disk_space(
+def ensure_remote_dpu_reboot_disk_space(
+    dpu_name: str,
+    platform_json_path: Optional[str] = None,
+    ssh_options: Optional[List[str]] = None,
+) -> bool:
+    """Compatibility wrapper for the reboot disk-space policy."""
+    return ensure_remote_dpu_disk_space_for_operation(
         dpu_name=dpu_name,
+        operation="reboot",
         platform_json_path=platform_json_path,
         ssh_options=ssh_options,
     )


### PR DESCRIPTION
Fixes #4661  
Fixes https://github.com/sonic-net/sonic-buildimage/issues/28734


#### What this PR does

Adds reusable disk-space validation for image installation and protects SmartSwitch DPU reboot from low-disk conditions.

- Validates free disk space before local NPU, local DPU, and remote DPU image installation.
- Before `reboot -d DPUx`, verifies that the target DPU has sufficient free space.
- If space is below the configured threshold, removes the oldest eligible files from configured retention paths and rechecks.
- Aborts the image installation or DPU reboot if sufficient space cannot be confirmed or recovered.
- Platforms without `dpu_storage_policy` retain the existing reboot behavior.

#### Configuration

The thresholds and DPU retention policy are configured in the NPU `platform.json`:

```json
{
    "min_free_disk_in_gb_for_npu_image": 16,
    "min_free_disk_in_gb_for_dpu_image": 12,

    "dpu_storage_policy": {
        "reboot": {
            "disk_path": "/",
            "min_free_disk_in_gb": 4
        },
        "retention": {
            "paths": {
                "/var/dump": {
                    "max_size_in_gb": 4,
                    "min_files_to_keep": 1,
                    "min_file_age_minutes": 10
                },
                "/var/core": {
                    "max_size_in_gb": 4,
                    "min_files_to_keep": 1,
                    "min_file_age_minutes": 10
                }
            }
        }
    }
}
```

Retention removes the oldest eligible files first while preserving the configured minimum number of files and files newer than min_file_age_minutes.

#### Implementation
utilities_common/image_disk_space.py
reusable local and remote image-installation disk checks
DPU reboot policy validation and retention-based recovery
sonic_installer/main.py
aborts image installation when the disk-space check fails
scripts/reboot_smartswitch_helper
performs the DPU disk-space check before service halt and reboot
Unit tests cover image thresholds, policy handling, retention selection, remote operations, and reboot success/failure paths.

#### Compatibility

Backward compatible with no CLI changes. Platforms without the new configuration continue using the existing behavior.

This combines the reusable image-installation scope from #4598 with the reboot recovery behavior from #4737 while keeping the description compact. :contentReference[oaicite:0]{index=0}

#### Verification
Unit tests
86 tests passed
100% statement coverage
100% branch coverage
Functional testing
Validated on a Cisco SmartSwitch.

Verified that the helper correctly locates:

/usr/share/sonic/device/<platform>/platform.json
without requiring:

/usr/share/sonic/platform

##### Configured:

"min_free_disk_in_gb_for_npu_image": 100
to force an insufficient disk-space condition.

##### Verified:

check_image_install_free_disk_space() returns False
sonic-installer install  aborts before image installation begins
the configured platform threshold is honored
Observed output:

Downloading image...

ERROR:root:
Insufficient local disk space:
image_type=npu available=19GB required=100GB path=/host

Insufficient free disk space to install the image. Aborting...
Aborted!
This confirms that image installation is prevented when the configured minimum free disk-space requirement is not satisfied.


#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202605

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A