### PR TITLE
[route_check] Close the vtysh read end before waiting on a parse failure

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -81,8 +81,11 @@ PRINT_MSG_TRUNCATION_SUFFIX = " ... (truncated)"
 FRR_CHECK_RETRIES = 3
 FRR_WAIT_TIME = 15
 
-# How long to wait for the vtysh process group to be reaped after SIGKILL
-KILL_WAIT_SECONDS = 10
+# How long to wait for vtysh to exit once we have closed the read end
+VTYSH_EXIT_TIMEOUT_SECONDS = 10
+
+# How long to wait for the direct child to be reaped after we SIGKILL it
+SIGKILL_REAP_TIMEOUT_SECONDS = 3
 
 REDIS_TIMEOUT_MSECS = 0
 
@@ -401,48 +404,6 @@ def is_suppress_fib_pending_enabled(namespace):
     return state == 'enabled'
 
 
-def terminate_vtysh_process_group(proc):
-    """
-    SIGKILL the whole process group started for the vtysh command and reap it.
-
-    fetch_routes runs "sudo vtysh", and on a SONiC host /usr/bin/vtysh is a
-    wrapper script that runs "docker exec -i bgp vtysh ...". proc.kill() only
-    signals sudo: the wrapper and the docker exec client survive it, the vtysh
-    inside the container stays blocked writing into a pipe nobody reads any
-    more, and from then on the bgp container cannot be stopped - every later
-    docker exec into it hangs. Signalling the whole group is what actually
-    releases the exec session.
-
-    This relies on Popen(start_new_session=True) making the child a process
-    group leader, so its pgid equals its pid. Do not derive the group with
-    os.getpgid(): if the new session was not created that returns route_check's
-    own group and we would kill ourselves.
-
-    It also assumes sudo leaves the command in that group. That holds for the
-    sudo we ship, but not under "Defaults use_pty" (the default from sudo
-    1.9.14), where sudo runs the command in its own session behind a pty and
-    only the sudo front-end would be signalled.
-
-    :return True if the process was reaped, False if it outlived the SIGKILL.
-    """
-    try:
-        os.killpg(proc.pid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError) as e:
-        # Best effort: a cleanup failure must never mask the error that got us here.
-        # Reported at WARNING because this is the only early signal that the
-        # cleanup did not take effect; the default report level hides DEBUG.
-        # Deliberately not "except Exception": a bad pid is a bug, not a
-        # cleanup failure, and must not be swallowed.
-        print_message(syslog.LOG_WARNING, f"Could not signal process group {proc.pid}: {e}")
-
-    try:
-        proc.wait(timeout=KILL_WAIT_SECONDS)
-        return True
-    except subprocess.TimeoutExpired:
-        print_message(syslog.LOG_ERR, f"vtysh (pid {proc.pid}) still alive after SIGKILL")
-        return False
-
-
 def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
     """
     Fetch routes using the given command.
@@ -476,15 +437,12 @@ def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
             failing_routes.append(prefix)
 
     try:
-        # start_new_session puts sudo, the /usr/bin/vtysh wrapper and the
-        # docker exec client it spawns into one process group we can signal.
         # Deliberately not used as a context manager: Popen.__exit__ ends in an
-        # unbounded wait(), which is the hang this whole change removes.
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=0,
-                                start_new_session=True)
+        # unbounded wait(), which is the hang this whole change removes. Every
+        # wait() below is bounded.
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=0)
         completed = False
-        killed = False
-        abandoned = False
+        return_code = None
         try:
             # Use ijson to parse the JSON stream incrementally
             # kvitems('') iterates over key-value pairs at the root level
@@ -504,32 +462,52 @@ def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
             # returns whatever it managed to parse.
             print_message(syslog.LOG_WARNING, f"Error while parsing vtysh JSON stream: {e}")
         finally:
-            # Only an abandoned read needs the kill. On a clean parse vtysh has
-            # closed stdout and is exiting on its own, and poll() often has not
-            # reaped it yet - killing there would SIGKILL a healthy group and
-            # mask its exit code. A finally (not a flag) so KeyboardInterrupt
-            # takes this path too: start_new_session means a terminal SIGINT no
-            # longer reaches the chain by itself.
-            if not completed and proc.poll() is None:
-                killed = True
-                # Never return from here: a return inside finally would swallow
-                # an in-flight KeyboardInterrupt.
-                abandoned = not terminate_vtysh_process_group(proc)
+            # Closing the read end is what releases the chain, and it has to
+            # happen before any wait(). An abandoned read leaves vtysh blocked
+            # in write() with megabytes still queued; closing makes that write
+            # fail with EPIPE, so vtysh, the /usr/bin/vtysh wrapper and the
+            # docker exec client all unwind and the exec session is released.
+            # Waiting first is the deadlock this change removes.
+            # A finally (not a flag) so KeyboardInterrupt takes this path too.
             if proc.stdout:
                 proc.stdout.close()
+            try:
+                # In the same finally so the child is reaped even while a
+                # KeyboardInterrupt is propagating, which would otherwise skip
+                # this and leave the direct child a zombie. Bounded: nothing
+                # left to wait on, and fetch_routes runs on a worker thread the
+                # SIGALRM watchdog cannot interrupt, so it must not block here.
+                return_code = proc.wait(timeout=VTYSH_EXIT_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                # Closing only releases a process that goes on to write. One
+                # hung without writing needs the signal, and route_check runs
+                # on a timer, so walking away would leak a child per timeout.
+                #
+                # This reaches the direct child only: sudo does not propagate
+                # SIGKILL, so the /usr/bin/vtysh wrapper and the docker exec
+                # client below it are not covered. Reaching those would need
+                # the process group, which this function deliberately does not
+                # use - os.killpg() cannot signal the root-owned processes sudo
+                # spawns unless route_check is root, and kill(-pgid) reports
+                # success as long as it reached sudo, so the failure is silent.
+                # Whatever it does not cover still unwinds by itself the moment
+                # it writes into the pipe we closed above.
+                print_message(syslog.LOG_ERR,
+                              f"vtysh (pid {proc.pid}) did not exit; killing the direct child")
+                proc.kill()
+                try:
+                    # Leave return_code as None: the exit code from here on is
+                    # our own SIGKILL, not something vtysh should be judged by.
+                    proc.wait(timeout=SIGKILL_REAP_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    print_message(syslog.LOG_ERR,
+                                  f"vtysh (pid {proc.pid}) survived SIGKILL; abandoning")
+            # Never return from here: a return inside finally would swallow an
+            # in-flight KeyboardInterrupt.
 
-        if abandoned:
-            # Unreapable: waiting on it would hang forever, and fetch_routes
-            # runs on a worker thread the SIGALRM watchdog cannot interrupt.
-            return missing_routes, failing_routes
-
-        try:
-            return_code = proc.wait(timeout=KILL_WAIT_SECONDS)
-        except subprocess.TimeoutExpired:
-            print_message(syslog.LOG_ERR, f"vtysh (pid {proc.pid}) did not exit; abandoning")
-            return missing_routes, failing_routes
-        # Not for a SIGKILL we sent ourselves - that would read as a vtysh crash.
-        if not killed and return_code != 0:
+        # After an abandoned read vtysh dies of SIGPIPE, which sudo reports as
+        # 141. That is this function's own doing, not a vtysh failure.
+        if completed and return_code not in (None, 0):
             print_message(syslog.LOG_WARNING, f"Subprocess exited with non-zero return code: {return_code}")
 
     except FileNotFoundError:

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -81,6 +81,9 @@ PRINT_MSG_TRUNCATION_SUFFIX = " ... (truncated)"
 FRR_CHECK_RETRIES = 3
 FRR_WAIT_TIME = 15
 
+# How long to wait for the vtysh process group to be reaped after SIGKILL
+KILL_WAIT_SECONDS = 10
+
 REDIS_TIMEOUT_MSECS = 0
 
 
@@ -398,6 +401,48 @@ def is_suppress_fib_pending_enabled(namespace):
     return state == 'enabled'
 
 
+def terminate_vtysh_process_group(proc):
+    """
+    SIGKILL the whole process group started for the vtysh command and reap it.
+
+    fetch_routes runs "sudo vtysh", and on a SONiC host /usr/bin/vtysh is a
+    wrapper script that runs "docker exec -i bgp vtysh ...". proc.kill() only
+    signals sudo: the wrapper and the docker exec client survive it, the vtysh
+    inside the container stays blocked writing into a pipe nobody reads any
+    more, and from then on the bgp container cannot be stopped - every later
+    docker exec into it hangs. Signalling the whole group is what actually
+    releases the exec session.
+
+    This relies on Popen(start_new_session=True) making the child a process
+    group leader, so its pgid equals its pid. Do not derive the group with
+    os.getpgid(): if the new session was not created that returns route_check's
+    own group and we would kill ourselves.
+
+    It also assumes sudo leaves the command in that group. That holds for the
+    sudo we ship, but not under "Defaults use_pty" (the default from sudo
+    1.9.14), where sudo runs the command in its own session behind a pty and
+    only the sudo front-end would be signalled.
+
+    :return True if the process was reaped, False if it outlived the SIGKILL.
+    """
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError) as e:
+        # Best effort: a cleanup failure must never mask the error that got us here.
+        # Reported at WARNING because this is the only early signal that the
+        # cleanup did not take effect; the default report level hides DEBUG.
+        # Deliberately not "except Exception": a bad pid is a bug, not a
+        # cleanup failure, and must not be swallowed.
+        print_message(syslog.LOG_WARNING, f"Could not signal process group {proc.pid}: {e}")
+
+    try:
+        proc.wait(timeout=KILL_WAIT_SECONDS)
+        return True
+    except subprocess.TimeoutExpired:
+        print_message(syslog.LOG_ERR, f"vtysh (pid {proc.pid}) still alive after SIGKILL")
+        return False
+
+
 def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
     """
     Fetch routes using the given command.
