### PR TITLE
[pfc]: Reject non-existent interfaces in config asymmetric

### DIFF
--- a/pfc/main.py
+++ b/pfc/main.py
@@ -43,6 +43,10 @@ class Pfc(object):
         """
         PFC handler to configure asymmetric PFC.
         """
+        if interface not in self.config_db.get_keys(PORT_TABLE_NAME):
+            click.echo('Cannot find interface {0}'.format(interface))
+            return
+
         self.config_db.mod_entry(PORT_TABLE_NAME, interface, {'pfc_asym': pfc_asym})
         self.dump_config_to_json(PORT_TABLE_NAME, self.multi_asic.current_namespace)
 

--- a/tests/multi_asic_pfc_test.py
+++ b/tests/multi_asic_pfc_test.py
@@ -111,6 +111,12 @@ class TestPfcMultiAsic(TestPfcBase):
     def test_pfc_config_asymmetric_invalid_all_masic(self):
         self.executor(testData['pfc_config_asymmetric_invalid_all_masic'])
 
+    def test_pfc_config_asymmetric_invalid_intf_one_masic(self):
+        self.executor(testData['pfc_config_asymmetric_invalid_intf_one_masic'])
+
+    def test_pfc_config_asymmetric_invalid_intf_all_masic(self):
+        self.executor(testData['pfc_config_asymmetric_invalid_intf_all_masic'])
+
     def test_pfc_config_priority_one_masic(self):
         self.executor(testData['pfc_config_priority_one_masic'])
 

