### PR TITLE
Fix memory_checker false alarms during config reload (#4710)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1017,13 +1017,33 @@ def _monit_service_exists(service):
         return False
 
 
+def _get_monit_services_by_prefix(prefix):
+    """Return list of monit service names that start with the given prefix."""
+    try:
+        output = subprocess.check_output(
+            ['sudo', 'monit', 'summary'],
+            stderr=subprocess.DEVNULL,
+            text=True
+        )
+        services = []
+        for line in output.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(prefix):
+                services.append(stripped.split()[0])
+        return services
+    except subprocess.CalledProcessError:
+        return []
+
+
 def _stop_services():
     try:
         subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        click.echo("Disabling container and routeCheck monitoring ...")
+        click.echo("Disabling container, routeCheck and memory monitoring ...")
         clicommon.run_command(['sudo', 'monit', 'unmonitor', 'container_checker'])
         if _monit_service_exists('routeCheck'):
             clicommon.run_command(['sudo', 'monit', 'unmonitor', 'routeCheck'])
+        for svc in _get_monit_services_by_prefix('container_memory_'):
+            clicommon.run_command(['sudo', 'monit', 'unmonitor', svc])
     except subprocess.CalledProcessError as err:
         pass
 
@@ -1177,11 +1197,13 @@ def _restart_services():
     wait_service_restart_finish('networking', last_networking_timestamp)
     try:
         subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        click.echo("Enabling container and routeCheck monitoring ...")
+        click.echo("Enabling container, routeCheck and memory monitoring ...")
         has_route_check = _monit_service_exists('routeCheck')
         if has_route_check:
             clicommon.run_command(['sudo', 'monit', 'monitor', 'routeCheck'])
         clicommon.run_command(['sudo', 'monit', 'monitor', 'container_checker'])
+        for svc in _get_monit_services_by_prefix('container_memory_'):
+            clicommon.run_command(['sudo', 'monit', 'monitor', svc])
         log.log_notice("Waiting for monit monitor actions to complete ...")
         if has_route_check:
             _wait_for_monit_service_monitored('routeCheck')

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4,6 +4,7 @@ import pytest
 import filecmp
 import importlib
 import os
+import subprocess
 import traceback
 import json
 import jsonpatch
@@ -52,14 +53,14 @@ load_minigraph_platform_false_path = os.path.join(load_minigraph_input_path, "pl
 
 load_minigraph_command_output="""\
 Acquired lock on {0}
-Disabling container and routeCheck monitoring ...
+Disabling container, routeCheck and memory monitoring ...
 Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
 Running command: config qos reload --no-dynamic-buffer --no-delay
 Running command: pfcwd start_default
 Restarting SONiC target ...
-Enabling container and routeCheck monitoring ...
+Enabling container, routeCheck and memory monitoring ...
 Reloading Monit configuration ...
 Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
 Released lock on {0}
@@ -5374,3 +5375,97 @@ class TestConfigBanner(object):
     @classmethod
     def teardown_class(cls):
         print('TEARDOWN')
+
+
+class TestSwssReady(object):
+    """Tests for the 'config reload' swss readiness gate on platforms without
+    swss (e.g. BMC), plus regression guards for normal switches."""
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        import config.main
+        importlib.reload(config.main)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+    def test_swss_ready_when_service_not_found(self):
+        # BMC: swss not built in -> not-found -> ready, only LoadState queried.
+        with mock.patch('config.main.clicommon.run_command',
+                        mock.MagicMock(return_value=("not-found", 0))) as mock_run:
+            assert config._per_namespace_swss_ready("swss.service") is True
+            assert mock_run.call_count == 1
+
+    def test_swss_ready_when_service_masked(self):
+        # Masked service -> ready, same as not-found.
+        with mock.patch('config.main.clicommon.run_command',
+                        mock.MagicMock(return_value=("masked", 0))) as mock_run:
+            assert config._per_namespace_swss_ready("swss.service") is True
+            assert mock_run.call_count == 1
+
+    def test_swss_not_ready_when_loaded_but_inactive(self):
+        # Switch still booting: loaded but inactive -> not ready.
+        side_effect = [("loaded", 0), ("inactive", 0)]
+        with mock.patch('config.main.clicommon.run_command',
+                        mock.MagicMock(side_effect=side_effect)):
+            assert config._per_namespace_swss_ready("swss.service") is False
+
+    def test_swss_not_ready_when_active_but_not_settled(self):
+        # Active for < 120s -> not ready.
+        side_effect = [("loaded", 0), ("active", 0), ("1000000000", 0)]  # up = 1000s
+        with mock.patch('config.main.clicommon.run_command',
+                        mock.MagicMock(side_effect=side_effect)), \
+                mock.patch('config.main.time.monotonic',
+                           mock.MagicMock(return_value=1050.0)):  # 50s < 120s
+            assert config._per_namespace_swss_ready("swss.service") is False
+
+    def test_swss_ready_when_active_and_settled(self):
+        # Active for > 120s -> ready.
+        side_effect = [("loaded", 0), ("active", 0), ("1000000000", 0)]  # up = 1000s
+        with mock.patch('config.main.clicommon.run_command',
+                        mock.MagicMock(side_effect=side_effect)), \
+                mock.patch('config.main.time.monotonic',
+                           mock.MagicMock(return_value=2000.0)):  # 1000s > 120s
+            assert config._per_namespace_swss_ready("swss.service") is True
+
+    def test_swss_ready_single_asic_not_found(self):
+        # _swss_ready() end-to-end, single-ASIC, swss not-found.
+        with mock.patch('config.main.multi_asic.get_num_asics',
+                        mock.MagicMock(return_value=1)), \
+                mock.patch('config.main.clicommon.run_command',
+                           mock.MagicMock(return_value=("not-found", 0))):
+            assert config._swss_ready() is True
+
+
+class TestGetMonitServicesByPrefix(object):
+    """Tests for _get_monit_services_by_prefix()."""
+
+    @mock.patch('config.main.subprocess.check_output')
+    def test_finds_container_memory_services(self, mock_check_output):
+        mock_check_output.return_value = (
+            "Monit 5.33.0 uptime: 1h 2m\n"
+            " routeCheck                       OK                          Program\n"
+            " container_checker                OK                          Program\n"
+            " container_memory_snmp            OK                          Program\n"
+            " container_memory_gnmi            OK                          Program\n"
+            " container_memory_bmp             OK                          Program\n"
+        )
+        result = config._get_monit_services_by_prefix('container_memory_')
+        assert result == ['container_memory_snmp', 'container_memory_gnmi', 'container_memory_bmp']
+
+    @mock.patch('config.main.subprocess.check_output')
+    def test_no_matching_services(self, mock_check_output):
+        mock_check_output.return_value = (
+            " routeCheck                       OK                          Program\n"
+            " container_checker                OK                          Program\n"
+        )
+        result = config._get_monit_services_by_prefix('container_memory_')
+        assert result == []
+
+    @mock.patch('config.main.subprocess.check_output',
+                side_effect=subprocess.CalledProcessError(1, 'monit'))
+    def test_monit_not_running(self, mock_check_output):
+        result = config._get_monit_services_by_prefix('container_memory_')
+        assert result == []


### PR DESCRIPTION
* Fix memory_checker false alarms during config reload

During config reload, Monit continues to invoke `memory_checker` for individual containers (`container_memory_gnmi`, `container_memory_snmp`, etc.) while those containers are being stopped and restarted. This causes `memory_checker` to log syslog errors like "`Failed to get container ID of 'gnmi'`" which LogAnalyzer catches. Two fixes:

1. [sonic-utilities]: Unmonitor container_memory_* checks during service restart. Add `_get_monit_services_by_prefix()` to discover `container_memory_*` services from monit summary, and unmonitor/monitor them in `_stop_services()`/`_restart_services()`.

2. [memory_checker]: Re-check container state before logging errors. If memory_checker was already running when config reload starts, the unmonitor only prevents future invocations. Add `exit_if_container_stopped()` to re-check whether the container is still running before logging error. If it stopped, exit gracefully.



* add uts



---------


(cherry picked from commit 9f5ee85c8cf79657259a954830fb75862c13e492)

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