@@ -431,34 +476,61 @@ def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
             failing_routes.append(prefix)
 
     try:
-        with subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=0) as proc:
-            try:
-                # Use ijson to parse the JSON stream incrementally
-                # kvitems('') iterates over key-value pairs at the root level
-                # This gives us each prefix and its route entries as they become available
-                for prefix, route_entries in ijson.kvitems(proc.stdout, ''):
-                    # Process each route entry for this prefix
-                    if isinstance(route_entries, list):
-                        for route_entry in route_entries:
-                            process_route_entry(prefix, route_entry)
-                    else:
-                        # Handle case where route_entries is not a list (shouldn't happen with valid FRR output)
-                        print_message(syslog.LOG_WARNING, f"Unexpected route entry format for prefix {prefix}")
+        # start_new_session puts sudo, the /usr/bin/vtysh wrapper and the
+        # docker exec client it spawns into one process group we can signal.
+        # Deliberately not used as a context manager: Popen.__exit__ ends in an
+        # unbounded wait(), which is the hang this whole change removes.
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=0,
+                                start_new_session=True)
+        completed = False
+        killed = False
+        abandoned = False
+        try:
+            # Use ijson to parse the JSON stream incrementally
+            # kvitems('') iterates over key-value pairs at the root level
+            # This gives us each prefix and its route entries as they become available
+            for prefix, route_entries in ijson.kvitems(proc.stdout, ''):
+                # Process each route entry for this prefix
+                if isinstance(route_entries, list):
+                    for route_entry in route_entries:
+                        process_route_entry(prefix, route_entry)
+                else:
+                    # Handle case where route_entries is not a list (shouldn't happen with valid FRR output)
+                    print_message(syslog.LOG_WARNING, f"Unexpected route entry format for prefix {prefix}")
+            completed = True
 
-            except ijson.JSONError as e:
-                # Handle JSON parsing errors
-                print_message(syslog.LOG_WARNING, f"Failed to parse JSON stream: {e}")
-            except UnicodeDecodeError as e:
-                # Handle UTF-8 decoding errors
-                print_message(syslog.LOG_WARNING, f"UTF-8 decoding error: {e}")
-            except Exception as e:
-                # Handle any other unexpected errors during parsing
-                print_message(syslog.LOG_WARNING, f"Error during JSON parsing: {e}")
+        except Exception as e:
+            # Parse errors are logged and swallowed, exactly as before: this
+            # returns whatever it managed to parse.
+            print_message(syslog.LOG_WARNING, f"Error while parsing vtysh JSON stream: {e}")
+        finally:
+            # Only an abandoned read needs the kill. On a clean parse vtysh has
+            # closed stdout and is exiting on its own, and poll() often has not
+            # reaped it yet - killing there would SIGKILL a healthy group and
+            # mask its exit code. A finally (not a flag) so KeyboardInterrupt
+            # takes this path too: start_new_session means a terminal SIGINT no
+            # longer reaches the chain by itself.
+            if not completed and proc.poll() is None:
+                killed = True
+                # Never return from here: a return inside finally would swallow
+                # an in-flight KeyboardInterrupt.
+                abandoned = not terminate_vtysh_process_group(proc)
+            if proc.stdout:
+                proc.stdout.close()
 
-            # Wait for the process to terminate and get the return code
-            return_code = proc.wait()
-            if return_code != 0:
-                print_message(syslog.LOG_WARNING, f"Subprocess exited with non-zero return code: {return_code}")
+        if abandoned:
+            # Unreapable: waiting on it would hang forever, and fetch_routes
+            # runs on a worker thread the SIGALRM watchdog cannot interrupt.
+            return missing_routes, failing_routes
+
+        try:
+            return_code = proc.wait(timeout=KILL_WAIT_SECONDS)
+        except subprocess.TimeoutExpired:
+            print_message(syslog.LOG_ERR, f"vtysh (pid {proc.pid}) did not exit; abandoning")
+            return missing_routes, failing_routes
+        # Not for a SIGKILL we sent ourselves - that would read as a vtysh crash.
+        if not killed and return_code != 0:
+            print_message(syslog.LOG_WARNING, f"Subprocess exited with non-zero return code: {return_code}")
 
     except FileNotFoundError:
         print_message(syslog.LOG_ERR, f"Error: Command '{cmd[0]}' not found.")

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -1,9 +1,14 @@
 import copy
