### PR TITLE
[generic_config_updater] Cache loadData() calls to reduce redundant YANG parsing (#4476) [202511]

### DIFF
--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -9,6 +9,7 @@ import yang as ly
 import copy
 import re
 import os
+import hashlib
 from sonic_py_common import logger, multi_asic
 from enum import Enum
 from functools import cmp_to_key
@@ -81,6 +82,8 @@ class ConfigWrapper:
         self.scope = scope
         self.yang_dir = YANG_DIR
         self.sonic_yang_with_loaded_models = None
+        self._validate_config_cache = {}
+        self._currently_loaded_hash = None
 
     def get_config_db_as_json(self):
         return get_config_db_as_json(self.scope)
@@ -138,6 +141,16 @@ class ConfigWrapper:
             return False, ex
 
     def validate_config_db_config(self, config_db_as_json):
+        # Cache validation results by config content hash.
+        # validate_config_db_config is a pure function: same config always produces
+        # the same result. Caching avoids redundant loadData() calls when the DFS
+        # revisits the same config state during backtracking.
+        _cache_key = hashlib.md5(
+            json.dumps(config_db_as_json, sort_keys=True).encode()
+        ).hexdigest()
+        if _cache_key in self._validate_config_cache:
+            return self._validate_config_cache[_cache_key]
+
         sy = self.create_sonic_yang_with_loaded_models()
 
         # TODO: Move these validators to YANG models
@@ -152,14 +165,22 @@ class ConfigWrapper:
             # tuple / SonicYangException, so callers retain full error
             # signal -- only the duplicate syslog spam is silenced.
             sy.loadData(config_db_as_json, quiet=True)
+            self._currently_loaded_hash = _cache_key
             for supplemental_yang_validator in supplemental_yang_validators:
                 success, error = supplemental_yang_validator(config_db_as_json)
                 if not success:
-                    return success, error
+                    result = (success, error)
+                    self._validate_config_cache[_cache_key] = result
+                    return result
         except sonic_yang.SonicYangException as ex:
-            return False, str(ex)
+            self._currently_loaded_hash = None
+            result = (False, str(ex))
+            self._validate_config_cache[_cache_key] = result
+            return result
 
-        return True, None
+        result = (True, None)
+        self._validate_config_cache[_cache_key] = result
+        return result
 
     def validate_field_operation(self, old_config, target_config):
         """
@@ -542,7 +563,17 @@ class PathAddressing:
         # caller passes reload_config=False (e.g. the recursive
         # __remove_dependents path). Load whenever nothing is loaded yet.
         if reload_config or sy.root is None:
-            sy.loadData(config)
+            _config_hash = hashlib.md5(
+                json.dumps(config, sort_keys=True).encode()
+            ).hexdigest()
+            already_loaded = (
+                self.config_wrapper is not None and
+                self.config_wrapper._currently_loaded_hash == _config_hash
+            )
+            if not already_loaded:
+                sy.loadData(config)
+                if self.config_wrapper is not None:
+                    self.config_wrapper._currently_loaded_hash = _config_hash
 
         # Force to be a list
         if not isinstance(paths, list):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1025,15 +1025,15 @@ class NoDependencyMoveValidator:
         """
         deleted_paths, added_paths = self._get_paths(diff.current_config, simulated_config, [])
 
-        # Note: on replace operations we are loading both current and simulated configs so we have to
-        #       load twice :(
-
-        # For deleted paths, we check the current config has no dependencies between nodes under the removed path
-        if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
+        # Validate added_paths against simulated_config first: FullConfigMoveValidator has
+        # already loaded simulated_config into the sy singleton (via validate_config_db_config),
+        # so _currently_loaded_hash will match and find_ref_paths skips loadData.
+        # Then validate deleted_paths against current_config (requires a fresh loadData).
+        # This ordering gives 2 loadData calls instead of 3 for REPLACE operations.
+        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True):
             return False
 
