### PR TITLE
[Warm-reboot][teamd_increase_retyry_count] Fix decoding None lldp neighbors to JSON when lldp is down

### DIFF
--- a/scripts/teamd_increase_retry_count.py
+++ b/scripts/teamd_increase_retry_count.py
@@ -185,8 +185,11 @@ def getLldpNeighbors(namespace=""):
     container = "lldp"
     if namespace:
         container += namespace.removeprefix("asic")
-    (processStdout, _) = getCmdOutput(["docker", "exec", container, "lldpctl", "-f", "json"])
-    return json.loads(processStdout)
+    try:
+        (processStdout, _) = getCmdOutput(["docker", "exec", container, "lldpctl", "-f", "json"])
+        return json.loads(processStdout)
+    except json.JSONDecodeError:
+        return None
 
 def craftLacpPacket(portChannelConfig, portName, isResetPacket=False, newVersion=True):
     portConfig = portChannelConfig["ports"][portName]
@@ -254,6 +257,11 @@ def main(probeOnly=False, namespace=""):
         for portChannel in portChannels:
             config = getPortChannelConfig(portChannel)
             lldpInfo = getLldpNeighbors(namespace)
+            if not lldpInfo:
+                log.log_error(f"ERROR: Failed to get LLDP neighbors for port channel {portChannel}; "
+                              "make sure lldp container is running", also_print_to_console=True)
+                failedPortChannels.append(portChannel)
+                continue
             portChannelChecked = False
             for portName in config["ports"].keys():
                 if not "runner" in config["ports"][portName] or \


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed JSON decoding of a None object received when lldp is down

#### How I did it
By wrapping the JSON decoding and checking the returned value

#### How to verify it

1. Stop the lldp container
2. Run teamd_increase_retry_count.py --probe-only
3. Verify no Traceback from JSON None decoding

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

#### Tested branch
- [x] master
- [x] 202605
