### PR TITLE
Allow App-extension services to avoid docker kill on warm/fast boot

### DIFF
--- a/sonic-utilities-data/templates/service_mgmt.sh.j2
+++ b/sonic-utilities-data/templates/service_mgmt.sh.j2
@@ -118,12 +118,19 @@ function stop() {
     docker exec -t ${SERVICE}${DEV} {{ manifest.service["pre-shutdown-action"] }}
 {%- endif %}
 
+{%- if manifest.service["graceful-stop-on-warm-fast-boot"] %}
+
+    # Package opted out of being killed on WARM/FAST boot
+    /usr/bin/${SERVICE}.sh stop $DEV
+{%- else %}
+
     # For WARM/FAST boot do not perform service stop
     if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
         /usr/bin/${SERVICE}.sh stop $DEV
     else
         docker kill ${SERVICE}$DEV &> /dev/null || debug "Docker ${SERVICE}$DEV is not running ($?) ..."
     fi
+{%- endif %}
 
     debug "Stopped ${SERVICE}$DEV service..."
 

--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -199,6 +199,7 @@ class ManifestSchema:
             ManifestArray('dependent-of', DefaultMarshaller(str)),
             ManifestField('post-start-action', DefaultMarshaller(str), ''),
             ManifestField('pre-shutdown-action', DefaultMarshaller(str), ''),
+            ManifestField('graceful-stop-on-warm-fast-boot', DefaultMarshaller(bool), False),
             ManifestField('asic-service', DefaultMarshaller(bool), False),
             ManifestField('host-service', DefaultMarshaller(bool), True),
             ManifestField('delayed', DefaultMarshaller(bool), False),


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added an optional manifest field, service.graceful-stop-on-warm-fast-boot, that lets an application extension keep its graceful stop path during a warm or fast boot instead of being SIGKILLed.

#### How I did it

1. manifest.py: new boolean ManifestField, default False.
2. service_mgmt.sh.j2: when the field is set, stop() calls the graceful "<service>.sh stop" path instead of the warm/fast boot "docker kill" branch.


#### How to verify it

1. Set `graceful-stop-on-warm-fast-boot`: `true` in an app extension manifest.
3. Deploy a switch with this change, so manifest.py exposes the field and service_mgmt.sh.j2 honors it. The generated `/usr/local/bin/<service>.sh stop()` must call `<service>.sh stop` instead of `docker kill`.
4. Run warm-reboot.
5. Confirm the service is stopped via `container stop` and not `docker kill` (the container exits with 0/143 (`SIGTERM`) instead of 137 (`SIGKILL`)).

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

