### PR TITLE
[WIP] isis: Add IS-IS Click CLI commands, passive mode, and unit tests

### DIFF
--- a/config/isis.py
+++ b/config/isis.py
@@ -1,0 +1,427 @@
+import click
+import re
+import utilities_common.cli as clicommon
+from sonic_py_common import logger
+
+# Table names
+CFG_ISIS_GLOBALS = "ISIS_GLOBALS"
+CFG_ISIS_GLOBALS_TIMERS = "ISIS_GLOBALS_TIMERS"
+CFG_ISIS_INTERFACE = "ISIS_INTERFACE"
+
+# Logger
+log = logger.Logger("isis_cli")
+log.set_min_log_priority_info()
+
+
+def _alias_to_name(db_conn, interface_alias):
+    """Resolve interface alias to native name if alias mode is active"""
+    port_dict = db_conn.get_table('PORT')
+    if not port_dict:
+        return interface_alias
+    for port_name, info in port_dict.items():
+        if interface_alias == info.get('alias'):
+            return port_name
+    return interface_alias
+
+
+def _validate_interface(db_conn, interface_name):
+    """Validate that the interface exists in ConfigDB"""
+    port_dict = db_conn.get_table('PORT')
+    port_channel_dict = db_conn.get_table('PORTCHANNEL')
+    vlan_dict = db_conn.get_table('VLAN')
+    loopback_dict = db_conn.get_table('LOOPBACK_INTERFACE')
+    vlan_sub_dict = db_conn.get_table('VLAN_SUB_INTERFACE')
+
+    if port_dict and interface_name in port_dict:
+        return True
+    if port_channel_dict and interface_name in port_channel_dict:
+        return True
+    if vlan_dict and interface_name in vlan_dict:
+        return True
+    if loopback_dict and interface_name in loopback_dict:
+        return True
+    if vlan_sub_dict and interface_name in vlan_sub_dict:
+        return True
+
+    return False
+
+
+#
+# IS-IS Global Configuration --------------------------------------------------
+#
+
+@click.group(
+    name="isis",
+    cls=clicommon.AliasedGroup
+)
+def ISIS():
+    """Configure IS-IS routing protocol"""
+    pass
+
+
+@ISIS.command(name="enable")
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_enable(ctx, db, vrf):
+    """Enable IS-IS routing process for a VRF"""
+    table = CFG_ISIS_GLOBALS
+    key = vrf
+
+    cfg = db.cfgdb.get_config()
+    cfg.setdefault(table, {})
+
+    if key in cfg[table]:
+        data = cfg[table][key]
+        if data.get("enabled") == "true":
+            click.echo("IS-IS is already enabled for VRF '{}'".format(vrf))
+            return
+
+    data = {"enabled": "true"}
+    try:
+        db.cfgdb.set_entry(table, key, data)
+        click.echo("Enabled IS-IS routing process for VRF '{}'".format(vrf))
+        log.log_notice("Enabled IS-IS routing process for VRF '{}'".format(vrf))
+    except Exception as e:
+        log.log_error("Failed to enable IS-IS for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+@ISIS.command(name="disable")
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_disable(ctx, db, vrf):
+    """Disable IS-IS routing process for a VRF"""
+    table = CFG_ISIS_GLOBALS
+    key = vrf
+
+    cfg = db.cfgdb.get_config()
+    if table not in cfg or key not in cfg[table]:
+        click.echo("IS-IS routing process for VRF '{}' is not configured".format(vrf))
+        return
+
+    try:
+        db.cfgdb.set_entry(table, key, None)
+        # Clean up timers table if exists
+        timers_table = CFG_ISIS_GLOBALS_TIMERS
+        if timers_table in cfg and key in cfg[timers_table]:
+            db.cfgdb.set_entry(timers_table, key, None)
+
+        click.echo("Disabled IS-IS routing process for VRF '{}'".format(vrf))
+        log.log_notice("Disabled IS-IS routing process for VRF '{}'".format(vrf))
+    except Exception as e:
+        log.log_error("Failed to disable IS-IS for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+@ISIS.command(name="net")
+@click.argument("net_title")
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_net(ctx, db, net_title, vrf):
+    """Configure Network Entity Title (NET) for IS-IS"""
+    # Strict validation of NET (e.g. 49.0001.1921.6800.0001.00)
+    net_pattern = re.compile(r'^[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){1,9}\.[a-fA-F0-9]{2}$')
+    if not net_pattern.match(net_title):
+        ctx.fail("Invalid NET format '{}'. Example format: 49.0001.1921.6800.0001.00".format(net_title))
+
+    table = CFG_ISIS_GLOBALS
+    key = vrf
+
+    cfg = db.cfgdb.get_config()
+    if table not in cfg or key not in cfg[table]:
+        ctx.fail("IS-IS routing process for VRF '{}' is not enabled. Please enable it first using 'config isis enable {}'".format(vrf, vrf))
+
+    data = cfg[table][key]
+    data["net_title"] = net_title
+
+    try:
+        db.cfgdb.set_entry(table, key, data)
+        click.echo("Configured IS-IS NET to '{}' for VRF '{}'".format(net_title, vrf))
+        log.log_notice("Configured IS-IS NET to '{}' for VRF '{}'".format(net_title, vrf))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS NET for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+@ISIS.command(name="level")
+@click.argument("level", type=click.Choice(['level-1', 'level-2', 'level-1-2']))
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_level(ctx, db, level, vrf):
+    """Configure IS-IS routing level"""
+    table = CFG_ISIS_GLOBALS
+    key = vrf
+
+    cfg = db.cfgdb.get_config()
+    if table not in cfg or key not in cfg[table]:
+        ctx.fail("IS-IS routing process for VRF '{}' is not enabled. Please enable it first using 'config isis enable {}'".format(vrf, vrf))
+
+    data = cfg[table][key]
+    data["level"] = level
+
+    try:
+        db.cfgdb.set_entry(table, key, data)
+        click.echo("Configured IS-IS level to '{}' for VRF '{}'".format(level, vrf))
+        log.log_notice("Configured IS-IS level to '{}' for VRF '{}'".format(level, vrf))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS level for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+@ISIS.command(name="hostname")
+@click.argument("state", type=click.Choice(['enabled', 'disabled']))
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_hostname(ctx, db, state, vrf):
+    """Configure dynamic hostname support for IS-IS"""
+    table = CFG_ISIS_GLOBALS
+    key = vrf
+
+    cfg = db.cfgdb.get_config()
+    if table not in cfg or key not in cfg[table]:
+        ctx.fail("IS-IS routing process for VRF '{}' is not enabled. Please enable it first using 'config isis enable {}'".format(vrf, vrf))
+
+    data = cfg[table][key]
+    data["dynamic_hostname"] = "true" if state == "enabled" else "false"
+
+    try:
+        db.cfgdb.set_entry(table, key, data)
+        click.echo("Configured IS-IS dynamic hostname to '{}' for VRF '{}'".format(state, vrf))
+        log.log_notice("Configured IS-IS dynamic hostname to '{}' for VRF '{}'".format(state, vrf))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS dynamic hostname for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+@ISIS.group(name="timer")
+def ISIS_TIMER():
+    """Configure IS-IS global timers"""
+    pass
+
+
+@ISIS_TIMER.command(name="lsp-mtu")
+@click.argument("mtu", type=click.IntRange(128, 4352))
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_timer_lsp_mtu(ctx, db, mtu, vrf):
+    """Configure IS-IS LSP MTU size"""
+    cfg = db.cfgdb.get_config()
+    if CFG_ISIS_GLOBALS not in cfg or vrf not in cfg[CFG_ISIS_GLOBALS]:
+        ctx.fail("IS-IS routing process for VRF '{}' is not enabled. Please enable it first.".format(vrf))
+
+    table = CFG_ISIS_GLOBALS_TIMERS
+    key = vrf
+    cfg.setdefault(table, {})
+    data = cfg[table].setdefault(key, {})
+    data["lsp_mtu"] = str(mtu)
+
+    try:
+        db.cfgdb.set_entry(table, key, data)
+        click.echo("Configured IS-IS LSP MTU to {} for VRF '{}'".format(mtu, vrf))
+        log.log_notice("Configured IS-IS LSP MTU to {} for VRF '{}'".format(mtu, vrf))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS LSP MTU for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+@ISIS_TIMER.command(name="lsp-refresh")
+@click.argument("interval", type=click.IntRange(1, 65535))
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_timer_lsp_refresh(ctx, db, interval, vrf):
+    """Configure IS-IS LSP refresh interval (seconds)"""
+    cfg = db.cfgdb.get_config()
+    if CFG_ISIS_GLOBALS not in cfg or vrf not in cfg[CFG_ISIS_GLOBALS]:
+        ctx.fail("IS-IS routing process for VRF '{}' is not enabled. Please enable it first.".format(vrf))
+
+    table = CFG_ISIS_GLOBALS_TIMERS
+    key = vrf
+    cfg.setdefault(table, {})
+    data = cfg[table].setdefault(key, {})
+    data["lsp_refresh_interval"] = str(interval)
+
+    try:
+        db.cfgdb.set_entry(table, key, data)
+        click.echo("Configured IS-IS LSP refresh interval to {}s for VRF '{}'".format(interval, vrf))
+        log.log_notice("Configured IS-IS LSP refresh interval to {}s for VRF '{}'".format(interval, vrf))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS LSP refresh interval for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+@ISIS_TIMER.command(name="lsp-lifetime")
+@click.argument("lifetime", type=click.IntRange(350, 65535))
+@click.argument("vrf", required=False, default="default")
+@clicommon.pass_db
+@click.pass_context
+def isis_timer_lsp_lifetime(ctx, db, lifetime, vrf):
+    """Configure IS-IS max LSP lifetime (seconds)"""
+    cfg = db.cfgdb.get_config()
+    if CFG_ISIS_GLOBALS not in cfg or vrf not in cfg[CFG_ISIS_GLOBALS]:
+        ctx.fail("IS-IS routing process for VRF '{}' is not enabled. Please enable it first.".format(vrf))
+
+    table = CFG_ISIS_GLOBALS_TIMERS
+    key = vrf
+    cfg.setdefault(table, {})
+    data = cfg[table].setdefault(key, {})
+    data["lsp_lifetime"] = str(lifetime)
+
+    try:
+        db.cfgdb.set_entry(table, key, data)
+        click.echo("Configured IS-IS LSP max lifetime to {}s for VRF '{}'".format(lifetime, vrf))
+        log.log_notice("Configured IS-IS LSP max lifetime to {}s for VRF '{}'".format(lifetime, vrf))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS LSP max lifetime for VRF '{}': {}".format(vrf, str(e)))
+        ctx.fail(str(e))
+
+
+#
+# IS-IS Interface Configuration -----------------------------------------------
+#
+
+@click.group(
+    name="isis",
+    cls=clicommon.AliasedGroup
+)
+@click.pass_context
+def INTERFACE_ISIS(ctx):
+    """Configure IS-IS interface settings"""
+    if not ctx.obj or 'config_db' not in ctx.obj:
+        ctx.fail("config_db is not initialized")
+
+
+@INTERFACE_ISIS.command(name="enable")
+@click.argument("interface_name")
+@click.pass_context
+def interface_isis_enable(ctx, interface_name):
+    """Enable IS-IS routing on an interface"""
+    db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = _alias_to_name(db, interface_name)
+        if not interface_name:
+            ctx.fail("Invalid interface alias")
+
+    if not _validate_interface(db, interface_name):
+        ctx.fail("Interface '{}' does not exist".format(interface_name))
+
+    table = CFG_ISIS_INTERFACE
+    key = interface_name
+
+    cfg = db.get_config()
+    cfg.setdefault(table, {})
+
+    if key in cfg[table]:
+        click.echo("IS-IS is already enabled on interface {}".format(interface_name))
+        return
+
+    # Use a dummy dict containing just enabled: true to trigger creation
+    data = {"enabled": "true"}
+
+    try:
+        db.set_entry(table, key, data)
+        click.echo("Enabled IS-IS on interface {}".format(interface_name))
+        log.log_notice("Enabled IS-IS on interface {}".format(interface_name))
+    except Exception as e:
+        log.log_error("Failed to enable IS-IS on interface {}: {}".format(interface_name, str(e)))
+        ctx.fail(str(e))
+
+
+@INTERFACE_ISIS.command(name="disable")
+@click.argument("interface_name")
+@click.pass_context
+def interface_isis_disable(ctx, interface_name):
+    """Disable IS-IS routing on an interface"""
+    db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = _alias_to_name(db, interface_name)
+        if not interface_name:
+            ctx.fail("Invalid interface alias")
+
+    table = CFG_ISIS_INTERFACE
+    key = interface_name
+
+    cfg = db.get_config()
+    if table not in cfg or key not in cfg[table]:
+        click.echo("IS-IS routing is not enabled on interface {}".format(interface_name))
+        return
+
+    try:
+        db.set_entry(table, key, None)
+        click.echo("Disabled IS-IS on interface {}".format(interface_name))
+        log.log_notice("Disabled IS-IS on interface {}".format(interface_name))
+    except Exception as e:
+        log.log_error("Failed to disable IS-IS on interface {}: {}".format(interface_name, str(e)))
+        ctx.fail(str(e))
+
+
+@INTERFACE_ISIS.command(name="metric")
+@click.argument("interface_name")
+@click.argument("metric_val", type=click.IntRange(1, 16777215))
+@click.pass_context
+def interface_isis_metric(ctx, interface_name, metric_val):
+    """Configure IS-IS metric for an interface"""
+    db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = _alias_to_name(db, interface_name)
+        if not interface_name:
+            ctx.fail("Invalid interface alias")
+
+    table = CFG_ISIS_INTERFACE
+    key = interface_name
+
+    cfg = db.get_config()
+    if table not in cfg or key not in cfg[table]:
+        ctx.fail("IS-IS routing is not enabled on interface {}. Please enable it first using 'config interface isis enable {}'".format(interface_name, interface_name))
+
+    data = cfg[table][key]
+    data["metric"] = str(metric_val)
+
+    try:
+        db.set_entry(table, key, data)
+        click.echo("Configured IS-IS metric to {} on interface {}".format(metric_val, interface_name))
+        log.log_notice("Configured IS-IS metric to {} on interface {}".format(metric_val, interface_name))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS metric on interface {}: {}".format(interface_name, str(e)))
+        ctx.fail(str(e))
+
+
+@INTERFACE_ISIS.command(name="circuit-type")
+@click.argument("interface_name")
+@click.argument("circuit_type", type=click.Choice(['p2p', 'lan']))
+@click.pass_context
+def interface_isis_circuit_type(ctx, interface_name, circuit_type):
+    """Configure IS-IS circuit type for an interface"""
+    db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = _alias_to_name(db, interface_name)
+        if not interface_name:
+            ctx.fail("Invalid interface alias")
+
+    table = CFG_ISIS_INTERFACE
+    key = interface_name
+
+    cfg = db.get_config()
+    if table not in cfg or key not in cfg[table]:
+        ctx.fail("IS-IS routing is not enabled on interface {}. Please enable it first using 'config interface isis enable {}'".format(interface_name, interface_name))
+
+    data = cfg[table][key]
+    data["circuit_type"] = circuit_type
+
+    try:
+        db.set_entry(table, key, data)
+        click.echo("Configured IS-IS circuit type to '{}' on interface {}".format(circuit_type, interface_name))
+        log.log_notice("Configured IS-IS circuit type to '{}' on interface {}".format(circuit_type, interface_name))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS circuit type on interface {}: {}".format(interface_name, str(e)))
+        ctx.fail(str(e))

--- a/config/isis.py
+++ b/config/isis.py
@@ -425,3 +425,36 @@ def interface_isis_circuit_type(ctx, interface_name, circuit_type):
     except Exception as e:
         log.log_error("Failed to configure IS-IS circuit type on interface {}: {}".format(interface_name, str(e)))
         ctx.fail(str(e))
+
+
+@INTERFACE_ISIS.command(name="passive")
+@click.argument("interface_name")
+@click.argument("mode", type=click.Choice(['enable', 'disable']))
+@click.pass_context
+def interface_isis_passive(ctx, interface_name, mode):
+    """Configure IS-IS passive mode for an interface"""
+    db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = _alias_to_name(db, interface_name)
+        if not interface_name:
+            ctx.fail("Invalid interface alias")
+
+    table = CFG_ISIS_INTERFACE
+    key = interface_name
+
+    cfg = db.get_config()
+    if table not in cfg or key not in cfg[table]:
+        ctx.fail("IS-IS routing is not enabled on interface {}. Please enable it first using 'config interface isis enable {}'".format(interface_name, interface_name))
+
+    data = cfg[table][key]
+    data["passive"] = "true" if mode == "enable" else "false"
+
+    try:
+        db.set_entry(table, key, data)
+        click.echo("Configured IS-IS passive mode to '{}' on interface {}".format(mode, interface_name))
+        log.log_notice("Configured IS-IS passive mode to '{}' on interface {}".format(mode, interface_name))
+    except Exception as e:
+        log.log_error("Failed to configure IS-IS passive mode on interface {}: {}".format(interface_name, str(e)))
+        ctx.fail(str(e))
+

--- a/config/main.py
+++ b/config/main.py
@@ -72,6 +72,8 @@ from . import switchport
 from . import dns
 from . import bgp_cli
 from . import stp
+from . import isis
+
 
 # mock masic APIs for unit test
 try:
@@ -1815,6 +1817,12 @@ config.add_command(dns.dns)
 
 # Switchport module
 config.add_command(switchport.switchport)
+
+# IS-IS modules
+config.add_command(isis.ISIS)
+
+
+
 
 @config.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,
@@ -5140,6 +5148,9 @@ def interface(ctx, namespace):
     config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=str(namespace))
     config_db.connect()
     ctx.obj = {'config_db': config_db, 'namespace': str(namespace)}
+
+interface.add_command(isis.INTERFACE_ISIS)
+
 
 
 @config.group(cls=clicommon.AliasedGroup, name='switch-fast-linkup', context_settings=CONTEXT_SETTINGS)

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -39,6 +39,9 @@
   * [BMC config commands](#bmc-config-commands)
 * [BFD](#bfd)
   * [BFD show commands](#bfd-show-commands)
+* [IS-IS](#is-is)
+  * [IS-IS show commands](#is-is-show-commands)
+  * [IS-IS config commands](#is-is-config-commands)
 * [BGP](#bgp)
   * [BGP show commands](#bgp-show-commands)
   * [BGP config commands](#bgp-config-commands)
@@ -2676,6 +2679,153 @@ This command displays the state and key parameters of all BFD sessions that matc
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#bfd)
+
+## IS-IS
+
+This section explains all the IS-IS show commands and IS-IS configuration commands supported in SONiC.
+
+### IS-IS show commands
+
+**show isis neighbor**
+
+This command displays the IS-IS neighbor adjacencies and their current states.
+
+- Usage:
+  ```
+  show isis neighbor [--json]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show isis neighbor
+  Area default:
+   System Id           Interface   L  State         Holdtime SNPA
+   sonic               Ethernet0   3  Up            29       2020.2020.2020
+   sonic               Ethernet4   3  Up            28       2020.2020.2020
+  ```
+
+**show isis database**
+
+This command displays the IS-IS Link-State Database (LSDB).
+
+- Usage:
+  ```
+  show isis database [detail] [--json]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show isis database
+  IS-IS Level-1 link-state database:
+  LSP ID                  PduLen  SeqNumber   Chksum  Holdtime  ATT/P/OL
+  sonic.00-00          *     73   0x00000002  0x34a4    1217    0/0/0
+  ```
+
+**show isis summary**
+
+This command displays the IS-IS process summary.
+
+- Usage:
+  ```
+  show isis summary [--json]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show isis summary
+  vrf             : default
+  Process Id      : 42
+  System Id       : 1921.6800.0001
+  Up time         : 00:03:50 ago
+  Number of areas : 1
+  ```
+
+### IS-IS config commands
+
+**config isis net**
+
+This command configures the Network Entity Title (NET) for IS-IS.
+
+- Usage:
+  ```
+  config isis net <net_title>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config isis net 49.0001.0000.0000.0001.00
+  ```
+
+**config isis level**
+
+This command configures the router level for IS-IS.
+
+- Usage:
+  ```
+  config isis level <level-1|level-2|level-1-2>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config isis level level-1
+  ```
+
+**config interface isis enable / disable**
+
+This command enables or disables IS-IS on an interface.
+
+- Usage:
+  ```
+  config interface isis enable <interface_name>
+  config interface isis disable <interface_name>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config interface isis enable Ethernet0
+  ```
+
+**config interface isis passive**
+
+This command enables or disables passive mode for an interface in IS-IS.
+
+- Usage:
+  ```
+  config interface isis passive <interface_name> <enable|disable>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config interface isis passive Loopback0 enable
+  ```
+
+**config interface isis circuit-type**
+
+This command configures the circuit type (p2p or lan) for an interface in IS-IS.
+
+- Usage:
+  ```
+  config interface isis circuit-type <interface_name> <p2p|lan>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config interface isis circuit-type Ethernet0 p2p
+  ```
+
+**config interface isis metric**
+
+This command configures the IS-IS metric cost for an interface.
+
+- Usage:
+  ```
+  config interface isis metric <interface_name> <metric_val>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config interface isis metric Ethernet0 20
+  ```
 
 ## BGP
 

--- a/show/isis.py
+++ b/show/isis.py
@@ -1,0 +1,69 @@
+import click
+import sys
+import utilities_common.cli as clicommon
+import utilities_common.multi_asic as multi_asic_util
+from sonic_py_common import multi_asic
+
+
+def run_vtysh_command(vtysh_cmd, namespace=None):
+    """Run vtysh command in the correct namespace"""
+    cmd = ['sudo', 'vtysh']
+    if namespace and namespace != multi_asic.DEFAULT_NAMESPACE:
+        asic_id = multi_asic.get_asic_id_from_name(namespace)
+        if asic_id is not None:
+            cmd += ['-n', str(asic_id)]
+    cmd += ['-c', vtysh_cmd]
+
+    output, ret = clicommon.run_command(cmd, return_cmd=True)
+    return output
+
+
+@click.group(
+    name="isis",
+    cls=clicommon.AliasedGroup
+)
+def isis():
+    """Show IS-IS routing protocol information"""
+    pass
+
+
+@isis.command()
+@click.option('-j', '--json', 'json_format', is_flag=True, help="Display in JSON format")
+@click.option('--namespace', '-n', default=None, type=str,
+              help='Namespace name',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def summary(json_format, namespace):
+    """Show IS-IS summary"""
+    cmd = "show isis summary"
+    if json_format:
+        cmd += " json"
+    output = run_vtysh_command(cmd, namespace)
+    click.echo(output.rstrip('\n'))
+
+
+@isis.command()
+@click.option('-j', '--json', 'json_format', is_flag=True, help="Display in JSON format")
+@click.option('--namespace', '-n', default=None, type=str,
+              help='Namespace name',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def neighbor(json_format, namespace):
+    """Show IS-IS neighbors"""
+    cmd = "show isis neighbor"
+    if json_format:
+        cmd += " json"
+    output = run_vtysh_command(cmd, namespace)
+    click.echo(output.rstrip('\n'))
+
+
+@isis.command()
+@click.option('-j', '--json', 'json_format', is_flag=True, help="Display in JSON format")
+@click.option('--namespace', '-n', default=None, type=str,
+              help='Namespace name',
+              callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def database(json_format, namespace):
+    """Show IS-IS database"""
+    cmd = "show isis database"
+    if json_format:
+        cmd += " json"
+    output = run_vtysh_command(cmd, namespace)
+    click.echo(output.rstrip('\n'))

--- a/show/main.py
+++ b/show/main.py
@@ -69,6 +69,8 @@ from . import syslog
 from . import dns
 from . import bgp_cli
 from . import stp
+from . import isis
+
 from . import srv6
 from . import switch
 from . import icmp
@@ -344,6 +346,10 @@ if is_gearbox_configured():
 
 # bgp module
 cli.add_command(bgp_cli.BGP)
+
+# isis module
+cli.add_command(isis.isis)
+
 
 #
 # 'vrf' command ("show vrf")

--- a/tests/isis_test.py
+++ b/tests/isis_test.py
@@ -23,6 +23,7 @@ class TestIsis(object):
     config_interface_isis_disable = config.interface.commands["isis"].commands["disable"]
     config_interface_isis_metric = config.interface.commands["isis"].commands["metric"]
     config_interface_isis_circuit_type = config.interface.commands["isis"].commands["circuit-type"]
+    config_interface_isis_passive = config.interface.commands["isis"].commands["passive"]
 
     show_isis_summary = show.cli.commands["isis"].commands["summary"]
     show_isis_neighbor = show.cli.commands["isis"].commands["neighbor"]
@@ -144,6 +145,11 @@ class TestIsis(object):
         result = runner.invoke(self.config_interface_isis_circuit_type, ["Ethernet0", "p2p"], obj=obj)
         assert result.exit_code == 0
         assert db.cfgdb.get_table("ISIS_INTERFACE")["Ethernet0"]["circuit_type"] == "p2p"
+
+        # Configure Passive Mode
+        result = runner.invoke(self.config_interface_isis_passive, ["Ethernet0", "enable"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_INTERFACE")["Ethernet0"]["passive"] == "true"
 
         # Disable ISIS on Ethernet0
         result = runner.invoke(self.config_interface_isis_disable, ["Ethernet0"], obj=obj)

--- a/tests/isis_test.py
+++ b/tests/isis_test.py
@@ -1,0 +1,168 @@
+import os
+import pytest
+from unittest import mock
+from click.testing import CliRunner
+
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+
+class TestIsis(object):
+    config_isis_enable = config.config.commands["isis"].commands["enable"]
+    config_isis_disable = config.config.commands["isis"].commands["disable"]
+    config_isis_net = config.config.commands["isis"].commands["net"]
+    config_isis_level = config.config.commands["isis"].commands["level"]
+    config_isis_hostname = config.config.commands["isis"].commands["hostname"]
+
+    config_isis_timer_lsp_mtu = config.config.commands["isis"].commands["timer"].commands["lsp-mtu"]
+    config_isis_timer_lsp_refresh = config.config.commands["isis"].commands["timer"].commands["lsp-refresh"]
+    config_isis_timer_lsp_lifetime = config.config.commands["isis"].commands["timer"].commands["lsp-lifetime"]
+
+    config_interface_isis_enable = config.interface.commands["isis"].commands["enable"]
+    config_interface_isis_disable = config.interface.commands["isis"].commands["disable"]
+    config_interface_isis_metric = config.interface.commands["isis"].commands["metric"]
+    config_interface_isis_circuit_type = config.interface.commands["isis"].commands["circuit-type"]
+
+    show_isis_summary = show.cli.commands["isis"].commands["summary"]
+    show_isis_neighbor = show.cli.commands["isis"].commands["neighbor"]
+    show_isis_database = show.cli.commands["isis"].commands["database"]
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def test_isis_enable_disable(self):
+        db = Db()
+        runner = CliRunner()
+        obj = db
+
+        # Enable IS-IS default VRF
+        result = runner.invoke(self.config_isis_enable, [], obj=obj)
+        assert result.exit_code == 0
+        assert "default" in db.cfgdb.get_table("ISIS_GLOBALS")
+        assert db.cfgdb.get_table("ISIS_GLOBALS")["default"]["enabled"] == "true"
+
+        # Enable IS-IS for non-default VRF Vrf2
+        result = runner.invoke(self.config_isis_enable, ["Vrf2"], obj=obj)
+        assert result.exit_code == 0
+        assert "Vrf2" in db.cfgdb.get_table("ISIS_GLOBALS")
+        assert db.cfgdb.get_table("ISIS_GLOBALS")["Vrf2"]["enabled"] == "true"
+
+        # Disable IS-IS for Vrf2
+        result = runner.invoke(self.config_isis_disable, ["Vrf2"], obj=obj)
+        assert result.exit_code == 0
+        assert "Vrf2" not in db.cfgdb.get_table("ISIS_GLOBALS")
+
+        # Disable IS-IS default VRF
+        result = runner.invoke(self.config_isis_disable, [], obj=obj)
+        assert result.exit_code == 0
+        assert "default" not in db.cfgdb.get_table("ISIS_GLOBALS")
+
+    def test_isis_net_level_hostname(self):
+        db = Db()
+        runner = CliRunner()
+        obj = db
+
+        # Try configuring without enabling first (should fail)
+        result = runner.invoke(self.config_isis_net, ["49.0001.1921.6800.0001.00"], obj=obj)
+        assert result.exit_code != 0
+
+        # Enable first
+        runner.invoke(self.config_isis_enable, [], obj=obj)
+
+        # Set valid NET
+        result = runner.invoke(self.config_isis_net, ["49.0001.1921.6800.0001.00"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_GLOBALS")["default"]["net_title"] == "49.0001.1921.6800.0001.00"
+
+        # Set invalid NET (should fail)
+        result = runner.invoke(self.config_isis_net, ["invalid-net"], obj=obj)
+        assert result.exit_code != 0
+
+        # Set level
+        result = runner.invoke(self.config_isis_level, ["level-1"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_GLOBALS")["default"]["level"] == "level-1"
+
+        # Set hostname
+        result = runner.invoke(self.config_isis_hostname, ["enabled"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_GLOBALS")["default"]["dynamic_hostname"] == "true"
+
+    def test_isis_timers(self):
+        db = Db()
+        runner = CliRunner()
+        obj = db
+
+        # Enable first
+        runner.invoke(self.config_isis_enable, [], obj=obj)
+
+        # Set lsp-mtu
+        result = runner.invoke(self.config_isis_timer_lsp_mtu, ["1400"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_GLOBALS_TIMERS")["default"]["lsp_mtu"] == "1400"
+
+        # Set out-of-range lsp-mtu (should fail)
+        result = runner.invoke(self.config_isis_timer_lsp_mtu, ["9999"], obj=obj)
+        assert result.exit_code != 0
+
+        # Set lsp-refresh
+        result = runner.invoke(self.config_isis_timer_lsp_refresh, ["900"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_GLOBALS_TIMERS")["default"]["lsp_refresh_interval"] == "900"
+
+        # Set lsp-lifetime
+        result = runner.invoke(self.config_isis_timer_lsp_lifetime, ["1500"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_GLOBALS_TIMERS")["default"]["lsp_lifetime"] == "1500"
+
+    def test_isis_interface(self):
+        db = Db()
+        runner = CliRunner()
+
+        # Let's mock a port in CONFIG_DB so validation passes
+        db.cfgdb.set_entry("PORT", "Ethernet0", {"admin_status": "up"})
+
+        obj = {'config_db': db.cfgdb, 'namespace': 'default'}
+
+        # Enable ISIS on Ethernet0
+        result = runner.invoke(self.config_interface_isis_enable, ["Ethernet0"], obj=obj)
+        assert result.exit_code == 0
+        assert "Ethernet0" in db.cfgdb.get_table("ISIS_INTERFACE")
+
+        # Configure Metric
+        result = runner.invoke(self.config_interface_isis_metric, ["Ethernet0", "20"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_INTERFACE")["Ethernet0"]["metric"] == "20"
+
+        # Configure Circuit Type
+        result = runner.invoke(self.config_interface_isis_circuit_type, ["Ethernet0", "p2p"], obj=obj)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_table("ISIS_INTERFACE")["Ethernet0"]["circuit_type"] == "p2p"
+
+        # Disable ISIS on Ethernet0
+        result = runner.invoke(self.config_interface_isis_disable, ["Ethernet0"], obj=obj)
+        assert result.exit_code == 0
+        assert "Ethernet0" not in db.cfgdb.get_table("ISIS_INTERFACE")
+
+    @mock.patch('utilities_common.cli.run_command')
+    def test_show_isis(self, mock_run_command):
+        mock_run_command.return_value = ("IS-IS output summary mock", 0)
+        runner = CliRunner()
+
+        # show isis summary
+        result = runner.invoke(self.show_isis_summary, [])
+        assert result.exit_code == 0
+        assert "IS-IS output summary mock" in result.output
+        mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', 'show isis summary'], return_cmd=True)
+
+        # show isis neighbor --json
+        mock_run_command.return_value = ("[]", 0)
+        result = runner.invoke(self.show_isis_neighbor, ["--json"])
+        assert result.exit_code == 0
+        mock_run_command.assert_called_with(['sudo', 'vtysh', '-c', 'show isis neighbor json'], return_cmd=True)


### PR DESCRIPTION
#### What I did

Implemented the host-level `config isis` and `show isis` Click CLI command suite, added passive interface configuration support (`config interface isis passive`), updated `doc/Command-Reference.md`, and added unit tests in `tests/isis_test.py` as part of the Mentorship project "Enable ISIS functionality on Sonic".

#### Dependencies

- Requires `sonic-net/sonic-buildimage#28789` (provides YANG models, frrcfgd handlers, and template rendering for IS-IS).

#### How I did it

- Implemented `config/isis.py` commands (`net`, `level`, `hostname`, `timer`, `enable`, `disable`, `metric`, `circuit-type`, `passive`) to populate Redis ConfigDB (`ISIS_GLOBALS` and `ISIS_INTERFACE` tables). Registered in `config/main.py`.
- Implemented `show/isis.py` commands (`neighbor`, `database`, `summary`) wrapping `vtysh` command execution with `--json` option support. Registered in `show/main.py`.
- Added `config interface isis passive` command handling to configure `passive` attribute in `ISIS_INTERFACE` table.
- Documented all commands in `doc/Command-Reference.md` under the `## IS-IS` section.
- Implemented unit test cases in `tests/isis_test.py` covering Click runner invocations and ConfigDB state checks.

#### How to verify it

1. **Unit Test Coverage**:

   - Executed `pytest tests/isis_test.py` covering mock Redis ConfigDB operations and Click runner invocations for all IS-IS global and interface commands.
2. **Integration Verification**:

   - On a live SONiC node, verified dynamic DB updates and command execution for:
     - `sudo config isis net 49.0001.0000.0000.0001.00`
     - `sudo config isis level level-1-2`
     - `sudo config interface isis enable Ethernet0`
     - `sudo config interface isis passive Loopback0 enable`
     - `sudo config interface isis circuit-type Ethernet0 p2p`
     - `sudo config interface isis metric Ethernet0 20`
   - Verified `show isis neighbor`, `show isis database`, and `show isis summary` output in both text and `--json` formats.

#### Previous command output (if the output of a command-line utility has changed)

N/A (New feature commands).

#### New command output (if the output of a command-line utility has changed)

```text
admin@sonic:~$ show isis neighbor
Area default:
 System Id           Interface   L  State         Holdtime SNPA
 sonic               Ethernet0   3  Up            29       2020.2020.2020
 sonic               Ethernet4   3  Up            28       2020.2020.2020
```