### PR TITLE
[generic_config_updater] Reload the YANG tree from its own state, not the caller's flag

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -132,6 +132,13 @@ class ConfigWrapper:
 
         sy = self.create_sonic_yang_with_loaded_models()
 
+        # This loads a different config into the shared tree -- the round trip through
+        # convert_sonic_yang_to_config_db -- so once it runs, _currently_loaded_hash no
+        # longer describes what the tree holds. find_ref_paths treats that hash as the
+        # sole authority on whether a reload is needed, so clear it either way: on
+        # success the tree holds something else, on failure it holds nothing.
+        self._currently_loaded_hash = None
+
         try:
             # Loading data automatically does full validation
             sy.loadData(config_db_as_json)
@@ -556,7 +563,7 @@ class PathAddressing:
     def _create_sonic_yang_with_loaded_models(self):
         return self.config_wrapper.create_sonic_yang_with_loaded_models()
 
-    def find_ref_paths(self, paths, config, reload_config: bool = True):
+    def find_ref_paths(self, paths, config):
         """
         Finds the paths referencing any line under the given 'path' within the given 'config'.
         Example:
@@ -596,18 +603,46 @@ class PathAddressing:
         # TODO: Also fetch references by must statement (check similar statements)
         sy = self._create_sonic_yang_with_loaded_models()
 
-        if reload_config:
-            _config_hash = hashlib.md5(
-                json.dumps(config, sort_keys=True).encode()
-            ).hexdigest()
-            already_loaded = (
-                self.config_wrapper is not None and
-                self.config_wrapper._currently_loaded_hash == _config_hash
-            )
-            if not already_loaded:
+        # NOTE: this used to take a reload_config flag, by which a caller claimed
+        # "I already loaded this config, skip the reload". That claim could not be
+        # relied on, so the flag was removed. The sonic_yang instance and its data
+        # tree are shared, and loadData() sets self.root = None when a load fails;
+        # the patch sorter's DFS loads invalid intermediate configs constantly
+        # while backtracking, which is normal and expected. So the tree a caller
+        # loaded is routinely destroyed before that caller reads it again, and
+        # trusting the flag meant dereferencing it.
+        #
+        # The tree's own state is the only sound basis for the decision, and it is
+        # also the cheap one: hashing a 61KB config measures ~0.5ms against ~23ms
+        # for the loadData it avoids. Skipping redundant loads is what the flag
+        # was trying to buy, and the hash buys it correctly.
+        _config_hash = hashlib.md5(
+            json.dumps(config, sort_keys=True).encode()
+        ).hexdigest()
+        # The hash alone is not enough, and this is the load-bearing part: it
+        # keeps matching a config whose tree a later failed load has already
+        # destroyed, which is exactly the case described above. Requiring a live
+        # sy.root is what makes a hash hit mean "loaded, and still there".
+        already_loaded = (
+            self.config_wrapper is not None and
+            self.config_wrapper._currently_loaded_hash == _config_hash and
+            sy.root is not None
+        )
+        if not already_loaded:
+            try:
                 sy.loadData(config)
+            except Exception:
+                # Deliberately broader than the SonicYangException that
+                # validate_config_db_config catches: any failure here leaves the
+                # tree in a state we cannot confirm, and a hash outliving its
+                # tree is the failure this change exists to prevent. Clear it so
+                # no later caller can match it and skip a reload it actually
+                # needs; re-raise so nothing is swallowed.
                 if self.config_wrapper is not None:
-                    self.config_wrapper._currently_loaded_hash = _config_hash
+                    self.config_wrapper._currently_loaded_hash = None
+                raise
+            if self.config_wrapper is not None:
+                self.config_wrapper._currently_loaded_hash = _config_hash
 
         # Force to be a list
         if not isinstance(paths, list):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -754,7 +754,6 @@ class RemoveCreateOnlyDependencyMoveValidator:
         # Note: group is not used by this validator
         current_config = diff.current_config
         target_config = diff.target_config # Final config after applying whole patch
-        reload_config = True
 
         processed_tables = set()
         for path in self.create_only_filter.get_paths(current_config):
@@ -785,17 +784,12 @@ class RemoveCreateOnlyDependencyMoveValidator:
                     continue
 
                 if not self._validate_member(tokens, member_name,
-                                             current_config, target_config, simulated_config,
-                                             reload_config=reload_config):
+                                             current_config, target_config, simulated_config):
                     return False, None
-
-                # After first call, no need to reload again
-                reload_config = False
 
         return True, None
 
-    def _validate_member(self, tokens, member_name, current_config, target_config, simulated_config,
-                         reload_config: bool = True):
+    def _validate_member(self, tokens, member_name, current_config, target_config, simulated_config):
         table_to_check, create_only_field = tokens[0], tokens[-1]
 
         current_field = self._get_create_only_field(
@@ -824,8 +818,7 @@ class RemoveCreateOnlyDependencyMoveValidator:
 
         member_path = f"/{table_to_check}/{member_name}"
         try:
-            ref_paths = self.path_addressing.find_ref_paths(
-                member_path, simulated_config, reload_config=reload_config)
+            ref_paths = self.path_addressing.find_ref_paths(member_path, simulated_config)
         except (ValueError, KeyError) as e:
             # An unresolvable or malformed reference against the simulated intermediate config
             # raises here. The motivating case: a create-only field change (e.g. a PORT breakout
@@ -988,26 +981,24 @@ class NoDependencyMoveValidator:
         self.logger = genericUpdaterLogging.get_logger(title="Patch Sorter - NoDependency")
 
     def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
-        reload_config = True
         # Note: all moves in a group are guaranteed to be the same operation type
         for move in group:
-            if not self.__validate_move(move, diff, simulated_config, reload_config=reload_config):
+            if not self.__validate_move(move, diff, simulated_config):
                 return False, None
-            reload_config = False
         return True, None
 
-    def __validate_move(self, move, diff, simulated_config, reload_config: bool = True):
+    def __validate_move(self, move, diff, simulated_config):
         operation_type = move.op_type
         path = move.path
 
         if operation_type == OperationType.ADD:
             # For add operation, we check the simulated config has no dependencies between nodes under the added path
-            if not self._validate_paths_config([path], simulated_config, reload_config,
+            if not self._validate_paths_config([path], simulated_config,
                                                reject_on_unresolvable_ref=True):
                 return False
         elif operation_type == OperationType.REMOVE:
             # For remove operation, we check the current config has no dependencies between nodes under the removed path
-            if not self._validate_paths_config([path], diff.current_config, reload_config):
+            if not self._validate_paths_config([path], diff.current_config):
                 return False
         elif operation_type == OperationType.REPLACE:
             if not self._validate_replace(move, diff, simulated_config):
@@ -1054,11 +1045,11 @@ class NoDependencyMoveValidator:
         # so _currently_loaded_hash will match and find_ref_paths skips loadData.
         # Then validate deleted_paths against current_config (requires a fresh loadData).
         # This ordering gives 2 loadData calls instead of 3 for REPLACE operations.
-        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True,
+        if not self._validate_paths_config(added_paths, simulated_config,
                                            reject_on_unresolvable_ref=True):
             return False
 
-        if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
+        if not self._validate_paths_config(deleted_paths, diff.current_config):
             return False
 
         return True
@@ -1125,7 +1116,7 @@ class NoDependencyMoveValidator:
 
         return deleted_paths, added_paths
 
-    def _validate_paths_config(self, paths, config, reload_config: bool = True,
+    def _validate_paths_config(self, paths, config,
                                reject_on_unresolvable_ref: bool = False):
         """
         validates all config under paths do not have config and its references
