### PR TITLE
[counterpoll] Fix bash tab-completion by not requiring CONFIG_DB at import

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -1,12 +1,14 @@
 import click
 import os
-from sonic_py_common import device_info, multi_asic
+from sonic_py_common import device_info, multi_asic, logger
 import utilities_common.multi_asic as multi_asic_util
 from utilities_common.llr import is_llr_capable
 from tabulate import tabulate
 from flow_counter_util.route import exit_if_route_flow_counter_not_support
 from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig
 from swsscommon.swsscommon import CFG_FLEX_COUNTER_TABLE_NAME as CFG_FLEX_COUNTER_TABLE
+
+log = logger.Logger("counterpoll")
 
 BUFFER_POOL_WATERMARK = "BUFFER_POOL_WATERMARK"
 PORT_BUFFER_DROP = "PORT_BUFFER_DROP"
@@ -958,8 +960,18 @@ def register_dynamic_commands(cmds):
     """
     Dynamically register commands based on condition callback.
     """
-    db = ConfigDBConnector()
-    db.connect()
+    try:
+        db = ConfigDBConnector()
+        db.connect()
+    except RuntimeError as e:
+        # Runs at import time. swsscommon raises RuntimeError when CONFIG_DB is
+        # unreachable (e.g. build-time completion generation in a redis-less
+        # container). Skip DPU-only dynamic commands rather than fail the import,
+        # else the completion file is never generated.
+        log.log_warning(
+            "CONFIG_DB not available at import, skipping DPU dynamic commands "
+            "(eni/ha_set): {}".format(e))
+        return
     for cmd, cb in cmds:
         if cb(db):
             cli.add_command(cmd)

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -614,6 +614,28 @@ class TestCounterpoll(object):
         table = db.cfgdb.get_table("FLEX_COUNTER_TABLE")
         assert test_interval == table["TUNNEL"]["POLL_INTERVAL"]
 
+    def test_register_dynamic_commands_survives_db_connect_failure(self):
+        # Importing counterpoll.main must not require a live CONFIG_DB. The
+        # build-time bash-completion generator imports every CLI module in a
+        # redis-less container; if the connect failure (RuntimeError)
+        # propagates from register_dynamic_commands (which runs at import), the
+        # generator drops the counterpoll completion file and "counterpoll <Tab>"
+        # stops working.
+        mock_conn = mock.Mock()
+        mock_conn.connect.side_effect = RuntimeError("Unable to connect to redis")
+        with mock.patch.object(counterpoll, "ConfigDBConnector", return_value=mock_conn):
+            # Must not raise even though connect() fails.
+            counterpoll.register_dynamic_commands(counterpoll.dynamic_commands)
+
+    def test_register_dynamic_commands_propagates_unexpected_error(self):
+        # Only swsscommon connection failures (RuntimeError) are tolerated;
+        # unrelated errors must still surface rather than be silently swallowed.
+        mock_conn = mock.Mock()
+        mock_conn.connect.side_effect = ValueError("unexpected")
+        with mock.patch.object(counterpoll, "ConfigDBConnector", return_value=mock_conn):
+            with pytest.raises(ValueError):
+                counterpoll.register_dynamic_commands(counterpoll.dynamic_commands)
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")


### PR DESCRIPTION
#### Why I did it

`counterpoll <Tab>` does not auto-complete on the switch (e.g. `counterpoll water<Tab>` should complete to `watermark`), while `config`/`show` complete fine. Root cause: `register_dynamic_commands()` in `counterpoll/main.py` runs at **module-import time** and calls `ConfigDBConnector().connect()`.

The bash-completion generator (`sonic-utilities-data/generate_completions.py`) imports every CLI module in a **redis-less build container** to emit the completion wrappers. The `counterpoll` import raises there (no CONFIG_DB), `generate_completions` swallows the exception (`Cannot generate completion for counterpoll.main:cli!`), and **no `/etc/bash_completion.d/counterpoll` file is shipped** — so bash has nothing to complete against.

#### How I did it

Guard the import-time DB access. swsscommon raises `RuntimeError` when CONFIG_DB is unreachable or the DB config is missing, so catch only `RuntimeError` (unrelated errors still propagate) and log a warning naming the skipped DPU-only commands. Completion is dynamic (the wrapper re-invokes `counterpoll` at Tab time), so on a DPU with CONFIG_DB up the `eni`/`ha_set` commands are still registered and still complete; the guard only affects the redis-less build / non-DPU path where those DPU-only commands don't apply.

Also adds regression tests: `register_dynamic_commands()` swallows a `RuntimeError` connect failure but still propagates unrelated exceptions.

#### How to verify it

1. **Reproduce the bug**
   On a switch, `/etc/bash_completion.d/counterpoll` is missing, and typing `counterpoll water<Tab>` does not complete to `watermark`.

2. **Verify the fix**
   With the patch, the completion generator runs without a redis connection and installs the `counterpoll` completion file, `counterpoll water<Tab>` completes to `watermark`, and the skip path is logged to syslog (if log is kept from build time)
   ```
   WARNING counterpoll: CONFIG_DB not available at import, skipping DPU dynamic commands (eni/ha_set): Unable to connect to redis
   ```