### PR TITLE
[Mellanox] Add UT for preserving explicit buffer_model=dynamic in buffer migrator

### DIFF
--- a/tests/db_migrator_input/config_db/non-default-config-dynamic-acs-expected.json
+++ b/tests/db_migrator_input/config_db/non-default-config-dynamic-acs-expected.json
@@ -1,0 +1,1121 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "pg_lossless_10000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "pg_lossless_25000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "pg_lossless_40000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "pg_lossless_50000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "ingress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "ingress_lossless_pool",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "ingress_lossless_pool",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "ingress_lossless_pool",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN2700",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "buffer_model": "dynamic",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable"
+    },
+    "PORT|Ethernet0": {
+        "index": "1",
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1",
+        "admin_status": "up",
+        "speed": "10000",
+        "description": "etp1"
+    },
+    "PORT|Ethernet4": {
+        "index": "2",
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "index": "3",
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "index": "4",
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "index": "5",
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "index": "6",
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "index": "7",
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "index": "8",
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "index": "9",
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "index": "10",
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "index": "11",
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "index": "12",
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "index": "13",
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "index": "14",
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "index": "15",
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "index": "16",
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "index": "17",
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "index": "18",
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "index": "19",
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "index": "20",
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "index": "21",
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "index": "22",
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "index": "23",
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "index": "24",
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "index": "25",
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "index": "26",
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp26",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp26"
+    },
+    "PORT|Ethernet104": {
+        "index": "27",
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp27",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp27"
+    },
+    "PORT|Ethernet108": {
+        "index": "28",
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp28",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp28"
+    },
+    "PORT|Ethernet112": {
+        "index": "29",
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "index": "30",
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "index": "31",
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "index": "32",
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_3"
+    }
+}

