### PR TITLE
Speed up techsupport collection

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2582,11 +2582,34 @@ save_counter_snapshot() {
     save_cmd "show interface counters" "interface.counters_$idx"
     save_cmd "show interface counters fec-stats" "interface.counters.fec-stats_$idx"
 
-    for netdev in /sys/class/net/Ethernet* ; do
+    # Batch size selected to 8 to not overload CPU
+    local fec_histogram_batch_size=8
+    local -a fec_histogram_pids=()
+    local netdev iface pid
+
+    for netdev in /sys/class/net/Ethernet*; do
         # Skip the literal "Ethernet*" when the glob matches nothing.
         [ -e "$netdev" ] || continue
+
         iface=$(basename "$netdev")
-        save_cmd "show interface counters fec-histogram $iface" "interface.counters.fec-histogram.$iface.$idx"
+
+        save_cmd \
+            "show interface counters fec-histogram $iface" \
+            "interface.counters.fec-histogram.$iface.$idx" &
+
+        fec_histogram_pids+=("$!")
+
+        if [ "${#fec_histogram_pids[@]}" -ge "$fec_histogram_batch_size" ]; then
+            for pid in "${fec_histogram_pids[@]}"; do
+                wait "$pid"
+            done
+            fec_histogram_pids=()
+        fi
+    done
+
+    # Wait for the final batch, which may contain fewer than eight commands.
+    for pid in "${fec_histogram_pids[@]}"; do
+        wait "$pid"
     done
 
     if ! $IS_SUPERVISOR; then


### PR DESCRIPTION
generate_dump collects FEC histogram counters separately for every interface in two counter snapshots. On full-split systems, executing these commands sequentially significantly increases techsupport time.

Run the per-interface commands in bounded batches of eight and wait only for their recorded process IDs. Preserve the existing per-interface output files and unmatched-glob handling.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Reduced `show techsupport` execution time on full-split systems by
collecting per-interface FEC histogram counters in parallel.

The existing per-interface files and two counter snapshots are preserved.

Before, for a full-split 512 port config:

   ```bash
   time show techsupport
   ...
   real    9m48.540s
   user    0m0.327s
   sys     0m0.216s
   ```
After:
   ```bash
   time show techsupport
   ...
   real    4m31.055s
   user    0m0.318s
   sys     0m0.227s
   ```
#### How I did it

Updated `save_counter_snapshot()` to run FEC histogram commands in
bounded batches of eight.

Each background process ID is recorded and waited for before starting
the next batch. The final partial batch is also waited for, ensuring all
FEC files are complete before queue counters and `COUNTERS_DB` are
collected.

#### How to verify it

1. Validate the script syntax:

   ```bash
   bash -n /usr/local/bin/generate_dump
2. Run techsupport on a healthy full-split system:

   ```bash
    time show techsupport
 
3. Confirm the archive is generated successfully.

4.  Confirm that both snapshots contain one FEC histogram file per
interface:

   ```bash
    tar -tf <techsupport.tar.gz> |
    grep -E 'interface\.counters\.fec-histogram\.Ethernet.*\.[12]$' |
    wc -l
   ```
   For a system exposing 514 Ethernet interfaces, the expected total is
   1,028 files: 514 files for each snapshot.

5. Compare the execution time with the sequential implementation.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

#### Tested branch
 
- [x]  202511
- [x]  202605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * FEC histogram data is now collected more efficiently through concurrent processing, reducing snapshot generation time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->