### PR TITLE
[utilities] Add per-VLAN MAC learning control CLI commands

### DIFF
--- a/config/vlan.py
+++ b/config/vlan.py
@@ -508,3 +508,19 @@ def disable_vlan_sag(db, vid):
 
     db.cfgdb.mod_entry('VLAN_INTERFACE', vlan, {"static_anycast_gateway": "false"})
     click.echo('static-anycast-gateway setting saved to ConfigDB')
+
+@vlan.command('mac_learning')
+@click.argument('vid', metavar='<vid>', required=True, type=int)
+@click.argument('mode', metavar='<mode>', required=True, type=click.Choice(['enable', 'disable']))
+@click.pass_context
+@clicommon.pass_db
+def vlan_mac_learning(db, ctx, vid, mode):
+    """Enable or disable MAC learning on a VLAN"""
+    log.log_info("setting MAC learning to {} for Vlan{}".format(mode, vid))
+    config_db = get_config_db_from_context(ctx)
+    vlan = 'Vlan{}'.format(vid)
+    if clicommon.check_if_vlanid_exist(config_db, vlan) is False:
+        ctx.fail("{} does not exist".format(vlan))
+    learn_disable = "true" if mode == "disable" else "false"
+    config_db.mod_entry('VLAN', vlan, {'learn_disable': learn_disable})
+    click.echo("MAC learning {}d on {}".format(mode, vlan))

--- a/show/vlan.py
+++ b/show/vlan.py
@@ -240,3 +240,19 @@ def config(namespace):
         db = ConfigDbWrapper(config_db, ns_db)
         _config_helper(db)
 
+
+@vlan.command('learning')
+def learning():
+    """Show MAC learning status per VLAN"""
+    from swsscommon.swsscommon import ConfigDBConnector
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    vlan_data = config_db.get_table('VLAN')
+    header = ['VLAN ID', 'MAC Learning']
+    body = []
+    for vlan_name in natsorted(vlan_data):
+        vid = vlan_name.replace('Vlan', '')
+        learn_disable = vlan_data[vlan_name].get('learn_disable', 'false')
+        status = 'disabled' if learn_disable == 'true' else 'enabled'
+        body.append([vid, status])
+    click.echo(tabulate(body, header, tablefmt="grid"))


### PR DESCRIPTION
## Summary

Adds CLI commands for per-VLAN MAC learning control:
- `config vlan mac_learning <vid> enable|disable` - Configure learning per VLAN
- `show vlan learning` - Display MAC learning status for all VLANs

## What Changed

### config/vlan.py
New command: `config vlan mac_learning <vid> enable|disable`
- Validates VLAN exists before modification
- Writes `learn_disable` field to CONFIG_DB
- Proper error messages for non-existent VLANs
- Confirmation messages for successful operations

### show/vlan.py
New command: `show vlan learning`
- Displays all VLANs with learning status
- Shows "enabled" or "disabled" for each VLAN
- Defaults to enabled if not configured
- Table format output

## Testing

Tested on:
- **Single Switch Topology:** Command execution, CONFIG_DB updates, error handling, enable/disable toggling
- **Dual Switch + Trunk Topology:** Multi-switch command execution, per-switch configuration, settings persistence
- **Leaf-Spine CLOS Fabric:** Bulk operations on multiple leaves, show command across fabric, mixed policies verification

All commands working correctly with proper validation and error handling.

## Backward Compatibility

100% backward compatible
- New commands only (don't affect existing commands)
- Optional to use (feature is opt-in)
- Default behavior unchanged (learning enabled by default)

## Related PRs

Part of a coordinated 3-PR feature submission:
- **sonic-buildimage:** [Add learn_disable leaf to VLAN](https://github.com/sonic-net/sonic-buildimage/pull/28861)
- **sonic-swss:** [Support per-VLAN MAC learning disable](https://github.com/sonic-net/sonic-swss/pull/4819)