### PR TITLE
[generic_config_updater]: Remove empty leaf-lists from the simulated ConfigDB target (#4731) [202511]

### DIFF
--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -113,7 +113,7 @@ class PatchApplier:
 
         # Generate target config
         self.logger.log_notice(f"{scope}: simulating the target full config after applying the patch.")
-        target_config = self.patch_wrapper.simulate_patch(patch, old_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, old_config)
 
         # Validate all JsonPatch operations on specified fields
         self.logger.log_notice(f"{scope}: validating all JsonPatch operations are permitted on the specified fields")

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -406,6 +406,36 @@ class DryRunConfigWrapper(ConfigWrapper):
             self.imitated_config_db = super().get_config_db_as_json()
 
 
+def remove_empty_leaf_lists(config):
+    """Drop leaf-list fields whose value is an empty list.
+
+    Expects ConfigDB shaped json, i.e. table -> key -> field. At that shape a
+    list valued field is always a leaf-list, so every empty list found here is
+    an empty leaf-list. Do not call this with SonicYang shaped json, where a
+    list is a yang list of entries rather than a leaf-list.
+
+    ConfigDB has no representation for an empty leaf-list. set_entry serializes
+    [] to an empty string, which is then read back as [''], so a config that asks
+    for [] can never be satisfied. The canonical way to express "this leaf-list
+    has no items" is for the field to be absent.
+
+    Normalizing the simulated target keeps the patch sorter, the change applier
+    and the final verification in agreement: the sorter emits a field-level
+    remove instead of a replace-with-empty-list that ConfigDB cannot store.
+    """
+    for entries in config.values():
+        if not isinstance(entries, dict):
+            continue
+        for fields in entries.values():
+            if not isinstance(fields, dict):
+                continue
+            empty_leaf_lists = [field for field, value in fields.items()
+                                if isinstance(value, list) and len(value) == 0]
+            for field in empty_leaf_lists:
+                del fields[field]
+    return config
+
+
 class PatchWrapper:
     def __init__(self, config_wrapper=None, scope=multi_asic.DEFAULT_NAMESPACE):
         self.scope = scope
@@ -439,12 +469,21 @@ class PatchWrapper:
     def simulate_patch(self, patch, jsonconfig):
         return patch.apply(jsonconfig)
 
+    def simulate_config_db_patch(self, patch, config_db):
+        """Simulate a patch against ConfigDB shaped json.
+
+        Use this instead of simulate_patch whenever the result is meant to be a
+        ConfigDB target, so that empty leaf-lists are normalized to absent
+        fields, which is the only way ConfigDB can express them.
+        """
+        return remove_empty_leaf_lists(self.simulate_patch(patch, config_db))
+
     def convert_config_db_patch_to_sonic_yang_patch(self, patch):
         if not(self.validate_config_db_patch_has_yang_models(patch)):
             raise ValueError(f"Given patch is not valid")
 
         current_config_db = self.config_wrapper.get_config_db_as_json()
-        target_config_db = self.simulate_patch(patch, current_config_db)
+        target_config_db = self.simulate_config_db_patch(patch, current_config_db)
 
         current_yang = self.config_wrapper.convert_config_db_to_sonic_yang(current_config_db)
         target_yang = self.config_wrapper.convert_config_db_to_sonic_yang(target_config_db)

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1354,7 +1354,12 @@ class BulkLeafListMoveGenerator:
 
             if isinstance(current_val, list) and isinstance(target_val, list):
                 # Only handle leaf-lists (lists of scalars)
+                # An empty target leaf-list is deliberately excluded: a bulk
+                # REPLACE with [] serializes to an empty string in CONFIG_DB,
+                # which is an invalid state. Those transitions are left to the
+                # granular removal generators, which remove the field instead.
                 if (current_val != target_val and
+                        len(target_val) > 0 and
                         self._is_leaf_list(current_val) and
                         self._is_leaf_list(target_val)):
                     yield JsonMoveGroup(
@@ -2406,7 +2411,7 @@ class StrictPatchSorter:
         if not(self.patch_wrapper.validate_config_db_patch_has_yang_models(patch)):
             raise ValueError(f"Given patch is not valid because it has changes to tables without YANG models")
 
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         # Validate target config
         self.logger.log_info("Validating target config according to YANG models.")
@@ -2596,7 +2601,7 @@ class NonStrictPatchSorter:
 
     def sort(self, patch, algorithm=Algorithm.DFS, trace_io: Optional[IO] = None):
         current_config = self.config_wrapper.get_config_db_as_json()
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         # Splitting current/target config based on YANG covered vs non-YANG covered configs
         self.logger.log_info("Splitting current/target config based on YANG covered vs non-YANG covered configs.")
@@ -2658,7 +2663,7 @@ class PatchSorter:
 
     def sort(self, patch, algorithm=Algorithm.DFS, preloaded_current_config=None, trace_io: Optional[IO] = None):
         current_config = preloaded_current_config if preloaded_current_config else self.config_wrapper.get_config_db_as_json()
-        target_config = self.patch_wrapper.simulate_patch(patch, current_config)
+        target_config = self.patch_wrapper.simulate_config_db_patch(patch, current_config)
 
         diff = Diff(copy.deepcopy(current_config), target_config)
 

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -40,7 +40,7 @@ class TestPatchApplier(unittest.TestCase):
 
         # Assert
         patch_applier.config_wrapper.get_config_db_as_json.assert_has_calls([call(), call()])
-        patch_applier.patch_wrapper.simulate_patch.assert_has_calls(
+        patch_applier.patch_wrapper.simulate_config_db_patch.assert_has_calls(
             [call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, Files.CONFIG_DB_AS_JSON)])
         patch_applier.patchsorter.sort.assert_has_calls([call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, trace_io=None)])
         patch_applier.changeapplier.apply.assert_called()
@@ -59,7 +59,7 @@ class TestPatchApplier(unittest.TestCase):
             create_side_effect_dict({(str(Files.CONFIG_DB_AFTER_MULTI_PATCH),): empty_tables})
 
         patch_wrapper = Mock()
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(Files.MULTI_OPERATION_CONFIG_DB_PATCH), str(Files.CONFIG_DB_AS_JSON)):
                     Files.CONFIG_DB_AFTER_MULTI_PATCH})

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -658,6 +658,64 @@ class TestPatchWrapper(unittest.TestCase):
         # Assert
         self.assertDictEqual(expected, actual)
 
