### PR TITLE
[Nexthop] warm/fast-reboot: skip Control Plane Assistant on the Tomahawk4/5/6 chip family

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -606,13 +606,40 @@ function abort_reboot_if_cpa_tunnel_is_leftover()
     fi
 }
 
+# Tomahawk4/5/6 chip family (DEV_IS_LTSW_THX() in brcm_sai_feat_checks.h)
+# can't do the VxLAN tunnel CPA's neighbor_advertiser needs
+function is_th_ltsw_platform()
+{
+    local chip
+    chip=$(lspci -d 14e4: 2>/dev/null | grep -oP '\[\K(Tomahawk|Trident)[0-9A-Za-z]*(?=\])' | head -n1)
+    case "$chip" in
+        Tomahawk4|Tomahawk5|Tomahawk6*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# TH3 HW is not capable of VxLAN programming thus skipping TH3 platforms
+# neither are LTSW-generation chips (Tomahawk4/5/6 family).
+function is_cpa_supported()
+{
+    case "${HWSKU}" in
+        DellEMC-Z9332f-M-O16C64|DellEMC-Z9332f-M-O16C64-lab)
+            return 1
+            ;;
+    esac
+    ! is_th_ltsw_platform
+}
+
 function setup_control_plane_assistant()
 {
     abort_reboot_if_cpa_tunnel_is_leftover
 
     if [[ -n "${ASSISTANT_IP_LIST}" && -x ${ASSISTANT_SCRIPT} ]]; then
-        # TH3 HW is not capable of VxLAN programming thus skipping TH3 platforms
-        if [[ "${HWSKU}" != "DellEMC-Z9332f-M-O16C64" && "${HWSKU}" != "DellEMC-Z9332f-M-O16C64-lab" ]]; then
+        if is_cpa_supported; then
             debug "Setting up control plane assistant: ${ASSISTANT_IP_LIST} ..."
             ${ASSISTANT_SCRIPT} -s ${ASSISTANT_IP_LIST} -m set
 	    check_mirror_session_acls
@@ -628,8 +655,7 @@ function setup_control_plane_assistant()
 function teardown_control_plane_assistant()
 {
     if [[ -n "${ASSISTANT_IP_LIST}" && -x ${ASSISTANT_SCRIPT} ]]; then
-        # TH3 HW is not capable of VxLAN programming thus skipping TH3 platforms
-        if [[ "${HWSKU}" != "DellEMC-Z9332f-M-O16C64" && "${HWSKU}" != "DellEMC-Z9332f-M-O16C64-lab" ]]; then
+        if is_cpa_supported; then
             debug "Tearing down control plane assistant: ${ASSISTANT_IP_LIST} ..."
             ${ASSISTANT_SCRIPT} -s ${ASSISTANT_IP_LIST} -m reset
         fi


### PR DESCRIPTION
#### What I did

Resolves #4759

Skip the Control Plane Assistant on Broadcom's Tomahawk4/5/6 (LTSW) chip family during warm/fast-reboot, alongside the existing TH3 HWSKU exclusions.

On the LTSW family the SAI SDK does not support the general/L2 (VLAN-mapped) VxLAN tunnel that `neighbor_advertiser` builds to keep answering ARP during the reboot; the `VXLAN_TUNNEL_MAP` write is rejected with `SAI_STATUS_ATTR_NOT_IMPLEMENTED_0` ("Tunnel type VxLan not implemented"). The failed `create_tunnel()` leaves the `VXLAN_TUNNEL_MAP_TABLE` task permanently stuck in orchagent's consumer queue, so `orchagent_restart_check` reports `NOT_READY` forever and the warm/fast-reboot aborts at `pause_orchagent()`.

#### How I did it

- `is_th_ltsw_platform()` detects the Tomahawk4/5/6 family from the Broadcom PCI device name via `lspci` (matching `DEV_IS_LTSW_THX()` in the Broadcom SAI's feature checks).
- `is_cpa_supported()` combines the existing TH3 HWSKU exclusions with the new chip-family check.
- `setup_control_plane_assistant()` / `teardown_control_plane_assistant()` use `is_cpa_supported()` instead of the inline HWSKU comparisons.

#### How to verify it

1. On a Tomahawk5/6-based DUT, run `warm-reboot` with a Control Plane Assistant configured (`-c <assistant-ip>`): CPA setup is skipped and the reboot proceeds (previously it aborted `NOT_READY` after the SAI tunnel failure).
2. On non-LTSW platforms, CPA behavior is unchanged.

Verified on Broadcom Tomahawk5- and Tomahawk6-based platforms.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
