### PR TITLE
Adding infra for hardening of external containers

### DIFF
--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -219,6 +219,10 @@ class ManifestSchema:
         ]),
         ManifestRoot('container', [
             ManifestField('privileged', DefaultMarshaller(bool), False),
+            ManifestArray('cap-add', DefaultMarshaller(str)),
+            ManifestArray('security-opt', DefaultMarshaller(str)),
+            ManifestArray('ulimits', DefaultMarshaller(str)),
+            ManifestArray('devices', DefaultMarshaller(str)),
             ManifestArray('volumes', DefaultMarshaller(str)),
             ManifestArray('mounts', ManifestRoot('mounts', [
                 ManifestField('source', DefaultMarshaller(str)),

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -264,6 +264,18 @@ class ServiceCreator:
         if container_spec['privileged']:
             run_opt.append('--privileged')
 
+        for capability in container_spec['cap-add']:
+            run_opt.append(f'--cap-add={capability}')
+
+        for option in container_spec['security-opt']:
+            run_opt.append(f'--security-opt={option}')
+
+        for ulimit in container_spec['ulimits']:
+            run_opt.append(f'--ulimit={ulimit}')
+
+        for device in container_spec['devices']:
+            run_opt.append(f'--device={device}')
+
         run_opt.append('-t')
 
         for volume in container_spec['volumes']:

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -14,6 +14,8 @@ from sonic_package_manager.package import Package
 from sonic_package_manager.service_creator.creator import *
 from sonic_package_manager.service_creator.creator import ETC_SYSTEMD_LOCATION
 from sonic_package_manager.service_creator.feature import FeatureRegistry
+from sonic_package_manager.service_creator.creator import DOCKER_CTL_SCRIPT_LOCATION, DOCKER_CTL_SCRIPT_TEMPLATE
+from sonic_package_manager.service_creator.creator import TEMPLATES_PATH
 
 
 @pytest.fixture
@@ -149,6 +151,32 @@ def test_service_creator_with_debug_dump(sonic_fs, manifest, service_creator):
     service_creator.create(package)
 
     assert sonic_fs.exists(os.path.join(DEBUG_DUMP_SCRIPT_LOCATION, 'test'))
+
+
+def test_service_creator_container_hardening_opts(sonic_fs, manifest, service_creator):
+    entry = PackageEntry('test', 'azure/sonic-test')
+    manifest['container']['privileged'] = False
+    manifest['container']['cap-add'] = ['NET_ADMIN']
+    manifest['container']['security-opt'] = ['apparmor=unconfined']
+    manifest['container']['ulimits'] = ['nofile=65536:65536']
+    manifest['container']['devices'] = ['/dev/mem']
+
+    tmpl_path = os.path.join(TEMPLATES_PATH, DOCKER_CTL_SCRIPT_TEMPLATE)
+    with open(tmpl_path, 'w') as tmpl:
+        tmpl.write('{{ docker_image_run_opt }}')
+
+    package = Package(entry, Metadata(manifest))
+    service_creator.create(package)
+
+    with open(os.path.join(DOCKER_CTL_SCRIPT_LOCATION, 'test.sh')) as script:
+        run_opt = script.read()
+
+    assert '--privileged' not in run_opt
+    assert '--cap-add=NET_ADMIN' in run_opt
+    assert '--security-opt=apparmor=unconfined' in run_opt
+    assert '--ulimit=nofile=65536:65536' in run_opt
+    assert '--device=/dev/mem' in run_opt
+    assert '-v /etc/sonic:/etc/sonic:ro' in run_opt
 
 
 def test_service_creator_yang(sonic_fs, manifest, mock_sonic_db,


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added infra to support adding capabilities, security options, ulimits and devices to installed dockers by sonic-package-manager.
It was added to support hardening of external containers, enabling use of specific capabilities instead of privileged flag.
#### How I did it
Updated manifest.py to add new arrays for each of the new fields. Then updated creator.py to append per array each item in it with the correlating flag.
#### How to verify it
Install external packages using sonic-package-manager and inspect capabilities using docker --inspect.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