-from io import StringIO
+from io import BytesIO, StringIO
 import json
 import logging
+import os
+import shlex
+import signal
+import subprocess
 import syslog
 import sys
+import threading
 import time
 from sonic_py_common import device_info
 from unittest.mock import MagicMock, patch
@@ -208,14 +213,6 @@ def set_mock(mock_table, mock_conn, mock_sel, mock_subs, mock_config_db):
 
 
 class TestRouteCheck(object):
-    @staticmethod
-    def extract_namespace_from_args(args):
-        # args: ['show', 'ip', 'route', '-n', 'asic0', 'json'],
-        for i, arg in enumerate(args):
-            if arg == "-n" and i + 1 < len(args):
-                return args[i + 1]
-        return DEFAULTNS
-
     def setup_method(self):
         pass
 
@@ -258,7 +255,6 @@ class TestRouteCheck(object):
         with patch('sys.argv', ct_data[ARGS].split()), \
             patch('sonic_py_common.multi_asic.get_namespace_list', return_value=ct_data[NAMESPACE]), \
             patch('sonic_py_common.multi_asic.is_multi_asic', return_value=ct_data[MULTI_ASIC]), \
-            patch('route_check.subprocess.check_output', side_effect=lambda *args, **kwargs: self.mock_check_output(ct_data, *args, **kwargs)), \
             patch('route_check.check_frr_pending_routes',
                   side_effect=lambda *args, **kwargs:
                   self.mock_fetch_routes(ct_data, *args, **kwargs)), \
@@ -269,11 +265,6 @@ class TestRouteCheck(object):
 
             ret, res = route_check.main()
             self.assert_results(ct_data, ret, res)
-
-    def mock_check_output(self, ct_data, *args, **kwargs):
-        ns = self.extract_namespace_from_args(args[0])
-        routes = ct_data.get(FRR_ROUTES, {}).get(ns, {})
-        return json.dumps(routes)
 
     def mock_fetch_routes(self, ct_data, *args, **kwargs):
         ns = args[0]
@@ -367,3 +358,354 @@ class TestRouteCheck(object):
             route_check.mitigate_installed_not_offloaded_frr_routes(namespace, missed_frr_rt, rt_appl)
         # Verify that the stdout are suppressed in this function
         assert not mock_stdout.getvalue()
