### PR TITLE
GCU sort: batch leaf-list changes into single REPLACE move (#4478) [202511]

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1272,6 +1272,62 @@ class KeyLevelMoveGenerator:
                     yield [table, key]
 
 
+class BulkLeafListMoveGenerator:
+    """
+    A non-extendable generator that produces a single REPLACE move for each
+    leaf-list field whose items differ between current and target configs.
+
+    Instead of generating N individual REMOVE/ADD moves (one per list item),
+    this emits one REPLACE of the whole list. The DFS tries non-extendable
+    generators first, so if the bulk replace validates, we skip N-1 moves
+    and their associated loadData() calls.
+
+    This is conservative:
+    - Only handles leaf-lists (lists of scalars, not lists of dicts)
+    - Only replaces lists that already exist in both current and target
+    - If this move fails validation, DFS continues to other generators
+      which produce per-item moves (no explicit fallback mechanism)
+    """
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
+    def generate(self, diff):
+        for move in self._traverse(diff, diff.current_config, diff.target_config, []):
+            yield move
+
+    def _traverse(self, diff, current_ptr, target_ptr, tokens):
+        if not isinstance(current_ptr, dict) or not isinstance(target_ptr, dict):
+            return
+
+        for key in current_ptr:
+            if key not in target_ptr:
+                continue
+
+            tokens.append(key)
+            current_val = current_ptr[key]
+            target_val = target_ptr[key]
+
+            if isinstance(current_val, list) and isinstance(target_val, list):
+                # Only handle leaf-lists (lists of scalars)
+                if (current_val != target_val and
+                        self._is_leaf_list(current_val) and
+                        self._is_leaf_list(target_val)):
+                    yield JsonMoveGroup(
+                        self.__class__.__name__,
+                        JsonMove(diff, OperationType.REPLACE, list(tokens), list(tokens)),
+                    )
+            elif isinstance(current_val, dict) and isinstance(target_val, dict):
+                for move in self._traverse(diff, current_val, target_val, tokens):
+                    yield move
+
+            tokens.pop()
+
+    @staticmethod
+    def _is_leaf_list(lst):
+        """Return True if lst contains only scalars (str, int, float, bool)."""
+        return all(isinstance(item, (str, int, float, bool)) for item in lst)
+
+
 class BulkKeyLevelMoveGenerator:
     """
     Same concept as KeyLevelMoveGenerator, but groups additions and removals of sibling keys.
@@ -2259,6 +2315,7 @@ class SortAlgorithmFactory:
         move_generators = [LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
         move_non_extendable_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
+                                          BulkLeafListMoveGenerator(self.path_addressing),
                                           BulkKeyLevelMoveGenerator(self.path_addressing),
                                           KeyLevelMoveGenerator(self.path_addressing),
                                           BulkKeyGroupLowLevelMoveGenerator(self.path_addressing),

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -537,9 +537,13 @@
         "expected_changes": [
             [
                 {
-                    "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
-                    "value": "Ethernet0"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet0",
+                        "Ethernet4",
+                        "Ethernet8"
+                    ]
                 }
             ]
         ]
@@ -846,23 +850,14 @@
             ],
             [
                 {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1",
-                    "value": "Ethernet1"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/2",
-                    "value": "Ethernet2"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/3",
-                    "value": "Ethernet3"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0",
+                        "Ethernet1",
+                        "Ethernet2",
+                        "Ethernet3"
+                    ]
                 }
             ]
         ]
@@ -1491,15 +1486,12 @@
         "expected_changes": [
             [
                 {
-                    "op": "remove",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
-                    "value": "Ethernet0"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet0",
+                        "Ethernet8"
+                    ]
                 }
             ]
         ]
@@ -1706,8 +1698,13 @@
         "expected_changes": [
             [
                 {
-                    "op": "remove",
-                    "path": "/VLAN/Vlan1000/dhcp_servers/0"
+                    "op": "replace",
+                    "path": "/VLAN/Vlan1000/dhcp_servers",
+                    "value": [
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
                 }
             ]
         ]
@@ -2336,8 +2333,8 @@
                     "value": {
                         "Ethernet0": {
                             "alias": "Eth1",
-                            "description": "Ethernet0 100G link",
                             "lanes": "67",
+                            "description": "Ethernet0 100G link",
                             "speed": "100000"
                         }
                     }
@@ -3834,6 +3831,28 @@
         "expected_changes": [
             [
                 {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOW/ports",
+                    "value": [
+                        "Ethernet64",
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet64",
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
+                }
+            ],
+            [
+                {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.33",
                     "value": {
@@ -4173,20 +4192,6 @@
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOW/ports/0",
-                    "value": "Ethernet64"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
-                    "value": "Ethernet64"
                 }
             ],
             [
@@ -5367,6 +5372,26 @@
         "expected_changes": [
             [
                 {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOW/ports",
+                    "value": [
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
+                }
+            ],
+            [
+                {
                     "op": "remove",
                     "path": "/INTERFACE/Ethernet64|10.0.0.32~131"
                 },
@@ -5581,18 +5606,6 @@
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::a/admin_status"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/ACL_TABLE/EVERFLOW/ports/0"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0"
                 }
             ],
             [

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2232,6 +2232,91 @@ class TestKeyLevelMoveGenerator(unittest.TestCase):
             moves_ops.extend(move.get_jsonpatch())
         self.assertCountEqual(ops, moves_ops)
 
+
+class TestBulkLeafListMoveGenerator(unittest.TestCase):
+    def setUp(self):
+        path_addressing = PathAddressing()
+        self.generator = ps.BulkLeafListMoveGenerator(path_addressing)
+
+    def test_generate__leaf_list_items_removed__single_replace_move(self):
+        """Removing items from a leaf-list should produce one REPLACE move."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4", "Ethernet8"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet8"], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports",
+                     "value": ["Ethernet8"]}])
+
+    def test_generate__leaf_list_items_added__single_replace_move(self):
+        """Adding items to a leaf-list should produce one REPLACE move."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4", "Ethernet8"], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports",
+                     "value": ["Ethernet0", "Ethernet4", "Ethernet8"]}])
+
+    def test_generate__leaf_list_unchanged__no_moves(self):
+        """Identical leaf-lists should produce no moves."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
+            ex_ops=[])
+
+    def test_generate__non_list_fields_differ__no_moves(self):
+        """Non-list field changes should not produce moves from this generator."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "L3"}}},
+            ex_ops=[])
+
+    def test_generate__list_of_dicts__no_moves(self):
+        """Lists of dicts (not leaf-lists) should be skipped."""
+        self.verify(
+            current={"TABLE": {"KEY": {"items": [{"a": 1}, {"b": 2}]}}},
+            target={"TABLE": {"KEY": {"items": [{"a": 1}]}}},
+            ex_ops=[])
+
+    def test_generate__list_only_in_current__no_moves(self):
+        """List exists in current but not target — not a REPLACE, skip."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR"}}},
+            ex_ops=[])
+
+    def test_generate__list_only_in_target__no_moves(self):
+        """List exists in target but not current — handled by other generators, skip."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR", "ports": ["Ethernet0"]}}},
+            ex_ops=[])
+
+    def test_generate__leaf_list_all_items_removed__single_replace_move(self):
+        """Removing all items from a leaf-list should produce one REPLACE with empty list."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": [], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports", "value": []}])
+
+    def test_generate__multiple_tables_with_leaf_lists__multiple_moves(self):
+        """Multiple differing leaf-lists should each get a REPLACE move."""
+        self.verify(
+            current={"ACL_TABLE": {
+                "T1": {"ports": ["Ethernet0", "Ethernet4"], "type": "L3"},
+                "T2": {"ports": ["Ethernet8", "Ethernet12"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {
+                "T1": {"ports": ["Ethernet0"], "type": "L3"},
+                "T2": {"ports": ["Ethernet12"], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/T1/ports", "value": ["Ethernet0"]},
+                    {"op": "replace", "path": "/ACL_TABLE/T2/ports", "value": ["Ethernet12"]}])
+
+    def verify(self, current, target, ex_ops):
+        diff = ps.Diff(current, target)
+        moves = list(self.generator.generate(diff))
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.get_jsonpatch())
+        self.assertCountEqual(ex_ops, moves_ops)
+
+
 class TestLowLevelMoveGenerator(unittest.TestCase):
     def setUp(self):
         path_addressing = PathAddressing()
@@ -3332,7 +3417,8 @@ class TestSortAlgorithmFactory(unittest.TestCase):
                                               ps.BulkKeyLevelMoveGenerator,
                                               ps.KeyLevelMoveGenerator,
                                               ps.BulkKeyGroupLowLevelMoveGenerator,
-                                              ps.BulkLowLevelMoveGenerator]
+                                              ps.BulkLowLevelMoveGenerator,
+                                              ps.BulkLeafListMoveGenerator]
         expected_extenders = [ps.RequiredValueMoveExtender,
                               ps.UpperLevelMoveExtender,
                               ps.DeleteInsteadOfReplaceMoveExtender,


### PR DESCRIPTION
> **PR 5 of 8** in a `202511` GCU backport stack. **Draft until the PRs ahead of it merge.**
>
> **Merge order is mandatory** - this cherry-pick assumes the earlier ones. Because the commits are sequential, this PR currently also shows the commits belonging to the PRs ahead of it. Once those merge I will rebase and it will reduce to its own single commit. Please review the last commit only for now.
>
> Stack starts at #4810. Tracking issue: #4823 - full stack, merge order and evidence.


#### Why I did it

Cherry-pick of #4478. `202511` emits one move per leaf-list element, so shrinking a 512-member `ACL_TABLE.ports` produces 510 moves. This batches them into a single `REPLACE`.

**Must merge before #4476.**

#### How I did it

Clean cherry-pick. +57 lines of source.

#### How to verify it

Sorter micro-benchmark, clean `202511` vs the stack, in the faithful container:

| ports | before (moves / loads / wall) | after | speedup |
|---|---|---|---|
| 64 | 62 / 124 / 1.66 s | 1 / 2 / 0.17 s | 9.8× |
| 128 | 126 / 252 / 7.33 s | 1 / 2 / 0.21 s | 35× |
| 256 | 254 / 508 / 33.38 s | 1 / 2 / 0.30 s | 111× |
| 512 | 510 / 1020 / **179.88 s** | 1 / 2 / **0.60 s** | **300×** |

Before is clearly `O(N²)`; after is flat. Upstream #4478 claimed ~250×; we independently measure 300× on `202511`. On hardware, 19 moves → 1 and 57 moves → 3.

Correctness held in every run: resulting `ports` value identical on both arms.

#### Backport notes

Clean. Attribution note: the wall-clock figures are stack-level, since #4478 (fewer moves) and #4476 (fewer parses per move) compound.

---

#### Stack-level verification

Measured on the assembled stack, in a container built from the genuine `202511` `sonic_yang_mgmt` wheel (libyang 1.0.73, SWIG `import yang as ly`):

| Check | Result |
|---|---|
| Full GCU unit suite | **460 passed, 81 subtests, 0 failed** (clean `202511`: 434 passed, 80 subtests) |
| `flake8 --diff`, pre-commit hook semantics (4.0.1, `--max-line-length=120`) | **0 issues** - this commit individually, and the stack as a whole |
| Diff coverage, this PR | **96.0%** |
| Diff coverage, whole stack | **93.0%** (698 lines measured, 649 covered) - pipeline gate is 80% |

**Not run: `sonic-mgmt`.** I looked into running `tests/generic_config_updater/test_apply_patch_perf.py` and it **skips on every LAG topology** - its fixture builds the port list from `PORT` minus `PORTCHANNEL_MEMBER`, so on a T1 it finds 0 usable ports and bails with `Need at least 2 admin-up ports, have 0`. Across the last 45 days of nightly runs, every `202511` execution of it landed on a `t1-*-lag` bed and skipped, so **no `202511` baseline for that test exists**. It does run cleanly on t0 / m0 / mx / dualtor. Happy to book one of those beds and run it before merge - just ask.
