### PR TITLE
[SONiC BMC] Align BMC CLIs to use the new BMC OS configuration value

### DIFF
--- a/config/bmc.py
+++ b/config/bmc.py
@@ -1,4 +1,17 @@
 import click
+import utilities_common.cli as clicommon
+from sonic_py_common import device_info
+
+
+def _reject_non_switch_host():
+    if not device_info.is_switch_host():
+        raise click.ClickException('Operation only supported on Switch-Host')
+
+
+def _reject_unless_switch_host_openbmc():
+    _reject_non_switch_host()
+    if device_info.get_bmc_os() == device_info.BMC_OS_SONIC:
+        raise click.ClickException('Operation not supported when BMC OS is sonic')
 
 
 # 'bmc' group ('config bmc ...')
@@ -8,10 +21,24 @@ def bmc():
     pass
 
 
+# config bmc os <openbmc|sonic>
+@bmc.command('os')
+@click.argument('os_type', metavar='<os>',
+                type=click.Choice([device_info.BMC_OS_OPENBMC, device_info.BMC_OS_SONIC],
+                                  case_sensitive=False))
+@clicommon.pass_db
+def config_bmc_os(db, os_type):
+    """Configure BMC operating system (openbmc: Redfish, sonic: Redis)"""
+    _reject_non_switch_host()
+    db.cfgdb.mod_entry('DEVICE_METADATA', 'bmc', {'os': os_type.lower()})
+    click.echo(f"BMC OS set to {os_type.lower()}")
+
+
 # config bmc reset-root-password
 @bmc.command('reset-root-password')
 def reset_root_password():
     """Reset BMC root password to default"""
+    _reject_unless_switch_host_openbmc()
     try:
         import sonic_platform
         chassis = sonic_platform.platform.Platform().get_chassis()
@@ -32,6 +59,7 @@ def reset_root_password():
 @bmc.command('open-session')
 def open_session():
     """Open a session with the BMC"""
+    _reject_unless_switch_host_openbmc()
     try:
         import sonic_platform
         chassis = sonic_platform.platform.Platform().get_chassis()
@@ -54,6 +82,7 @@ def open_session():
 @click.option('-s', '--session-id', required=True, help='Session ID to close')
 def close_session(session_id):
     """Close a session with the BMC"""
+    _reject_unless_switch_host_openbmc()
     try:
         import sonic_platform
         chassis = sonic_platform.platform.Platform().get_chassis()

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -1186,9 +1186,27 @@ This command displays the status of the device's thermal sensors
      xSFP module 32 Temp           39.5       70.0       N/A            90.0            N/A      False  20200302 06:59:58
   ```
 
+**show platform bmc os**
+
+This command displays the configured BMC operating system (`openbmc` or `sonic`).
+
+- Usage:
+  ```
+  show platform bmc os
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show platform bmc os
+  sonic
+  ```
+
 **show platform bmc summary**
 
-This command displays BMC summary information including manufacturer, model, part number, serial number, power state, and firmware version
+This command displays BMC summary information including manufacturer, model, part number,
+serial number, power state, and firmware version. Supported for both BMC OS types; when
+BMC OS is `sonic`, `FirmwareVersion` is shown as `N/A` since it cannot be retrieved without
+Redfish.
 
 - Usage:
   ```
@@ -1198,7 +1216,7 @@ This command displays BMC summary information including manufacturer, model, par
 - Options:
   - `--json`: Output information in JSON format
 
-- Example:
+- Example (OpenBMC):
   ```
   admin@sonic:~$ show platform bmc summary
   Manufacturer: ASPEED
@@ -1207,6 +1225,17 @@ This command displays BMC summary information including manufacturer, model, par
   SerialNumber: 123456789
   PowerState: On
   FirmwareVersion: 1.0.0
+  ```
+
+- Example (SONiC BMC):
+  ```
+  admin@sonic:~$ show platform bmc summary
+  Manufacturer: NVIDIA
+  Model: P4102-A01
+  PartNumber: 699-24102-0100-EB1
+  SerialNumber: MT260560000K
+  PowerState: On
+  FirmwareVersion: N/A
   ```
 
 - Example (JSON format):
