### PR TITLE
[config]: Fix Python 3.13 SyntaxWarning 'is' with int literal in aaa.py

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -127,7 +127,7 @@ authentication.add_command(trace)
 @clicommon.pass_db
 def login(db, auth_protocol):
     """Switch login authentication [ {ldap, radius, tacacs+, local} | default ]"""
-    if len(auth_protocol) is 0:
+    if len(auth_protocol) == 0:
         click.echo('Argument "auth_protocol" is required')
         return
     elif len(auth_protocol) > 2:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed Python 3.12+ `SyntaxWarning: "is" with 'int' literal` in `config/aaa.py` by changing `is 0` to `== 0`.

#### How I did it
Using `is` with an integer literal checks object identity, not equality. Python 3.12+ raises SyntaxWarning for this pattern. The correct comparison is `==`.

#### How to verify it
Verified on community SONiC VS image (x86_64-kvm_x86_64-r0):

BEFORE:

2026-08-19T06:14:45.083537+00:00 sonic config-setup[1293]: /usr/local/lib/python3.13/dist-packages/config/aaa.py:130: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?
2026-08-19T06:14:45.083537+00:00 sonic config-setup[1293]: /usr/local/lib/python3.13/dist-packages/config/aaa.py:130: SyntaxWarning: "is" with 'int' literal. Did you mean "=="?

AFTER:

admin@sonic:~$ show logging | grep "SyntaxWarning" | wc -l
0
admin@sonic:~$ show logging | grep "SyntaxWarning"
admin@sonic:~$

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