+    def test_simulate_config_db_patch__empties_leaf_list__field_is_dropped(self):
+        # Arrange
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc01:20::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}])
+        # ConfigDB cannot store an empty leaf-list, the field has to be absent
+        expected = {"BGP_ALLOWED_PREFIXES": {"DEPLOYMENT_ID|0": {"prefixes_v6": ["fc01:20::/64"]}}}
+
+        # Act
+        actual = patch_wrapper.simulate_config_db_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
+    def test_simulate_config_db_patch__leaf_list_still_has_items__field_is_kept(self):
+        # Arrange
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "prefixes_v4": ["10.20.0.0/16", "10.30.0.0/16"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}])
+        expected = {"BGP_ALLOWED_PREFIXES": {"DEPLOYMENT_ID|0": {"prefixes_v4": ["10.30.0.0/16"]}}}
+
+        # Act
+        actual = patch_wrapper.simulate_config_db_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
+    def test_simulate_patch__sonic_yang_config__empty_yang_list_is_kept(self):
+        # Arrange
+        # simulate_patch must stay shape agnostic. In SonicYang json a list holds yang list
+        # entries, not leaf-list items, so it must not be treated as an empty leaf-list.
+        patch_wrapper = gu_common.PatchWrapper()
+        config = {"sonic-vlan:sonic-vlan": {"VLAN": {"VLAN_LIST": [{"name": "Vlan1000"}]}}}
+        patch = jsonpatch.JsonPatch(
+            [{"op": "remove", "path": "/sonic-vlan:sonic-vlan/VLAN/VLAN_LIST/0"}])
+        expected = {"sonic-vlan:sonic-vlan": {"VLAN": {"VLAN_LIST": []}}}
+
+        # Act
+        actual = patch_wrapper.simulate_patch(patch, config)
+
+        # Assert
+        self.assertDictEqual(expected, actual)
+
     def test_generate_patch__diff__non_empty_patch(self):
         # Arrange
         patch_wrapper = gu_common.PatchWrapper()

