### PR TITLE
[sonic_installer] Normalize M-prefixed Current and Next image names

### DIFF
--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -647,7 +647,7 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
 
 
 # List installed images
-def normalize_image_version_for_display(image):
+def normalize_image_name_for_display(image):
     manufacturing_prefix = IMAGE_PREFIX + "M."
     if image.startswith(manufacturing_prefix):
         return IMAGE_PREFIX + image[len(manufacturing_prefix):]
@@ -661,8 +661,8 @@ def list_command():
     images = bootloader.get_installed_images()
     curimage = bootloader.get_current_image()
     nextimage = bootloader.get_next_image()
-    click.echo("Current: " + normalize_image_version_for_display(curimage))
-    click.echo("Next: " + normalize_image_version_for_display(nextimage))
+    click.echo("Current: " + normalize_image_name_for_display(curimage))
+    click.echo("Next: " + normalize_image_name_for_display(nextimage))
     # Available entries remain exact bootloader identifiers for image commands.
     click.echo("Available: ")
     for image in images:

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -647,6 +647,13 @@ def install(url, force, skip_platform_check=False, skip_migration=False, skip_pa
 
 
 # List installed images
+def normalize_image_version_for_display(image):
+    manufacturing_prefix = IMAGE_PREFIX + "M."
+    if image.startswith(manufacturing_prefix):
+        return IMAGE_PREFIX + image[len(manufacturing_prefix):]
+    return image
+
+
 @sonic_installer.command('list')
 def list_command():
     """ Print installed images """
@@ -654,8 +661,9 @@ def list_command():
     images = bootloader.get_installed_images()
     curimage = bootloader.get_current_image()
     nextimage = bootloader.get_next_image()
-    click.echo("Current: " + curimage)
-    click.echo("Next: " + nextimage)
+    click.echo("Current: " + normalize_image_version_for_display(curimage))
+    click.echo("Next: " + normalize_image_version_for_display(nextimage))
+    # Available entries remain exact bootloader identifiers for image commands.
     click.echo("Available: ")
     for image in images:
         click.echo(image)

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -180,6 +180,29 @@ def test_runtime_exception(mock_popen):
     assert all(v in str(sre.value) for v in ['test.sh', 'Running', 'Failed']), "Invalid message"
 
 
+@pytest.mark.parametrize(
+    "stored_image, displayed_image",
+    [
+        ("SONiC-OS-M.20201231.08", "SONiC-OS-20201231.08"),
+        ("SONiC-OS-20201231.08", "SONiC-OS-20201231.08"),
+    ]
+)
+@patch("sonic_installer.main.get_bootloader")
+def test_list_normalizes_manufacturing_image_name_for_display(get_bootloader, stored_image, displayed_image):
+    mock_bootloader = Mock()
+    mock_bootloader.get_current_image.return_value = stored_image
+    mock_bootloader.get_next_image.return_value = stored_image
+    mock_bootloader.get_installed_images.return_value = [stored_image]
+    get_bootloader.return_value = mock_bootloader
+
+    result = CliRunner().invoke(sonic_installer.commands["list"])
+
+    assert result.exit_code == 0
+    assert "Current: {}".format(displayed_image) in result.output
+    assert "Next: {}".format(displayed_image) in result.output
+    assert "Available: \n{}".format(stored_image) in result.output
+
+
 @patch("sonic_installer.main.SWAPAllocator")
 @patch("sonic_installer.main.get_bootloader")
 @patch("sonic_installer.main.run_command_or_raise")


### PR DESCRIPTION
## What I did

Normalize the `Current` and `Next` values from `sonic-installer list` when a stored manufacturing image name starts with `SONiC-OS-M.`.

Before:
```text
Current: SONiC-OS-M.20201231.08
Next: SONiC-OS-M.20201231.08
Available:
SONiC-OS-M.20201231.08
```

After:
```text
Current: SONiC-OS-20201231.08
Next: SONiC-OS-20201231.08
Available:
SONiC-OS-M.20201231.08
```

`Available` retains the exact bootloader identifier required by image-management commands. No image directory or bootloader entry is renamed.

## Why I did it

Consumers parse `Current` and `Next` as canonical SONiC version strings. The optional manufacturing `M.` component adds an extra version segment and can break those consumers.

## How I did it

Add a display-only normalization helper and use it for `Current` and `Next`. Add command-level tests for M-prefixed and standard image names.

## Testing

- `git diff --check`: passed.
- `python3 -m py_compile sonic_installer/main.py tests/test_sonic_installer.py`: passed.
- Isolated normalization checks: 3 passed.
- Added `test_list_normalizes_manufacturing_image_name_for_display`, which invokes the Click `list` command and checks normalized status values plus the unchanged `Available` identifier.
- Full pytest did not collect locally because the required SONiC-built Python wheels are unavailable. Repository CI installs those dependencies before running pytest.

ADO: 39268226