### PR TITLE
Fix JsonMove._get_value to support both string and integer list indices (#4237) [202511]

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -98,10 +98,9 @@ class JsonMove:
     @staticmethod
     def _get_value(config, tokens):
         for token in tokens:
-            if isinstance(token, str) and token.isnumeric():
+            if isinstance(config, list):
                 token = int(token)
             config = config[token]
-
         return copy.deepcopy(config)
 
     @staticmethod

--- a/tests/generic_config_updater/test_patch_sorter_get_value.py
+++ b/tests/generic_config_updater/test_patch_sorter_get_value.py
@@ -1,0 +1,55 @@
+import unittest
+from generic_config_updater.patch_sorter import JsonMove
+
+
+class TestJsonMoveGetValue(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "table1": {
+                "key1": {
+                    "field": "value1"
+                },
+                "1": {
+                    "field": "value2"
+                }
+            },
+            "table2": [
+                {"name": "item0"},
+                {"name": "item1"}
+            ]
+        }
+
+    def test_get_value_dict(self):
+        tokens = ["table1", "key1", "field"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "value1")
+
+    def test_get_value_dict_numeric_string(self):
+        tokens = ["table1", "1", "field"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "value2")
+
+    def test_get_value_list(self):
+        # Should allow both int and string index for list
+        tokens = ["table2", 1, "name"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "item1")
+        tokens = ["table2", "1", "name"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "item1")
+
+    def test_get_value_missing_key(self):
+        tokens = ["table1", "not_exist"]
+        with self.assertRaises(KeyError):
+            JsonMove._get_value(self.config, tokens)
+
+    def test_get_value_list_invalid_index(self):
+        tokens = ["table2", "10", "name"]
+        with self.assertRaises(IndexError):
+            JsonMove._get_value(self.config, tokens)
+
+    def test_get_value_non_container(self):
+        tokens = ["table1", "key1", "field", "extra"]
+        with self.assertRaises(TypeError):
+            JsonMove._get_value(self.config, tokens)
+
+    def test_get_value_dict_numeric_keys(self):
+        self.config["7"] = {"8": "30"}
+        tokens = ["7", "8"]
+        self.assertEqual(JsonMove._get_value(self.config, tokens), "30")


### PR DESCRIPTION
> **PR 2 of 8** in a `202511` GCU backport stack. **Draft until the PRs ahead of it merge.**
>
> **Merge order is mandatory** - this cherry-pick assumes the earlier ones. Because the commits are sequential, this PR currently also shows the commits belonging to the PRs ahead of it. Once those merge I will rebase and it will reduce to its own single commit. Please review the last commit only for now.
>
> Stack starts at #4810. Tracking issue: #4823 - full stack, merge order and evidence.


#### Why I did it

Cherry-pick of #4237 (Xincun Li). `JsonMove._get_value` mishandled integer list indices, so patches addressing a list positionally (e.g. `TC_TO_QUEUE_MAP`, or removing an ACL port by index) resolved incorrectly.

#### How I did it

Clean cherry-pick. 3 lines of source plus a new 55-line test module.

#### How to verify it

```
python3 -m pytest tests/generic_config_updater/test_patch_sorter_get_value.py -q
```

Green in the full-suite run (460 passed). On hardware, removing 10 leaf-list members by index went from 10 moves / 6.40 s to 1 move / 0.76 s — though that figure is stack-level, since #4478 and #4476 act on the same path.

#### Backport notes

Clean; no conflicts.

---

#### Stack-level verification

Measured on the assembled stack, in a container built from the genuine `202511` `sonic_yang_mgmt` wheel (libyang 1.0.73, SWIG `import yang as ly`):

| Check | Result |
|---|---|
| Full GCU unit suite | **460 passed, 81 subtests, 0 failed** (clean `202511`: 434 passed, 80 subtests) |
| `flake8 --diff`, pre-commit hook semantics (4.0.1, `--max-line-length=120`) | **0 issues** - this commit individually, and the stack as a whole |
| Diff coverage, this PR | **100%** |
| Diff coverage, whole stack | **93.0%** (698 lines measured, 649 covered) - pipeline gate is 80% |

**Not run: `sonic-mgmt`.** I looked into running `tests/generic_config_updater/test_apply_patch_perf.py` and it **skips on every LAG topology** - its fixture builds the port list from `PORT` minus `PORTCHANNEL_MEMBER`, so on a T1 it finds 0 usable ports and bails with `Need at least 2 admin-up ports, have 0`. Across the last 45 days of nightly runs, every `202511` execution of it landed on a `t1-*-lag` bed and skipped, so **no `202511` baseline for that test exists**. It does run cleanly on t0 / m0 / mx / dualtor. Happy to book one of those beds and run it before merge - just ask.
