### PR TITLE
[Enhancement] Add show chassis system-lag-consistency for VOQ 

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -17889,3 +17889,42 @@ Yellow Action............... forward
 Green Action................ forward
 Red Action.................. drop
 ```
+
+## Chassis system LAG consistency
+
+VOQ chassis linecards only. Compares `CHASSIS_APP_DB` system LAG tables with local `ASIC_DB` on each ASIC namespace.
+
+**show chassis system-lag-consistency**
+
+- Full check: `SYSTEM_LAG_ID_TABLE` and `SYSTEM_LAG_MEMBER_TABLE` vs ASIC LAG / LAG member objects.
+- `--lag-id-only`: LAG ID table only (skips lag member checks).
+- `-j` / `--json`: structured JSON output (process exit code is always 0 with `--json`).
+
+Member status: chassis `disabled` is compared to ASIC `ingress_disable` / `egress_disable`.
+SWSS may leave both flags `false` on SYSTEM ports when chassis lists the member as
+disabled; symmetric flags (both true or both false) are treated as a match for
+`disabled`. Chassis `enabled` requires both ASIC disable flags to be false.
+
+Examples:
+
+```
+show chassis system-lag-consistency
+show chassis system-lag-consistency --lag-id-only
+show chassis system-lag-consistency --lag-id-only -j
+```
+
+The same logic is available as a standalone script:
+
+```
+/usr/local/bin/chassis_db_consistency_checker.py [--lag-id-only] [--json]
+```
+
+Standalone script exit behavior (Monit / manual, without `--json`):
+
+- Mismatch: CRITICAL syslog messages and non-zero exit (`RC_ERR`).
+- Success: exit 0 (`RC_OK`).
+- Not applicable (non-VOQ or supervisor): exit 0 with informational log.
+- `--json`: always exit 0; mismatches appear in the JSON `status` field.
+
+Full member checks issue several `redis-dump` calls per ASIC namespace; allow
+enough time in Monit cycle intervals on busy linecards.

--- a/scripts/chassis_db_consistency_checker.py
+++ b/scripts/chassis_db_consistency_checker.py
@@ -3,27 +3,40 @@
 """
 chassis_db_consistency_checker
 
-This script checks for synchronization of LAG (Link Aggregation Group) IDs
-between the chassis_db and asic_db on VOQ chassis Linecard.
-This script is intended to be run by Monit.
-It will write an alerting message into syslog if it finds any mismatches in
-LAG IDs between the chassis_db and asic_db.
+Checks synchronization of VOQ system LAG data between chassis_db and asic_db
+on linecards:
+- SYSTEM_LAG_ID_TABLE vs ASIC_DB SAI_OBJECT_TYPE_LAG aggregate IDs
+- SYSTEM_LAG_MEMBER_TABLE vs ASIC_DB SAI_OBJECT_TYPE_LAG_MEMBER objects
+  (including member status vs ingress/egress disable attributes)
 
-It performs the following steps:
-- Retrieves LAG IDs from the ASIC DBs (per namespace).
-- Retrieves the SYSTEM_LAG_ID_TABLE from the chassis DB.
-- Compares the LAG IDs in the chassis DB and ASIC DBs to identify mismatches.
-- Reports any mismatched LAG keys per ASIC namespace.
-- Exits with a non-zero status if mismatches are found.
+Member status: chassis ``disabled`` is compared to ASIC ingress/egress disable
+flags. SWSS may leave both flags ``false`` on SYSTEM ports even when chassis
+lists the member as disabled; symmetric flags (both true or both false) are
+treated as a match for ``disabled``. A chassis ``enabled`` member requires both
+ASIC disable flags to be false.
 
-Intended to be run on line cards (not on the supervisor) of a VOQ chassis
-device.
+Intended to run on line cards (not on the supervisor) of a VOQ chassis device.
+
+Consumers (same checker logic; different invocation and output):
+
+1. show CLI (``show chassis system-lag-consistency``) invokes this script with
+   ``--json``. The show command parses the JSON, prints human-readable output,
+   and always treats subprocess exit 0 as success (mismatches appear in the
+   result payload, not the exit code).
+
+2. Monit or manual runs invoke the script without ``--json``. On mismatch,
+   CRITICAL messages are logged to syslog and the process exits with RC_ERR;
+   on success it exits RC_OK. Full member checks run several redis-dump calls
+   per ASIC namespace; size the Monit cycle accordingly on busy linecards.
+
 Usage:
-    python3 chassis_db_consistency_checker [--log-level LEVEL]
+    python3 chassis_db_consistency_checker [--log-level LEVEL] [--lag-id-only] [--json]
 
 Arguments:
     --log-level LEVEL   Set the logging level (DEBUG, INFO, WARNING, ERROR,
                         CRITICAL). Default is WARNING.
+    --lag-id-only       Check SYSTEM_LAG_ID_TABLE only; skip lag member checks.
+    --json              Output structured consistency result as JSON and exit 0.
 
 """
 
@@ -31,11 +44,23 @@ import subprocess
 import json
 import logging
 import argparse
+import sys
 import sonic_py_common.multi_asic as multi_asic
 import sonic_py_common.device_info as device_info
+
 RC_OK = 0
 RC_ERR = -1
-RC_REDIS_ERR = -2
+
+# JSON result status values (used by show CLI and Monit logging).
+STATUS_OK = "ok"
+STATUS_FAILED = "failed"
+STATUS_ERROR = "error"
+STATUS_NOT_APPLICABLE = "not_applicable"
+
+REASON_NOT_VOQ_CHASSIS = "Not a voq chassis device"
+REASON_NOT_ON_SUPERVISOR = "Not supported on supervisor (VOQ chassis linecards only)"
+
+CHASSIS_LAG_MEMBER_TABLE_PREFIX = "SYSTEM_LAG_MEMBER_TABLE|"
 
 
 def run_redis_dump(cmd_args):
@@ -60,44 +85,75 @@ def extract_lag_ids_from_asic_db(db_output, key_pattern, lag_id_field):
             lag_id = info.get('value', {}).get(lag_id_field, None)
             if lag_id is None:
                 logging.error(f"{key} has bad lag_id")
-            lag_ids.add(lag_id)
+                continue
+            lag_ids.add(str(lag_id))
     logging.debug(f"Extracted LAG IDs from ASIC DB: {lag_ids}")
     return lag_ids
 
 
 def extract_table_ids_from_chassis_db(table_output):
     """Extract IDs from a table output (dict of key: id)."""
-    return set(table_output.values())
+    return {str(lag_id) for lag_id in table_output.values() if lag_id is not None}
 
 
-def get_lag_ids_asic_namespace(asic_netns):
-    """Get LAG IDs from a specific ASIC namespace."""
-    if asic_netns == multi_asic.DEFAULT_NAMESPACE:
-        asic_cmd = ["redis-dump", "-d", "1", "-k", "*SAI_OBJECT_TYPE_LAG:*", "-y"]
-    else:
-        asic_cmd = [
-            "sudo", "ip", "netns", "exec", asic_netns,
-            "redis-dump", "-d", "1", "-k", "*SAI_OBJECT_TYPE_LAG:*", "-y"
-        ]
-    asic_db_output = run_redis_dump(asic_cmd)
-    lag_id_ns = extract_lag_ids_from_asic_db(
-        asic_db_output, "SAI_OBJECT_TYPE_LAG", "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID"
-    )
-    logging.debug(f"LAG IDs in ASIC namespace {asic_netns}: {lag_id_ns}")
-    return lag_id_ns
+def run_redis_dump_asic_namespace(asic_netns, db_id, key_pattern):
+    """Run redis-dump against a local ASIC redis instance (optionally in a netns)."""
+    cmd = ["redis-dump", "-d", str(db_id), "-k", key_pattern, "-y"]
+    if asic_netns != multi_asic.DEFAULT_NAMESPACE:
+        cmd = ["sudo", "ip", "netns", "exec", asic_netns] + cmd
+    return run_redis_dump(cmd)
 
 
-def get_chassis_lag_db_table():
-    """Fetch and return the SYSTEM_LAG_ID_TABLE from chassis_db."""
-    chassis_db_cmd = [
+def run_redis_dump_chassis_app(key_pattern):
+    """Run redis-dump against CHASSIS_APP_DB on redis_chassis."""
+    cmd = [
         "redis-dump",
         "-H", "redis_chassis.server",
         "-p", "6380",
         "-d", "12",
-        "-k", "SYSTEM_LAG_ID_TABLE",
-        "-y"
+        "-k", key_pattern,
+        "-y",
     ]
-    chassis_db_raw = run_redis_dump(chassis_db_cmd)
+    return run_redis_dump(cmd)
+
+
+def oid_from_asic_state_key(redis_key):
+    if ":oid:" not in redis_key:
+        return None
+    return "oid:" + redis_key.rsplit(":oid:", 1)[1]
+
+
+def _is_sai_bool_true(value):
+    return str(value).lower() == "true"
+
+
+def _asic_display_name(asic_namespace):
+    if asic_namespace == multi_asic.DEFAULT_NAMESPACE:
+        return "localhost"
+    return asic_namespace
+
+
+def bidirectional_set_diff(left, right):
+    """Return items in left but not right, then items in right but not left."""
+    missing_in_right = left - right
+    extra_in_right = right - left
+    return missing_in_right, extra_in_right
+
+
+def format_bidirectional_diff(missing_in_right, extra_in_right):
+    return {
+        "missing_in_asic_db": sorted(missing_in_right),
+        "extra_in_asic_db": sorted(extra_in_right),
+    }
+
+
+def bidirectional_diff_has_mismatch(diff):
+    return diff["missing_in_asic_db"] or diff["extra_in_asic_db"]
+
+
+def get_chassis_lag_db_table():
+    """Fetch and return the SYSTEM_LAG_ID_TABLE from chassis_db."""
+    chassis_db_raw = run_redis_dump_chassis_app("SYSTEM_LAG_ID_TABLE")
     chassis_db_table = chassis_db_raw.get('SYSTEM_LAG_ID_TABLE', {}).get('value', {})
     if not chassis_db_table:
         logging.error("No SYSTEM_LAG_ID_TABLE found in chassis_db")
@@ -105,68 +161,462 @@ def get_chassis_lag_db_table():
     return chassis_db_table
 
 
-def compare_lag_ids(lag_ids_in_chassis_db, asic):
-    lag_ids_in_asic_db = get_lag_ids_asic_namespace(asic)
-    diff = lag_ids_in_chassis_db - lag_ids_in_asic_db
-    if not diff:
-        diff = lag_ids_in_asic_db - lag_ids_in_chassis_db
-    return diff
+def get_chassis_lag_member_table():
+    """Fetch and return the SYSTEM_LAG_MEMBER_TABLE from chassis_db."""
+    chassis_db_raw = run_redis_dump_chassis_app("SYSTEM_LAG_MEMBER_TABLE*")
+    return parse_chassis_lag_member_dump(chassis_db_raw)
 
 
-def check_lag_id_sync():
-    """Check if LAG IDs in chassis_db and asic_db are in sync."""
+def parse_chassis_lag_member_dump(dump_output):
+    """Parse redis-dump output for SYSTEM_LAG_MEMBER_TABLE entries."""
+    # redis-dump may return one SYSTEM_LAG_MEMBER_TABLE blob or per-member keys.
+    member_table = {}
+    single_table = dump_output.get("SYSTEM_LAG_MEMBER_TABLE", {}).get("value", {})
+    if isinstance(single_table, dict):
+        member_table.update(single_table)
 
-    rc = RC_OK
-    diff_summary = {}
+    for redis_key, info in dump_output.items():
+        if not redis_key.startswith(CHASSIS_LAG_MEMBER_TABLE_PREFIX):
+            continue
+        member_key = redis_key[len(CHASSIS_LAG_MEMBER_TABLE_PREFIX):]
+        member_table[member_key] = info.get("value", {})
+    return member_table
+
+
+def parse_chassis_lag_members(member_table):
+    """Return map of lag_member_key -> expected status from chassis table."""
+    members = {}
+    for member_key, fields in member_table.items():
+        if not isinstance(fields, dict):
+            members[member_key] = "enabled"
+            continue
+        status = fields.get("status", "enabled")
+        members[member_key] = status if status else "enabled"
+    return members
+
+
+def build_lag_oid_to_alias(lag_db_output, lag_id_table):
+    lag_id_to_alias = {str(lag_id): alias for alias, lag_id in lag_id_table.items() if lag_id is not None}
+    lag_oid_to_alias = {}
+    for key, info in lag_db_output.items():
+        if "SAI_OBJECT_TYPE_LAG" not in key:
+            continue
+        lag_oid = oid_from_asic_state_key(key)
+        aggregate_id = info.get("value", {}).get("SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID")
+        if lag_oid and aggregate_id is not None and str(aggregate_id) in lag_id_to_alias:
+            lag_oid_to_alias[lag_oid] = lag_id_to_alias[str(aggregate_id)]
+    return lag_oid_to_alias
+
+
+def build_lag_oid_to_aggregate_id(lag_db_output):
+    """Map SAI LAG OID strings to SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID values."""
+    lag_oid_to_aggregate_id = {}
+    for key, info in lag_db_output.items():
+        if "SAI_OBJECT_TYPE_LAG" not in key:
+            continue
+        lag_oid = oid_from_asic_state_key(key)
+        aggregate_id = info.get("value", {}).get("SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID")
+        if lag_oid and aggregate_id is not None:
+            lag_oid_to_aggregate_id[lag_oid] = str(aggregate_id)
+    return lag_oid_to_aggregate_id
+
+
+def normalize_member_port_alias(lag_alias, port_alias):
+    """Expand short port aliases (Ethernet0) to chassis system-port format."""
+    # Chassis member keys use slot|core|port; COUNTERS maps may return short Ethernet aliases.
+    if "|" in port_alias:
+        return port_alias
+    lag_parts = lag_alias.split("|")
+    if len(lag_parts) >= 2:
+        return f"{lag_parts[0]}|{lag_parts[1]}|{port_alias}"
+    return port_alias
+
+
+def build_port_oid_to_alias(asic_netns):
+    """Map SAI port OID strings to port/system-port aliases via COUNTERS maps."""
+    # ASIC_STATE_DB stores OIDs; COUNTERS_DB name maps provide alias <-> OID lookup.
+    oid_to_alias = {}
+    for map_name in ("COUNTERS_SYSTEM_PORT_NAME_MAP", "COUNTERS_PORT_NAME_MAP"):
+        raw = run_redis_dump_asic_namespace(asic_netns, 2, map_name)
+        name_map = raw.get(map_name, {}).get("value", {})
+        for alias, oid in name_map.items():
+            if oid:
+                oid_to_alias[oid] = alias
+    return oid_to_alias
+
+
+def build_valid_port_oids(port_db_output):
+    valid_port_oids = set()
+    for key in port_db_output:
+        if "SAI_OBJECT_TYPE_PORT" not in key and "SAI_OBJECT_TYPE_SYSTEM_PORT" not in key:
+            continue
+        port_oid = oid_from_asic_state_key(key)
+        if port_oid:
+            valid_port_oids.add(port_oid)
+    return valid_port_oids
+
+
+def extract_asic_lag_members(
+    lag_member_db_output,
+    lag_oid_to_alias,
+    oid_to_alias,
+    valid_port_oids,
+    lag_oid_to_aggregate_id=None,
+):
+    """Return lag member map keyed by chassis member key."""
+    members = {}
+    unresolved = []
+    invalid_port_id = []
+    incomplete_attrs = []
+    lag_oid_to_aggregate_id = lag_oid_to_aggregate_id or {}
+
+    for key, info in lag_member_db_output.items():
+        if "SAI_OBJECT_TYPE_LAG_MEMBER" not in key:
+            continue
+        value = info.get("value", {})
+        lag_oid = value.get("SAI_LAG_MEMBER_ATTR_LAG_ID")
+        port_oid = value.get("SAI_LAG_MEMBER_ATTR_PORT_ID")
+        if lag_oid is None or port_oid is None:
+            incomplete_attrs.append({
+                "lag_member_oid": oid_from_asic_state_key(key) or key,
+                "lag_oid": lag_oid,
+                "port_oid": port_oid,
+            })
+            logging.error("%s has incomplete lag member attributes", key)
+            continue
+
+        lag_alias = lag_oid_to_alias.get(lag_oid)
+        port_alias = oid_to_alias.get(port_oid)
+        if not lag_alias or not port_alias:
+            # OID present in ASIC_DB but not mappable to a chassis lag:port key.
+            unresolved.append({
+                "lag_oid": lag_oid,
+                "port_oid": port_oid,
+                "system_port_aggregate_id": lag_oid_to_aggregate_id.get(lag_oid),
+            })
+            continue
+
+        port_alias = normalize_member_port_alias(lag_alias, port_alias)
+        # Member key matches chassis_db: lag_alias:slot|core|port_alias
+        member_key = f"{lag_alias}:{port_alias}"
+        if port_oid not in valid_port_oids:
+            invalid_port_id.append({
+                "member": member_key,
+                "port_id": port_oid,
+            })
+            continue
+
+        members[member_key] = {
+            "ingress_disable": value.get("SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE", "false"),
+            "egress_disable": value.get("SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE", "false"),
+            "port_id": port_oid,
+        }
+
+    return members, unresolved, invalid_port_id, incomplete_attrs
+
+
+def member_disable_matches_status(ingress_disable, egress_disable, expected_status):
+    """Return True when ASIC disable flags match the chassis member status.
+
+    For ``enabled``, both ingress and egress disable must be false.
+
+    For ``disabled``, SWSS may omit disable attrs on SYSTEM ports (both false
+    while chassis still lists disabled). Symmetric flags (both true or both
+    false) are treated as a match. Mismatched flags (one true, one false) are not
+    a match.
+    """
+    ingress_disabled = _is_sai_bool_true(ingress_disable)
+    egress_disabled = _is_sai_bool_true(egress_disable)
+    if expected_status == "disabled":
+        return ingress_disabled == egress_disabled
+    return not ingress_disabled and not egress_disabled
+
+
+def find_member_status_mismatches(chassis_members, asic_members):
+    mismatches = []
+    for member_key in chassis_members.keys() & asic_members.keys():
+        expected_status = chassis_members[member_key]
+        asic_info = asic_members[member_key]
+        ingress_disable = asic_info["ingress_disable"]
+        egress_disable = asic_info["egress_disable"]
+        if member_disable_matches_status(ingress_disable, egress_disable, expected_status):
+            continue
+        mismatches.append({
+            "member": member_key,
+            "chassis_status": expected_status,
+            "ingress_disable": ingress_disable,
+            "egress_disable": egress_disable,
+        })
+    return mismatches
+
+
+def member_diff_has_mismatch(member_result):
+    return (
+        member_result["missing_in_asic_db"]
+        or member_result["extra_in_asic_db"]
+        or member_result["status_mismatch"]
+        or member_result["invalid_port_id"]
+        or member_result["unresolved"]
+        or member_result["incomplete_attrs"]
+    )
+
+
+def _empty_lag_members_result():
+    return {
+        "member_count": 0,
+        "missing_in_asic_db": [],
+        "extra_in_asic_db": [],
+        "status_mismatch": [],
+        "invalid_port_id": [],
+        "unresolved": [],
+        "incomplete_attrs": [],
+    }
+
+
+def check_asic_namespace(
+    asic_namespace,
+    lag_ids_in_chassis_db,
+    lag_id_table,
+    chassis_members=None,
+    check_members=True,
+):
+    """Check lag ID and optionally lag member consistency for one ASIC namespace."""
+    lag_db_output = run_redis_dump_asic_namespace(asic_namespace, 1, "*SAI_OBJECT_TYPE_LAG:*")
+    lag_ids_in_asic_db = extract_lag_ids_from_asic_db(
+        lag_db_output, "SAI_OBJECT_TYPE_LAG", "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID"
+    )
+    lag_id_missing, lag_id_extra = bidirectional_set_diff(lag_ids_in_chassis_db, lag_ids_in_asic_db)
+
+    lag_ids_result = {
+        "lag_id_count": len(lag_ids_in_asic_db),
+        **format_bidirectional_diff(lag_id_missing, lag_id_extra),
+    }
+    # --lag-id-only / Monit lagIdCheck: skip member redis dumps and comparisons.
+    if not check_members:
+        return {"lag_ids": lag_ids_result}
+
+    chassis_members = chassis_members or {}
+    lag_member_db_output = run_redis_dump_asic_namespace(
+        asic_namespace, 1, "*SAI_OBJECT_TYPE_LAG_MEMBER:*"
+    )
+    port_db_output = run_redis_dump_asic_namespace(asic_namespace, 1, "*SAI_OBJECT_TYPE_PORT:*")
+    system_port_db_output = run_redis_dump_asic_namespace(
+        asic_namespace, 1, "*SAI_OBJECT_TYPE_SYSTEM_PORT:*"
+    )
+
+    lag_oid_to_alias = build_lag_oid_to_alias(lag_db_output, lag_id_table)
+    lag_oid_to_aggregate_id = build_lag_oid_to_aggregate_id(lag_db_output)
+    oid_to_alias = build_port_oid_to_alias(asic_namespace)
+    valid_port_oids = build_valid_port_oids(port_db_output)
+    valid_port_oids.update(build_valid_port_oids(system_port_db_output))
+
+    asic_members, unresolved, invalid_port_id, incomplete_attrs = extract_asic_lag_members(
+        lag_member_db_output,
+        lag_oid_to_alias,
+        oid_to_alias,
+        valid_port_oids,
+        lag_oid_to_aggregate_id,
+    )
+    member_missing, member_extra = bidirectional_set_diff(
+        set(chassis_members.keys()), set(asic_members.keys())
+    )
+    # Invalid PORT_ID is reported separately; do not also count those keys as missing/extra.
+    invalid_member_keys = {item["member"] for item in invalid_port_id}
+    member_missing -= invalid_member_keys
+    member_extra -= invalid_member_keys
+    status_mismatch = find_member_status_mismatches(chassis_members, asic_members)
+
+    return {
+        "lag_ids": lag_ids_result,
+        "lag_members": {
+            "member_count": len(asic_members),
+            **format_bidirectional_diff(member_missing, member_extra),
+            "status_mismatch": status_mismatch,
+            "invalid_port_id": invalid_port_id,
+            "unresolved": unresolved,
+            "incomplete_attrs": incomplete_attrs,
+        },
+    }
+
+
+def _not_applicable_result(reason, lag_id_only=False):
+    return {
+        "status": STATUS_NOT_APPLICABLE,
+        "reason": reason,
+        "lag_id_only": lag_id_only,
+        "chassis_lag_id_count": 0,
+        "chassis_lag_member_count": 0,
+        "asics": {},
+    }
+
+
+def get_system_lag_consistency_result(check_members=True):
+    """Return structured system LAG consistency result for CLI or automation."""
+    # Internal flag is check_members; JSON/CLI surface the inverse as lag_id_only.
+    lag_id_only = not check_members
+
+    if not device_info.is_voq_chassis():
+        return _not_applicable_result(REASON_NOT_VOQ_CHASSIS, lag_id_only=lag_id_only)
+
+    if device_info.is_supervisor():
+        return _not_applicable_result(REASON_NOT_ON_SUPERVISOR, lag_id_only=lag_id_only)
+
     chassis_db_lag_table = get_chassis_lag_db_table()
     if not chassis_db_lag_table:
-        return RC_ERR, diff_summary
+        return {
+            "status": STATUS_ERROR,
+            "reason": "No SYSTEM_LAG_ID_TABLE found in chassis_db",
+            "lag_id_only": lag_id_only,
+            "chassis_lag_id_count": 0,
+            "chassis_lag_member_count": 0,
+            "asics": {},
+        }
+
+    chassis_members = {}
+    if check_members:
+        chassis_members = parse_chassis_lag_members(get_chassis_lag_member_table())
     lag_ids_in_chassis_db = extract_table_ids_from_chassis_db(chassis_db_lag_table)
     logging.debug(f"LAG IDs in chassis_db: {lag_ids_in_chassis_db}")
+    logging.debug(f"LAG members in chassis_db: {chassis_members}")
 
-    asic_namespaces = multi_asic.get_namespace_list()
+    asics = {}
+    for asic_namespace in multi_asic.get_namespace_list():
+        asic_name = _asic_display_name(asic_namespace)
+        asics[asic_name] = check_asic_namespace(
+            asic_namespace,
+            lag_ids_in_chassis_db,
+            chassis_db_lag_table,
+            chassis_members,
+            check_members=check_members,
+        )
 
-    for asic_namespace in asic_namespaces:
-        diff = compare_lag_ids(lag_ids_in_chassis_db, asic_namespace)
-        asic_name = "localhost" if asic_namespace == multi_asic.DEFAULT_NAMESPACE else asic_namespace
-        # Convert set to list for JSON/logging friendliness
-        diff_summary[asic_name] = sorted(list(diff))
+    any_mismatch = any(
+        bidirectional_diff_has_mismatch(asic_info["lag_ids"])
+        or (check_members and member_diff_has_mismatch(asic_info["lag_members"]))
+        for asic_info in asics.values()
+    )
 
-    return rc, diff_summary
+    return {
+        "status": STATUS_FAILED if any_mismatch else STATUS_OK,
+        "lag_id_only": lag_id_only,
+        "chassis_lag_id_count": len(lag_ids_in_chassis_db),
+        "chassis_lag_member_count": len(chassis_members),
+        "asics": asics,
+    }
+
+
+def get_lag_id_consistency_result():
+    """Return LAG ID consistency result without lag member checks."""
+    # Convenience entry for lag-id-only callers (e.g. future Monit lagIdCheck).
+    return get_system_lag_consistency_result(check_members=False)
+
+
+def _log_consistency_result(result):
+    """Log consistency result for Monit and return exit code."""
+    # Default invocation path: syslog CRITICAL on mismatch, RC_ERR for Monit.
+    if result["status"] == STATUS_NOT_APPLICABLE:
+        if result["reason"] == REASON_NOT_VOQ_CHASSIS:
+            logging.info("Not a voq chassis device. Exiting.....")
+        else:
+            logging.info("Not supported on supervisor. Exiting....")
+        return RC_OK
+
+    if result["status"] == STATUS_ERROR:
+        logging.error(result["reason"])
+        return RC_ERR
+
+    lag_id_only = result.get("lag_id_only", False)
+    mismatches_found = False
+    lag_id_summary = {}
+    lag_member_summary = {}
+
+    for asic, asic_info in result["asics"].items():
+        lag_ids = asic_info["lag_ids"]
+        lag_members = asic_info.get("lag_members", _empty_lag_members_result())
+        lag_id_summary[asic] = lag_ids
+        if not lag_id_only:
+            lag_member_summary[asic] = lag_members
+
+        lag_id_mismatch = bidirectional_diff_has_mismatch(lag_ids)
+        member_mismatch = not lag_id_only and member_diff_has_mismatch(lag_members)
+        if not lag_id_mismatch and not member_mismatch:
+            continue
+
+        mismatches_found = True
+        missing_in_asic = lag_ids["missing_in_asic_db"]
+        extra_in_asic = lag_ids["extra_in_asic_db"]
+        if missing_in_asic:
+            logging.critical(
+                "LAG IDs in chassis_db missing in %s ASIC_DB: %s", asic, missing_in_asic
+            )
+        if extra_in_asic:
+            logging.critical(
+                "LAG IDs in %s ASIC_DB missing from chassis_db: %s", asic, extra_in_asic
+            )
+
+        if not lag_id_only:
+            member_missing = lag_members["missing_in_asic_db"]
+            member_extra = lag_members["extra_in_asic_db"]
+            if member_missing:
+                logging.critical(
+                    "LAG members in chassis_db missing in %s ASIC_DB: %s", asic, member_missing
+                )
+            if member_extra:
+                logging.critical(
+                    "LAG members in %s ASIC_DB missing from chassis_db: %s", asic, member_extra
+                )
+            for item in lag_members["status_mismatch"]:
+                logging.critical("LAG member status mismatch in %s: %s", asic, item)
+            for item in lag_members["invalid_port_id"]:
+                logging.critical("LAG member invalid PORT_ID in %s: %s", asic, item)
+            for item in lag_members["unresolved"]:
+                logging.critical(
+                    "LAG member could not be resolved to chassis key in %s: %s", asic, item
+                )
+            for item in lag_members["incomplete_attrs"]:
+                logging.critical(
+                    "LAG member with incomplete attributes in %s: %s", asic, item
+                )
+
+    if mismatches_found:
+        summary = {"lag_ids": lag_id_summary}
+        if not lag_id_only:
+            summary["lag_members"] = lag_member_summary
+        logging.critical(
+            "Summary of mismatches:\n%s",
+            json.dumps(summary, indent=4),
+        )
+        return RC_ERR
+
+    logging.info("All ASICs are in sync with chassis_db")
+    return RC_OK
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Check LAG ID sync between chassis_db and asic_db")
+    parser = argparse.ArgumentParser(
+        description="Check VOQ system LAG sync between chassis_db and asic_db"
+    )
     parser.add_argument('--log-level', default='WARNING', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                         help='Set the logging level')
+    parser.add_argument('--lag-id-only', action='store_true',
+                        help='Check SYSTEM_LAG_ID_TABLE only; skip lag member checks')
+    parser.add_argument('--json', action='store_true',
+                        help='Output structured consistency result as JSON and exit 0')
     args = parser.parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level))
 
-    if not device_info.is_voq_chassis():
-        logging.info("Not a voq chassis device. Exiting.....")
+    # CLI --lag-id-only maps to skipping member checks inside get_system_lag_consistency_result().
+    check_members = not args.lag_id_only
+    result = get_system_lag_consistency_result(check_members=check_members)
+
+    # show chassis system-lag-consistency: JSON payload, always exit 0; show prints text.
+    if args.json:
+        print(json.dumps(result, indent=2))
         return RC_OK
 
-    if device_info.is_supervisor():
-        logging.info("Not supported on supervisor. Exiting....")
-        return RC_OK
-
-    rc, diff_summary = check_lag_id_sync()
-    if rc != RC_OK:
-        return rc
-
-    mismatches_found = False
-    for asic, mismatches in diff_summary.items():
-        if mismatches:
-            logging.critical(f"Mismatched LAG keys in {asic}: {mismatches}")
-            mismatches_found = True
-
-    if mismatches_found:
-        logging.critical("Summary of mismatches:\n%s", json.dumps(diff_summary, indent=4))
-        return RC_ERR
-    else:
-        logging.info("All ASICs are in sync with chassis_db")
-        return RC_OK
+    # Monit / manual: syslog + non-zero exit on mismatch.
+    return _log_consistency_result(result)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/show/chassis_modules.py
+++ b/show/chassis_modules.py
@@ -22,6 +22,7 @@ STATUS_NOT_APPLICABLE = "not_applicable"
 _CONSISTENCY_CHECKER_SCRIPT = "chassis_db_consistency_checker.py"
 _CONSISTENCY_CHECKER_TIMEOUT_SEC = 120
 
+
 def _consistency_checker_script_path():
     script = shutil.which(_CONSISTENCY_CHECKER_SCRIPT)
     if script is not None:

--- a/show/chassis_modules.py
+++ b/show/chassis_modules.py
@@ -1,3 +1,9 @@
+import json
+import os
+import shutil
+import subprocess
+import sys
+
 import click
 from natsort import natsorted
 from tabulate import tabulate
@@ -8,6 +14,199 @@ from sonic_platform_base.module_base import ModuleBase
 
 import utilities_common.cli as clicommon
 from sonic_py_common import multi_asic
+
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+STATUS_NOT_APPLICABLE = "not_applicable"
+
+_CONSISTENCY_CHECKER_SCRIPT = "chassis_db_consistency_checker.py"
+_CONSISTENCY_CHECKER_TIMEOUT_SEC = 120
+
+def _consistency_checker_script_path():
+    script = shutil.which(_CONSISTENCY_CHECKER_SCRIPT)
+    if script is not None:
+        return script
+    return os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "scripts", _CONSISTENCY_CHECKER_SCRIPT)
+    )
+
+
+def _run_system_lag_consistency_checker(lag_id_only=False):
+    """Run chassis_db_consistency_checker --json and return parsed result."""
+    script = _consistency_checker_script_path()
+    cmd = [sys.executable, script, "--json"]
+    if lag_id_only:
+        cmd.append("--lag-id-only")
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_CONSISTENCY_CHECKER_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        raise click.ClickException(
+            f"{_CONSISTENCY_CHECKER_SCRIPT} timed out after "
+            f"{_CONSISTENCY_CHECKER_TIMEOUT_SEC}s"
+        )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "no output"
+        raise click.ClickException(
+            f"{_CONSISTENCY_CHECKER_SCRIPT} failed (rc={proc.returncode}): {detail}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"{_CONSISTENCY_CHECKER_SCRIPT} returned invalid JSON: {exc}"
+        )
+
+
+def _echo_indented_lines(lines, indent="    "):
+    for line in lines:
+        click.echo(f"{indent}{line}")
+
+
+def _echo_indented_block(title, lines):
+    if not lines:
+        return
+    click.echo(f"  {title}:")
+    _echo_indented_lines(lines)
+
+
+def _format_lag_member_key(member_key):
+    if ":" in member_key:
+        lag_alias, port_alias = member_key.rsplit(":", 1)
+        return f"{lag_alias} : {port_alias}"
+    return member_key
+
+
+def _format_unresolved_lag_member(item):
+    aggregate_id = item.get("system_port_aggregate_id")
+    aggregate_label = aggregate_id if aggregate_id is not None else "unknown"
+    return (
+        f"lag_oid={item['lag_oid']}, "
+        f"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID={aggregate_label}, "
+        f"port_oid={item['port_oid']}"
+    )
+
+
+def _lag_member_issue_count(lag_members):
+    return (
+        len(lag_members["missing_in_asic_db"])
+        + len(lag_members["extra_in_asic_db"])
+        + len(lag_members["status_mismatch"])
+        + len(lag_members["invalid_port_id"])
+        + len(lag_members["unresolved"])
+        + len(lag_members["incomplete_attrs"])
+    )
+
+
+def _print_system_lag_consistency_text(result, lag_id_only_mode):
+    status = result["status"]
+    status_label = "OK" if status == STATUS_OK else "FAILED"
+    click.echo(f"System LAG consistency: {status_label}")
+    click.echo("")
+    if lag_id_only_mode:
+        click.echo("Mode: LAG ID only (lag members not checked)")
+        click.echo("")
+    click.echo("Chassis summary:")
+    click.echo(f"  SYSTEM_LAG_ID_TABLE:      {result['chassis_lag_id_count']} lag IDs")
+    if not lag_id_only_mode:
+        click.echo(
+            f"  SYSTEM_LAG_MEMBER_TABLE:  {result['chassis_lag_member_count']} lag members"
+        )
+    click.echo("")
+
+    asic_names = sorted(result["asics"].keys())
+    for index, asic_name in enumerate(asic_names):
+        asic_info = result["asics"][asic_name]
+        lag_ids = asic_info["lag_ids"]
+        lag_members = asic_info.get("lag_members", {})
+        lag_id_mismatch_count = (
+            len(lag_ids["missing_in_asic_db"]) + len(lag_ids["extra_in_asic_db"])
+        )
+        lag_id_mismatch_label = "mismatch" if lag_id_mismatch_count == 1 else "mismatches"
+
+        click.echo(f"ASIC namespace: {asic_name}")
+        click.echo(
+            f"  Lag IDs in ASIC_DB:      {lag_ids['lag_id_count']} "
+            f"({lag_id_mismatch_count} {lag_id_mismatch_label})"
+        )
+        if not lag_id_only_mode:
+            member_issue_count = _lag_member_issue_count(lag_members)
+            issue_label = "issue" if member_issue_count == 1 else "issues"
+            click.echo(
+                f"  Lag members in ASIC_DB:  {lag_members['member_count']} "
+                f"({member_issue_count} {issue_label})"
+            )
+
+        # LAG IDs configured in chassis_db but missing from this ASIC_DB's SAI LAG objects
+        _echo_indented_block(
+            "Lag IDs missing in ASIC_DB (in CHASSIS_DB - SYSTEM_LAG_ID_TABLE)",
+            lag_ids["missing_in_asic_db"],
+        )
+        # LAG IDs present on ASIC_DB but not listed in chassis_db SYSTEM_LAG_ID_TABLE
+        _echo_indented_block(
+            "Lag IDs extra in ASIC_DB (not in CHASSIS_DB - SYSTEM_LAG_ID_TABLE)",
+            lag_ids["extra_in_asic_db"],
+        )
+
+        if not lag_id_only_mode:
+            # Chassis SYSTEM_LAG_MEMBER_TABLE entries with no matching ASIC_DB LAG member
+            _echo_indented_block(
+                "Lag members missing in ASIC_DB (in CHASSIS_DB - SYSTEM_LAG_MEMBER_TABLE)",
+                [_format_lag_member_key(m) for m in lag_members["missing_in_asic_db"]],
+            )
+            # ASIC_DB LAG members not defined in chassis_db SYSTEM_LAG_MEMBER_TABLE
+            _echo_indented_block(
+                "Lag members extra in ASIC_DB (not in CHASSIS_DB - SYSTEM_LAG_MEMBER_TABLE)",
+                [_format_lag_member_key(m) for m in lag_members["extra_in_asic_db"]],
+            )
+            # Member exists on both sides but chassis status vs ingress/egress_disable disagree
+            _echo_indented_block(
+                "Lag member status mismatch",
+                [
+                    f"{item['member']} (chassis={item['chassis_status']}, "
+                    f"ingress_disable={item['ingress_disable']}, "
+                    f"egress_disable={item['egress_disable']})"
+                    for item in lag_members["status_mismatch"]
+                ],
+            )
+            # Member key resolved but PORT_ID OID is not a valid PORT/SYSTEM_PORT object
+            _echo_indented_block(
+                "Lag member invalid PORT_ID",
+                [
+                    f"{item['member']} (port_id={item['port_id']})"
+                    for item in lag_members["invalid_port_id"]
+                ],
+            )
+            # LAG member has LAG_ID and PORT_ID but OID-to-alias mapping failed
+            _echo_indented_block(
+                "Lag member unresolved OID mapping",
+                [_format_unresolved_lag_member(item) for item in lag_members["unresolved"]],
+            )
+            # SAI LAG member object missing SAI_LAG_MEMBER_ATTR_LAG_ID or PORT_ID
+            _echo_indented_block(
+                "Lag member incomplete attributes",
+                [
+                    f"lag_member_oid={item['lag_member_oid']}, lag_oid={item['lag_oid']}, "
+                    f"port_oid={item['port_oid']}"
+                    for item in lag_members["incomplete_attrs"]
+                ],
+            )
+
+        if index < len(asic_names) - 1:
+            click.echo("")
+
+    if status == STATUS_OK:
+        click.echo("")
+        click.echo("All ASIC namespaces are in sync with chassis_db.")
+    else:
+        click.echo("")
+        click.echo("One or more ASIC namespaces are out of sync with chassis_db.")
+
 
 CHASSIS_MODULE_INFO_TABLE = 'CHASSIS_MODULE_TABLE'
 CHASSIS_MODULE_INFO_KEY_TEMPLATE = 'CHASSIS_MODULE {}'
@@ -322,3 +521,38 @@ def system_lags(systemlagname, asicname, linecardname, verbose):
         cmd += ['-l', str(linecardname)]
 
     clicommon.run_command(cmd, display_cmd=verbose)
+
+
+@chassis.command(name="system-lag-consistency")
+@click.option(
+    "--lag-id-only",
+    is_flag=True,
+    help="Check SYSTEM_LAG_ID_TABLE only; skip lag member checks",
+)
+@click.option("-j", "--json", "json_output", is_flag=True, help="Output in JSON format")
+def system_lag_consistency(json_output, lag_id_only):
+    """Verify system LAG consistency between CHASSIS_APP_DB and ASIC_DB.
+
+    Default: SYSTEM_LAG_ID_TABLE and SYSTEM_LAG_MEMBER_TABLE. With --lag-id-only,
+    SYSTEM_LAG_ID_TABLE only (VOQ chassis linecards).
+    """
+
+    result = _run_system_lag_consistency_checker(lag_id_only=lag_id_only)
+
+    if json_output:
+        click.echo(clicommon.json_dump(result))
+        return
+
+    lag_id_only_mode = result.get("lag_id_only", lag_id_only)
+    status = result["status"]
+    if status == STATUS_NOT_APPLICABLE:
+        click.echo("System LAG consistency: not applicable")
+        click.echo(f"Reason: {result['reason']}")
+        return
+
+    if status == STATUS_ERROR:
+        click.echo("System LAG consistency: error")
+        click.echo(f"Reason: {result['reason']}")
+        return
+
+    _print_system_lag_consistency_text(result, lag_id_only_mode)

--- a/tests/chassis_db_consistency_checker_test.py
+++ b/tests/chassis_db_consistency_checker_test.py
@@ -8,33 +8,6 @@ import sonic_py_common.device_info as device_info
 sys.path.append("scripts")  # noqa: E402
 import chassis_db_consistency_checker  # noqa: E402
 
-MULTI_ASIC_MISMATCH_LOGS = """CRITICAL root:chassis_db_consistency_checker.py:160 Mismatched LAG keys in asic0: ['264', '265', '266']
-CRITICAL root:chassis_db_consistency_checker.py:160 Mismatched LAG keys in asic1: ['264', '265', '266']
-CRITICAL root:chassis_db_consistency_checker.py:164 Summary of mismatches:
-{
-    "asic0": [
-        "264",
-        "265",
-        "266"
-    ],
-    "asic1": [
-        "264",
-        "265",
-        "266"
-    ]
-}
-"""
-SINGLE_ASIC_MISMATCH_LOGS = """
-CRITICAL root:chassis_db_consistency_checker.py:160 Mismatched LAG keys in localhost: ['264', '265', '266']
-CRITICAL root:chassis_db_consistency_checker.py:164 Summary of mismatches:
-{
-    "localhost": [
-        "264",
-        "265",
-        "266"
-    ]
-}"""
-
 
 @pytest.fixture
 def mock_run_redis_dump(monkeypatch):
@@ -207,13 +180,13 @@ def test_extract_lag_ids_from_asic_db():
     db_output = {
         "SAI_OBJECT_TYPE_LAG:1": {"value": {"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID": "100"}},
         "SAI_OBJECT_TYPE_LAG:2": {"value": {"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID": "200"}},
+        "SAI_OBJECT_TYPE_LAG:3": {"value": {}},
         "OTHER_KEY": {"value": {"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID": "999"}}
     }
     lag_ids = chassis_db_consistency_checker.extract_lag_ids_from_asic_db(
         db_output, "SAI_OBJECT_TYPE_LAG", "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID"
     )
-    assert "100" in lag_ids
-    assert "200" in lag_ids
+    assert lag_ids == {"100", "200"}
 
 
 def test_extract_table_ids_from_chassis_db():
@@ -222,16 +195,212 @@ def test_extract_table_ids_from_chassis_db():
     assert ids == {"100", "200"}
 
 
-def test_compare_lag_ids(mock_run_redis_dump, mock_multi_asic):
+def test_extract_table_ids_from_chassis_db_skips_none():
+    table_output = {"PortChannel1": "100", "PortChannel2": None}
+    ids = chassis_db_consistency_checker.extract_table_ids_from_chassis_db(table_output)
+    assert ids == {"100"}
+
+
+def test_extract_table_ids_from_chassis_db_normalizes_integers():
+    table_output = {"PortChannel1": "262", "PortChannel2": 262}
+    ids = chassis_db_consistency_checker.extract_table_ids_from_chassis_db(table_output)
+    assert ids == {"262"}
+
+
+def test_parse_chassis_lag_member_dump_prefixed_keys():
+    dump_output = {
+        "SYSTEM_LAG_MEMBER_TABLE|lagA:host|asic0|port1": {
+            "value": {"status": "disabled"},
+        },
+        "SYSTEM_LAG_MEMBER_TABLE|lagA:host|asic0|port2": {
+            "value": {"status": "enabled"},
+        },
+    }
+    member_table = chassis_db_consistency_checker.parse_chassis_lag_member_dump(dump_output)
+    assert member_table == {
+        "lagA:host|asic0|port1": {"status": "disabled"},
+        "lagA:host|asic0|port2": {"status": "enabled"},
+    }
+
+
+def test_normalize_member_port_alias():
+    lag_alias = "ixre-egl-board211|asic0|PortChannel102"
+    assert chassis_db_consistency_checker.normalize_member_port_alias(
+        lag_alias, "Ethernet0"
+    ) == "ixre-egl-board211|asic0|Ethernet0"
+    assert chassis_db_consistency_checker.normalize_member_port_alias(
+        lag_alias, "ixre-egl-board211|asic0|Ethernet0"
+    ) == "ixre-egl-board211|asic0|Ethernet0"
+
+
+def test_extract_lag_ids_from_asic_db_normalizes_integers():
+    db_output = {
+        "SAI_OBJECT_TYPE_LAG:1": {"value": {"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID": 262}},
+        "SAI_OBJECT_TYPE_LAG:2": {"value": {"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID": "263"}},
+    }
+    lag_ids = chassis_db_consistency_checker.extract_lag_ids_from_asic_db(
+        db_output, "SAI_OBJECT_TYPE_LAG", "SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID"
+    )
+    assert lag_ids == {"262", "263"}
+
+
+def test_bidirectional_set_diff_member_keys():
+    chassis_members = {"lag:port1": "enabled", "lag:port2": "disabled"}
+    asic_members = {"lag:port1": {}, "lag:port3": {}}
+    missing, extra = chassis_db_consistency_checker.bidirectional_set_diff(
+        set(chassis_members.keys()), set(asic_members.keys())
+    )
+    assert missing == {"lag:port2"}
+    assert extra == {"lag:port3"}
+
+
+def test_member_disable_matches_status():
+    assert chassis_db_consistency_checker.member_disable_matches_status("true", "true", "disabled")
+    assert chassis_db_consistency_checker.member_disable_matches_status("false", "false", "disabled")
+    assert chassis_db_consistency_checker.member_disable_matches_status("false", "false", "enabled")
+    assert not chassis_db_consistency_checker.member_disable_matches_status(
+        "true", "false", "disabled"
+    )
+    assert not chassis_db_consistency_checker.member_disable_matches_status(
+        "true", "false", "enabled"
+    )
+    assert not chassis_db_consistency_checker.member_disable_matches_status(
+        "false", "true", "enabled"
+    )
+
+
+def test_bidirectional_set_diff_lag_ids():
+    missing, extra = chassis_db_consistency_checker.bidirectional_set_diff(
+        {"100", "175"}, {"100", "171"}
+    )
+    assert missing == {"175"}
+    assert extra == {"171"}
+
+
+def test_extract_asic_lag_members_incomplete_attrs():
+    lag_member_db_output = {
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:0x1": {
+            "value": {
+                "SAI_LAG_MEMBER_ATTR_LAG_ID": "oid:lag1",
+                "SAI_LAG_MEMBER_ATTR_PORT_ID": None,
+            }
+        }
+    }
+    members, unresolved, invalid_port_id, incomplete_attrs = (
+        chassis_db_consistency_checker.extract_asic_lag_members(
+            lag_member_db_output, {}, {}, set(), {}
+        )
+    )
+    assert members == {}
+    assert unresolved == []
+    assert invalid_port_id == []
+    assert len(incomplete_attrs) == 1
+    assert incomplete_attrs[0]["port_oid"] is None
+
+
+def test_extract_asic_lag_members_invalid_port_id_not_counted_as_member():
+    lag_member_db_output = {
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:0x1": {
+            "value": {
+                "SAI_LAG_MEMBER_ATTR_LAG_ID": "oid:lag1",
+                "SAI_LAG_MEMBER_ATTR_PORT_ID": "oid:badport",
+                "SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE": "false",
+                "SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE": "false",
+            }
+        }
+    }
+    members, unresolved, invalid_port_id, incomplete_attrs = (
+        chassis_db_consistency_checker.extract_asic_lag_members(
+            lag_member_db_output,
+            {"oid:lag1": "host|asic0|PortChannel1"},
+            {"oid:badport": "Ethernet0"},
+            set(),
+            {},
+        )
+    )
+    assert members == {}
+    assert unresolved == []
+    assert invalid_port_id == [
+        {"member": "host|asic0|PortChannel1:host|asic0|Ethernet0", "port_id": "oid:badport"},
+    ]
+    assert incomplete_attrs == []
+
+
+def test_member_missing_excludes_invalid_port_id():
+    chassis_members = {
+        "lag:host|asic0|Ethernet0": "enabled",
+    }
+    asic_members = {}
+    invalid_port_id = [
+        {"member": "lag:host|asic0|Ethernet0", "port_id": "oid:badport"},
+    ]
+    member_missing, member_extra = chassis_db_consistency_checker.bidirectional_set_diff(
+        set(chassis_members.keys()), set(asic_members.keys())
+    )
+    invalid_member_keys = {item["member"] for item in invalid_port_id}
+    member_missing -= invalid_member_keys
+    member_extra -= invalid_member_keys
+    assert member_missing == set()
+    assert member_extra == set()
+    member_result = {
+        "missing_in_asic_db": [],
+        "extra_in_asic_db": [],
+        "status_mismatch": [],
+        "invalid_port_id": [],
+        "unresolved": [],
+        "incomplete_attrs": [{"lag_member_oid": "oid:0x1"}],
+    }
+    assert chassis_db_consistency_checker.member_diff_has_mismatch(member_result)
+
+
+def test_check_asic_namespace_lag_id_diff(mock_run_redis_dump, mock_multi_asic):
+    chassis_table = chassis_db_consistency_checker.get_chassis_lag_db_table()
     lag_ids_in_chassis_db = {"262", "264"}
-    diff = chassis_db_consistency_checker.compare_lag_ids(lag_ids_in_chassis_db, "asic0")
-    assert diff == {'263', '265', '266'}
+    result = chassis_db_consistency_checker.check_asic_namespace(
+        "asic0", lag_ids_in_chassis_db, chassis_table, {}
+    )
+    assert result["lag_ids"]["missing_in_asic_db"] == []
+    assert result["lag_ids"]["extra_in_asic_db"] == ["263", "265", "266"]
 
 
-def test_check_lag_id_sync(mock_run_redis_dump, mock_multi_asic):
-    rc, diff_summary = chassis_db_consistency_checker.check_lag_id_sync()
+def test_get_lag_id_consistency_result_ok(mock_run_redis_dump, mock_multi_asic, mock_device_info):
+    result = chassis_db_consistency_checker.get_lag_id_consistency_result()
+    assert result["status"] == chassis_db_consistency_checker.STATUS_OK
+    assert result["lag_id_only"] is True
+    assert result["chassis_lag_id_count"] == 5
+    assert result["chassis_lag_member_count"] == 0
+    assert result["asics"]["asic0"]["lag_ids"]["missing_in_asic_db"] == []
+    assert result["asics"]["asic0"]["lag_ids"]["extra_in_asic_db"] == []
+
+
+def test_get_lag_id_consistency_result_not_applicable(mock_device_info_supervisor):
+    result = chassis_db_consistency_checker.get_lag_id_consistency_result()
+    assert result["status"] == chassis_db_consistency_checker.STATUS_NOT_APPLICABLE
+    assert "supervisor" in result["reason"].lower()
+
+
+def test_json_output(monkeypatch, mock_run_redis_dump, mock_multi_asic, mock_device_info, capsys):
+    monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py", "--json"])
+    rc = chassis_db_consistency_checker.main()
+    captured = capsys.readouterr()
     assert rc == 0
-    assert {'asic0': [], 'asic1': []} == diff_summary
+    payload = json.loads(captured.out)
+    assert payload["status"] == chassis_db_consistency_checker.STATUS_OK
+    assert payload["lag_id_only"] is False
+
+
+def test_json_output_lag_id_only(
+    monkeypatch, mock_run_redis_dump, mock_multi_asic, mock_device_info, capsys
+):
+    monkeypatch.setattr(
+        sys, "argv", ["chassis_db_consistency_checker.py", "--lag-id-only", "--json"]
+    )
+    rc = chassis_db_consistency_checker.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["lag_id_only"] is True
+    assert payload["chassis_lag_member_count"] == 0
 
 
 def test_check_no_voq_chassis(monkeypatch, mock_run_redis_dump, mock_device_info_no_voq, caplog):
@@ -239,8 +408,7 @@ def test_check_no_voq_chassis(monkeypatch, mock_run_redis_dump, mock_device_info
     monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py"])
     rc = chassis_db_consistency_checker.main()
     assert rc == 0
-    expected_msg = "INFO     root:chassis_db_consistency_checker.py:146 Not a voq chassis device. Exiting....."
-    assert caplog.text.strip() == expected_msg
+    assert "Not a voq chassis device. Exiting....." in caplog.text
 
 
 def test_check_no_supervisor(monkeypatch, mock_run_redis_dump, mock_device_info_supervisor, caplog):
@@ -248,8 +416,7 @@ def test_check_no_supervisor(monkeypatch, mock_run_redis_dump, mock_device_info_
     monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py"])
     rc = chassis_db_consistency_checker.main()
     assert rc == 0
-    expected_msg = "INFO     root:chassis_db_consistency_checker.py:150 Not supported on supervisor. Exiting...."
-    assert caplog.text.strip() == expected_msg
+    assert "Not supported on supervisor. Exiting...." in caplog.text
 
 
 def test_no_mismatch(monkeypatch, mock_run_redis_dump, mock_multi_asic, mock_device_info):
@@ -270,8 +437,39 @@ def test_with_mismatch(monkeypatch, mock_run_redis_dump_mismatch, mock_multi_asi
     caplog.set_level(logging.CRITICAL)
     monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py"])
     rc = chassis_db_consistency_checker.main()
-    assert caplog.text.strip() == MULTI_ASIC_MISMATCH_LOGS.strip()
-    assert rc == -1
+    assert "LAG IDs in chassis_db missing in asic0 ASIC_DB" not in caplog.text
+    assert "LAG IDs in asic0 ASIC_DB missing from chassis_db" in caplog.text
+    assert "LAG IDs in asic1 ASIC_DB missing from chassis_db" in caplog.text
+    assert "Summary of mismatches" in caplog.text
+    assert rc == chassis_db_consistency_checker.RC_ERR
+
+
+def test_main_json_returns_ok_on_mismatch(
+    monkeypatch, mock_run_redis_dump_mismatch, mock_multi_asic, mock_device_info, capsys
+):
+    monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py", "--json"])
+    rc = chassis_db_consistency_checker.main()
+    captured = capsys.readouterr()
+    assert rc == chassis_db_consistency_checker.RC_OK
+    payload = json.loads(captured.out)
+    assert payload["status"] == chassis_db_consistency_checker.STATUS_FAILED
+
+
+def test_main_sys_exit_nonzero_on_mismatch(
+    monkeypatch, mock_run_redis_dump_mismatch, mock_multi_asic, mock_device_info
+):
+    exit_code = None
+
+    def capture_exit(code):
+        nonlocal exit_code
+        exit_code = code
+        raise SystemExit(code)
+
+    monkeypatch.setattr(chassis_db_consistency_checker.sys, "exit", capture_exit)
+    monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py"])
+    with pytest.raises(SystemExit):
+        chassis_db_consistency_checker.sys.exit(chassis_db_consistency_checker.main())
+    assert exit_code == chassis_db_consistency_checker.RC_ERR
 
 
 def test_with_mismatch_single_asic(monkeypatch, mock_run_redis_dump_mismatch,
@@ -279,9 +477,9 @@ def test_with_mismatch_single_asic(monkeypatch, mock_run_redis_dump_mismatch,
     caplog.set_level(logging.CRITICAL)
     monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py"])
     rc = chassis_db_consistency_checker.main()
-    # The following line is within 120 columns
-    assert caplog.text.strip() == SINGLE_ASIC_MISMATCH_LOGS.strip()
-    assert rc == -1
+    assert "LAG IDs in localhost ASIC_DB missing from chassis_db" in caplog.text
+    assert "Summary of mismatches" in caplog.text
+    assert rc == chassis_db_consistency_checker.RC_ERR
 
 
 def test_redis_dump_no_output(monkeypatch, run_redis_dump_empty,
@@ -289,12 +487,8 @@ def test_redis_dump_no_output(monkeypatch, run_redis_dump_empty,
     caplog.set_level(logging.ERROR)
     monkeypatch.setattr(sys, "argv", ["chassis_db_consistency_checker.py"])
     rc = chassis_db_consistency_checker.main()
-    assert rc == -1
-    expected_msg = (
-        "ERROR    root:chassis_db_consistency_checker.py:103 "
-        "No SYSTEM_LAG_ID_TABLE found in chassis_db"
-    )
-    assert caplog.text.strip() == expected_msg
+    assert rc == chassis_db_consistency_checker.RC_ERR
+    assert "No SYSTEM_LAG_ID_TABLE found in chassis_db" in caplog.text
 
 
 def test_run_redis_dump_failure(monkeypatch):
@@ -335,6 +529,187 @@ def test_run_redis_dump(monkeypatch, caplog):
     # Patch subprocess.run
     monkeypatch.setattr(chassis_db_consistency_checker.subprocess, "run", fake_run)
 
-    # Now call script functions; they will use the mocked run
+    # Now call module functions; they will use the mocked run
     table = chassis_db_consistency_checker.get_chassis_lag_db_table()
     assert table == {"hostname|asic0|PortChannel1": "100"}
+
+
+@pytest.fixture
+def mock_member_consistency(monkeypatch):
+    """Mock redis data for lag member consistency checks."""
+    lag_alias = "sonic-lc1-1|asic0|PortChannel112"
+    lag_id_table = {lag_alias: "262"}
+    lag_db_output = {
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG:oid:0xlag262": {
+            "value": {"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID": "262"},
+        },
+    }
+    port_db_output = {
+        "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0xport1": {"value": {}},
+        "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0xport4": {"value": {}},
+    }
+    lag_member_db_output = {
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:0xmember1": {
+            "value": {
+                "SAI_LAG_MEMBER_ATTR_LAG_ID": "oid:0xlag262",
+                "SAI_LAG_MEMBER_ATTR_PORT_ID": "oid:0xport1",
+                "SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE": "false",
+                "SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE": "false",
+            },
+        },
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:0xmember4": {
+            "value": {
+                "SAI_LAG_MEMBER_ATTR_LAG_ID": "oid:0xlag262",
+                "SAI_LAG_MEMBER_ATTR_PORT_ID": "oid:0xport4",
+                "SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE": "false",
+                "SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE": "false",
+            },
+        },
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:0xmember2": {
+            "value": {
+                "SAI_LAG_MEMBER_ATTR_LAG_ID": "oid:0xlag262",
+                "SAI_LAG_MEMBER_ATTR_PORT_ID": "oid:0xport2",
+                "SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE": "true",
+                "SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE": "true",
+            },
+        },
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:0xmember_incomplete": {
+            "value": {
+                "SAI_LAG_MEMBER_ATTR_LAG_ID": None,
+                "SAI_LAG_MEMBER_ATTR_PORT_ID": "oid:0xport1",
+            },
+        },
+    }
+    member_table = {
+        f"{lag_alias}:sonic-lc1-1|asic0|Ethernet0": {"status": "enabled"},
+        f"{lag_alias}:sonic-lc1-1|asic0|Ethernet4": {"status": "disabled"},
+        f"{lag_alias}:sonic-lc1-1|asic0|Ethernet8": {"status": "enabled"},
+    }
+
+    def _mock(cmd_args):
+        cmd = str(cmd_args)
+        if "SYSTEM_LAG_ID_TABLE" in cmd:
+            return {"SYSTEM_LAG_ID_TABLE": {"value": lag_id_table}}
+        if "SYSTEM_LAG_MEMBER_TABLE" in cmd:
+            return {"SYSTEM_LAG_MEMBER_TABLE": {"value": member_table}}
+        if "SAI_OBJECT_TYPE_LAG:" in cmd:
+            return lag_db_output
+        if "SAI_OBJECT_TYPE_LAG_MEMBER:" in cmd:
+            return lag_member_db_output
+        if "SAI_OBJECT_TYPE_PORT:" in cmd:
+            return port_db_output
+        if "COUNTERS_PORT_NAME_MAP" in cmd:
+            return {
+                "COUNTERS_PORT_NAME_MAP": {
+                    "value": {
+                        "sonic-lc1-1|asic0|Ethernet0": "oid:0xport1",
+                        "sonic-lc1-1|asic0|Ethernet4": "oid:0xport4",
+                        "sonic-lc1-1|asic0|Ethernet2": "oid:0xport2",
+                    },
+                },
+            }
+        if "COUNTERS_SYSTEM_PORT_NAME_MAP" in cmd:
+            return {"COUNTERS_SYSTEM_PORT_NAME_MAP": {"value": {}}}
+        return {}
+
+    monkeypatch.setattr(chassis_db_consistency_checker, "run_redis_dump", _mock)
+    monkeypatch.setattr(multi_asic, "get_namespace_list", lambda: ["asic0"])
+
+
+def test_get_system_lag_consistency_member_issues(
+    monkeypatch, mock_member_consistency, mock_device_info
+):
+    lag_alias = "sonic-lc1-1|asic0|PortChannel112"
+    result = chassis_db_consistency_checker.get_system_lag_consistency_result()
+    lag_members = result["asics"]["asic0"]["lag_members"]
+
+    assert result["status"] == chassis_db_consistency_checker.STATUS_FAILED
+    assert lag_members["missing_in_asic_db"] == [
+        f"{lag_alias}:sonic-lc1-1|asic0|Ethernet8",
+    ]
+    assert lag_members["extra_in_asic_db"] == []
+    assert lag_members["status_mismatch"] == []
+    assert lag_members["invalid_port_id"] == [
+        {
+            "member": f"{lag_alias}:sonic-lc1-1|asic0|Ethernet2",
+            "port_id": "oid:0xport2",
+        },
+    ]
+    assert lag_members["member_count"] == 2
+    assert lag_members["unresolved"] == []
+    assert len(lag_members["incomplete_attrs"]) == 1
+
+
+def test_get_system_lag_consistency_member_issues_lag_id_only_ok(
+    monkeypatch, mock_member_consistency, mock_device_info
+):
+    result = chassis_db_consistency_checker.get_system_lag_consistency_result(check_members=False)
+    assert result["status"] == chassis_db_consistency_checker.STATUS_OK
+    assert result["lag_id_only"] is True
+    assert result["chassis_lag_member_count"] == 0
+    assert "lag_members" not in result["asics"]["asic0"]
+
+
+@pytest.fixture
+def mock_member_unresolved(monkeypatch):
+    lag_alias = "sonic-lc1-1|asic0|PortChannel112"
+    lag_id_table = {lag_alias: "262"}
+    lag_db_output = {
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG:oid:0xlag262": {
+            "value": {"SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID": "262"},
+        },
+    }
+    lag_member_db_output = {
+        "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER:oid:0xmember_unknown": {
+            "value": {
+                "SAI_LAG_MEMBER_ATTR_LAG_ID": "oid:0xlag262",
+                "SAI_LAG_MEMBER_ATTR_PORT_ID": "oid:0xport_missing",
+                "SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE": "false",
+                "SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE": "false",
+            },
+        },
+    }
+    member_table = {
+        f"{lag_alias}:sonic-lc1-1|asic0|Ethernet8": {"status": "enabled"},
+    }
+
+    def _mock(cmd_args):
+        cmd = str(cmd_args)
+        if "SYSTEM_LAG_ID_TABLE" in cmd:
+            return {"SYSTEM_LAG_ID_TABLE": {"value": lag_id_table}}
+        if "SYSTEM_LAG_MEMBER_TABLE" in cmd:
+            return {"SYSTEM_LAG_MEMBER_TABLE": {"value": member_table}}
+        if "SAI_OBJECT_TYPE_LAG:" in cmd:
+            return lag_db_output
+        if "SAI_OBJECT_TYPE_LAG_MEMBER:" in cmd:
+            return lag_member_db_output
+        if "SAI_OBJECT_TYPE_PORT:" in cmd:
+            return {}
+        if "COUNTERS_PORT_NAME_MAP" in cmd:
+            return {"COUNTERS_PORT_NAME_MAP": {"value": {}}}
+        if "COUNTERS_SYSTEM_PORT_NAME_MAP" in cmd:
+            return {"COUNTERS_SYSTEM_PORT_NAME_MAP": {"value": {}}}
+        return {}
+
+    monkeypatch.setattr(chassis_db_consistency_checker, "run_redis_dump", _mock)
+    monkeypatch.setattr(multi_asic, "get_namespace_list", lambda: ["asic0"])
+
+
+def test_get_system_lag_consistency_unresolved_member(
+    mock_member_unresolved, mock_device_info
+):
+    lag_alias = "sonic-lc1-1|asic0|PortChannel112"
+    member_key = f"{lag_alias}:sonic-lc1-1|asic0|Ethernet8"
+    result = chassis_db_consistency_checker.get_system_lag_consistency_result()
+    lag_members = result["asics"]["asic0"]["lag_members"]
+
+    assert result["status"] == chassis_db_consistency_checker.STATUS_FAILED
+    assert lag_members["missing_in_asic_db"] == [member_key]
+    assert lag_members["extra_in_asic_db"] == []
+    assert lag_members["unresolved"] == [
+        {
+            "lag_oid": "oid:0xlag262",
+            "port_oid": "oid:0xport_missing",
+            "system_port_aggregate_id": "262",
+        },
+    ]

--- a/tests/chassis_system_lag_id_consistency_test.py
+++ b/tests/chassis_system_lag_id_consistency_test.py
@@ -1,0 +1,232 @@
+import json
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from show.main import cli
+
+REASON_NOT_ON_SUPERVISOR = "Not supported on supervisor (VOQ chassis linecards only)"
+STATUS_ERROR = "error"
+STATUS_FAILED = "failed"
+STATUS_NOT_APPLICABLE = "not_applicable"
+STATUS_OK = "ok"
+
+EMPTY_LAG_IDS = {"lag_id_count": 0, "missing_in_asic_db": [], "extra_in_asic_db": []}
+EMPTY_LAG_MEMBERS = {
+    "member_count": 0,
+    "missing_in_asic_db": [],
+    "extra_in_asic_db": [],
+    "status_mismatch": [],
+    "invalid_port_id": [],
+    "unresolved": [],
+    "incomplete_attrs": [],
+}
+
+
+def _asics_ok(lag_id_only):
+    asic0 = {
+        "lag_ids": {"lag_id_count": 5, "missing_in_asic_db": [], "extra_in_asic_db": []},
+    }
+    asic1 = {
+        "lag_ids": {"lag_id_count": 5, "missing_in_asic_db": [], "extra_in_asic_db": []},
+    }
+    if not lag_id_only:
+        asic0["lag_members"] = {
+            "member_count": 2,
+            "missing_in_asic_db": [],
+            "extra_in_asic_db": [],
+            "status_mismatch": [],
+            "invalid_port_id": [],
+            "unresolved": [],
+            "incomplete_attrs": [],
+        }
+        asic1["lag_members"] = EMPTY_LAG_MEMBERS
+    return {"asic0": asic0, "asic1": asic1}
+
+
+def _asics_failed(lag_id_only):
+    asic0 = {
+        "lag_ids": {
+            "lag_id_count": 19,
+            "missing_in_asic_db": ["175"],
+            "extra_in_asic_db": ["171"],
+        },
+    }
+    if not lag_id_only:
+        asic0["lag_members"] = {
+            "member_count": 2,
+            "missing_in_asic_db": ["lag:port1"],
+            "extra_in_asic_db": [],
+            "status_mismatch": [
+                {
+                    "member": "lag:port2",
+                    "chassis_status": "enabled",
+                    "ingress_disable": "true",
+                    "egress_disable": "true",
+                }
+            ],
+            "invalid_port_id": [],
+            "unresolved": [],
+            "incomplete_attrs": [],
+        }
+    return {"asic0": asic0}
+
+
+@pytest.fixture
+def mock_consistency_ok(monkeypatch):
+    monkeypatch.setattr(
+        "show.chassis_modules._run_system_lag_consistency_checker",
+        lambda lag_id_only=False: {
+            "status": STATUS_OK,
+            "lag_id_only": lag_id_only,
+            "chassis_lag_id_count": 5,
+            "chassis_lag_member_count": 0 if lag_id_only else 2,
+            "asics": _asics_ok(lag_id_only),
+        },
+    )
+
+
+@pytest.fixture
+def mock_consistency_failed(monkeypatch):
+    monkeypatch.setattr(
+        "show.chassis_modules._run_system_lag_consistency_checker",
+        lambda lag_id_only=False: {
+            "status": STATUS_FAILED,
+            "lag_id_only": lag_id_only,
+            "chassis_lag_id_count": 5,
+            "chassis_lag_member_count": 0 if lag_id_only else 2,
+            "asics": _asics_failed(lag_id_only),
+        },
+    )
+
+
+@pytest.fixture
+def mock_consistency_not_applicable(monkeypatch):
+    monkeypatch.setattr(
+        "show.chassis_modules._run_system_lag_consistency_checker",
+        lambda lag_id_only=False: {
+            "status": STATUS_NOT_APPLICABLE,
+            "reason": REASON_NOT_ON_SUPERVISOR,
+            "lag_id_only": lag_id_only,
+            "chassis_lag_id_count": 0,
+            "chassis_lag_member_count": 0,
+            "asics": {},
+        },
+    )
+
+
+@pytest.fixture
+def mock_consistency_error(monkeypatch):
+    monkeypatch.setattr(
+        "show.chassis_modules._run_system_lag_consistency_checker",
+        lambda lag_id_only=False: {
+            "status": STATUS_ERROR,
+            "reason": "No SYSTEM_LAG_ID_TABLE found in chassis_db",
+            "lag_id_only": lag_id_only,
+            "chassis_lag_id_count": 0,
+            "chassis_lag_member_count": 0,
+            "asics": {},
+        },
+    )
+
+
+def _invoke_consistency(args=None):
+    runner = CliRunner()
+    return runner.invoke(
+        cli.commands["chassis"].commands["system-lag-consistency"],
+        args or [],
+    )
+
+
+def test_show_chassis_system_lag_consistency_ok(mock_consistency_ok):
+    result = _invoke_consistency()
+    assert result.exit_code == 0
+    assert "System LAG consistency: OK" in result.output
+    assert "SYSTEM_LAG_ID_TABLE:      5 lag IDs" in result.output
+    assert "SYSTEM_LAG_MEMBER_TABLE:  2 lag members" in result.output
+    assert "ASIC namespace: asic0" in result.output
+    assert "Lag IDs in ASIC_DB:      5 (0 mismatches)" in result.output
+    assert "All ASIC namespaces are in sync with chassis_db." in result.output
+
+
+def test_show_chassis_system_lag_consistency_failed(mock_consistency_failed):
+    result = _invoke_consistency()
+    assert result.exit_code == 0
+    assert "System LAG consistency: FAILED" in result.output
+    assert "One or more ASIC namespaces are out of sync with chassis_db." in result.output
+    assert "Lag IDs missing in ASIC_DB (in CHASSIS_DB - SYSTEM_LAG_ID_TABLE):" in result.output
+    assert "    175" in result.output
+    assert "Lag IDs extra in ASIC_DB (not in CHASSIS_DB - SYSTEM_LAG_ID_TABLE):" in result.output
+    assert "    171" in result.output
+    assert "Lag members missing in ASIC_DB (in CHASSIS_DB - SYSTEM_LAG_MEMBER_TABLE):" in result.output
+    assert "    lag : port1" in result.output
+    assert "Lag member status mismatch:" in result.output
+    assert "lag:port2" in result.output
+
+
+def test_show_chassis_system_lag_consistency_not_applicable(mock_consistency_not_applicable):
+    result = _invoke_consistency()
+    assert result.exit_code == 0
+    assert "System LAG consistency: not applicable" in result.output
+    assert "Not supported on supervisor" in result.output
+
+
+def test_show_chassis_system_lag_consistency_error(mock_consistency_error):
+    result = _invoke_consistency()
+    assert result.exit_code == 0
+    assert "System LAG consistency: error" in result.output
+    assert "No SYSTEM_LAG_ID_TABLE found in chassis_db" in result.output
+
+
+def test_show_chassis_system_lag_consistency_json(mock_consistency_ok):
+    result = _invoke_consistency(["--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == STATUS_OK
+    assert payload["chassis_lag_id_count"] == 5
+    assert payload["chassis_lag_member_count"] == 2
+    assert payload["lag_id_only"] is False
+
+
+def test_show_chassis_system_lag_consistency_lag_id_only(mock_consistency_ok):
+    result = _invoke_consistency(["--lag-id-only"])
+    assert result.exit_code == 0
+    assert "Mode: LAG ID only (lag members not checked)" in result.output
+    assert "SYSTEM_LAG_MEMBER_TABLE" not in result.output
+    assert "Lag members in ASIC_DB" not in result.output
+    assert "ASIC namespace: asic0" in result.output
+    assert "Lag IDs in ASIC_DB:      5 (0 mismatches)" in result.output
+
+
+def test_show_chassis_system_lag_consistency_lag_id_only_json(mock_consistency_ok):
+    result = _invoke_consistency(["--lag-id-only", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["lag_id_only"] is True
+    assert payload["chassis_lag_member_count"] == 0
+    assert "lag_members" not in payload["asics"]["asic0"]
+
+
+def test_show_chassis_system_lag_consistency_lag_id_only_skips_member_output(
+    mock_consistency_failed,
+):
+    result = _invoke_consistency(["--lag-id-only"])
+    assert result.exit_code == 0
+    assert "Lag IDs missing in ASIC_DB (in CHASSIS_DB - SYSTEM_LAG_ID_TABLE):" in result.output
+    assert "    175" in result.output
+    assert "Lag members missing in ASIC_DB" not in result.output
+    assert "Lag member status mismatch" not in result.output
+
+
+def test_show_chassis_system_lag_consistency_checker_failure(monkeypatch):
+    def _raise(*_args, **_kwargs):
+        raise click.ClickException("checker subprocess failed")
+
+    monkeypatch.setattr(
+        "show.chassis_modules._run_system_lag_consistency_checker",
+        _raise,
+    )
+    result = _invoke_consistency()
+    assert result.exit_code != 0
+    assert "checker subprocess failed" in result.output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Extended chassis_db_consistency_checker.py on VOQ linecards to verify sync between CHASSIS_APP_DB and local ASIC_DB for:
SYSTEM_LAG_ID_TABLE vs SAI LAG aggregate IDs
SYSTEM_LAG_MEMBER_TABLE vs SAI LAG member objects (including member status vs ingress/egress disable)
Added show chassis system-lag-consistency with output and -j / --json
Added --lag-id-only on the checker and show command to skip member checks (lighter path for Monit / quick checks)
Preserved Monit/manual use: without --json, mismatches log CRITICAL to syslog and exit non-zero (RC_ERR)
Added --json mode: structured result payload, exit 0 (mismatches in JSON status, not exit code)

#### How I did it
Checker script (scripts/chassis_db_consistency_checker.py):

Central logic in get_system_lag_consistency_result(); returns structured JSON (status, per-ASIC lag_ids / lag_members, issue categories)
Chassis data via redis-dump against redis_chassis (CHASSIS_APP_DB); ASIC data per namespace via redis-dump in ASIC netns
LAG members resolved through OID→alias maps (COUNTERS_PORT_NAME_MAP, COUNTERS_SYSTEM_PORT_NAME_MAP) and compared with bidirectional set diffs
Member issues categorized: missing/extra, status mismatch, invalid PORT_ID, unresolved OID mapping, incomplete attributes
--lag-id-only skips member redis-dumps and comparisons (check_members=False)
--json → print JSON, exit 0; default path → _log_consistency_result() for syslog + RC_ERR on mismatch
Show CLI (show/chassis_modules.py):

show chassis system-lag-consistency runs the checker as subprocess with --json
Formats per-ASIC mismatch details; supports --lag-id-only and -j
120s subprocess timeout; errors surfaced via click.ClickException
Tests: expanded chassis_db_consistency_checker_test.py; new chassis_system_lag_id_consistency_test.py for show paths (OK/FAILED/not applicable/error, JSON, lag-id-only, subprocess failure)


#### How to verify it
Verified the following commands in Voq systems
show chassis system-lag-consistency
show chassis system-lag-consistency --lag-id-only
show chassis system-lag-consistency -j
show chassis system-lag-consistency --lag-id-only -j
#### Previous command output (if the output of a command-line utility has changed)
New command
#### New command output (if the output of a command-line utility has changed)

dmin@ixre-egl-board211:/usr$ sudo cp ~/chassis_modules.py ./local/lib/python3.13/dist-packages/show/chassis_modules.py
admin@ixre-egl-board211:/usr$ show chassis system-lag-consistency 
System LAG consistency: FAILED

Chassis summary:
  SYSTEM_LAG_ID_TABLE:      19 lag IDs
  SYSTEM_LAG_MEMBER_TABLE:  40 lag members

ASIC namespace: asic0
  Lag IDs in ASIC_DB:      20 (1 mismatch)
  Lag members in ASIC_DB:  38 (4 issues)
  Lag IDs extra in ASIC_DB (not in CHASSIS_DB - SYSTEM_LAG_ID_TABLE):
    4
  Lag members missing in ASIC_DB (in CHASSIS_DB - SYSTEM_LAG_MEMBER_TABLE):
    ixre-egl-board211|asic1|PortChannel134 : ixre-egl-board211|asic1|Ethernet192
    ixre-egl-board211|asic1|PortChannel134 : ixre-egl-board211|asic1|Ethernet200
  Lag member unresolved OID mapping:
    lag_oid=oid:0x2000000000935, SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID=4, port_oid=oid:0x5d000000000049
    lag_oid=oid:0x2000000000935, SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID=4, port_oid=oid:0x5d00000000004a

ASIC namespace: asic1
  Lag IDs in ASIC_DB:      20 (1 mismatch)
  Lag members in ASIC_DB:  38 (4 issues)
  Lag IDs extra in ASIC_DB (not in CHASSIS_DB - SYSTEM_LAG_ID_TABLE):
    4
  Lag members missing in ASIC_DB (in CHASSIS_DB - SYSTEM_LAG_MEMBER_TABLE):
    ixre-egl-board211|asic1|PortChannel134 : ixre-egl-board211|asic1|Ethernet192
    ixre-egl-board211|asic1|PortChannel134 : ixre-egl-board211|asic1|Ethernet200
  Lag member unresolved OID mapping:
    lag_oid=oid:0x1020000000008b4, SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID=4, port_oid=oid:0x101000000000007
    lag_oid=oid:0x1020000000008b4, SAI_LAG_ATTR_SYSTEM_PORT_AGGREGATE_ID=4, port_oid=oid:0x101000000000008
admin@ixre-egl-board211:/usr$ show chassis system-lag-consistency --lag-id-only 
System LAG consistency: FAILED

Mode: LAG ID only (lag members not checked)

Chassis summary:
  SYSTEM_LAG_ID_TABLE:      19 lag IDs

ASIC namespace: asic0
  Lag IDs in ASIC_DB:      20 (1 mismatch)
  Lag IDs extra in ASIC_DB (not in CHASSIS_DB - SYSTEM_LAG_ID_TABLE):
    4

ASIC namespace: asic1
  Lag IDs in ASIC_DB:      20 (1 mismatch)
  Lag IDs extra in ASIC_DB (not in CHASSIS_DB - SYSTEM_LAG_ID_TABLE):
    4
admin@ixre-egl-board211:/usr$ exit

