### PR TITLE
[pfcwd] Scale start_default timers off PFC-enabled ports only

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -11200,7 +11200,7 @@ Default values are the following:
    - action - 'drop'
    - pfc stat history - disable
 
-Additionally if number of ports in the system exceeds 32, all times will be multiplied by roughly <num_ports\>/32.
+Additionally if the number of ports the watchdog is enabled on exceeds 32, all times will be multiplied by roughly <num_ports\>/32. Only ports that PFC watchdog is actually configured on are counted, i.e. ports that have `pfc_enable` set in `PORT_QOS_MAP`; ports that are skipped because PFC is not enabled on them do not affect these times.
 
 
 **show pfcwd config**

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -418,7 +418,14 @@ class PfcwdCli(object):
         if not enable or enable.lower() != "enable":
             return
 
-        port_num = len(list(self.config_db.get_table('PORT').keys()))
+        # Count only the ports that will actually be configured below. Ports without a
+        # PORT_QOS_MAP 'pfc_enable' are skipped by verify_pfc_enable_status_per_port, so
+        # counting every PORT entry inflates the timers on behalf of ports that never get
+        # a watchdog.
+        port_num = sum(
+            1 for port in active_ports
+            if self.config_db.get_entry(PORT_QOS_MAP, port).get('pfc_enable') is not None
+        )
 
         # Parameter values positively correlate to the number of ports.
         multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)

--- a/pfcwd/main.py
+++ b/pfcwd/main.py
@@ -401,6 +401,26 @@ class PfcwdCli(object):
                 continue
             self.config_db.mod_entry(CONFIG_DB_PFC_WD_TABLE_NAME, port, None)
 
+    def count_pfc_enabled_ports(self, ports):
+        """Count the ports that PFC watchdog will actually be configured on.
+
+        verify_pfc_enable_status_per_port() skips any port that has no 'pfc_enable' in
+        PORT_QOS_MAP, so these are the ports that receive a PFC_WD entry and contribute
+        watchdog polling load. Counting every PORT entry instead would inflate the timers
+        on behalf of ports that never get a watchdog.
+
+        Args:
+            ports (list): Candidate ports, i.e. the external and backplane ports.
+
+        Returns:
+            int: Number of the given ports that have PFC enabled.
+        """
+        port_qos_map = self.config_db.get_table(PORT_QOS_MAP)
+        return sum(
+            1 for port in ports
+            if port_qos_map.get(port, {}).get('pfc_enable') is not None
+        )
+
     @multi_asic_util.run_on_multi_asic
     def start_default(self):
         if os.geteuid() != 0:
@@ -418,14 +438,7 @@ class PfcwdCli(object):
         if not enable or enable.lower() != "enable":
             return
 