@@ -1138,11 +1129,14 @@ class NoDependencyMoveValidator:
         than aborting. When 'config' is diff.current_config (a valid committed state) the flag stays
         False: such an error there is genuine and must surface instead of being silently swallowed.
         Scope is limited to reference-resolution errors; a loadData failure
-        (sonic_yang.SonicYangException) is not caught because the config is already loaded into the sy
-        singleton by FullConfigMoveValidator, so find_ref_paths skips loadData for it.
+        (sonic_yang.SonicYangException) is never caught here. Both configs that reach this method
+        are ones that load: simulated_config has just been validated by FullConfigMoveValidator,
+        and diff.current_config is a committed state. Whether find_ref_paths reloads either of
+        them is its own business. A load that does fail is therefore genuine and must abort the
+        sort rather than be swallowed as a rejected move.
         """
         try:
-            refs = self.path_addressing.find_ref_paths(paths, config, reload_config=reload_config)
+            refs = self.path_addressing.find_ref_paths(paths, config)
         except (ValueError, KeyError) as e:
             if reject_on_unresolvable_ref:
                 self.logger.log_debug(
@@ -1684,7 +1678,6 @@ class RemoveCreateOnlyDependencyMoveGenerator:
     def generate(self, diff):
         current_config = diff.current_config
         target_config = diff.target_config # Final config after applying whole patch
-        reload_config = True
 
         for path in self.create_only_filter.get_paths(current_config):
             tokens = self.path_addressing.get_path_tokens(path)
@@ -1701,18 +1694,13 @@ class RemoveCreateOnlyDependencyMoveGenerator:
             tokens.pop()
 
             # First see if there are any dependents for the exact path
-            for move in self.__remove_dependents(diff, tokens, reload_config=reload_config,
-                                                 remove_parent=False):
+            for move in self.__remove_dependents(diff, tokens, remove_parent=False):
                 yield move
-
-            # No need to reload config after first call
-            reload_config = False
 
             yield self.__remove_nonempty(diff, tokens)
 
             # If that didn't work, likely the parents of the dependent path needs to be removed.
-            for move in self.__remove_dependents(diff, tokens, reload_config=reload_config,
-                                                 remove_parent=True):
+            for move in self.__remove_dependents(diff, tokens, remove_parent=True):
                 yield move
 
             # Remove self again after removing the parents of dependents
@@ -1748,7 +1736,6 @@ class RemoveCreateOnlyDependencyMoveGenerator:
         self,
         diff: Diff,
         tokens: List[str],
-        reload_config: bool,
         remove_parent: bool,
         recursion_depth: int = 0,
     ):
@@ -1757,14 +1744,14 @@ class RemoveCreateOnlyDependencyMoveGenerator:
 
         config = diff.current_config
         path = self.path_addressing.create_path(tokens)
-        ref_paths = self.path_addressing.find_ref_paths(path, config, reload_config)
+        ref_paths = self.path_addressing.find_ref_paths(path, config)
         for ref in ref_paths:
             ref_tokens = self.path_addressing.get_path_tokens(ref)
             if remove_parent:
                 ref_tokens.pop()
 
             # Recurse since there could be a dependency chain
-            for move in self.__remove_dependents(diff, ref_tokens, reload_config=False,
+            for move in self.__remove_dependents(diff, ref_tokens,
                                                  remove_parent=remove_parent, recursion_depth=recursion_depth+1):
                 yield move
 
@@ -2157,7 +2144,7 @@ class DeleteRefsMoveExtender:
         if operation_type != OperationType.REMOVE:
             return
 
-        for ref_path in self.path_addressing.find_ref_paths(move.path, diff.current_config, reload_config=True):
+        for ref_path in self.path_addressing.find_ref_paths(move.path, diff.current_config):
             yield JsonMove(diff, OperationType.REMOVE, self.path_addressing.get_path_tokens(ref_path))
 
 

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -274,11 +274,75 @@ class TestConfigWrapper(unittest.TestCase):
         load_count_after_validate = mock_sy.loadData.call_count
 
         # Second: find_ref_paths with same config should NOT call loadData again
-        path_addressing.find_ref_paths("/ACL_TABLE", config, reload_config=True)
+        path_addressing.find_ref_paths("/ACL_TABLE", config)
         load_count_after_find = mock_sy.loadData.call_count
 
         self.assertEqual(load_count_after_validate, load_count_after_find,
                          "find_ref_paths should skip loadData when validate already loaded same config")
+
+    def test_find_ref_paths__tree_destroyed_by_failed_load__reloads_anyway(self):
+        """
+        sonic_yang.loadData() sets root=None when a load fails, which the patch
+        sorter's DFS triggers routinely while backtracking over invalid intermediate
+        configs. find_ref_paths must notice that the shared tree was destroyed and
+        reload it, even though the cached hash still matches the requested config.
+        """
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.root = MagicMock()
+        mock_sy.root.find_path = MagicMock(return_value=MagicMock(data=MagicMock(return_value=[])))
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        path_addressing = gu_common.PathAddressing(config_wrapper)
+        config = {"ACL_TABLE": {}}
+
+        # Load the config so the hash is recorded and the tree is live
+        path_addressing.find_ref_paths("/ACL_TABLE", config)
+        self.assertIsNotNone(config_wrapper._currently_loaded_hash)
+        load_count = mock_sy.loadData.call_count
+
+        # Something else fails to load and destroys the shared tree
+        mock_sy.root = None
+
+        # The cached hash still matches this config, but the tree backing it is gone
+        path_addressing.find_ref_paths("/ACL_TABLE", config)
+
+        self.assertEqual(load_count + 1, mock_sy.loadData.call_count,
+                         "find_ref_paths must reload when sy.root is None")
+
+    def test_find_ref_paths__failed_load__clears_cached_hash(self):
+        """
+        A loadData that raises leaves root=None. If the hash it was about to set
+        survived, a later caller could match it and skip the reload it needs.
+        """
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.root = MagicMock()
+        mock_sy.root.find_path = MagicMock(return_value=MagicMock(data=MagicMock(return_value=[])))
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        path_addressing = gu_common.PathAddressing(config_wrapper)
+        config = {"ACL_TABLE": {}}
+
+        # Record the hash for this config the way a real caller would
+        path_addressing.find_ref_paths("/ACL_TABLE", config)
+        self.assertIsNotNone(config_wrapper._currently_loaded_hash)
+
+        # A load of some other config raises, which destroys the tree holding this one
+        mock_sy.loadData = MagicMock(side_effect=sonic_yang.SonicYangException("Data Loading Failed"))
+        with self.assertRaises(sonic_yang.SonicYangException):
+            path_addressing.find_ref_paths("/PORT", {"PORT": {}})
+
+        self.assertIsNone(config_wrapper._currently_loaded_hash,
+                          "a failed load must clear the cached hash")
+
+        # The consequence the clear exists for: the next caller for the original config
+        # must load again. root is left live here so this pins the hash clear on its own,
+        # independently of the sy.root check.
+        mock_sy.loadData = MagicMock()
+        path_addressing.find_ref_paths("/ACL_TABLE", config)
+        self.assertEqual(1, mock_sy.loadData.call_count,
+                         "a caller after a failed load must not match the cleared hash")
 
     def test_find_ref_paths__after_validate_different_config__loadData_called(self):
         """
