### PR TITLE
[reboot] fix shell substitution mismatch (command vs. variable) in blocking mode

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -263,7 +263,7 @@ function parse_config_file
                     [ "${value}" = "true" ] && BLOCKING_MODE="yes"
                     ;;
                 blocking_mode_timeout)
-                    [[ "${value}" =~ ^[0-9]+$ ]] && BLOCKING_MODE_TIMEOUT_IN_SECOND=$(value)
+                    [[ "${value}" =~ ^[0-9]+$ ]] && BLOCKING_MODE_TIMEOUT_IN_SECOND=${value}
                     ;;
                 show_timer)
                     [ "${value}" = "true" ] && SHOW_TIMER="yes"
@@ -414,7 +414,7 @@ else
             CURRENT_TIME=$(date +%s)
             ELAPSED=$((CURRENT_TIME - REBOOT_START_TIME))
             if (( ELAPSED >= BLOCKING_MODE_TIMEOUT_IN_SECOND )); then
-                echo "[REBOOT FAILED] The reboot used $(ELAPSED)seconds while the timeout is configured as $(BLOCKING_MODE_TIMEOUT_IN_SECOND)seconds"
+                echo "[REBOOT FAILED] The reboot used ${ELAPSED} seconds while the timeout is configured as ${BLOCKING_MODE_TIMEOUT_IN_SECOND} seconds"
                 exit ${EXIT_TIMEOUT}
             fi
 


### PR DESCRIPTION
#### What I did
Changed shell substitution syntax from `$()` (command substitution) to `${}` (variable substitution) in `scripts/reboot`, where the value of the variable was intended.

`scripts/reboot` used `$(VAR)` in three places (across two lines) where `${VAR}` was intended. Bash treats `$(VAR)` as command substitution and tries to execute a program named `VAR`, which fails with `command not found` and assigns an empty string.

The remaining `$()` uses in reboot ( `$(date) ,  $(logname) ,  $(is_smartswitch) ,  $(date +%s)` ) are genuine command substitutions and are unchanged.

#### How I did it
Replaced `$(...)` with `${...}` at three sites. The message change also restores the space before `seconds`, which had been absorbed into the broken `$(ELAPSED)seconds`.

No behavioural change beyond correcting the substitution: the parse now assigns the configured value, and the blocking loop honours it.

#### How to verify it
Covered by a new sonic-mgmt regression test in sonic-net/sonic-mgmt#27262, which configures a non-zero `blocking_mode_timeout` and asserts the script blocks for at least that long. The pre-existing `test_timeout_for_blocking_mode` uses `blocking_mode_timeout=0`, where a correct parse and a failed parse are indistinguishable, since the shell evaluates an empty arithmetic operand as `0`.

#### Previous command output (if the output of a command-line utility has changed)
From a run of the sonic-mgmt test `reboot test_reboot_blocking_mode.py::TestRebootBlockingModeConfigFile::test_timeout_for_blocking_mode` . That test writes `/etc/sonic/reboot.conf` with `blocking_mode=true`, `blocking_mode_timeout=0 `, `show_timer=true` and mocks `/sbin/reboot`, which is what makes the defect observable.

`stdout` (trailing portion):
```
.[REBOOT FAILED] The reboot used seconds while the timeout is configured as seconds
```

`stderr`:

```
/usr/local/bin/reboot: line 266: value: command not found
/usr/local/bin/reboot: line 417: ELAPSED: command not found
/usr/local/bin/reboot: line 417: BLOCKING_MODE_TIMEOUT_IN_SECOND: command not found
```

#### New command output (if the output of a command-line utility has changed)
`stdout` (trailing portion):

```
.[REBOOT FAILED] The reboot used 1 seconds while the timeout is configured as 0 seconds
```

`stderr` : empty

#### Tested branch (Please provide the tested image version)

- [x] 202605, `SONiC.20260510.11`

Failure type: day-one issue

#### Test result

202605: PASS. Ran `reboot/test_reboot_blocking_mode.py` from sonic-net/sonic-mgmt#27262 on `Mellanox-SN4600C-C64` before and after applying this change to `/usr/local/bin/reboot`.

- Before: 1 failed, 3 passed. https://elastictest.org/scheduler/testplan/6a87eb2124f9645a147a4ec3
- After: 4 passed. https://elastictest.org/scheduler/testplan/6a8801fbeb9272f85921dcbf

Failure output from the "before" run:

```
E  Failed: Reboot blocked for 15s, expected at least the configured 30s.
E  .[REBOOT FAILED] The reboot used seconds while the timeout is configured as seconds
E  BLOCKED_FOR=15
```

That run used a 30s threshold, later raised to 50s for timing margin. 15s fails either way.