### PR TITLE
[tacacs]: Add SSH client TraceId configuration CLI

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -257,6 +257,18 @@ tacacs.add_command(passkey)
 default.add_command(passkey)
 
 
+@click.command()
+@click.argument('option', type=click.Choice(["enable", "disable", "default"]))
+@clicommon.pass_db
+def traceid_authorization(db, option):
+    """Send SSH_CLIENT_TRACEID in TACACS+ authorization [enable | disable | default]"""
+    if option == 'default':
+        del_table_key(db, 'TACPLUS', 'global', 'traceid_authorization')
+    else:
+        add_table_kv(db, 'TACPLUS', 'global', 'traceid_authorization', option == 'enable')
+tacacs.add_command(traceid_authorization)
+
+
 # cmd: tacacs add <ip_address> --timeout SECOND --key SECRET --type TYPE --port PORT --pri PRIORITY
 @click.command()
 @click.argument('address', metavar='<ip_address>')

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2300,6 +2300,7 @@ This command displays the global configuration fields and the list of all tacacs
   TACPLUS global auth_type pap (default)
   TACPLUS global timeout 99
   TACPLUS global passkey <EMPTY_STRING> (default)
+  TACPLUS global traceid_authorization false (default)
 
   TACPLUS_SERVER address 10.11.12.14
                          priority 9
@@ -2323,6 +2324,7 @@ Some of the parameters like authtype, passkey and timeout can be either configur
 3) default - reset the authtype or passkey or timeout to the default values.
 4) passkey - global configuration that is applied to all servers if there is no server specific configuration.
 5) timeout - global configuration that is applied to all servers if there is no server specific configuration.
+6) traceid-authorization - control whether validated SSH_CLIENT_TRACEID values are sent in TACACS+ command authorization requests.
 
 **config tacacs add**
 
@@ -2443,6 +2445,25 @@ When user has not configured server specific timeout, this global value shall be
 - Example: To configure non-default timeout value
   ```
   admin@sonic:~$ sudo config tacacs timeout 60
+  ```
+
+**config tacacs traceid-authorization**
+
+This command controls whether validated `SSH_CLIENT_TRACEID` values are sent as the `traceid` attribute in TACACS+ command authorization requests. The feature is disabled by default.
+
+- Usage:
+  ```
+  config tacacs traceid-authorization (enable | disable | default)
+  ```
+
+  - Options:
+    - `enable`: Send valid `SSH_CLIENT_TRACEID` values in TACACS+ command authorization requests.
+    - `disable`: Explicitly disable sending `SSH_CLIENT_TRACEID` values.
+    - `default`: Remove the explicit configuration and use the default value, which is disabled.
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config tacacs traceid-authorization enable
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#tacacs)

--- a/show/main.py
+++ b/show/main.py
@@ -2330,7 +2330,8 @@ def tacacs():
         'global': {
             'auth_type': 'pap (default)',
             'timeout': '5 (default)',
-            'passkey': '<EMPTY_STRING> (default)'
+            'passkey': '<EMPTY_STRING> (default)',
+            'traceid_authorization': 'false (default)'
         }
     }
     if 'global' in data:

--- a/tests/aaa_test.py
+++ b/tests/aaa_test.py
@@ -168,6 +168,30 @@ AAA accounting login disable (default)
 
 """
 
+show_tacacs_default_output="""\
+TACPLUS global auth_type pap (default)
+TACPLUS global timeout 5 (default)
+TACPLUS global passkey <EMPTY_STRING> (default)
+TACPLUS global traceid_authorization false (default)
+
+"""
+
+show_tacacs_traceid_enable_output="""\
+TACPLUS global auth_type pap (default)
+TACPLUS global timeout 5 (default)
+TACPLUS global passkey <EMPTY_STRING> (default)
+TACPLUS global traceid_authorization True
+
+"""
+
+show_tacacs_traceid_disable_output="""\
+TACPLUS global auth_type pap (default)
+TACPLUS global timeout 5 (default)
+TACPLUS global passkey <EMPTY_STRING> (default)
+TACPLUS global traceid_authorization False
+
+"""
+
 class TestAaa(object):
     @classmethod
     def setup_class(cls):
@@ -481,6 +505,42 @@ class TestAaa(object):
         result = runner.invoke(show.cli.commands["aaa"], [], obj=db)
         assert result.exit_code == 0
         assert result.output == show_aaa_disable_accounting_output
+
+    def test_config_tacacs_traceid_authorization(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(show.cli.commands["tacacs"], [], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_tacacs_default_output
+
+        result = runner.invoke(config.config.commands["tacacs"],
+                               ["traceid-authorization", "enable"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == config_aaa_empty_output
+
+        result = runner.invoke(show.cli.commands["tacacs"], [], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_tacacs_traceid_enable_output
+
+        result = runner.invoke(config.config.commands["tacacs"],
+                               ["traceid-authorization", "disable"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == config_aaa_empty_output
+
+        result = runner.invoke(show.cli.commands["tacacs"], [], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_tacacs_traceid_disable_output
+
+        result = runner.invoke(config.config.commands["tacacs"],
+                               ["traceid-authorization", "default"], obj=db)
+        assert result.exit_code == 0
+        assert result.output == config_aaa_empty_output
+
+        result = runner.invoke(show.cli.commands["tacacs"], [], obj=db)
+        assert result.exit_code == 0
+        assert result.output == show_tacacs_default_output
 
     @patch("validated_config_db_connector.device_info.is_yang_config_validation_enabled", mock.Mock(return_value=True))
     @patch("config.validated_config_db_connector.ValidatedConfigDBConnector.validated_set_entry", mock.Mock(side_effect=JsonPatchConflict))


### PR DESCRIPTION
#### What I did

Added CLI support for configuring SSH client TraceId propagation in TACACS+ command authorization requests.

This adds:

- `config tacacs traceid-authorization enable`
- `config tacacs traceid-authorization disable`
- `config tacacs traceid-authorization default`
- TraceId authorization status to `show tacacs`

The feature remains disabled by default for backward compatibility.

This supports the HLD in sonic-net/SONiC#2358 and complements:

- sonic-net/sonic-buildimage#27667
- sonic-net/sonic-host-services#407

##### Work item tracking

- Microsoft ADO: 38265947

#### How I did it

- `config/aaa.py`: added the `traceid-authorization` command.
  - `enable` writes `traceid_authorization=true` to `TACPLUS|global`.
  - `disable` writes `traceid_authorization=false`.
  - `default` removes the field, restoring the disabled default.
- `show/main.py`: displays `traceid_authorization false (default)` when the field is absent.
- `tests/aaa_test.py`: added coverage for the default, enabled, disabled, and reset states.
- `doc/Command-Reference.md`: documented the new command and updated `show tacacs` output.

#### How to verify it

Run the focused unit test in a SONiC test environment:

```bash
python3 -m pytest tests/aaa_test.py::TestAaa::test_config_tacacs_traceid_authorization -q
```

Verify the CLI manually:

```bash
sudo config tacacs traceid-authorization enable
show tacacs
```

Confirm the output contains:

```text
TACPLUS global traceid_authorization True
```

Disable it:

```bash
sudo config tacacs traceid-authorization disable
show tacacs
```

Confirm:

```text
TACPLUS global traceid_authorization False
```

Restore the default:

```bash
sudo config tacacs traceid-authorization default
show tacacs
```

Confirm:

```text
TACPLUS global traceid_authorization false (default)
```

With sonic-net/sonic-buildimage#27667 and sonic-net/sonic-host-services#407 installed, enable the option and confirm valid `SSH_CLIENT_TRACEID` values are included as `traceid` attributes in TACACS+ command authorization requests.

#### Previous command output

`show tacacs` did not report TraceId authorization state:

```text
TACPLUS global auth_type pap (default)
TACPLUS global timeout 5 (default)
TACPLUS global passkey <EMPTY_STRING> (default)
```

There was no supported `config tacacs` command for changing this setting.

#### New command output

```text
TACPLUS global auth_type pap (default)
TACPLUS global timeout 5 (default)
TACPLUS global passkey <EMPTY_STRING> (default)
TACPLUS global traceid_authorization false (default)
```