### PR TITLE
Implement BMC Firmware Update in sonic-utilities

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -6,6 +6,7 @@
 
 try:
     import glob
+    import inspect
     import os
     import json
     import shutil
@@ -152,6 +153,30 @@ class URL(object):
     url = property(fget=get_url)
 
 
+def supports_force_update(update_callable):
+    """Return True if ``update_callable`` accepts a ``force_update`` argument.
+
+    Support is determined from the callable's signature *before* invocation, so
+    a ``TypeError`` raised from inside a firmware install/update (a genuine bug,
+    or an error after the transfer has already started) is never misread as
+    "force-update unsupported" and silently retried without it. The keyword is
+    omitted only when it is definitively unsupported; otherwise the caller
+    invokes with ``force_update`` and lets any exception propagate.
+    """
+    try:
+        sig = inspect.signature(update_callable)
+    except (TypeError, ValueError):
+        # C-implemented / builtin callables may not expose a signature;
+        # treat as not supporting the explicit force_update kwarg.
+        return False
+    for param in sig.parameters.values():
+        if param.name == "force_update":
+            return True
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
+
+
 class PlatformDataProvider(object):
     """
     PlatformDataProvider
@@ -201,7 +226,13 @@ class PlatformDataProvider(object):
         return self.__chassis.is_smartswitch()
 
     def is_modular_chassis(self):
-        return len(self.module_component_map) > 0
+        # A chassis is modular (for firmware purposes) only if at least one
+        # module actually exposes firmware components. Merely having modules in
+        # the map is not enough: platforms may expose non-firmware modules
+        # (e.g. the NVIDIA AST2700 BMC exposes a component-less SWITCH-HOST
+        # module), and those must not force a "module" section in
+        # platform_components.json on an otherwise non-modular device.
+        return any(self.module_component_map.values())
 
     def is_chassis_has_components(self):
         return self.__chassis.get_num_components() > 0
@@ -593,11 +624,19 @@ class ComponentUpdateProvider(PlatformDataProvider):
             pcp.chassis_component_map
         )
 
-        self.__validate_component_map(
-            self.SECTION_MODULE,
-            self.module_component_map,
-            pcp.module_component_map
-        )
+        # For a non-modular chassis the parser does not read a "module" section
+        # (see parse_platform_components), so pcp.module_component_map is empty,
+        # while the data provider may still report component-less modules (e.g.
+        # the NVIDIA AST2700 BMC's SWITCH-HOST). Comparing the two would raise a
+        # spurious "module names mismatch", so only validate the module map when
+        # the chassis is actually modular. SmartSwitch keeps its existing
+        # per-mismatch handling inside __validate_component_map.
+        if self.is_modular_chassis():
+            self.__validate_component_map(
+                self.SECTION_MODULE,
+                self.module_component_map,
+                pcp.module_component_map
+            )
 
     def get_updates_status(self):
         status_table = [ ]
@@ -772,7 +811,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
         return component.get_firmware_update_notification(firmware_path)
 
-    def update_firmware(self, chassis_name, module_name, component_name):
+    def update_firmware(self, chassis_name, module_name, component_name, *, force_update=False):
         if module_name is not None:
             component = self.module_component_map[module_name][component_name]
             parser = self.__pcp.module_component_map[module_name][component_name]
@@ -796,7 +835,14 @@ class ComponentUpdateProvider(PlatformDataProvider):
             click.echo("Updating firmware:")
             click.echo(TAB + firmware_path)
             log_helper.log_fw_update_start(component_path, firmware_path)
-            component.update_firmware(firmware_path)
+            if force_update and supports_force_update(component.update_firmware):
+                component.update_firmware(firmware_path, force_update=True)
+            else:
+                if force_update:
+                    log_helper.print_warning(
+                        "Component does not support --force-update; continuing without it"
+                    )
+                component.update_firmware(firmware_path)
             log_helper.log_fw_update_end(component_path, firmware_path, True)
         except KeyboardInterrupt:
             log_helper.log_fw_update_end(component_path, firmware_path, False, "Keyboard interrupt")

--- a/fwutil/main.py
+++ b/fwutil/main.py
@@ -10,7 +10,7 @@ try:
     import click
 
     from .lib import PlatformDataProvider, ComponentStatusProvider, ComponentUpdateProvider
-    from .lib import URL, SquashFs, FWPackage
+    from .lib import URL, SquashFs, FWPackage, supports_force_update
     from .log import LogHelper
 except ImportError as e:
     raise ImportError("Required module not found: {}".format(str(e)))
@@ -171,6 +171,23 @@ def component_handler(ctx, component_name):
     ctx.obj[COMPONENT_PATH_CTX_KEY].append(component_name)
 
 
+def _invoke_install_firmware(component, fw_path, *, force_update=False) -> bool:
+    """Call install_firmware, passing force_update only when it is supported.
+
+    Support is detected from install_firmware's signature before invocation. A
+    TypeError raised from inside install_firmware is therefore never masked or
+    retried (which could re-run a firmware install that already started) - it
+    propagates to the caller.
+    """
+    if force_update and supports_force_update(component.install_firmware):
+        return component.install_firmware(fw_path, force_update=True)
+    if force_update:
+        log_helper.print_warning(
+            "Component does not support --force-update; continuing without it"
+        )
+    return component.install_firmware(fw_path)
+
+
 def validate_component(ctx, param, value):
     pdp = get_pdp()
     if value == HELP:
@@ -209,7 +226,7 @@ def component_update(ctx, component_name):
     component_handler(ctx, component_name)
 
 
-def install_fw(ctx, fw_path):
+def install_fw(ctx, fw_path, *, force_update=False):
     component = ctx.obj[COMPONENT_CTX_KEY]
     component_path = PATH_SEPARATOR.join(ctx.obj[COMPONENT_PATH_CTX_KEY])
 
@@ -219,7 +236,7 @@ def install_fw(ctx, fw_path):
         click.echo("Installing firmware:")
         click.echo(TAB + fw_path)
         log_helper.log_fw_install_start(component_path, fw_path)
-        status = component.install_firmware(fw_path)
+        status = _invoke_install_firmware(component, fw_path, force_update=force_update)
         log_helper.log_fw_install_end(component_path, fw_path, status)
     except KeyboardInterrupt:
         log_helper.log_fw_install_end(component_path, fw_path, False, "Keyboard interrupt")
@@ -271,9 +288,10 @@ def validate_fw(ctx, param, value):
 # 'fw' subcommand
 @component_install.command(name='fw')
 @click.option('-y', '--yes', 'yes', is_flag=True, show_default=True, help="Assume \"yes\" as answer to all prompts and run non-interactively")
+@click.option('--force-update', 'force_update', is_flag=True, show_default=True, help="Pass --force-update to the component update backend (e.g. PLDM Force Update)")
 @click.argument('fw_path', metavar='<fw_path>', callback=validate_fw)
 @click.pass_context
-def fw_install(ctx, yes, fw_path):
+def fw_install(ctx, yes, force_update, fw_path):
     """Install firmware from local path or URL"""
     url = None
 
@@ -291,7 +309,7 @@ def fw_install(ctx, yes, fw_path):
         if not yes:
             click.confirm("New firmware will be installed, continue?", abort=True)
 
-        install_fw(ctx, fw_path)
+        install_fw(ctx, fw_path, force_update=force_update)
     finally:
         if url is not None and os.path.exists(fw_path):
             os.remove(fw_path)
@@ -301,9 +319,10 @@ def fw_install(ctx, yes, fw_path):
 @component_update.command(name='fw')
 @click.option('-y', '--yes', 'yes', is_flag=True, show_default=True, help="Assume \"yes\" as answer to all prompts and run non-interactively")
 @click.option('-f', '--force', 'force', is_flag=True, show_default=True, help="Update firmware regardless the current version")
+@click.option('--force-update', 'force_update', is_flag=True, show_default=True, help="Pass --force-update to the component update backend (e.g. PLDM Force Update)")
 @click.option('-i', '--image', 'image', type=click.Choice(["current", "next"]), default="current", show_default=True, help="Update firmware using current/next SONiC image")
 @click.pass_context
-def fw_update(ctx, yes, force, image):
+def fw_update(ctx, yes, force, force_update, image):
     """Update firmware from SONiC image"""
     if CHASSIS_NAME_CTX_KEY in ctx.obj:
         chassis_name = ctx.obj[CHASSIS_NAME_CTX_KEY]
@@ -344,7 +363,7 @@ def fw_update(ctx, yes, force, image):
             if not yes:
                 click.confirm("New firmware will be installed, continue?", abort=True)
 
-            cup.update_firmware(chassis_name, module_name, component_name)
+            cup.update_firmware(chassis_name, module_name, component_name, force_update=force_update)
         finally:
             if squashfs is not None:
                 squashfs.umount_next_image_fs()

--- a/fwutil/main.py
+++ b/fwutil/main.py
@@ -288,7 +288,8 @@ def validate_fw(ctx, param, value):
 # 'fw' subcommand
 @component_install.command(name='fw')
 @click.option('-y', '--yes', 'yes', is_flag=True, show_default=True, help="Assume \"yes\" as answer to all prompts and run non-interactively")
-@click.option('--force-update', 'force_update', is_flag=True, show_default=True, help="Pass --force-update to the component update backend (e.g. PLDM Force Update)")
+@click.option('--force-update', 'force_update', is_flag=True, show_default=True,
+              help="Pass --force-update to the component update backend (e.g. PLDM Force Update)")
 @click.argument('fw_path', metavar='<fw_path>', callback=validate_fw)
 @click.pass_context
 def fw_install(ctx, yes, force_update, fw_path):
@@ -319,7 +320,8 @@ def fw_install(ctx, yes, force_update, fw_path):
 @component_update.command(name='fw')
 @click.option('-y', '--yes', 'yes', is_flag=True, show_default=True, help="Assume \"yes\" as answer to all prompts and run non-interactively")
 @click.option('-f', '--force', 'force', is_flag=True, show_default=True, help="Update firmware regardless the current version")
-@click.option('--force-update', 'force_update', is_flag=True, show_default=True, help="Pass --force-update to the component update backend (e.g. PLDM Force Update)")
+@click.option('--force-update', 'force_update', is_flag=True, show_default=True,
+              help="Pass --force-update to the component update backend (e.g. PLDM Force Update)")
 @click.option('-i', '--image', 'image', type=click.Choice(["current", "next"]), default="current", show_default=True, help="Update firmware using current/next SONiC image")
 @click.pass_context
 def fw_update(ctx, yes, force, force_update, image):

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2255,6 +2255,11 @@ echo CT_TABLE_DUMP_ENABLE=true >> "$profile"
 ###############################################################################
 collect_nvidia_bmc_dump() {
     trap 'handle_error $? $LINENO' ERR
+    # BMC component firmware versions (BMC image, etc.). Captured before the
+    # hw-management dump so they are collected even if that script is absent or
+    # times out. save_cmd tolerates fwutil failures without aborting the dump.
+    save_cmd "fwutil show status"  "fwutil.status"
+    save_cmd "fwutil show version" "fwutil.version"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local HW_BMC_DUMP_FILE=/usr/bin/hw-management-bmc-generate-dump.sh
 

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -11,6 +11,42 @@ sys.modules['sonic_platform'] = MagicMock()
 sys.modules['sonic_platform.platform'] = MagicMock()
 import fwutil.lib as fwutil_lib
 
+
+def make_fw_double(method_name, *, supports_force, raises_type_error=False,
+                   return_value=None):
+    """Build a firmware component test double for install/update tests.
+
+    Returns an object exposing a single ``method_name`` (``install_firmware`` or
+    ``update_firmware``) that appends every call to ``.calls`` and then returns
+    ``return_value`` (or raises ``TypeError`` when ``raises_type_error``).
+
+    ``force_update`` support is expressed through the method's *real* signature so
+    ``supports_force_update`` (which inspects the signature) sees it correctly:
+    when ``supports_force`` the method takes ``force_update=False`` and records
+    ``(path, force_update)``; otherwise it takes only ``path`` and records
+    ``(path,)``. A ``**kwargs``-style shortcut is deliberately avoided because it
+    would be misdetected as force-update-capable.
+    """
+    calls = []
+
+    if supports_force:
+        def method(self, path, force_update=False):
+            calls.append((path, force_update))
+            if raises_type_error:
+                raise TypeError("backend boom")
+            return return_value
+    else:
+        def method(self, path):
+            calls.append((path,))
+            if raises_type_error:
+                raise TypeError("backend boom")
+            return return_value
+
+    double = type("_FwDouble", (), {method_name: method})()
+    double.calls = calls
+    return double
+
+
 class TestSquashFs(object):
     def setup_method(self):
         print('SETUP')
@@ -156,11 +192,17 @@ class TestComponentUpdateProvider(object):
     @patch('fwutil.lib.ComponentUpdateProvider._ComponentUpdateProvider__validate_platform_schema')
     @patch('os.mkdir')
     def test_regular_modular_chassis_parsing(self, mock_mkdir, mock_validate, mock_parser_class, mock_platform_class):
-        """Test that regular modular chassis is treated as modular for parsing"""
-        # Setup mock chassis that is not SmartSwitch but has modules
+        """Test that a chassis with module firmware components is treated as modular"""
+        # Setup mock chassis that is not SmartSwitch and has a module that
+        # actually exposes firmware components (a genuine modular chassis).
         mock_chassis = MagicMock()
         mock_chassis.is_smartswitch.return_value = False
-        mock_chassis.get_all_modules.return_value = [MagicMock(), MagicMock()]  # 2 modules
+        mock_component = MagicMock()
+        mock_component.get_name.return_value = "CPLD"
+        mock_module = MagicMock()
+        mock_module.get_name.return_value = "Module1"
+        mock_module.get_all_components.return_value = [mock_component]
+        mock_chassis.get_all_modules.return_value = [mock_module]
 
         # Setup mock platform
         mock_platform = MagicMock()
@@ -177,6 +219,162 @@ class TestComponentUpdateProvider(object):
         # Verify that PlatformComponentsParser was called with is_modular_chassis=True
         # because regular modular chassis should be treated as modular
         mock_parser_class.assert_called_once_with(True)
+
+    @patch('fwutil.lib.Platform')
+    @patch('fwutil.lib.PlatformComponentsParser')
+    @patch('fwutil.lib.ComponentUpdateProvider._ComponentUpdateProvider__validate_platform_schema', MagicMock())
+    @patch('os.mkdir', MagicMock())
+    def test_module_without_components_is_non_modular(self, mock_parser_class, mock_platform_class):
+        """A chassis whose modules expose no firmware components is NOT modular.
+
+        Mirrors the NVIDIA AST2700 BMC, which exposes a component-less
+        SWITCH-HOST module. Such a module must not make fwutil treat the device
+        as modular (which would wrongly require a "module" section in
+        platform_components.json).
+        """
+        mock_chassis = MagicMock()
+        mock_chassis.is_smartswitch.return_value = False
+        mock_module = MagicMock()
+        mock_module.get_name.return_value = "SWITCH-HOST"
+        mock_module.get_all_components.return_value = []  # no firmware components
+        mock_chassis.get_all_modules.return_value = [mock_module]
+
+        mock_platform = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_platform_class.return_value = mock_platform
+        mock_parser_class.return_value = MagicMock()
+
+        fwutil_lib.ComponentUpdateProvider()
+
+        # A component-less module must be treated as non-modular.
+        mock_parser_class.assert_called_once_with(False)
+
+    @patch('fwutil.lib.Platform')
+    @patch('fwutil.lib.PlatformComponentsParser')
+    @patch('fwutil.lib.ComponentUpdateProvider._ComponentUpdateProvider__validate_platform_schema')
+    @patch('os.mkdir')
+    def test_any_module_with_components_is_modular(self, mock_mkdir, mock_validate,
+                                                   mock_parser_class, mock_platform_class):
+        """Covers the any-module-has-components contract.
+
+        A chassis may mix a component-less module (e.g. the BMC's SWITCH-HOST)
+        with a module that does expose firmware components. If *any* module has
+        components the chassis must be treated as modular, so the component-less
+        module alongside it must not suppress modularity.
+        """
+        mock_chassis = MagicMock()
+        mock_chassis.is_smartswitch.return_value = False
+
+        empty_module = MagicMock()
+        empty_module.get_name.return_value = "SWITCH-HOST"
+        empty_module.get_all_components.return_value = []  # no firmware components
+
+        component = MagicMock()
+        component.get_name.return_value = "CPLD"
+        fw_module = MagicMock()
+        fw_module.get_name.return_value = "Module1"
+        fw_module.get_all_components.return_value = [component]
+
+        mock_chassis.get_all_modules.return_value = [empty_module, fw_module]
+
+        mock_platform = MagicMock()
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_platform_class.return_value = mock_platform
+        mock_parser_class.return_value = MagicMock()
+
+        fwutil_lib.ComponentUpdateProvider()
+
+        # Any module with components makes the chassis modular.
+        mock_parser_class.assert_called_once_with(True)
+
+    def test_component_less_module_construction_succeeds(self, tmp_path):
+        """Integration test with REAL schema parsing/validation.
+
+        A chassis that exposes a component-less module (e.g. the NVIDIA AST2700
+        BMC's SWITCH-HOST) together with a platform_components.json that has no
+        'module' section must construct without error. This exercises the real
+        PlatformComponentsParser and __validate_platform_schema (neither is
+        mocked), guarding against the regression where the non-modular chassis
+        still tripped a spurious 'module names mismatch'.
+        """
+        import json
+
+        root = str(tmp_path)
+        platform_components = {
+            "chassis": {
+                "BMC-CHASSIS": {
+                    "component": {}
+                }
+            }
+        }
+        with open(os.path.join(root, "platform_components.json"), "w") as f:
+            json.dump(platform_components, f)
+
+        module = MagicMock()
+        module.get_name.return_value = "SWITCH-HOST"
+        module.get_all_components.return_value = []  # component-less module
+
+        chassis = MagicMock()
+        chassis.is_smartswitch.return_value = False
+        chassis.get_name.return_value = "BMC-CHASSIS"
+        chassis.get_all_components.return_value = []
+        chassis.get_all_modules.return_value = [module]
+
+        # Route the parser at our temp platform_components.json (the FWUPDATE
+        # path branch just joins root + filename) and skip real dir creation.
+        with patch('fwutil.lib.Platform') as platform_cls, \
+             patch('fwutil.lib.FWUPDATE_FWPACKAGE_DIR', root), \
+             patch('os.path.isdir', return_value=True):
+            platform_cls.return_value.get_chassis.return_value = chassis
+            cup = fwutil_lib.ComponentUpdateProvider(root)
+
+        assert cup.is_modular_chassis() is False
+        # The real parser must not have required/parsed a module section for a
+        # non-modular chassis: the parsed schema's module map is empty.
+        pcp = cup._ComponentUpdateProvider__pcp
+        assert pcp.module_component_map == {}
+
+    def test_modular_chassis_missing_module_section_fails(self, tmp_path):
+        """Complement to test_component_less_module_construction_succeeds.
+
+        A genuinely modular chassis (a module exposes firmware components) with
+        the SAME missing 'module' section must FAIL, proving the module-section
+        requirement is enforced conditionally on modularity - not skipped
+        unconditionally. Exercises the real PlatformComponentsParser and
+        __validate_platform_schema paths (neither is mocked).
+        """
+        import json
+
+        root = str(tmp_path)
+        # Identical to the non-modular case: chassis section only, no 'module'.
+        platform_components = {
+            "chassis": {
+                "BMC-CHASSIS": {
+                    "component": {}
+                }
+            }
+        }
+        with open(os.path.join(root, "platform_components.json"), "w") as f:
+            json.dump(platform_components, f)
+
+        component = MagicMock()
+        component.get_name.return_value = "CPLD"
+        module = MagicMock()
+        module.get_name.return_value = "Module1"
+        module.get_all_components.return_value = [component]  # modular chassis
+
+        chassis = MagicMock()
+        chassis.is_smartswitch.return_value = False
+        chassis.get_name.return_value = "BMC-CHASSIS"
+        chassis.get_all_components.return_value = []
+        chassis.get_all_modules.return_value = [module]
+
+        with patch('fwutil.lib.Platform') as platform_cls, \
+             patch('fwutil.lib.FWUPDATE_FWPACKAGE_DIR', root), \
+             patch('os.path.isdir', return_value=True):
+            platform_cls.return_value.get_chassis.return_value = chassis
+            with pytest.raises(RuntimeError, match="module"):
+                fwutil_lib.ComponentUpdateProvider(root)
 
     @patch('fwutil.lib.Platform')
     @patch('fwutil.lib.PlatformComponentsParser')
@@ -334,6 +532,67 @@ class TestFwutilMain(object):
         assert result == "Comp1"
         assert ctx.obj[fw_main.COMPONENT_CTX_KEY] is component
 
+    def test_invoke_install_firmware_is_keyword_only(self):
+        # force_update is keyword-only: a positional boolean must be rejected.
+        import fwutil.main as fw_main
+        component = MagicMock()
+        with pytest.raises(TypeError):
+            fw_main._invoke_install_firmware(component, "/tmp/fw.bin", True)
+        component.install_firmware.assert_not_called()
+
+    def test_invoke_install_firmware_uses_force_when_supported(self):
+        import fwutil.main as fw_main
+        component = make_fw_double(
+            "install_firmware", supports_force=True, return_value=True
+        )
+        result = fw_main._invoke_install_firmware(
+            component, "/tmp/fw.bin", force_update=True
+        )
+        assert result is True
+        assert component.calls == [("/tmp/fw.bin", True)]
+
+    def test_invoke_install_firmware_no_force(self):
+        import fwutil.main as fw_main
+        component = make_fw_double(
+            "install_firmware", supports_force=True, return_value=True
+        )
+        result = fw_main._invoke_install_firmware(
+            component, "/tmp/fw.bin", force_update=False
+        )
+        assert result is True
+        assert component.calls == [("/tmp/fw.bin", False)]
+
+    def test_invoke_install_firmware_falls_back_when_unsupported(self):
+        # A component whose install_firmware lacks force_update is detected via
+        # its signature (not by catching TypeError) and gets a plain install.
+        import fwutil.main as fw_main
+        component = make_fw_double(
+            "install_firmware", supports_force=False, return_value=True
+        )
+        with patch.object(fw_main, "log_helper") as mock_log:
+            result = fw_main._invoke_install_firmware(
+                component, "/tmp/fw.bin", force_update=True
+            )
+        assert result is True
+        assert component.calls == [("/tmp/fw.bin",)]
+        mock_log.print_warning.assert_called_once()
+
+    def test_invoke_install_firmware_backend_typeerror_propagates_without_retry(self):
+        # A TypeError from a force-update-capable install_firmware must propagate
+        # unchanged and must NOT trigger a second, force_update-less install.
+        import fwutil.main as fw_main
+        component = make_fw_double(
+            "install_firmware", supports_force=True, raises_type_error=True,
+            return_value=True,
+        )
+        with patch.object(fw_main, "log_helper") as mock_log:
+            with pytest.raises(TypeError, match="backend boom"):
+                fw_main._invoke_install_firmware(
+                    component, "/tmp/fw.bin", force_update=True
+                )
+        assert component.calls == [("/tmp/fw.bin", True)]  # single call, no retry
+        mock_log.print_warning.assert_not_called()
+
 
 class TestFWPackageUntar(object):
     """Tests for FWPackage.untar_fwpackage() path traversal protection."""
@@ -410,3 +669,69 @@ class TestFWPackageUntar(object):
         with patch('fwutil.lib.FWUPDATE_FWPACKAGE_DIR', extract_dir):
             result = pkg.untar_fwpackage()
         assert result is True
+
+
+class TestForceUpdateSupport:
+    """update_firmware() must decide --force-update support from the backend's
+    signature (before invocation), not by catching a TypeError from the backend
+    call. Catching a runtime TypeError could mask a real backend bug and, worse,
+    silently re-run a firmware update that may have already started."""
+
+    def _make_cup(self, component, firmware_path="/tmp/fw.bin"):
+        cup = fwutil_lib.ComponentUpdateProvider.__new__(fwutil_lib.ComponentUpdateProvider)
+        fw_key = fwutil_lib.PlatformComponentsParser.FIRMWARE_KEY
+        cup.chassis_component_map = {"CHASSIS": {"COMP": component}}
+        cup.module_component_map = {}
+        pcp = MagicMock()
+        pcp.FIRMWARE_KEY = fw_key
+        pcp.chassis_component_map = {"CHASSIS": {"COMP": {fw_key: firmware_path}}}
+        cup._ComponentUpdateProvider__pcp = pcp
+        cup._ComponentUpdateProvider__root_path = None
+        return cup
+
+    @patch("fwutil.lib.log_helper")
+    def test_force_update_used_when_supported(self, mock_log):
+        comp = make_fw_double("update_firmware", supports_force=True)
+        cup = self._make_cup(comp)
+        cup.update_firmware("CHASSIS", None, "COMP", force_update=True)
+        assert comp.calls == [("/tmp/fw.bin", True)]
+        mock_log.print_warning.assert_not_called()
+
+    @patch("fwutil.lib.log_helper")
+    def test_falls_back_when_force_update_unsupported(self, mock_log):
+        comp = make_fw_double("update_firmware", supports_force=False)
+        cup = self._make_cup(comp)
+        cup.update_firmware("CHASSIS", None, "COMP", force_update=True)
+        assert comp.calls == [("/tmp/fw.bin",)]
+        mock_log.print_warning.assert_called_once()
+
+    @patch("fwutil.lib.log_helper")
+    def test_backend_typeerror_propagates_without_retry(self, mock_log):
+        # The regression this fix guards: a TypeError from a force-update-capable
+        # backend must propagate unchanged and must NOT trigger a second,
+        # force_update-less invocation.
+        comp = make_fw_double(
+            "update_firmware", supports_force=True, raises_type_error=True
+        )
+        cup = self._make_cup(comp)
+        with pytest.raises(TypeError, match="backend boom"):
+            cup.update_firmware("CHASSIS", None, "COMP", force_update=True)
+        assert comp.calls == [("/tmp/fw.bin", True)]  # single call, no retry
+        mock_log.print_warning.assert_not_called()
+
+    @patch("fwutil.lib.log_helper")
+    def test_no_force_update_calls_without_force(self, mock_log):
+        comp = make_fw_double("update_firmware", supports_force=True)
+        cup = self._make_cup(comp)
+        cup.update_firmware("CHASSIS", None, "COMP", force_update=False)
+        assert comp.calls == [("/tmp/fw.bin", False)]
+        mock_log.print_warning.assert_not_called()
+
+    def test_force_update_is_keyword_only(self):
+        # force_update is keyword-only: passing it positionally must be rejected
+        # so it can never be misbound to another positional argument.
+        comp = make_fw_double("update_firmware", supports_force=True)
+        cup = self._make_cup(comp)
+        with pytest.raises(TypeError):
+            cup.update_firmware("CHASSIS", None, "COMP", True)
+        assert comp.calls == []


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fixed `fwutil` incorrectly treating a non-modular chassis as modular when the platform exposes a module that has **no firmware components**.

On the NVIDIA AST2700 BMC, `chassis.get_all_modules()` returns a single component-less `SWITCH-HOST` module. `PlatformDataProvider.is_modular_chassis()` only checked whether *any* module existed (`len(self.module_component_map) > 0`), so it concluded the BMC was a modular chassis. `fwutil` then required a `module` section in `platform_components.json`; since the BMC (correctly) has none, every `fwutil` command that instantiates a `ComponentUpdateProvider` (e.g. `fwutil show status`, `fwutil update ...`) aborted while parsing the platform schema.

Also adds a `--force-update` flag to `fwutil install/update fw` for platforms (e.g. PLDM-based BMC firmware update) that support forced reinstall or downgrade, and captures BMC firmware versions via `fwutil` in `generate_dump`.

#### How I did it

Changed `is_modular_chassis()` to base modularity on whether any module actually exposes firmware components, rather than on the mere presence of modules:

```python
# fwutil/lib.py
def is_modular_chassis(self):
    return any(self.module_component_map.values())
```

`module_component_map` maps each module name to its `{component: ...}` dict, so a component-less module contributes an empty dict and no longer forces the chassis to be considered modular. Genuine modular chassis (modules that expose components) are unaffected, and SmartSwitch handling — which is explicitly forced non-modular for parsing via `is_modular_chassis() and not is_smart_switch()` — is unchanged.

Added `--force-update` to `fwutil install/update fw` commands. Components that support it (detected via signature inspection) receive `force_update=True`; unsupported components log a warning and proceed normally.

Added `fwutil show status` and `fwutil show version` captures to `collect_nvidia_bmc_dump` in `generate_dump` so BMC firmware versions are collected even if the hw-management dump script is absent or times out.

Tests (`tests/fwutil_test.py`):
- Updated `test_regular_modular_chassis_parsing` to model a module that actually exposes a component, so it still verifies a genuine modular chassis is parsed as modular.
- Added `test_module_without_components_is_non_modular`, mirroring the BMC's component-less `SWITCH-HOST` module and asserting the chassis is parsed as non-modular.
- Added tests for `--force-update` behavior including backend support detection, warning/fallback paths, and keyword-only enforcement.
- Added tests ensuring techsupport dumps include firmware status/version information even when BMC dump scripts fail.

#### How to verify it

Run the fwutil unit tests:

```
pytest tests/fwutil_test.py -k "modular or module_without or smartswitch or force"
```

All modular/SmartSwitch/force-update cases pass, including the new component-less-module test.

On a platform whose `get_all_modules()` returns only component-less modules with a `platform_components.json` that has **no** `module` section, run `fwutil show status`. It now succeeds instead of aborting with a platform-schema parse error.

#### Previous command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ fwutil show status
Error: Failed to parse "platform_components.json": invalid platform schema: "module" key hasn't been found. Aborting...
```

#### New command output (if the output of a command-line utility has changed)

```
admin@sonic:~$ fwutil show status
Chassis    Module    Component    Version (Current/Available)    Status
---------  --------  -----------  -----------------------------  --------------
P4102-A01  N/A       BMC          88.0060.2212 / N/A             up-to-date
```