### PR TITLE
sonic-utilities: Tolerate ENOENT in vlanintf_validator ip neigh flush

### DIFF
--- a/.azure-pipelines/pre-commit-check.yml
+++ b/.azure-pipelines/pre-commit-check.yml
@@ -5,7 +5,7 @@ steps:
 
 - script: |
     set -x
-    sudo pip install pre-commit
+    sudo uv pip install --system pre-commit
     pre-commit install-hooks
   displayName: 'Prepare pre-commit check'
 
@@ -20,7 +20,7 @@ steps:
     To run the pre-commit checks locally, you can follow below steps:\n\
       1. Ensure that default python is python3.\n\
       2. Ensure that the 'pre-commit' package is installed:\n\
-         sudo pip install pre-commit\n\
+         sudo uv pip install --system pre-commit\n\
       3. Go to repository root folder\n\
       4. Install the pre-commit hooks:\n\
          pre-commit install\n\

--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -72,6 +72,7 @@ class AclLoader(object):
 
     ACL_TABLE = "ACL_TABLE"
     ACL_RULE = "ACL_RULE"
+    ACL_TABLE_TYPE = "ACL_TABLE_TYPE"
     CFG_ACL_TABLE = "ACL_TABLE"
     APPL_ACL_TABLE = "ACL_TABLE_TABLE"
     STATE_ACL_TABLE = "ACL_TABLE_TABLE"
@@ -121,6 +122,7 @@ class AclLoader(object):
         self.mirror_stage = None
         self.current_table = None
         self.tables_db_info = {}
+        self.tables_type_info = {}
         self.rules_db_info = {}
         self.rules_info = {}
         self.tables_state_info = None
@@ -202,6 +204,19 @@ class AclLoader(object):
                     else:
                         self.tables_db_info[table]['ports'] += entry.get(
                             'ports', [])
+
+        # Update user defined acl table types
+        if self.per_npu_configdb:
+            # On multi-asic the acl table type should be defined in both the global namespace
+            # and the asic namespaces but using the asic namespace definition to be consistent
+            # with the way tables_db_info is populated.
+            for ns, config_db in self.per_npu_configdb.items():
+                acl_table_type = config_db.get_table(self.ACL_TABLE_TYPE)
+                for table_type, entry in acl_table_type.items():
+                    if table_type not in self.tables_type_info:
+                        self.tables_type_info[table_type] = entry
+        else:
+            self.tables_type_info.update(self.configdb.get_table(self.ACL_TABLE_TYPE))
 
         if self.per_npu_configdb:
             # Note: Ability to read table information from APPL_DB is not yet supported for masic devices
@@ -455,6 +470,22 @@ class AclLoader(object):
         :return: True if table type is ACL_TABLE_TYPE_CTRLPLANE else False
         """
         return self.tables_db_info[tname]['type'].upper() == self.ACL_TABLE_TYPE_CTRLPLANE
+
+    def acl_table_has_match(self, tname, match):
+        """
+        Check if the ACL table supports matching on a given qualifier.
+        Non-user defined ACL table types will always return true here as we assume they
+        support all qualifiers
+        :param tname: ACL table name
+        :param match: ACL qualifier to query support for
+        :return: True if qualifier is supported or table type is not user defined
+        """
+        table_type = self.tables_db_info[tname]["type"]
+        # Predefined table types aren't defined in the tables_type_info
+        if table_type not in self.tables_type_info:
+            return True
+        else:
+            return match in self.tables_type_info[table_type]["MATCHES"]
 
     @staticmethod
     def parse_acl_json(filename):
@@ -795,7 +826,8 @@ class AclLoader(object):
         deep_update(rule_props, self.convert_transport(table_name, rule_idx, rule))
         deep_update(rule_props, self.convert_input_interface(table_name, rule_idx, rule))
 
-        if "IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props:
+        if ("IP_PROTOCOL" in rule_props and "IP_TYPE" not in rule_props
+                and self.acl_table_has_match(table_name, "IP_TYPE")):
             # If we don't include IP_TYPE as a qualifier in the IP_PROTOCOL rule
             # we could match on non-IP packets if the bits at the same offset match
             # https://github.com/sonic-net/sonic-mgmt/issues/23960

--- a/config/main.py
+++ b/config/main.py
@@ -2196,6 +2196,24 @@ def reload(db, filename, yes, load_sysinfo, no_service_restart, force, file_form
 
     #Stop services before config push
     if not no_service_restart:
+        try:
+            _db = swsscommon.DBConnector('STATE_DB', 0)
+            boot_type = None
+            # fast-reboot sets both FAST_RESTART_ENABLE_TABLE and WARM_RESTART_ENABLE_TABLE;
+            # check fast first so the label is correct when both flags are set.
+            if swsscommon.RestartWaiter.isFastBootInProgress(_db):
+                boot_type = 'fast-reboot'
+            elif swsscommon.RestartWaiter.isWarmBootInProgress(_db):
+                boot_type = 'warm-boot'
+            if boot_type:
+                click.echo(f"A {boot_type} is still in progress. Please wait for finalization to complete.")
+                sys.exit(CONFIG_RELOAD_NOT_READY)
+        except SystemExit:
+            raise
+        except Exception:
+            pass
+
+    if not no_service_restart:
         log.log_notice("'reload' stopping services...")
         _stop_services()
 

--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -46,6 +46,7 @@ def get_asic_name():
             spc3_hwskus = asic_mapping["mellanox_asics"]["spc3"]
             spc4_hwskus = asic_mapping["mellanox_asics"]["spc4"]
             spc5_hwskus = asic_mapping["mellanox_asics"]["spc5"]
+            spc6_hwskus = asic_mapping["mellanox_asics"]["spc6"]
             if hwsku.lower() in [spc1_hwsku.lower() for spc1_hwsku in spc1_hwskus]:
                 asic = "spc1"
                 return asic
@@ -60,6 +61,9 @@ def get_asic_name():
                 return asic
             if hwsku.lower() in [spc5_hwsku.lower() for spc5_hwsku in spc5_hwskus]:
                 asic = "spc5"
+                return asic
+            if hwsku.lower() in [spc6_hwsku.lower() for spc6_hwsku in spc6_hwskus]:
+                asic = "spc6"
                 return asic
         if asic_type == 'broadcom' or asic_type == 'vs':
             broadcom_asics = asic_mapping["broadcom_asics"]

--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -24,7 +24,7 @@
                           "Mellanox-SN4700-A96C8V8", "Mellanox-SN4700-C128", "Mellanox-SN4700-O28", "Mellanox-SN4700-O8V48", "Mellanox-SN4700-V48C32", "Mellanox-SN4280-O28", "Mellanox-SN4280-O8C80", "Mellanox-SN4280-C48", "Mellanox-SN4280-O8C40", "Mellanox-SN4280-O8V40", "Mellanox-SN4280-O4X96"],
                 "spc4": [ "ACS-SN5600", "Mellanox-SN5600-O128", "Mellanox-SN5600-V256", "Mellanox-SN5600-C256S1", "ACS-SN5400", "Mellanox-SN5600-C224O8", "Mellanox-SN5610N-C256S2", "Mellanox-SN5610N-C224O8" ],
                 "spc5": ["ACS-SN5640", "Mellanox-SN5640-C512S2", "Mellanox-SN5640-C448O16", "Mellanox-SN5640-C512X2", "Mellanox-SN5640-C508O1X2", "Mellanox-SN5640-O128X2" ],
-                "spc6": ["ACS-SN6600_LD"]
+                "spc6": ["ACS-SN6600_LD", "Mellanox-SN6600_LD-P128C2", "Mellanox-SN6600_LD-P64O128C2"]
             },
             "broadcom_asics": {
                 "th": [ "Force10-S6100", "Arista-7060CX-32S-C32", "Arista-7060CX-32S-C32-T1", "Arista-7060CX-32S-D48C8", "Celestica-DX010-C32", "Seastone-DX010" ],
@@ -67,6 +67,7 @@
                             "spc3": "20220500",
                             "spc4": "20221100",
                             "spc5": "20241200",
+                            "spc6": "20260500",
                             "td2": "20181100",
                             "th": "20181100",
                             "th2": "20181100",
@@ -119,6 +120,7 @@
                             "spc3": "20220500",
                             "spc4": "20221100",
                             "spc5": "20241200",
+                            "spc6": "20260500",
                             "td2": "20181100",
                             "th": "20181100",
                             "th2": "20181100",
@@ -148,6 +150,7 @@
                             "spc3": "20220500",
                             "spc4": "20221100",
                             "spc5": "20241200",
+                            "spc6": "20260500",
                             "td2": "",
                             "th": "20221100",
                             "th2": "20221100",
@@ -174,6 +177,7 @@
                         "platforms": {
                             "spc4": "20241200",
                             "spc5": "20241200",
+                            "spc6": "20260500",
                             "th5": "20241200",
                             "th6": "20251100"
                         }

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -114,7 +114,7 @@ class PatchApplier:
 
         # Generate target config
         self.logger.log_notice(f"{scope}: simulating the target full config after applying the patch.")
-        target_config = self.patch_wrapper.simulate_patch(patch, old_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, old_config)
 
         # Validate all JsonPatch operations on specified fields
         self.logger.log_notice(f"{scope}: validating all JsonPatch operations are permitted on the specified fields")

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -405,6 +405,36 @@ class DryRunConfigWrapper(ConfigWrapper):
             self.imitated_config_db = super().get_config_db_as_json()
 
 
+def remove_empty_leaf_lists(config):
+    """Drop leaf-list fields whose value is an empty list.
+
+    Expects ConfigDB shaped json, i.e. table -> key -> field. At that shape a
+    list valued field is always a leaf-list, so every empty list found here is
+    an empty leaf-list. Do not call this with SonicYang shaped json, where a
+    list is a yang list of entries rather than a leaf-list.
+
+    ConfigDB has no representation for an empty leaf-list. set_entry serializes
+    [] to an empty string, which is then read back as [''], so a config that asks
+    for [] can never be satisfied. The canonical way to express "this leaf-list
+    has no items" is for the field to be absent.
+
+    Normalizing the simulated target keeps the patch sorter, the change applier
+    and the final verification in agreement: the sorter emits a field-level
+    remove instead of a replace-with-empty-list that ConfigDB cannot store.
+    """
+    for entries in config.values():
+        if not isinstance(entries, dict):
+            continue
+        for fields in entries.values():
+            if not isinstance(fields, dict):
+                continue
+            empty_leaf_lists = [field for field, value in fields.items()
+                                if isinstance(value, list) and len(value) == 0]
+            for field in empty_leaf_lists:
+                del fields[field]
+    return config
+
+
 class PatchWrapper:
     def __init__(self, config_wrapper=None, scope=multi_asic.DEFAULT_NAMESPACE):
         self.scope = scope
@@ -438,12 +468,21 @@ class PatchWrapper:
     def simulate_patch(self, patch, jsonconfig):
         return patch.apply(jsonconfig)
 
+    def simulate_config_db_patch(self, patch, config_db):
+        """Simulate a patch against ConfigDB shaped json.
+
+        Use this instead of simulate_patch whenever the result is meant to be a
+        ConfigDB target, so that empty leaf-lists are normalized to absent
+        fields, which is the only way ConfigDB can express them.
+        """
+        return remove_empty_leaf_lists(self.simulate_patch(patch, config_db))
+
     def convert_config_db_patch_to_sonic_yang_patch(self, patch):
         if not(self.validate_config_db_patch_has_yang_models(patch)):
             raise ValueError(f"Given patch is not valid")
 
         current_config_db = self.config_wrapper.get_config_db_as_json()
-        target_config_db = self.simulate_patch(patch, current_config_db)
+        target_config_db = self.simulate_config_db_patch(patch, current_config_db)
 
         current_yang = self.config_wrapper.convert_config_db_to_sonic_yang(current_config_db)
         target_yang = self.config_wrapper.convert_config_db_to_sonic_yang(target_config_db)

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -748,6 +748,7 @@ class RemoveCreateOnlyDependencyMoveValidator:
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
         self.create_only_filter = CreateOnlyFilter(path_addressing).get_filter()
+        self.logger = genericUpdaterLogging.get_logger(title="Patch Sorter - RemoveCreateOnly")
 
     def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         # Note: group is not used by this validator
@@ -822,7 +823,28 @@ class RemoveCreateOnlyDependencyMoveValidator:
                 return False
 
         member_path = f"/{table_to_check}/{member_name}"
-        for ref_path in self.path_addressing.find_ref_paths(member_path, simulated_config, reload_config=reload_config):
+        try:
+            ref_paths = self.path_addressing.find_ref_paths(
+                member_path, simulated_config, reload_config=reload_config)
+        except (ValueError, KeyError) as e:
+            # An unresolvable or malformed reference against the simulated intermediate config
+            # raises here. The motivating case: a create-only field change (e.g. a PORT breakout
+            # that rewrites lanes) has transiently removed this member from a multi-member leaf-list
+            # (e.g. ACL_TABLE.ports) while a leafref to it is still present, so the dangling leafref
+            # fails to resolve (list.index raises ValueError). Other resolution failures in the
+            # xpath<->configdb-path conversion (schema/key-count mismatches raise ValueError; a table
+            # with no YANG model raises KeyError) likewise indicate the reference cannot be resolved
+            # against this intermediate config. In every case the ordering is an invalid intermediate
+            # move, so reject it and let the sort backtrack rather than aborting the whole sort.
+            # Scope is deliberately limited to reference-resolution errors: a loadData failure
+            # (sonic_yang.SonicYangException) is not caught here because FullConfigMoveValidator has
+            # already loaded this config into the sy singleton, so find_ref_paths skips loadData.
+            self.logger.log_debug(
+                f"Rejecting move: reference resolution failed against simulated config "
+                f"for '{member_path}': {type(e).__name__}: {e}")
+            return False
+
+        for ref_path in ref_paths:
             if not self.path_addressing.has_path(current_config, ref_path):
                 return False
 
@@ -963,6 +985,7 @@ class NoDependencyMoveValidator:
     def __init__(self, path_addressing, config_wrapper):
         self.path_addressing = path_addressing
         self.config_wrapper = config_wrapper
+        self.logger = genericUpdaterLogging.get_logger(title="Patch Sorter - NoDependency")
 
     def validate(self, group: JsonMoveGroup, diff, simulated_config) -> Tuple[bool, Optional[str]]:
         reload_config = True
@@ -979,7 +1002,8 @@ class NoDependencyMoveValidator:
 
         if operation_type == OperationType.ADD:
             # For add operation, we check the simulated config has no dependencies between nodes under the added path
-            if not self._validate_paths_config([path], simulated_config, reload_config):
+            if not self._validate_paths_config([path], simulated_config, reload_config,
+                                               reject_on_unresolvable_ref=True):
                 return False
         elif operation_type == OperationType.REMOVE:
             # For remove operation, we check the current config has no dependencies between nodes under the removed path
@@ -1030,7 +1054,8 @@ class NoDependencyMoveValidator:
         # so _currently_loaded_hash will match and find_ref_paths skips loadData.
         # Then validate deleted_paths against current_config (requires a fresh loadData).
         # This ordering gives 2 loadData calls instead of 3 for REPLACE operations.
-        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True):
+        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True,
+                                           reject_on_unresolvable_ref=True):
             return False
 
         if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
@@ -1100,11 +1125,31 @@ class NoDependencyMoveValidator:
 
         return deleted_paths, added_paths
 
-    def _validate_paths_config(self, paths, config, reload_config: bool = True):
+    def _validate_paths_config(self, paths, config, reload_config: bool = True,
+                               reject_on_unresolvable_ref: bool = False):
         """
         validates all config under paths do not have config and its references
