### PR TITLE
[Mellanox]: Add warmboot CLI support

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -23,6 +23,7 @@ WATCHDOG_UTIL="/usr/local/bin/watchdogutil"
 SKIP_ASIC_LIST=""
 DEVPATH="/usr/share/sonic/device"
 PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+HWSKU=$(sonic-db-cli CONFIG_DB HGET "DEVICE_METADATA|localhost" "hwsku")
 PLATFORM_PLUGIN="${REBOOT_TYPE}_plugin"
 LOG_SSD_HEALTH="/usr/local/bin/log_ssd_health"
 SSD_UTIL="/usr/local/bin/ssdutil"
@@ -643,7 +644,6 @@ function is_secureboot() {
 function setup_reboot_variables()
 {
     # Kernel and initrd image
-    HWSKU=$(show platform summary --json | python -c 'import sys, json; print(json.load(sys.stdin)["hwsku"])')
     CURR_SONIC_IMAGE=$(sonic-installer list | grep "Current: " | cut -d ' ' -f 2)
     NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
     IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
@@ -1000,11 +1000,49 @@ case "$REBOOT_TYPE" in
     "warm-reboot")
         execute_in_namespaces all check_warm_restart_in_progress
         if [[ "$sonic_asic_type" == "mellanox" ]]; then
-            REBOOT_TYPE="fastfast-reboot"
-            BOOT_TYPE_ARG="fastfast"
-            # source mlnx-ffb.sh file with
-            # functions to check ISSU upgrade possibility
-            source mlnx-ffb.sh
+            HWSKU_DIR="${DEVPATH}/${PLATFORM}/${HWSKU}"
+            SAI_PROFILE="${HWSKU_DIR}/sai.profile"
+
+            if [[ ! -f "${SAI_PROFILE}" ]]; then
+                error "Failed to find SAI profile: ${SAI_PROFILE}"
+                exit "${EXIT_FAILURE}"
+            fi
+
+            SAI_INIT_CONFIG_FILE=$(awk -F= '/^SAI_INIT_CONFIG_FILE=/{print $2; exit}' "${SAI_PROFILE}")
+            SAI_INIT_CONFIG_FILE="${HWSKU_DIR}/$(basename "${SAI_INIT_CONFIG_FILE}")"
+
+            if [[ ! -f "${SAI_INIT_CONFIG_FILE}" ]]; then
+                error "Failed to resolve SAI XML from ${SAI_PROFILE}"
+                exit "${EXIT_FAILURE}"
+            fi
+
+            NVIDIA_WARMBOOT_MODE=$(
+                sed -n 's:.*<issu-enabled>\([0-9]*\)</issu-enabled>.*:\1:p' "${SAI_INIT_CONFIG_FILE}" |
+                head -n1
+            )
+
+            case "${NVIDIA_WARMBOOT_MODE}" in
+                2)
+                    debug "Starting NVIDIA warmboot"
+                    BOOT_TYPE_ARG="warm"
+                    ;;
+                1)
+                    debug "Starting NVIDIA fastfastboot"
+                    REBOOT_TYPE="fastfast-reboot"
+                    BOOT_TYPE_ARG="fastfast"
+                    # source mlnx-ffb.sh file with
+                    # functions to check NVIDIA fastfast upgrade possibility
+                    source mlnx-ffb.sh
+                    ;;
+                0)
+                    error "NVIDIA warmboot is disabled"
+                    exit "${EXIT_NOT_SUPPORTED}"
+                    ;;
+                *)
+                    error "Invalid NVIDIA warmboot mode: ${NVIDIA_WARMBOOT_MODE}"
+                    exit "${EXIT_FAILURE}"
+                    ;;
+            esac
         else
             BOOT_TYPE_ARG="warm"
         fi

--- a/show/plugins/mlnx.py
+++ b/show/plugins/mlnx.py
@@ -128,7 +128,7 @@ def is_issu_status_enabled_container(container_name):
     el = root.find('platform_info').find('issu-enabled')
 
     if el is not None:
-        issu_enabled = int(el.text) == 1
+        issu_enabled = int(el.text) in (1, 2)
 
     return issu_enabled
 

--- a/tests/fast_reboot_test.py
+++ b/tests/fast_reboot_test.py
@@ -22,6 +22,7 @@ class TestFastReboot:
                 os.chmod(working_script_path, 0o700)
             shutil.copy('/bin/false', os.path.join(tmp_dir, failing_script))
             shutil.copy('/bin/true', os.path.join(tmp_dir, 'sonic-cfggen'))
+            shutil.copy('/bin/true', os.path.join(tmp_dir, 'sonic-db-cli'))
             env = os.environ.copy()
             env['PATH'] = f"{tmp_dir}:{env.get('PATH', '')}"
             res = subprocess.run([fast_reboot, '-h'], env=env)

--- a/tests/show_mlnx_test.py
+++ b/tests/show_mlnx_test.py
@@ -58,9 +58,9 @@ class TestShowMlnx(object):
         assert e.value.code == 1
         mock_runcmd.assert_called_with(expected_calls, print_to_console=False)
 
-    @pytest.mark.parametrize("status", [True, False])
+    @pytest.mark.parametrize("issu_xml_value,expected", [(0, False), (1, True), (2, True)])
     @patch('show.plugins.mlnx.run_command')