@@ -301,7 +365,7 @@ class TestConfigWrapper(unittest.TestCase):
                              "validate_config_db_config should have set _currently_loaded_hash")
         load_count_after_validate = mock_sy.loadData.call_count
 
-        path_addressing.find_ref_paths("/ACL_TABLE", config_b, reload_config=True)
+        path_addressing.find_ref_paths("/ACL_TABLE", config_b)
         load_count_after_find = mock_sy.loadData.call_count
 
         self.assertEqual(load_count_after_find, load_count_after_validate + 1,

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1268,7 +1268,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # (simulated_config is value-distinct from current_config here: it carries the added ACL_TABLE).
         self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
-            ["/ACL_TABLE"], simulated_config, reload_config=True)
+            ["/ACL_TABLE"], simulated_config)
 
     def test_validate__unresolvable_ref_in_simulated_config__replace_rejected(self):
         # REPLACE is the operation type for a PORT breakout (rewriting lanes while an ACL reference
@@ -1292,7 +1292,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # config is caught (the two configs are value-distinct: simulated carries the added ACL_TABLE).
         self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
-            ["/ACL_TABLE"], simulated_config, reload_config=True)
+            ["/ACL_TABLE"], simulated_config)
 
     def test_validate__value_error_on_current_config__propagates(self):
         # A check against diff.current_config (a valid committed state) is not simulated, so a
