### PR TITLE
Fix flow control display for unconfigured console lines

### DIFF
--- a/consutil/lib.py
+++ b/consutil/lib.py
@@ -27,6 +27,9 @@ CONSOLE_SWITCH_TABLE = "CONSOLE_SWITCH"
 
 LINE_KEY = "LINE"
 CUR_STATE_KEY = "CUR_STATE"
+# Internal marker (not a CONFIG_DB/STATE_DB field) set only on bare tty lines discovered
+# on the filesystem that have no CONSOLE_PORT entry.
+UNCONFIGURED_KEY = "_UNCONFIGURED"
 
 # CONFIG_DB Keys
 BAUD_KEY = "baud_rate"
@@ -192,7 +195,10 @@ class ConsolePortProvider(object):
             for tty in available_ttys:
                 k = tty[len(SysInfoProvider.DEVICE_PREFIX):]
                 if k not in keys:
-                    port = { LINE_KEY: k }
+                    port = {
+                        LINE_KEY: k,
+                        UNCONFIGURED_KEY: True,
+                    }
                     ports.append(port)
         self._ports = ports
 
@@ -217,6 +223,10 @@ class ConsolePortInfo(object):
     @property
     def flow_control(self):
         return FLOW_KEY in self._info and self._info[FLOW_KEY] == "1"
+
+    @property
+    def configured(self):
+        return not self._info.get(UNCONFIGURED_KEY, False)
 
     @property
     def remote_device(self):

--- a/consutil/main.py
+++ b/consutil/main.py
@@ -47,7 +47,10 @@ def show(db, brief):
         pid = port.session_pid if port.session_pid else "-"
         date = port.session_start_date if port.session_start_date else "-"
         baud = port.baud if port.baud else "-"
-        flow_control = "Enabled" if port.flow_control else "Disabled"
+        if not port.configured:
+            flow_control = "-"
+        else:
+            flow_control = "Enabled" if port.flow_control else "Disabled"
         remote_device = port.remote_device if port.remote_device else "-"
         oper_state = port.oper_state if port.oper_state else "-"
         state_duration = port.state_duration if port.state_duration else "-"

--- a/tests/console_test.py
+++ b/tests/console_test.py
@@ -871,6 +871,24 @@ class TestConsutilLib(object):
         print('[{}]'.format(', '.join(map(str, ports))))
         assert len(ports) == 2
 
+    @mock.patch('consutil.lib.SysInfoProvider.list_console_ttys',
+                mock.MagicMock(return_value=["/dev/ttyUSB2"]))
+    def test_console_port_info_configured_unconfigured_line(self):
+        """Regression test for #4745: a tty with no CONSOLE_PORT entry is not
+        'configured', so it must be rendered as '-' rather than as a
+        configured-but-disabled ('Disabled') line."""
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", "1", {"baud_rate": "9600"})
+
+        provider = ConsolePortProvider(db, configured_only=False)
+        ports = {port.line_num: port for port in provider.get_all()}
+
+        # configured port with flow_control field omitted -> still configured, "Disabled"
+        assert ports["1"].configured is True
+        assert ports["1"].flow_control is False
+        # tty with no CONSOLE_PORT entry at all -> not configured
+        assert ports["2"].configured is False
+
     def test_console_port_provider_get_line_success(self):
         db = Db()
         db.cfgdb.set_entry("CONSOLE_PORT", "1", {"baud_rate": "9600"})
@@ -1224,6 +1242,30 @@ class TestConsutilShow(object):
         print(sys.stderr, result.output)
         assert result.exit_code == 0
         assert result.output == TestConsutilShow.expect_show_output
+
+    @mock.patch('consutil.lib.SysInfoProvider.init_device_prefix', mock.MagicMock(return_value=None))
+    @mock.patch('consutil.lib.SysInfoProvider.list_active_console_processes',
+                mock.MagicMock(return_value={}))
+    @mock.patch('consutil.lib.SysInfoProvider.list_console_ttys',
+                mock.MagicMock(return_value=["/dev/ttyUSB2"]))
+    def test_show_unconfigured_line_flow_control(self):
+        """Regression test for #4745: an available tty with no CONSOLE_PORT entry must
+        show '-' for Flow Control, not 'Disabled'."""
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.set_entry("CONSOLE_PORT", 1, {"baud_rate": "9600"})
+        db.cfgdb.set_entry("CONSOLE_PORT", 3, {"baud_rate": "9600", "flow_control": "1"})
+
+        # do not use '--brief' so the unconfigured tty (line 2) is included
+        result = runner.invoke(consutil.consutil.commands["show"], [], obj=db)
+        print(result.exit_code)
+        print(sys.stderr, result.output)
+        assert result.exit_code == 0
+
+        rows = {row.split()[0].lstrip('*'): row.split() for row in result.output.splitlines()[2:] if row.strip()}
+        assert rows["1"][2] == "Disabled"  # configured, flow_control field omitted
+        assert rows["2"][2] == "-"         # unconfigured tty
+        assert rows["3"][2] == "Enabled"   # configured, flow_control=1
 
 
 class TestConsutilShowEscape(object):


### PR DESCRIPTION
#### What I did

Fixed `show line` so an available console tty with no corresponding `CONSOLE_PORT` configuration displays `-` for Flow Control instead of `Disabled`.

Fixes #4745.

#### How I did it

Marked filesystem-discovered tty lines that have no `CONSOLE_PORT` entry as unconfigured.

The `show` command now distinguishes those lines from configured ports:

- configured with flow control enabled: `Enabled`
- configured with flow control disabled: `Disabled`
- unconfigured tty: `-`

The existing boolean behavior of `ConsolePortInfo.flow_control` is unchanged.

Added regression coverage for both the provider state and CLI output.

#### How to verify it

Local verification:

- `python3 -m py_compile consutil/lib.py consutil/main.py tests/console_test.py`
- `git diff --check`
- focused standalone harness covering configured-disabled, configured-enabled, and unconfigured tty cases

The full `pytest` suite was not runnable in the local WSL environment because it requires SONiC-specific `swsscommon`/test dependencies provided by the SONiC build environment.

#### Previous command output (if the output of a command-line utility has changed)

```text
  Line    Baud    Flow Control    PID    Start Time    Device
------  ------  --------------  -----  ------------  --------
     0       -        Disabled      -             -
```

#### New command output (if the output of a command-line utility has changed)

```text
  Line    Baud    Flow Control    PID    Start Time    Device
------  ------  --------------  -----  ------------  --------
     0       -               -      -             -
```