-    def test_is_issue_status_enabled(self, mock_runcmd, status):
+    def test_is_issue_status_enabled(self, mock_runcmd, issu_xml_value, expected):
         def mock_return(*args, **kwargs):
             cmd = ' '.join(args[0])
             if cmd == f"docker exec {show.CONTAINER_NAME} cat /{show.HWSKU_PATH}/sai.profile":
@@ -69,7 +69,7 @@ class TestShowMlnx(object):
                 return (f"""<?xml version="1.0"?>
                 <root>
                     <platform_info>
-                        <issu-enabled>{int(status)}</issu-enabled>
+                        <issu-enabled>{issu_xml_value}</issu-enabled>
                     </platform_info>
                 </root>
                 """, '')
@@ -78,12 +78,12 @@ class TestShowMlnx(object):
 
         mock_runcmd.side_effect = mock_return
         result = show.is_issu_status_enabled()
-        assert result is status
+        assert result is expected
 
-    @pytest.mark.parametrize("status", [True, False])
+    @pytest.mark.parametrize("issu_xml_value,expected", [(0, False), (1, True), (2, True)])
     @patch('show.plugins.mlnx.multi_asic.get_num_asics', return_value=4)
     @patch('show.plugins.mlnx.run_command')
-    def test_is_issue_status_enabled_multi_asic(self, mock_runcmd, mock_get_numasics, status):
+    def test_is_issue_status_enabled_multi_asic(self, mock_runcmd, mock_get_numasics, issu_xml_value, expected):
         def mock_return(*args, **kwargs):
             cmd = ' '.join(args[0])
             if (
@@ -102,7 +102,7 @@ class TestShowMlnx(object):
                 return (f"""<?xml version="1.0"?>
                 <root>
                     <platform_info>
-                        <issu-enabled>{int(status)}</issu-enabled>
+                        <issu-enabled>{issu_xml_value}</issu-enabled>
                     </platform_info>
                 </root>
                 """, '')
@@ -111,7 +111,7 @@ class TestShowMlnx(object):
 
         mock_runcmd.side_effect = mock_return
         result = show.is_issu_status_enabled()
-        assert result is status
+        assert result is expected
 
     def teardown_method(self):
         print('TEARDOWN')


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add **NVIDIA warmboot** CLI / reboot orchestration support so `sudo warm-reboot` on
Mellanox platforms follows SAI XML `<issu-enabled>` instead of always remapping
to fastfast.

On NVIDIA platforms:

* `<issu-enabled>2</issu-enabled>` — warmboot (`SONIC_BOOT_TYPE=warm`)
* `<issu-enabled>1</issu-enabled>` — fastfast (`SONIC_BOOT_TYPE=fastfast`)
* `<issu-enabled>0</issu-enabled>` — disabled (warm-reboot rejected)

Also treat both fastfast and warmboot as ISSU-enabled for
`show platform mlnx issu`.

#### How I did it

1. **`scripts/fast-reboot`** — for `sonic_asic_type=mellanox` on `warm-reboot`:
   * Resolve HWSKU SAI profile / SAI XML early (HWSKU via `sonic-db-cli CONFIG_DB`)
   * Parse `<issu-enabled>` and select the boot path:
     * `2` → keep community warm-reboot (`BOOT_TYPE_ARG=warm`)
     * `1` → remap to fastfast-reboot and source `mlnx-ffb.sh` (existing path)
     * `0` → exit not-supported
     * other / missing → fail with a clear error
   * Non-Mellanox platforms unchanged (`BOOT_TYPE_ARG=warm`)

2. **`show/plugins/mlnx.py`** — `is_issu_status_enabled_container()` treats
   `<issu-enabled>` values `1` and `2` as enabled (previously only `1`)

3. **Tests**
   * `tests/show_mlnx_test.py` — parametrize ISSU status for XML values `0` / `1` / `2`
   * `tests/fast_reboot_test.py` — stub `sonic-db-cli` on `PATH` (now used at script start)

#### How to verify it

1. **Unit tests**
   * `pytest tests/show_mlnx_test.py`
   * `pytest tests/fast_reboot_test.py`

2. **Warmboot** (e.g. ACS-SN5600 with `<issu-enabled>2</issu-enabled>`)
   * `sudo warm-reboot`
   * Confirm log: `Starting NVIDIA warmboot`
   * Confirm `/proc/cmdline` has `SONIC_BOOT_TYPE=warm` (not remapped to fastfast)

3. **fastfast** (`<issu-enabled>1</issu-enabled>`)
   * `sudo warm-reboot`
   * Confirm log: `Starting NVIDIA fastfastboot`
   * Confirm remap to fastfast-reboot / `SONIC_BOOT_TYPE=fastfast`

4. **Disabled** (`<issu-enabled>0</issu-enabled>`)
   * `sudo warm-reboot` is rejected (`NVIDIA warmboot is disabled`)

5. **Show status**
   * With XML `1` or `2`: `show platform mlnx issu` → `ISSU is enabled`
   * With XML `0`: `show platform mlnx issu` → `ISSU is disabled`

#### Previous command output (if the output of a command-line utility has changed)

```
# HWSKU with <issu-enabled>2</issu-enabled>
root@sonic:/home/admin# show platform mlnx issu
ISSU is disabled
```

#### New command output (if the output of a command-line utility has changed)

```
# Same HWSKU with <issu-enabled>2</issu-enabled>
root@sonic:/home/admin# show platform mlnx issu
ISSU is enabled
```

#### A picture of a cute animal (not mandatory but encouraged)

```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```