--- a/tests/pfc_input/pfc_test_vectors.py
+++ b/tests/pfc_input/pfc_test_vectors.py
@@ -235,8 +235,8 @@ testData = {
              'pfc_config_asymmetric_all_masic': {'cmd': ['config', 'asymmetric',
                                                          'on', 'Ethernet0'],
                                                  'rc': 0,
-                                                 'cmp_args': [['asic0', 'PORT', 'Ethernet0', 'pfc_asym', 'on'],
-                                                              ['asic1', 'PORT', 'Ethernet0', 'pfc_asym', 'on']]
+                                                 'cmp_args': [['asic0', 'PORT', 'Ethernet0', 'pfc_asym', 'on']],
+                                                 'rc_msg': 'Cannot find interface Ethernet0'
                                                  },
              'pfc_config_asymmetric_invalid_all_masic': {'cmd': ['config', 'asymmetric',
                                                                  'onn', 'Ethernet0'],
@@ -245,6 +245,17 @@ testData = {
                                                                     '\'{on|off}\': \'onn\' is not '
                                                                     'one of \'on\', \'off\'')
                                                          },
+             'pfc_config_asymmetric_invalid_intf_one_masic': {'cmd': ['config', 'asymmetric',
+                                                                      'on', 'Ethernet1234',
+                                                                      '--namespace', 'asic0'],
+                                                              'rc': 0,
+                                                              'rc_msg': 'Cannot find interface Ethernet1234'
+                                                              },
+             'pfc_config_asymmetric_invalid_intf_all_masic': {'cmd': ['config', 'asymmetric',
+                                                                      'on', 'Ethernet1234'],
+                                                              'rc': 0,
+                                                              'rc_msg': 'Cannot find interface Ethernet1234'
+                                                              },
              'pfc_config_priority_one_masic': {'cmd': ['config', 'priority',
                                                        'on', 'Ethernet0', '5',
                                                        '--namespace', 'asic0'],

--- a/tests/pfc_test.py
+++ b/tests/pfc_test.py
@@ -93,6 +93,10 @@ class TestPfc(TestPfcBase):
                       # namespace, table, key, field, expected_val
                       expected_cfgdb_entries=[('', 'PORT', 'Ethernet0', 'pfc_asym', 'on')])
 
+    def test_pfc_config_asymmetric_intf_fake(self):
+        self.executor(pfc.cli, ['config', 'asymmetric', 'on', 'Ethernet1234'],
+                      expected_output=pfc_cannot_find_intf)
+
     def test_pfc_config_priority(self):
         self.executor(pfc.cli, ['config', 'priority', 'on', 'Ethernet0', '5'],
                       # namespace, table, key, field, expected_val


### PR DESCRIPTION
#### What I did

Fixes #756.

`pfc config asymmetric <on|off> <interface>` accepted any string as an interface
name. It wrote to CONFIG_DB with no existence check, and because
`ConfigDBConnector.mod_entry()` creates the key when it is absent, a typo did not
just produce a bad error message — it silently created a junk `PORT|<name>` entry
holding a lone `pfc_asym` field. The command exited 0 and printed nothing.

`config interface pfc asymmetric <interface> <on|off>` shells out to this same
handler (`config/main.py` runs `pfc config asymmetric ...`), so it had the same
behaviour and needs no separate change.

The sibling handler `configPfcPrio()`, 30-odd lines below in the same class,
already performs exactly this check against the table it writes to. This change
makes `configPfcAsym()` do the same.

#### How I did it

Four lines in `pfc/main.py`, mirroring `configPfcPrio()`:

```python
@multi_asic_util.run_on_multi_asic
def configPfcAsym(self, interface, pfc_asym):
    """
    PFC handler to configure asymmetric PFC.
    """
    if interface not in self.config_db.get_keys(PORT_TABLE_NAME):
        click.echo('Cannot find interface {0}'.format(interface))
        return

    self.config_db.mod_entry(PORT_TABLE_NAME, interface, {'pfc_asym': pfc_asym})
    self.dump_config_to_json(PORT_TABLE_NAME, self.multi_asic.current_namespace)
```

`PORT` is the right table to check against: it is the table this handler writes
to, and the one `showPfcAsym()` reads back. The message string reuses the
existing `pfc_cannot_find_intf` fixture in `tests/pfc_input/assert_show_output.py`
— no new user-facing strings.

I deliberately did not reach for `interface_name_is_valid()` from
`config/main.py`; that would add a `pfc/` -> `config/` dependency and diverge from
the neighbouring function.

**One existing test encoded the bug, and I had to correct it.** Calling this out
up front rather than burying it in the diff:

```python
# tests/pfc_input/pfc_test_vectors.py, before
'pfc_config_asymmetric_all_masic': {'cmd': ['config', 'asymmetric', 'on', 'Ethernet0'],
                                    'rc': 0,
                                    'cmp_args': [['asic0', 'PORT', 'Ethernet0', 'pfc_asym', 'on'],
                                                 ['asic1', 'PORT', 'Ethernet0', 'pfc_asym', 'on']]}
```

`Ethernet0` exists only in `asic0`'s mock config_db (`tests/mock_tables/asic1/config_db.json`
has `Ethernet64`, `Ethernet-BP256`, `Ethernet-BP260`). The `asic1` half of that
assertion passed *only because* `mod_entry()` fabricated the missing key. A port
lives in exactly one namespace, so without `--namespace` the write belongs in
`asic0` and must be a no-op in `asic1` — which is precisely what
`show asymmetric Ethernet0` already reports (see `show_asym_intf_all_masic`,
same file). The vector now asserts that, plus the rejection message.

Test changes:

- `tests/pfc_test.py` — single-ASIC negative case for a non-existent interface.
- `tests/pfc_input/pfc_test_vectors.py` — corrected `pfc_config_asymmetric_all_masic`
  as described; two new vectors for an invalid interface, with and without
  `--namespace`. Named `*_invalid_intf_*` because the pre-existing `*_invalid_*`
  vectors cover an invalid *status* (`onn`, caught by `click.Choice`, rc=2).
- `tests/multi_asic_pfc_test.py` — wiring for the two new vectors.

#### How to verify it

```
python3 -m pytest tests/pfc_test.py tests/multi_asic_pfc_test.py
```

| | result |
|---|---|
| master, unmodified | 29 passed |
| src fix only, tests untouched | **1 failed**, 28 passed — `test_pfc_config_asymmetric_all_masic`, the vector described above |
| src fix + test changes | 32 passed |
| test changes only, src reverted | **4 failed**, 28 passed |
| \+ `tests/show_test.py tests/trimming_test.py` | 204 passed, no collateral |

The fourth row is the one that matters: with `pfc/main.py` reverted the four
asymmetric tests fail, so the new tests genuinely exercise the fix rather than
restating current behaviour.

#### Previous command output (if the output of a command-line utility has changed)

```
$ pfc config asymmetric on Ethernet1234
$ echo $?
0
```

No output, exit 0, and CONFIG_DB gains a bogus entry:

```
PORT|Ethernet1234 = {'pfc_asym': 'on'}
```

#### New command output (if the output of a command-line utility has changed)

```
$ pfc config asymmetric on Ethernet1234
Cannot find interface Ethernet1234
$ echo $?
0
```

No CONFIG_DB write occurs.

---

Notes for reviewers:

1. **Exit code stays 0 on the error path.** `configPfcPrio()` does `click.echo` +
   `return` with exit 0, and I matched it for consistency. If you want non-zero,
   `configPfcPrio()` should change too, or the asymmetry just moves — happy to do
   that here or as a follow-up, your call.
2. **The message carries no namespace label.** Without `-n` on a multi-ASIC box it
   prints once per namespace that lacks the port. `showPfcPrio()` uses a richer
   `'Cannot find interface {0} for Namespace {1}'`; I kept the plain form to match
   `configPfcPrio()`. Also easy to change if preferred.
3. **`doc/Command-Reference.md` is untouched** — the command surface, syntax and
   options are unchanged; only an invalid-input path is corrected.
4. PR #1316 (Dec 2020) attempted the same fix. It predates the refactor of `pfc`
   into a class with `@run_on_multi_asic` (#3057) and the multi-ASIC support in
   #3521, targets the old module-level `swsssdk` code, and carries no tests. It
   stalled without a review rather than on any technical objection. This PR is
   written against current master and covers the multi-ASIC paths.