-        # For added paths, we check the simulated config has no dependencies between nodes under the added path
-        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True):
+        if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
             return False
 
         return True

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -221,6 +221,92 @@ class TestConfigWrapper(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertIsNotNone(error)
 
+    def test_validate_config_db_config__same_config_called_twice__loadData_called_once(self):
+        """Cache hit: second call with same config must not call loadData again."""
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        mock_sy.loadYangModel = MagicMock()
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        config = {"ACL_TABLE": {}}
+
+        config_wrapper.validate_config_db_config(config)
+        config_wrapper.validate_config_db_config(config)
+
+        # loadData should only be called once — second call hits the result cache
+        mock_sy.loadData.assert_called_once()
+
+    def test_validate_config_db_config__different_configs__loadData_called_each_time(self):
+        """Cache miss: different configs must each call loadData."""
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        config_a = {"ACL_TABLE": {"rule1": {}}}
+        config_b = {"ACL_TABLE": {"rule2": {}}}
+
+        config_wrapper.validate_config_db_config(config_a)
+        config_wrapper.validate_config_db_config(config_b)
+
+        self.assertEqual(2, mock_sy.loadData.call_count)
+
+    def test_find_ref_paths__after_validate_same_config__loadData_skipped(self):
+        """
+        Core optimization: if validate_config_db_config already loaded config into sy,
+        find_ref_paths with the same config must skip loadData entirely.
+        """
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        mock_sy.root = MagicMock()
+        mock_sy.root.find_path = MagicMock(return_value=MagicMock(data=MagicMock(return_value=[])))
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        path_addressing = gu_common.PathAddressing(config_wrapper)
+        config = {"ACL_TABLE": {}}
+
+        # First: validate loads the config into sy and sets _currently_loaded_hash
+        config_wrapper.validate_config_db_config(config)
+        self.assertIsNotNone(config_wrapper._currently_loaded_hash,
+                             "validate_config_db_config should have set _currently_loaded_hash")
+        load_count_after_validate = mock_sy.loadData.call_count
+
+        # Second: find_ref_paths with same config should NOT call loadData again
+        path_addressing.find_ref_paths("/ACL_TABLE", config, reload_config=True)
+        load_count_after_find = mock_sy.loadData.call_count
+
+        self.assertEqual(load_count_after_validate, load_count_after_find,
+                         "find_ref_paths should skip loadData when validate already loaded same config")
+
+    def test_find_ref_paths__after_validate_different_config__loadData_called(self):
+        """
+        Cache miss in find_ref_paths: if validate loaded config_A, calling find_ref_paths
+        with config_B must still call loadData.
+        """
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        mock_sy.root = MagicMock()
+        mock_sy.root.find_path = MagicMock(return_value=MagicMock(data=MagicMock(return_value=[])))
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        path_addressing = gu_common.PathAddressing(config_wrapper)
+        config_a = {"ACL_TABLE": {"rule1": {}}}
+        config_b = {"ACL_TABLE": {"rule2": {}}}
+
+        config_wrapper.validate_config_db_config(config_a)
+        self.assertIsNotNone(config_wrapper._currently_loaded_hash,
+                             "validate_config_db_config should have set _currently_loaded_hash")
+        load_count_after_validate = mock_sy.loadData.call_count
+
+        path_addressing.find_ref_paths("/ACL_TABLE", config_b, reload_config=True)
+        load_count_after_find = mock_sy.loadData.call_count
+
+        self.assertEqual(load_count_after_find, load_count_after_validate + 1,
+                         "find_ref_paths should call loadData exactly once when config differs")
+
     def test_validate_bgp_peer_group__valid_non_intersecting_ip_ranges__returns_true(self):
         # Arrange
         config_wrapper = gu_common.ConfigWrapper()

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1396,6 +1396,54 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # Act and assert
         self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config))[0])
 