+
+        reject_on_unresolvable_ref: set only when 'config' is the transient simulated intermediate
+        state. A dangling leafref in that state (e.g. a create-only PORT change that has transiently
+        removed the port from a leaf-list such as ACL_TABLE.ports while a reference to it lingers)
+        makes find_ref_paths raise ValueError; a table with no YANG model makes it raise KeyError.
+        Either way it is an invalid intermediate move, so reject it and let the sort backtrack rather
+        than aborting. When 'config' is diff.current_config (a valid committed state) the flag stays
+        False: such an error there is genuine and must surface instead of being silently swallowed.
+        Scope is limited to reference-resolution errors; a loadData failure
+        (sonic_yang.SonicYangException) is not caught because the config is already loaded into the sy
+        singleton by FullConfigMoveValidator, so find_ref_paths skips loadData for it.
         """
-        refs = self.path_addressing.find_ref_paths(paths, config, reload_config=reload_config)
+        try:
+            refs = self.path_addressing.find_ref_paths(paths, config, reload_config=reload_config)
+        except (ValueError, KeyError) as e:
+            if reject_on_unresolvable_ref:
+                self.logger.log_debug(
+                    f"Rejecting move: reference resolution failed against simulated config "
+                    f"for {paths}: {type(e).__name__}: {e}")
+                return False
+            raise
         for ref in refs:
             for path in paths:
                 if ref.startswith(path):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1354,7 +1354,12 @@ class BulkLeafListMoveGenerator:
 
             if isinstance(current_val, list) and isinstance(target_val, list):
                 # Only handle leaf-lists (lists of scalars)
+                # An empty target leaf-list is deliberately excluded: a bulk
+                # REPLACE with [] serializes to an empty string in CONFIG_DB,
+                # which is an invalid state. Those transitions are left to the
+                # granular removal generators, which remove the field instead.
                 if (current_val != target_val and
+                        len(target_val) > 0 and
                         self._is_leaf_list(current_val) and
                         self._is_leaf_list(target_val)):
                     yield JsonMoveGroup(
@@ -2406,7 +2411,7 @@ class StrictPatchSorter:
         if not(self.patch_wrapper.validate_config_db_patch_has_yang_models(patch)):
             raise ValueError(f"Given patch is not valid because it has changes to tables without YANG models")
 
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         # Validate target config
         self.logger.log_info("Validating target config according to YANG models.")
@@ -2596,7 +2601,7 @@ class NonStrictPatchSorter:
 
     def sort(self, patch, algorithm=Algorithm.DFS, trace_io: Optional[IO] = None):
         current_config = self.config_wrapper.get_config_db_as_json()
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         # Splitting current/target config based on YANG covered vs non-YANG covered configs
         self.logger.log_info("Splitting current/target config based on YANG covered vs non-YANG covered configs.")
@@ -2658,7 +2663,7 @@ class PatchSorter:
 
     def sort(self, patch, algorithm=Algorithm.DFS, preloaded_current_config=None, trace_io: Optional[IO] = None):
         current_config = preloaded_current_config if preloaded_current_config else self.config_wrapper.get_config_db_as_json()
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         diff = Diff(copy.deepcopy(current_config), target_config)
 

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1912,7 +1912,7 @@ class LowLevelMoveGenerator:
             yield move
 
     def _traverse_current_list(self, ptr, current_tokens):
-        if len(ptr) == 0:
+        if len(ptr) <= 1:
             yield JsonMoveGroup(self.__class__.__name__, JsonMove(self.diff, OperationType.REMOVE, current_tokens))
             return
 

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -175,10 +175,20 @@ def vlanintf_validator(old_config, upd_config, keys):
     deleted_keys = list(set(old_keys) - set(upd_keys))
     for key in deleted_keys:
         iface, iface_ip = key
-        rc = command_wrapper(f"ip neigh flush dev {iface} {iface_ip}")
-        if rc:
+        cmd = f"ip neigh flush dev {iface} {iface_ip}"
+        result = subprocess.run(
+            shlex.split(cmd), capture_output=True, check=False, text=True
+        )
+        if result.returncode != 0:
+            if "No such file or directory" in result.stderr:
+                continue
             logger.log(logger.LOG_PRIORITY_ERROR,
-                       f"vlanintf_validator: Failed to flush neighbors for {iface} {iface_ip}, returncode={rc}",
+                       f"vlanintf_validator: Failed to flush neighbors for "
+                       f"{iface} {iface_ip}, returncode={result.returncode}",
                        print_to_console)
+            if result.stderr:
+                logger.log(logger.LOG_PRIORITY_ERROR,
+                           f"stderr: {result.stderr}",
+                           print_to_console)
             return False
     return True

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2233,13 +2233,7 @@ save_log_files() {
 #  0 if BMC is supported, 1 otherwise
 ###############################################################################
 is_bmc_supported() {
-    local platform=$(python3 -c "from sonic_py_common import device_info; print(device_info.get_platform())")
-    # Check if the required file exists
-    if [ ! -f /usr/share/sonic/device/$platform/bmc.json ]; then
-        return 1
-    else
-        return 0
-    fi
+    python3 -c "from sonic_py_common import device_info; import sys; sys.exit(0 if (device_info.is_switch_host() and device_info.get_bmc_data()) else 1)"
 }
 
 ###############################################################################

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -417,7 +417,7 @@ def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
         if not route_entry.get('selected', False):
             return
         if not route_entry.get('offloaded', False):
-            missing_routes.append(prefix)
+            missing_routes.append({'prefix': prefix, 'protocol': route_entry.get('protocol', '')})
         if route_entry.get('failed', False):
             failing_routes.append(prefix)
 

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -80,6 +80,12 @@ PRINT_MSG_LEN_MAX = 1000
 FRR_CHECK_RETRIES = 3
 FRR_WAIT_TIME = 15
 
+# How long to wait for vtysh to exit once we have closed the read end
+VTYSH_EXIT_TIMEOUT_SECONDS = 10
+
+# How long to wait for the direct child to be reaped after we SIGKILL it
+SIGKILL_REAP_TIMEOUT_SECONDS = 3
+
 REDIS_TIMEOUT_MSECS = 0
 
 
@@ -422,34 +428,78 @@ def fetch_routes(ipv6=False, namespace=multi_asic.DEFAULT_NAMESPACE):
             failing_routes.append(prefix)
 
     try:
-        with subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=0) as proc:
+        # Deliberately not used as a context manager: Popen.__exit__ ends in an
+        # unbounded wait(), which is the hang this whole change removes. Every
+        # wait() below is bounded.
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, bufsize=0)
+        completed = False
+        return_code = None
+        try:
+            # Use ijson to parse the JSON stream incrementally
+            # kvitems('') iterates over key-value pairs at the root level
+            # This gives us each prefix and its route entries as they become available
+            for prefix, route_entries in ijson.kvitems(proc.stdout, ''):
+                # Process each route entry for this prefix
+                if isinstance(route_entries, list):
+                    for route_entry in route_entries:
+                        process_route_entry(prefix, route_entry)
+                else:
+                    # Handle case where route_entries is not a list (shouldn't happen with valid FRR output)
+                    print_message(syslog.LOG_WARNING, f"Unexpected route entry format for prefix {prefix}")
+            completed = True
+
+        except Exception as e:
+            # Parse errors are logged and swallowed, exactly as before: this
+            # returns whatever it managed to parse.
+            print_message(syslog.LOG_WARNING, f"Error while parsing vtysh JSON stream: {e}")
+        finally:
+            # Closing the read end is what releases the chain, and it has to
+            # happen before any wait(). An abandoned read leaves vtysh blocked
+            # in write() with megabytes still queued; closing makes that write
+            # fail with EPIPE, so vtysh, the /usr/bin/vtysh wrapper and the
+            # docker exec client all unwind and the exec session is released.
+            # Waiting first is the deadlock this change removes.
+            # A finally (not a flag) so KeyboardInterrupt takes this path too.
+            if proc.stdout:
+                proc.stdout.close()
             try:
-                # Use ijson to parse the JSON stream incrementally
-                # kvitems('') iterates over key-value pairs at the root level
-                # This gives us each prefix and its route entries as they become available
-                for prefix, route_entries in ijson.kvitems(proc.stdout, ''):
-                    # Process each route entry for this prefix
-                    if isinstance(route_entries, list):
-                        for route_entry in route_entries:
-                            process_route_entry(prefix, route_entry)
-                    else:
-                        # Handle case where route_entries is not a list (shouldn't happen with valid FRR output)
-                        print_message(syslog.LOG_WARNING, f"Unexpected route entry format for prefix {prefix}")
+                # In the same finally so the child is reaped even while a
+                # KeyboardInterrupt is propagating, which would otherwise skip
+                # this and leave the direct child a zombie. Bounded: nothing
+                # left to wait on, and fetch_routes runs on a worker thread the
+                # SIGALRM watchdog cannot interrupt, so it must not block here.
+                return_code = proc.wait(timeout=VTYSH_EXIT_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                # Closing only releases a process that goes on to write. One
+                # hung without writing needs the signal, and route_check runs
+                # on a timer, so walking away would leak a child per timeout.
+                #
+                # This reaches the direct child only: sudo does not propagate
+                # SIGKILL, so the /usr/bin/vtysh wrapper and the docker exec
+                # client below it are not covered. Reaching those would need
+                # the process group, which this function deliberately does not
+                # use - os.killpg() cannot signal the root-owned processes sudo
+                # spawns unless route_check is root, and kill(-pgid) reports
+                # success as long as it reached sudo, so the failure is silent.
+                # Whatever it does not cover still unwinds by itself the moment
+                # it writes into the pipe we closed above.
+                print_message(syslog.LOG_ERR,
+                              f"vtysh (pid {proc.pid}) did not exit; killing the direct child")
+                proc.kill()
+                try:
+                    # Leave return_code as None: the exit code from here on is
+                    # our own SIGKILL, not something vtysh should be judged by.
+                    proc.wait(timeout=SIGKILL_REAP_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    print_message(syslog.LOG_ERR,
+                                  f"vtysh (pid {proc.pid}) survived SIGKILL; abandoning")
+            # Never return from here: a return inside finally would swallow an
+            # in-flight KeyboardInterrupt.
 
-            except ijson.JSONError as e:
-                # Handle JSON parsing errors
-                print_message(syslog.LOG_WARNING, f"Failed to parse JSON stream: {e}")
-            except UnicodeDecodeError as e:
-                # Handle UTF-8 decoding errors
-                print_message(syslog.LOG_WARNING, f"UTF-8 decoding error: {e}")
-            except Exception as e:
-                # Handle any other unexpected errors during parsing
-                print_message(syslog.LOG_WARNING, f"Error during JSON parsing: {e}")
-
-            # Wait for the process to terminate and get the return code
-            return_code = proc.wait()
-            if return_code != 0:
-                print_message(syslog.LOG_WARNING, f"Subprocess exited with non-zero return code: {return_code}")
+        # After an abandoned read vtysh dies of SIGPIPE, which sudo reports as
+        # 141. That is this function's own doing, not a vtysh failure.
+        if completed and return_code not in (None, 0):
+            print_message(syslog.LOG_WARNING, f"Subprocess exited with non-zero return code: {return_code}")
 
     except FileNotFoundError:
         print_message(syslog.LOG_ERR, f"Error: Command '{cmd[0]}' not found.")

--- a/show/chassis_modules.py
+++ b/show/chassis_modules.py
@@ -21,6 +21,16 @@ CHASSIS_MIDPLANE_INFO_TABLE = 'CHASSIS_MIDPLANE_TABLE'
 CHASSIS_MIDPLANE_INFO_IP_FIELD = 'ip_address'
 CHASSIS_MIDPLANE_INFO_ACCESS_FIELD = 'access'
 
+DPU_STATE_TABLE = 'DPU_STATE'
+DPU_STATE_READY_STATUS_FIELD = 'ready_status'
+DPU_STATE_RECOVERY_STATUS_FIELD = 'recovery_status'
+DPU_STATE_RESET_COUNT_FIELD = 'reset_count'
+DPU_STATE_LAST_DOWN_TIME_FIELD = 'last_down_time'
+DPU_STATE_LAST_READY_TIME_FIELD = 'last_ready_time'
+
+CHASSIS_SERVER = 'redis_chassis.server'
+CHASSIS_SERVER_PORT = 6380
+
 @click.group(cls=clicommon.AliasedGroup)
 def chassis():
     """Chassis commands group"""
@@ -37,7 +47,11 @@ def modules():
 def status(db, chassis_module_name):
     """Show chassis-modules status"""
 
+    smartswitch = is_smartswitch()
     header = ['Name', 'Description', 'Physical-Slot', 'Oper-Status', 'Admin-Status', 'Serial']
+    if smartswitch:
+        header.append('Ready-Status')
+
     chassis_cfg_table = db.cfgdb.get_table('CHASSIS_MODULE')
 
     state_db = SonicV2Connector(host="127.0.0.1")
@@ -65,6 +79,27 @@ def status(db, chassis_module_name):
         except Exception:
             pass
 
+    # For SmartSwitch, connect to CHASSIS_STATE_DB to read DPU_STATE
+    dpu_state_data = {}
+    chassis_state_db = None
+    if smartswitch:
+        try:
+            chassis_state_db = SonicV2Connector(host=CHASSIS_SERVER, port=CHASSIS_SERVER_PORT)
+            chassis_state_db.connect(chassis_state_db.CHASSIS_STATE_DB)
+            if chassis_module_name:
+                dpu_key_pattern = DPU_STATE_TABLE + '|' + chassis_module_name
+            else:
+                dpu_key_pattern = DPU_STATE_TABLE + '|*'
+            dpu_keys = chassis_state_db.keys(chassis_state_db.CHASSIS_STATE_DB, dpu_key_pattern)
+            if dpu_keys:
+                for dpu_key in dpu_keys:
+                    dpu_name = dpu_key.split('|')[1]
+                    dpu_state_data[dpu_name] = chassis_state_db.get_all(
+                        chassis_state_db.CHASSIS_STATE_DB, dpu_key)
+        except Exception:
+            chassis_state_db = None
+            dpu_state_data = {}
+
     table = []
     for key in natsorted(keys):
         key_list = key.split('|')
@@ -87,7 +122,7 @@ def status(db, chassis_module_name):
                 oper_status = platform_oper_status
 
         # Determine admin_status
-        if is_smartswitch():
+        if smartswitch:
             admin_status = 'down'
         else:
             admin_status = 'up'
@@ -95,12 +130,79 @@ def status(db, chassis_module_name):
         if config_data is not None:
             admin_status = config_data.get(CHASSIS_MODULE_INFO_ADMINSTATUS_FIELD, admin_status)
 
-        table.append((key_list[1], desc, slot, oper_status, admin_status, serial))
+        row = [key_list[1], desc, slot, oper_status, admin_status, serial]
+
+        if smartswitch:
+            dpu_info = dpu_state_data.get(key_list[1], {})
+            ready_status = dpu_info.get(DPU_STATE_READY_STATUS_FIELD, 'N/A')
+            row.append(ready_status)
+
+        table.append(tuple(row))
+
+    if chassis_state_db:
+        chassis_state_db.close(chassis_state_db.CHASSIS_STATE_DB)
 
     if table:
         click.echo(tabulate(table, header, tablefmt='simple', stralign='right'))
     else:
         click.echo('No data available in CHASSIS_MODULE_TABLE\n')
+
+
+@modules.command()
+@click.argument('chassis_module_name', metavar='<module_name>', required=False)
+def recovery(chassis_module_name):
+    """Show chassis-modules recovery information"""
+
+    if not is_smartswitch():
+        click.echo('This command is only supported on SmartSwitch platforms')
+        return
+
+    header = ['Name', 'Ready-Status', 'Recovery-Status', 'Reset-Count',
+              'Last-Down-Time', 'Last-Ready-Time']
+
+    try:
+        chassis_state_db = SonicV2Connector(host=CHASSIS_SERVER, port=CHASSIS_SERVER_PORT)
+        chassis_state_db.connect(chassis_state_db.CHASSIS_STATE_DB)
+    except Exception:
+        click.echo('Unable to connect to CHASSIS_STATE_DB')
+        return
+
+    key_pattern = DPU_STATE_TABLE + '|*'
+    if chassis_module_name:
+        key_pattern = DPU_STATE_TABLE + '|' + chassis_module_name
+
+    keys = chassis_state_db.keys(chassis_state_db.CHASSIS_STATE_DB, key_pattern)
+    if not keys:
+        chassis_state_db.close(chassis_state_db.CHASSIS_STATE_DB)
+        if chassis_module_name:
+            click.echo('DPU recovery data not found for module {}'.format(chassis_module_name))
+        else:
+            click.echo('No DPU recovery data available')
+        return
+
+    table = []
+    for key in natsorted(keys):
+        key_list = key.split('|')
+        if len(key_list) != 2:
+            continue
+
+        data_dict = chassis_state_db.get_all(chassis_state_db.CHASSIS_STATE_DB, key)
+
+        ready_status = data_dict.get(DPU_STATE_READY_STATUS_FIELD, 'N/A')
+        recovery_status = data_dict.get(DPU_STATE_RECOVERY_STATUS_FIELD, 'N/A')
+        reset_count = data_dict.get(DPU_STATE_RESET_COUNT_FIELD, 'N/A')
+        last_down_time = data_dict.get(DPU_STATE_LAST_DOWN_TIME_FIELD, 'N/A')
+        last_ready_time = data_dict.get(DPU_STATE_LAST_READY_TIME_FIELD, 'N/A')
+
+        table.append((key_list[1], ready_status, recovery_status, reset_count,
+                      last_down_time, last_ready_time))
+
+    chassis_state_db.close(chassis_state_db.CHASSIS_STATE_DB)
+
+    if table:
+        click.echo(tabulate(table, header, tablefmt='simple', stralign='right'))
+    else:
+        click.echo('No DPU recovery data available')
 
 @modules.command()
 @click.argument('chassis_module_name', metavar='<module_name>', required=False)
@@ -143,7 +245,7 @@ def midplane_status(chassis_module_name):
 
 @chassis.command()
 @click.argument('systemportname', required=False)
-@click.option('--namespace', '-n', 'namespace', required=True if multi_asic.is_multi_asic() else False, 
+@click.option('--namespace', '-n', 'namespace', required=True if multi_asic.is_multi_asic() else False,
                 default=None, type=str, show_default=False, help='Namespace name or all')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def system_ports(systemportname, namespace, verbose):
@@ -153,7 +255,7 @@ def system_ports(systemportname, namespace, verbose):
 
     if systemportname is not None:
         cmd += ['-i', str(systemportname)]
-    
+
     if namespace is not None:
         cmd += ['-n', str(namespace)]
 

--- a/sonic_installer/main.py
+++ b/sonic_installer/main.py
@@ -387,13 +387,20 @@ def migrate_sonic_packages(bootloader, binary_image_version):
             # Inject host DNS into chroot for sonic-package-manager to resolve hostnames.
             chroot_resolv = os.path.join(new_image_mount, RESOLV_CONF_FILE)
             if os.path.islink(chroot_resolv):
-                # Symlink: populate the target inside the chroot so the symlink resolves.
-                # Cannot cp over the symlink because the absolute target path escapes
-                # the overlay mount to the host filesystem ("are the same file" error).
+                # Symlink: populate its target inside the chroot ("cp" over the link
+                # would write through it, outside the overlay mount).
                 resolv_target = os.readlink(chroot_resolv)
+                if not os.path.isabs(resolv_target):
+                    # Relative target resolves against the symlink's directory
+                    resolv_target = os.path.join("/", os.path.dirname(RESOLV_CONF_FILE), resolv_target)
+                # Leading "/" makes normpath clamp ".." at the chroot root
+                resolv_target = os.path.normpath(resolv_target)
                 chroot_target = os.path.join(new_image_mount, resolv_target.lstrip("/"))
                 run_command_or_raise(["mkdir", "-p", os.path.dirname(chroot_target)])
-                run_command_or_raise(["cp", "-L", os.path.join("/", RESOLV_CONF_FILE), chroot_target])
+                # --remove-destination: if the target is itself a symlink, replace it
+                # instead of writing through it (could escape the mount again)
+                run_command_or_raise(["cp", "-L", "--remove-destination",
+                                      os.path.join("/", RESOLV_CONF_FILE), chroot_target])
             else:
                 # Regular file: overwrite with host DNS content.
                 run_command_or_raise(["cp", os.path.join("/", RESOLV_CONF_FILE), chroot_resolv])

--- a/tests/abbreviation_group_test.py
+++ b/tests/abbreviation_group_test.py
@@ -1,0 +1,36 @@
+import click
+import pytest
+
+from utilities_common.cli import AbbreviationGroup
+
+
+@click.group(cls=AbbreviationGroup)
+def cli():
+    pass
+
+
+@cli.command(name="switch-hash")
+def switch_hash():
+    pass
+
+
+@cli.command(name="switchport")
+def switchport():
+    pass
+
+
+class TestAbbreviationGroup:
+    def test_ambiguous_prefix_returns_none_during_completion(self):
+        # During shell completion Click sets ctx.resilient_parsing and does not
+        # catch exceptions from get_command, so an ambiguous prefix must return
+        # None instead of raising (which would dump a traceback to the terminal).
+        ctx = click.Context(cli, resilient_parsing=True)
+        assert cli.get_command(ctx, "switch") is None
+
+    def test_ambiguous_prefix_fails_on_invocation(self):
+        # On a real invocation the ambiguous prefix must still fail with the
+        # "Too many matches" usage error.
+        ctx = click.Context(cli)
+        with pytest.raises(click.exceptions.UsageError) as exc_info:
+            cli.get_command(ctx, "switch")
+        assert "Too many matches" in str(exc_info.value)

--- a/tests/acl_input/acl1.json
+++ b/tests/acl_input/acl1.json
@@ -359,6 +359,30 @@
 						"name": "bmc_acl_northbound_v6"
 					}
 				},
+				"acl_noiptype": {
+					"acl-entries": {
+						"acl-entry": {
+							"1": {
+								"config": {
+									"sequence-id": 1
+								},
+								"actions": {
+									"config": {
+										"forwarding-action": "ACCEPT"
+									}
+								},
+								"ip": {
+									"config": {
+										"protocol": "1"
+									}
+								}
+							}
+						}
+					},
+					"config": {
+						"name": "acl_noiptype"
+					}
+				},
 				"DATAACLV4V6": {
 					"acl-entries": {
 						"acl-entry": {

--- a/tests/acl_loader_test.py
+++ b/tests/acl_loader_test.py
@@ -22,7 +22,7 @@ class TestAclLoader(object):
 
     def test_valid(self):
         yang_acl = AclLoader.parse_acl_json(os.path.join(test_path, 'acl_input/acl1.json'))
-        assert len(yang_acl.acl.acl_sets.acl_set) == 9
+        assert len(yang_acl.acl.acl_sets.acl_set) == 10
 
     def test_invalid(self):
         with pytest.raises(AclLoaderException):
@@ -229,6 +229,16 @@ class TestAclLoader(object):
             'IP_TYPE': 'IP',
             "PACKET_ACTION": "FORWARD",
             "PRIORITY": "9998"
+        }
+
+    def test_noiptype_custom_acl_table_type(self, acl_loader):
+        acl_loader.rules_info = {}
+        acl_loader.load_rules_from_file(os.path.join(test_path, 'acl_input/acl1.json'))
+        assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")]
+        assert acl_loader.rules_info[("ACL_NOIPTYPE", "RULE_1")] == {
+            "IP_PROTOCOL": 1,
+            "PACKET_ACTION": "FORWARD",
+            "PRIORITY": "9999"
         }
 
     def test_ingress_default_deny_rule(self, acl_loader):

--- a/tests/aclshow_test.py
+++ b/tests/aclshow_test.py
@@ -90,7 +90,7 @@ RULE NAME    TABLE NAME    PRIO    PACKETS COUNT    BYTES COUNT
 # Expected output for aclshow -r RULE_4,RULE_6 -vv
 rule4_rule6_verbose_output = '' + \
 """Reading ACL info...