+
+
+# fetch_routes runs "sudo vtysh", and /usr/bin/vtysh is a wrapper that runs
+# "docker exec -i bgp vtysh ...". Killing only the direct child leaves that
+# docker exec client behind, holding an exec session the bgp container can
+# never be stopped with. The fakes below reproduce that shape without docker:
+# the process that floods the pipe is a grandchild, not the direct child.
+GOOD_ROUTES = {
+    "10.0.0.0/24": [{"protocol": "bgp", "vrfName": "default", "selected": True, "offloaded": False}],
+    "10.0.1.0/24": [{"protocol": "bgp", "vrfName": "default", "selected": True,
+                     "offloaded": True, "failed": True}],
+    "10.0.2.0/24": [{"protocol": "connected", "vrfName": "default", "selected": True}],
+}
+
+# Emits a truncated JSON object so ijson raises, then floods stdout from a
+# grandchild so it blocks in write() once the 64KB pipe fills up.
+FLOOD_MARKER = "ROUTE_CHECK_TEST_FLOOD"
+
+# fetch_routes must not take anywhere near this long; it is only here so a
+# regression shows up as a failure instead of hanging the test run forever.
+FETCH_TIMEOUT_SECONDS = 60
+
+
+def _proc_readable():
+    """/proc must be usable or the liveness checks below silently pass."""
+    try:
+        with open('/proc/self/stat'):
+            return True
+    except OSError:
+        return False
+
+
+def _pid_running(pid):
+    """True only while pid exists and has not become a zombie."""
+    try:
+        with open('/proc/{}/stat'.format(pid)) as f:
+            state = f.read().rsplit(')', 1)[1].split()[0]
+    except OSError:
+        return False
+    return state != 'Z'
+
+
+def _wait_until(predicate, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.1)
+    return predicate()
+
+
+def _wait_until_gone(pid, timeout=10):
+    return _wait_until(lambda: not _pid_running(pid), timeout)
+
+
+@pytest.mark.skipif(not _proc_readable(),
+                    reason="needs a readable /proc to prove the group is gone")
+class TestFetchRoutesProcessGroup(object):
+    """fetch_routes must never leave the vtysh / docker exec chain behind."""
+
+    @staticmethod
+    def _fake_popen(fake_cmd, captured):
+        """Run fake_cmd instead of vtysh, keeping real process-group semantics."""
+        real_popen = subprocess.Popen
+
+        def _popen(cmd, **kwargs):
+            proc = real_popen(fake_cmd, **kwargs)
+            captured['pid'] = proc.pid
+            captured['kwargs'] = kwargs
+            return proc
+        return _popen
+
+    @staticmethod
+    def _flooding_cmd(pidfile):
+        """A three level chain whose deepest process floods the pipe.
+
+        The grandchild records its own pid before emitting anything, so the
+        file is always in place by the time the parse fails and cleanup runs.
+        Writing it from the parent after the fork loses that race: the parse
+        can fail and the group be signalled before the parent gets to write.
+        exec keeps the pid, so it identifies the flooding process too.
+        """
+        tmp = shlex.quote(str(pidfile) + '.tmp')
+        final = shlex.quote(str(pidfile))
+        inner = ("echo $$ > " + tmp + "; mv " + tmp + " " + final
+                 + "; printf '%s' '{\"10.0.0.0/24\": zzz'; exec yes " + FLOOD_MARKER)
+        return ['sh', '-c', 'sh -c ' + shlex.quote(inner) + ' & wait']
+
+    @staticmethod
+    def _live_cmd():
+        """Emits a JSON object then stays alive, so cleanup has something to kill.
+
+        A command that exits immediately makes proc.poll() non-None by the time
+        the finally runs, and the cleanup assertions become scheduling-dependent.
+        """
+        return ['sh', '-c', "printf '%s' '{}'; exec sleep 30"]
+
+    @staticmethod
+    def _reap_group(pid):
+        """Best effort cleanup so a failing assertion does not leak the chain."""
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+    def _run_fetch_routes(self):
+        """Call fetch_routes off the main thread so a deadlock fails the test."""
+        outcome = {}
+
+        def run():
+            try:
+                outcome['result'] = route_check.fetch_routes()
+            except BaseException as e:  # noqa: B036, BLE001 - the point is to capture anything
+                outcome['exc'] = e
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join(timeout=FETCH_TIMEOUT_SECONDS)
+        assert not thread.is_alive(), \
+            "fetch_routes deadlocked: the vtysh process group was not terminated"
+        return outcome
+
+    def test_terminates_whole_process_group_on_parse_error(self, tmp_path):
+        """The regression guard: without the group kill this deadlocks."""
+        pidfile = tmp_path / 'grandchild.pid'
+        captured = {}
+        cmd = self._flooding_cmd(pidfile)
+        try:
+            with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)):
+                outcome = self._run_fetch_routes()
+
+            # The parse error itself stays swallowed, as it always was.
+            assert 'exc' not in outcome, outcome.get('exc')
+            assert outcome['result'] == ([], [])
+
+            # The grandchild is the stand-in for the docker exec client: it is
+            # what proc.kill() would have missed, so it is what has to be gone.
+            assert _wait_until(pidfile.exists), "the fake chain never recorded its grandchild"
+            grandchild = int(pidfile.read_text().strip())
+            assert _wait_until_gone(grandchild), \
+                "grandchild {} survived: only the direct child was killed".format(grandchild)
+        finally:
+            if 'pid' in captured:
+                self._reap_group(captured['pid'])
+
+    @pytest.mark.parametrize("error", [
+        UnicodeDecodeError('utf-8', b'\xff', 0, 1, 'invalid start byte'),
+        ValueError('something unexpected'),
+    ])
+    def test_other_parse_errors_take_the_same_cleanup_path(self, error):
+        """Every branch that abandons the read has to terminate the group."""
+        captured = {}
+        try:
+            with patch('route_check.subprocess.Popen',
+                       side_effect=self._fake_popen(self._live_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=error), \
+                    patch('route_check.KILL_WAIT_SECONDS', 0.3), \
+                    patch('route_check.os.killpg') as mock_killpg:
+                outcome = self._run_fetch_routes()
+
+            assert 'exc' not in outcome, outcome.get('exc')
+            assert outcome['result'] == ([], [])
+            mock_killpg.assert_called_once_with(captured['pid'], signal.SIGKILL)
+        finally:
+            if 'pid' in captured:
+                self._reap_group(captured['pid'])
+
+    def test_cleanup_runs_for_non_exception_interrupts(self):
+        """KeyboardInterrupt is not an Exception, so a flag would miss it.
+
+        start_new_session also means a terminal SIGINT no longer reaches the
+        chain on its own, so this is the only thing releasing the exec session.
+        """
+        captured = {}
+        try:
+            with patch('route_check.subprocess.Popen',
+                       side_effect=self._fake_popen(self._live_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=KeyboardInterrupt), \
+                    patch('route_check.KILL_WAIT_SECONDS', 0.3), \
+                    patch('route_check.os.killpg') as mock_killpg:
+                outcome = self._run_fetch_routes()
+
+            assert isinstance(outcome.get('exc'), KeyboardInterrupt), \
+                "KeyboardInterrupt must still propagate"
+            mock_killpg.assert_called_once_with(captured['pid'], signal.SIGKILL)
+        finally:
+            if 'pid' in captured:
+                self._reap_group(captured['pid'])
+
+    def test_clean_parse_does_not_kill_a_healthy_group(self):
+        """A finished read must not SIGKILL vtysh on its way out.
+
+        On a clean parse poll() has often not reaped vtysh yet, so a cleanup
+        gated on liveness alone would kill a healthy group and mask its exit
+        code.
+        """
+        captured = {}
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES))]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
+                patch('route_check.os.killpg') as mock_killpg:
+            outcome = self._run_fetch_routes()
+
+        assert 'exc' not in outcome, outcome.get('exc')
+        missing, failing = outcome['result']
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        assert failing == ['10.0.1.0/24']
+        mock_killpg.assert_not_called()
+
+    def test_non_zero_exit_is_reported_when_we_did_not_kill(self):
+        """A real vtysh failure must survive the SIGKILL suppression."""
+        captured = {}
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES)) + "; exit 3"]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
+                patch('route_check.print_message') as mock_msg:
+            outcome = self._run_fetch_routes()
+
+        assert 'exc' not in outcome, outcome.get('exc')
+        missing, failing = outcome['result']
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        assert any('non-zero return code: 3' in str(c) for c in mock_msg.call_args_list)
+
+    def test_self_sent_sigkill_is_not_reported_as_a_crash(self):
+        """-9 from our own cleanup must not read as a vtysh crash."""
+        captured = {}
+        try:
+            with patch('route_check.subprocess.Popen',
+                       side_effect=self._fake_popen(self._live_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=ValueError('boom')), \
+                    patch('route_check.print_message') as mock_msg:
+                outcome = self._run_fetch_routes()
+
+            assert 'exc' not in outcome, outcome.get('exc')
+            assert not any('non-zero return code' in str(c) for c in mock_msg.call_args_list)
+        finally:
+            if 'pid' in captured:
+                self._reap_group(captured['pid'])
+
+    def test_lingering_process_after_clean_parse_is_abandoned(self):
+        """A clean parse whose process never exits must not block forever.
+
+        Nothing killed it, so the group cleanup does not run and the only
+        thing standing between fetch_routes and a permanent hang is the
+        bounded wait plus its early return.
+        """
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.poll.return_value = 0
+        proc.stdout = BytesIO(json.dumps(GOOD_ROUTES).encode())
+        proc.wait.side_effect = subprocess.TimeoutExpired(
+            cmd='vtysh', timeout=route_check.KILL_WAIT_SECONDS)
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.print_message') as mock_msg:
+            missing, failing = route_check.fetch_routes()
+
+        # Whatever was parsed before the hang still comes back.
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        assert failing == ['10.0.1.0/24']
+        assert any('did not exit; abandoning' in str(c) for c in mock_msg.call_args_list)
+
+    def test_unexpected_route_entry_format_is_reported(self):
+        """FRR should never emit this, but the guard must still be exercised."""
+        captured = {}
+        payload = json.dumps({"10.0.0.0/24": "not-a-list"})
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(payload)]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
+                patch('route_check.print_message') as mock_msg:
+            outcome = self._run_fetch_routes()
+
+        assert 'exc' not in outcome, outcome.get('exc')
+        assert outcome['result'] == ([], [])
+        assert any('Unexpected route entry format' in str(c) for c in mock_msg.call_args_list)
+
+    def test_starts_new_session(self):
+        """killpg(proc.pid) is only safe because the child leads its own group."""
+        captured = {}
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES))]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)):
+            self._run_fetch_routes()
+
+        assert captured['kwargs'].get('start_new_session') is True
+
+    def test_terminate_signals_child_pid_not_our_own_group(self):
+        """Guard against 'simplifying' proc.pid into os.getpgid(proc.pid)."""
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.wait.return_value = 0
+
+        with patch('route_check.os.killpg') as mock_killpg:
+            assert route_check.terminate_vtysh_process_group(proc) is True
+
+        mock_killpg.assert_called_once_with(proc.pid, signal.SIGKILL)
+        proc.wait.assert_called_once_with(timeout=route_check.KILL_WAIT_SECONDS)
+
+    def test_terminate_tolerates_already_dead_group(self):
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.wait.return_value = 0
+
+        with patch('route_check.os.killpg', side_effect=ProcessLookupError), \
+                patch('route_check.print_message') as mock_msg:
+            assert route_check.terminate_vtysh_process_group(proc) is True
+
+        proc.wait.assert_called_once_with(timeout=route_check.KILL_WAIT_SECONDS)
+        # A failed killpg is the only early signal that this fix did not take
+        # effect, so it has to clear the default report level. Keep it visible.
+        assert any(c.args[0] == syslog.LOG_WARNING and 'Could not signal process group' in str(c)
+                   for c in mock_msg.call_args_list)
+
+    def test_terminate_does_not_swallow_programming_errors(self):
+        """A bad pid is a bug, not a cleanup failure - it must not be hidden.
+
+        A catch-all here silently turns os.killpg(<Mock>) into a no-op, which
+        makes callers that pass a mocked proc look like they exercise this path
+        when they do not.
+        """
+        proc = MagicMock()
+        proc.pid = object()
+
+        with pytest.raises(TypeError):
+            route_check.terminate_vtysh_process_group(proc)
+
+    def test_terminate_reports_survivor_instead_of_raising(self):
+        """A process stuck in D state must not mask the parse error."""
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.wait.side_effect = subprocess.TimeoutExpired(
+            cmd='vtysh', timeout=route_check.KILL_WAIT_SECONDS)
+
+        with patch('route_check.os.killpg'), \
+                patch('route_check.print_message') as mock_msg:
+            assert route_check.terminate_vtysh_process_group(proc) is False
+
+        assert any('still alive after SIGKILL' in str(c) for c in mock_msg.call_args_list)
+
+    def test_unreapable_group_is_abandoned_not_waited_on(self):
+        """The bounded wait is pointless if the next line waits unbounded.
+
+        fetch_routes runs on a worker thread the SIGALRM watchdog cannot
+        interrupt, so an unreapable group has to be abandoned, not waited on.
+        """
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.poll.return_value = None
+        proc.stdout = BytesIO(b'{"10.0.0.0/24": zzz')
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.terminate_vtysh_process_group', return_value=False):
+            assert route_check.fetch_routes() == ([], [])
+
+        proc.wait.assert_not_called()

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -361,10 +361,12 @@ class TestRouteCheck(object):
 
 
 # fetch_routes runs "sudo vtysh", and /usr/bin/vtysh is a wrapper that runs
