### PR TITLE
Add show interfaces breakout supported-mode CLI

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -7036,6 +7036,8 @@ This show command displays the port capability for all interfaces i.e. index, la
   show interfaces breakout
   show interfaces breakout current-mode
   show interfaces breakout current-mode <interface_name>
+  show interfaces breakout supported-mode
+  show interfaces breakout supported-mode <interface_name>
   ```
 
 - Example:
@@ -7075,6 +7077,16 @@ The "current-mode" subcommand is used to display current breakout mode for all i
   +=============+=========================+
   | Ethernet0   | 4x25G[10G]              |
   +-------------+-------------------------+
+  ```
+
+The "supported-mode" subcommand displays the breakout modes supported by the platform for all interfaces or a specified interface.
+  ```
+  admin@lnos-x1-a-fab01:~$ show interfaces breakout supported-mode Ethernet0
+  +-------------+----------------------------+
+  | Interface   | Supported Breakout Modes   |
+  +=============+============================+
+  | Ethernet0   | 1x400G,2x200G,4x100G       |
+  +-------------+----------------------------+
   ```
 
 **show interfaces counters**

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -209,6 +209,9 @@ def tpid(interfacename, namespace, display, verbose):
 @click.pass_context
 def breakout(ctx):
     """Show Breakout Mode information by interfaces"""
+    if ctx.invoked_subcommand == 'supported-mode':
+        return
+
     # Reading data from Redis configDb
     config_db = ConfigDBConnector()
     config_db.connect()
@@ -298,6 +301,55 @@ def currrent_mode(ctx, interface):
     # Show current Breakout Mode for all interfaces
     for name in natsorted(list(cur_brkout_tbl.keys())):
         body.append([name, str(cur_brkout_tbl[name]['brkout_mode'])])
+    click.echo(tabulate(body, header, tablefmt="grid"))
+
+
+# 'breakout supported-mode' subcommand ("show interfaces breakout supported-mode")
+@breakout.command('supported-mode')
+@click.argument('interface', metavar='<interface_name>', required=False, type=str)
+@click.pass_context
+def supported_mode(ctx, interface):
+    """
+    Show supported Breakout modes by interface(s).
+
+    Args:
+        ctx: Click context for the breakout command group.
+        interface: Optional interface name to query.
+
+    Returns:
+        None.
+    """
+
+    platform_file = device_info.get_path_to_port_config_file()
+    platform_data = readJsonFile(platform_file)
+    platform_dict = platform_data.get('interfaces', {})
+
+    if not platform_dict:
+        click.echo("Can not load port config from {} file".format(platform_file))
+        raise click.Abort()
+
+    header = ['Interface', 'Supported Breakout Modes']
+    body = []
+    interface_names = [interface] if interface is not None else natsorted(platform_dict.keys())
+
+    for name in interface_names:
+        interface_data = platform_dict.get(name)
+        if interface_data is None:
+            body.append([name, "Not Available"])
+            continue
+
+        modes = interface_data.get('breakout_modes')
+        if isinstance(modes, dict):
+            modes = ",".join(modes.keys())
+        elif isinstance(modes, (list, tuple)):
+            modes = ",".join(str(mode) for mode in modes)
+        elif modes is not None:
+            modes = str(modes)
+        else:
+            modes = "Not Available"
+
+        body.append([name, modes])
+
     click.echo(tabulate(body, header, tablefmt="grid"))
 
 

--- a/tests/show_breakout_test.py
+++ b/tests/show_breakout_test.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from click.testing import CliRunner
-from unittest import TestCase
+from unittest import TestCase, mock
 from swsscommon.swsscommon import ConfigDBConnector
 
 test_path = os.path.dirname(os.path.abspath(__file__))