-Total number of ACL Tables: 16
+Total number of ACL Tables: 17
 Total number of ACL Rules: 21
 
 RULE NAME    TABLE NAME      PRIO    PACKETS COUNT    BYTES COUNT

--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -868,3 +868,164 @@ class TestChassisModuleBMCStartupShutdown(object):
     def teardown_class(cls):
         print("TEARDOWN")
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
+
+
+class TestChassisModulesRecovery(object):
+    """Tests for 'show chassis modules recovery' and Ready-Status in status command"""
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["UTILITIES_UNIT_TESTING"] = "1"
+
+    def _setup_dpu_state_db(self):
+        """Create a mock SonicV2Connector with DPU_STATE data in CHASSIS_STATE_DB."""
+        from swsssdk import SonicV2Connector as MockSonicV2Connector
+        conn = MockSonicV2Connector()
+        conn.connect(conn.CHASSIS_STATE_DB)
+        # DPU0 - healthy
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU0', "ready_status", "true")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU0', "recovery_status", "recoverable")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU0', "reset_count", "2")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU0', "last_down_time", "2026-05-28 10:15:30 UTC")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU0', "last_ready_time", "2026-05-28 10:18:45 UTC")
+        # DPU1 - healthy with no failures
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU1', "ready_status", "true")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU1', "recovery_status", "recoverable")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU1', "reset_count", "0")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU1', "last_ready_time", "2026-05-28 09:00:12 UTC")
+        # DPU2 - unrecoverable
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU2', "ready_status", "false")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU2', "recovery_status", "unrecoverable")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU2', "reset_count", "2")
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU2', "last_down_time", "2026-05-28 11:02:00 UTC")
+        return conn
+
+    def test_show_recovery_all(self):
+        """Test show chassis modules recovery shows all DPUs."""
+        conn = self._setup_dpu_state_db()
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=True), \
+             mock.patch('show.chassis_modules.SonicV2Connector', return_value=conn):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["recovery"], [])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "DPU0" in result.output
+        assert "DPU1" in result.output
+        assert "DPU2" in result.output
+        assert "recoverable" in result.output
+        assert "unrecoverable" in result.output
+
+    def test_show_recovery_single_module(self):
+        """Test show chassis modules recovery for a specific DPU."""
+        conn = self._setup_dpu_state_db()
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=True), \
+             mock.patch('show.chassis_modules.SonicV2Connector', return_value=conn):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["recovery"], ["DPU0"])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "DPU0" in result.output
+        assert "true" in result.output
+        assert "recoverable" in result.output
+        assert "2026-05-28 10:15:30 UTC" in result.output
+        assert "2026-05-28 10:18:45 UTC" in result.output
+
+    def test_show_recovery_non_smartswitch(self):
+        """Test recovery command on non-SmartSwitch platform."""
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=False):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["recovery"], [])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "only supported on SmartSwitch" in result.output
+
+    def test_show_recovery_no_data(self):
+        """Test recovery command when no DPU_STATE data is available."""
+        from swsssdk import SonicV2Connector as MockSonicV2Connector
+        conn = MockSonicV2Connector()
+        conn.connect(conn.CHASSIS_STATE_DB)
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=True), \
+             mock.patch('show.chassis_modules.SonicV2Connector', return_value=conn):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["recovery"], [])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "No DPU recovery data available" in result.output
+
+    def test_show_recovery_module_not_found(self):
+        """Test recovery command with specific module name that doesn't exist in DPU_STATE."""
+        from swsssdk import SonicV2Connector as MockSonicV2Connector
+        conn = MockSonicV2Connector()
+        conn.connect(conn.CHASSIS_STATE_DB)
+        # Add some DPU data but not the one we'll query
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU0', "ready_status", "true")
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=True), \
+             mock.patch('show.chassis_modules.SonicV2Connector', return_value=conn):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["recovery"], ["DPU5"])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "DPU recovery data not found for module DPU5" in result.output
+
+    def test_show_status_with_ready_status_smartswitch(self):
+        """Test show chassis modules status includes Ready-Status on SmartSwitch."""
+        conn = self._setup_dpu_state_db()
+        # status command also reads STATE_DB CHASSIS_MODULE_TABLE
+        conn.connect(conn.STATE_DB)
+        conn.set(conn.STATE_DB, 'CHASSIS_MODULE_TABLE|DPU0', "desc", "DPU Module")
+        conn.set(conn.STATE_DB, 'CHASSIS_MODULE_TABLE|DPU0', "slot", "N/A")
+        conn.set(conn.STATE_DB, 'CHASSIS_MODULE_TABLE|DPU0', "oper_status", "Online")
+        conn.set(conn.STATE_DB, 'CHASSIS_MODULE_TABLE|DPU0', "serial", "SN001")
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=True), \
+             mock.patch('show.chassis_modules.is_bmc', return_value=False), \
+             mock.patch('show.chassis_modules.SonicV2Connector', return_value=conn):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["status"], [])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Ready-Status" in result.output
+        assert "true" in result.output
+
+    def test_show_recovery_unrecoverable_dpu(self):
+        """Test that unrecoverable DPU shows correct status."""
+        conn = self._setup_dpu_state_db()
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=True), \
+             mock.patch('show.chassis_modules.SonicV2Connector', return_value=conn):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["recovery"], ["DPU2"])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "DPU2" in result.output
+        assert "false" in result.output
+        assert "unrecoverable" in result.output
+        assert "2026-05-28 11:02:00 UTC" in result.output
+
+    def test_show_recovery_missing_fields(self):
+        """Test recovery command gracefully handles missing fields."""
+        from swsssdk import SonicV2Connector as MockSonicV2Connector
+        conn = MockSonicV2Connector()
+        conn.connect(conn.CHASSIS_STATE_DB)
+        # DPU with only ready_status set
+        conn.set(conn.CHASSIS_STATE_DB, 'DPU_STATE|DPU0', "ready_status", "false")
+        runner = CliRunner()
+        with mock.patch('show.chassis_modules.is_smartswitch', return_value=True), \
+             mock.patch('show.chassis_modules.SonicV2Connector', return_value=conn):
+            result = runner.invoke(
+                show.cli.commands["chassis"].commands["modules"].commands["recovery"], [])
+        print(result.output)
+        assert result.exit_code == 0
+        assert "DPU0" in result.output
+        assert "false" in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"

