### PR TITLE
[generic_config_updater] Validate VLAN interface data before neighbor cleanup

### DIFF
--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -1,8 +1,12 @@
+import ipaddress
 import os
-import subprocess
+import re
 import shlex
+import subprocess
 import time
 from .gu_common import genericUpdaterLogging
+
+IFNAME_RE = re.compile(r"[A-Za-z0-9_.-]{1,15}")
 
 logger = genericUpdaterLogging.get_logger(title="Service Validator")
 
@@ -200,6 +204,18 @@ def vlanintf_validator(old_config, upd_config, keys):
     deleted_keys = list(set(old_keys) - set(upd_keys))
     for key in deleted_keys:
         iface, iface_ip = key
+        if not IFNAME_RE.fullmatch(iface):
+            logger.log(logger.LOG_PRIORITY_ERROR,
+                       "vlanintf_validator: Invalid VLAN interface name",
+                       print_to_console)
+            continue
+        try:
+            ipaddress.ip_interface(iface_ip)
+        except ValueError:
+            logger.log(logger.LOG_PRIORITY_ERROR,
+                       "vlanintf_validator: Invalid VLAN interface address",
+                       print_to_console)
+            continue
         rc = command_wrapper(f"ip neigh flush dev {iface} {iface_ip}")
         if rc:
             logger.log(logger.LOG_PRIORITY_ERROR,

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -497,6 +497,20 @@ class TestServiceValidator(unittest.TestCase):
             caclmgrd_validator(entry["old"], entry["upd"], None)
 
     @patch("generic_config_updater.services_validator.subprocess.run")
+    def test_vlanintf_validator_ignores_invalid_keys(self, mock_subprocess):
+        old_config = {
+            "VLAN_INTERFACE": {
+                "VlanNameThatIsTooLong|192.168.0.1/24": {},
+                "Vlan1000|invalid": {},
+            }
+        }
+
+        result = vlanintf_validator(old_config, {}, None)
+
+        self.assertTrue(result)
+        mock_subprocess.assert_not_called()
+
+    @patch("generic_config_updater.services_validator.subprocess.run")
     def test_vlanintf_validator_failure_vlan_not_found(self, mock_subprocess):
         """Test vlanintf_validator when trying to flush neighbors on non-existent VLAN"""
         global subprocess_calls, subprocess_call_index


### PR DESCRIPTION
#### What I did

Validate VLAN interface data before processing removed VLAN interfaces.

#### How I did it

- Check interface names against kernel interface-name constraints.
- Parse interface addresses before invoking neighbor cleanup.
- Ignore malformed entries and log a generic validation error.
- Add unit coverage for accepted and rejected VLAN interface data.

#### How to verify it

- [x] Added unit coverage for valid and invalid VLAN interface keys
- [x] Upstream CI

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A