### PR TITLE
[scripts/wredstat]: Show N/A in --summary when all entries are N/A

### DIFF
--- a/scripts/wredstat
+++ b/scripts/wredstat
@@ -305,6 +305,12 @@ class Wredstat(object):
             return 0
 
 
+    def _is_na(self, val):
+        if val is None:
+            return True
+        s = str(val).strip()
+        return s == "" or s.upper() == "N/A"
+
     def aggregate_from_json_output(self, json_output):
         """
         json_output: { port: { ... queue_key: {queueindex, ... counters ...}, ... }, ... }
@@ -313,6 +319,14 @@ class Wredstat(object):
         { queueindex: {queueindex, queuetype, wredDrppacket, wredDrpbytes, ecnpacket, ecnbytes}, ... }
         """
         agg = {}
+        # Track fields that had at least one applicable (non-N/A) value.
+        field_map = {
+            "wredDrppacket": "wreddroppacket",
+            "wredDrpbytes": "wreddropbytes",
+            "ecnpacket": "ecnmarkedpacket",
+            "ecnbytes": "ecnmarkedbytes",
+        }
+        applicable = {}
 
         for port, port_blob in (json_output or {}).items():
             if not isinstance(port_blob, dict):
@@ -340,11 +354,19 @@ class Wredstat(object):
                         "ecnpacket": 0,
                         "ecnbytes": 0,
                     })
+                    applicable.setdefault(key, {field: False for field in field_map})
 
-                    agg[key]["wredDrppacket"] += self._to_int(data.get("wreddroppacket"))
-                    agg[key]["wredDrpbytes"]  += self._to_int(data.get("wreddropbytes"))
-                    agg[key]["ecnpacket"]     += self._to_int(data.get("ecnmarkedpacket"))
-                    agg[key]["ecnbytes"]      += self._to_int(data.get("ecnmarkedbytes"))
+                    for field, src in field_map.items():
+                        val = data.get(src)
+                        agg[key][field] += self._to_int(val)
+                        if not self._is_na(val):
+                            applicable[key][field] = True
+
+        # If every individual entry for a field was N/A, display N/A instead of 0.
+        for key, fields in applicable.items():
+            for field, has_value in fields.items():
+                if not has_value:
+                    agg[key][field] = STATUS_NA
 
         return agg
 

--- a/tests/wred_queue_counter_test.py
+++ b/tests/wred_queue_counter_test.py
@@ -1384,80 +1384,80 @@ show_wred_queue_counters_summary = """\
  MC17             139              154               154                173
  MC18             170              143                89                190
  MC19             134               50               114                141
-ALL20               0                0                 0                  0
-ALL21               0                0                 0                  0
-ALL22               0                0                 0                  0
-ALL23               0                0                 0                  0
-ALL24               0                0                 0                  0
-ALL25               0                0                 0                  0
-ALL26               0                0                 0                  0
-ALL27               0                0                 0                  0
-ALL28               0                0                 0                  0
-ALL29               0                0                 0                  0
+ALL20             N/A              N/A               N/A                N/A
+ALL21             N/A              N/A               N/A                N/A
+ALL22             N/A              N/A               N/A                N/A
+ALL23             N/A              N/A               N/A                N/A
+ALL24             N/A              N/A               N/A                N/A
+ALL25             N/A              N/A               N/A                N/A
+ALL26             N/A              N/A               N/A                N/A
+ALL27             N/A              N/A               N/A                N/A
+ALL28             N/A              N/A               N/A                N/A
+ALL29             N/A              N/A               N/A                N/A
 
 """
 
 show_queue_counters_summary_json = """\
 {
   "ALL20": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL21": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL22": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL23": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL24": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL25": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL26": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL27": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL28": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "ALL29": {
-    "ecnbytes": 0,
-    "ecnpacket": 0,
-    "wredDrpbytes": 0,
-    "wredDrppacket": 0
+    "ecnbytes": "N/A",
+    "ecnpacket": "N/A",
+    "wredDrpbytes": "N/A",
+    "wredDrppacket": "N/A"
   },
   "MC10": {
     "ecnbytes": 164,


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
With --summary, if the field in every entry is N/A, summary also shows N/A instead of 0.

#### How I did it
With --summary, the aggregation now tracks per field whether any individual entry had an applicable (non-N/A) value. If every contributing entry for a field (e.g. EcnMarked/bytes) is N/A, the summary displays N/A instead of 0; otherwise the numeric sum is shown as before.

#### How to verify it
Verified on testbed.

#### Previous command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show queue wredcounter --summary -n asic0
  TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
-----  --------------  ---------------  ----------------  -----------------
  UC0               0                0                 0                  0
  UC1               0                0                 0                  0
  UC2               0                0                 0                  0
  UC3               0                0                 0                  0
  UC4               0                0                 0                  0
  UC5               0                0                 0                  0
  UC6               0                0                 0                  0
  UC7               0                0                 0                  0
  MC8               0                0                 0                  0
  MC9               0                0                 0                  0
 MC10               0                0                 0                  0
 MC11               0                0                 0                  0
 MC12               0                0                 0                  0
 MC13               0                0                 0                  0
 MC14               0                0                 0                  0
 MC15               0                0                 0                  0
```

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show queue wredcounter --summary -n asic0
  TxQ    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
-----  --------------  ---------------  ----------------  -----------------
  UC0               0                0                 0                N/A
  UC1               0                0                 0                N/A
  UC2               0                0                 0                N/A
  UC3               0                0                 0                N/A
  UC4               0                0                 0                N/A
  UC5               0                0                 0                N/A
  UC6               0                0                 0                N/A
  UC7               0                0                 0                N/A
  MC8               0                0                 0                  0
  MC9               0                0                 0                  0
 MC10               0                0                 0                  0
 MC11               0                0                 0                  0
 MC12               0                0                 0                  0
 MC13               0                0                 0                  0
 MC14               0                0                 0                  0
 MC15               0                0                 0                  0
```
