### PR TITLE
[route_check] Normalize VNET host prefixes and safely filter IP2ME routes

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -721,7 +721,7 @@ def filter_out_vnet_routes(namespace, routes):
 
     for vnet_route_db_key in vnet_routes_db_keys:
         vnet_route_attrs = vnet_route_db_key.split(':', 1)
-        vnet_route = vnet_route_attrs[1]
+        vnet_route = add_prefix_ifnot(vnet_route_attrs[1].lower())
         vnet_routes.append(vnet_route)
 
     updated_routes = []

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -194,12 +194,13 @@ def filter_out_vnet_ip2me_routes(vnet_routes):
             ip2me_route = rif_ip + '/32'
             vnet_ip2me_routes.append(ip2me_route)
 
-    for vnet, vnet_attrs in vnet_routes.items():
-        for route in vnet_attrs['routes']:
-            if route in vnet_ip2me_routes:
-                vnet_attrs['routes'].remove(route)
+    for vnet in list(vnet_routes.keys()):
+        vnet_routes[vnet]['routes'] = [
+            route for route in vnet_routes[vnet]['routes']
+            if route not in vnet_ip2me_routes
+        ]
 
-        if not vnet_attrs['routes']:
+        if not vnet_routes[vnet]['routes']:
             vnet_routes.pop(vnet)
 
 

--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -5,6 +5,7 @@ import json
 import syslog
 import subprocess
 import argparse