--- a/tests/chassis_modules_test.py
+++ b/tests/chassis_modules_test.py
@@ -14,17 +14,6 @@ from .utils import get_result_and_return_code
 sys.modules['clicommon'] = mock.Mock()
 
 
-@pytest.fixture(autouse=True)
-def _inject_sonic_platform():
-    # conftest._reset_between_files() clears sys.modules['sonic_platform']
-    # before the first test of each file. Re-inject before every test so that
-    # chassis command handlers that import sonic_platform at call time can find
-    # it. Module-level injection is not sufficient because it runs before the
-    # conftest hook that clears it.
-    sys.modules['sonic_platform'] = mock.MagicMock()
-    yield
-
-
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -9,6 +10,8 @@ from utilities_common.db import Db
 from utilities_common.general import load_module_from_source
 
 import config.main as config
+
+from .utils import worker_tmp_path
 
 # Load sonic-cfggen from source since /usr/local/bin/sonic-cfggen does not have .py extension.
 sonic_cfggen = load_module_from_source('sonic_cfggen', '/usr/local/bin/sonic-cfggen')
@@ -162,8 +165,9 @@ def config_mgmt_dpb(cfgdb):
     '''
     curConfig = read_config_db(cfgdb)
     # create object
-    config_mgmt.CONFIG_DB_JSON_FILE = "/tmp/startConfigDb.json"
-    config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "/tmp/portBreakOutConfigDb.json"
+    config_mgmt.CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
+    config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = worker_tmp_path(
+        'portBreakOutConfigDb.json')
     # write in temp file
     writeJson(curConfig, config_mgmt.CONFIG_DB_JSON_FILE)
     writeJson(portBreakOutConfigDbJson, config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE)
@@ -704,8 +708,8 @@ class TestConfigDPB(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-        os.system("rm -f /tmp/startConfigDb.json")
-        os.system("rm -f /tmp/portBreakOutConfigDb.json")
+        Path(worker_tmp_path('startConfigDb.json')).unlink(missing_ok=True)
+        Path(worker_tmp_path('portBreakOutConfigDb.json')).unlink(missing_ok=True)
 
 ###########GLOBAL Configs#####################################
 '''

--- a/tests/config_mgmt_test.py
+++ b/tests/config_mgmt_test.py
@@ -7,6 +7,8 @@ from unittest import mock, TestCase
 import pytest
 from utilities_common.general import load_module_from_source
 
+from .utils import worker_tmp_path
+
 # Import file under test i.e., config_mgmt.py
 config_mgmt_py_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config_mgmt.py')
 config_mgmt = load_module_from_source('config_mgmt', config_mgmt_py_path)
@@ -19,8 +21,11 @@ class TestConfigMgmt(TestCase):
     '''
 
     def setUp(self):
-        config_mgmt.CONFIG_DB_JSON_FILE = "startConfigDb.json"
-        config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = "portBreakOutConfigDb.json"
+        # Per-worker paths: shared basenames in the repo root race under pytest-xdist
+        # (see sonic-utilities #4516 / config_override_test startConfigDb.json).
+        config_mgmt.CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
+        config_mgmt.DEFAULT_CONFIG_DB_JSON_FILE = worker_tmp_path(
+            'portBreakOutConfigDb.json')
         return
 
     def test_config_get_module_check(self):
@@ -80,8 +85,9 @@ class TestConfigMgmt(TestCase):
         Libyang converts from 'XX:XX:XX:E4:B3:DD' -> 'xx:xx:xx:e4:b3:dd'
         '''
         curConfig = deepcopy(configDbJson)
