### PR TITLE
Prevent rare leftover ASIC DB VXLAN objects following neighbor_advertiser cleanup

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -30,6 +30,7 @@ DEFAULT_DURATION = 300
 DEFAULT_REQUEST_TIMEOUT = 2
 DEFAULT_FERRET_QUERY_RETRIES = 3
 DEFAULT_CONFIG_DB_WAIT_TIME = 3 # seconds
+DEFAULT_VXLAN_CONFIG_DB_WAIT_TIME = 1 # seconds
 SYSLOG_IDENTIFIER = 'neighbor_advertiser'
 
 
@@ -556,6 +557,9 @@ def remove_vxlan_tunnel_map():
 
 def reset_vxlan_tunnel():
     remove_vxlan_tunnel_map()
+    # Allow orchagent to process the tunnel map deletion before the tunnel deletion.
+    # Otherwise, a scheduling race can leave orphaned VXLAN objects in ASIC_DB.
+    time.sleep(DEFAULT_VXLAN_CONFIG_DB_WAIT_TIME)
     remove_vxlan_tunnel()
     log.log_info('Finish resetting vxlan tunnel')
 

--- a/tests/neighbor_advertiser_test.py
+++ b/tests/neighbor_advertiser_test.py
@@ -66,3 +66,21 @@ class TestNeighborAdvertiser(object):
         for key in expected_mapping.keys():
             assert(key in tunnel_mapping.keys())
             assert(expected_mapping[key] == tunnel_mapping[key])
+
+    @mock.patch.object(neighbor_advertiser, 'remove_vxlan_tunnel')
+    @mock.patch.object(neighbor_advertiser.time, 'sleep')
+    @mock.patch.object(neighbor_advertiser, 'remove_vxlan_tunnel_map')
+    def test_reset_vxlan_tunnel_teardown_order(
+            self, remove_vxlan_tunnel_map, sleep, remove_vxlan_tunnel):
+        teardown_calls = mock.Mock()
+        teardown_calls.attach_mock(remove_vxlan_tunnel_map, 'remove_map')
+        teardown_calls.attach_mock(sleep, 'sleep')
+        teardown_calls.attach_mock(remove_vxlan_tunnel, 'remove_tunnel')
+
+        neighbor_advertiser.reset_vxlan_tunnel()
+
+        assert teardown_calls.mock_calls == [
+            mock.call.remove_map(),
+            mock.call.sleep(neighbor_advertiser.DEFAULT_VXLAN_CONFIG_DB_WAIT_TIME),
+            mock.call.remove_tunnel()
+        ]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

A rare orchagent scheduling race can reverse Neighbor Advertiser VXLAN cleanup events.

Neighbor Advertiser deletes  `VXLAN_TUNNEL_MAP|neigh_adv:map_1`  before  `VXLAN_TUNNEL|neigh_adv`  in CONFIG_DB:
```
Neighbor Advertiser cleanup
  → CONFIG_DB
  → VxlanMgr::doVxlanTunnelMapDeleteTask()
  → APP_DB: VXLAN_TUNNEL_MAP_TABLE DEL
  → VxlanMgr::doVxlanTunnelDeleteTask()
  → APP_DB: VXLAN_TUNNEL_TABLE DEL
  → orchagent
  → sairedis / ASIC_DB
  → syncd / SAI / hardware
```

 `VxlanMgr::doVxlanTunnelDeleteTask()`  defers the tunnel deletion while  vlan_vni_refcnt  is nonzero.  `VxlanMgr::doVxlanTunnelMapDeleteTask()`  publishes the map deletion and decrements that count first. Therefore, vxlanmgrd preserves the intended APP_DB order.

Orchagent consumes the APP_DB tables independently:
```
VXLAN_TUNNEL_TABLE
  → VxlanTunnelOrch::delOperation()

VXLAN_TUNNEL_MAP_TABLE
  → VxlanTunnelMapOrch::delOperation()
```
The orchestrators are added to  `OrchDaemon::m_orchList`  in a hardcoded order in  `OrchDaemon::init()` :
```
m_orchList.push_back(vxlan_tunnel_orch);
m_orchList.push_back(evpn_nvo_orch);
m_orchList.push_back(vxlan_tunnel_map_orch);
```
 `OrchDaemon::start()`  registers each orchestrator's independent  ConsumerStateTable  with  Select .  `Select::select()` reports one ready selectable at a time and does not preserve publication order across different APP_DB tables.

After processing a selected consumer,  `OrchDaemon::start()`  drains pending work in  m_orchList  order:
```
for (Orch *o : m_orchList)
    o->doTask();
```
Because  `vxlan_tunnel_orch`  is hardcoded before  `vxlan_tunnel_map_orch` , when both consumers have buffered work in the same scheduling window, pending tunnel work is considered first. Usually the map delete is processed first, but rarely the timing and buffering align such that the later tunnel deletion is processed before the earlier map deletion.