+from ipaddress import ip_network
 from swsscommon import swsscommon
 
 ''' vnet_route_check.py: tool that verifies VNET routes consistency between SONiC and vendor SDK DBs.
@@ -52,6 +53,13 @@ default_vrf_oid = ""
 
 report_level = syslog.LOG_WARNING
 write_to_syslog = True
+
+
+def add_prefix_ifnot(ip):
+    """Return a canonical route prefix, adding a host mask when absent."""
+    if '/' not in ip:
+        ip += '/128' if ':' in ip else '/32'
+    return str(ip_network(ip))
 
 
 def set_level(lvl, log_to_syslog):
@@ -214,7 +222,7 @@ def get_vnet_routes_from_app_db():
     for vnet_route_db_key in vnet_routes_db_keys:
         vnet_route_list = vnet_route_db_key.split(':',1)
         vnet_name = vnet_route_list[0]
-        vnet_route = vnet_route_list[1]
+        vnet_route = add_prefix_ifnot(vnet_route_list[1].lower())
 
         if vnet_name not in vnet_routes:
             vnet_routes[vnet_name] = {}

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -243,6 +243,24 @@ class TestRouteCheck(object):
             set_mock(mock_table, mock_conn, mock_sel, mock_subs, mock_config_db)
             yield
 
+    def test_filter_out_vnet_routes_normalizes_host_prefixes(self):
+        vnet_table = MagicMock()
+        vnet_table.getKeys.return_value = [
+            "Vnet1:50.0.0.1",
+            "Vnet1:2001:db8::1",
+        ]
+        tunnel_table = MagicMock()
+        tunnel_table.getKeys.return_value = []
+
+        with patch("route_check.swsscommon.DBConnector", create=True), \
+                patch("route_check.swsscommon.Table",
+                      side_effect=[vnet_table, tunnel_table],
+                      create=True):
+            routes = route_check.filter_out_vnet_routes(
+                "", ["50.0.0.1/32", "2001:db8::1/128", "10.0.0.0/24"])
+
+        assert routes == ["10.0.0.0/24"]
+
     @pytest.mark.parametrize("test_num", TEST_DATA.keys())
     def test_route_check(self, mock_dbs, test_num):
         logger.debug("test_route_check: test_num={}".format(test_num))

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -764,6 +764,39 @@ class TestVnetRouteCheck(object):
             "2001:db8::1/128",
         ]
 
+    def test_filter_out_vnet_ip2me_routes_handles_consecutive_routes(self):
+        intf_table = MagicMock()
+        intf_table.getKeys.return_value = [
+            "PortChannel1.1102:100.1.0.17/30",
+            "PortChannel2.1102:100.1.0.21/30",
+        ]
+        vnet_routes = {
+            "Vnet3": {
+                "routes": [
+                    "100.1.0.17/32",
+                    "100.1.0.21/32",
+                    "50.0.2.1/32",
+                ],
+                "vrf_oid": "oid:0x3",
+            }
+        }
+
+        with patch("vnet_route_check.swsscommon.DBConnector", create=True), \
+                patch(
+                    "vnet_route_check.swsscommon.Table",
+                    return_value=intf_table,
+                    create=True,
+                ), \
+                patch(
+                    "vnet_route_check.get_vnet_intfs",
+                    return_value={
+                        "Vnet3": ["PortChannel1.1102", "PortChannel2.1102"]
+                    },
+                ):
+            vnet_route_check.filter_out_vnet_ip2me_routes(vnet_routes)
+
+        assert vnet_routes["Vnet3"]["routes"] == ["50.0.2.1/32"]
+
     @patch("vnet_route_check.swsscommon.DBConnector")
     @patch("vnet_route_check.swsscommon.Table")
     def test_vnet_route_check(self, mock_table, mock_conn):

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -736,6 +736,34 @@ class TestVnetRouteCheck(object):
     def init(self):
         vnet_route_check.UNIT_TESTING = 1
 
+    def test_get_vnet_routes_from_app_db_normalizes_host_prefixes(self):
+        vnet_table = MagicMock()
+        vnet_table.getKeys.return_value = [
+            "Vnet1:50.0.0.1",
+            "Vnet1:2001:db8::1",
+        ]
+        tunnel_table = MagicMock()
+        tunnel_table.getKeys.return_value = []
+
+        with patch("vnet_route_check.swsscommon.DBConnector", create=True), \
+                patch("vnet_route_check.swsscommon.Table",
+                      side_effect=[vnet_table, tunnel_table],
+                      create=True), \
+                patch(
+                    "vnet_route_check.get_vnet_intfs",
+                    return_value={"Vnet1": ["Vlan3001"]},
+                ), \
+                patch(
+                    "vnet_route_check.get_vrf_entries",
+                    return_value={"Vlan3001": "oid:0x3000000000d4b"},
+                ):
+            routes = vnet_route_check.get_vnet_routes_from_app_db()
+
+        assert routes["Vnet1"]["routes"] == [
+            "50.0.0.1/32",
+            "2001:db8::1/128",
+        ]
+
     @patch("vnet_route_check.swsscommon.DBConnector")
     @patch("vnet_route_check.swsscommon.Table")
     def test_vnet_route_check(self, mock_table, mock_conn):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

- Normalized VNET host routes that are stored in APP_DB  without explicit prefixes to canonical IPv4 `/32` or IPv6 `/128` prefixes before comparing APP_DB and ASIC_DB routes.

Example : VNET_ROUTE_TABLE:Vnet1:50.0.0.1

- Fixed IP2ME filtering so it does not mutate route lists or the VNET dictionary while iterating.
- Added regression tests for host-prefix normalization and consecutive IP2ME routes.

#### How I did it

- Added `add_prefix_ifnot()` normalization to `vnet_route_check.py` and applied it when reading VNET routes from APP_DB.
- Applied the existing host-prefix normalization when `route_check.py` filters VNET routes.
- Replaced in-loop removal with a list comprehension while iterating over a snapshot of the VNET keys.

#### How to verify it

Using the sonic-buildimage test environment, the three new regression tests fail against upstream commit `1ba80ce4` and pass with this change:

```
3 passed in 0.22s
```

The change was also validated on a DUT:

```
vnet_route_check.py        RC=0
vnet_route_check.py --all  RC=0
route_check.py -m INFO     RC=0
```

#### Previous command output (if the output of a command-line utility has changed)

```
Unaccounted_ROUTE_ENTRY_TABLE_entries:
50.0.0.1/32
50.0.1.1/32
50.0.2.1/32

missed_in_app_db_routes:
Vnet3:
  routes:
    - 100.1.0.17/32
```

#### New command output (if the output of a command-line utility has changed)

```
vnet_route_check.py        RC=0
vnet_route_check.py --all  RC=0
route_check.py -m INFO     RC=0
```

#### Which release branch to backport :

- [x] 202605


#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202605

SONiC Software Version: SONiC.HEAD.48043-dirty-20260826.185243
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 313b8e0b3
Build date: Thu Aug 27 01:59:24 UTC 2026
Built by: sonicci@sonic-ci-23-lnx.cisco.com

#### Test result

202605: PASS. The three regression tests fail against upstream commit `1ba80ce4` and pass with this change in the sonic-buildimage test environment:

```
3 passed in 0.22s
```

DUT validation on `SONiC.HEAD.48043-dirty-20260826.185243`:

```
vnet_route_check.py        RC=0
vnet_route_check.py --all  RC=0
route_check.py -m INFO     RC=0
```
