### PR TITLE
[Nexthop] fast-reboot: save FDB, ARP and route state for platforms that cold-start SAI after kexec

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -35,6 +35,9 @@ LOG_PATH="/var/log/${REBOOT_TYPE}.txt"
 UIMAGE_HDR_SIZE=64
 REQUIRE_TEAMD_RETRY_COUNT=no
 
+FAST_BOOT_DIR=/host/fast-reboot
+FAST_REBOOT_DUMP=/usr/local/bin/fast-reboot-dump.py
+
 EXIT_SUCCESS=0
 EXIT_FAILURE=1
 EXIT_NOT_SUPPORTED=2
@@ -500,6 +503,25 @@ function backup_database()
     STATE=$(timeout 5s docker exec database$DEV rm /var/lib/$target_db_inst/$REDIS_FILE; if [[ $? == 124 ]]; then echo "timed out"; fi)
     if [[ x"${STATE}" == x"timed out" ]]; then
         error "Timed out during attempting to remove Redis dump file from database container"
+    fi
+}
+
+function dump_state_for_fast_boot()
+{
+    if [[ ! -x "$FAST_REBOOT_DUMP" ]]; then
+        debug "$FAST_REBOOT_DUMP not found; skipping fast-boot state dump"
+        return
+    fi
+    if [[ $NUM_ASIC -gt 1 ]]; then
+        debug "Multi-ASIC: skipping fast-boot state dump (unsupported)"
+        return
+    fi
+    rm -rf "$FAST_BOOT_DIR"
+    mkdir -p "$FAST_BOOT_DIR"
+    debug "Dumping FDB/ARP/route/serdes state to $FAST_BOOT_DIR ..."
+    if ! "$FAST_REBOOT_DUMP" -t "$FAST_BOOT_DIR"; then
+        debug "fast-reboot-dump.py exited $? — cleaning up $FAST_BOOT_DIR and continuing"
+        rm -rf "$FAST_BOOT_DIR"
     fi
 }
 
@@ -1131,6 +1153,9 @@ if [[ "${REBOOT_TYPE}" = "warm-reboot" || "${REBOOT_TYPE}" = "fastfast-reboot" |
     execute_in_namespaces asic increase_teamd_retry_count
 fi
 
+if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
+    dump_state_for_fast_boot
+fi
 
 # We are fully committed to reboot from this point on because critical
 # service will go down and we cannot recover from it.


### PR DESCRIPTION
#### What I did

Resolves #4754

Save FDB, ARP/neighbor, default-route and media state to `/host/fast-reboot` before the fast-reboot kexec, so swss can restore it after boot.

swss startup already restores these snapshots — `files/build_templates/docker_image_ctl.j2` copies `fdb.json` / `arp.json` / `default_routes.json` / `media_config.json` into the swss container before signaling swssconfig — but nothing in the fast-reboot flow produces them anymore. On platforms where fast-reboot re-initializes the ASIC after kexec (no SAI warm-boot state is preserved), the snapshots are the recovery input that shortens post-boot relearning.

#### How I did it

Add `dump_state_for_fast_boot()` to `scripts/fast-reboot`, called for `fast-reboot` only, right before the point of no return:

- Skips (with a debug log) when `fast-reboot-dump.py` is not present, and on multi-ASIC platforms.
- Recreates `/host/fast-reboot`, runs `fast-reboot-dump.py -t /host/fast-reboot`, and removes the directory again if the dump fails so a partial snapshot is never restored.

#### How to verify it

1. `sudo fast-reboot -v` — the log shows `Dumping FDB/ARP/route/serdes state to /host/fast-reboot ...`.
2. Before kexec, `/host/fast-reboot` contains `fdb.json`, `arp.json`, `default_routes.json`, `media_config.json`.
3. After boot, swssconfig logs show the JSON files being loaded, and the directory is cleaned up by the existing swss startup logic.

Verified on Broadcom Tomahawk-based platforms whose fast-reboot path cold-starts SAI after kexec.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