-# "docker exec -i bgp vtysh ...". Killing only the direct child leaves that
-# docker exec client behind, holding an exec session the bgp container can
-# never be stopped with. The fakes below reproduce that shape without docker:
-# the process that floods the pipe is a grandchild, not the direct child.
+# "docker exec -i bgp vtysh ...". The process holding the exec session into
+# the bgp container is a grandchild of what Popen returns, and it is the one
+# left blocked in write() when a parse is abandoned - out of reach of
+# proc.kill(), but not of closing the read end. The fakes below reproduce
+# that shape without docker: the process that floods the pipe is a
+# grandchild, not the direct child.
 GOOD_ROUTES = {
     "10.0.0.0/24": [{"protocol": "bgp", "vrfName": "default", "selected": True, "offloaded": False}],
     "10.0.1.0/24": [{"protocol": "bgp", "vrfName": "default", "selected": True,
@@ -413,14 +415,27 @@ def _wait_until_gone(pid, timeout=10):
     return _wait_until(lambda: not _pid_running(pid), timeout)
 
 
+def _pid_exists(pid):
+    """True while pid is in the process table at all, zombies included.
+
+    _pid_running() deliberately forgives a zombie, so it cannot see a child
+    that died but was never reaped. This one can.
+    """
+    return os.path.exists('/proc/{}'.format(pid))
+
+
+def _wait_until_reaped(pid, timeout=10):
+    return _wait_until(lambda: not _pid_exists(pid), timeout)
+
+
 @pytest.mark.skipif(not _proc_readable(),
-                    reason="needs a readable /proc to prove the group is gone")
-class TestFetchRoutesProcessGroup(object):
+                    reason="needs a readable /proc to prove the chain is gone")
+class TestFetchRoutesCleanup(object):
     """fetch_routes must never leave the vtysh / docker exec chain behind."""
 
     @staticmethod
     def _fake_popen(fake_cmd, captured):
-        """Run fake_cmd instead of vtysh, keeping real process-group semantics."""
+        """Run fake_cmd instead of vtysh, keeping real pipe semantics."""
         real_popen = subprocess.Popen
 
         def _popen(cmd, **kwargs):
@@ -434,11 +449,12 @@ class TestFetchRoutesProcessGroup(object):
     def _flooding_cmd(pidfile):
         """A three level chain whose deepest process floods the pipe.
 
-        The grandchild records its own pid before emitting anything, so the
-        file is always in place by the time the parse fails and cleanup runs.
-        Writing it from the parent after the fork loses that race: the parse
-        can fail and the group be signalled before the parent gets to write.
-        exec keeps the pid, so it identifies the flooding process too.
+        The grandchild is the stand-in for the docker exec client: it is the
+        one blocked in write(), and closing the read end is what has to reach
+        it. It records its own pid before emitting anything, so the file is
+        always in place by the time the parse fails and cleanup runs. Writing
+        it from the parent after the fork loses that race. exec keeps the pid,
+        so it identifies the flooding process too.
         """
         tmp = shlex.quote(str(pidfile) + '.tmp')
         final = shlex.quote(str(pidfile))
@@ -447,21 +463,28 @@ class TestFetchRoutesProcessGroup(object):
         return ['sh', '-c', 'sh -c ' + shlex.quote(inner) + ' & wait']
 
     @staticmethod
-    def _live_cmd():
-        """Emits a JSON object then stays alive, so cleanup has something to kill.
+    def _writer_cmd():
+        """Emits a JSON object then keeps writing, like vtysh with more to send.
 
-        A command that exits immediately makes proc.poll() non-None by the time
-        the finally runs, and the cleanup assertions become scheduling-dependent.
+        It has to keep writing: closing the read end only releases a process
+        that goes on to write. A sleeper would sit there untouched until the
+        bounded wait expired, which is a different code path.
         """
-        return ['sh', '-c', "printf '%s' '{}'; exec sleep 30"]
+        return ['sh', '-c', "printf '%s' '{}'; exec yes " + FLOOD_MARKER]
 
     @staticmethod
-    def _reap_group(pid):
-        """Best effort cleanup so a failing assertion does not leak the chain."""
-        try:
-            os.killpg(pid, signal.SIGKILL)
-        except OSError:
-            pass
+    def _reap(*pids):
+        """Best effort cleanup so a failing assertion does not leak the chain.
+
+        Never killpg here: fetch_routes no longer starts a new session, so the
+        child shares the test runner's process group and killpg would take the
+        whole test session down with it.
+        """
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (OSError, TypeError):
+                pass
 
     def _run_fetch_routes(self):
         """Call fetch_routes off the main thread so a deadlock fails the test."""
@@ -477,13 +500,14 @@ class TestFetchRoutesProcessGroup(object):
         thread.start()
         thread.join(timeout=FETCH_TIMEOUT_SECONDS)
         assert not thread.is_alive(), \
-            "fetch_routes deadlocked: the vtysh process group was not terminated"
+            "fetch_routes deadlocked: the read end was not closed before waiting"
         return outcome
 
-    def test_terminates_whole_process_group_on_parse_error(self, tmp_path):
-        """The regression guard: without the group kill this deadlocks."""
+    def test_releases_whole_process_chain_on_parse_error(self, tmp_path):
+        """The regression guard: with wait() before close() this deadlocks."""
         pidfile = tmp_path / 'grandchild.pid'
         captured = {}
+        grandchild = None
         cmd = self._flooding_cmd(pidfile)
         try:
             with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)):
@@ -493,81 +517,110 @@ class TestFetchRoutesProcessGroup(object):
             assert 'exc' not in outcome, outcome.get('exc')
             assert outcome['result'] == ([], [])
 
-            # The grandchild is the stand-in for the docker exec client: it is
-            # what proc.kill() would have missed, so it is what has to be gone.
+            # The grandchild is two levels below the process Popen returned, so
+            # proc.kill() would never have reached it. Closing the read end does.
             assert _wait_until(pidfile.exists), "the fake chain never recorded its grandchild"
             grandchild = int(pidfile.read_text().strip())
             assert _wait_until_gone(grandchild), \
-                "grandchild {} survived: only the direct child was killed".format(grandchild)
+                "grandchild {} survived: the chain was not released".format(grandchild)
         finally:
-            if 'pid' in captured:
-                self._reap_group(captured['pid'])
+            self._reap(captured.get('pid'), grandchild)
+
+    def test_stdout_is_closed_before_wait(self):
+        """The whole deadlock was wait() running before the read end was closed.
+
+        Ordering is the fix. Closing afterwards is what the context manager did
+        on its own, and it never got there because wait() blocked first.
+        """
+        events = []
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.stdout.close.side_effect = lambda: events.append('close')
+        proc.wait.side_effect = lambda **kwargs: (events.append('wait'), 0)[1]
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.ijson.kvitems', side_effect=ValueError('boom')):
+            assert route_check.fetch_routes() == ([], [])
+
+        assert events == ['close', 'wait'], \
+            "the read end must be closed before vtysh is waited on"
 
     @pytest.mark.parametrize("error", [
         UnicodeDecodeError('utf-8', b'\xff', 0, 1, 'invalid start byte'),
         ValueError('something unexpected'),
     ])
     def test_other_parse_errors_take_the_same_cleanup_path(self, error):
-        """Every branch that abandons the read has to terminate the group."""
+        """Every branch that abandons the read has to release the chain."""
         captured = {}
         try:
             with patch('route_check.subprocess.Popen',
-                       side_effect=self._fake_popen(self._live_cmd(), captured)), \
-                    patch('route_check.ijson.kvitems', side_effect=error), \
-                    patch('route_check.KILL_WAIT_SECONDS', 0.3), \
-                    patch('route_check.os.killpg') as mock_killpg:
+                       side_effect=self._fake_popen(self._writer_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=error):
                 outcome = self._run_fetch_routes()
 
             assert 'exc' not in outcome, outcome.get('exc')
             assert outcome['result'] == ([], [])
-            mock_killpg.assert_called_once_with(captured['pid'], signal.SIGKILL)
+            assert _wait_until_gone(captured['pid']), \
+                "vtysh stand-in survived a {}".format(type(error).__name__)
         finally:
-            if 'pid' in captured:
-                self._reap_group(captured['pid'])
+            self._reap(captured.get('pid'))
 
     def test_cleanup_runs_for_non_exception_interrupts(self):
-        """KeyboardInterrupt is not an Exception, so a flag would miss it.
-
-        start_new_session also means a terminal SIGINT no longer reaches the
-        chain on its own, so this is the only thing releasing the exec session.
-        """
+        """KeyboardInterrupt is not an Exception, so a flag would miss it."""
         captured = {}
         try:
             with patch('route_check.subprocess.Popen',
-                       side_effect=self._fake_popen(self._live_cmd(), captured)), \
-                    patch('route_check.ijson.kvitems', side_effect=KeyboardInterrupt), \
-                    patch('route_check.KILL_WAIT_SECONDS', 0.3), \
-                    patch('route_check.os.killpg') as mock_killpg:
+                       side_effect=self._fake_popen(self._writer_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=KeyboardInterrupt):
                 outcome = self._run_fetch_routes()
 
             assert isinstance(outcome.get('exc'), KeyboardInterrupt), \
                 "KeyboardInterrupt must still propagate"
-            mock_killpg.assert_called_once_with(captured['pid'], signal.SIGKILL)
+            assert _wait_until_gone(captured['pid']), \
+                "the chain outlived a KeyboardInterrupt"
+            assert _wait_until_reaped(captured['pid']), \
+                "child {} left unreaped: the bounded wait was skipped".format(captured['pid'])
         finally:
-            if 'pid' in captured:
-                self._reap_group(captured['pid'])
+            self._reap(captured.get('pid'))
 
-    def test_clean_parse_does_not_kill_a_healthy_group(self):
-        """A finished read must not SIGKILL vtysh on its way out.
+    def test_child_is_reaped_when_keyboard_interrupt_propagates(self):
+        """An interrupt must not skip the wait and leave the child a zombie.
 
-        On a clean parse poll() has often not reaped vtysh yet, so a cleanup
-        gated on liveness alone would kill a healthy group and mask its exit
-        code.
+        KeyboardInterrupt is not an Exception, so it leaves the parse through
+        the finally and would skip anything placed after it. The process level
+        test above cannot see the difference on its own, because _pid_running()
+        reports a zombie as gone.
         """
+        events = []
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.stdout.close.side_effect = lambda: events.append('close')
+        proc.wait.side_effect = lambda **kwargs: (events.append('wait'), 0)[1]
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.ijson.kvitems', side_effect=KeyboardInterrupt), \
+                pytest.raises(KeyboardInterrupt):
+            route_check.fetch_routes()
+
+        assert events == ['close', 'wait'], \
+            "the interrupt must not skip closing the pipe and reaping the child"
+
+    def test_clean_parse_returns_parsed_routes(self):
+        """The happy path must be untouched by the cleanup change."""
         captured = {}
         cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES))]
         with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