+    def test_validate_replace__calls_find_ref_paths_simulated_config_before_current_config(self):
+        """
+        _validate_replace must check added_paths/simulated_config FIRST, then deleted_paths/current_config.
+        This ordering lets find_ref_paths reuse the sy singleton already loaded with simulated_config
+        by FullConfigMoveValidator (via _currently_loaded_hash), saving one loadData call per REPLACE.
+        """
+        config_wrapper = ConfigWrapper()
+        mock_pa = MagicMock(spec=PathAddressing)
+
+        # Track which config is passed to find_ref_paths in call order
+        configs_seen = []
+
+        def track_find_ref_paths(paths, config, reload_config=True):
+            configs_seen.append(config)
+            return []  # no refs → validation passes
+        mock_pa.find_ref_paths = MagicMock(side_effect=track_find_ref_paths)
+        mock_pa.create_path = PathAddressing.create_path
+
+        validator = ps.NoDependencyMoveValidator(mock_pa, config_wrapper)
+
+        # Patch _get_paths on the validator instance (not on mock_pa — _get_paths is a method
+        # on NoDependencyMoveValidator, not on PathAddressing)
+        deleted_paths = ["/PORT/Ethernet0"]
+        added_paths = ["/PORT/Ethernet4"]
+        validator._get_paths = MagicMock(return_value=(deleted_paths, added_paths))
+
+        current_config = {"PORT": {"Ethernet0": {"lanes": "0"}}}
+        simulated_config = {"PORT": {"Ethernet4": {"lanes": "4"}}}
+        diff = ps.Diff(current_config, simulated_config)
+
+        # Create a move mock with the right attributes, wrapped in a group mock
+        # that is iterable (validate() does `for move in group:`)
+        inner_move = MagicMock()
+        inner_move.op_type = OperationType.REPLACE
+        inner_move.path = ""
+        group = MagicMock()
+        group.__iter__ = MagicMock(return_value=iter([inner_move]))
+
+        validator.validate(group, diff, simulated_config)
+
+        # Assert: simulated_config must be checked first (for added_paths),
+        # then current_config (for deleted_paths)
+        self.assertEqual(len(configs_seen), 2, "find_ref_paths should be called exactly twice")
+        self.assertIs(configs_seen[0], simulated_config,
+                      "First find_ref_paths call must use simulated_config (for added_paths)")
+        self.assertIs(configs_seen[1], current_config,
+                      "Second find_ref_paths call must use current_config (for deleted_paths)")
+
     def prepare_config(self, config, patch):
         return patch.apply(config)
 


### PR DESCRIPTION
> **PR 6 of 8** in a `202511` GCU backport stack. **Draft until the PRs ahead of it merge.**
>
> **Merge order is mandatory** - this cherry-pick assumes the earlier ones. Because the commits are sequential, this PR currently also shows the commits belonging to the PRs ahead of it. Once those merge I will rebase and it will reduce to its own single commit. Please review the last commit only for now.
>
> Stack starts at #4810. Tracking issue: #4823 - full stack, merge order and evidence.


#### Why I did it

Cherry-pick of #4476. Every move validation re-parses the entire config through libyang. On `202511` this shows up as the exact invariant `loadData calls == 2 × moves`, measured on real hardware (38 = 2×19, 20 = 2×10, 114 = 2×57). At 512 ports that is **1020** parses; upstream reported ~1027.

#### How I did it

Cherry-pick plus one manual conflict resolution — **please review this hunk specifically.**

#4476 adds md5-based caching *inside* the `if reload_config:` block introduced by #3831. On this branch that condition was widened to `if reload_config or sy.root is None:` (see PR 1). The resolution keeps the widened condition and takes #4476's caching body:

```python
if reload_config or sy.root is None:
    <#4476 md5 hash-caching body>
```

The optimisation is fully preserved — the hash check still skips redundant loads. Only the entry condition differs from master, and only because `202511` lacks #4118.

#### How to verify it

`loadData` count collapses to **2**, independent of scale (512-port case: 1020 → 2). Confirmed on hardware in all four leaf-list scenarios. Full suite green: 460 passed, 81 subtests.

#### Backport notes

- Manual conflict as described above. This is the one hunk in the stack that intentionally differs from master.

---

#### Stack-level verification

Measured on the assembled stack, in a container built from the genuine `202511` `sonic_yang_mgmt` wheel (libyang 1.0.73, SWIG `import yang as ly`):

| Check | Result |
|---|---|
| Full GCU unit suite | **460 passed, 81 subtests, 0 failed** (clean `202511`: 434 passed, 80 subtests) |
| `flake8 --diff`, pre-commit hook semantics (4.0.1, `--max-line-length=120`) | **0 issues** - this commit individually, and the stack as a whole |
| Diff coverage, this PR | **100%** |
| Diff coverage, whole stack | **93.0%** (698 lines measured, 649 covered) - pipeline gate is 80% |

**Not run: `sonic-mgmt`.** I looked into running `tests/generic_config_updater/test_apply_patch_perf.py` and it **skips on every LAG topology** - its fixture builds the port list from `PORT` minus `PORTCHANNEL_MEMBER`, so on a T1 it finds 0 usable ports and bails with `Need at least 2 admin-up ports, have 0`. Across the last 45 days of nightly runs, every `202511` execution of it landed on a `t1-*-lag` bed and skipped, so **no `202511` baseline for that test exists**. It does run cleanly on t0 / m0 / mx / dualtor. Happy to book one of those beds and run it before merge - just ask.