@@ -1224,7 +1253,10 @@ This command displays BMC summary information including manufacturer, model, par
 
 **show platform bmc eeprom**
 
-This command displays BMC EEPROM information
+This command displays BMC EEPROM information. When BMC OS is `openbmc`, fields come from
+Redfish. When BMC OS is `sonic`, Manufacturer, Model, PartNumber, and SerialNumber are read
+from the BMC remote STATE_DB; PowerState reflects the reachability of the BMC (`On` if it
+responds to ping, `Off` otherwise).
 
 - Usage:
   ```
@@ -1234,7 +1266,7 @@ This command displays BMC EEPROM information
 - Options:
   - `--json`: Output information in JSON format
 
-- Example:
+- Example (OpenBMC):
   ```
   admin@sonic:~$ show platform bmc eeprom
   Manufacturer: ASPEED
@@ -1242,6 +1274,16 @@ This command displays BMC EEPROM information
   PartNumber: 123-12345-1234-AB1
   PowerState: On
   SerialNumber: 123456789
+  ```
+
+- Example (SONiC BMC):
+  ```
+  admin@sonic:~$ show platform bmc eeprom
+  Manufacturer: NVIDIA
+  Model: P4102-A01
+  PartNumber: 699-24102-0100-EB1
+  PowerState: On
+  SerialNumber: MT260560000K
   ```
 
 - Example (JSON format):
@@ -3013,11 +3055,47 @@ Go Back To [Beginning of the document](#) or [Beginning of this section](#arp--n
 
 ## BMC
 
+On Switch-Host platforms, the BMC peer on the USB/BMC link may run OpenBMC (Redfish) or
+SONiC-on-BMC (Redis). The configured type is stored in CONFIG_DB as
+`DEVICE_METADATA|bmc` field `os` (`openbmc` or `sonic`; default `sonic`). Use
+`config bmc os` to set it and `show platform bmc os` to display the current value.
+
+All BMC commands are supported only when run on the Switch-Host (not on the BMC
+itself). OpenBMC-only commands (Redfish session management: `reset-root-password`,
+`open-session`, `close-session`) additionally require `os` to be `openbmc`.
+`show platform bmc eeprom` and `show platform bmc summary` work for both: OpenBMC returns full Redfish
+EEPROM fields and firmware version; SONiC BMC returns Manufacturer, Model, PartNumber, and
+SerialNumber from remote STATE_DB, with PowerState derived from BMC reachability (ping) and
+FirmwareVersion shown as `N/A`.
+
 ### BMC config commands
+
+**config bmc os**
+
+This command configures the BMC operating system type for Switch-Host communication with
+the BMC on the USB/BMC link.
+
+- Usage:
+  ```
+  config bmc os <openbmc|sonic>
+  ```
+
+- Arguments:
+  - `<openbmc|sonic>`: `openbmc` — Redfish APIs; `sonic` — Redis over the BMC link
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config bmc os sonic
+  BMC OS set to sonic
+
+  admin@sonic:~$ sudo config bmc os openbmc
+  BMC OS set to openbmc
+  ```
 
 **config bmc open-session**
 
-This command opens a session with the BMC and returns session credentials
+This command opens a session with the BMC and returns session credentials. Supported only
+when BMC OS is `openbmc`.
 
 - Usage:
   ```
@@ -3033,7 +3111,8 @@ This command opens a session with the BMC and returns session credentials
 
 **config bmc close-session**
 
-This command closes a BMC session using the provided session ID
+This command closes a BMC session using the provided session ID. Supported only when BMC
+OS is `openbmc`.
 
 - Usage:
   ```
@@ -3051,7 +3130,8 @@ This command closes a BMC session using the provided session ID
 
 **config bmc reset-root-password**
 