--- a/tests/generic_config_updater/multiasic_generic_updater_test.py
+++ b/tests/generic_config_updater/multiasic_generic_updater_test.py
@@ -16,7 +16,7 @@ class TestMultiAsicPatchApplier(unittest.TestCase):
 
     @patch('generic_config_updater.gu_common.ConfigWrapper.get_empty_tables', return_value=[])
     @patch('generic_config_updater.gu_common.ConfigWrapper.get_config_db_as_json')
-    @patch('generic_config_updater.gu_common.PatchWrapper.simulate_patch')
+    @patch('generic_config_updater.gu_common.PatchWrapper.simulate_config_db_patch')
     @patch('generic_config_updater.generic_updater.ChangeApplier')
     def test_apply_patch_specific_namespace(self, mock_ChangeApplier, mock_simulate_patch, mock_get_config, mock_get_empty_tables):
         scope = "asic0"

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2493,12 +2493,12 @@ class TestBulkLeafListMoveGenerator(unittest.TestCase):
             target={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR", "ports": ["Ethernet0"]}}},
             ex_ops=[])
 
-    def test_generate__leaf_list_all_items_removed__single_replace_move(self):
-        """Removing all items from a leaf-list should produce one REPLACE with empty list."""
+    def test_generate__leaf_list_all_items_removed__no_bulk_replace_move(self):
+        """Removing all items from a leaf-list should not bulk-replace with an empty list."""
         self.verify(
             current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
             target={"ACL_TABLE": {"EVERFLOW": {"ports": [], "type": "MIRROR"}}},
-            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports", "value": []}])
+            ex_ops=[])
 
     def test_generate__multiple_tables_with_leaf_lists__multiple_moves(self):
         """Multiple differing leaf-lists should each get a REPLACE move."""
@@ -3729,6 +3729,42 @@ class TestPatchSorter(unittest.TestCase):
             if notfound_substrings:
                 self.fail(f"Did not find the substrings {notfound_substrings} in the error: '{error}'")
 
+    def test_patch_sorter__remove_last_bgp_allowed_prefix__removes_field_instead_of_emptying_it(self):
+        current_config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "deployment": "DEPLOYMENT_ID",
+                    "id": 0,
+                    "prefixes_v4": ["10.20.0.0/16"],
+                    "prefixes_v6": ["fc00:f0::/64"],
+                }
+            }
+        }
+        patch = jsonpatch.JsonPatch([
+            {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4/0"}
+        ])
+        sorter = self.create_patch_sorter(current_config)
+
+        actual_changes = sorter.sort(patch)
+        # Removing the only item has to drop the whole field. ConfigDB cannot store an
+        # empty leaf-list, it would be written as "" and read back as [""].
+        expected_changes = [
+            JsonChange(jsonpatch.JsonPatch([
+                {"op": "remove", "path": "/BGP_ALLOWED_PREFIXES/DEPLOYMENT_ID|0/prefixes_v4"}
+            ]))
+        ]
+
+        self.assertEqual(expected_changes, actual_changes)
+
+        target_config = PatchWrapper().simulate_config_db_patch(patch, current_config)
+        self.assertNotIn("prefixes_v4", target_config["BGP_ALLOWED_PREFIXES"]["DEPLOYMENT_ID|0"])
+        simulated_config = current_config
+        for change in actual_changes:
+            simulated_config = change.apply(simulated_config)
+            is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
+            self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
+        self.assertEqual(target_config, simulated_config)
+
     def test_sort__does_not_remove_tables_without_yang_unintentionally_if_generated_change_replaces_whole_config(self):
         # Arrange
         current_config = Files.CONFIG_DB_AS_JSON # has a table without yang named 'TABLE_WITHOUT_YANG'
@@ -4002,7 +4038,7 @@ class TestNonStrictPatchSorter(unittest.TestCase):
         config_wrapper.get_config_db_as_json.side_effect = \
             [any_current_config]
 
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(patch), str(any_current_config)):
                     any_target_config})