-                patch('route_check.os.killpg') as mock_killpg:
+                patch('route_check.print_message') as mock_msg:
             outcome = self._run_fetch_routes()
 
         assert 'exc' not in outcome, outcome.get('exc')
         missing, failing = outcome['result']
         assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
         assert failing == ['10.0.1.0/24']
-        mock_killpg.assert_not_called()
+        assert not any('non-zero return code' in str(c) for c in mock_msg.call_args_list)
 
-    def test_non_zero_exit_is_reported_when_we_did_not_kill(self):
-        """A real vtysh failure must survive the SIGKILL suppression."""
+    def test_non_zero_exit_is_reported_after_a_clean_parse(self):
+        """A real vtysh failure must survive the SIGPIPE suppression."""
         captured = {}
         cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES)) + "; exit 3"]
         with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
@@ -579,12 +632,16 @@ class TestFetchRoutesProcessGroup(object):
         assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
         assert any('non-zero return code: 3' in str(c) for c in mock_msg.call_args_list)
 
-    def test_self_sent_sigkill_is_not_reported_as_a_crash(self):
-        """-9 from our own cleanup must not read as a vtysh crash."""
+    def test_sigpipe_from_our_own_close_is_not_reported_as_a_crash(self):
+        """Closing the read end kills vtysh with SIGPIPE; sudo reports 141.
+
+        That exit code is this function's own doing, so reporting it would send
+        a misleading warning to syslog on every parse failure.
+        """
         captured = {}
         try:
             with patch('route_check.subprocess.Popen',
-                       side_effect=self._fake_popen(self._live_cmd(), captured)), \
+                       side_effect=self._fake_popen(self._writer_cmd(), captured)), \
                     patch('route_check.ijson.kvitems', side_effect=ValueError('boom')), \
                     patch('route_check.print_message') as mock_msg:
                 outcome = self._run_fetch_routes()
