### PR TITLE
Add show interfaces l1-summary command

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -7639,6 +7639,36 @@ The show interface errors command provides detailed statistics and error counter
   no_rx_reachability                 0               Never
   ```
 
+**show interfaces l1-summary**
+
+The show interfaces l1-summary command aggregates the layer-1 health of each interface into a single view: operational mode (speed/lane count), FEC, pre-FEC BER, oper/admin status, local/remote fault status, transceiver vendor and model, media interface, and link flap history. It combines information that would otherwise require running show interfaces status, show interfaces transceiver, show interfaces errors and show interfaces flap separately.
+
+- Usage:
+  ```
+  show interfaces l1-summary [OPTIONS] [<interface_name>]
+
+  Options:
+  -d, --display [all|frontend]   Show internal interfaces  [default: frontend]
+  -n, --namespace <namespace>    Namespace name or all
+  --verbose                      Enable verbose output
+  -?, -h, --help                 Show this message and exit.
+  ```
+- Example:
+  ```
+  admin@sonic:~$ show interfaces l1-summary
+    Interface    Alias     Mode    FEC    Pre-FEC BER    Oper    Admin    Fault                    Transceiver    Media Interface    Flaps          Last Up        Last Down
+  -----------  -------  -------  -----  -------------  ------  -------  -------  -----------------------------  -----------------  -------  ---------------  ---------------
+    Ethernet0    Port1  1600G/8     rs       3.94e-08      up       up     none           TERAHOP T-OH8ENH-N00       200GBASE-DR1        1  Jan 06 22:48:57              N/A
+    Ethernet8    Port2  1600G/8     rs       1.11e-07      up       up     none           TERAHOP T-OH8ENH-N00       200GBASE-DR1        1  Jan 06 22:48:57              N/A
+   Ethernet32    Port5  1600G/8     rs       6.06e-10    down       up    local    FINISAR CORP. FTCF2519T6PCA       800GBASE-DR4        3  Jan 06 22:49:03  Jan 07 04:12:44
+  ```
+- Example (to display a specific interface):
+  ```
+  admin@sonic:~$ show interfaces l1-summary Ethernet0
+    Interface    Alias     Mode    FEC    Pre-FEC BER    Oper    Admin    Fault             Transceiver    Media Interface    Flaps          Last Up    Last Down
+  -----------  -------  -------  -----  -------------  ------  -------  -------  ----------------------  -----------------  -------  ---------------  -----------
+    Ethernet0    Port1  1600G/8     rs       3.94e-08      up       up     none    TERAHOP T-OH8ENH-N00       200GBASE-DR1        1  Jan 06 22:48:57          N/A
+  ```
 
 **show interfaces mpls**
 

--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -27,7 +27,7 @@ from tabulate import tabulate
 from utilities_common import constants
 from utilities_common import multi_asic as multi_asic_util
 from utilities_common.intf_filter import parse_interface_in_filter
-from utilities_common.netstat import table_as_json
+from utilities_common.netstat import table_as_json, format_fec_ber
 from utilities_common.platform_sfputil_helper import is_rj45_port, RJ45_PORT_TYPE
 from sonic_py_common.interface import get_intf_longname
 from sonic_py_common import multi_asic
@@ -38,6 +38,7 @@ from sonic_py_common import multi_asic
 PORT_STATUS_TABLE_PREFIX = "PORT_TABLE:"
 PORT_STATE_TABLE_PREFIX = "PORT_TABLE|"
 PORT_TRANSCEIVER_TABLE_PREFIX = "TRANSCEIVER_INFO|"
+PORT_OPERR_TABLE_PREFIX = "PORT_OPERR_TABLE|"
 PORT_LANES_STATUS = "lanes"
 PORT_ALIAS = "alias"
 PORT_OPER_STATUS = "oper_status"
@@ -58,6 +59,25 @@ OPTICS_TYPE_RJ45 = RJ45_PORT_TYPE
 TYPE_DPC = 'DPU-NPU Data Port'
 PORT_LINK_TRAINING = 'link_training'
 PORT_LINK_TRAINING_STATUS = 'link_training_status'
+PORT_APPLICATION_ADVERTISEMENT = "application_advertisement"
+PORT_HOST_ELECTRICAL_INTERFACE_ID = "host_electrical_interface_id"
+PORT_MODULE_MEDIA_INTERFACE_ID = "module_media_interface_id"
+PORT_MEDIA_LANE_COUNT = "media_lane_count"
+PORT_HOST_LANE_COUNT = "host_lane_count"
+PORT_MODEL = "model"
+PORT_MANUFACTURER = "manufacturer"
+PORT_LAST_UP_TIME = "last_up_time"
+PORT_LAST_DOWN_TIME = "last_down_time"
+PORT_FLAP_COUNT = "flap_count"
+PORT_OPER_ERROR_STATUS = "oper_error_status"
+
+# Pre-FEC BER is computed by the rate daemon and published to COUNTERS_DB
+# under RATES:<oid>; the port-name-to-oid mapping lives in
+# COUNTERS_PORT_NAME_MAP. This is the same source 'show interface counters'
+# (portstat) reads from, so the l1-summary value stays consistent with it.
+COUNTERS_PORT_NAME_MAP = "COUNTERS_PORT_NAME_MAP"
+RATES_TABLE_PREFIX = "RATES:"
+PORT_FEC_PRE_BER = "FEC_PRE_BER"
 
 VLAN_SUB_INTERFACE_SEPARATOR = "."
 VLAN_SUB_INTERFACE_TYPE = "802.1q-encapsulation"
@@ -231,6 +251,23 @@ def port_oper_speed_get_raw(db, intf_name):
     if speed is None or speed == "N/A" or oper_status != "up":
         speed = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_SPEED)
     return speed
+
+
+def port_pre_fec_ber_get(db, intf_name):
+    """
+    Get the port's current pre-FEC bit error rate, the same value shown by
+    'show interface counters' (see portstat.py). The rate is read from
+    COUNTERS_DB at RATES:<oid>, where <oid> is resolved through
+    COUNTERS_PORT_NAME_MAP, and rendered with the shared format_fec_ber()
+    formatter so the two views agree.
+    """
+    oid = db.get(db.COUNTERS_DB, COUNTERS_PORT_NAME_MAP, intf_name)
+    if oid is None:
+        return "N/A"
+    rate = db.get(db.COUNTERS_DB, RATES_TABLE_PREFIX + oid, PORT_FEC_PRE_BER)
+    if rate is None:
+        return "N/A"
+    return format_fec_ber(rate)
 
 def port_optics_get(db, intf_name, type):
     """
@@ -454,6 +491,217 @@ def appl_db_sub_intf_status_get(appl_db, config_db, front_panel_ports_list, port
                 return "N/A"
 
     return "N/A"
+
+
+def get_port_application_info(db, intf_name, form_factor):
+    """
+    Get host_electrical_id and module_media_id for CMIS transceivers without placeholder text
+    """
+    full_table_id = f"{PORT_TRANSCEIVER_TABLE_PREFIX}{intf_name}"
+    xcvr_info = db.get_all(db.STATE_DB, full_table_id)
+
+    if not xcvr_info or xcvr_info.get("cmis_rev") is None:
+        return ("N/A", "N/A")
+
+    # Find the first valid appsel from active_apsel_hostlane{N} entries.
+    appsel = None
+    for key, value in xcvr_info.items():
+        if key.startswith("active_apsel_hostlane") and value != "N/A":
+            appsel = value
+            break
+
+    if appsel is None:
+        return ("N/A", "N/A")
+
+    app_addv_str = xcvr_info.get(PORT_APPLICATION_ADVERTISEMENT)
+    if not app_addv_str:
+        return ("N/A", "N/A")
+
+    try:
+        appsel = int(appsel)
+        app_addv = eval(app_addv_str)
+        host_electrical_id = app_addv[appsel][PORT_HOST_ELECTRICAL_INTERFACE_ID]
+        module_media_id = app_addv[appsel][PORT_MODULE_MEDIA_INTERFACE_ID]
+    except (ValueError, KeyError, SyntaxError, TypeError, NameError):
+        return ("N/A", "N/A")
+
+    module_media_id = clean_media_interface_text(module_media_id)
+
+    return (host_electrical_id, module_media_id)
+
+
+def clean_media_interface_text(media_id):
+    """
+    Clean up media interface text by removing placeholder and clause reference suffixes.
+    E.g., "400GBASE-DR4 (Cl 124)" -> "400GBASE-DR4"
+          "800GBASE-DR8 (placeholder)" -> "800GBASE-DR8"
+    """
+    # Remove (placeholder), (Cl NNN), (Annex NNNG), etc.
+    cleaned = re.sub(r'\s*\([^)]*\)', '', media_id)
+    return cleaned.strip()
+
+
+def state_db_transceiver_info_get(db, port_name, status_type):
+    """
+    Get the transceiver info
+    """
+    full_table_id = f"{PORT_TRANSCEIVER_TABLE_PREFIX}{port_name}"
+    status = db.get(db.STATE_DB, full_table_id, status_type)
+    if status is None:
+        return "N/A"
+    return status
+
+
+def state_db_port_operr_status_get(db, port_name, status_type):
+    """
+    Get the port_operr_status
+    """
+    full_table_id = f"{PORT_OPERR_TABLE_PREFIX}{port_name}"
+    status = db.get(db.STATE_DB, full_table_id, status_type)
+    if status is None:
+        return "0"
+    return status
+
+
+def is_bit_set(oper_error_status, bit_position):
+    """
+    Check if bit is set at specified position
+    """
+    mask = 1 << bit_position
+    return (oper_error_status & mask) != 0
+
+
+def get_fault_status(local_fault, remote_fault):
+    """
+    Convert local and remote fault booleans to a display string.
+    """
+    if local_fault and remote_fault:
+        return "local+remote"
+    elif local_fault:
+        return "local"
+    elif remote_fault:
+        return "remote"
+    return "none"
+
+
+def get_transceiver_display(db, intf_name):
+    """
+    Get combined vendor and model string for transceiver display.
+    Returns "N/A" if either vendor or model is not available.
+    """
+    vendor = state_db_transceiver_info_get(db, intf_name, PORT_MANUFACTURER)
+    model = state_db_transceiver_info_get(db, intf_name, PORT_MODEL)
+    if vendor == "N/A" or model == "N/A":
+        return "N/A"
+    return f"{vendor} {model}".strip()
+
+
+def format_link_change_time(timestamp):
+    """
+    Format a link change timestamp for display.
+    Input format: "Wed Oct 10 02:19:46 2025" (ctime format)
+    Output format: "Oct 10 02:19:46" (month day time, without weekday and year)
+
+    Returns "N/A" if timestamp is "N/A" or cannot be parsed.
+    """
+    if timestamp == "N/A" or not timestamp:
+        return "N/A"
+    # Split the timestamp and extract month, day, and time (skip weekday at [0] and year at [-1])
+    parts = timestamp.split()
+    if len(parts) >= 4:
+        return " ".join(parts[1:-1])
+    return timestamp
+
+
+# ========================== interface-l1-summary logic ==========================
+
+header_l1_summary = ['Interface', 'Alias', 'Mode', 'FEC', 'Pre-FEC BER', 'Oper', 'Admin', 'Fault',
+                     'Transceiver', 'Media Interface', 'Flaps', 'Last Up', 'Last Down']
+
+
+class IntfL1Summary(object):
+
+    def __init__(self, intf_name, namespace_option, display_option):
+        """
+        Class constructor method
+        :param self:
+        :param intf_name: string of interface
+        :return:
+        """
+        self.db = None
+        self.config_db = None
+        self.sub_intf_only = False
+        self.intf_name = intf_name
+        self.sub_intf_name = intf_name
+        self.table = []
+        self.multi_asic = multi_asic_util.MultiAsic(
+            display_option, namespace_option)
+
+    def display_intf_l1_summary(self):
+        self.get_intf_l1_summary()
+        sorted_table = natsorted(self.table)
+        print(tabulate(sorted_table,
+                       header_l1_summary if not self.sub_intf_only else header_stat_sub_intf,
+                       tablefmt="simple",
+                       stralign='right'))
+
+    def generate_intf_l1_summary(self):
+        """
+            Generate interface-l1-summary output
+        """
+
+        i = {}
+        table = []
+        key = []
+
+        intf_fs = parse_interface_in_filter(self.intf_name)
+        #
+        # Iterate through all the keys and append port's associated state to
+        # the result table.
+        #
+        for i in self.appl_db_keys:
+            key = re.split(':', i, maxsplit=1)[-1].strip()
+            if key in self.front_panel_ports_list:
+                if self.multi_asic.skip_display(constants.PORT_OBJ, key):
+                    continue
+
+                # Entries that need additional processing before printing
+                form_factor = port_optics_get(self.db, key, PORT_OPTICS_TYPE).split()[0]
+                lanes_str = appl_db_port_status_get(self.db, key, PORT_LANES_STATUS)
+                num_lanes = len(lanes_str.split(','))
+                host_electrical_id, module_media_id = get_port_application_info(self.db, key, form_factor)
+                oper_error_status = int(state_db_port_operr_status_get(self.db, key, PORT_OPER_ERROR_STATUS))
+                local_fault = is_bit_set(oper_error_status, 0)
+                remote_fault = is_bit_set(oper_error_status, 1)
+                last_up_time = appl_db_port_status_get(self.db, key, PORT_LAST_UP_TIME)
+                last_down_time = appl_db_port_status_get(self.db, key, PORT_LAST_DOWN_TIME)
+
+                if self.intf_name is None or key in intf_fs:
+                    fault_status = get_fault_status(local_fault, remote_fault)
+                    transceiver = get_transceiver_display(self.db, key)
+
+                    table.append((
+                        key,
+                        appl_db_port_status_get(self.db, key, PORT_ALIAS),
+                        f"{port_oper_speed_get(self.db, key)}/{num_lanes}",
+                        appl_db_port_status_get(self.db, key, PORT_FEC),
+                        port_pre_fec_ber_get(self.db, key),
+                        appl_db_port_status_get(self.db, key, PORT_OPER_STATUS),
+                        appl_db_port_status_get(self.db, key, PORT_ADMIN_STATUS),
+                        fault_status,
+                        transceiver,
+                        module_media_id,
+                        appl_db_port_status_get(self.db, key, PORT_FLAP_COUNT),
+                        format_link_change_time(last_up_time),
+                        format_link_change_time(last_down_time)))
+        return table
+
+    @multi_asic_util.run_on_multi_asic
+    def get_intf_l1_summary(self):
+        self.front_panel_ports_list = get_frontpanel_port_list(self.config_db)
+        self.appl_db_keys = appl_db_keys_get(self.db, self.front_panel_ports_list, None)
+        if self.appl_db_keys:
+            self.table += self.generate_intf_l1_summary()
 
 # ========================== interface-status logic ==========================
 
@@ -935,6 +1183,9 @@ def main():
     if args.command == "status":
         interface_stat = IntfStatus(args.interface, args.namespace, args.display, args.json)
         interface_stat.display_intf_status()
+    elif args.command == "l1_summary":
+        interface_stat = IntfL1Summary(args.interface, args.namespace, args.display)
+        interface_stat.display_intf_l1_summary()
     elif args.command == "description":
         interface_desc = IntfDescription(args.interface, args.namespace, args.display, args.json)
         interface_desc.display_intf_description()

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -142,6 +142,31 @@ def naming_mode(verbose):
     click.echo(clicommon.get_interface_naming_mode())
 
 
+@interfaces.command('l1-summary')
+@click.argument('interfacename', required=False)
+@multi_asic_util.multi_asic_click_options
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def l1_summary(interfacename, namespace, display, verbose):
+    """Show Interface l1 summary"""
+
+    ctx = click.get_current_context()
+
+    cmd = ['intfutil', '-c', 'l1_summary']
+
+    if interfacename is not None:
+        interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
+
+        cmd += ['-i', str(interfacename)]
+
+    else:
+        cmd += ['-d', str(display)]
+
+    if namespace is not None:
+        cmd += ['-n', str(namespace)]
+
+    clicommon.run_command(cmd, display_cmd=verbose)
+
+
 @interfaces.command()
 @click.argument('interfacename', required=False)
 @multi_asic_util.multi_asic_click_options

--- a/tests/mock_tables/asic0/counters_db.json
+++ b/tests/mock_tables/asic0/counters_db.json
@@ -2071,13 +2071,15 @@
             "RX_BPS": "0",
             "RX_PPS": "0",
             "TX_BPS": "0",
-            "TX_PPS": "0"
+            "TX_PPS": "0",
+            "FEC_PRE_BER": "6.05e-10"
     },
     "RATES:oid:0x1000000000004": {
             "RX_BPS": "0",
             "RX_PPS": "0",
             "TX_BPS": "0",
-            "TX_PPS": "0"
+            "TX_PPS": "0",
+            "FEC_PRE_BER": "0"
     },
     "RATES:oid:0x1000000000006": {
             "RX_BPS": "0",

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -1,4 +1,22 @@
 {
+    "PORT_OPERR_TABLE|Ethernet0": {
+        "oper_error_status": "3"
+    },
+    "PORT_OPERR_TABLE|Ethernet4": {
+        "oper_error_status": "1"
+    },
+    "PORT_OPERR_TABLE|Ethernet-BP0": {
+        "oper_error_status": "0"
+    },
+    "PORT_OPERR_TABLE|Ethernet-BP4": {
+        "oper_error_status": "0"
+    },
+    "PORT_OPERR_TABLE|Ethernet-BP256": {
+        "oper_error_status": "0"
+    },
+    "PORT_OPERR_TABLE|Ethernet-BP260": {
+        "oper_error_status": "0"
+    },
     "TRANSCEIVER_INFO|Ethernet0": {
         "type": "QSFP28 or later",
         "vendor_rev": "AC",

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -1,4 +1,7 @@
 {
+    "PORT_OPERR_TABLE|Ethernet64": {
+        "oper_error_status": "2"
+    },
     "TRANSCEIVER_INFO|Ethernet64": {
         "type" : "QSFP-DD Double Density 8X Pluggable Transceiver",
         "hardware_rev" : "X.X",

--- a/tests/multi_asic_intfutil_test.py
+++ b/tests/multi_asic_intfutil_test.py
@@ -99,6 +99,37 @@ Ethernet-BP4      up       up  Ethernet-BP4          ASIC1:Eth1-ASIC1
 
 intf_invalid_asic_error = """ValueError: Unknown Namespace asic99"""
 
+intf_l1_summary = (
+    "     Interface           Alias    Mode    FEC    Pre-FEC BER    Oper    Admin         Fault            "
+    "Transceiver         Media Interface    Flaps          Last Up        Last Down\n"
+    "--------------  --------------  ------  -----  -------------  ------  -------  ------------  "
+    "---------------------  ----------------------  -------  ---------------  ---------------\n"
+    "     Ethernet0     Ethernet1/1   40G/4    N/A       6.05e-10      up       up  local+remote  "
+    "Mellanox MFA1A00-C003                     N/A      N/A              N/A              N/A\n"
+    "     Ethernet4     Ethernet1/2   40G/4    N/A       0.00e+00      up       up         local          "
+    "          N/A                     N/A      N/A              N/A              N/A\n"
+    "    Ethernet64    Ethernet1/17   40G/4    N/A            N/A      up       up        remote         "
+    "      XXXX XXX  400ZR, DWDM, amplified        2  Feb 12 23:25:31  Feb 12 23:03:40\n"
+    "  Ethernet-BP0    Ethernet-BP0   40G/4    N/A            N/A      up       up          none          "
+    "          N/A                     N/A      N/A              N/A              N/A\n"
+    "  Ethernet-BP4    Ethernet-BP4   40G/4    N/A            N/A      up       up          none          "
+    "          N/A                     N/A      N/A              N/A              N/A\n"
+    "Ethernet-BP256  Ethernet-BP256   40G/4    N/A            N/A      up       up          none          "
+    "          N/A                     N/A      N/A              N/A              N/A\n"
+    "Ethernet-BP260  Ethernet-BP260   40G/4    N/A            N/A      up       up          none          "
+    "          N/A                     N/A      N/A              N/A              N/A\n"
+)
+
+intf_l1_summary_asic1_ethernet64 = (
+    "  Interface         Alias    Mode    FEC    Pre-FEC BER    Oper    Admin    Fault    Transceiver   "
+    "      Media Interface    Flaps          Last Up        Last Down\n"
+    "-----------  ------------  ------  -----  -------------  ------  -------  -------  -------------  "
+    "----------------------  -------  ---------------  ---------------\n"
+    " Ethernet64  Ethernet1/17   40G/4    N/A            N/A      up       up   remote       XXXX XXX  "
+    "400ZR, DWDM, amplified        2  Feb 12 23:25:31  Feb 12 23:03:40\n"
+)
+
+
 
 @pytest.mark.usefixtures("setup_multi_asic_env", "setup_env_paths")
 class TestInterfacesMultiAsic(object):
@@ -195,6 +226,21 @@ class TestInterfacesMultiAsic(object):
         print("result = {}".format(result))
         assert return_code == 1
         assert result == intf_invalid_asic_error
+
+    def test_multi_asic_interface_l1_summary(self):
+        return_code, result = get_result_and_return_code(['intfutil', '-c', 'l1_summary', '-d', 'all'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == intf_l1_summary
+
+    def test_multi_asic_interface_l1_summary_asic1_l1_ethernet64(self):
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'l1_summary', '-n', 'asic1', '-i', 'Ethernet64'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == intf_l1_summary_asic1_ethernet64
 
 
 @pytest.mark.usefixtures("setup_multi_asic_env", "setup_env_paths")

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -923,6 +923,28 @@ class TestShowInterfaces(object):
             display_cmd=True,
         )
 
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='asic0'))
+    def test_l1_summary_asic0(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands['interfaces'].commands['l1-summary'], ['Ethernet0', '-n', 'asic0'])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'l1_summary', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=False)
+
+    @patch('utilities_common.cli.run_command')
+    def test_l1_summary_all(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['l1-summary'],
+            ['-d', 'all'])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(['intfutil', '-c', 'l1_summary', '-d', 'all'], display_cmd=False)
+
     def teardown_method(self):
         print('TEAR DOWN')
 


### PR DESCRIPTION
#### What I did

Added a new `show interfaces l1-summary` command that aggregates the layer-1 health of each interface into a single view: operational mode (speed/lane count), FEC, pre-FEC BER, oper/admin status, local/remote MAC fault status, transceiver vendor and model, media interface, and link flap history (flap count, last up/down times).

#### Why I did it

To get an idea of the state of interfaces from the L1 perspective, today you have to combine several commands per interface: `show interfaces status`, `show interfaces transceiver eeprom`, `show interfaces errors` and `show interfaces flap`. When qualifying links across multiple transceiver vendors, models and technologies, a single summary view makes it much easier to see which interface has what, and which links are unhealthy.

#### How I did it

- Added an `l1_summary` mode and support functions to `scripts/intfutil`, reading from the existing APPL_DB PORT_TABLE (oper/admin/fec/alias/flap fields), STATE_DB (TRANSCEIVER_INFO, PORT_OPERR_TABLE, port speed) and COUNTERS_DB (`RATES:<oid>` `FEC_PRE_BER`, the same source used by `show interfaces counters fec-stats`)
- Added the `l1-summary` subcommand to `show/interfaces`, with the standard interface-name argument, multi-ASIC namespace/display options and interface-alias conversion
- Documented the command in `doc/Command-Reference.md`
- Added tests in `tests/show_test.py` and `tests/multi_asic_intfutil_test.py` plus mock table entries

#### How to verify it

Unit tests pass. On a device:

```
admin@sonic:~$ show interfaces l1-summary
  Interface    Alias     Mode    FEC    Pre-FEC BER    Oper    Admin    Fault                    Transceiver    Media Interface    Flaps          Last Up        Last Down
-----------  -------  -------  -----  -------------  ------  -------  -------  -----------------------------  -----------------  -------  ---------------  ---------------
  Ethernet0    Port1  1600G/8     rs       3.94e-08      up       up     none           TERAHOP T-OH8ENH-N00       200GBASE-DR1        1  Jan 06 22:48:57              N/A
  Ethernet8    Port2  1600G/8     rs       1.11e-07      up       up     none           TERAHOP T-OH8ENH-N00       200GBASE-DR1        1  Jan 06 22:48:57              N/A
 Ethernet32    Port5  1600G/8     rs       6.06e-10    down       up    local    FINISAR CORP. FTCF2519T6PCA       800GBASE-DR4        3  Jan 06 22:49:03  Jan 07 04:12:44
```

Interfaces without the relevant DB fields (e.g. non-CMIS ports, or platforms that do not populate flap/fault data) degrade gracefully to N/A.

#### Previous command output (if the output of a command-line utility has changed)

N/A (new command)

#### New command output (if the output of a command-line utility has changed)

See above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)