### PR TITLE
fwutil reports no update available when available version is unknown

### DIFF
--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -540,9 +540,22 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
     FW_STATUS_UPDATE_REQUIRED = "update is required"
     FW_STATUS_UP_TO_DATE = "up-to-date"
+    FW_STATUS_NO_UPDATE_AVAILABLE = "no update is available"
+
+    # Values a platform's get_available_firmware_version() returns when the
+    # version cannot be determined (e.g. the firmware file is not on the
+    # switch). No update can be offered from an indeterminate version.
+    FW_VERSION_UNKNOWN_VALUES = (NA, "Unknown")
 
     SECTION_CHASSIS = "Chassis"
     SECTION_MODULE = "Module"
+
+    def __get_update_status(self, firmware_version_current, firmware_version_available):
+        if firmware_version_available in self.FW_VERSION_UNKNOWN_VALUES:
+            return self.FW_STATUS_NO_UPDATE_AVAILABLE
+        if firmware_version_current != firmware_version_available:
+            return self.FW_STATUS_UPDATE_REQUIRED
+        return self.FW_STATUS_UP_TO_DATE
 
     def __init__(self, root_path=None):
         PlatformDataProvider.__init__(self)
@@ -631,10 +644,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                     firmware_version = "{} / {}".format(firmware_version_current, firmware_version_available)
 
-                    if firmware_version_current != firmware_version_available:
-                        status = self.FW_STATUS_UPDATE_REQUIRED
-                    else:
-                        status = self.FW_STATUS_UP_TO_DATE
+                    status = self.__get_update_status(firmware_version_current, firmware_version_available)
 
                     if self.__pcp.UTILITY_KEY in component:
                         update_utility = component[self.__pcp.UTILITY_KEY]
@@ -698,10 +708,7 @@ class ComponentUpdateProvider(PlatformDataProvider):
 
                         firmware_version = "{} / {}".format(firmware_version_current, firmware_version_available)
 
-                        if firmware_version_current != firmware_version_available:
-                            status = self.FW_STATUS_UPDATE_REQUIRED
-                        else:
-                            status = self.FW_STATUS_UP_TO_DATE
+                        status = self.__get_update_status(firmware_version_current, firmware_version_available)
 
                         if self.__pcp.UTILITY_KEY in component:
                             update_utility = component[self.__pcp.UTILITY_KEY]

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -98,6 +98,14 @@ class TestComponentUpdateProvider(object):
         assert CUProvider.is_capable_auto_update('none') == True
         assert CUProvider.is_capable_auto_update('def') == True
 
+    def test_get_update_status(self):
+        cup_cls = fwutil_lib.ComponentUpdateProvider
+        get_status = cup_cls._ComponentUpdateProvider__get_update_status
+        assert get_status(cup_cls, "0.0", "1.2") == cup_cls.FW_STATUS_UPDATE_REQUIRED
+        assert get_status(cup_cls, "1.2", "1.2") == cup_cls.FW_STATUS_UP_TO_DATE
+        assert get_status(cup_cls, "0.0", "Unknown") == cup_cls.FW_STATUS_NO_UPDATE_AVAILABLE
+        assert get_status(cup_cls, "0.0", "N/A") == cup_cls.FW_STATUS_NO_UPDATE_AVAILABLE
+
     @patch('fwutil.lib.Platform')
     @patch('fwutil.lib.PlatformComponentsParser')
     @patch('fwutil.lib.ComponentUpdateProvider._ComponentUpdateProvider__validate_platform_schema')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Made `fwutil show updates` report an honest status when a components fw version is not available.

Previously if the available version was "Unknown" it would report "update is required" due to relying on string matching.

Now it will report:  `no update is available` 

#### How I did it

Factored the status decision in `fwutil/lib.py` into a new
`ComponentUpdateProvider.__get_update_status` helper:

- An available version  of `N/A` or `Unknown` returns "no update is available"
- Otherwise the existing compare is unchanged: 
 on a mismatch:   `FW_STATUS_UPDATE_REQUIRED`
 on a match: `FW_STATUS_UP_TO_DATE`.

#### How to verify it

- New unit test `test_get_update_status` in `tests/fwutil_test.py` covers all three statuses.
- On a NH-4210-F, unprogrammed rails, manifests without `version`:
  `sudo fwutil show updates` with no firmware bundle reports
  `0.0 / Unknown   no update is available` for every DCDC; with a bundle
  (`-f <bundle>.tgz`) the file-parsed versions report
  `0.0 / 1.1   update is required` as before. No update was run.

#### Previous command output (if the output of a command-line utility has changed)

```
~$ sudo fwutil show updates
Chassis    Module    Component    Firmware                                            Version (Current/Available)    Status
---------  --------  -----------  --------------------------------------------------  -----------------------------  ------------------
NH-4210-F  N/A       DCDC0        swt_dcdc0_rev2_xdpe1a2g5c_0x70-0x1C3119DC.txt       0.0 / Unknown                  update is required
                     DCDC1        swt_dcdc1-2_rev1_raa228244-1_0x60_v1_r0.hex         0.0 / Unknown                  update is required
                     ...
```

#### New command output (if the output of a command-line utility has changed)

```
~$ sudo fwutil show updates
Chassis    Module    Component    Firmware                                            Version (Current/Available)    Status
---------  --------  -----------  --------------------------------------------------  -----------------------------  ----------------------
NH-4210-F  N/A       DCDC0        swt_dcdc0_rev2_xdpe1a2g5c_0x70-0x1C3119DC.txt       0.0 / Unknown                  no update is available
                     DCDC1        swt_dcdc1-2_rev1_raa228244-1_0x60_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC2        swt_dcdc1-2_rev1_raa228244-1_0x60_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC3        swt_dcdc3-5_rev1_raa228244-1_0x61_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC4        swt_dcdc4-6_rev1_raa228244-1_0x62_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC5        swt_dcdc3-5_rev1_raa228244-1_0x61_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC6        swt_dcdc4-6_rev1_raa228244-1_0x62_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC7        swt_dcdc7-8_rev1_raa228244-1_0x63_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC8        swt_dcdc7-8_rev1_raa228244-1_0x63_v1_r0.hex         0.0 / Unknown                  no update is available
                     DCDC9        swt_dcdc9-10_rev2_raa228244-1_0x72_v0x01_r0x02.hex  0.0 / Unknown                  no update is available
                     DCDC10       swt_dcdc9-10_rev2_raa228244-1_0x72_v0x01_r0x02.hex  0.0 / Unknown                  no update is available
                     DCDC11       mezz_dcdc0_rev2_raa228244-1_0x62_v0x01_r0x02.hex    0.0 / Unknown                  no update is available
                     DCDC12       mezz_dcdc0_rev2_raa228244-1_0x62_v0x01_r0x02.hex    0.0 / Unknown                  no update is available
```