-        # Keep only PORT part to skip dependencies.
-        curConfig = {'PORT': curConfig['PORT']}
+        # Use the full sample CONFIG_DB so YANG loadData() satisfies cross-table
+        # must/when constraints (a PORT-only snapshot can fail model validation on
+        # some branches). DEVICE_METADATA is added below for the MAC case test.
         # add DEVICE_METADATA Config
         curConfig['DEVICE_METADATA'] = {
             "localhost": {

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -11,6 +11,8 @@ from utilities_common.db import Db
 from utilities_common.general import load_module_from_source
 from minigraph import minigraph_encoder
 
+from .utils import worker_tmp_path
+
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 DATA_DIR = os.path.join(SCRIPT_DIR, "config_override_input")
 EMPTY_INPUT = os.path.join(DATA_DIR, "empty_input.json")
@@ -202,7 +204,7 @@ class TestConfigOverride(object):
         # ConfigMgmt will call ConfigDBConnector to load default config_db.json.
         # Here I modify the ConfigMgmt initialization and make it initiated with
         # a source file which share the same as what we write to cfgdb.
-        CONFIG_DB_JSON_FILE = "startConfigDb.json"
+        CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
         write_config_to_file(read_data['running_config'], CONFIG_DB_JSON_FILE)
         with mock.patch('config.main.device_info.is_yang_config_validation_enabled',
                         mock.MagicMock(side_effect=is_yang_config_validation_enabled_side_effect)), \
@@ -246,7 +248,7 @@ class TestConfigOverride(object):
         # ConfigMgmt will call ConfigDBConnector to load default config_db.json.
         # Here I modify the ConfigMgmt initialization and make it initiated with
         # a source file which share the same as what we write to cfgdb.
-        CONFIG_DB_JSON_FILE = "startConfigDb.json"
+        CONFIG_DB_JSON_FILE = worker_tmp_path('startConfigDb.json')
         write_config_to_file(running_config, CONFIG_DB_JSON_FILE)
         with mock.patch('config.main.read_json_file',
                         mock.MagicMock(side_effect=read_json_file_side_effect)), \

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -754,6 +754,90 @@ class TestConfigReload(object):
             assert "\n".join([line.rstrip() for line in result.output.split('\n')][:2]) == \
                 reload_config_with_sys_info_command_output.format(config.SYSTEM_RELOAD_LOCK)
 
+    def test_config_reload_blocked_during_warm_boot(self, get_cmd_module, setup_single_broadcom_asic):
+        """config reload must abort when a warm-boot is in progress (Redmine #5154490)."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = True
+        mock_swsscommon.RestartWaiter.isFastBootInProgress.return_value = False
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch('config.main._is_system_starting', return_value=False), \
+                mock.patch('config.main._swss_ready', return_value=True), \
+                mock.patch.object(config, 'config_file_yang_validation'):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y"])
+            assert result.exit_code != 0
+            assert "warm-boot" in result.output
+            assert "still in progress" in result.output
+
+    def test_config_reload_blocked_during_fast_boot(self, get_cmd_module, setup_single_broadcom_asic):
+        """config reload must abort when a fast-reboot is in progress.
+        fast-reboot sets both FAST_RESTART_ENABLE_TABLE and WARM_RESTART_ENABLE_TABLE;
+        isFastBootInProgress is checked first so the label is correct."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = True
+        mock_swsscommon.RestartWaiter.isFastBootInProgress.return_value = True
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch('config.main._is_system_starting', return_value=False), \
+                mock.patch('config.main._swss_ready', return_value=True), \
+                mock.patch.object(config, 'config_file_yang_validation'):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y"])
+            assert result.exit_code != 0
+            assert "fast-reboot" in result.output
+            assert "still in progress" in result.output
+
+    def test_config_reload_not_blocked_when_no_boot_in_progress(self, get_cmd_module, setup_single_broadcom_asic):
+        """Guard runs but does not block when no boot is in progress; both checks are invoked."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = False
+        mock_swsscommon.RestartWaiter.isFastBootInProgress.return_value = False
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch.object(config, 'config_file_yang_validation'), \
+                mock.patch('config.main._is_system_starting', return_value=False), \
+                mock.patch('config.main._swss_ready', return_value=True), \
+                mock.patch('config.main._stop_services'), \
+                mock.patch('config.main._restart_services'), \
+                mock.patch('config.main._reset_failed_services'), \
+                mock.patch("utilities_common.cli.run_command",
+                           mock.MagicMock(side_effect=mock_run_command_side_effect)):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y"])
+            assert result.exit_code == 0
+            assert "still in progress" not in result.output
+            mock_swsscommon.RestartWaiter.isFastBootInProgress.assert_called_once()
+            mock_swsscommon.RestartWaiter.isWarmBootInProgress.assert_called_once()
+
+    def test_config_reload_no_service_restart_skips_guard(self, get_cmd_module, setup_single_broadcom_asic):
+        """With -n (no_service_restart), guard is skipped — no syncd teardown, no risk."""
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+
+        mock_swsscommon = mock.MagicMock()
+        mock_swsscommon.RestartWaiter.isWarmBootInProgress.return_value = True
+
+        with mock.patch.object(config, "DEFAULT_CONFIG_DB_FILE", jsonfile_config), \
+                mock.patch('config.main.swsscommon', mock_swsscommon), \
+                mock.patch.object(config, 'config_file_yang_validation'), \
+                mock.patch("utilities_common.cli.run_command",
+                           mock.MagicMock(side_effect=mock_run_command_side_effect)):
+            result = CliRunner().invoke(config.config.commands["reload"], ["-y", "-n"])
+            assert result.exit_code == 0
+            assert "still in progress" not in result.output
+            mock_swsscommon.RestartWaiter.isFastBootInProgress.assert_not_called()
+            mock_swsscommon.RestartWaiter.isWarmBootInProgress.assert_not_called()
+
     def test_config_reload_stdin(self, get_cmd_module, setup_single_broadcom_asic):
         def mock_json_load(f):
             device_metadata = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,6 +293,31 @@ generated_services_list = [
 
 
 @pytest.fixture(autouse=True)
+def _ensure_sonic_platform_mock():
+    """Ensure sonic_platform is always mockable in sys.modules.
+
+    _reset_between_files() clears sonic_platform entries from sys.modules
+    between test files to prevent cross-file mock leakage under xdist.
+    This fixture re-injects a MagicMock stub so that any test using
+    @patch('sonic_platform.platform.Platform') (or similar) can resolve
+    the target without ModuleNotFoundError — even if the test file forgot
+    to inject it manually.
+
+    Note: test files that import sonic_platform at module level (e.g.
+    fwutil_test.py, psuutil_test.py, sfputil_test.py) still need their
+    own sys.modules injection before the import line, because module
+    collection happens before fixtures run.
+
+    Runs before every test function (autouse=True).
+    """
+    if 'sonic_platform' not in sys.modules:
+        sys.modules['sonic_platform'] = mock.MagicMock()
+    if 'sonic_platform.platform' not in sys.modules:
+        sys.modules['sonic_platform.platform'] = mock.MagicMock()
+    yield
+
+
+@pytest.fixture(autouse=True)
 def setup_env():
     # This is needed because we call scripts from this module as a separate
     # process when running tests, and so the PYTHONPATH needs to be set

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -14,18 +14,6 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 
-sys.modules['sonic_platform'] = mock.MagicMock()
-
-
-@pytest.fixture(autouse=True)
-def _inject_sonic_platform():
-    # conftest._reset_between_files() clears sys.modules['sonic_platform']
-    # before the first test of each file; re-inject before every test so that
-    # lazy imports inside scripts (e.g. instantiate_eeprom_object) still find
-    # the mock. Module-level injection runs before the conftest hook clears it.
-    sys.modules['sonic_platform'] = mock.MagicMock()
-    yield
-
 
 decode_syseeprom_path = os.path.join(scripts_path, 'decode-syseeprom')
 decode_syseeprom = load_module_from_source('decode_syseeprom', decode_syseeprom_path)

--- a/tests/fetch_routes_chunk_test.py
+++ b/tests/fetch_routes_chunk_test.py
@@ -19,6 +19,11 @@ sys.path.append("scripts")
 import route_check  # noqa: E402
 
 
+def get_missing_prefixes(result):
+    """Extract prefix strings from missing_routes dicts for assertion comparison."""
+    return {entry['prefix'] for entry in result}
+
+
 class ChunkedBytesIO:
     def __init__(self, chunks):
         self.chunks = chunks
@@ -79,7 +84,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert result == (["192.168.1.0/24"], [])
+        assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_json_split_across_chunks(self):
         """Test parsing when JSON is split across multiple chunks"""
@@ -116,7 +121,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == {"10.0.0.0/8", "172.16.0.0/12"}
+        assert get_missing_prefixes(result[0]) == {"10.0.0.0/8", "172.16.0.0/12"}
 
     def test_routes_with_offloaded_flag(self):
         """Test that routes with offloaded=True are not included in missing
@@ -144,7 +149,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert result == (["192.168.2.0/24"], [])
+        assert result == ([{"prefix": "192.168.2.0/24", "protocol": "bgp"}], [])
 
     def test_filter_connected_kernel_static_protocols(self):
         """Test that connected, kernel and static protocols are filtered out"""
@@ -186,7 +191,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes()
 
         # Only BGP route should be in the result
-        assert result == (["192.168.4.0/24"], [])
+        assert result == ([{"prefix": "192.168.4.0/24", "protocol": "bgp"}], [])
 
     def test_filter_non_default_vrf(self):
         """Test that routes in non-default VRF are filtered out"""
@@ -221,7 +226,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes()
 
         # Only default VRF route should be in the result
-        assert result == (["192.168.2.0/24"], [])
+        assert result == ([{"prefix": "192.168.2.0/24", "protocol": "bgp"}], [])
 
     def test_filter_not_selected_routes(self):
         """Test that routes not selected as best are filtered out"""
@@ -249,7 +254,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes()
 
         # Only selected route should be in the result
-        assert result == (["192.168.2.0/24"], [])
+        assert result == ([{"prefix": "192.168.2.0/24", "protocol": "bgp"}], [])
 
     def test_empty_json_response(self):
         """Test handling of empty JSON response"""
@@ -297,7 +302,7 @@ class TestFetchRoutes:
             with patch('route_check.subprocess.Popen', return_value=mock_proc):
                 result = route_check.fetch_routes()
 
-            assert result == (["192.168.1.0/24"], [])
+            assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_very_small_chunks(self):
         """Test parsing with very small chunk sizes (byte-by-byte)"""
@@ -324,7 +329,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert result == (["10.0.0.0/8"], [])
+        assert result == ([{"prefix": "10.0.0.0/8", "protocol": "bgp"}], [])
 
     def test_large_json_with_many_routes(self):
         """Test parsing large JSON with many route entries"""
@@ -350,7 +355,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == set(expected_missing)
+        assert get_missing_prefixes(result[0]) == set(expected_missing)
         assert len(result[0]) == 100
 
     def test_ipv6_command(self):
@@ -377,7 +382,7 @@ class TestFetchRoutes:
             call_args = mock_popen.call_args[0][0]
             assert call_args == ["sudo", "vtysh", "-c", "show ipv6 route json"]
 
-        assert result == (["2001:db8::/32"], [])
+        assert result == ([{"prefix": "2001:db8::/32", "protocol": "bgp"}], [])
 
     def test_subprocess_non_zero_exit_code(self):
         """Test handling of subprocess with non-zero exit code"""
@@ -402,7 +407,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes()
 
         # Should still return the parsed routes
-        assert result == (["192.168.1.0/24"], [])
+        assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_file_not_found_error(self):
         """Test handling of FileNotFoundError when vtysh is not found"""
@@ -469,7 +474,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert result == (["192.168.1.0/24"], [])
+        assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_variable_chunk_boundary(self):
         """Test when chunk boundary falls at variious locations"""
@@ -500,7 +505,7 @@ class TestFetchRoutes:
             with patch('route_check.subprocess.Popen', return_value=mock_proc):
                 result = route_check.fetch_routes()
 
-            assert result == (["192.168.1.0/24"], [])
+            assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_chunk_boundary_in_string_value(self):
         """Test when chunk boundary falls in the middle of a string value"""
@@ -532,7 +537,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert result == (["192.168.1.0/24"], [])
+        assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_escaped_quotes_in_json(self):
         """Test handling of escaped quotes in JSON strings"""
@@ -553,7 +558,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert result == (["192.168.1.0/24"], [])
+        assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_whitespace_handling(self):
         """Test handling of JSON with various whitespace"""
@@ -576,7 +581,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert result == (["192.168.1.0/24"], [])
+        assert result == ([{"prefix": "192.168.1.0/24", "protocol": "bgp"}], [])
 
     def test_mixed_ipv4_and_ipv6_routes(self):
         """Test parsing JSON with both IPv4 and IPv6 routes"""
@@ -603,7 +608,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == {"192.168.1.0/24", "2001:db8::/32"}
+        assert get_missing_prefixes(result[0]) == {"192.168.1.0/24", "2001:db8::/32"}
 
     def test_malformed_json_in_buffer(self):
         """Test handling of malformed JSON that cannot be parsed"""
@@ -649,7 +654,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == {"192.168.1.0/24",
+        assert get_missing_prefixes(result[0]) == {"192.168.1.0/24",
                                   "192.168.2.0/24",
                                   "192.168.3.0/24"}
 
@@ -693,7 +698,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert get_missing_prefixes(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
 
     def test_incremental_parsing_across_multiple_chunks(self):
         # Create a large JSON with many prefixes
@@ -727,7 +732,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == set(expected_missing)
+        assert get_missing_prefixes(result[0]) == set(expected_missing)
         assert len(result[0]) == 50
 
     def test_incremental_parsing_prefix_boundary_at_comma(self):
@@ -766,7 +771,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert get_missing_prefixes(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
 
     def test_incremental_parsing_mixed_offloaded_states(self):
         """Test incremental parsing with mixed offloaded states across multiple prefixes"""
@@ -808,7 +813,7 @@ class TestFetchRoutes:
             result = route_check.fetch_routes()
 
         # Only the non-offloaded routes should be in the result
-        assert set(result[0]) == {"192.168.2.0/24", "192.168.4.0/24"}
+        assert get_missing_prefixes(result[0]) == {"192.168.2.0/24", "192.168.4.0/24"}
 
     def test_incremental_parsing_with_whitespace_variations(self):
         """Test incremental parsing with various whitespace formatting"""
@@ -840,7 +845,7 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert get_missing_prefixes(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
 
     def test_incremental_parsing_prefix_with_special_characters(self):
         """Test incremental parsing of prefixes with special characters in descriptions"""
@@ -869,4 +874,4 @@ class TestFetchRoutes:
         with patch('route_check.subprocess.Popen', return_value=mock_proc):
             result = route_check.fetch_routes()
 
-        assert set(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}
+        assert get_missing_prefixes(result[0]) == {"192.168.1.0/24", "192.168.2.0/24"}

--- a/tests/fwutil_test.py
+++ b/tests/fwutil_test.py
@@ -5,6 +5,9 @@ import sys
 import pytest
 from unittest.mock import call, patch, MagicMock
 
+# fwutil/__init__.py imports sonic_platform at module level;
+# inject before importing fwutil.lib so collection succeeds.
+sys.modules['sonic_platform'] = MagicMock()
 sys.modules['sonic_platform.platform'] = MagicMock()
 import fwutil.lib as fwutil_lib
 

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -785,6 +785,15 @@ class TestGetAsicName(unittest.TestCase):
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
+    def test_get_asic_spc6(self, mock_popen, mock_get_sonic_version_info):
+        mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
+        mock_popen.return_value = mock.Mock()
+        mock_popen.return_value.communicate.return_value = ["Mellanox-SN6600_LD-P64O128C2", 0]
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "spc6")
+
+    @patch('sonic_py_common.device_info.get_sonic_version_info')
+    @patch('subprocess.Popen')
     def test_get_asic_th(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -40,7 +40,7 @@ class TestPatchApplier(unittest.TestCase):
 
         # Assert
         patch_applier.config_wrapper.get_config_db_as_json.assert_has_calls([call(), call()])
-        patch_applier.patch_wrapper.simulate_patch.assert_has_calls(
+        patch_applier.patch_wrapper.simulate_config_db_patch.assert_has_calls(
             [call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, Files.CONFIG_DB_AS_JSON)])
         patch_applier.patchsorter.sort.assert_has_calls([call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, trace_io=None)])
         patch_applier.changeapplier.apply.assert_called()
@@ -59,7 +59,7 @@ class TestPatchApplier(unittest.TestCase):
             create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): empty_tables})
 
         patch_wrapper = Mock()
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(Files.MULTI_OPERATION_CONFIG_DB_PATCH), str(Files.CONFIG_DB_AS_JSON)):
                     Files.CONFIG_DB_AFTER_MULTI_PATCH})

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -658,6 +658,64 @@ class TestPatchWrapper(unittest.TestCase):
         # Assert
         self.assertDictEqual(expected, actual)
 