@@ -4095,7 +4131,7 @@ class TestStrictPatchSorter(unittest.TestCase):
         config_wrapper.get_config_db_as_json.side_effect = \
             [any_current_config, any_target_config]
 
-        patch_wrapper.simulate_patch.side_effect = \
+        patch_wrapper.simulate_config_db_patch.side_effect = \
             create_side_effect_dict(
                 {(str(patch), str(any_current_config)):
                     any_target_config})


### PR DESCRIPTION
> **PR 8 of 8** in a `202511` GCU backport stack. **Draft until the PRs ahead of it merge.**
>
> **Merge order is mandatory** - this cherry-pick assumes the earlier ones. Because the commits are sequential, this PR currently also shows the commits belonging to the PRs ahead of it. Once those merge I will rebase and it will reduce to its own single commit. Please review the last commit only for now.
>
> Stack starts at #4810. Tracking issue: #4823 - full stack, merge order and evidence.


#### Why I did it

Cherry-pick of #4731. **The upstream rationale does not apply to `202511`, but the fix is still needed — for a different reason.**

Upstream describes a CONFIG_DB corruption that only reproduces on libyang3 (`import libyang as ly`). `202511` uses libyang 1.0.73 via SWIG (`import yang as ly`) — verified against the installed `202511` wheel (`sonic_yang_ext.py:5`). **So the corruption is not reachable here.**

However, emptying a leaf-list on `202511` fails hard regardless:

```
GenericConfigUpdaterError: There is no possible sorting
```

#### How I did it

Clean cherry-pick.

#### How to verify it

Isolated revert test — remove only this commit from the assembled stack:

```
clean 202511      : EXCEPTION "There is no possible sorting"
full stack        : OK — 2 moves
stack minus #4731 : EXCEPTION "There is no possible sorting"
```

So this commit is precisely what makes the operation work. On hardware, emptying a leaf-list went from **TIMEOUT >300 s** on stock to **14.09 s / 24 moves** patched.

#### Backport notes

Clean. Worth flagging to the branch manager that this is being taken for a different reason than its upstream title suggests.

---

#### Stack-level verification

Measured on the assembled stack, in a container built from the genuine `202511` `sonic_yang_mgmt` wheel (libyang 1.0.73, SWIG `import yang as ly`):

| Check | Result |
|---|---|
| Full GCU unit suite | **460 passed, 81 subtests, 0 failed** (clean `202511`: 434 passed, 80 subtests) |
| `flake8 --diff`, pre-commit hook semantics (4.0.1, `--max-line-length=120`) | **0 issues** - this commit individually, and the stack as a whole |
| Diff coverage, this PR | **94.4%** |
| Diff coverage, whole stack | **93.0%** (698 lines measured, 649 covered) - pipeline gate is 80% |

**Not run: `sonic-mgmt`.** I looked into running `tests/generic_config_updater/test_apply_patch_perf.py` and it **skips on every LAG topology** - its fixture builds the port list from `PORT` minus `PORTCHANNEL_MEMBER`, so on a T1 it finds 0 usable ports and bails with `Need at least 2 admin-up ports, have 0`. Across the last 45 days of nightly runs, every `202511` execution of it landed on a `t1-*-lag` bed and skipped, so **no `202511` baseline for that test exists**. It does run cleanly on t0 / m0 / mx / dualtor. Happy to book one of those beds and run it before merge - just ask.
