### PR TITLE
[Nexthop] fast-reboot: run syncd SAI pre-shutdown to keep the dataplane forwarding across kexec

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -1228,7 +1228,7 @@ for service in ${SERVICES_TO_STOP}; do
     stop_service $service
 
     if [[ "${service}" = "swss" ]]; then
-        if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" || "$REBOOT_TYPE" = "express-reboot" ]]; then
+        if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" || "$REBOOT_TYPE" = "express-reboot" || "$REBOOT_TYPE" = "fast-reboot" ]]; then
             # Pre-shutdown syncd
             execute_in_namespaces asic initialize_pre_shutdown
             execute_in_namespaces asic request_pre_shutdown

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -1228,7 +1228,8 @@ for service in ${SERVICES_TO_STOP}; do
     stop_service $service
 
     if [[ "${service}" = "swss" ]]; then
-        if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" || "$REBOOT_TYPE" = "express-reboot" || "$REBOOT_TYPE" = "fast-reboot" ]]; then
+        if [[ "$REBOOT_TYPE" = "warm-reboot" || "$REBOOT_TYPE" = "fastfast-reboot" || "$REBOOT_TYPE" = "express-reboot" ]] ||
+           [[ "$REBOOT_TYPE" = "fast-reboot" && "$PLATFORM" == x86_64-nexthop* ]]; then
             # Pre-shutdown syncd
             execute_in_namespaces asic initialize_pre_shutdown
             execute_in_namespaces asic request_pre_shutdown


### PR DESCRIPTION
#### What I did

Resolves #4755

Run the syncd/SAI pre-shutdown sequence for `fast-reboot`, the same way `warm-reboot` does, so the ASIC keeps forwarding on the existing tables across kexec.

Without it, the ASIC stops forwarding the moment `kexec -e` fires and the dataplane stays down for the entire reboot (kexec + kernel boot + platform init + SAI re-init) instead of only the ASIC re-initialization window.

#### How I did it

Add `fast-reboot` to the reboot types that run `initialize_pre_shutdown` / `request_pre_shutdown` / `wait_for_pre_shutdown_complete_or_fail` after stopping swss. The SAI/SDK saves its state and leaves the ASIC forwarding, so traffic keeps flowing on the existing tables across kexec and through early boot, until the new image re-initializes the ASIC.

#### How to verify it

1. Run continuous traffic through the ASIC (10Hz dataplane probe).
2. `sudo fast-reboot -v`.
3. `Pre-shutdown succeeded` appears in the fast-reboot log, and traffic keeps flowing past `Rebooting with /sbin/kexec -e`.

Measured on a Broadcom Tomahawk5-based platform: without this change forwarding stops at kexec+0.6s; with it, forwarding continues into the new kernel's boot and the fast-reboot dataplane outage shrinks accordingly.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
