### PR TITLE
[cherry-pick][202605] Fix memory_checker false alarms during config reload (#4710)

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1017,13 +1017,33 @@ def _monit_service_exists(service):
         return False
 
 
+def _get_monit_services_by_prefix(prefix):
+    """Return list of monit service names that start with the given prefix."""
+    try:
+        output = subprocess.check_output(
+            ['sudo', 'monit', 'summary'],
+            stderr=subprocess.DEVNULL,
+            text=True
+        )
+        services = []
+        for line in output.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(prefix):
+                services.append(stripped.split()[0])
+        return services
+    except subprocess.CalledProcessError:
+        return []
+
+
 def _stop_services():
     try:
         subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        click.echo("Disabling container and routeCheck monitoring ...")
+        click.echo("Disabling container, routeCheck and memory monitoring ...")
         clicommon.run_command(['sudo', 'monit', 'unmonitor', 'container_checker'])
         if _monit_service_exists('routeCheck'):
             clicommon.run_command(['sudo', 'monit', 'unmonitor', 'routeCheck'])
+        for svc in _get_monit_services_by_prefix('container_memory_'):
+            clicommon.run_command(['sudo', 'monit', 'unmonitor', svc])
     except subprocess.CalledProcessError as err:
         pass
 
@@ -1177,11 +1197,13 @@ def _restart_services():
     wait_service_restart_finish('networking', last_networking_timestamp)
     try:
         subprocess.check_call(['sudo', 'monit', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        click.echo("Enabling container and routeCheck monitoring ...")
+        click.echo("Enabling container, routeCheck and memory monitoring ...")
         has_route_check = _monit_service_exists('routeCheck')
         if has_route_check:
             clicommon.run_command(['sudo', 'monit', 'monitor', 'routeCheck'])
         clicommon.run_command(['sudo', 'monit', 'monitor', 'container_checker'])
+        for svc in _get_monit_services_by_prefix('container_memory_'):
+            clicommon.run_command(['sudo', 'monit', 'monitor', svc])
         log.log_notice("Waiting for monit monitor actions to complete ...")
         if has_route_check:
             _wait_for_monit_service_monitored('routeCheck')

--- a/config/main.py
+++ b/config/main.py
@@ -1202,12 +1202,15 @@ def _restart_services():
         if has_route_check:
             clicommon.run_command(['sudo', 'monit', 'monitor', 'routeCheck'])
         clicommon.run_command(['sudo', 'monit', 'monitor', 'container_checker'])
-        for svc in _get_monit_services_by_prefix('container_memory_'):
+        memory_services = _get_monit_services_by_prefix('container_memory_')
+        for svc in memory_services:
             clicommon.run_command(['sudo', 'monit', 'monitor', svc])
         log.log_notice("Waiting for monit monitor actions to complete ...")
         if has_route_check:
             _wait_for_monit_service_monitored('routeCheck')
         _wait_for_monit_service_monitored('container_checker')
+        for svc in memory_services:
+            _wait_for_monit_service_monitored(svc)
     except subprocess.CalledProcessError as err:
         pass
     # Reload Monit configuration to pick up new hostname in case it changed

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4,6 +4,7 @@ import pytest
 import filecmp
 import importlib
 import os
+import subprocess
 import traceback
 import json
 import jsonpatch
@@ -52,14 +53,14 @@ load_minigraph_platform_false_path = os.path.join(load_minigraph_input_path, "pl
 
 load_minigraph_command_output="""\
 Acquired lock on {0}
-Disabling container and routeCheck monitoring ...
+Disabling container, routeCheck and memory monitoring ...
 Running command: sudo systemctl stop featured.timer
 Stopping SONiC target ...
 Running command: /usr/local/bin/sonic-cfggen -H -m --write-to-db
 Running command: config qos reload --no-dynamic-buffer --no-delay
 Running command: pfcwd start_default
 Restarting SONiC target ...
-Enabling container and routeCheck monitoring ...
+Enabling container, routeCheck and memory monitoring ...
 Reloading Monit configuration ...
 Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
 Released lock on {0}
@@ -5374,3 +5375,35 @@ class TestConfigBanner(object):
     @classmethod
     def teardown_class(cls):
         print('TEARDOWN')
+
+
+class TestGetMonitServicesByPrefix(object):
+    """Tests for _get_monit_services_by_prefix()."""
+
+    @mock.patch('config.main.subprocess.check_output')
+    def test_finds_container_memory_services(self, mock_check_output):
+        mock_check_output.return_value = (
+            "Monit 5.33.0 uptime: 1h 2m\n"
+            " routeCheck                       OK                          Program\n"
+            " container_checker                OK                          Program\n"
+            " container_memory_snmp            OK                          Program\n"
+            " container_memory_gnmi            OK                          Program\n"
+            " container_memory_bmp             OK                          Program\n"
+        )
+        result = config._get_monit_services_by_prefix('container_memory_')
+        assert result == ['container_memory_snmp', 'container_memory_gnmi', 'container_memory_bmp']
+
+    @mock.patch('config.main.subprocess.check_output')
+    def test_no_matching_services(self, mock_check_output):
+        mock_check_output.return_value = (
+            " routeCheck                       OK                          Program\n"
+            " container_checker                OK                          Program\n"
+        )
+        result = config._get_monit_services_by_prefix('container_memory_')
+        assert result == []
+
+    @mock.patch('config.main.subprocess.check_output',
+                side_effect=subprocess.CalledProcessError(1, 'monit'))
+    def test_monit_not_running(self, mock_check_output):
+        result = config._get_monit_services_by_prefix('container_memory_')
+        assert result == []

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -5407,3 +5407,71 @@ class TestGetMonitServicesByPrefix(object):
     def test_monit_not_running(self, mock_check_output):
         result = config._get_monit_services_by_prefix('container_memory_')
         assert result == []
+
+
+class TestRestartServicesMonitOrdering(object):
+    """Regression test for sonic-net/sonic-utilities#4774.
+
+    `monit monitor <service>` is asynchronous. If `monit reload` runs before
+    the monitor action for a container_memory_* service has completed, that
+    service can be left "Not monitored" permanently. This test verifies that
+    every container_memory_* service discovered by
+    _get_monit_services_by_prefix() is both monitored and waited on (via
+    _wait_for_monit_service_monitored()) strictly before `monit reload`.
+    """
+
+    @mock.patch('config.main.reset_mgmt_interface_if_usb_not_running')
+    @mock.patch('config.main.get_device_name', return_value=None)
+    @mock.patch('config.main._monit_service_exists', return_value=False)
+    @mock.patch('config.main.subprocess.check_call')
+    @mock.patch('config.main.wait_service_restart_finish')
+    @mock.patch('config.main.get_service_finish_timestamp', return_value="0")
+    @mock.patch('config.main._get_monit_services_by_prefix',
+                return_value=['container_memory_snmp', 'container_memory_gnmi'])
+    @mock.patch('config.main._wait_for_monit_service_monitored')
+    @mock.patch('config.main.clicommon.run_command')
+    def test_memory_services_monitored_and_waited_before_reload(
+        self, run_cmd, wait_mock, get_svcs, _gst, _wsrf, _check_call,
+        _monit_exists, _get_dev, _reset_usb,
+    ):
+        # Shared event recorder so ordering across the two independent mocks
+        # (clicommon.run_command and _wait_for_monit_service_monitored) can
+        # actually be compared on a single timeline.
+        events = []
+
+        def run_command_side_effect(cmd, *args, **kwargs):
+            if cmd[:3] == ['sudo', 'monit', 'monitor']:
+                events.append(('monitor', cmd[3]))
+            elif cmd == ['sudo', 'monit', 'reload']:
+                events.append(('reload', None))
+            return ("", 0)
+
+        def wait_side_effect(service, timeout=10):
+            events.append(('wait', service))
+
+        run_cmd.side_effect = run_command_side_effect
+        wait_mock.side_effect = wait_side_effect
+
+        config._restart_services()
+
+        memory_services = {'container_memory_snmp', 'container_memory_gnmi'}
+        monitored = [svc for kind, svc in events if kind == 'monitor']
+        waited = [svc for kind, svc in events if kind == 'wait']
+
+        # sudo monit monitor container_checker / container_memory_snmp / container_memory_gnmi
+        assert 'container_checker' in monitored
+        assert memory_services <= set(monitored)
+
+        # _wait_for_monit_service_monitored() called for container_checker and
+        # both container_memory_* services.
+        assert 'container_checker' in waited
+        assert memory_services <= set(waited)
+
+        # All memory-service waits must occur strictly before monit reload.
+        reload_idx = next(i for i, e in enumerate(events) if e[0] == 'reload')
+        memory_wait_idxs = [
+            i for i, (kind, svc) in enumerate(events)
+            if kind == 'wait' and svc in memory_services
+        ]
+        assert memory_wait_idxs, "no wait recorded for container_memory_* services"
+        assert all(i < reload_idx for i in memory_wait_idxs)


### PR DESCRIPTION
* Fix memory_checker false alarms during config reload

During config reload, Monit continues to invoke `memory_checker` for individual containers (`container_memory_gnmi`, `container_memory_snmp`, etc.) while those containers are being stopped and restarted. This causes `memory_checker` to log syslog errors like "`Failed to get container ID of 'gnmi'`" which LogAnalyzer catches. Two fixes:

1. [sonic-utilities]: Unmonitor container_memory_* checks during service restart. Add `_get_monit_services_by_prefix()` to discover `container_memory_*` services from monit summary, and unmonitor/monitor them in `_stop_services()`/`_restart_services()`.

2. [memory_checker]: Re-check container state before logging errors. If memory_checker was already running when config reload starts, the unmonitor only prevents future invocations. Add `exit_if_container_stopped()` to re-check whether the container is still running before logging error. If it stopped, exit gracefully.




---------

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

