### PR TITLE
[vlan] Add VLAN administrative state CLI support

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -59,6 +59,40 @@ def get_config_db_from_context(ctx):
     return multi_asic.connect_config_db_for_ns(namespace)
 
 
+def set_vlan_admin_status(ctx, vid, admin_status):
+    """Set the administrative status of an existing VLAN."""
+    if not vid.isdigit():
+        ctx.fail("{} is not integer".format(vid))
+
+    vlan_id = int(vid)
+    if not clicommon.is_vlanid_in_range(vlan_id):
+        ctx.fail("Invalid VLAN ID {} (2-4094)".format(vlan_id))
+
+    config_db = get_config_db_from_context(ctx)
+    vlan_name = 'Vlan{}'.format(vlan_id)
+    if not clicommon.check_if_vlanid_exist(config_db, vlan_name):
+        ctx.fail("{} does not exist".format(vlan_name))
+
+    log.log_info("'vlan {} {}' executing...".format(admin_status, vlan_id))
+    config_db.mod_entry('VLAN', vlan_name, {'admin_status': admin_status})
+
+
+@vlan.command('shutdown')
+@click.argument('vid', metavar='<vid>', required=True)
+@click.pass_context
+def shutdown_vlan(ctx, vid):
+    """Shut down a VLAN."""
+    set_vlan_admin_status(ctx, vid, 'down')
+
+
+@vlan.command('startup')
+@click.argument('vid', metavar='<vid>', required=True)
+@click.pass_context
+def startup_vlan(ctx, vid):
+    """Start up a VLAN."""
+    set_vlan_admin_status(ctx, vid, 'up')
+
+
 def get_namespace_from_context(ctx):
     """Extract namespace from context object."""
     if isinstance(ctx.obj, dict):

--- a/show/vlan.py
+++ b/show/vlan.py
@@ -101,6 +101,14 @@ def get_static_anycast_gateway(ctx, vlan):
 
     return "disabled"
 