+    def test_simulate_config_db_patch__empties_leaf_list__field_is_dropped(self):
+        # Arrange
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc01:20::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}])
+        # ConfigDB cannot store an empty leaf-list, the field has to be absent
+        expected = {"BGP_ALLOWED_PREFIXES": {"DEPLOYMENT_ID|0": {"prefixes_v6": ["fc01:20::/64"]}}}
+
+        # Act
+        actual = patch_wrapper.simulate_config_db_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
+    def test_simulate_config_db_patch__leaf_list_still_has_items__field_is_kept(self):
+        # Arrange
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "prefixes_v4": ["10.20.0.0/16", "10.30.0.0/16"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}])
+        expected = {"BGP_ALLOWED_PREFIXES": {"DEPLOYMENT_ID|0": {"prefixes_v4": ["10.30.0.0/16"]}}}
+
+        # Act
+        actual = patch_wrapper.simulate_config_db_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
+    def test_simulate_patch__sonic_yang_config__empty_yang_list_is_kept(self):
+        # Arrange
+        # simulate_patch must stay shape agnostic. In SonicYang json a list holds yang list
+        # entries, not leaf-list items, so it must not be treated as an empty leaf-list.
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {"sonic-vlan:sonic-vlan": {"VLAN": {"VLAN_LIST": [{"name": "Vlan1000"}]}}}
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST/0"}])
+        expected = {"sonic-vlan:sonic-vlan": {"VLAN": {"VLAN_LIST": []}}}
+
+        # Act
+        actual = patch_wrapper.simulate_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
     def test_generate_patch__diff__non_empty_patch(self):
         # Arrange
         patch_wrapper = gu_common.PatchWrapper()

--- a/tests/generic_config_updater/multiasic_generic_updater_test.py
+++ b/tests/generic_config_updater/multiasic_generic_updater_test.py
@@ -16,7 +16,7 @@ class TestMultiAsicPatchApplier(unittest.TestCase):
 
     @patch('generic_config_updater.gu_common.ConfigWrapper.get_empty_tables', return_value=[])
     @patch('generic_config_updater.gu_common.ConfigWrapper.get_config_db_as_json')
-    @patch('generic_config_updater.gu_common.PatchWrapper.simulate_patch')
+    @patch('generic_config_updater.gu_common.PatchWrapper.simulate_config_db_patch')
     @patch('generic_config_updater.generic_updater.ChangeApplier')
     def test_apply_patch_specific_namespace(self, mock_ChangeApplier, mock_simulate_patch, mock_get_config, mock_get_empty_tables):
         scope = "asic0"

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1246,6 +1246,78 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         path_addressing = ps.PathAddressing(config_wrapper)
         self.validator = ps.NoDependencyMoveValidator(path_addressing, config_wrapper)
 
+    def test_validate__unresolvable_ref_in_simulated_config__add_rejected(self):
+        # A dangling leafref in the transient simulated intermediate config makes find_ref_paths
+        # raise ValueError. For a simulated-config-facing check (ADD here), the validator must reject
+        # the move (return False) so the sort backtracks, rather than letting the exception abort the
+        # whole sort.
+        current_config = {"PORT": {"Ethernet0": {}}}
+        target_config = {
+            "PORT": {"Ethernet0": {}},
+            "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
+        }
+        diff = ps.Diff(current_config, target_config)
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"]))
+        simulated_config = move.apply(diff.current_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=ValueError("'Ethernet0' is not in list"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack. Pin the exact arguments so a
+        # regression swapping simulated_config <-> diff.current_config in the ADD branch is caught
+        # (simulated_config is value-distinct from current_config here: it carries the added ACL_TABLE).
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            ["/ACL_TABLE"], simulated_config, reload_config=True)
+
+    def test_validate__unresolvable_ref_in_simulated_config__replace_rejected(self):
+        # REPLACE is the operation type for a PORT breakout (rewriting lanes while an ACL reference
+        # lingers). _validate_replace validates added_paths against the simulated intermediate config,
+        # so an unresolvable reference there (KeyError here, e.g. a table with no YANG model) must
+        # reject the move rather than aborting the sort.
+        current_config = {"PORT": {"Ethernet0": {}}}
+        target_config = {
+            "PORT": {"Ethernet0": {}},
+            "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
+        }
+        diff = ps.Diff(current_config, target_config)
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        simulated_config = move.apply(diff.current_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=KeyError("ACL_TABLE"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack. Pin the config argument so a
+        # regression routing REPLACE added_paths through diff.current_config instead of the simulated
+        # config is caught (the two configs are value-distinct: simulated carries the added ACL_TABLE).
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            ["/ACL_TABLE"], simulated_config, reload_config=True)
+
+    def test_validate__value_error_on_current_config__propagates(self):
+        # A check against diff.current_config (a valid committed state) is not simulated, so a
+        # ValueError from find_ref_paths signals a genuine schema error and must propagate rather
+        # than being silently swallowed as a move rejection.
+        current_config = {
+            "PORT": {"Ethernet0": {}},
+            "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
+        }
+        target_config = {"PORT": {"Ethernet0": {}}}
+        diff = ps.Diff(current_config, target_config)
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"]))
+        simulated_config = move.apply(diff.current_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=ValueError("Keys in configDb not matching keys in SonicYang"))
+
+        with self.assertRaises(ValueError):
+            self.validator.validate(move, diff, simulated_config)
+        # Pin that the REMOVE validation ran against diff.current_config (unguarded), not
+        # simulated_config: the re-raise must be the guaranteed-current-config path, not a lucky
+        # raise that a config swap could mask. Configs are value-distinct (current has ACL_TABLE).
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            ["/ACL_TABLE"], diff.current_config, reload_config=True)
+
     def test_validate__add_full_config_has_dependencies__failure(self):
         # Arrange
         # CROPPED_CONFIG_DB_AS_JSON has dependencies between PORT and ACL_TABLE
@@ -2060,6 +2132,90 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
         for test_case_name in test_cases:
             with self.subTest(name=test_case_name):
                 self._run_single_test(test_cases[test_case_name])
+
+    def test_validate__unresolvable_ref_in_simulated_config__move_rejected(self):
+        # A create-only PORT field change (breakout rewriting lanes) can transiently
+        # remove the port from a multi-member leaf-list (e.g. ACL_TABLE.ports) in the simulated
+        # intermediate config while a leafref to it is still present. Resolving that dangling
+        # leafref raises ValueError ("'<port>' is not in list"). The validator must treat this as
+        # an invalid intermediate move (return False) so the sort backtracks, rather than letting
+        # the exception propagate and abort the whole sort.
+        current_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305,306,307,308,309,310,311,312", "admin_status": "up"}
+            },
+            "ACL_TABLE": {
+                "DATAACL": {"type": "L3", "ports": ["Ethernet312", "Ethernet280"]}
+            }
+        }
+        target_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            },
+            "ACL_TABLE": {
+                "DATAACL": {"type": "L3", "ports": ["Ethernet280"]}
+            }
+        }
+        # The transient intermediate config the sorter is validating: Ethernet312's create-only
+        # 'lanes' field has already been rewritten toward the target, but the ACL_TABLE leafref to
+        # it has not been removed yet, so the reference is momentarily dangling. Resolving it raises
+        # ValueError. Kept value-distinct from current_config (different lanes) so the argument
+        # assertion below would catch a regression that passed current_config to find_ref_paths.
+        simulated_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            },
+            "ACL_TABLE": {
+                "DATAACL": {"type": "L3", "ports": ["Ethernet312", "Ethernet280"]}
+            }
+        }
+
+        move = JsonMoveGroup("", Mock())
+        diff = ps.Diff(current_config, target_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=ValueError("'Ethernet312' is not in list"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack.
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        # Pin the assertion to the code path under test: the rejection must come from the guarded
+        # find_ref_paths call raising, resolved against the simulated (intermediate) config. Asserting
+        # the exact arguments also catches a regression that swapped simulated_config <-> current_config.
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            "/PORT/Ethernet312", simulated_config, reload_config=True)
+
+    def test_validate__keyerror_in_simulated_config__move_rejected(self):
+        # find_ref_paths also raises KeyError (not just ValueError) when a referenced path's table
+        # has no YANG model in the simulated intermediate config. The guard must treat that the same
+        # way as an unresolvable reference: reject the move so the sort backtracks, not abort it.
+        current_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305,306,307,308,309,310,311,312", "admin_status": "up"}
+            }
+        }
+        target_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            }
+        }
+        # Value-distinct from current_config (lanes already rewritten toward the target) so the
+        # argument assertion below catches a regression that passed current_config instead.
+        simulated_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            }
+        }
+
+        move = JsonMoveGroup("", Mock())
+        diff = ps.Diff(current_config, target_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=KeyError("ACL_TABLE"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack.
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            "/PORT/Ethernet312", simulated_config, reload_config=True)
 
     def _run_single_test(self, test_case):
         # Arrange

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2493,12 +2493,12 @@ class TestBulkLeafListMoveGenerator(unittest.TestCase):
             target={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR", "ports": ["Ethernet0"]}}},
             ex_ops=[])
 
-    def test_generate__leaf_list_all_items_removed__single_replace_move(self):
-        """Removing all items from a leaf-list should produce one REPLACE with empty list."""
+    def test_generate__leaf_list_all_items_removed__no_bulk_replace_move(self):
+        """Removing all items from a leaf-list should not bulk-replace with an empty list."""
         self.verify(
             current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
             target={"ACL_TABLE": {"EVERFLOW": {"ports": [], "type": "MIRROR"}}},
-            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports", "value": []}])
+            ex_ops=[])
 
     def test_generate__multiple_tables_with_leaf_lists__multiple_moves(self):
         """Multiple differing leaf-lists should each get a REPLACE move."""
@@ -3729,6 +3729,42 @@ class TestPatchSorter(unittest.TestCase):
             if notfound_substrings:
                 self.fail(f"Did not find the substrings {notfound_substrings} in the error: '{error}'")
 
+    def test_patch_sorter__remove_last_bgp_allowed_prefix__removes_field_instead_of_emptying_it(self):
+        current_config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "deployment": "DEPLOYMENT_ID",
+                    "id": 0,
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc00:f0::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch([
+            {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+        ])
+        sorter = self.create_patch_sorter(current_config)
+
+        actual_changes = sorter.sort(patch)
+        # Removing the only item has to drop the whole field. ConfigDB cannot store an
+        # empty leaf-list, it would be written as "" and read back as [""].
+        expected_changes = [
+            JsonChange(jsonpatch.JsonPatch([
+                {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4"}
+            ]))
+        ]
+
+        self.assertEqual(expected_changes, actual_changes)
+
+        target_config = PatchWrapper().simulate_config_db_patch(patch, current_config)
+        self.assertNotIn("prefixes_v4", target_config["BGP_ALLOWED_PREFIXES"]["DEPLOYMENT_ID|0"])
+        simulated_config = current_config
+        for change in actual_changes:
+            simulated_config = change.apply(simulated_config)
+            is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
+            self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
+        self.assertEqual(target_config, simulated_config)
+
     def test_sort__does_not_remove_tables_without_yang_unintentionally_if_generated_change_replaces_whole_config(self):
         # Arrange
         current_config = Files.CONFIG_DB_AS_JSON # has a table without yang named 'TABLE_WITHOUT_YANG'
@@ -4002,7 +4038,7 @@ class TestNonStrictPatchSorter(unittest.TestCase):
         config_wrapper.get_config_db_as_json.side_effect = \
             [any_current_config]
 
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(patch), str(any_current_config)):
                     any_target_config})
@@ -4095,7 +4131,7 @@ class TestStrictPatchSorter(unittest.TestCase):
         config_wrapper.get_config_db_as_json.side_effect = \
             [any_current_config, any_target_config]
 
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(patch), str(any_current_config)):
                     any_target_config})

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -588,6 +588,12 @@
         "stage": "ingress",
         "type": "BMCDATAV6"
     },