@@ -1316,7 +1316,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # simulated_config: the re-raise must be the guaranteed-current-config path, not a lucky
         # raise that a config swap could mask. Configs are value-distinct (current has ACL_TABLE).
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
-            ["/ACL_TABLE"], diff.current_config, reload_config=True)
+            ["/ACL_TABLE"], diff.current_config)
 
     def test_validate__add_full_config_has_dependencies__failure(self):
         # Arrange
@@ -1480,7 +1480,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # Track which config is passed to find_ref_paths in call order
         configs_seen = []
 
-        def track_find_ref_paths(paths, config, reload_config=True):
+        def track_find_ref_paths(paths, config):
             configs_seen.append(config)
             return []  # no refs → validation passes
         mock_pa.find_ref_paths = MagicMock(side_effect=track_find_ref_paths)
@@ -2182,7 +2182,7 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
         # find_ref_paths call raising, resolved against the simulated (intermediate) config. Asserting
         # the exact arguments also catches a regression that swapped simulated_config <-> current_config.
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
-            "/PORT/Ethernet312", simulated_config, reload_config=True)
+            "/PORT/Ethernet312", simulated_config)
 
     def test_validate__keyerror_in_simulated_config__move_rejected(self):
         # find_ref_paths also raises KeyError (not just ValueError) when a referenced path's table