+
+def get_admin_status(ctx, vlan):
+    cfg, _ = ctx
+    vlan_data, _, _ = cfg
+
+    return vlan_data[vlan].get("admin_status", "up")
+
+
 class VlanBrief:
     """ This class is used as a namespace to
     define columns for "show vlan brief" command.
@@ -133,7 +141,11 @@ class VlanBrief:
 def brief(verbose, namespace):
     def _brief_helper(db):
         """Show all bridge information"""
-        header = [colname for colname, getter in VlanBrief.COLUMNS]
+        columns = VlanBrief.COLUMNS
+        if verbose:
+            columns = columns + [("Admin Status", get_admin_status)]
+
+        header = [colname for colname, getter in columns]
         body = []
 
         # Fetching data from config db for VLAN, VLAN_INTERFACE and VLAN_MEMBER
@@ -144,7 +156,7 @@ def brief(verbose, namespace):
 
         for vlan in natsorted(vlan_data):
             row = []
-            for column in VlanBrief.COLUMNS:
+            for column in columns:
                 column_name, getter = column
                 row.append(getter((vlan_cfg, db), vlan))
             body.append(row)

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -412,12 +412,28 @@ class TestVlan(object):
         assert result.output == show_vlan_brief_output
 
     def test_show_vlan_brief_verbose(self):
-        runner = CliRunner()
-        result = runner.invoke(show.cli.commands["vlan"].commands["brief"], ["--verbose"])
-        print(result.exit_code)
-        print(result.output)
-        assert result.exit_code == 0
-        assert result.output == show_vlan_brief_output
+        db = Db()
+        vlan_name = "Vlan3999"
+        try:
+            db.cfgdb.set_entry("VLAN", vlan_name, {
+                "vlanid": "3999",
+                "admin_status": "down"
+            })
+
+            runner = CliRunner()
+            result = runner.invoke(
+                show.cli.commands["vlan"].commands["brief"],
+                ["--verbose"],
+                obj=db
+            )
+            print(result.exit_code)
+            print(result.output)
+            assert result.exit_code == 0
+            assert "Admin Status" in result.output
+            assert "| up             |" in result.output
+            assert "| down           |" in result.output
+        finally:
+            db.cfgdb.set_entry("VLAN", vlan_name, None)
 
     def test_show_vlan_brief_in_alias_mode(self):
         runner = CliRunner()
@@ -499,6 +515,52 @@ class TestVlan(object):
         result = runner.invoke(config.config.commands["vlan"].commands["del"], ["1001"])
         print(result.exit_code)
         print(result.output)
+        assert result.exit_code != 0
+        assert "Error: Vlan1001 does not exist" in result.output
+
+    @pytest.mark.parametrize("command,admin_status", [
+        ("shutdown", "down"),
+        ("startup", "up"),
+    ])
+    def test_config_vlan_admin_status(self, command, admin_status):
+        db = Db()
+        vlan_name = "Vlan3999"
+        try:
+            db.cfgdb.set_entry("VLAN", vlan_name, {"vlanid": "3999"})
+
+            runner = CliRunner()
+            result = runner.invoke(
+                config.config.commands["vlan"].commands[command],
+                ["3999"],
+                obj={"config_db": db.cfgdb, "namespace": ""}
+            )
+
+            assert result.exit_code == 0
+            vlan = db.cfgdb.get_entry("VLAN", vlan_name)
+            assert vlan["admin_status"] == admin_status
+            assert vlan["vlanid"] == "3999"
+        finally:
+            db.cfgdb.set_entry("VLAN", vlan_name, None)
+
+    @pytest.mark.parametrize("command", ["shutdown", "startup"])
+    def test_config_vlan_admin_status_invalid_vlanid(self, command):
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["vlan"].commands[command],
+            ["4096"]
+        )
+
+        assert result.exit_code != 0
+        assert "Error: Invalid VLAN ID 4096 (2-4094)" in result.output
+
+    @pytest.mark.parametrize("command", ["shutdown", "startup"])
+    def test_config_vlan_admin_status_nonexistent_vlan(self, command):
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["vlan"].commands[command],
+            ["1001"]
+        )
+
         assert result.exit_code != 0
         assert "Error: Vlan1001 does not exist" in result.output
 


### PR DESCRIPTION
## Why I did it

SONiC does not provide a persistent CLI under `config vlan` to control the administrative state of an existing VLAN. Using `ip link set Vlan<vid> down/up` directly is temporary and does not update CONFIG_DB.

## How I did it

- Add `config vlan shutdown <vid>` and `config vlan startup <vid>`.
- Validate the VLAN ID and require the VLAN to exist.
- Store the requested state as `VLAN.admin_status` (`down` or `up`).
- Add an `Admin Status` column to `show vlan brief --verbose`.
- Default the displayed status to `up` when `admin_status` is absent, preserving compatibility with existing VLAN entries.
- Preserve the existing non-verbose `show vlan brief` output.

The current vlanmgrd behavior applies this state to the Linux `Vlan<vid>` netdev/SVI. This change does not claim to suspend Layer-2 forwarding for the VLAN; L2 VLAN suspension can be considered separately.

## How to verify it

```bash
sudo config vlan shutdown 100
show vlan brief --verbose
sonic-db-cli CONFIG_DB hgetall "VLAN|Vlan100"
ip link show Vlan100

sudo config vlan startup 100
show vlan brief --verbose
sonic-db-cli CONFIG_DB hgetall "VLAN|Vlan100"
ip link show Vlan100
```

## Test results

- `sonic-utilities` wheel build: passed.
- Unit suite: 5195 passed, 19 skipped, 1 expected failure.
- SONiC-VS two-node containerlab A/B testing: passed.
- Verified shutdown/startup transitions for SVI VLAN 100 and L2-only VLAN 200.
- Verified invalid and nonexistent VLAN IDs are rejected.
- Verified VLAN membership and physical member-port state remain unchanged.

## Test environment

- SONiC-VS, x86_64 KVM, Debian 13.
- Containerlab/vrnetlab; no physical hardware was used.