### PR TITLE
[neighbor_advertiser] Set explicit pipe VXLAN TTL mode

### DIFF
--- a/scripts/neighbor_advertiser
+++ b/scripts/neighbor_advertiser
@@ -515,7 +515,8 @@ def check_existing_tunnel():
 def add_vxlan_tunnel(dst_ipv4_addr):
     vxlan_tunnel_info = {
         'src_ip': get_loopback_addr(4),
-        'dst_ip': dst_ipv4_addr
+        'dst_ip': dst_ipv4_addr,
+        'ttl_mode': 'pipe'
     }
 
     config_db.set_entry('VXLAN_TUNNEL', VXLAN_TUNNEL_NAME, vxlan_tunnel_info)
@@ -608,4 +609,3 @@ if __name__ == '__main__':
     except Exception as e:
         log.log_error('! [Failure] {} {}'.format(e, traceback.format_exc()))
         sys.exit(1)
-

--- a/tests/neighbor_advertiser_test.py
+++ b/tests/neighbor_advertiser_test.py
@@ -66,3 +66,19 @@ class TestNeighborAdvertiser(object):
         for key in expected_mapping.keys():
             assert(key in tunnel_mapping.keys())
             assert(expected_mapping[key] == tunnel_mapping[key])
+
+    def test_add_vxlan_tunnel_sets_pipe_ttl_mode(self):
+        config_db = mock.MagicMock()
+        with mock.patch.object(neighbor_advertiser, 'get_loopback_addr', return_value='10.0.0.1'), \
+                mock.patch.object(neighbor_advertiser, 'config_db', config_db):
+            neighbor_advertiser.add_vxlan_tunnel('10.0.0.2')
+
+        config_db.set_entry.assert_called_once_with(
+            'VXLAN_TUNNEL',
+            neighbor_advertiser.VXLAN_TUNNEL_NAME,
+            {
+                'src_ip': '10.0.0.1',
+                'dst_ip': '10.0.0.2',
+                'ttl_mode': 'pipe'
+            }
+        )


### PR DESCRIPTION
#### What I did

Set the VXLAN tunnel created by `neighbor_advertiser` to use an explicit pipe TTL mode.

This makes the Control Plane Assistant tunnel behavior explicit and independent of changes to the default handling of an omitted VXLAN TTL mode. Existing VXLAN tunnels reused by `neighbor_advertiser` are not modified.

Added a unit test that verifies the CONFIG_DB tunnel entry includes `ttl_mode` set to `pipe`.

#### How I did it

Added `ttl_mode: pipe` to the `VXLAN_TUNNEL` entry constructed by `add_vxlan_tunnel()`.

#### How to verify it

Run the targeted unit test in a SONiC runtime container:

```sh
python3 -m pytest -q tests/neighbor_advertiser_test.py
```

#### Additional info

This PR aligns the Control Plane Assistant tunnel with the pipe-mode transition in [sonic-net/sonic-swss#4825](https://github.com/sonic-net/sonic-swss/pull/4825).

#### Which release branch to backport :

- [x] 202605

#### Tested branch (Please provide the tested image version)

- [x] 202605 (`sonic-utilities` commit `2c44f94f`)

#### Test result

202605: PASS. Applied commit `29f48f34` to the `sonic-utilities` 202605 branch at `2c44f94f`; the patch applied cleanly. A targeted behavioral check verified that `add_vxlan_tunnel()` writes `ttl_mode: pipe` to the `VXLAN_TUNNEL` CONFIG_DB entry. Python compilation of `scripts/neighbor_advertiser` and `tests/neighbor_advertiser_test.py` also passed.
