### PR TITLE
[config] Support interface ranges with --from and --to

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5337,35 +5337,96 @@ def fast_linkup(ctx, interface_name, mode, verbose):
     if verbose:
         command += ['-vv']
     clicommon.run_command(command, display_cmd=verbose)
+
+
+def _get_configured_interface_range(config_db, from_intf, to_intf):
+    """Return the naturally-sorted list of actually configured PORT interfaces
+    between from_intf and to_intf (inclusive).
+
+    Only physical PORT-table entries that already exist in CONFIG_DB are
+    considered, so gaps in interface numbering (e.g. Ethernet0, Ethernet4,
+    Ethernet8, ...) are handled correctly instead of assuming a fixed stride.
+    """
+    port_dict = config_db.get_table('PORT')
+    sorted_ports = natsorted(port_dict.keys())
+
+    if from_intf not in sorted_ports:
+        raise ValueError("Interface '{}' is not a configured interface".format(from_intf))
+    if to_intf not in sorted_ports:
+        raise ValueError("Interface '{}' is not a configured interface".format(to_intf))
+
+    from_idx = sorted_ports.index(from_intf)
+    to_idx = sorted_ports.index(to_intf)
+
+    if from_idx > to_idx:
+        raise ValueError(
+            "Invalid interface range: '--from {}' comes after '--to {}' in the "
+            "configured interface order".format(from_intf, to_intf))
+
+    return sorted_ports[from_idx:to_idx + 1]
+
+
 #
 # 'startup' subcommand
 #
 
 @interface.command()
-@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_name', metavar='<interface_name>', required=False)
+@click.option('--from', 'from_intf', metavar='<from_interface>', default=None,
+              help='Start interface of an interface range (must be used with --to)')
+@click.option('--to', 'to_intf', metavar='<to_interface>', default=None,
+              help='End interface of an interface range (must be used with --from)')
 @click.pass_context
-def startup(ctx, interface_name):
+def startup(ctx, interface_name, from_intf, to_intf):
     """Start up interface"""
     # Get the config_db connector
     config_db = ctx.obj['config_db']
 
-    if clicommon.get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(config_db, interface_name)
+    if from_intf or to_intf:
+        if interface_name is not None:
+            ctx.fail("Cannot specify <interface_name> together with --from/--to")
+        if not from_intf or not to_intf:
+            ctx.fail("Both --from and --to must be specified together")
+
+        if clicommon.get_interface_naming_mode() == "alias":
+            from_intf = interface_alias_to_name(config_db, from_intf)
+            to_intf = interface_alias_to_name(config_db, to_intf)
+            if from_intf is None:
+                ctx.fail("Unable to resolve alias for '--from' interface")
+            if to_intf is None:
+                ctx.fail("Unable to resolve alias for '--to' interface")
+
+        try:
+            intf_fs = _get_configured_interface_range(config_db, from_intf, to_intf)
+        except ValueError as e:
+            ctx.fail(str(e))
+
+        if len(intf_fs) > 1 and multi_asic.is_multi_asic():
+            ctx.fail("Interface range not supported in multi-asic platforms !!")
+
+        log.log_info("'interface startup --from {} --to {}' executing...".format(from_intf, to_intf))
+    else:
         if interface_name is None:
-            ctx.fail("'interface_name' is None!")
+            ctx.fail("Interface name is required, or specify both --from and --to")
 
-    try:
-        intf_fs = parse_interface_in_filter(interface_name)
-    except ValueError as e:
-        ctx.fail(str(e))
+        if clicommon.get_interface_naming_mode() == "alias":
+            interface_name = interface_alias_to_name(config_db, interface_name)
+            if interface_name is None:
+                ctx.fail("'interface_name' is None!")
 
-    if len(intf_fs) > 1 and multi_asic.is_multi_asic():
-        ctx.fail("Interface range not supported in multi-asic platforms !!")
+        try:
+            intf_fs = parse_interface_in_filter(interface_name)
+        except ValueError as e:
+            ctx.fail(str(e))
 
-    if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
-        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+        if len(intf_fs) > 1 and multi_asic.is_multi_asic():
+            ctx.fail("Interface range not supported in multi-asic platforms !!")
 
-    log.log_info("'interface startup {}' executing...".format(interface_name))
+        if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
+            ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+        log.log_info("'interface startup {}' executing...".format(interface_name))
+
     port_dict = config_db.get_table('PORT')
     for port_name in port_dict:
         if port_name in intf_fs:
@@ -5391,29 +5452,61 @@ def startup(ctx, interface_name):
 #
 
 @interface.command()
-@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_name', metavar='<interface_name>', required=False)
+@click.option('--from', 'from_intf', metavar='<from_interface>', default=None,
+              help='Start interface of an interface range (must be used with --to)')
+@click.option('--to', 'to_intf', metavar='<to_interface>', default=None,
+              help='End interface of an interface range (must be used with --from)')
 @click.pass_context
-def shutdown(ctx, interface_name):
+def shutdown(ctx, interface_name, from_intf, to_intf):
     """Shut down interface"""
-    log.log_info("'interface shutdown {}' executing...".format(interface_name))
     # Get the config_db connector
     config_db = ctx.obj['config_db']
 
-    if clicommon.get_interface_naming_mode() == "alias":
-        interface_name = interface_alias_to_name(config_db, interface_name)
+    if from_intf or to_intf:
+        if interface_name is not None:
+            ctx.fail("Cannot specify <interface_name> together with --from/--to")
+        if not from_intf or not to_intf:
+            ctx.fail("Both --from and --to must be specified together")
+
+        if clicommon.get_interface_naming_mode() == "alias":
+            from_intf = interface_alias_to_name(config_db, from_intf)
+            to_intf = interface_alias_to_name(config_db, to_intf)
+            if from_intf is None:
+                ctx.fail("Unable to resolve alias for '--from' interface")
+            if to_intf is None:
+                ctx.fail("Unable to resolve alias for '--to' interface")
+
+        try:
+            intf_fs = _get_configured_interface_range(config_db, from_intf, to_intf)
+        except ValueError as e:
+            ctx.fail(str(e))
+
+        if len(intf_fs) > 1 and multi_asic.is_multi_asic():
+            ctx.fail("Interface range not supported in multi-asic platforms !!")
+
+        log.log_info("'interface shutdown --from {} --to {}' executing...".format(from_intf, to_intf))
+    else:
         if interface_name is None:
-            ctx.fail("'interface_name' is None!")
+            ctx.fail("Interface name is required, or specify both --from and --to")
 
-    try:
-        intf_fs = parse_interface_in_filter(interface_name)
-    except ValueError as e:
-        ctx.fail(str(e))
+        log.log_info("'interface shutdown {}' executing...".format(interface_name))
 
-    if len(intf_fs) > 1 and multi_asic.is_multi_asic():
-        ctx.fail("Interface range not supported in multi-asic platforms !!")
+        if clicommon.get_interface_naming_mode() == "alias":
+            interface_name = interface_alias_to_name(config_db, interface_name)
+            if interface_name is None:
+                ctx.fail("'interface_name' is None!")
 
-    if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
-        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+        try:
+            intf_fs = parse_interface_in_filter(interface_name)
+        except ValueError as e:
+            ctx.fail(str(e))
+
+        if len(intf_fs) > 1 and multi_asic.is_multi_asic():
+            ctx.fail("Interface range not supported in multi-asic platforms !!")
+
+        if len(intf_fs) == 1 and interface_name_is_valid(config_db, interface_name) is False:
+            ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
 
     port_dict = config_db.get_table('PORT')
     for port_name in port_dict:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -8064,6 +8064,7 @@ This command is used to administratively shut down either the Physical interface
   *Versions >= 201904*
   ```
   config interface shutdown <interface_name> (for 201904+ version)
+  config interface shutdown --from <from_interface> --to <to_interface>
   ```
   *Versions <= 201811*
   ```
@@ -8086,6 +8087,11 @@ This command is used to administratively shut down either the Physical interface
   admin@sonic:~$ sudo config interface shutdown Ethernet8,Ethernet16-20,Ethernet32
   ```
 
+  shutdown a range of configured physical interfaces using --from/--to
+  ```
+  admin@sonic:~$ sudo config interface shutdown --from Ethernet0 --to Ethernet40
+  ```
+
 **config interface startup <interface_name> (Versions >= 201904)**
 
 **config interface <interface_name> startup (Versions <= 201811)**