+    "ACL_TABLE|ACL_NOIPTYPE": {
+        "policy_desc": "ACL_NOIPTYPE",
+        "ports@": "Ethernet8,Ethernet0,Ethernet17,Ethernet16,Ethernet37,Ethernet4,Ethernet13,Ethernet45,Ethernet19,Ethernet24,Ethernet31,Ethernet30,Ethernet39,Ethernet40,Ethernet27,Ethernet43,Ethernet7,Ethernet3,Ethernet20,Ethernet6,Ethernet12,Ethernet34,Ethernet26,Ethernet11,Ethernet42,Ethernet5,Ethernet32,Ethernet36,Ethernet15,Ethernet33,Ethernet35,Ethernet9,Ethernet29,Ethernet21,Ethernet18,Ethernet38,Ethernet23,Ethernet41,Ethernet14,Ethernet2,Ethernet28,Ethernet22,Ethernet10,Ethernet25,Ethernet44,Ethernet1",
+        "stage": "ingress",
+        "type": "NOIPTYPE"
+    },
     "ACL_TABLE|DATAACL": {
         "policy_desc": "DATAACL",
         "ports@": "PortChannel0002,PortChannel0005,PortChannel0008,PortChannel0011,PortChannel0014,PortChannel0017,PortChannel0020,PortChannel0023,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124",
@@ -668,6 +674,11 @@
         "ACTIONS": "PACKET_ACTION,COUNTER",
         "BIND_POINTS": "PORT",
         "MATCHES": "SRC_IPV6,DST_IPV6,ETHER_TYPE,IP_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
+    },
+    "ACL_TABLE_TYPE|NOIPTYPE": {
+        "ACTIONS": "PACKET_ACTION,COUNTER",
+        "BIND_POINTS": "PORT",
+        "MATCHES": "SRC_IP,DST_IP,ETHER_TYPE,IP_PROTOCOL,IN_PORTS,TCP_FLAGS"
     },
     "PBH_TABLE|pbh_table1": {
         "description": "NVGRE",

--- a/tests/psushow_test.py
+++ b/tests/psushow_test.py
@@ -13,8 +13,6 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 
-sys.modules['sonic_platform'] = mock.MagicMock()
-
 # Load the file under test
 psushow_path = os.path.join(scripts_path, 'psushow')
 psushow = load_module_from_source('psushow', psushow_path)

--- a/tests/psuutil_test.py
+++ b/tests/psuutil_test.py
@@ -10,6 +10,8 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+# psuutil.main imports sonic_platform at module level;
+# inject before importing so collection succeeds.
 sys.modules['sonic_platform'] = mock.MagicMock()
 import psuutil.main as psuutil
 

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -291,7 +291,7 @@ class TestRouteCheck(object):
                 if not e.get('selected', False):
                     continue
                 if not e.get('offloaded', False):
-                    missed_route_list.append(r)
+                    missed_route_list.append({'prefix': r, 'protocol': e.get('protocol', '')})
                 if e.get('failed', False):
                     failed_route_list.append(r)
         return missed_route_list, failed_route_list  # Return tuple of (missed_routes, failed_routes)

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -1,9 +1,14 @@
 import copy
-from io import StringIO
+from io import BytesIO, StringIO
 import json
 import logging
+import os
+import shlex
+import signal
+import subprocess
 import syslog
 import sys
+import threading
 import time
 from sonic_py_common import device_info
 from unittest.mock import MagicMock, patch
@@ -208,14 +213,6 @@ def set_mock(mock_table, mock_conn, mock_sel, mock_subs, mock_config_db):
 
 
 class TestRouteCheck(object):
-    @staticmethod
-    def extract_namespace_from_args(args):
-        # args: ['show', 'ip', 'route', '-n', 'asic0', 'json'],
-        for i, arg in enumerate(args):
-            if arg == "-n" and i + 1 < len(args):
-                return args[i + 1]
-        return DEFAULTNS
-
     def setup_method(self):
         pass
 
@@ -258,7 +255,6 @@ class TestRouteCheck(object):
         with patch('sys.argv', ct_data[ARGS].split()), \
             patch('sonic_py_common.multi_asic.get_namespace_list', return_value=ct_data[NAMESPACE]), \
             patch('sonic_py_common.multi_asic.is_multi_asic', return_value=ct_data[MULTI_ASIC]), \
-            patch('route_check.subprocess.check_output', side_effect=lambda *args, **kwargs: self.mock_check_output(ct_data, *args, **kwargs)), \
             patch('route_check.check_frr_pending_routes',
                   side_effect=lambda *args, **kwargs:
                   self.mock_fetch_routes(ct_data, *args, **kwargs)), \
@@ -269,11 +265,6 @@ class TestRouteCheck(object):
 
             ret, res = route_check.main()
             self.assert_results(ct_data, ret, res)
-
-    def mock_check_output(self, ct_data, *args, **kwargs):
-        ns = self.extract_namespace_from_args(args[0])
-        routes = ct_data.get(FRR_ROUTES, {}).get(ns, {})
-        return json.dumps(routes)
 
     def mock_fetch_routes(self, ct_data, *args, **kwargs):
         ns = args[0]
@@ -349,3 +340,370 @@ class TestRouteCheck(object):
             route_check.mitigate_installed_not_offloaded_frr_routes(namespace, missed_frr_rt, rt_appl)
         # Verify that the stdout are suppressed in this function
         assert not mock_stdout.getvalue()
+
+
+# fetch_routes runs "sudo vtysh", and /usr/bin/vtysh is a wrapper that runs
+# "docker exec -i bgp vtysh ...". The process holding the exec session into
+# the bgp container is a grandchild of what Popen returns, and it is the one
+# left blocked in write() when a parse is abandoned - out of reach of
+# proc.kill(), but not of closing the read end. The fakes below reproduce
+# that shape without docker: the process that floods the pipe is a
+# grandchild, not the direct child.
+GOOD_ROUTES = {
+    "10.0.0.0/24": [{"protocol": "bgp", "vrfName": "default", "selected": True, "offloaded": False}],
+    "10.0.1.0/24": [{"protocol": "bgp", "vrfName": "default", "selected": True,
+                     "offloaded": True, "failed": True}],
+    "10.0.2.0/24": [{"protocol": "connected", "vrfName": "default", "selected": True}],
+}
+
+# Emits a truncated JSON object so ijson raises, then floods stdout from a
+# grandchild so it blocks in write() once the 64KB pipe fills up.
+FLOOD_MARKER = "ROUTE_CHECK_TEST_FLOOD"
+
+# fetch_routes must not take anywhere near this long; it is only here so a
+# regression shows up as a failure instead of hanging the test run forever.
+FETCH_TIMEOUT_SECONDS = 60
+
+
+def _proc_readable():
+    """/proc must be usable or the liveness checks below silently pass."""
+    try:
+        with open('/proc/self/stat'):
+            return True
+    except OSError:
+        return False
+
+
+def _pid_running(pid):
+    """True only while pid exists and has not become a zombie."""
+    try:
+        with open('/proc/{}/stat'.format(pid)) as f:
+            state = f.read().rsplit(')', 1)[1].split()[0]
+    except OSError:
+        return False
+    return state != 'Z'
+
+
+def _wait_until(predicate, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.1)
+    return predicate()
+
+
+def _wait_until_gone(pid, timeout=10):
+    return _wait_until(lambda: not _pid_running(pid), timeout)
+
+
+def _pid_exists(pid):
+    """True while pid is in the process table at all, zombies included.
+
+    _pid_running() deliberately forgives a zombie, so it cannot see a child
+    that died but was never reaped. This one can.
+    """
+    return os.path.exists('/proc/{}'.format(pid))
+
+
+def _wait_until_reaped(pid, timeout=10):
+    return _wait_until(lambda: not _pid_exists(pid), timeout)
+
+
+@pytest.mark.skipif(not _proc_readable(),
+                    reason="needs a readable /proc to prove the chain is gone")
+class TestFetchRoutesCleanup(object):
+    """fetch_routes must never leave the vtysh / docker exec chain behind."""
+
+    @staticmethod
+    def _fake_popen(fake_cmd, captured):
+        """Run fake_cmd instead of vtysh, keeping real pipe semantics."""
+        real_popen = subprocess.Popen
+
+        def _popen(cmd, **kwargs):
+            proc = real_popen(fake_cmd, **kwargs)
+            captured['pid'] = proc.pid
+            captured['kwargs'] = kwargs
+            return proc
+        return _popen
+
+    @staticmethod
+    def _flooding_cmd(pidfile):
+        """A three level chain whose deepest process floods the pipe.
+
+        The grandchild is the stand-in for the docker exec client: it is the
+        one blocked in write(), and closing the read end is what has to reach
+        it. It records its own pid before emitting anything, so the file is
+        always in place by the time the parse fails and cleanup runs. Writing
+        it from the parent after the fork loses that race. exec keeps the pid,
+        so it identifies the flooding process too.
+        """
+        tmp = shlex.quote(str(pidfile) + '.tmp')
+        final = shlex.quote(str(pidfile))
+        inner = ("echo $$ > " + tmp + "; mv " + tmp + " " + final
+                 + "; printf '%s' '{\"10.0.0.0/24\": zzz'; exec yes " + FLOOD_MARKER)
+        return ['sh', '-c', 'sh -c ' + shlex.quote(inner) + ' & wait']
+
+    @staticmethod
+    def _writer_cmd():
+        """Emits a JSON object then keeps writing, like vtysh with more to send.
+
+        It has to keep writing: closing the read end only releases a process
+        that goes on to write. A sleeper would sit there untouched until the
+        bounded wait expired, which is a different code path.
+        """
+        return ['sh', '-c', "printf '%s' '{}'; exec yes " + FLOOD_MARKER]
+
+    @staticmethod
+    def _reap(*pids):
+        """Best effort cleanup so a failing assertion does not leak the chain.
+
+        Never killpg here: fetch_routes no longer starts a new session, so the
+        child shares the test runner's process group and killpg would take the
+        whole test session down with it.
+        """
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (OSError, TypeError):
+                pass
+
+    def _run_fetch_routes(self):
+        """Call fetch_routes off the main thread so a deadlock fails the test."""
+        outcome = {}
+
+        def run():
+            try:
+                outcome['result'] = route_check.fetch_routes()
+            except BaseException as e:  # noqa: B036, BLE001 - the point is to capture anything
+                outcome['exc'] = e
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join(timeout=FETCH_TIMEOUT_SECONDS)
+        assert not thread.is_alive(), \
+            "fetch_routes deadlocked: the read end was not closed before waiting"
+        return outcome
+
+    def test_releases_whole_process_chain_on_parse_error(self, tmp_path):
+        """The regression guard: with wait() before close() this deadlocks."""
+        pidfile = tmp_path / 'grandchild.pid'
+        captured = {}
+        grandchild = None
+        cmd = self._flooding_cmd(pidfile)
+        try:
+            with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)):
+                outcome = self._run_fetch_routes()
+
+            # The parse error itself stays swallowed, as it always was.
+            assert 'exc' not in outcome, outcome.get('exc')
+            assert outcome['result'] == ([], [])
+
+            # The grandchild is two levels below the process Popen returned, so
+            # proc.kill() would never have reached it. Closing the read end does.
+            assert _wait_until(pidfile.exists), "the fake chain never recorded its grandchild"
+            grandchild = int(pidfile.read_text().strip())
+            assert _wait_until_gone(grandchild), \
+                "grandchild {} survived: the chain was not released".format(grandchild)
+        finally:
+            self._reap(captured.get('pid'), grandchild)
+
+    def test_stdout_is_closed_before_wait(self):
+        """The whole deadlock was wait() running before the read end was closed.
+
+        Ordering is the fix. Closing afterwards is what the context manager did
+        on its own, and it never got there because wait() blocked first.
+        """
+        events = []
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.stdout.close.side_effect = lambda: events.append('close')
+        proc.wait.side_effect = lambda **kwargs: (events.append('wait'), 0)[1]
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.ijson.kvitems', side_effect=ValueError('boom')):
+            assert route_check.fetch_routes() == ([], [])
+
+        assert events == ['close', 'wait'], \
+            "the read end must be closed before vtysh is waited on"
+
+    @pytest.mark.parametrize("error", [
+        UnicodeDecodeError('utf-8', b'\xff', 0, 1, 'invalid start byte'),
+        ValueError('something unexpected'),
+    ])
+    def test_other_parse_errors_take_the_same_cleanup_path(self, error):
+        """Every branch that abandons the read has to release the chain."""
+        captured = {}
+        try:
+            with patch('route_check.subprocess.Popen',
+                       side_effect=self._fake_popen(self._writer_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=error):
+                outcome = self._run_fetch_routes()
+
+            assert 'exc' not in outcome, outcome.get('exc')
+            assert outcome['result'] == ([], [])
+            assert _wait_until_gone(captured['pid']), \
+                "vtysh stand-in survived a {}".format(type(error).__name__)
+        finally:
+            self._reap(captured.get('pid'))
+
+    def test_cleanup_runs_for_non_exception_interrupts(self):
+        """KeyboardInterrupt is not an Exception, so a flag would miss it."""
+        captured = {}
+        try:
+            with patch('route_check.subprocess.Popen',
+                       side_effect=self._fake_popen(self._writer_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=KeyboardInterrupt):
+                outcome = self._run_fetch_routes()
+
+            assert isinstance(outcome.get('exc'), KeyboardInterrupt), \
+                "KeyboardInterrupt must still propagate"
+            assert _wait_until_gone(captured['pid']), \
+                "the chain outlived a KeyboardInterrupt"
+            assert _wait_until_reaped(captured['pid']), \
+                "child {} left unreaped: the bounded wait was skipped".format(captured['pid'])
+        finally:
+            self._reap(captured.get('pid'))
+
+    def test_child_is_reaped_when_keyboard_interrupt_propagates(self):
+        """An interrupt must not skip the wait and leave the child a zombie.
+
+        KeyboardInterrupt is not an Exception, so it leaves the parse through
+        the finally and would skip anything placed after it. The process level
+        test above cannot see the difference on its own, because _pid_running()
+        reports a zombie as gone.
+        """
+        events = []
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.stdout.close.side_effect = lambda: events.append('close')
+        proc.wait.side_effect = lambda **kwargs: (events.append('wait'), 0)[1]
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.ijson.kvitems', side_effect=KeyboardInterrupt), \
+                pytest.raises(KeyboardInterrupt):
+            route_check.fetch_routes()
+
+        assert events == ['close', 'wait'], \
+            "the interrupt must not skip closing the pipe and reaping the child"
+
+    def test_clean_parse_returns_parsed_routes(self):
+        """The happy path must be untouched by the cleanup change."""
+        captured = {}
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES))]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
+                patch('route_check.print_message') as mock_msg:
+            outcome = self._run_fetch_routes()
+
+        assert 'exc' not in outcome, outcome.get('exc')
+        missing, failing = outcome['result']
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        assert failing == ['10.0.1.0/24']
+        assert not any('non-zero return code' in str(c) for c in mock_msg.call_args_list)
+
+    def test_non_zero_exit_is_reported_after_a_clean_parse(self):
+        """A real vtysh failure must survive the SIGPIPE suppression."""
+        captured = {}
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES)) + "; exit 3"]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
+                patch('route_check.print_message') as mock_msg:
+            outcome = self._run_fetch_routes()
+
+        assert 'exc' not in outcome, outcome.get('exc')
+        missing, failing = outcome['result']
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        assert any('non-zero return code: 3' in str(c) for c in mock_msg.call_args_list)
+
+    def test_sigpipe_from_our_own_close_is_not_reported_as_a_crash(self):
+        """Closing the read end kills vtysh with SIGPIPE; sudo reports 141.
+
+        That exit code is this function's own doing, so reporting it would send
+        a misleading warning to syslog on every parse failure.
+        """
+        captured = {}
+        try:
+            with patch('route_check.subprocess.Popen',
+                       side_effect=self._fake_popen(self._writer_cmd(), captured)), \
+                    patch('route_check.ijson.kvitems', side_effect=ValueError('boom')), \
+                    patch('route_check.print_message') as mock_msg:
+                outcome = self._run_fetch_routes()
+
+            assert 'exc' not in outcome, outcome.get('exc')
+            assert not any('non-zero return code' in str(c) for c in mock_msg.call_args_list)
+        finally:
+            self._reap(captured.get('pid'))
+
+    def test_process_that_never_exits_is_killed_then_abandoned(self):
+        """Closing only releases a writer; one hung without writing needs the signal.
+
+        Walking away would leak a child on every timeout, and route_check runs
+        on a timer. It still must not block: fetch_routes runs on a worker
+        thread the SIGALRM watchdog cannot interrupt, so both waits are bounded.
+        """
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.stdout = BytesIO(json.dumps(GOOD_ROUTES).encode())
+        proc.wait.side_effect = subprocess.TimeoutExpired(
+            cmd='vtysh', timeout=route_check.VTYSH_EXIT_TIMEOUT_SECONDS)
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.print_message') as mock_msg:
+            missing, failing = route_check.fetch_routes()
+
+        # Whatever was parsed before the hang still comes back.
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        assert failing == ['10.0.1.0/24']
+        proc.kill.assert_called_once_with()
+        assert any('did not exit; killing the direct child' in str(c)
+                   for c in mock_msg.call_args_list)
+        assert any('survived SIGKILL' in str(c) for c in mock_msg.call_args_list)
+
+    def test_kill_after_timeout_reaps_without_reporting_a_crash(self):
+        """The -9 from our own SIGKILL must not surface as a vtysh failure.
+
+        A real non-zero exit still has to be reported, so the suppression has
+        to come from not recording our own exit code rather than from a blanket
+        rule.
+        """
+        proc = MagicMock()
+        proc.pid = 424242
+        proc.stdout = BytesIO(json.dumps(GOOD_ROUTES).encode())
+        proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd='vtysh', timeout=route_check.VTYSH_EXIT_TIMEOUT_SECONDS),
+            -9,
+        ]
+
+        with patch('route_check.subprocess.Popen', return_value=proc), \
+                patch('route_check.print_message') as mock_msg:
+            missing, failing = route_check.fetch_routes()
+
+        assert missing == [{'prefix': '10.0.0.0/24', 'protocol': 'bgp'}]
+        proc.kill.assert_called_once_with()
+        assert not any('survived SIGKILL' in str(c) for c in mock_msg.call_args_list)
+        assert not any('non-zero return code' in str(c) for c in mock_msg.call_args_list)
+
+    def test_unexpected_route_entry_format_is_reported(self):
+        """FRR should never emit this, but the guard must still be exercised."""
+        captured = {}
+        payload = json.dumps({"10.0.0.0/24": "not-a-list"})
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(payload)]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)), \
+                patch('route_check.print_message') as mock_msg:
+            outcome = self._run_fetch_routes()
+
+        assert 'exc' not in outcome, outcome.get('exc')
+        assert outcome['result'] == ([], [])
+        assert any('Unexpected route entry format' in str(c) for c in mock_msg.call_args_list)
+
+    def test_does_not_start_a_new_session(self):
+        """Nothing needs the child detached now that cleanup is a close().
+
+        Leaving it in our session keeps a terminal SIGINT reaching vtysh on its
+        own, and keeps the test helpers from having to reason about groups.
+        """
+        captured = {}
+        cmd = ['sh', '-c', "printf '%s' " + shlex.quote(json.dumps(GOOD_ROUTES))]
+        with patch('route_check.subprocess.Popen', side_effect=self._fake_popen(cmd, captured)):
+            self._run_fetch_routes()
+
+        assert 'start_new_session' not in captured['kwargs']

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -561,7 +561,7 @@ TEST_DATA = {
             },
         },
         RESULT: {
-            DEFAULTNS: {"missed_FRR_routes": ['10.10.196.12/31']}
+            DEFAULTNS: {"missed_FRR_routes": [{"prefix": "10.10.196.12/31", "protocol": "bgp"}]}
         },
         RET: -1,
     },