@@ -592,22 +649,20 @@ class TestFetchRoutesProcessGroup(object):
             assert 'exc' not in outcome, outcome.get('exc')
             assert not any('non-zero return code' in str(c) for c in mock_msg.call_args_list)
         finally:
-            if 'pid' in captured:
-                self._reap_group(captured['pid'])
+            self._reap(captured.get('pid'))
 
-    def test_lingering_process_after_clean_parse_is_abandoned(self):
-        """A clean parse whose process never exits must not block forever.
+    def test_process_that_never_exits_is_killed_then_abandoned(self):
+        """Closing only releases a writer; one hung without writing needs the signal.
 
-        Nothing killed it, so the group cleanup does not run and the only
-        thing standing between fetch_routes and a permanent hang is the
-        bounded wait plus its early return.
+        Walking away would leak a child on every timeout, and route_check runs
+        on a timer. It still must not block: fetch_routes runs on a worker
+        thread the SIGALRM watchdog cannot interrupt, so both waits are bounded.
         """
         proc = MagicMock()
         proc.pid = 424242
-        proc.poll.return_value = 0
         proc.stdout = BytesIO(json.dumps(GOOD_ROUTES).encode())
         proc.wait.side_effect = subprocess.TimeoutExpired(
-            cmd='vtysh', timeout=route_check.KILL_WAIT_SECONDS)
+            cmd='vtysh', timeout=route_check.VTYSH_EXIT_TIMEOUT_SECONDS)
 
         with patch('route_check.subprocess.Popen', return_value=proc), \
                 patch('route_check.print_message') as mock_msg:
@@ -616,7 +671,34 @@ class TestFetchRoutesProcessGroup(object):
         # Whatever was parsed before the hang still comes back.
         assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
         assert failing == ['10.0.1.0/24']
-        assert any('did not exit; abandoning' in str(c) for c in mock_msg.call_args_list)
+        proc.kill.assert_called_once_with()
+        assert any('did not exit; killing the direct child' in str(c)
+                   for c in mock_msg.call_args_list)
+        assert any('survived SIGKILL' in str(c) for c in mock_msg.call_args_list)
+
+    def test_kill_after_timeout_reaps_without_reporting_a_crash(self):
+        """The -9 from our own SIGKILL must not surface as a vtysh failure.
+
+        A real non-zero exit still has to be reported, so the suppression has
+        to come from not recording our own exit code rather than from a blanket
+        rule.
+        """
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.stdout = BytesIO(json.dumps(GOOD_ROUTES).encode())
+        proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd='vtysh', timeout=route_check.VTYSH_EXIT_TIMEOUT_SECONDS),
+            -9,
+        ]
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.print_message') as mock_msg:
+            missing, failing = route_check.fetch_routes()
+
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        proc.kill.assert_called_once_with()
+        assert not any('survived SIGKILL' in str(c) for c in mock_msg.call_args_list)
+        assert not any('non-zero return code' in str(c) for c in mock_msg.call_args_list)
 
     def test_unexpected_route_entry_format_is_reported(self):
         """FRR should never emit this, but the guard must still be exercised."""
@@ -631,81 +713,15 @@ class TestFetchRoutesProcessGroup(object):
         assert outcome['result'] == ([], [])
         assert any('Unexpected route entry format' in str(c) for c in mock_msg.call_args_list)
 
-    def test_starts_new_session(self):
-        """killpg(proc.pid) is only safe because the child leads its own group."""
+    def test_does_not_start_a_new_session(self):
+        """Nothing needs the child detached now that cleanup is a close().
+
+        Leaving it in our session keeps a terminal SIGINT reaching vtysh on its
+        own, and keeps the test helpers from having to reason about groups.
+        """
         captured = {}
         cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES))]
         with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)):
             self._run_fetch_routes()
 
-        assert captured['kwargs'].get('start_new_session') is True
-
-    def test_terminate_signals_child_pid_not_our_own_group(self):
-        """Guard against 'simplifying' proc.pid into os.getpgid(proc.pid)."""
-        proc = MagicMock()
-        proc.pid = 424242
-        proc.wait.return_value = 0
-
-        with patch('route_check.os.killpg') as mock_killpg:
-            assert route_check.terminate_vtysh_process_group(proc) is True
-
-        mock_killpg.assert_called_once_with(proc.pid, signal.SIGKILL)
-        proc.wait.assert_called_once_with(timeout=route_check.KILL_WAIT_SECONDS)
-
-    def test_terminate_tolerates_already_dead_group(self):
-        proc = MagicMock()
-        proc.pid = 424242
-        proc.wait.return_value = 0
-
-        with patch('route_check.os.killpg', side_effect=ProcessLookupError), \
-                patch('route_check.print_message') as mock_msg:
-            assert route_check.terminate_vtysh_process_group(proc) is True
-
-        proc.wait.assert_called_once_with(timeout=route_check.KILL_WAIT_SECONDS)
-        # A failed killpg is the only early signal that this fix did not take
-        # effect, so it has to clear the default report level. Keep it visible.
-        assert any(c.args[0] == syslog.LOG_WARNING and 'Could not signal process group' in str(c)
-                   for c in mock_msg.call_args_list)
-
-    def test_terminate_does_not_swallow_programming_errors(self):
-        """A bad pid is a bug, not a cleanup failure - it must not be hidden.
-
-        A catch-all here silently turns os.killpg(<Mock>) into a no-op, which
-        makes callers that pass a mocked proc look like they exercise this path
-        when they do not.
-        """
-        proc = MagicMock()
-        proc.pid = object()
-
-        with pytest.raises(TypeError):
-            route_check.terminate_vtysh_process_group(proc)
-
-    def test_terminate_reports_survivor_instead_of_raising(self):
-        """A process stuck in D state must not mask the parse error."""
-        proc = MagicMock()
-        proc.pid = 424242
-        proc.wait.side_effect = subprocess.TimeoutExpired(
-            cmd='vtysh', timeout=route_check.KILL_WAIT_SECONDS)
-
-        with patch('route_check.os.killpg'), \
-                patch('route_check.print_message') as mock_msg:
-            assert route_check.terminate_vtysh_process_group(proc) is False
-
-        assert any('still alive after SIGKILL' in str(c) for c in mock_msg.call_args_list)
-
-    def test_unreapable_group_is_abandoned_not_waited_on(self):
-        """The bounded wait is pointless if the next line waits unbounded.
-
-        fetch_routes runs on a worker thread the SIGALRM watchdog cannot
-        interrupt, so an unreapable group has to be abandoned, not waited on.
-        """
-        proc = MagicMock()
-        proc.pid = 424242
-        proc.poll.return_value = None
-        proc.stdout = BytesIO(b'{"10.0.0.0/24": zzz')
-
-        with patch('route_check.subprocess.Popen', return_value=proc), \
-                patch('route_check.terminate_vtysh_process_group', return_value=False):
-            assert route_check.fetch_routes() == ([], [])
-
-        proc.wait.assert_not_called()
+        assert 'start_new_session' not in captured['kwargs']


### PR DESCRIPTION
#### What I did

Made `fetch_routes()` terminate the entire `vtysh` process group when the streaming JSON parse fails, instead of logging a warning and calling `proc.wait()` on a child it never drained.

`fetch_routes` runs `sudo vtysh -c "show ip route json"`. On a SONiC host `/usr/bin/vtysh` is a wrapper script that runs `docker exec -i bgp vtysh ...`, so the process actually holding the exec session into the bgp container sits two levels below the child `Popen` returns:

```
sudo                              <- Popen's direct child
  └─ /bin/bash /usr/bin/vtysh     <- wrapper
       └─ docker exec -i bgp vtysh -c "show ip route json"
            ┊ containerd-shim
            └─ vtysh (in container)   <- blocked in write()
```

When the parse raised, the read was abandoned while `vtysh` still had megabytes queued. On a route table larger than the 64KB pipe buffer the in-container `vtysh` stays blocked in `write()`, so `proc.wait()` never returns and the exec session is never released. From that point the bgp container can no longer be stopped, and every later `docker exec` into it fails in `setns`:

```
OCI runtime exec failed: exec failed: unable to start container process:
error starting setns process: fork/exec /proc/self/fd/6: no such file or directory
```

`docker ps` still reports the container as `Up`, so this presents as a healthy container that nothing can talk to.

The exposure was introduced when `fetch_routes` moved from a single full read to a streaming parse. Until then it was `subprocess.check_output(cmd, text=True)` followed by `json.loads(output)`: stdout is drained to EOF before anything is parsed, so a parse error is raised after the child has already exited, and there is no state in which the reader stops while the writer still has data queued. Streaming with `ijson` made that state reachable — any exception leaving the `ijson.kvitems` loop ends the read for good, while `vtysh` may still have megabytes to write into a 64KB pipe, so it blocks deterministically rather than as a race.

#### How I did it

- `subprocess.Popen(..., start_new_session=True)`, so the child leads its own process group and the wrapper plus the `docker exec` client inherit it. This also isolates the concurrent IPv4 and IPv6 fetches from each other and from route_check's own process group.
- New `terminate_vtysh_process_group()` helper that does `os.killpg(proc.pid, SIGKILL)` and reaps with a bounded `wait()`. Signalling is best effort: a cleanup failure must never mask the error that got us there. It is reported at `WARNING` rather than `DEBUG` because a failed `killpg` is the only early signal that this cleanup did not take effect, and the default report level hides `DEBUG`.
- On any parse failure the helper runs before `proc.wait()`, which is what releases the exec session.

Error handling is otherwise untouched: parse failures, a missing command and unexpected errors are still logged and swallowed, and `fetch_routes` still returns whatever it managed to parse. This PR changes cleanup only.

One thing worth calling out for review: the helper deliberately passes `proc.pid` rather than `os.getpgid(proc.pid)`. It is only correct because `start_new_session=True` makes pgid == pid; deriving the group would target route_check's *own* group if the session was ever not created. There is a unit test guarding this.

Killing only the direct child — `proc.kill()` — does not fix this. `SIGKILL` cannot be propagated by `sudo`, so the wrapper and the `docker exec` client are orphaned and keep the exec session open. Measured on a switch with a 6.7MB route table, six concurrent abandoned parses, with the container-recreate workaround removed so the container ID is reused on restart:

| route_check behaviour | sudo | wrapper | docker exec client | in-container vtysh | container stop | result |
|---|---|---|---|---|---|---|
| no kill (before this change) | alive | alive | alive | alive | 15s + 15s timeouts | every later `docker exec` hangs |
| `proc.kill()` | dead | **alive** | **alive** | **alive** | 15s + 15s timeouts | every later `docker exec` hangs |
| `os.killpg(SIGKILL)` (this change) | dead | dead | dead | **dead** | **clean, no timeouts** | healthy |

Note that the in-container `vtysh` is reaped indirectly: killing the host-side `docker exec` client drops the attach, the daemon closes the exec stdout stream, and the in-container process gets `EPIPE`. The container-side process is not in the signalled group.

#### How to verify it

Unit tests:

```
pytest tests/route_check_test.py -k TestFetchRoutes -v
```

`test_terminates_whole_process_group_on_parse_error` is the regression guard. It builds a three level process chain whose *grandchild* floods the pipe — the stand-in for the `docker exec` client — feeds `fetch_routes` truncated JSON, and asserts the call still returns `([], [])` while the grandchild is gone and the group no longer exists. Against the previous code it does not fail fast, it deadlocks: the call is made on a worker thread so the hang is reported as a failure after 60s instead of stalling the run.

On a switch, with the container-recreate workaround removed from `bgp.sh` so the container ID is reused:

1. Wait for BGP to converge to a route table well over 64KB (a few MB makes it deterministic).
2. Drive six concurrent `fetch_routes()` calls with `ijson.kvitems` patched to consume a chunk, wait long enough for the pipe to fill, then raise.
3. Before the kill, confirm the chain really formed: six `docker exec -i bgp vtysh` clients on the host and six in-container `vtysh` processes with `wchan == pipe_write`.
4. After the kill, all of those counts must be zero.
5. `systemctl restart bgp`, then confirm the journal has no `Container failed to exit within ...` lines and that a burst of parallel `docker exec bgp true` all succeed.

Result of that run: preconditions met (6/6 and 6/6 before the kill), everything reaped afterwards, container stop clean with zero timeout messages even though the container ID was reused, and 240/240 parallel `docker exec` returned 0. A normal `route_check.py -m DEBUG` run against the same 6.7MB table completed with exit 0 and empty missing/failing lists.