@@ -45,6 +45,15 @@ current_mode_intf_output_Ethernet60 = ''+ \
 +-------------+-------------------------+
 """
 
+# Expected output for 'show breakout supported-mode Ethernet0'
+supported_mode_intf_output = ''+ \
+"""+-------------+----------------------------+
+| Interface   | Supported Breakout Modes   |
++=============+============================+
+| Ethernet0   | 1x400G,2x200G,4x100G       |
++-------------+----------------------------+
+"""
+
 class TestBreakout(TestCase):
     @classmethod
     def setup_class(cls):
@@ -70,10 +79,33 @@ class TestBreakout(TestCase):
         assert result.output == current_mode_intf_output
 
     # Negetive Test 'show interfaces  breakout current-mode Ethernet60'
-    def test_single_intf_current_mode(self):
+    def test_unknown_intf_current_mode(self):
         result = self.runner.invoke(show.cli.commands["interfaces"].commands["breakout"].commands["current-mode"], ["Ethernet60"], obj=self.obj)
         print(sys.stderr, result.output)
         assert result.output == current_mode_intf_output_Ethernet60
+
+    # Test 'show interfaces breakout supported-mode Ethernet0' without ConfigDB
+    def test_single_intf_supported_mode(self):
+        platform_data = {
+            'interfaces': {
+                'Ethernet0': {
+                    'breakout_modes': {
+                        '1x400G': ['etp1'],
+                        '2x200G': ['etp1a', 'etp1b'],
+                        '4x100G': ['etp1a', 'etp1b', 'etp1c', 'etp1d']
+                    }
+                }
+            }
+        }
+        command = show.cli.commands["interfaces"].commands["breakout"]
+        with mock.patch("show.interfaces.readJsonFile", return_value=platform_data), \
+                mock.patch("show.interfaces.device_info.get_path_to_port_config_file",
+                            return_value='platform.json'), \
+                mock.patch("show.interfaces.ConfigDBConnector",
+                            side_effect=AssertionError("ConfigDB must not be accessed")):
+            result = self.runner.invoke(command, ["supported-mode", "Ethernet0"], obj={})
+        print(sys.stderr, result.output)
+        assert result.output == supported_mode_intf_output
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
#### What I did
Added `show interfaces breakout supported-mode [interface_name]` to display supported breakout modes.

#### How I did it
Implemented the supported breakout-mode CLI using platform.json, added unit-test coverage for the command without ConfigDB dependency.

#### How to verify it
  Copied the updated `show` module to the testbed and ran:
  `show interfaces breakout supported-mode Ethernet0`

  Verified that the output matched the platform-supported breakout modes.

#### Previous command output (if the output of a command-line utility has changed)
Not applicable; this is a new subcommand.

#### New command output (if the output of a command-line utility has changed)
```
show interfaces breakout supported-mode Ethernet0
+-------------+--------------------------------------------------------------------------------------------------------+
| Interface   | Supported Breakout Modes                                                                               |
+=============+========================================================================================================+
| Ethernet0   | 1x800G,1x400G,1x200G(4),1x100G(4),8x100G,4x200G,4x100G,2x400G,2x200G,2x100G,1x50G(1),1x25G(1),1x10G(1) |
+-------------+--------------------------------------------------------------------------------------------------------+ 
 ```

```
aisjoshi@4f038229d865:/sonic/src/sonic-utilities$ python3 -m pytest -o addopts='-vv -n 0' \
    tests/show_breakout_test.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/src/sonic-utilities/tests, configfile: pytest.ini
plugins: xdist-3.8.0, pyfakefs-6.2.0, cov-4.0.0
collected 4 items                                                                                                                                                                                                                         

tests/show_breakout_test.py::TestBreakout::test_all_intf_current_mode PASSED                                                                                                                                                        [ 25%]
tests/show_breakout_test.py::TestBreakout::test_single_intf_current_mode PASSED                                                                                                                                                     [ 50%]
tests/show_breakout_test.py::TestBreakout::test_single_intf_supported_mode PASSED                                                                                                                                                   [ 75%]
tests/show_breakout_test.py::TestBreakout::test_unknown_intf_current_mode PASSED                                                                                                                                                    [100%]
```
