### PR TITLE
GCU generates suboptimal plan for CreateOnly paths (#4335) [202511]

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -4,7 +4,7 @@ import jsonpatch
 import sonic_yang
 from collections import deque, OrderedDict
 from enum import Enum
-from typing import IO, Optional, Tuple
+from typing import Any, IO, List, Optional, Tuple
 from .gu_common import OperationWrapper, OperationType, GenericConfigUpdaterError, \
                        JsonChange, PathAddressing, genericUpdaterLogging
 
@@ -1580,55 +1580,89 @@ class RemoveCreateOnlyDependencyMoveGenerator:
         target_config = diff.target_config # Final config after applying whole patch
         reload_config = True
 
-        processed_tables = set()
         for path in self.create_only_filter.get_paths(current_config):
             tokens = self.path_addressing.get_path_tokens(path)
-            table_to_check, create_only_field = tokens[0], tokens[-1]
+            current_field = self.__fetch_path(current_config, tokens)
+            target_field = self.__fetch_path(target_config, tokens)
 
-            if table_to_check in processed_tables:
-                continue
-            else:
-                processed_tables.add(table_to_check)
-
-            if table_to_check not in current_config:
+            # If field is deleted or created we don't care, we only care when it was
+            # already set and is changing value.
+            if current_field is None or target_field is None or current_field == target_field:
                 continue
 
-            current_members = current_config[table_to_check]
-            if not current_members:
-                continue
+            # Create only filters may reference an exact leaf, but it's really the parent that is the
+            # object we're after.
+            tokens.pop()
 
-            if table_to_check not in target_config:
-                continue
+            # First see if there are any dependents for the exact path
+            for move in self.__remove_dependents(diff, tokens, reload_config=reload_config,
+                                                 remove_parent=False):
+                yield move
 
-            target_members = target_config[table_to_check]
-            if not target_members:
-                continue
+            # No need to reload config after first call
+            reload_config = False
 
-            for member_name in current_members:
-                if member_name not in target_members:
-                    continue
+            yield self.__remove_nonempty(diff, tokens)
 
-                current_field = self._get_create_only_field(
-                    current_config, table_to_check, member_name, create_only_field)
-                target_field = self._get_create_only_field(
-                    target_config, table_to_check, member_name, create_only_field)
+            # If that didn't work, likely the parents of the dependent path needs to be removed.
+            for move in self.__remove_dependents(diff, tokens, reload_config=reload_config,
+                                                 remove_parent=True):
+                yield move
 
-                if current_field == target_field:
-                    continue
+            # Remove self again after removing the parents of dependents
+            # NOTE: When we use the DFS sorter this is irrelevant.  Right now we only use DFS so we don't need it
+            #       as it will be called again after it removed any parent dependents.  Commenting out for now.
+            #
+            # yield self.__remove_nonempty(diff, tokens)
 
-                member_path = f"/{table_to_check}/{member_name}"
+    def __fetch_path(self, config, tokens: List[str]) -> Any:
+        for token in tokens:
+            config = config.get(token)
+            if config is None:
+                return None
+        return config
 
-                for ref_path in self.path_addressing.find_ref_paths(member_path, current_config,
-                                                                    reload_config=reload_config):
-                    yield JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.REMOVE,
-                                        self.path_addressing.get_path_tokens(ref_path)))
+    def __get_path_count(self, config, tokens: List[str]) -> int:
+        config = self.__fetch_path(config, tokens)
+        if config is None:
+            return 0
+        return len(config)
 
-                # No need to reload config after first call
-                reload_config = False
+    def __remove_nonempty(self, diff: Diff, tokens: List[str]):
+        remove_tokens = list(tokens)
+        # Only trim while there is at least one table token and one deeper level.
+        # This prevents generating an empty path ("") and avoids an infinite loop
+        # when the top-level config has a single table.
+        while len(remove_tokens) > 1 and \
+                self.__get_path_count(diff.current_config, remove_tokens[:-1]) == 1:
+            remove_tokens = remove_tokens[:-1]
+        return JsonMoveGroup(self.__class__.__name__, JsonMove(diff, OperationType.REMOVE, remove_tokens))
 