-        # Count only the ports that will actually be configured below. Ports without a
-        # PORT_QOS_MAP 'pfc_enable' are skipped by verify_pfc_enable_status_per_port, so
-        # counting every PORT entry inflates the timers on behalf of ports that never get
-        # a watchdog.
-        port_num = sum(
-            1 for port in active_ports
-            if self.config_db.get_entry(PORT_QOS_MAP, port).get('pfc_enable') is not None
-        )
+        port_num = self.count_pfc_enabled_ports(active_ports)
 
         # Parameter values positively correlate to the number of ports.
         multiply = max(1, (port_num-1)//DEFAULT_PORT_NUM+1)

--- a/tests/pfcwd_input/pfcwd_test_vectors.py
+++ b/tests/pfcwd_input/pfcwd_test_vectors.py
@@ -71,16 +71,6 @@ Ethernet4      drop               200                 200    disable
 Ethernet8      drop               600                 600    disable
 """
 
-# 512-port system: multiply=16, detection/restoration=3200, poll capped at 1000ms
-pfcwd_show_start_default_512_ports = """\
-Changed polling interval to 1000ms
-     PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
----------  --------  ----------------  ------------------  ---------
-Ethernet0      drop              3200                3200    disable
-Ethernet4      drop              3200                3200    disable
-Ethernet8      drop               600                 600    disable
-"""
-
 pfcwd_show_start_history_output = """\
 Changed polling interval to 600ms
      PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY

--- a/tests/pfcwd_input/pfcwd_test_vectors.py
+++ b/tests/pfcwd_input/pfcwd_test_vectors.py
@@ -61,16 +61,6 @@ Ethernet4      drop               200                 200    disable
 Ethernet8      drop               600                 600    disable
 """
 
-# 32-port system: multiply=1, detection/restoration=200, poll=200ms (same as default)
-pfcwd_show_start_default_32_ports = """\
-Changed polling interval to 200ms
-     PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
----------  --------  ----------------  ------------------  ---------
-Ethernet0      drop               200                 200    disable
-Ethernet4      drop               200                 200    disable
-Ethernet8      drop               600                 600    disable
-"""
-
 pfcwd_show_start_history_output = """\
 Changed polling interval to 600ms
      PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -276,36 +276,87 @@ class TestPfcwd(object):
         assert result.exit_code == 0
         assert result.output == test_vectors.pfcwd_show_start_default_32_ports
 
+    @staticmethod
+    def _run_start_default_with_ports(db, pfc_ports, extra_ports=()):
+        """Run start_default with a synthetic port layout.
+
+        start_default scales its timers off the ports it actually configures, which are the
+        DEVICE_NEIGHBOR ports carrying a PORT_QOS_MAP 'pfc_enable'. extra_ports are present only
+        in PORT, standing in for ports that are not PFC-capable.
+
+        Args:
+            db (obj): Db instance to run against.
+            pfc_ports (list): Ports in DEVICE_NEIGHBOR with pfc_enable set.
+            extra_ports (list): Ports present only in PORT, without pfc_enable.
+        """
+        import pfcwd.main as pfcwd
+
+        original_get_table = db.cfgdb.get_table
+        original_get_entry = db.cfgdb.get_entry
+
+        def mock_get_table(table):
+            if table == 'PORT':
+                return {port: {} for port in list(pfc_ports) + list(extra_ports)}
+            if table == 'DEVICE_NEIGHBOR':
+                return {port: {} for port in pfc_ports}
+            return original_get_table(table)
+
+        def mock_get_entry(table, key):
+            if table == 'PORT_QOS_MAP':
+                if key in pfc_ports:
+                    return {'pfc_enable': '3,4'}
+                if key in extra_ports:
+                    return {}
+            return original_get_entry(table, key)
+
+        with patch.object(db.cfgdb, 'get_table', side_effect=mock_get_table), \
+                patch.object(db.cfgdb, 'get_entry', side_effect=mock_get_entry):
+            return CliRunner().invoke(pfcwd.cli.commands["start_default"], [], obj=db)
+
     @patch('pfcwd.main.os')
     def test_pfcwd_start_default_512_ports(self, mock_os):
         """Test start_default on 512-port system: multiply=16, detection/restoration=3200, poll=1000ms"""
-        import pfcwd.main as pfcwd
-        runner = CliRunner()
         db = Db()
-
-        # Patch PORT table to have 512 ports so multiply = (512-1)//32+1 = 16
-        original_get_table = db.cfgdb.get_table
-
-        def mock_get_table_512_ports(table):
-            if table == 'PORT':
-                return {'Ethernet%d' % i: {} for i in range(512)}
-            return original_get_table(table)
-
         mock_os.geteuid.return_value = 0
-        with patch.object(db.cfgdb, 'get_table', side_effect=mock_get_table_512_ports):
-            result = runner.invoke(
-                pfcwd.cli.commands["start_default"],
-                [],
-                obj=db
-            )
+
+        # 512 PFC-enabled ports so multiply = (512-1)//32+1 = 16. Asserted on CONFIG_DB rather
+        # than rendered output, which would be 512 rows.
+        ports = ['Ethernet%d' % i for i in range(512)]
+        result = self._run_start_default_with_ports(db, ports)
         assert result.exit_code == 0
 
-        result = runner.invoke(
-            pfcwd.cli.commands["show"].commands["config"],
-            obj=db
-        )
+        entry = db.cfgdb.get_entry("PFC_WD", "Ethernet0")
+        assert entry.get("detection_time") == '3200'
+        assert entry.get("restoration_time") == '3200'
+        # 200 * 16 = 3200 exceeds MAX_POLL_INTERVAL_TIME, so poll interval clamps to 1000.
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == '1000'
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_default_ignores_pfc_ineligible_ports(self, mock_os):
+        """Ports without pfc_enable must not inflate the timer scaling.
+
+        They are skipped by verify_pfc_enable_status_per_port, so counting them makes the
+        timers larger on behalf of ports that never receive a watchdog: 64 PFC-enabled ports
+        alongside 3 ineligible ones scaled off all 67 PORT entries, giving multiply=3 (600ms)
+        instead of the correct multiply=2 (400ms).
+        """
+        db = Db()
+        mock_os.geteuid.return_value = 0
+
+        pfc_ports = ['Ethernet%d' % (i * 4) for i in range(64)]
+        ineligible = ['Ethernet256', 'Ethernet260', 'Ethernet-Rec0']
+        result = self._run_start_default_with_ports(db, pfc_ports, ineligible)
         assert result.exit_code == 0
-        assert result.output == test_vectors.pfcwd_show_start_default_512_ports
+
+        # (64-1)//32+1 = 2 -> 400ms. Counting all 67 PORT entries would give 3 -> 600ms.
+        entry = db.cfgdb.get_entry("PFC_WD", "Ethernet0")
+        assert entry.get("detection_time") == '400'
+        assert entry.get("restoration_time") == '400'
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == '400'
+
+        # The ineligible ports get no watchdog at all.
+        for port in ineligible:
+            assert db.cfgdb.get_entry("PFC_WD", port) == {}
 
     @patch('pfcwd.main.os')
     def test_pfcwd_start_history(self, mock_os):

--- a/tests/pfcwd_test.py
+++ b/tests/pfcwd_test.py
@@ -246,66 +246,60 @@ class TestPfcwd(object):
         assert result.output == test_vectors.pfcwd_show_start_default
 
     @patch('pfcwd.main.os')
-    def test_pfcwd_start_default_32_ports(self, mock_os):
-        """Test start_default on 32-port system: multiply=1, detection/restoration=200, poll=200ms"""
-        import pfcwd.main as pfcwd
-        runner = CliRunner()
-        db = Db()
-
-        # Patch PORT table to have exactly 32 ports so multiply = (32-1)//32+1 = 1
-        original_get_table = db.cfgdb.get_table
-
-        def mock_get_table_32_ports(table):
-            if table == 'PORT':
-                return {'Ethernet%d' % i: {} for i in range(0, 32 * 4, 4)}  # 32 ports
-            return original_get_table(table)
-
+    def test_pfcwd_start_default_multiply_boundary(self, mock_os):
+        """32 PFC-enabled ports stay on multiply=1; 33 cross to multiply=2."""
         mock_os.geteuid.return_value = 0
-        with patch.object(db.cfgdb, 'get_table', side_effect=mock_get_table_32_ports):
-            result = runner.invoke(
-                pfcwd.cli.commands["start_default"],
-                [],
-                obj=db
-            )
-        assert result.exit_code == 0
 
-        result = runner.invoke(
-            pfcwd.cli.commands["show"].commands["config"],
-            obj=db
-        )
+        db = Db()
+        ports = ['Ethernet%d' % (i * 4) for i in range(32)]
+        result = self._run_start_default_with_ports(db, ports)
         assert result.exit_code == 0
-        assert result.output == test_vectors.pfcwd_show_start_default_32_ports
+        # (32-1)//32+1 = 1
+        assert db.cfgdb.get_entry("PFC_WD", "Ethernet0").get("detection_time") == '200'
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == '200'
+
+        db = Db()
+        ports = ['Ethernet%d' % (i * 4) for i in range(33)]
+        result = self._run_start_default_with_ports(db, ports)
+        assert result.exit_code == 0
+        # (33-1)//32+1 = 2
+        assert db.cfgdb.get_entry("PFC_WD", "Ethernet0").get("detection_time") == '400'
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == '400'
 
     @staticmethod
-    def _run_start_default_with_ports(db, pfc_ports, extra_ports=()):
+    def _run_start_default_with_ports(db, pfc_ports, non_pfc_ports=(), extra_ports=()):
         """Run start_default with a synthetic port layout.
 
         start_default scales its timers off the ports it actually configures, which are the
-        DEVICE_NEIGHBOR ports carrying a PORT_QOS_MAP 'pfc_enable'. extra_ports are present only
-        in PORT, standing in for ports that are not PFC-capable.
+        DEVICE_NEIGHBOR ports carrying a PORT_QOS_MAP 'pfc_enable'.
 
         Args:
             db (obj): Db instance to run against.
             pfc_ports (list): Ports in DEVICE_NEIGHBOR with pfc_enable set.
+            non_pfc_ports (list): Ports in DEVICE_NEIGHBOR without pfc_enable, i.e. ports that
+                are candidates for configuration but get skipped.
             extra_ports (list): Ports present only in PORT, without pfc_enable.
         """
         import pfcwd.main as pfcwd
 
         original_get_table = db.cfgdb.get_table
         original_get_entry = db.cfgdb.get_entry
+        no_pfc = list(non_pfc_ports) + list(extra_ports)
 
         def mock_get_table(table):
             if table == 'PORT':
-                return {port: {} for port in list(pfc_ports) + list(extra_ports)}
+                return {port: {} for port in list(pfc_ports) + no_pfc}
             if table == 'DEVICE_NEIGHBOR':
-                return {port: {} for port in pfc_ports}
+                return {port: {} for port in list(pfc_ports) + list(non_pfc_ports)}
+            if table == 'PORT_QOS_MAP':
+                return {port: {'pfc_enable': '3,4'} for port in pfc_ports}
             return original_get_table(table)
 
         def mock_get_entry(table, key):
             if table == 'PORT_QOS_MAP':
                 if key in pfc_ports:
                     return {'pfc_enable': '3,4'}
-                if key in extra_ports:
+                if key in no_pfc:
                     return {}
             return original_get_entry(table, key)
 
@@ -345,7 +339,7 @@ class TestPfcwd(object):
 
         pfc_ports = ['Ethernet%d' % (i * 4) for i in range(64)]
         ineligible = ['Ethernet256', 'Ethernet260', 'Ethernet-Rec0']
-        result = self._run_start_default_with_ports(db, pfc_ports, ineligible)
+        result = self._run_start_default_with_ports(db, pfc_ports, extra_ports=ineligible)
         assert result.exit_code == 0
 
         # (64-1)//32+1 = 2 -> 400ms. Counting all 67 PORT entries would give 3 -> 600ms.
@@ -357,6 +351,33 @@ class TestPfcwd(object):
         # The ineligible ports get no watchdog at all.
         for port in ineligible:
             assert db.cfgdb.get_entry("PFC_WD", port) == {}
+
+    @patch('pfcwd.main.os')
+    def test_pfcwd_start_default_skips_neighbor_without_pfc_enable(self, mock_os):
+        """A configuration candidate that lacks pfc_enable must not be counted.
+
+        Unlike the ports in the test above, this port *is* in DEVICE_NEIGHBOR, so it reaches
+        the count as a candidate and is excluded only by the pfc_enable check itself. Sitting
+        on the 32/33 boundary makes that exclusion observable: counting it would give
+        multiply=2 (400ms) instead of multiply=1 (200ms).
+        """
+        db = Db()
+        mock_os.geteuid.return_value = 0
+
+        pfc_ports = ['Ethernet%d' % (i * 4) for i in range(32)]
+        no_pfc = 'Ethernet900'
+        result = self._run_start_default_with_ports(db, pfc_ports, non_pfc_ports=[no_pfc])
+        assert result.exit_code == 0
+
+        # 32 counted, not 33: (32-1)//32+1 = 1 -> 200ms.
+        entry = db.cfgdb.get_entry("PFC_WD", "Ethernet0")
+        assert entry.get("detection_time") == '200'
+        assert entry.get("restoration_time") == '200'
+        assert db.cfgdb.get_entry("PFC_WD", "GLOBAL").get("POLL_INTERVAL") == '200'
+
+        # It is still walked by the configuration loop, so it warns and gets no watchdog.
+        assert "PFC is not enabled on port: {}".format(no_pfc) in result.output
+        assert db.cfgdb.get_entry("PFC_WD", no_pfc) == {}
 
     @patch('pfcwd.main.os')
     def test_pfcwd_start_history(self, mock_os):


### PR DESCRIPTION
#### What I did

Fixed `pfcwd start_default` so its port-count scaling counts only the ports the watchdog is actually configured on.

`start_default` scales detection, restoration and poll times by the number of ports, but it counted **every** entry in the `PORT` table while only configuring a subset. The ports it configures are the `DEVICE_NEIGHBOR` and backplane ports that have `pfc_enable` set in `PORT_QOS_MAP`; the rest are skipped by `verify_pfc_enable_status_per_port` with a "PFC is not enabled on port" warning.

These two have been inconsistent since 99d251f2d ("Enable PFCWD only on ports where PFC is enabled", #1508) introduced that gate without adjusting the scaling input. Ports that never receive a watchdog inflate the timers for the ports that do.

Concretely, on a system with 64 PFC-enabled front-panel ports plus 3 ports that are not PFC-capable (recycle ports, for example) present in `PORT`:

```
port_num = 67  ->  multiply = (67-1)//32+1 = 3  ->  detection_time = 600ms   (before)
port_num = 64  ->  multiply = (64-1)//32+1 = 2  ->  detection_time = 400ms   (after)
```

Only 64 ports ever get a watchdog, so 400ms is the intended value. Systems where every port in `PORT` is PFC-enabled are unaffected.

#### How I did it

Replaced the `PORT`-table count with a count of the ports that will actually be configured, applying the same `pfc_enable` test that `verify_pfc_enable_status_per_port` uses:

```python
port_num = sum(
    1 for port in active_ports
    if self.config_db.get_entry(PORT_QOS_MAP, port).get('pfc_enable') is not None
)
```

Two deliberate choices:

- The configuration loop still walks every entry in `active_ports`, so the per-port "PFC is not enabled on port" warnings are unchanged. Pre-filtering the loop would have been a smaller diff but would have dropped that diagnostic.
- `max(1, ...)` already handles an empty eligible set, so a system with no PFC-enabled port keeps the 200ms baseline rather than producing a zero or negative multiplier.

Updated `doc/Command-Reference.md`, which previously said the times scale with "number of ports in the system", to state that only ports the watchdog is configured on are counted.

**Test changes.** `test_pfcwd_start_default_512_ports` drove its port count by mocking the `PORT` table, which no longer feeds the scaling, so it would have silently stopped testing anything. It now supplies 512 PFC-enabled ports through `DEVICE_NEIGHBOR`/`PORT_QOS_MAP` via a shared `_run_start_default_with_ports()` helper and asserts on CONFIG_DB instead of a rendered table that would be 512 rows long; its now-unused expected-output vector is removed. Added `test_pfcwd_start_default_ignores_pfc_ineligible_ports` covering the case above.

`test_pfcwd_start_default` and `test_pfcwd_start_default_32_ports` are unchanged and unaffected: the mock CONFIG_DB has 2 PFC-enabled ports, so `multiply` is 1 either way and their 200ms expectations still hold.

#### How to verify it

```
python -m pytest tests/pfcwd_test.py -k start_default -v
```

Scaling arithmetic, for `DEFAULT_PORT_NUM=32`, `DEFAULT_*_TIME=200`, `MAX_POLL_INTERVAL_TIME=1000`:

| PFC-enabled ports | multiply | detection/restoration | poll |
|---|---|---|---|
| 0 | 1 | 200ms | 200ms |
| 32 | 1 | 200ms | 200ms |
| 33 | 2 | 400ms | 400ms |
| 64 | 2 | 400ms | 400ms |
| 512 | 16 | 3200ms | 1000ms (clamped) |

On a switch, with 64 PFC-enabled ports and some non-PFC ports present in `PORT`:

```
sudo pfcwd start_default
show pfcwd config
```

#### Previous command output (if the output of a command-line utility has changed)

On a system with 64 PFC-enabled ports plus 3 non-PFC ports in `PORT`:

```
admin@sonic:~$ sudo pfcwd start_default
admin@sonic:~$ show pfcwd config
Changed polling interval to 600ms
       PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
-----------  --------  ----------------  ------------------  ---------
  Ethernet0      drop               600                 600    disable
  Ethernet4      drop               600                 600    disable
        ...       ...               ...                 ...        ...
Ethernet252      drop               600                 600    disable
```

#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ sudo pfcwd start_default
admin@sonic:~$ show pfcwd config
Changed polling interval to 400ms
       PORT    ACTION    DETECTION TIME    RESTORATION TIME    HISTORY
-----------  --------  ----------------  ------------------  ---------
  Ethernet0      drop               400                 400    disable
  Ethernet4      drop               400                 400    disable
        ...       ...               ...                 ...        ...
Ethernet252      drop               400                 400    disable
```

The set of configured ports is unchanged (64 in both cases); only the timer values differ.