@@ -8097,6 +8103,7 @@ This command is used for administratively bringing up the Physical interface or 
   *Versions >= 201904*
   ```
   config interface startup <interface_name> (for 201904+ version)
+  config interface startup --from <from_interface> --to <to_interface>
   ```
   *Versions <= 201811*
   ```
@@ -8118,6 +8125,14 @@ This command is used for administratively bringing up the Physical interface or 
   ```
   admin@sonic:~$ sudo config interface startup Ethernet8,Ethernet16-20,Ethernet32
   ```
+
+  startup a range of configured physical interfaces using --from/--to
+  ```
+  admin@sonic:~$ sudo config interface startup --from Ethernet0 --to Ethernet40
+  ```
+
+  Note: --from and --to are inclusive, and only the configured physical interfaces between them are
+  affected. Both endpoints must be configured physical interfaces.
 
 **config interface <interface_name> speed (Versions >= 202006)**
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4496,6 +4496,123 @@ class TestConfigInterface(object):
         assert result.exit_code != 0
         assert "Invalid interface range" in result.output
 
+    # --- config interface startup/shutdown --from/--to (issue #790) ---
+    #
+    # The mock PORT table intentionally has gaps (Ethernet0, Ethernet4,
+    # Ethernet8, ... Ethernet40, Ethernet44, ...), so a range between
+    # Ethernet0 and Ethernet40 must only ever touch the ports that are
+    # actually configured, never fabricate Ethernet1/2/3/etc.
+    FROM_TO_IN_RANGE = [
+        "Ethernet0", "Ethernet4", "Ethernet8", "Ethernet12", "Ethernet16",
+        "Ethernet20", "Ethernet24", "Ethernet28", "Ethernet32", "Ethernet36",
+        "Ethernet40",
+    ]
+    FROM_TO_OUT_OF_RANGE = "Ethernet44"
+
+    @pytest.mark.parametrize("cmd_name,target_status,other_status", [
+        ("shutdown", "down", "up"),
+        ("startup", "up", "down"),
+    ])
+    def test_from_to_range_success(self, cmd_name, target_status, other_status):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        for port in self.FROM_TO_IN_RANGE + [self.FROM_TO_OUT_OF_RANGE]:
+            db.cfgdb.mod_entry("PORT", port, {"admin_status": other_status})
+
+        result = runner.invoke(config.config.commands['interface'].commands[cmd_name],
+                               ['--from', 'Ethernet0', '--to', 'Ethernet40'], obj=obj)
+        assert result.exit_code == 0, result.output
+
+        port_dict = db.cfgdb.get_table('PORT')
+        for port in self.FROM_TO_IN_RANGE:
+            assert port_dict[port]['admin_status'] == target_status
+        # A port just outside the requested range must not be touched.
+        assert port_dict[self.FROM_TO_OUT_OF_RANGE]['admin_status'] == other_status
+
+    @pytest.mark.parametrize("cmd_name,target_status,other_status", [
+        ("shutdown", "down", "up"),
+        ("startup", "up", "down"),
+    ])
+    def test_from_to_range_degenerate(self, cmd_name, target_status, other_status):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        db.cfgdb.mod_entry("PORT", "Ethernet8", {"admin_status": other_status})
+        db.cfgdb.mod_entry("PORT", "Ethernet12", {"admin_status": other_status})
+
+        result = runner.invoke(config.config.commands['interface'].commands[cmd_name],
+                               ['--from', 'Ethernet8', '--to', 'Ethernet8'], obj=obj)
+        assert result.exit_code == 0, result.output
+
+        port_dict = db.cfgdb.get_table('PORT')
+        assert port_dict['Ethernet8']['admin_status'] == target_status
+        assert port_dict['Ethernet12']['admin_status'] == other_status
+
+    def test_from_to_range_alias_mode(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        # Ethernet0/Ethernet4/Ethernet8 are aliased etp1/etp2/etp3 in the mock DB.
+        for port in ["Ethernet0", "Ethernet4", "Ethernet8"]:
+            db.cfgdb.mod_entry("PORT", port, {"admin_status": "up"})
+
+        os.environ['SONIC_CLI_IFACE_MODE'] = "alias"
+        try:
+            result = runner.invoke(config.config.commands['interface'].commands['shutdown'],
+                                   ['--from', 'etp1', '--to', 'etp3'], obj=obj)
+        finally:
+            os.environ['SONIC_CLI_IFACE_MODE'] = "default"
+
+        assert result.exit_code == 0, result.output
+        port_dict = db.cfgdb.get_table('PORT')
+        assert port_dict['Ethernet0']['admin_status'] == 'down'
+        assert port_dict['Ethernet4']['admin_status'] == 'down'
+        assert port_dict['Ethernet8']['admin_status'] == 'down'
+
+    # Table of (args, expected substring of the error message) for every
+    # --from/--to validation failure. Exercised against both startup and
+    # shutdown, since they share the same validation logic.
+    FROM_TO_ERROR_CASES = [
+        (['--from', 'Ethernet0'], "--from and --to"),                                    # --to missing
+        (['--to', 'Ethernet0'], "--from and --to"),                                       # --from missing
+        ([], "Interface name is required"),                                               # neither given
+        (['Ethernet0', '--from', 'Ethernet0', '--to', 'Ethernet40'], "Cannot specify"),    # positional + range
+        (['--from', 'Ethernet995', '--to', 'Ethernet40'], "not a configured interface"),  # --from not configured
+        (['--from', 'Ethernet0', '--to', 'Ethernet995'], "not a configured interface"),   # --to not configured
+        (['--from', 'Ethernet40', '--to', 'Ethernet0'], "comes after"),                   # reversed range
+    ]
+
+    @pytest.mark.parametrize("cmd_name", ["startup", "shutdown"])
+    @pytest.mark.parametrize("args,expected_message", FROM_TO_ERROR_CASES)
+    def test_from_to_range_errors(self, args, expected_message, cmd_name):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands['interface'].commands[cmd_name],
+                               args, obj=obj)
+        assert result.exit_code != 0
+        assert expected_message in result.output
+
+    @pytest.mark.parametrize("cmd_name", ["startup", "shutdown"])
+    @patch('config.main.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_from_to_range_rejected_multi_asic(self, cmd_name):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db': db.cfgdb}
+
+        for port in self.FROM_TO_IN_RANGE:
+            db.cfgdb.mod_entry("PORT", port, {"admin_status": "up"})
+
+        result = runner.invoke(config.config.commands['interface'].commands[cmd_name],
+                               ['--from', 'Ethernet0', '--to', 'Ethernet40'], obj=obj)
+        assert result.exit_code != 0
+        assert "Interface range not supported in multi-asic platforms" in result.output
+
     def teardown_method(self):
         print("TEARDOWN")
 


### PR DESCRIPTION
# [config] Support interface ranges with --from and --to

## What I did

Added `--from` and `--to` options to `config interface startup` and `config interface shutdown` to operate on an inclusive range of configured physical interfaces.

This implements the syntax suggested in #790 while preserving the existing positional single-interface, comma-list, and dash-range behavior.

Examples:

```text
config interface shutdown --from Ethernet0 --to Ethernet40
config interface startup --from Ethernet0 --to Ethernet40
```

## How I did it

- Added `--from` / `--to` options to `config interface startup` and `shutdown`.
- Selected the range from interfaces actually present in the `PORT` table.
- Used natural ordering so sparse interface numbering is handled correctly.
- Resolved `--from` and `--to` endpoints individually in interface alias mode.
- Preserved the existing multi-ASIC range restriction.
- Added validation for incomplete, reversed, missing-endpoint, and mixed positional/range input.
- Updated `doc/Command-Reference.md`.
- Added unit coverage for success and validation paths.

For example, if configured ports are:

```text
Ethernet0
Ethernet4
Ethernet8
...
Ethernet40
```

then `--from Ethernet0 --to Ethernet40` operates only on those configured ports and does not generate nonexistent interfaces such as `Ethernet1`, `Ethernet2`, or `Ethernet3`.

## How to verify it

Local validation completed successfully:

```text
python3 -m py_compile config/main.py tests/config_test.py
git diff --check
```

Targeted unit tests were added to `tests/config_test.py`.

The full unit test environment requires SONiC-specific dependencies such as `sonic_py_common` and `swsscommon`, which are not available in the local WSL environment. The PR CI environment can run the complete dependency-backed checks.

## Previous command output

Existing positional syntax remains unchanged, for example:

```text
config interface shutdown Ethernet0
config interface startup Ethernet0
config interface shutdown Ethernet8,Ethernet16-20,Ethernet32
config interface startup Ethernet8,Ethernet16-20,Ethernet32
```

## New command output

New range syntax:

```text
config interface shutdown --from Ethernet0 --to Ethernet40
config interface startup --from Ethernet0 --to Ethernet40
```

Fixes #790