Happy path — map processed first:
```
syncd: remove SAI_OBJECT_TYPE_TUNNEL_MAP_ENTRY
orchagent: vni count = 0
syncd: remove SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY
syncd: remove SAI_OBJECT_TYPE_TUNNEL
syncd: remove SAI_OBJECT_TYPE_TUNNEL_MAP  # four objects
orchagent: Vxlan tunnel map entry 'map_1' for tunnel 'neigh_adv' was removed
orchagent: Vxlan tunnel 'neigh_adv' was removed
```
 `VxlanTunnelMapOrch::delOperation()`  removes the map entry, decrements  `VxlanTunnel::vlan_vrf_vni_count` , and calls  `VxlanTunnel::deleteTunnelHw()`. This removes the tunnel termination entry, tunnel, and mapper objects.

Rare bad path — tunnel processed first:
```
vxlanmgrd: Delete vxlan tunnel neigh_adv
orchagent: Vxlan tunnel 'neigh_adv' was removed
syncd: remove SAI_OBJECT_TYPE_TUNNEL_MAP_ENTRY
orchagent: Vxlan tunnel 'neigh_adv' doesn't exist
orchagent: Vxlan tunnel map 'neigh_adv:map_1' doesn't exist
```
`VxlanTunnelOrch::delOperation()` first erases the tunnel from  vxlan_tunnel_table. `VxlanTunnel::~VxlanTunnel()` updates state but does not perform SAI cleanup.

When `VxlanTunnelMapOrch::delOperation()` runs afterward, it removes the individual  `SAI_OBJECT_TYPE_TUNNEL_MAP_ENTRY`, then fails `VxlanTunnelOrch::isTunnelExists()`. It returns before decrementing the VNI count or calling `VxlanTunnel::deleteTunnelHw()`.

This leaves the following six orphaned objects in ASIC_DB/hardware:
```
1 × SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY
1 × SAI_OBJECT_TYPE_TUNNEL
4 × SAI_OBJECT_TYPE_TUNNEL_MAP
```
The four mapper objects are the encap/decap VLAN and VRF tunnel maps. The corresponding orchagent tunnel object has already been erased, so no owner remains to remove these objects later. These leftover VXLAN objects can silently conflict with creation of a new tunnel causing it to function unexpectedly.


MSFT ADO: 38555190

#### What I did

Added a 1s delay to increase the probability that VXLAN tunnel map deletion is processed through orchagent before VXLAN tunnel deletion.

#### How I did it

Added a sleep

#### How to verify it / Testing on 20260510.10

Let the following run for a few hours (2 hours in my case below) to repro the original issue:
```
while :; do neighbor_advertiser -s 10.64.246.107 -m set ; neighbor_advertiser -s 10.64.246.107 -m reset ; done
```
Observe the leftover ASIC DB content with:
```
{
  "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:oid:0x2a000000002b5f": {
    "SAI_TUNNEL_ATTR_DECAP_MAPPERS": "2:oid:0x29000000002b5b,oid:0x29000000002b5d",
    "SAI_TUNNEL_ATTR_ENCAP_MAPPERS": "2:oid:0x29000000002b5c,oid:0x29000000002b5e",
    "SAI_TUNNEL_ATTR_ENCAP_SRC_IP": "10.1.0.32",
    "SAI_TUNNEL_ATTR_ENCAP_TTL_MODE": "SAI_TUNNEL_TTL_MODE_PIPE_MODEL",
    "SAI_TUNNEL_ATTR_ENCAP_TTL_VAL": "255",
    "SAI_TUNNEL_ATTR_PEER_MODE": "SAI_TUNNEL_PEER_MODE_P2MP",
    "SAI_TUNNEL_ATTR_TYPE": "SAI_TUNNEL_TYPE_VXLAN",
    "SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE": "oid:0x600000000229a"
  },

  "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_MAP:oid:0x29000000002b5b": {
    "SAI_TUNNEL_MAP_ATTR_TYPE": "SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID"
  },
  "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_MAP:oid:0x29000000002b5c": {
    "SAI_TUNNEL_MAP_ATTR_TYPE": "SAI_TUNNEL_MAP_TYPE_VLAN_ID_TO_VNI"
  },
  "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_MAP:oid:0x29000000002b5d": {
    "SAI_TUNNEL_MAP_ATTR_TYPE": "SAI_TUNNEL_MAP_TYPE_VNI_TO_VIRTUAL_ROUTER_ID"
  },
  "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_MAP:oid:0x29000000002b5e": {
    "SAI_TUNNEL_MAP_ATTR_TYPE": "SAI_TUNNEL_MAP_TYPE_VIRTUAL_ROUTER_ID_TO_VNI"
  },

  "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY:oid:0x2b000000002b60": {
    "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID": "oid:0x2a000000002b5f",
    "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP": "10.1.0.32",
    "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_SRC_IP": "192.168.8.1",
    "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE": "SAI_TUNNEL_TYPE_VXLAN",
    "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE": "SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2P",
    "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID": "oid:0x3000000000022"
  }
}
```
Apply the changes here then repeat for at least the same duration (i ran for 4 hours) and you shouldn't see any leftover ASIC DB VXLAN SAI Objects.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A