@@ -971,7 +971,7 @@ TEST_DATA = {
             },
         },
         RESULT: {
-            ASIC1: {"missed_FRR_routes": ['10.10.196.12/31']},
+            ASIC1: {"missed_FRR_routes": [{"prefix": "10.10.196.12/31", "protocol": "bgp"}]},
         },
         RET: -1,
     },
@@ -1497,7 +1497,7 @@ TEST_DATA = {
         RESULT: {
             ASIC0: {
                 "missed_FRR_routes": [
-                    "10.10.196.20/31"
+                    {"prefix": "10.10.196.20/31", "protocol": "bgp"}
                 ],
                 "failed_FRR_routes": [
                     "10.10.196.12/31",
@@ -1590,8 +1590,8 @@ TEST_DATA = {
         RESULT: {
             DEFAULTNS: {
                 "missed_FRR_routes": [
-                    "10.10.196.12/31",
-                    "192.168.1.0/24"
+                    {"prefix": "10.10.196.12/31", "protocol": "bgp"},
+                    {"prefix": "192.168.1.0/24", "protocol": "bgp"}
                 ],
                 "failed_FRR_routes": [
                     "10.10.196.20/31",

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -14,6 +14,8 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+# sfputil.main imports sonic_platform at module level;
+# inject before importing so collection succeeds.
 sys.modules['sonic_platform'] = mock.MagicMock()
 import sfputil.main as sfputil
 

--- a/tests/sonic_package_manager/test_registry.py
+++ b/tests/sonic_package_manager/test_registry.py
@@ -9,7 +9,7 @@ def test_get_registry_for():
     resolver = RegistryResolver()
     registry = resolver.get_registry_for('debian')
     assert registry is resolver.DockerHubRegistry
-    registry = resolver.get_registry_for('Azure/sonic')
+    registry = resolver.get_registry_for('azure/sonic')
     assert registry is resolver.DockerHubRegistry
     registry = resolver.get_registry_for('registry-server:5000/docker')
     assert registry.url == 'https://registry-server:5000'

--- a/tests/ssdutil_test.py
+++ b/tests/ssdutil_test.py
@@ -29,7 +29,6 @@ def load_ssdutil_with_mocked_libs(monkeypatch):
     yield
 
 
-sys.modules['sonic_platform'] = MagicMock()
 sys.modules['sonic_platform_base.sonic_ssd.ssd_generic'] = MagicMock()
 
 

--- a/tests/test_sonic_installer.py
+++ b/tests/test_sonic_installer.py
@@ -13,11 +13,18 @@ def test_run_command():
         output = sonic_installer_common.run_command([sys.executable, "-c", "import sys; sys.exit(6)"])
     assert e.value.code == 6
 
+
+@pytest.mark.parametrize("resolv_conf_symlink_target", [
+    "/run/resolvconf/resolv.conf",       # absolute symlink
+    "../run/resolvconf/resolv.conf",     # relative symlink (resolvconf package default)
+    "../../run/resolvconf/resolv.conf",  # excess ".." clamps at the chroot root
+    None,                                # regular file
+])
 @patch("sonic_installer.main.SWAPAllocator")
 @patch("sonic_installer.main.get_bootloader")
 @patch("sonic_installer.main.run_command_or_raise")
 @patch("sonic_installer.main.run_command")
-def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
+def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs, resolv_conf_symlink_target):
     """ This test covers the execution of "sonic-installer install" command. """
 
     sonic_image_filename = "sonic.bin"
@@ -34,8 +41,11 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
     fs.create_dir(os.path.join(mounted_image_folder, "usr/lib/docker/docker.sh"))
     fs.create_file("/var/run/docker.pid", contents="15")
     fs.create_file("/proc/15/cmdline", contents="\x00".join(["dockerd"] + dockerd_opts))
-    # Simulate new image: /etc/resolv.conf is a dangling symlink (target doesn't exist in squashfs)
-    fs.create_symlink(f"{mounted_image_folder}/etc/resolv.conf", "/run/resolvconf/resolv.conf")
+    # New image /etc/resolv.conf: dangling symlink or regular file
+    if resolv_conf_symlink_target:
+        fs.create_symlink(f"{mounted_image_folder}/etc/resolv.conf", resolv_conf_symlink_target)
+    else:
+        fs.create_file(f"{mounted_image_folder}/etc/resolv.conf")
 
     # Expect fd:// to be replaced by unix://
     expected_dockerd_opts = [opt if opt != "fd://" else "unix://" for opt in dockerd_opts]
@@ -101,9 +111,20 @@ def test_install(run_command, run_command_or_raise, get_bootloader, swap, fs):
              f"{mounted_image_folder}/var/lib/sonic-package-manager"]),
         call(["touch", f"{mounted_image_folder}/tmp/docker.sock"]),
         call(["mount", "--bind", "/var/run/docker.sock", f"{mounted_image_folder}/tmp/docker.sock"]),
-        # /etc/resolv.conf is a dangling symlink -> /run/resolvconf/resolv.conf, populate its target
-        call(["mkdir", "-p", f"{mounted_image_folder}/run/resolvconf"]),
-        call(["cp", "-L", "/etc/resolv.conf", f"{mounted_image_folder}/run/resolvconf/resolv.conf"]),
+    ]
+    if resolv_conf_symlink_target:
+        # Symlink target resolves to /run/resolvconf/resolv.conf inside the chroot
+        expected_call_list += [
+            call(["mkdir", "-p", f"{mounted_image_folder}/run/resolvconf"]),
+            call(["cp", "-L", "--remove-destination", "/etc/resolv.conf",
+                  f"{mounted_image_folder}/run/resolvconf/resolv.conf"]),
+        ]
+    else:
+        # Regular file overwritten in place
+        expected_call_list += [
+            call(["cp", "/etc/resolv.conf", f"{mounted_image_folder}/etc/resolv.conf"]),
+        ]
+    expected_call_list += [
         call(["chroot", mounted_image_folder, "sh", "-c", "command -v sonic-package-manager"]),
         call(["chroot", mounted_image_folder, "sonic-package-manager", "migrate", "/tmp/packages.json", "--dockerd-socket", "/tmp/docker.sock", "-y"], capture=False),
         call(["chroot", mounted_image_folder, "/usr/lib/docker/docker.sh", "stop"], raise_exception=False),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,27 @@
 
 import importlib.util
 import importlib.machinery
+import os
 import subprocess
 import sys
+import tempfile
+
+
+def worker_tmp_path(filename):
+    """
+    Per-xdist-worker scratch file path (see tests/conftest.py setup_db_config).
+
+    Avoids races when multiple pytest workers read/write the same basename in
+    the source tree (e.g. startConfigDb.json under --dist loadfile).
+    """
+    base_dir = os.environ.get('WORKER_TMP')
+    if not base_dir:
+        worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'gw0')
+        base_dir = os.path.join(
+            tempfile.gettempdir(), f'sonic-utilities-{worker_id}')
+
+    os.makedirs(base_dir, exist_ok=True)
+    return os.path.join(base_dir, filename)
 
 
 def load_source(modname, filename, cache_module=False):

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -56,6 +56,12 @@ class AbbreviationGroup(click.Group):
             else:
                 return click.Group.get_command(self, ctx, shortest)
 
+            # During shell completion Click sets ctx.resilient_parsing and does not
+            # catch exceptions raised from get_command. Raising here would dump a
+            # traceback into the user's terminal, so degrade gracefully instead.
+            if ctx.resilient_parsing:
+                return None
+
             ctx.fail('Too many matches: %s' % ', '.join(sorted(matches)))
 
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When GCU deletes a VLAN prefix from CONFIG_DB, intfmgrd
asynchronously removes the address and its neighbors from the
kernel. The subsequent ip neigh flush in vlanintf_validator can
race with this removal and fail with ENOENT ("No such file or
directory"), which is benign since the neighbors are already gone.

Treat this specific failure as success instead of logging ERR
records that cause LogAnalyzer teardown failures in test suites.
Other flush failures (device not found, etc.) still fail as before.

#### How I did it

Here we are log logging the benign ENOENT in this specific scenario as syslog errors.

#### How to verify it

Running the scenario manually / running generic_config_updater/test_vlan_interface.py::test_vlan_interface_tc1_suite sonic-mgmt test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