--- a/tests/db_migrator_input/config_db/non-default-config-dynamic-acs-input.json
+++ b/tests/db_migrator_input/config_db/non-default-config-dynamic-acs-input.json
@@ -1,0 +1,1065 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN2700",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable",
+        "buffer_model": "dynamic"
+    },
+    "PORT|Ethernet0": {
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp1",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "description": "etp1",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet4": {
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp26",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet104": {
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp27",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp27",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet108": {
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp28",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet112": {
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_input/config_db/non-default-config-dynamic-mellanox-expected.json
+++ b/tests/db_migrator_input/config_db/non-default-config-dynamic-mellanox-expected.json
@@ -1,0 +1,1121 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "pg_lossless_10000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "pg_lossless_25000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "pg_lossless_40000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "pg_lossless_50000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "ingress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "ingress_lossless_pool",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "ingress_lossless_pool",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "ingress_lossless_pool",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN2700",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "buffer_model": "traditional",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable"
+    },
+    "PORT|Ethernet0": {
+        "index": "1",
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1",
+        "admin_status": "up",
+        "speed": "10000",
+        "description": "etp1"
+    },
+    "PORT|Ethernet4": {
+        "index": "2",
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "index": "3",
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "index": "4",
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "index": "5",
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "index": "6",
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "index": "7",
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "index": "8",
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "index": "9",
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "index": "10",
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "index": "11",
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "index": "12",
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "index": "13",
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "index": "14",
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "index": "15",
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "index": "16",
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "index": "17",
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "index": "18",
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "index": "19",
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "index": "20",
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "index": "21",
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "index": "22",
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "index": "23",
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "index": "24",
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "index": "25",
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "index": "26",
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp26",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp26"
+    },
+    "PORT|Ethernet104": {
+        "index": "27",
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp27",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp27"
+    },
+    "PORT|Ethernet108": {
+        "index": "28",
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp28",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp28"
+    },
+    "PORT|Ethernet112": {
+        "index": "29",
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "index": "30",
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "index": "31",
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "index": "32",
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_3"
+    }
+}

--- a/tests/db_migrator_input/config_db/non-default-config-dynamic-mellanox-input.json
+++ b/tests/db_migrator_input/config_db/non-default-config-dynamic-mellanox-input.json
@@ -1,0 +1,1065 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN2700",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable",
+        "buffer_model": "dynamic"
+    },
+    "PORT|Ethernet0": {
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp1",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "description": "etp1",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet4": {
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp26",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet104": {
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp27",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp27",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet108": {
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp28",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet112": {
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_input/config_db/non-default-config-dynamic-nvidia-expected.json
+++ b/tests/db_migrator_input/config_db/non-default-config-dynamic-nvidia-expected.json
@@ -1,0 +1,1121 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "pg_lossless_10000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "pg_lossless_25000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "pg_lossless_40000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "pg_lossless_50000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "ingress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "ingress_lossless_pool",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "ingress_lossless_pool",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "ingress_lossless_pool",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN5600-O128",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-nvidia_sn5600-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "buffer_model": "dynamic",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable"
+    },
+    "PORT|Ethernet0": {
+        "index": "1",
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1",
+        "admin_status": "up",
+        "speed": "10000",
+        "description": "etp1"
+    },
+    "PORT|Ethernet4": {
+        "index": "2",
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "index": "3",
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "index": "4",
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "index": "5",
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "index": "6",
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "index": "7",
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "index": "8",
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "index": "9",
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "index": "10",
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "index": "11",
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "index": "12",
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "index": "13",
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "index": "14",
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "index": "15",
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "index": "16",
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "index": "17",
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "index": "18",
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "index": "19",
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "index": "20",
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "index": "21",
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "index": "22",
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "index": "23",
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "index": "24",
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "index": "25",
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "index": "26",
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp26",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp26"
+    },
+    "PORT|Ethernet104": {
+        "index": "27",
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp27",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp27"
+    },
+    "PORT|Ethernet108": {
+        "index": "28",
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp28",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp28"
+    },
+    "PORT|Ethernet112": {
+        "index": "29",
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "index": "30",
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "index": "31",
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "index": "32",
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_3"
+    }
+}

--- a/tests/db_migrator_input/config_db/non-default-config-dynamic-nvidia-input.json
+++ b/tests/db_migrator_input/config_db/non-default-config-dynamic-nvidia-input.json
@@ -1,0 +1,1065 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "Mellanox-SN5600-O128",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-nvidia_sn5600-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable",
+        "buffer_model": "dynamic"
+    },
+    "PORT|Ethernet0": {
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp1",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "description": "etp1",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet4": {
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp26",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet104": {
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp27",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp27",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet108": {
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp28",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet112": {
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_input/config_db/non-default-config-traditional-acs-expected.json
+++ b/tests/db_migrator_input/config_db/non-default-config-traditional-acs-expected.json
@@ -1,0 +1,1121 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "pg_lossless_10000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "pg_lossless_25000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "pg_lossless_40000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "pg_lossless_50000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "pg_lossless_100000_5m_profile"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "pg_lossless_100000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "ingress_lossy_profile"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "pg_lossless_50000_40m_profile"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "egress_lossless_profile,egress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet0": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet100": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet104": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet108": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "ingress_lossless_profile,ingress_lossy_profile"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "egress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "ingress_lossless_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "ingress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "ingress_lossless_pool",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "ingress_lossless_pool",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "ingress_lossless_pool",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "ingress_lossless_pool",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "egress_lossy_pool",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "q_lossy_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "egress_lossless_profile"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "q_lossy_profile"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN2700",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "buffer_model": "traditional",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable"
+    },
+    "PORT|Ethernet0": {
+        "index": "1",
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp1",
+        "admin_status": "up",
+        "speed": "10000",
+        "description": "etp1"
+    },
+    "PORT|Ethernet4": {
+        "index": "2",
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "index": "3",
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "index": "4",
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "index": "5",
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "index": "6",
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "index": "7",
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "index": "8",
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "index": "9",
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "index": "10",
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "index": "11",
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "index": "12",
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "index": "13",
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "index": "14",
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "index": "15",
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "index": "16",
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "index": "17",
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "index": "18",
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "index": "19",
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "index": "20",
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "index": "21",
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "index": "22",
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "index": "23",
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "index": "24",
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "index": "25",
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "index": "26",
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp26",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp26"
+    },
+    "PORT|Ethernet104": {
+        "index": "27",
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp27",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp27"
+    },
+    "PORT|Ethernet108": {
+        "index": "28",
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp28",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "etp28"
+    },
+    "PORT|Ethernet112": {
+        "index": "29",
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "index": "30",
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "index": "31",
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "index": "32",
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_3"
+    }
+}

--- a/tests/db_migrator_input/config_db/non-default-config-traditional-acs-input.json
+++ b/tests/db_migrator_input/config_db/non-default-config-traditional-acs-input.json
@@ -1,0 +1,1065 @@
+{
+    "BUFFER_PG|Ethernet0|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_10000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet4|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_25000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet8|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet12|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet16|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet20|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet24|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet28|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet32|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet36|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet40|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet44|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet48|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet52|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet56|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet60|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet64|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet68|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet72|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet76|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet80|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet84|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet88|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet92|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet96|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet100|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet104|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet108|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_5m_profile]"
+    },
+    "BUFFER_PG|Ethernet112|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet116|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_100000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet120|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_PG|Ethernet124|0": {
+        "profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PG|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|pg_lossless_50000_40m_profile]"
+    },
+    "BUFFER_POOL|egress_lossless_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "13000000"
+    },
+    "BUFFER_POOL|egress_lossy_pool": {
+        "type": "egress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_POOL|ingress_lossless_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "4194304"
+    },
+    "BUFFER_POOL|ingress_lossy_pool": {
+        "type": "ingress",
+        "mode": "dynamic",
+        "size": "7340032"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet4": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet8": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet12": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet16": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet20": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet24": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet28": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet32": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet36": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet40": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet44": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet48": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet52": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet56": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet60": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet64": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet68": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet72": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet76": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet80": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet84": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet88": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet92": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet96": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet112": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet116": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet120": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST|Ethernet124": {
+        "profile_list": "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+    },
+    "BUFFER_PROFILE|egress_lossless_profile": {
+        "dynamic_th": "7",
+        "pool": "[BUFFER_POOL|egress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|egress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "4096"
+    },
+    "BUFFER_PROFILE|ingress_lossless_profile": {
+        "dynamic_th": "0",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|ingress_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|ingress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_PROFILE|pg_lossless_10000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_25000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_40000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "16384",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "34816"
+    },
+    "BUFFER_PROFILE|pg_lossless_50000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "23552",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "41984"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_5m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "18432",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "36864"
+    },
+    "BUFFER_PROFILE|pg_lossless_100000_40m_profile": {
+        "xon": "18432",
+        "dynamic_th": "0",
+        "xoff": "35840",
+        "pool": "[BUFFER_POOL|ingress_lossless_pool]",
+        "size": "54272"
+    },
+    "BUFFER_PROFILE|q_lossy_profile": {
+        "dynamic_th": "3",
+        "pool": "[BUFFER_POOL|egress_lossy_pool]",
+        "size": "0"
+    },
+    "BUFFER_QUEUE|Ethernet4|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet4|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet8|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet12|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet16|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet20|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet24|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet28|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet32|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet36|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet40|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet44|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet48|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet52|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet56|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet60|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet64|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet68|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet72|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet76|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet80|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet84|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet88|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet92|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet96|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet112|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet116|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet120|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|0-2": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|3-4": {
+        "profile": "[BUFFER_PROFILE|egress_lossless_profile]"
+    },
+    "BUFFER_QUEUE|Ethernet124|5-6": {
+        "profile": "[BUFFER_PROFILE|q_lossy_profile]"
+    },
+    "CABLE_LENGTH|AZURE": {
+        "Ethernet8": "5m",
+        "Ethernet0": "5m",
+        "Ethernet4": "5m",
+        "Ethernet108": "5m",
+        "Ethernet100": "5m",
+        "Ethernet104": "5m",
+        "Ethernet96": "5m",
+        "Ethernet124": "40m",
+        "Ethernet92": "5m",
+        "Ethernet120": "40m",
+        "Ethernet52": "5m",
+        "Ethernet56": "5m",
+        "Ethernet76": "5m",
+        "Ethernet72": "5m",
+        "Ethernet32": "5m",
+        "Ethernet16": "5m",
+        "Ethernet36": "5m",
+        "Ethernet12": "5m",
+        "Ethernet28": "5m",
+        "Ethernet88": "5m",
+        "Ethernet24": "5m",
+        "Ethernet116": "40m",
+        "Ethernet80": "5m",
+        "Ethernet112": "40m",
+        "Ethernet84": "5m",
+        "Ethernet48": "5m",
+        "Ethernet44": "5m",
+        "Ethernet40": "5m",
+        "Ethernet64": "5m",
+        "Ethernet60": "5m",
+        "Ethernet20": "5m",
+        "Ethernet68": "5m"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku": "ACS-MSN2700",
+        "default_bgp_status": "up",
+        "docker_routing_config_mode": "separated",
+        "hostname": "sonic",
+        "platform": "x86_64-mlnx_msn2700-r0",
+        "mac": "00:01:02:03:04:00",
+        "default_pfcwd_status": "disable",
+        "bgp_asn": "65100",
+        "deployment_id": "1",
+        "type": "ToRRouter",
+        "synchronous_mode": "enable",
+        "buffer_model": "traditional"
+    },
+    "PORT|Ethernet0": {
+        "lanes": "0,1,2,3",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp1",
+        "pfc_asym": "off",
+        "speed": "10000",
+        "description": "etp1",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet4": {
+        "lanes": "4,5,6,7",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp2",
+        "admin_status": "up",
+        "speed": "25000",
+        "description": "Servers0:eth0"
+    },
+    "PORT|Ethernet8": {
+        "lanes": "8,9,10,11",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp3",
+        "admin_status": "up",
+        "speed": "40000",
+        "description": "Servers1:eth0"
+    },
+    "PORT|Ethernet12": {
+        "lanes": "12,13,14,15",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp4",
+        "admin_status": "up",
+        "speed": "50000",
+        "description": "Servers2:eth0"
+    },
+    "PORT|Ethernet16": {
+        "lanes": "16,17,18,19",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp5",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers3:eth0"
+    },
+    "PORT|Ethernet20": {
+        "lanes": "20,21,22,23",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp6",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers4:eth0"
+    },
+    "PORT|Ethernet24": {
+        "lanes": "24,25,26,27",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp7",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers5:eth0"
+    },
+    "PORT|Ethernet28": {
+        "lanes": "28,29,30,31",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp8",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers6:eth0"
+    },
+    "PORT|Ethernet32": {
+        "lanes": "32,33,34,35",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp9",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers7:eth0"
+    },
+    "PORT|Ethernet36": {
+        "lanes": "36,37,38,39",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp10",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers8:eth0"
+    },
+    "PORT|Ethernet40": {
+        "lanes": "40,41,42,43",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp11",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers9:eth0"
+    },
+    "PORT|Ethernet44": {
+        "lanes": "44,45,46,47",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp12",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers10:eth0"
+    },
+    "PORT|Ethernet48": {
+        "lanes": "48,49,50,51",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp13",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers11:eth0"
+    },
+    "PORT|Ethernet52": {
+        "lanes": "52,53,54,55",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp14",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers12:eth0"
+    },
+    "PORT|Ethernet56": {
+        "lanes": "56,57,58,59",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp15",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers13:eth0"
+    },
+    "PORT|Ethernet60": {
+        "lanes": "60,61,62,63",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp16",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers14:eth0"
+    },
+    "PORT|Ethernet64": {
+        "lanes": "64,65,66,67",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp17",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers15:eth0"
+    },
+    "PORT|Ethernet68": {
+        "lanes": "68,69,70,71",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp18",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers16:eth0"
+    },
+    "PORT|Ethernet72": {
+        "lanes": "72,73,74,75",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp19",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers17:eth0"
+    },
+    "PORT|Ethernet76": {
+        "lanes": "76,77,78,79",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp20",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers18:eth0"
+    },
+    "PORT|Ethernet80": {
+        "lanes": "80,81,82,83",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp21",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers19:eth0"
+    },
+    "PORT|Ethernet84": {
+        "lanes": "84,85,86,87",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp22",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers20:eth0"
+    },
+    "PORT|Ethernet88": {
+        "lanes": "88,89,90,91",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp23",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers21:eth0"
+    },
+    "PORT|Ethernet92": {
+        "lanes": "92,93,94,95",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp24",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers22:eth0"
+    },
+    "PORT|Ethernet96": {
+        "lanes": "96,97,98,99",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp25",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "Servers23:eth0"
+    },
+    "PORT|Ethernet100": {
+        "lanes": "100,101,102,103",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp26",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp26",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet104": {
+        "lanes": "104,105,106,107",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp27",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp27",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet108": {
+        "lanes": "108,109,110,111",
+        "fec": "rs",
+        "mtu": "9100",
+        "alias": "etp28",
+        "pfc_asym": "off",
+        "speed": "100000",
+        "description": "etp28",
+        "admin_status": "up"
+    },
+    "PORT|Ethernet112": {
+        "lanes": "112,113,114,115",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp29",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA01T1:Ethernet1"
+    },
+    "PORT|Ethernet116": {
+        "lanes": "116,117,118,119",
+        "fec": "rs",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp30",
+        "admin_status": "up",
+        "speed": "100000",
+        "description": "ARISTA02T1:Ethernet1"
+    },
+    "PORT|Ethernet120": {
+        "lanes": "120,121,122,123",
+        "description": "ARISTA03T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp31",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "PORT|Ethernet124": {
+        "lanes": "124,125,126,127",
+        "description": "ARISTA04T1:Ethernet1",
+        "pfc_asym": "off",
+        "mtu": "9100",
+        "alias": "etp32",
+        "admin_status": "up",
+        "speed": "50000"
+    },
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_1_0_1"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -166,7 +166,15 @@ class TestMellanoxBufferMigrator(object):
                               'non-default-xoff',
                               'non-default-lossless-profile-in-pg',
                               'non-default-lossy-profile-in-pg',
-                              'non-default-pg'
+                              'non-default-pg',
+                              # An explicit buffer_model=dynamic must survive migration on any SKU for which
+                              # dynamic is not the default-traditional model, ie. non "Mellanox-" prefixed SKUs
+                              # and the SKUs listed in mellanox_buffer_migrator.dynamic_model_skus.
+                              'non-default-config-dynamic-acs',
+                              'non-default-config-dynamic-nvidia',
+                              # A "Mellanox-" prefixed SKU outside that list is still forced to traditional
+                              'non-default-config-dynamic-mellanox',
+                              'non-default-config-traditional-acs'
                              ])
     def test_mellanox_buffer_migrator_negative_cold_reboot(self, scenario):
         db_before_migrate = scenario + '-input'
@@ -267,6 +275,22 @@ class TestMellanoxBufferMigrator(object):
         input_config_db = 'non-default-config-input'
         input_appl_db = 'non-default-input'
         self.mellanox_buffer_migrator_warm_reboot_runner(input_config_db, input_appl_db, expected_config_db, expected_appl_db, False)
+
+    def test_mellanox_buffer_migrator_dynamic_preserved_for_warm_reboot(self):
+        """
+        mlnx_flush_new_buffer_configuration is reached from the warm reboot path as well,
+        verify the explicit buffer_model=dynamic is preserved there too
+        """
+        device_info.get_sonic_version_info = get_sonic_version_info_mlnx
+        expected_config_db = 'non-default-config-dynamic-acs-expected'
+        expected_appl_db = 'non-default-expected'
+        input_config_db = 'non-default-config-dynamic-acs-input'
+        input_appl_db = 'non-default-input'
+        self.mellanox_buffer_migrator_warm_reboot_runner(input_config_db,
+                                                         input_appl_db,
+                                                         expected_config_db,
+                                                         expected_appl_db,
+                                                         is_buffer_config_default_expected=False)
 
     @pytest.mark.parametrize('buffer_model', ['traditional', 'dynamic'])
     @pytest.mark.parametrize('ingress_pools', ['double-pools', 'single-pool'])


### PR DESCRIPTION
  #### What I did
  
  Add unit tests covering the `already_dynamic` guard introduced by sonic-net/sonic-utilities#4609
  ("[Mellanox] Preserve explicit buffer_model=dynamic in buffer migrator"), which was merged with
  no test changes. Redmine #5119457.
  
  The guard had **zero** coverage before this PR:
  
  - every scenario in `test_mellanox_buffer_migrator_negative_cold_reboot` omits `buffer_model`
    from its input, so `already_dynamic` is always False;
  - the only fixtures that do set `buffer_model=dynamic` (`reclaiming-buffer-dynamic-*`) start at
    `version_3_0_2` and therefore never reach `mlnx_flush_new_buffer_configuration()`, which is
    only called from the `version_1_0_2` .. `version_1_0_6` steps.
  
  #### How I did it
  
  Four cold-reboot scenarios plus one warm-reboot test. Every fixture derives from
  `non-default-config` and differs from it only in `DEVICE_METADATA|localhost`:
  
  | scenario | hwsku | input `buffer_model` | expected |
  |---|---|---|---|
  | `non-default-config-dynamic-acs` | ACS-MSN2700 | dynamic | **dynamic** |
  | `non-default-config-dynamic-nvidia` | Mellanox-SN5600-O128 | dynamic | **dynamic** |
  | `non-default-config-dynamic-mellanox` | Mellanox-SN2700 | dynamic | traditional |
  | `non-default-config-traditional-acs` | ACS-MSN2700 | traditional | traditional |
  
  `dynamic-acs` covers the legacy `ACS-*` SKUs, where `is_default_traditional_model` is False for
  any non-`Mellanox-` prefixed SKU, so #4609 changed behaviour there too. `dynamic-nvidia` covers
  the allowlisted SKU the PR was written for. `dynamic-mellanox` is the negative control.
  
  The warm-reboot case covers `mlnx_flush_new_buffer_configuration()` reached via
  `mellanox_buffer_migrator_warm_reboot_runner`, which no cold-reboot scenario exercises.
  
  #### How to verify it
  
  ```
  pytest tests/db_migrator_test.py -k MellanoxBufferMigrator -vv -n 0 --no-cov
  ```
  
  80 passed. Verified by mutation, not just by passing:
  
  | mutation to `mlnx_flush_new_buffer_configuration()` | result |
  |---|---|
  | drop `and not already_dynamic` (reverts #4609) | `dynamic-acs`, `dynamic-nvidia` and the warm-reboot case fail; **all 77 pre-existing tests still pass** |
  | drop `and not self.is_default_traditional_model` from `already_dynamic` | `dynamic-mellanox` fails, and only it |
  
  The first mutation reproduces the original bug, so those three cases are what would have caught
  it, and the pre-existing suite staying green under it is direct evidence that #4609 was
  previously untested. The second shows `dynamic-mellanox` pins the `dynamic_model_skus` allowlist
  so it cannot be widened silently.                                             Jump to bottom (ctrl+End) ↓ 
  
  `non-default-config-traditional-acs` is a characterization case: it records that an explicit
  `traditional` is left untouched. It does not distinguish a presence-based check from a
  value-based one, since both leave the value as `traditional`.
  
  #### Previous command output (if the output of a command-line utility has changed)
  
  N/A - test-only change.
  
  #### New command output (if the output of a command-line utility has changed)
  
  N/A - test-only change.