-    def _get_create_only_field(self, config, table_to_check,
-                               member_name, create_only_field):
-        return config[table_to_check][member_name].get(create_only_field, None)
+    def __remove_dependents(
+        self,
+        diff: Diff,
+        tokens: List[str],
+        reload_config: bool,
+        remove_parent: bool,
+        recursion_depth: int = 0,
+    ):
+        if recursion_depth >= 10:
+            return
+
+        config = diff.current_config
+        path = self.path_addressing.create_path(tokens)
+        ref_paths = self.path_addressing.find_ref_paths(path, config, reload_config)
+        for ref in ref_paths:
+            ref_tokens = self.path_addressing.get_path_tokens(ref)
+            if remove_parent:
+                ref_tokens.pop()
+
+            # Recurse since there could be a dependency chain
+            for move in self.__remove_dependents(diff, ref_tokens, reload_config=False,
+                                                 remove_parent=remove_parent, recursion_depth=recursion_depth+1):
+                yield move
+
+            yield self.__remove_nonempty(diff, ref_tokens)
 
 
 class LowLevelMoveGenerator:
@@ -2222,10 +2256,10 @@ class SortAlgorithmFactory:
         self.path_addressing = path_addressing
 
     def create(self, algorithm=Algorithm.DFS, path_trace: bool = False):