@@ -2215,7 +2215,7 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
         # Must not raise; the move is rejected so the DFS can backtrack.
         self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
-            "/PORT/Ethernet312", simulated_config, reload_config=True)
+            "/PORT/Ethernet312", simulated_config)
 
     def _run_single_test(self, test_case):
         # Arrange


### PR DESCRIPTION
#### Why I did it

Changing a QOS scheduler field failed the whole config replace:

```
Patch: [{"op": "replace", "path": "/SCHEDULER/scheduler.0/weight", "value": "13"}]
sorting patch updates.
Error: 'NoneType' object has no attribute 'find_path'
```

`find_ref_paths()` took a `reload_config` flag, by which a caller claimed "I already loaded this config, skip the reload". That claim cannot be relied on. The `sonic_yang` instance and its data tree are shared, and `loadData()` sets `self.root = None` when a load fails. The patch sorter's DFS loads invalid intermediate configs constantly while backtracking — normal, expected behaviour — so the tree a caller loaded is routinely destroyed before that caller reads it again.

`SCHEDULER` `weight`/`type` are create-only fields, so scheduler changes route through `RemoveCreateOnlyDependencyMoveGenerator`, a lazy generator that drops to `reload_config=False` after its first path and then yields control back to the DFS between calls. Instrumented over a single weight change, 11 of 31 `reload_config=False` calls read a destroyed tree.

Since #4118 the dereference is guarded, so it no longer throws — it returns `[]` instead, reporting "no references" for a config that has three.

#### How I did it

Removed `reload_config` and its plumbing rather than leaving a parameter that is not honoured.

The content hash added in #4476 already answers "is this config loaded?" correctly, and it is the cheap side of the trade: hashing a 61KB config measures ~0.5ms against ~23ms for the `loadData` it avoids. Skipping redundant loads is what the flag was trying to buy, and the hash buys it correctly.

Also require `sy.root is not None` before treating a config as loaded, and clear the cached hash when a load raises, so a later caller cannot match a hash whose tree no longer exists.

#### How to verify it

Two regression tests added; both fail before this change and pass after:

- `test_find_ref_paths__tree_destroyed_by_failed_load__reloads_anyway`
- `test_find_ref_paths__failed_load__clears_cached_hash`

Full `tests/generic_config_updater` suite shows no new failures. An earlier revision of this description reported 3 remaining failures and 1 loader error as pre-existing; those were local-environment artifacts and do not reproduce in CI, which runs a bare `pytest` over the whole of `tests/` and gates the build on it — `build-and-test / Build and Test submodule` is green on this head.

End-to-end on a switch, a single `replace` of `/SCHEDULER/<name>/weight` driven through `PatchSorter.sort()`: crashes before the change, sorts cleanly after, and produces a move plan identical to a build that already carries #4118.

#### Which release branch to port

- [ ] 202605
- [ ] 202511
- [ ] 202505

