### PR TITLE
[show] Use default system-health config when missing

### DIFF
--- a/show/system_health.py
+++ b/show/system_health.py
@@ -31,10 +31,6 @@ def get_system_health_status():
 
 
     manager = HealthCheckerManager()
-    if not manager.config.config_file_exists():
-        click.echo("System health configuration file not found, exit...")
-        exit(1)
-
     chassis = Chassis()
     stat = manager.check(chassis)
     chassis.initizalize_system_led()

--- a/tests/system_health_test.py
+++ b/tests/system_health_test.py
@@ -15,14 +15,9 @@ sys.path.insert(0, modules_path)
 class MockerConfig(object):
     ignore_devices = []
     ignore_services = []
-    first_time = True
 
     def config_file_exists(self):
-        if MockerConfig.first_time:
-            MockerConfig.first_time = False
-            return False
-        else:
-            return True
+        return False
 
 class MockerManager(object):
     counter = 0
@@ -75,12 +70,6 @@ class TestHealth(object):
 
     def test_health_summary(self):
         runner = CliRunner()
-        result = runner.invoke(show.cli.commands["system-health"].commands["summary"])
-        click.echo(result.output)
-        expected = """\
-System health configuration file not found, exit...
-"""
-        assert result.output == expected
         result = runner.invoke(show.cli.commands["system-health"].commands["summary"])
         expected = """\
 System status summary


### PR DESCRIPTION
#### What I did

Allow `show system-health` commands to continue when the platform-specific `system_health_monitoring_config.json` file is missing.

The system-health library already supports this case by using its default configuration, but the CLI exited before that fallback could run.

Fixes #1610

#### How I did it

Removed the redundant `config_file_exists()` early-exit check from `get_system_health_status()` so `HealthCheckerManager.check()` can load the existing default configuration.

Updated the system-health unit-test mock to consistently represent a missing configuration file and verify that the command continues normally instead of exiting.

#### How to verify it

Local checks:

- `python3 -m py_compile show/system_health.py tests/system_health_test.py` — passed
- `git diff --check` — passed
- Updated `tests/system_health_test.py` to cover the missing-config path

The pytest suite could not be executed in the local WSL environment because SONiC-specific test dependencies such as `sonic_py_common` and `swsscommon` are not installed there; collection stops in `tests/conftest.py` before the test runs. Repository CI provides these dependencies.

#### Previous command output (if the output of a command-line utility has changed)

When the platform configuration file was absent:

```text
$ sudo show system-health summary
System health configuration file not found, exit...
```

#### New command output (if the output of a command-line utility has changed)

The command now continues with the normal system-health summary using the existing default configuration:

```text
$ sudo show system-health summary
System status summary
...
```
