### PR TITLE
Allow ENOENT in vlanintf_validator ip neigh flush

### DIFF
--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -175,10 +175,20 @@ def vlanintf_validator(old_config, upd_config, keys):
     deleted_keys = list(set(old_keys) - set(upd_keys))
     for key in deleted_keys:
         iface, iface_ip = key
-        rc = command_wrapper(f"ip neigh flush dev {iface} {iface_ip}")
-        if rc:
+        cmd = f"ip neigh flush dev {iface} {iface_ip}"
+        result = subprocess.run(
+            shlex.split(cmd), capture_output=True, check=False, text=True
+        )
+        if result.returncode != 0:
+            if "No such file or directory" in result.stderr:
+                continue
             logger.log(logger.LOG_PRIORITY_ERROR,
-                       f"vlanintf_validator: Failed to flush neighbors for {iface} {iface_ip}, returncode={rc}",
+                       f"vlanintf_validator: Failed to flush neighbors for "
+                       f"{iface} {iface_ip}, returncode={result.returncode}",
                        print_to_console)
+            if result.stderr:
+                logger.log(logger.LOG_PRIORITY_ERROR,
+                           f"stderr: {result.stderr}",
+                           print_to_console)
             return False
     return True


### PR DESCRIPTION
When GCU deletes a VLAN prefix from CONFIG_DB, intfmgrd asynchronously removes the address and its neighbors from the kernel. The subsequent ip neigh flush in vlanintf_validator can race with this removal and fail with ENOENT ("No such file or directory"), which is benign since the neighbors are already gone.

Treat this specific failure as success instead of logging ERR records that cause LogAnalyzer teardown failures in test suites. Other flush failures (device not found, etc.) still fail as before.

The change can be verified by reproducing the scenario by running generic_config_updater/test_vlan_interface.py::test_vlan_interface_tc1_suite sonic-mgmt test. 

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Given the scenario not being an ERR state, change the vlanintf_validator behavior to not log benign messages as ERRs

#### How I did it

By NOT logging benign ENOENT in vlanintf_validator as syslog ERR

#### How to verify it

The change can be verified by reproducing the scenario by running generic_config_updater/test_vlan_interface.py::test_vlan_interface_tc1_suite sonic-mgmt test. 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

closes #4836

