### PR TITLE
[Warm-reboot] Skip lag_keepalive on inactive LAG members

### DIFF
--- a/scripts/lag_keepalive.py
+++ b/scripts/lag_keepalive.py
@@ -76,6 +76,8 @@ def get_lacpdu_per_lag_member(namespace):
     appDB = ConfigDBConnector(namespace=namespace)
     appDB.db_connect('APPL_DB')
     appDB_lag_info = appDB.get_keys('LAG_MEMBER_TABLE')
+    configDB = ConfigDBConnector(namespace=namespace)
+    configDB.connect()
     active_lag_members = list()
     lag_member_to_packet = dict()
     for lag_entry in appDB_lag_info:
@@ -85,7 +87,7 @@ def get_lacpdu_per_lag_member(namespace):
             # only apply the workaround for active lags
             lag_member = str(lag_entry[1])
             # Skip admin-down members — L2socket raises ENETDOWN on them
-            port_admin = appDB.get(appDB.APPL_DB, "PORT_TABLE:{}".format(lag_member), "admin_status")
+            port_admin = configDB.get_entry('PORT', lag_member).get('admin_status')
             if port_admin != "up":
                 log_info("lag member {} is admin-down, skipping".format(lag_member))
                 continue

--- a/scripts/lag_keepalive.py
+++ b/scripts/lag_keepalive.py
@@ -84,6 +84,11 @@ def get_lacpdu_per_lag_member(namespace):
         if oper_status == "up":
             # only apply the workaround for active lags
             lag_member = str(lag_entry[1])
+            # Skip admin-down members — L2socket raises ENETDOWN on them
+            port_admin = appDB.get(appDB.APPL_DB, "PORT_TABLE:{}".format(lag_member), "admin_status")
+            if port_admin != "up":
+                log_info("lag member {} is admin-down, skipping".format(lag_member))
+                continue
             active_lag_members.append(lag_member)
             # craft lacpdu packets for each lag member based on config
             port_channel_config = get_port_channel_config(lag_name, namespace)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Skip inactive LAG members from sending LACPDUs during fast/warm reboot

#### How I did it
By checking each LAG member admin status before crafting LACPDU packets

#### How to verify it

1. Configure a portchannel with multiple members
2. Shutdown 1 of the LAG members
3. Run the lag_keepalive script and make sure LACPDUs are sent only for the active LAG members
4. Verify no lag_keepalive errors

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

#### Tested branch
- [x] master
- [x] 202605