-        move_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
-                           LowLevelMoveGenerator(self.path_addressing)]
+        move_generators = [LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
-        move_non_extendable_generators = [BulkKeyLevelMoveGenerator(self.path_addressing),
+        move_non_extendable_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
+                                          BulkKeyLevelMoveGenerator(self.path_addressing),
                                           KeyLevelMoveGenerator(self.path_addressing),
                                           BulkKeyGroupLowLevelMoveGenerator(self.path_addressing),
                                           BulkLowLevelMoveGenerator(self.path_addressing)]

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -739,27 +739,6 @@
         "expected_changes": [
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/alias",
-                    "value": "Eth1/1"
-                }
-            ],
-            [
-                {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/description",
-                    "value": ""
-                }
-            ],
-            [
-                {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/speed",
-                    "value": "10000"
-                }
-            ],
-            [
-                {
                     "op": "remove",
                     "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
                 }
@@ -1017,42 +996,37 @@
             [
                 {
                     "op": "remove",
-                    "path": "/VLAN_MEMBER/Vlan100|Ethernet1"
-                },
-                {
-                    "op": "remove",
-                    "path": "/VLAN_MEMBER/Vlan100|Ethernet2"
-                },
-                {
-                    "op": "remove",
-                    "path": "/VLAN_MEMBER/Vlan100|Ethernet3"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
                     "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/0"
                 }
             ],
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/alias",
-                    "value": "Eth1"
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet0"
                 }
             ],
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/description",
-                    "value": "Ethernet0 100G link"
+                    "op": "remove",
+                    "path": "/PORT/Ethernet0"
                 }
             ],
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/speed",
-                    "value": "100000"
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet1"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet2"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER"
                 }
             ],
             [
@@ -1117,25 +1091,6 @@
             ],
             [
                 {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/0",
-                    "value": "Ethernet0"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/PORT/Ethernet3"
-                }
-            ],
-            [
-                {
                     "op": "remove",
                     "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
                 }
@@ -1143,10 +1098,8 @@
             [
                 {
                     "op": "remove",
-                    "path": "/VLAN_MEMBER"
-                }
-            ],
-            [
+                    "path": "/PORT/Ethernet3"
+                },
                 {
                     "op": "remove",
                     "path": "/PORT"
@@ -1159,8 +1112,8 @@
                     "value": {
                         "Ethernet0": {
                             "alias": "Eth1",
-                            "description": "Ethernet0 100G link",
                             "lanes": "65, 66, 67, 68",
+                            "description": "Ethernet0 100G link",
                             "speed": "100000"
                         }
                     }
@@ -5689,6 +5642,126 @@
                 {
                     "op": "remove",
                     "path": "/PORT_QOS_MAP/Ethernet64"
+                }
+            ]
+        ]
+    },
+    "CREATE_ONLY_PATH_TEST_MIRROR_SESSION__SUCCESS": {
+        "desc": "Mirror changes should not remove ACL Table.",
+        "current_config": {
+            "MIRROR_SESSION": {
+                "EVERFLOW_TUNNEL": {
+                    "dscp": "8",
+                    "dst_ip": "200.1.1.200",
+                    "src_ip": "100.1.1.1",
+                    "ttl": "255",
+                    "type": "ERSPAN"
+                }
+            },
+            "ACL_TABLE": {
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "ACL_RULE": {
+                "DATAACL|RULE_1": {
+                    "DST_IP": "192.168.1.1/32",
+                    "IP_TYPE": "IP",
+                    "L4_DST_PORT": "22",
+                    "PACKET_ACTION": "DROP",
+                    "PRIORITY": "10"
+                },
+                "EVERFLOW|RULE_1": {
+                    "PRIORITY": "1000",
+                    "IP_TYPE": "IP",
+                    "MIRROR_INGRESS_ACTION": "EVERFLOW_TUNNEL"
+                }
+            },
+            "PORT": {
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/MIRROR_SESSION/EVERFLOW_TUNNEL/dst_ip",
+                "value": "200.1.1.203"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_RULE/EVERFLOW|RULE_1/MIRROR_INGRESS_ACTION"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/MIRROR_SESSION"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/MIRROR_SESSION",
+                    "value": {
+                        "EVERFLOW_TUNNEL": {
+                            "dscp": "8",
+                            "dst_ip": "200.1.1.203",
+                            "src_ip": "100.1.1.1",
+                            "ttl": "255",
+                            "type": "ERSPAN"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_RULE/EVERFLOW|RULE_1/MIRROR_INGRESS_ACTION",
+                    "value": "EVERFLOW_TUNNEL"
                 }
             ]
         ]

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2545,8 +2545,20 @@ class RemoveCreateOnlyDependencyMoveGenerator(unittest.TestCase):
         moves = list(self.generator.generate(diff))
 
         # Assert
+
+        # This is a proper output even though it looks wrong.
+        # Due to logic in the generator to ensure it removes the exact referenced
+        # leaves for dependents, then the CreateOnly path, followed by the parents
+        # of the dependent paths.  Since this is a generator called by DFS it will
+        # be called recursively so the parent may not ever be removed in practice.
+        # Also since it is recursive and starts over, in practice if it did need
+        # to delete the parent path, it would emit another delete of the
+        # create-only attribute parent.
         self.verify_moves([{'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports/0'},
-                           {'op': 'remove', 'path': '/VLAN_MEMBER/Vlan100|Ethernet0'}],
+                           {'op': 'remove', 'path': '/VLAN_MEMBER/Vlan100|Ethernet0'},
+                           {'op': 'remove', 'path': '/PORT/Ethernet0'},
+                           {'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports'},
+                           {'op': 'remove', 'path': '/VLAN_MEMBER'}],
                           moves)
 
     def test_generate__dpb_1_to_4_example(self):
@@ -2557,8 +2569,20 @@ class RemoveCreateOnlyDependencyMoveGenerator(unittest.TestCase):
         moves = list(self.generator.generate(diff))
 
         # Assert
-        self.verify_moves([{'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports/0'},
-                           {'op': 'remove', 'path': '/VLAN_MEMBER/Vlan100|Ethernet0'}],
+
+        # This is a proper output even though it looks wrong on a couple of fronts.
+        # Due to logic in the generator to ensure it doesn't create empty tables, it
+        # will remove the parent if it removed the last entry in the table.  In this
+        # case in each of the tables we are removing the only entry.  Then the repetition
+        # is due to logic to remove the parent of a dependent if the prior generator
+        # failed to validate, which ends up resolving to the same path as the original
+        # due to the no-empty-table logic.  Since no validators are run we see the same
+        # output twice.
+        self.verify_moves([{'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports'},
+                           {'op': 'remove', 'path': '/VLAN_MEMBER'},
+                           {'op': 'remove', 'path': '/PORT'},
+                           {'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports'},
+                           {'op': 'remove', 'path': '/VLAN_MEMBER'}],
                           moves)
 
     def verify_moves(self, ops, moves):
@@ -3303,9 +3327,9 @@ class TestSortAlgorithmFactory(unittest.TestCase):
         # Arrange
         config_wrapper = ConfigWrapper()
         factory = ps.SortAlgorithmFactory(OperationWrapper(), config_wrapper, PathAddressing(config_wrapper))
-        expected_generators = [ps.RemoveCreateOnlyDependencyMoveGenerator,
-                               ps.LowLevelMoveGenerator]
-        expected_non_extendable_generators = [ps.BulkKeyLevelMoveGenerator,
+        expected_generators = [ps.LowLevelMoveGenerator]
+        expected_non_extendable_generators = [ps.RemoveCreateOnlyDependencyMoveGenerator,
+                                              ps.BulkKeyLevelMoveGenerator,
                                               ps.KeyLevelMoveGenerator,
                                               ps.BulkKeyGroupLowLevelMoveGenerator,
                                               ps.BulkLowLevelMoveGenerator]


### PR DESCRIPTION
> **PR 4 of 8** in a `202511` GCU backport stack. **Draft until the PRs ahead of it merge.**
>
> **Merge order is mandatory** - this cherry-pick assumes the earlier ones. Because the commits are sequential, this PR currently also shows the commits belonging to the PRs ahead of it. Once those merge I will rebase and it will reduce to its own single commit. Please review the last commit only for now.
>
> Stack starts at #4810. Tracking issue: #4823 - full stack, merge order and evidence.


#### Why I did it

Cherry-pick of #4335 (Brad House, Nexthop). **This is a correctness and blast-radius bug, not a performance one.**

When a create-only field changes — the PR's own example is `replace /MIRROR_SESSION/EVERFLOW_TUNNEL/dst_ip` — `202511` generates a plan that includes:

```json
{"op": "remove", "path": "/ACL_RULE"}
```

That **removes every ACL rule on the box** as an intermediate step. On a live switch that is a traffic-affecting window.

#### How I did it

Clean cherry-pick.

#### How to verify it

**Isolated per-PR A/B** — the two arms differ only by this commit (`1004a8fe` vs `fec4f3fb`), with everything earlier in the stack, including the branch fix, present in both:

| | moves |
|---|---|
| before (#4317) | **31** |
| after (#4335) | **4** |

The 4-move result is byte-identical to the optimal plan published in the upstream PR body:

```
remove /ACL_RULE/EVERFLOW|RULE_1/MIRROR_INGRESS_ACTION
remove /MIRROR_SESSION
add    /MIRROR_SESSION            (with dst_ip 200.1.1.203)
add    /ACL_RULE/EVERFLOW|RULE_1/MIRROR_INGRESS_ACTION
```

The 31-move "before" plan contains the pathological `remove /ACL_RULE` at move 4. Measured against clean `202511` (rather than against #4317) the same scenario is 36 moves / 489 `loadData` / 1.46 s versus 4 moves / 8 loads / 0.17 s.

#### Caveats

This is a plan-*quality* fix. It does **not** make the create-only path fast at scale — see the tracking PR.

#### Backport notes

Clean; no conflicts.

---

#### Stack-level verification

Measured on the assembled stack, in a container built from the genuine `202511` `sonic_yang_mgmt` wheel (libyang 1.0.73, SWIG `import yang as ly`):

| Check | Result |
|---|---|
| Full GCU unit suite | **460 passed, 81 subtests, 0 failed** (clean `202511`: 434 passed, 80 subtests) |
| `flake8 --diff`, pre-commit hook semantics (4.0.1, `--max-line-length=120`) | **0 issues** - this commit individually, and the stack as a whole |
| Diff coverage, this PR | **92.9%** |
| Diff coverage, whole stack | **93.0%** (698 lines measured, 649 covered) - pipeline gate is 80% |

**Not run: `sonic-mgmt`.** I looked into running `tests/generic_config_updater/test_apply_patch_perf.py` and it **skips on every LAG topology** - its fixture builds the port list from `PORT` minus `PORTCHANNEL_MEMBER`, so on a T1 it finds 0 usable ports and bails with `Need at least 2 admin-up ports, have 0`. Across the last 45 days of nightly runs, every `202511` execution of it landed on a `t1-*-lag` bed and skipped, so **no `202511` baseline for that test exists**. It does run cleanly on t0 / m0 / mx / dualtor. Happy to book one of those beds and run it before merge - just ask.