-This command resets the BMC root password to default
+This command resets the BMC root password to default. Supported only when BMC OS is
+`openbmc`.
 
 - Usage:
   ```

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2384,7 +2384,7 @@ save_log_files() {
 #  0 if BMC is supported, 1 otherwise
 ###############################################################################
 is_bmc_supported() {
-    python3 -c "from sonic_py_common import device_info; import sys; sys.exit(0 if (device_info.is_switch_host() and device_info.get_bmc_data()) else 1)"
+    python3 -c "from sonic_py_common import device_info; import sys; sys.exit(0 if (device_info.is_switch_host() and device_info.get_bmc_data() and device_info.get_bmc_os() == device_info.BMC_OS_OPENBMC) else 1)"
 }
 
 ###############################################################################
@@ -2397,7 +2397,7 @@ is_bmc_supported() {
 trigger_bmc_debug_log_dump() {
     trap 'handle_error $? $LINENO' ERR
     if ! is_bmc_supported; then
-        echo "INFO: BMC is not found on this platform. Skipping..."
+        echo "INFO: BMC (OpenBMC) is not found on this platform. Skipping..."
         return
     fi
     # Trigger BMC redfish API to start BMC debug log dump task

--- a/show/platform.py
+++ b/show/platform.py
@@ -81,11 +81,25 @@ def bmc():
     pass
 
 
+def _reject_non_switch_host():
+    if not device_info.is_switch_host():
+        raise click.ClickException('Operation only supported on Switch-Host')
+
+
+# 'os' subcommand ("show platform bmc os")
+@bmc.command(name='os')
+def bmc_os():
+    """Show configured BMC operating system (openbmc or sonic)"""
+    _reject_non_switch_host()
+    click.echo(device_info.get_bmc_os())
+
+
 # 'summary' subcommand ("show platform bmc summary")
 @bmc.command(name='summary')
 @click.option('--json', is_flag=True, help="Output in JSON format")
 def bmc_summary(json):
     """Show BMC summary information"""
+    _reject_non_switch_host()
     try:
         import sonic_platform
         chassis = sonic_platform.platform.Platform().get_chassis()
@@ -106,7 +120,7 @@ def bmc_summary(json):
         part_number = eeprom_info.get('PartNumber', 'N/A')
         power_state = eeprom_info.get('PowerState', 'N/A')
         serial_number = eeprom_info.get('SerialNumber', 'N/A')
-        bmc_version = bmc.get_version()
+        bmc_version = 'N/A' if device_info.get_bmc_os() == device_info.BMC_OS_SONIC else bmc.get_version()
 
         if json:
             bmc_summary = {
@@ -135,6 +149,7 @@ def bmc_summary(json):
 @click.option('--json', is_flag=True, help="Output in JSON format")
 def eeprom(json):
     """Show BMC EEPROM information"""
+    _reject_non_switch_host()
     try:
         import sonic_platform
         chassis = sonic_platform.platform.Platform().get_chassis()

--- a/tests/bmc_test.py
+++ b/tests/bmc_test.py
@@ -5,10 +5,58 @@ import config.bmc as bmc
 from unittest import mock
 from click.testing import CliRunner
 from mock import MagicMock
+from sonic_py_common import device_info
+from utilities_common.db import Db
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
+
+OPENBMC_PATCH = mock.patch(
+    'config.bmc.device_info.get_bmc_os',
+    return_value=device_info.BMC_OS_OPENBMC)
+SONIC_BMC_PATCH = mock.patch(
+    'config.bmc.device_info.get_bmc_os',
+    return_value=device_info.BMC_OS_SONIC)
+SWITCH_HOST_PATCH = mock.patch(
+    'config.bmc.device_info.is_switch_host',
+    return_value=True)
+
+
+class TestBmcConfigOs(object):
+    """Test class for 'config bmc os' command"""
+
+    @SWITCH_HOST_PATCH
+    def test_config_bmc_os_sonic(self, mock_is_switch_host):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(bmc.config_bmc_os, ['sonic'], obj=db)
+        assert result.exit_code == 0
+        assert "BMC OS set to sonic" in result.output
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'bmc')['os'] == 'sonic'
+
+    @SWITCH_HOST_PATCH
+    def test_config_bmc_os_openbmc(self, mock_is_switch_host):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(bmc.config_bmc_os, ['openbmc'], obj=db)
+        assert result.exit_code == 0
+        assert "BMC OS set to openbmc" in result.output
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'bmc')['os'] == 'openbmc'
+
+    @SWITCH_HOST_PATCH
+    def test_config_bmc_os_case_insensitive(self, mock_is_switch_host):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(bmc.config_bmc_os, ['SONIC'], obj=db)
+        assert result.exit_code == 0
+        assert db.cfgdb.get_entry('DEVICE_METADATA', 'bmc')['os'] == 'sonic'
+
+    def test_config_bmc_os_invalid(self):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(bmc.config_bmc_os, ['linux'], obj=db)
+        assert result.exit_code != 0
 
 
 class TestBmcResetRootPassword(object):
@@ -18,7 +66,9 @@ class TestBmcResetRootPassword(object):
     def setup_class(cls):
         print("SETUP")
 
-    def test_reset_root_password_success(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_reset_root_password_success(self, mock_get_bmc_os, mock_is_switch_host):
         """Test successful root password reset"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -38,7 +88,18 @@ class TestBmcResetRootPassword(object):
             assert "BMC root password reset successful" in result.output
             mock_bmc.reset_root_password.assert_called_once()
 
-    def test_reset_root_password_failure(self):
+    @SWITCH_HOST_PATCH
+    @SONIC_BMC_PATCH
+    def test_reset_root_password_rejected_when_sonic_bmc(self, mock_get_bmc_os, mock_is_switch_host):
+        """Test root password reset rejected when BMC OS is sonic"""
+        runner = CliRunner()
+        result = runner.invoke(bmc.reset_root_password, [])
+        assert result.exit_code != 0
+        assert "Operation not supported when BMC OS is sonic" in result.output
+
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_reset_root_password_failure(self, mock_get_bmc_os, mock_is_switch_host):
         """Test failed root password reset"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -58,7 +119,9 @@ class TestBmcResetRootPassword(object):
             assert "BMC root password reset failed: Password reset failed" in result.output
             mock_bmc.reset_root_password.assert_called_once()
 
-    def test_reset_root_password_bmc_not_available(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_reset_root_password_bmc_not_available(self, mock_get_bmc_os, mock_is_switch_host):
         """Test when BMC is not available"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -75,7 +138,9 @@ class TestBmcResetRootPassword(object):
             assert result.exit_code == 0
             assert "BMC is not available on this platform" in result.output
 
-    def test_reset_root_password_exception(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_reset_root_password_exception(self, mock_get_bmc_os, mock_is_switch_host):
         """Test when an exception occurs"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -100,7 +165,9 @@ class TestBmcOpenSession(object):
     def setup_class(cls):
         print("SETUP")
 
-    def test_open_session_success(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_open_session_success(self, mock_get_bmc_os, mock_is_switch_host):
         """Test successful session opening"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -121,7 +188,18 @@ class TestBmcOpenSession(object):
             assert "Token: token_abc" in result.output
             mock_bmc.open_session.assert_called_once()
 
-    def test_open_session_failure_no_credentials(self):
+    @SWITCH_HOST_PATCH
+    @SONIC_BMC_PATCH
+    def test_open_session_rejected_when_sonic_bmc(self, mock_get_bmc_os, mock_is_switch_host):
+        """Test open-session rejected when BMC OS is sonic"""
+        runner = CliRunner()
+        result = runner.invoke(bmc.open_session, [])
+        assert result.exit_code != 0
+        assert "Operation not supported when BMC OS is sonic" in result.output
+
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_open_session_failure_no_credentials(self, mock_get_bmc_os, mock_is_switch_host):
         """Test failed session opening with no credentials"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -141,7 +219,9 @@ class TestBmcOpenSession(object):
             assert "Failed to open session: Login failed" in result.output
             mock_bmc.open_session.assert_called_once()
 
-    def test_open_session_failure_empty_credentials(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_open_session_failure_empty_credentials(self, mock_get_bmc_os, mock_is_switch_host):
         """Test failed session opening with empty credentials"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -161,7 +241,9 @@ class TestBmcOpenSession(object):
             assert "Failed to open session: Login successful" in result.output
             mock_bmc.open_session.assert_called_once()
 
-    def test_open_session_bmc_not_available(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_open_session_bmc_not_available(self, mock_get_bmc_os, mock_is_switch_host):
         """Test when BMC is not available"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -178,7 +260,9 @@ class TestBmcOpenSession(object):
             assert result.exit_code == 0
             assert "BMC is not available on this platform" in result.output
 
-    def test_open_session_exception(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_open_session_exception(self, mock_get_bmc_os, mock_is_switch_host):
         """Test when an exception occurs"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -203,7 +287,9 @@ class TestBmcCloseSession(object):
     def setup_class(cls):
         print("SETUP")
 
-    def test_close_session_success(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_close_session_success(self, mock_get_bmc_os, mock_is_switch_host):
         """Test successful session closing"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -223,7 +309,18 @@ class TestBmcCloseSession(object):
             assert "Session closed successfully" in result.output
             mock_bmc.close_session.assert_called_once_with('session_123')
 
-    def test_close_session_failure(self):
+    @SWITCH_HOST_PATCH
+    @SONIC_BMC_PATCH
+    def test_close_session_rejected_when_sonic_bmc(self, mock_get_bmc_os, mock_is_switch_host):
+        """Test close-session rejected when BMC OS is sonic"""
+        runner = CliRunner()
+        result = runner.invoke(bmc.close_session, ['--session-id', 'session_123'])
+        assert result.exit_code != 0
+        assert "Operation not supported when BMC OS is sonic" in result.output
+
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_close_session_failure(self, mock_get_bmc_os, mock_is_switch_host):
         """Test failed session closing"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -243,7 +340,9 @@ class TestBmcCloseSession(object):
             assert "Failed to close session: Session not found" in result.output
             mock_bmc.close_session.assert_called_once_with('invalid_session')
 
-    def test_close_session_bmc_not_available(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_close_session_bmc_not_available(self, mock_get_bmc_os, mock_is_switch_host):
         """Test when BMC is not available"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()
@@ -260,7 +359,9 @@ class TestBmcCloseSession(object):
             assert result.exit_code == 0
             assert "BMC is not available on this platform" in result.output
 
-    def test_close_session_exception(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_close_session_exception(self, mock_get_bmc_os, mock_is_switch_host):
         """Test when an exception occurs"""
         runner = CliRunner()
         mock_sonic_platform = MagicMock()

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -6,11 +6,42 @@ from unittest import mock
 
 import pytest
 from click.testing import CliRunner
+from sonic_py_common import device_info
+from sonic_platform_base.bmc_base import BMCBase
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 import show.main as show
+
+OPENBMC_PATCH = mock.patch(
+    'sonic_py_common.device_info.get_bmc_os',
+    return_value=device_info.BMC_OS_OPENBMC)
+SONIC_BMC_PATCH = mock.patch(
+    'sonic_py_common.device_info.get_bmc_os',
+    return_value=device_info.BMC_OS_SONIC)
+SWITCH_HOST_PATCH = mock.patch(
+    'sonic_py_common.device_info.is_switch_host',
+    return_value=True)
+
+
+class _ShowTestBMC(BMCBase):
+    """Minimal BMCBase subclass for show platform BMC EEPROM tests."""
+
+    def _get_login_user_callback(self):
+        return 'testuser'
+
+    def _get_login_password_callback(self):
+        return 'testpass'
+
+    def _get_default_root_password(self):
+        return 'rootpass'
+
+    def get_firmware_id(self):
+        return 'BMC_FW_0'
+
+    def _get_eeprom_id(self):
+        return 'BMC_eeprom'
 
 
 @pytest.fixture(scope='class')
@@ -345,9 +376,29 @@ class TestShowPlatformBmc(object):
         'SerialNumber': '1320725102601'
     }
 
+    TEST_SONIC_BMC_EEPROM_INFO = {
+        'Model': 'P4102-A01',
+        'PartNumber': '699-24102-0100-EB1',
+        'SerialNumber': 'MT260560000K',
+        'Revision': 'A02',
+        'Manufacturer': 'NVIDIA',
+        'PowerState': 'On'
+    }
+
     TEST_BMC_VERSION = '88.0002.1252'
 
-    def test_bmc_summary_regular_output(self):
+    @SWITCH_HOST_PATCH
+    def test_bmc_os(self, mock_is_switch_host):
+        """Test 'show platform bmc os'"""
+        with mock.patch('show.platform.device_info.get_bmc_os', return_value='sonic'):
+            result = CliRunner().invoke(
+                show.cli.commands['platform'].commands['bmc'].commands['os'], [])
+            assert result.exit_code == 0, result.output
+            assert result.output.strip() == 'sonic'
+
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_summary_regular_output(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc summary' with regular output"""
         expected_output = """\
             Manufacturer: {}
@@ -384,7 +435,48 @@ class TestShowPlatformBmc(object):
             assert result.exit_code == 0, result.output
             assert result.output == textwrap.dedent(expected_output)
 
-    def test_bmc_summary_json_output(self):
+    @SWITCH_HOST_PATCH
+    @SONIC_BMC_PATCH
+    def test_bmc_summary_sonic_bmc_output(self, mock_get_bmc_os, mock_is_switch_host):
+        """Test 'show platform bmc summary' with SONiC BMC (FirmwareVersion is N/A)"""
+        expected_output = """\
+            Manufacturer: {}
+            Model: {}
+            PartNumber: {}
+            SerialNumber: {}
+            PowerState: {}
+            FirmwareVersion: N/A
+            """.format(
+                self.TEST_SONIC_BMC_EEPROM_INFO['Manufacturer'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['Model'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['PartNumber'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['SerialNumber'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['PowerState']
+            )
+
+        mock_sonic_platform = mock.MagicMock()
+        mock_platform = mock.MagicMock()
+        mock_chassis = mock.MagicMock()
+        mock_bmc = mock.MagicMock()
+
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = mock_bmc
+        mock_bmc.get_eeprom.return_value = self.TEST_SONIC_BMC_EEPROM_INFO
+        mock_bmc.get_version.side_effect = Exception('Operation not supported when BMC OS is sonic')
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = CliRunner().invoke(show.cli.commands['platform'].commands['bmc'].commands['summary'], [])
+            assert result.exit_code == 0, result.output
+            assert result.output == textwrap.dedent(expected_output)
+            mock_bmc.get_version.assert_not_called()
+
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_summary_json_output(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc summary' with JSON output"""
         expected_json = {
             'Manufacturer': self.TEST_BMC_EEPROM_INFO['Manufacturer'],
@@ -415,7 +507,9 @@ class TestShowPlatformBmc(object):
             output_json = json.loads(result.output)
             assert output_json == expected_json
 
-    def test_bmc_eeprom_regular_output(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_eeprom_regular_output(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc eeprom' with regular output"""
         expected_output = """\
             Manufacturer: {}
@@ -449,7 +543,47 @@ class TestShowPlatformBmc(object):
             assert result.exit_code == 0, result.output
             assert result.output == textwrap.dedent(expected_output)
 
-    def test_bmc_eeprom_json_output(self):
+    @SWITCH_HOST_PATCH
+    @SONIC_BMC_PATCH
+    @mock.patch.object(_ShowTestBMC, '_get_eeprom_from_sonic_bmc_redis')
+    def test_bmc_eeprom_sonic_bmc_output(self, mock_get_sonic_eeprom, mock_get_bmc_os, mock_is_switch_host):
+        """Test 'show platform bmc eeprom' with SONiC BMC EEPROM fields"""
+        mock_get_sonic_eeprom.return_value = self.TEST_SONIC_BMC_EEPROM_INFO
+        expected_output = """\
+            Manufacturer: {}
+            Model: {}
+            PartNumber: {}
+            PowerState: {}
+            SerialNumber: {}
+            """.format(
+                self.TEST_SONIC_BMC_EEPROM_INFO['Manufacturer'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['Model'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['PartNumber'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['PowerState'],
+                self.TEST_SONIC_BMC_EEPROM_INFO['SerialNumber']
+            )
+
+        mock_sonic_platform = mock.MagicMock()
+        mock_platform = mock.MagicMock()
+        mock_chassis = mock.MagicMock()
+
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = _ShowTestBMC('169.254.0.1')
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = CliRunner().invoke(
+                show.cli.commands['platform'].commands['bmc'].commands['eeprom'], [])
+            assert result.exit_code == 0, result.output
+            assert result.output == textwrap.dedent(expected_output)
+            mock_get_sonic_eeprom.assert_called_once()
+
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_eeprom_json_output(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc eeprom' with JSON output"""
         expected_json = {
             'Manufacturer': self.TEST_BMC_EEPROM_INFO['Manufacturer'],
@@ -478,7 +612,41 @@ class TestShowPlatformBmc(object):
             output_json = json.loads(result.output)
             assert output_json == expected_json
 
-    def test_bmc_summary_bmc_not_available(self):
+    @SWITCH_HOST_PATCH
+    @SONIC_BMC_PATCH
+    @mock.patch.object(_ShowTestBMC, '_get_eeprom_from_sonic_bmc_redis')
+    def test_bmc_eeprom_sonic_bmc_json_output(self, mock_get_sonic_eeprom, mock_get_bmc_os, mock_is_switch_host):
+        """Test 'show platform bmc eeprom --json' with SONiC BMC EEPROM fields"""
+        mock_get_sonic_eeprom.return_value = self.TEST_SONIC_BMC_EEPROM_INFO
+        expected_json = {
+            'Manufacturer': self.TEST_SONIC_BMC_EEPROM_INFO['Manufacturer'],
+            'Model': self.TEST_SONIC_BMC_EEPROM_INFO['Model'],
+            'PartNumber': self.TEST_SONIC_BMC_EEPROM_INFO['PartNumber'],
+            'PowerState': self.TEST_SONIC_BMC_EEPROM_INFO['PowerState'],
+            'SerialNumber': self.TEST_SONIC_BMC_EEPROM_INFO['SerialNumber']
+        }
+
+        mock_sonic_platform = mock.MagicMock()
+        mock_platform = mock.MagicMock()
+        mock_chassis = mock.MagicMock()
+
+        mock_platform.get_chassis.return_value = mock_chassis
+        mock_chassis.get_bmc.return_value = _ShowTestBMC('169.254.0.1')
+        mock_sonic_platform.platform.Platform.return_value = mock_platform
+
+        with mock.patch.dict('sys.modules', {
+            'sonic_platform': mock_sonic_platform,
+            'sonic_platform.platform': mock_sonic_platform.platform
+        }):
+            result = CliRunner().invoke(
+                show.cli.commands['platform'].commands['bmc'].commands['eeprom'], ['--json'])
+            assert result.exit_code == 0, result.output
+            assert json.loads(result.output) == expected_json
+            mock_get_sonic_eeprom.assert_called_once()
+
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_summary_bmc_not_available(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc summary' when BMC is not available"""
         mock_sonic_platform = mock.MagicMock()
         mock_platform = mock.MagicMock()
@@ -496,7 +664,9 @@ class TestShowPlatformBmc(object):
             assert result.exit_code == 0, result.output
             assert "BMC is not available on this platform" in result.output
 
-    def test_bmc_summary_eeprom_info_empty(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_summary_eeprom_info_empty(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc summary' when EEPROM info is empty"""
         mock_sonic_platform = mock.MagicMock()
         mock_platform = mock.MagicMock()
@@ -516,7 +686,9 @@ class TestShowPlatformBmc(object):
             assert result.exit_code == 0, result.output
             assert "Failed to retrieve BMC EEPROM information" in result.output
 
-    def test_bmc_summary_exception(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_summary_exception(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc summary' when an exception occurs"""
         mock_sonic_platform = mock.MagicMock()
         mock_platform = mock.MagicMock()
@@ -534,7 +706,9 @@ class TestShowPlatformBmc(object):
             assert result.exit_code == 0, result.output
             assert "Error retrieving BMC information: Test exception" in result.output
 
-    def test_bmc_eeprom_bmc_not_available(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_eeprom_bmc_not_available(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc eeprom' when BMC is not available"""
         mock_sonic_platform = mock.MagicMock()
         mock_platform = mock.MagicMock()
@@ -552,7 +726,9 @@ class TestShowPlatformBmc(object):
             assert result.exit_code == 0, result.output
             assert "BMC is not available on this platform" in result.output
 
-    def test_bmc_eeprom_info_empty(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_eeprom_info_empty(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc eeprom' when EEPROM info is empty"""
         mock_sonic_platform = mock.MagicMock()
         mock_platform = mock.MagicMock()
@@ -572,7 +748,9 @@ class TestShowPlatformBmc(object):
             assert result.exit_code == 0, result.output
             assert "Failed to retrieve BMC EEPROM information" in result.output
 
-    def test_bmc_eeprom_exception(self):
+    @SWITCH_HOST_PATCH
+    @OPENBMC_PATCH
+    def test_bmc_eeprom_exception(self, mock_get_bmc_os, mock_is_switch_host):
         """Test 'show platform bmc eeprom' when an exception occurs"""
         mock_sonic_platform = mock.MagicMock()
         mock_platform = mock.MagicMock()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

Dependent on: https://github.com/sonic-net/sonic-buildimage/pull/29206

#### What I did
Wire Switch-Host BMC CLIs to the new `DEVICE_METADATA|bmc os` configuration (`openbmc` |
`sonic`):

- Added `config bmc os <openbmc|sonic>` and `show platform bmc os`.
- Blocked OpenBMC-only commands when BMC OS is `sonic` (`config bmc reset-root-password`,
  `open-session`, `close-session`; `show platform bmc summary`).
- Left `show platform bmc eeprom` available for both paths (OpenBMC Redfish vs SONiC Redis
  EEPROM fields).
- Limited techsupport BMC log collection to OpenBMC only (`generate_dump`).

#### How I did it
- **`config/bmc.py`**: `config_bmc_os` writes `DEVICE_METADATA|bmc` `os`; `_reject_sonic_bmc_os()`
  guards Redfish session commands.
- **`show/platform.py`**: `show platform bmc os`; `_reject_sonic_bmc_os_for_openbmc_command()`
  on `bmc summary`.
- **`scripts/generate_dump`**: `is_bmc_supported()` requires `get_bmc_os() == openbmc`.
- **Tests**: `tests/bmc_test.py`, `tests/show_platform_test.py` — new OS config/show tests,
  sonic rejection tests, SONiC EEPROM output.

#### How to verify it
Unit tests:

```bash
cd sonic-utilities
pytest tests/bmc_test.py -v
pytest tests/show_platform_test.py::TestShowPlatformBmc -v
```

Manual (Switch-Host with companion image):

```bash
show platform bmc os                    # sonic (default)
config bmc os openbmc
show platform bmc os                    # openbmc
config bmc os sonic

config bmc reset-root-password          # rejected on sonic
show platform bmc summary               # rejected on sonic
show platform bmc eeprom                # works on sonic (Model/PartNumber/SerialNumber)

config bmc os openbmc                   # restore OpenBMC path
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

