### PR TITLE
Add Secure Boot show and config CLI support

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -74,6 +74,7 @@ from . import bgp_cli
 from . import stp
 from . import evpn_mh
 from . import llr
+from . import secure_boot
 
 # mock masic APIs for unit test
 try:
@@ -1847,6 +1848,9 @@ config.add_command(dns.dns)
 
 # Switchport module
 config.add_command(switchport.switchport)
+
+# Secure Boot module
+config.add_command(secure_boot.secure_boot)
 
 @config.command()
 @click.option('-y', '--yes', is_flag=True, callback=_abort_if_false,

--- a/config/secure_boot.py
+++ b/config/secure_boot.py
@@ -1,0 +1,96 @@
+"""config secure-boot commands."""
+
+import json
+import subprocess
+import click
+
+try:
+    import utilities_common.cli as clicommon
+    GROUP_CLS = clicommon.AliasedGroup
+except Exception:  # pragma: no cover
+    GROUP_CLS = click.Group
+
+BACKEND = "/usr/sbin/tam-uefi-tool"
+TIMEOUT = 300
+
+class BackendError(RuntimeError):
+    pass
+
+def run_backend(*args):
+    try:
+        cp = subprocess.run([BACKEND] + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=TIMEOUT, check=False)
+    except FileNotFoundError:
+        raise BackendError(f"{BACKEND} is not installed")
+    except subprocess.TimeoutExpired:
+        raise BackendError("secure boot backend timed out")
+    try:
+        data = json.loads(cp.stdout or "{}")
+    except json.JSONDecodeError:
+        raise BackendError("invalid backend response: {}".format((cp.stdout or "").strip()))
+    if cp.returncode != 0 or "error" in data:
+        raise BackendError(data.get("error", "secure boot backend failed"))
+    return data
+
+@click.group(name="secure-boot", cls=GROUP_CLS)
+def secure_boot():
+    """Configure Secure Boot certificate backend."""
+    pass
+
+@secure_boot.group(cls=GROUP_CLS)
+def certificate():
+    """Configure Secure Boot certificates."""
+    pass
+
+@certificate.command(name="update")
+@click.argument("variable", type=click.Choice(["PK","KEK","db","dbx"], case_sensitive=False))
+@click.argument("auth_var_file", type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.option("--operation", type=click.Choice(["append","update","remove"]), default="update", show_default=True)
+def certificate_update(variable, auth_var_file, operation):
+    """Submit an authenticated variable update file."""
+    try:
+        result = run_backend("update", variable, "--file", auth_var_file, "--operation", operation)
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    click.echo("Secure Boot certificate update submitted successfully")
+    click.echo("Variable: {}".format(result.get("variable", variable)))
+    click.echo("Operation: {}".format(result.get("operation", operation)))
+
+@certificate.command(name="install")
+@click.argument("variable", type=click.Choice(["PK","KEK","db","dbx"], case_sensitive=False))
+@click.argument("auth_var_file", type=click.Path(exists=True, dir_okay=False, readable=True))
+def certificate_install(variable, auth_var_file):
+    """Install/append an authenticated certificate update."""
+    try:
+        run_backend("update", variable, "--file", auth_var_file, "--operation", "append")
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    click.echo("Secure Boot certificate install submitted successfully")
+
+@certificate.command(name="revoke")
+@click.argument("variable", type=click.Choice(["db","dbx"], case_sensitive=False))
+@click.argument("auth_var_file", type=click.Path(exists=True, dir_okay=False, readable=True))
+def certificate_revoke(variable, auth_var_file):
+    """Submit an authenticated revocation update."""
+    try:
+        run_backend("update", variable, "--file", auth_var_file, "--operation", "append")
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    click.echo("Secure Boot revocation update submitted successfully")
+
+@secure_boot.group(cls=GROUP_CLS)
+def mode():
+    """Configure platform Secure Boot mode."""
+    pass
+
+@mode.command(name="set")
+@click.argument("ownership_voucher_file", type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.option("--yes", is_flag=True, help="Confirm platform ownership/mode update.")
+def mode_set(ownership_voucher_file, yes):
+    """Submit a platform ownership voucher."""
+    if not yes:
+        raise click.ClickException("mode set requires --yes confirmation")
+    try:
+        run_backend("set-mode", "--file", ownership_voucher_file)
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    click.echo("Secure Boot mode update submitted successfully")

--- a/config/secure_boot.py
+++ b/config/secure_boot.py
@@ -1,8 +1,8 @@
 """config secure-boot commands."""
 
-import json
-import subprocess
 import click
+
+from utilities_common.secure_boot import BackendError, run_backend
 
 try:
     import utilities_common.cli as clicommon
@@ -10,35 +10,7 @@ try:
 except Exception:  # pragma: no cover
     GROUP_CLS = click.Group
 
-BACKEND = "/usr/sbin/secure-boot-backend"
 TIMEOUT = 300
-
-
-class BackendError(RuntimeError):
-    pass
-
-
-def run_backend(*args):
-    try:
-        cp = subprocess.run(
-            [BACKEND] + list(args),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            timeout=TIMEOUT,
-            check=False,
-        )
-    except FileNotFoundError:
-        raise BackendError(f"{BACKEND} is not installed")
-    except subprocess.TimeoutExpired:
-        raise BackendError("secure boot backend timed out")
-    try:
-        data = json.loads(cp.stdout or "{}")
-    except json.JSONDecodeError:
-        raise BackendError("invalid backend response: {}".format((cp.stdout or "").strip()))
-    if cp.returncode != 0 or "error" in data:
-        raise BackendError(data.get("error", "secure boot backend failed"))
-    return data
 
 
 @click.group(name="secure-boot", cls=GROUP_CLS)
@@ -60,7 +32,7 @@ def certificate():
 def certificate_update(variable, auth_var_file, operation):
     """Submit an authenticated variable update file."""
     try:
-        result = run_backend("update", variable, "--file", auth_var_file, "--operation", operation)
+        result = run_backend(("update", variable, "--file", auth_var_file, "--operation", operation), TIMEOUT)
     except BackendError as exc:
         raise click.ClickException(str(exc))
     click.echo("Secure Boot certificate update submitted successfully")

--- a/config/secure_boot.py
+++ b/config/secure_boot.py
@@ -10,15 +10,24 @@ try:
 except Exception:  # pragma: no cover
     GROUP_CLS = click.Group
 
-BACKEND = "/usr/sbin/tam-uefi-tool"
+BACKEND = "/usr/sbin/secure-boot-backend"
 TIMEOUT = 300
+
 
 class BackendError(RuntimeError):
     pass
 
+
 def run_backend(*args):
     try:
-        cp = subprocess.run([BACKEND] + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=TIMEOUT, check=False)
+        cp = subprocess.run(
+            [BACKEND] + list(args),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=TIMEOUT,
+            check=False,
+        )
     except FileNotFoundError:
         raise BackendError(f"{BACKEND} is not installed")
     except subprocess.TimeoutExpired:
@@ -31,20 +40,23 @@ def run_backend(*args):
         raise BackendError(data.get("error", "secure boot backend failed"))
     return data
 
+
 @click.group(name="secure-boot", cls=GROUP_CLS)
 def secure_boot():
     """Configure Secure Boot certificate backend."""
     pass
+
 
 @secure_boot.group(cls=GROUP_CLS)
 def certificate():
     """Configure Secure Boot certificates."""
     pass
 
+
 @certificate.command(name="update")
-@click.argument("variable", type=click.Choice(["PK","KEK","db","dbx"], case_sensitive=False))
+@click.argument("variable", type=click.Choice(["PK", "KEK", "db", "dbx"], case_sensitive=False))
 @click.argument("auth_var_file", type=click.Path(exists=True, dir_okay=False, readable=True))
-@click.option("--operation", type=click.Choice(["append","update","remove"]), default="update", show_default=True)
+@click.option("--operation", type=click.Choice(["append", "update", "remove"]), default="update", show_default=True)
 def certificate_update(variable, auth_var_file, operation):
     """Submit an authenticated variable update file."""
     try:
@@ -54,43 +66,3 @@ def certificate_update(variable, auth_var_file, operation):
     click.echo("Secure Boot certificate update submitted successfully")
     click.echo("Variable: {}".format(result.get("variable", variable)))
     click.echo("Operation: {}".format(result.get("operation", operation)))
-
-@certificate.command(name="install")
-@click.argument("variable", type=click.Choice(["PK","KEK","db","dbx"], case_sensitive=False))
-@click.argument("auth_var_file", type=click.Path(exists=True, dir_okay=False, readable=True))
-def certificate_install(variable, auth_var_file):
-    """Install/append an authenticated certificate update."""
-    try:
-        run_backend("update", variable, "--file", auth_var_file, "--operation", "append")
-    except BackendError as exc:
-        raise click.ClickException(str(exc))
-    click.echo("Secure Boot certificate install submitted successfully")
-
-@certificate.command(name="revoke")
-@click.argument("variable", type=click.Choice(["db","dbx"], case_sensitive=False))
-@click.argument("auth_var_file", type=click.Path(exists=True, dir_okay=False, readable=True))
-def certificate_revoke(variable, auth_var_file):
-    """Submit an authenticated revocation update."""
-    try:
-        run_backend("update", variable, "--file", auth_var_file, "--operation", "append")
-    except BackendError as exc:
-        raise click.ClickException(str(exc))
-    click.echo("Secure Boot revocation update submitted successfully")
-
-@secure_boot.group(cls=GROUP_CLS)
-def mode():
-    """Configure platform Secure Boot mode."""
-    pass
-
-@mode.command(name="set")
-@click.argument("ownership_voucher_file", type=click.Path(exists=True, dir_okay=False, readable=True))
-@click.option("--yes", is_flag=True, help="Confirm platform ownership/mode update.")
-def mode_set(ownership_voucher_file, yes):
-    """Submit a platform ownership voucher."""
-    if not yes:
-        raise click.ClickException("mode set requires --yes confirmation")
-    try:
-        run_backend("set-mode", "--file", ownership_voucher_file)
-    except BackendError as exc:
-        raise click.ClickException(str(exc))
-    click.echo("Secure Boot mode update submitted successfully")

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -207,6 +207,9 @@
   * [sFlow Config commands](#sflow-config-commands)
 * [SED](#sed)
   * [SED Config commands](#sed-config-commands)
+* [Secure Boot Commands](#secure-boot-commands)
+  * [Secure Boot show commands](#secure-boot-show-commands)
+  * [Secure Boot config commands](#secure-boot-config-commands)
 * [SNMP](#snmp)
   * [SNMP Show commands](#snmp-show-commands)
   * [SNMP Config commands](#snmp-config-commands)
@@ -293,6 +296,7 @@
 
 | Version | Modification Date | Details |
 | --- | --- | --- |
+| v13 | Sep-01-2026 | Add Secure Boot show and config commands |
 | v12 | Jul-16-2026 | Add console mirror commands |
 | v11 | May-13-2026 | Add multi-ASIC namespace support for `config vrf` and `sonic-clear flowcnt-trap` |
 | v10 | Mar-07-2026 | Update VxLAN and Vnet command reference for namespace-aware multi-ASIC behavior |
@@ -13320,6 +13324,148 @@ This command resets the SED password to the default value.
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#sed)
+
+
+## Secure Boot Commands
+
+Secure Boot commands are used to display Secure Boot mode and variable state, and to submit authenticated-variable update operations for the standard UEFI Secure Boot variables `PK`, `KEK`, `db`, and `dbx`.
+
+The commands use a platform Secure Boot backend. The platform backend is responsible for validating authenticated-variable payloads, enforcing platform policy, and accessing protected Secure Boot variable storage. The exact mode, policy state, variable state, and entry counts are platform dependent.
+
+### Secure Boot show commands
+
+**show secure-boot status**
+
+This command displays the Secure Boot backend mode together with the state and entry count of `PK`, `KEK`, `db`, and `dbx` in the vendor and customer stores.
+
+- Usage:
+  ```
+  show secure-boot status
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show secure-boot status
+  Secure Boot Backend: platform
+  UEFI Mode: 43 (0x002b, Generic Mode)
+
+  Variable    Vendor State      Vendor Entries    Customer State      Customer Entries
+  ----------  ----------------  ----------------  ------------------  ------------------
+  PK          present                          1  empty                                0
+  KEK         present                          1  empty                                0
+  db          present                         23  empty                                0
+  dbx         empty                            0  empty                                0
+  ```
+
+**show secure-boot mode**
+
+This command displays the Secure Boot mode and the write/lock policy reported by the platform backend.
+
+- Usage:
+  ```
+  show secure-boot mode
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show secure-boot mode
+  Mode                  43 (Generic Mode)
+  Mode Hex              0x002b
+  Vendor store write    yes
+  Vendor store lock     yes
+  Customer store write  no
+  Customer store lock   yes
+  ```
+
+**show secure-boot keys**
+
+This command displays the state and entry count for `PK`, `KEK`, `db`, and `dbx` in each supported Secure Boot variable store.
+
+- Usage:
+  ```
+  show secure-boot keys
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ show secure-boot keys
+  Variable    Store       State      Entries
+  ----------  ----------  ---------  -------
+  PK          vendor      present          1
+  PK          customer    empty            0
+  KEK         vendor      present          1
+  KEK         customer    empty            0
+  db          vendor      present         23
+  db          customer    empty            0
+  dbx         vendor      empty            0
+  dbx         customer    empty            0
+  ```
+
+**show secure-boot key**
+
+This command displays the state and entry count for one Secure Boot variable.
+
+- Usage:
+  ```
+  show secure-boot key <PK|KEK|db|dbx> [--store <vendor|customer|unified>]
+  ```
+
+- Parameters:
+  - _variable_: Secure Boot variable to display. Valid values are `PK`, `KEK`, `db`, and `dbx`.
+  - `--store`: Secure Boot variable store to query. Valid values are `vendor`, `customer`, and `unified`. The default is `customer`.
+
+- Example:
+  ```
+  admin@sonic:~$ show secure-boot key PK --store vendor
+  Variable  PK
+  Store     vendor
+  State     present
+  Entries   1
+  ```
+
+  The `unified` store reports the effective Secure Boot variable state exposed by platforms that provide a unified view of the underlying Secure Boot variable stores:
+  ```
+  admin@sonic:~$ show secure-boot key db --store unified
+  Variable  db
+  Store     unified
+  State     present
+  Entries   23
+  ```
+
+### Secure Boot config commands
+
+Secure Boot configuration commands submit authenticated update material to the platform Secure Boot backend. The CLI does not generate or store private signing keys.
+
+**config secure-boot certificate update**
+
+This command submits an authenticated-variable update file for `PK`, `KEK`, `db`, or `dbx`.
+
+- Usage:
+  ```
+  config secure-boot certificate update <PK|KEK|db|dbx> <auth-var-file> [--operation <append|update|remove>]
+  ```
+
+- Parameters:
+  - _variable_: Secure Boot variable to update. Valid values are `PK`, `KEK`, `db`, and `dbx`.
+  - _auth-var-file_: Path to the authenticated-variable update file.
+  - `--operation`: Update operation. Valid values are `append`, `update`, and `remove`. The default is `update`.
+
+  This single command covers authenticated-variable update operations:
+  - Append new material to a variable: `--operation append`.
+  - Replace the current contents of a variable: `--operation update`.
+  - Remove authorized material from a variable: `--operation remove`.
+
+  For example, revoking a previously trusted image or certificate can be performed by submitting an authenticated update that appends the corresponding revocation entry to `dbx`.
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config secure-boot certificate update db db.auth --operation append
+  Secure Boot certificate update submitted successfully
+  Variable: db
+  Operation: append
+  ```
+
+Go Back To [Beginning of the document](#) or [Beginning of this section](#secure-boot-commands)
 
 ## SNMP
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -13330,7 +13330,7 @@ Go Back To [Beginning of the document](#) or [Beginning of this section](#sed)
 
 Secure Boot commands are used to display Secure Boot mode and variable state, and to submit authenticated-variable update operations for the standard UEFI Secure Boot variables `PK`, `KEK`, `db`, and `dbx`.
 
-The commands use a platform Secure Boot backend. The platform backend is responsible for validating authenticated-variable payloads, enforcing platform policy, and accessing protected Secure Boot variable storage. The exact mode, policy state, variable state, and entry counts are platform dependent.
+The commands talk to a single stable entry point, `/usr/sbin/secure-boot-backend`, which is the SONiC Secure Boot backend selector. The selector uses an explicitly registered platform backend when present, otherwise the SONiC generic UEFI backend when standard UEFI variable services are available, and otherwise reports Secure Boot management as unsupported. A platform backend is registered by providing `/usr/lib/sonic/secure-boot/platform-backend`. The selected backend is responsible for validating authenticated-variable payloads, enforcing policy, and accessing protected Secure Boot variable storage. The exact mode, policy state, variable state, and entry counts are backend and platform dependent.
 
 ### Secure Boot show commands
 
@@ -13346,7 +13346,6 @@ This command displays the Secure Boot backend mode together with the state and e
 - Example:
   ```
   admin@sonic:~$ show secure-boot status
-  Secure Boot Backend: platform
   UEFI Mode: 43 (0x002b, Generic Mode)
 
   Variable    Vendor State      Vendor Entries    Customer State      Customer Entries
@@ -13359,7 +13358,7 @@ This command displays the Secure Boot backend mode together with the state and e
 
 **show secure-boot mode**
 
-This command displays the Secure Boot mode and the write/lock policy reported by the platform backend.
+This command displays the Secure Boot mode and the write/lock policy reported by the backend.
 
 - Usage:
   ```
@@ -13434,7 +13433,7 @@ This command displays the state and entry count for one Secure Boot variable.
 
 ### Secure Boot config commands
 
-Secure Boot configuration commands submit authenticated update material to the platform Secure Boot backend. The CLI does not generate or store private signing keys.
+Secure Boot configuration commands submit authenticated update material to the Secure Boot backend. The CLI does not generate or store private signing keys.
 
 **config secure-boot certificate update**
 

--- a/secure_boot/generic_uefi_backend.py
+++ b/secure_boot/generic_uefi_backend.py
@@ -332,4 +332,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/secure_boot/generic_uefi_backend.py
+++ b/secure_boot/generic_uefi_backend.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+
+"""Generic SONiC Secure Boot backend using Linux UEFI variable services.
+
+This backend is selected by ``secure_boot_backend.py`` when no platform
+backend is registered and standard UEFI variable services are available. It
+speaks the same stdout-JSON / stderr-diagnostics contract as any other
+Secure Boot backend.
+
+Standard UEFI has no vendor/customer split, so this backend exposes only the
+effective ("unified") variables. The ``vendor`` and ``customer`` stores are
+rejected.
+"""
+
+import argparse
+import json
+import os
+import struct
+import sys
+
+EFIVARS_PATH = "/sys/firmware/efi/efivars"
+
+EFI_GLOBAL_VARIABLE_GUID = "8be4df61-93ca-11d2-aa0d-00e098032b8c"
+EFI_IMAGE_SECURITY_DATABASE_GUID = "d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+
+VARIABLES = {
+    "PK": EFI_GLOBAL_VARIABLE_GUID,
+    "KEK": EFI_GLOBAL_VARIABLE_GUID,
+    "db": EFI_IMAGE_SECURITY_DATABASE_GUID,
+    "dbx": EFI_IMAGE_SECURITY_DATABASE_GUID,
+}
+
+EFI_VARIABLE_NON_VOLATILE = 0x00000001
+EFI_VARIABLE_BOOTSERVICE_ACCESS = 0x00000002
+EFI_VARIABLE_RUNTIME_ACCESS = 0x00000004
+EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS = 0x00000020
+EFI_VARIABLE_APPEND_WRITE = 0x00000040
+
+DEFAULT_ATTRIBUTES = (
+    EFI_VARIABLE_NON_VOLATILE
+    | EFI_VARIABLE_BOOTSERVICE_ACCESS
+    | EFI_VARIABLE_RUNTIME_ACCESS
+    | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS
+)
+
+
+class BackendError(RuntimeError):
+    pass
+
+
+def json_error(message, rc=1):
+    print(json.dumps({"error": message}))
+    return rc
+
+
+def json_output(data):
+    print(json.dumps(data, separators=(",", ":")))
+    return 0
+
+
+def _require_root():
+    if os.geteuid() != 0:
+        raise BackendError("Secure Boot backend requires root privileges")
+
+
+def _uefi_available():
+    return os.path.isdir(EFIVARS_PATH)
+
+
+def _variable_path(variable):
+    try:
+        guid = VARIABLES[variable]
+    except KeyError:
+        raise BackendError("unsupported Secure Boot variable: {}".format(variable))
+
+    return os.path.join(EFIVARS_PATH, "{}-{}".format(variable, guid))
+
+
+def _read_variable(variable):
+    path = _variable_path(variable)
+
+    if not os.path.exists(path):
+        return {"state": "empty", "entry_count": 0, "data_length": 0}
+
+    try:
+        with open(path, "rb") as fp:
+            raw = fp.read()
+    except OSError as exc:
+        raise BackendError("failed to read {}: {}".format(variable, exc))
+
+    if len(raw) < 4:
+        raise BackendError("invalid efivarfs data for {}".format(variable))
+
+    # efivarfs prepends a 32-bit EFI attribute word.
+    payload = raw[4:]
+
+    if not payload:
+        return {"state": "empty", "entry_count": 0, "data_length": 0}
+
+    return {
+        "state": "present",
+        "entry_count": _count_signature_entries(payload),
+        "data_length": len(payload),
+    }
+
+
+def _count_signature_entries(payload):
+    """Count EFI_SIGNATURE_DATA entries across one or more EFI_SIGNATURE_LISTs.
+
+    EFI_SIGNATURE_LIST layout::
+
+        EFI_GUID SignatureType         16 bytes
+        UINT32   SignatureListSize       4
+        UINT32   SignatureHeaderSize     4
+        UINT32   SignatureSize           4
+        UINT8    SignatureHeader[]
+        EFI_SIGNATURE_DATA Signatures[]
+
+    This only counts entries; it does not interpret certificate contents.
+    """
+
+    offset = 0
+    count = 0
+
+    while offset < len(payload):
+        if len(payload) - offset < 28:
+            raise BackendError("malformed EFI signature list")
+
+        signature_list_size, signature_header_size, signature_size = \
+            struct.unpack_from("<III", payload, offset + 16)
+
+        if signature_list_size < 28:
+            raise BackendError("invalid EFI signature list size")
+
+        if signature_size == 0:
+            raise BackendError("invalid EFI signature size")
+
+        end = offset + signature_list_size
+
+        if end > len(payload):
+            raise BackendError("truncated EFI signature list")
+
+        entries_start = offset + 28 + signature_header_size
+
+        if entries_start > end:
+            raise BackendError("invalid EFI signature header size")
+
+        entries_len = end - entries_start
+
+        if entries_len % signature_size != 0:
+            raise BackendError("malformed EFI signature entries")
+
+        count += entries_len // signature_size
+        offset = end
+
+    return count
+
+
+def _read_raw_byte_variable(name):
+    path = os.path.join(EFIVARS_PATH, "{}-{}".format(name, EFI_GLOBAL_VARIABLE_GUID))
+
+    if not os.path.exists(path):
+        return None
+
+    try:
+        with open(path, "rb") as fp:
+            raw = fp.read()
+    except OSError as exc:
+        raise BackendError("failed to read {}: {}".format(name, exc))
+
+    if len(raw) < 5:
+        raise BackendError("invalid UEFI variable data for {}".format(name))
+
+    # First 4 bytes are the EFI attribute word; the value byte follows.
+    return raw[4]
+
+
+def _mode():
+    """Report standard UEFI SecureBoot/SetupMode state.
+
+    The generic backend cannot expose platform-specific mode numbers or
+    vendor/customer policy, so all policy flags are reported as ``False``.
+    """
+
+    secure_boot = _read_raw_byte_variable("SecureBoot")
+    setup_mode = _read_raw_byte_variable("SetupMode")
+
+    if secure_boot is None and setup_mode is None:
+        raise BackendError("standard UEFI Secure Boot mode variables are not available")
+
+    name = "Unknown"
+
+    if setup_mode == 1:
+        name = "Setup Mode"
+    elif secure_boot == 1:
+        name = "Secure Boot Enabled"
+    elif secure_boot == 0:
+        name = "Secure Boot Disabled"
+
+    return {
+        "raw": secure_boot if secure_boot is not None else -1,
+        "hex": "0x{:02x}".format(secure_boot) if secure_boot is not None else "unknown",
+        "name": name,
+        # Standard UEFI has no vendor/customer logical stores; these platform
+        # policy flags are intentionally always False for the generic backend.
+        "policy": {
+            "vendor_store_write": False,
+            "vendor_store_lock": False,
+            "customer_store_write": False,
+            "customer_store_lock": False,
+        },
+    }
+
+
+def cmd_mode():
+    return json_output(_mode())
+
+
+def cmd_keys():
+    result = {}
+    for variable in ("PK", "KEK", "db", "dbx"):
+        result["{}Unified".format(variable)] = _read_variable(variable)
+    return json_output(result)
+
+
+def cmd_key(variable, store):
+    if store != "unified":
+        raise BackendError(
+            "{} store is not supported by the generic UEFI backend".format(store)
+        )
+    return json_output({"{}Unified".format(variable): _read_variable(variable)})
+
+
+def cmd_status():
+    keys = {}
+    for variable in ("PK", "KEK", "db", "dbx"):
+        keys["{}Unified".format(variable)] = _read_variable(variable)
+    return json_output({"mode": _mode(), "keys": keys})
+
+
+def _write_authenticated_variable(variable, auth_file, operation):
+    _require_root()
+
+    path = _variable_path(variable)
+
+    try:
+        with open(auth_file, "rb") as fp:
+            payload = fp.read()
+    except OSError as exc:
+        raise BackendError("failed to read authenticated-variable file: {}".format(exc))
+
+    if not payload:
+        raise BackendError("authenticated-variable file is empty")
+
+    # The payload is passed unchanged to the firmware UEFI variable service.
+    # The firmware remains the cryptographic authorization boundary: it
+    # validates the authenticated-variable signature, timestamp/replay
+    # protection, and authorization chain. This backend deliberately does not
+    # re-implement that verification in Python.
+    #
+    # Operation -> efivarfs attribute mapping:
+    #   append -> DEFAULT_ATTRIBUTES | EFI_VARIABLE_APPEND_WRITE
+    #   update -> DEFAULT_ATTRIBUTES (authenticated replacement semantics)
+    #   remove -> DEFAULT_ATTRIBUTES (authenticated payload controls removal)
+    attributes = DEFAULT_ATTRIBUTES
+
+    if operation == "append":
+        attributes |= EFI_VARIABLE_APPEND_WRITE
+    elif operation not in ("update", "remove"):
+        raise BackendError("unsupported Secure Boot update operation: {}".format(operation))
+
+    # efivarfs write format:
+    #
+    #   UINT32 attributes
+    #   variable payload
+    #
+    # For authenticated Secure Boot variables, the payload must already
+    # contain the UEFI authenticated-variable structure expected by firmware.
+    raw = struct.pack("<I", attributes) + payload
+
+    try:
+        with open(path, "wb") as fp:
+            fp.write(raw)
+    except OSError as exc:
+        raise BackendError("Secure Boot update failed: {}".format(exc))
+
+    return json_output({"result": "success", "variable": variable, "operation": operation})
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="SONiC generic UEFI Secure Boot backend")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("status")
+    subparsers.add_parser("mode")
+    subparsers.add_parser("keys")
+
+    key_parser = subparsers.add_parser("key")
+    key_parser.add_argument("variable", choices=["PK", "KEK", "db", "dbx"])
+    key_parser.add_argument("--store", choices=["vendor", "customer", "unified"], default="unified")
+
+    update_parser = subparsers.add_parser("update")
+    update_parser.add_argument("variable", choices=["PK", "KEK", "db", "dbx"])
+    update_parser.add_argument("--file", required=True)
+    update_parser.add_argument("--operation", choices=["append", "update", "remove"], default="update")
+
+    return parser
+
+
+def main():
+    if not _uefi_available():
+        return json_error("standard UEFI variable services are not available")
+
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        if args.command == "status":
+            return cmd_status()
+        if args.command == "mode":
+            return cmd_mode()
+        if args.command == "keys":
+            return cmd_keys()
+        if args.command == "key":
+            return cmd_key(args.variable, args.store)
+        if args.command == "update":
+            return _write_authenticated_variable(args.variable, args.file, args.operation)
+        return json_error("missing Secure Boot backend operation")
+    except BackendError as exc:
+        return json_error(str(exc))
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/secure_boot/secure_boot_backend.py
+++ b/secure_boot/secure_boot_backend.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+"""
+SONiC Secure Boot backend selector.
+
+This is the stable ``/usr/sbin/secure-boot-backend`` entry point used by the
+``show secure-boot`` and ``config secure-boot`` CLI commands. It does not
+implement any Secure Boot logic itself; it only selects the backend that does
+and hands control to it unchanged.
+
+Selection order:
+
+1. Explicitly registered platform backend.
+2. SONiC generic UEFI backend when standard UEFI variable services are
+   available.
+3. Report Secure Boot management unsupported.
+"""
+
+import json
+import os
+import sys
+
+PLATFORM_BACKEND = "/usr/lib/sonic/secure-boot/platform-backend"
+GENERIC_UEFI_BACKEND = "/usr/lib/sonic/secure-boot/generic-uefi-backend"
+
+# Linux exposes UEFI runtime variables here when EFI variable services
+# are available to the operating system.
+EFIVARS_PATH = "/sys/firmware/efi/efivars"
+
+
+def _error(message, rc=1):
+    print(json.dumps({"error": message}))
+    return rc
+
+
+def _is_executable(path):
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def _uefi_services_available():
+    return os.path.isdir(EFIVARS_PATH)
+
+
+def _select_backend():
+    """Return the Secure Boot backend executable per the HLD selection order."""
+
+    # 1. Explicit platform override takes precedence.
+    if _is_executable(PLATFORM_BACKEND):
+        return PLATFORM_BACKEND
+
+    # 2. Fall back to SONiC generic UEFI implementation.
+    if _uefi_services_available() and _is_executable(GENERIC_UEFI_BACKEND):
+        return GENERIC_UEFI_BACKEND
+
+    # 3. Secure Boot management is unsupported.
+    return None
+
+
+def main():
+    backend = _select_backend()
+
+    if backend is None:
+        return _error("Secure Boot management is not supported on this platform")
+
+    try:
+        # Replace the selector process so stdout/stderr/return code come
+        # directly from the selected backend.
+        os.execv(backend, [backend] + sys.argv[1:])
+    except OSError as exc:
+        return _error("failed to execute Secure Boot backend: {}".format(exc))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'pddf_ledutil',
         'syslog_util',
         'rcli',
+        'secure_boot',
         'show',
         'show.interfaces',
         'show.plugins',

--- a/show/main.py
+++ b/show/main.py
@@ -77,6 +77,7 @@ from . import switch
 from . import icmp
 from . import copp
 from . import orchagent
+from . import secure_boot
 
 # Global Variables
 PLATFORM_JSON = 'platform.json'
@@ -347,6 +348,7 @@ cli.add_command(switch.switch)
 cli.add_command(icmp.icmp)
 cli.add_command(copp.copp)
 cli.add_command(orchagent.orchagent)
+cli.add_command(secure_boot.secure_boot)
 
 # syslog module
 cli.add_command(syslog.syslog)

--- a/show/secure_boot.py
+++ b/show/secure_boot.py
@@ -12,15 +12,24 @@ try:
 except Exception:  # pragma: no cover
     GROUP_CLS = click.Group
 
-BACKEND = "/usr/sbin/tam-uefi-tool"
+BACKEND = "/usr/sbin/secure-boot-backend"
 TIMEOUT = 180
+
 
 class BackendError(RuntimeError):
     pass
 
+
 def run_backend(*args):
     try:
-        cp = subprocess.run([BACKEND] + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=TIMEOUT, check=False)
+        cp = subprocess.run(
+            [BACKEND] + list(args),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=TIMEOUT,
+            check=False,
+        )
     except FileNotFoundError:
         raise BackendError(f"{BACKEND} is not installed")
     except subprocess.TimeoutExpired:
@@ -33,10 +42,12 @@ def run_backend(*args):
         raise BackendError(data.get("error", "secure boot backend failed"))
     return data
 
+
 @click.group(name="secure-boot", cls=GROUP_CLS)
 def secure_boot():
     """Show Secure Boot certificate backend state."""
     pass
+
 
 @secure_boot.command()
 def status():
@@ -49,12 +60,24 @@ def status():
     click.echo("Secure Boot Backend: platform")
     click.echo("UEFI Mode: {} ({}, {})".format(m["raw"], m["hex"], m["name"]))
     click.echo("")
-    rows=[]; keys=data["keys"]
+    rows = []
+    keys = data["keys"]
     for var in ("PK", "KEK", "db", "dbx"):
-        vendor=keys.get(f"{var}Vendor", {})
-        customer=keys.get(f"{var}Customer", {})
-        rows.append([var, vendor.get("state","unknown"), vendor.get("entry_count","-"), customer.get("state","unknown"), customer.get("entry_count","-")])
-    click.echo(tabulate(rows, headers=["Variable","Vendor State","Vendor Entries","Customer State","Customer Entries"], tablefmt="simple"))
+        vendor = keys.get(f"{var}Vendor", {})
+        customer = keys.get(f"{var}Customer", {})
+        rows.append([
+            var,
+            vendor.get("state", "unknown"),
+            vendor.get("entry_count", "-"),
+            customer.get("state", "unknown"),
+            customer.get("entry_count", "-"),
+        ])
+    click.echo(tabulate(
+        rows,
+        headers=["Variable", "Vendor State", "Vendor Entries", "Customer State", "Customer Entries"],
+        tablefmt="simple",
+    ))
+
 
 @secure_boot.command()
 def mode():
@@ -73,6 +96,7 @@ def mode():
     ]
     click.echo(tabulate(rows, tablefmt="plain"))
 
+
 @secure_boot.command(name="keys")
 def keys_cmd():
     """Show PK/KEK/db/dbx state."""
@@ -80,16 +104,17 @@ def keys_cmd():
         data = run_backend("keys")
     except BackendError as exc:
         raise click.ClickException(str(exc))
-    rows=[]
-    for var in ("PK","KEK","db","dbx"):
-        for store,suffix in (("vendor","Vendor"),("customer","Customer")):
-            item=data.get(f"{var}{suffix}", {})
-            rows.append([var,store,item.get("state","unknown"),item.get("entry_count","-")])
-    click.echo(tabulate(rows, headers=["Variable","Store","State","Entries"], tablefmt="simple"))
+    rows = []
+    for var in ("PK", "KEK", "db", "dbx"):
+        for store, suffix in (("vendor", "Vendor"), ("customer", "Customer")):
+            item = data.get(f"{var}{suffix}", {})
+            rows.append([var, store, item.get("state", "unknown"), item.get("entry_count", "-")])
+    click.echo(tabulate(rows, headers=["Variable", "Store", "State", "Entries"], tablefmt="simple"))
+
 
 @secure_boot.command(name="key")
-@click.argument("variable", type=click.Choice(["PK","KEK","db","dbx"], case_sensitive=False))
-@click.option("--store", type=click.Choice(["vendor","customer"]), default="customer", show_default=True)
+@click.argument("variable", type=click.Choice(["PK", "KEK", "db", "dbx"], case_sensitive=False))
+@click.option("--store", type=click.Choice(["vendor", "customer", "unified"]), default="customer", show_default=True)
 def key_cmd(variable, store):
     """Show one Secure Boot variable state."""
     try:
@@ -97,5 +122,10 @@ def key_cmd(variable, store):
     except BackendError as exc:
         raise click.ClickException(str(exc))
     item = next(iter(data.values()))
-    rows = [["Variable", variable], ["Store", store], ["State", item.get("state","unknown")], ["Entries", item.get("entry_count","-")]]
+    rows = [
+        ["Variable", variable],
+        ["Store", store],
+        ["State", item.get("state", "unknown")],
+        ["Entries", item.get("entry_count", "-")],
+    ]
     click.echo(tabulate(rows, tablefmt="plain"))

--- a/show/secure_boot.py
+++ b/show/secure_boot.py
@@ -1,10 +1,9 @@
 """show secure-boot commands."""
 
-import json
-import subprocess
-
 import click
 from tabulate import tabulate
+
+from utilities_common.secure_boot import BackendError, run_backend
 
 try:
     import utilities_common.cli as clicommon
@@ -12,35 +11,7 @@ try:
 except Exception:  # pragma: no cover
     GROUP_CLS = click.Group
 
-BACKEND = "/usr/sbin/secure-boot-backend"
 TIMEOUT = 180
-
-
-class BackendError(RuntimeError):
-    pass
-
-
-def run_backend(*args):
-    try:
-        cp = subprocess.run(
-            [BACKEND] + list(args),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            timeout=TIMEOUT,
-            check=False,
-        )
-    except FileNotFoundError:
-        raise BackendError(f"{BACKEND} is not installed")
-    except subprocess.TimeoutExpired:
-        raise BackendError("secure boot backend timed out")
-    try:
-        data = json.loads(cp.stdout or "{}")
-    except json.JSONDecodeError:
-        raise BackendError("invalid backend response: {}".format((cp.stdout or "").strip()))
-    if cp.returncode != 0 or "error" in data:
-        raise BackendError(data.get("error", "secure boot backend failed"))
-    return data
 
 
 @click.group(name="secure-boot", cls=GROUP_CLS)
@@ -53,15 +24,26 @@ def secure_boot():
 def status():
     """Show Secure Boot backend mode and key state."""
     try:
-        data = run_backend("status")
+        data = run_backend(("status",), TIMEOUT)
     except BackendError as exc:
         raise click.ClickException(str(exc))
     m = data["mode"]
-    click.echo("Secure Boot Backend: platform")
     click.echo("UEFI Mode: {} ({}, {})".format(m["raw"], m["hex"], m["name"]))
     click.echo("")
-    rows = []
     keys = data["keys"]
+    has_unified = any(f"{var}Unified" in keys for var in ("PK", "KEK", "db", "dbx"))
+    if has_unified:
+        rows = []
+        for var in ("PK", "KEK", "db", "dbx"):
+            item = keys.get(f"{var}Unified", {})
+            rows.append([var, item.get("state", "unknown"), item.get("entry_count", "-")])
+        click.echo(tabulate(
+            rows,
+            headers=["Variable", "State", "Entries"],
+            tablefmt="simple",
+        ))
+        return
+    rows = []
     for var in ("PK", "KEK", "db", "dbx"):
         vendor = keys.get(f"{var}Vendor", {})
         customer = keys.get(f"{var}Customer", {})
@@ -83,7 +65,7 @@ def status():
 def mode():
     """Show Secure Boot backend mode."""
     try:
-        data = run_backend("mode")
+        data = run_backend(("mode",), TIMEOUT)
     except BackendError as exc:
         raise click.ClickException(str(exc))
     rows = [
@@ -101,11 +83,15 @@ def mode():
 def keys_cmd():
     """Show PK/KEK/db/dbx state."""
     try:
-        data = run_backend("keys")
+        data = run_backend(("keys",), TIMEOUT)
     except BackendError as exc:
         raise click.ClickException(str(exc))
     rows = []
     for var in ("PK", "KEK", "db", "dbx"):
+        unified = data.get(f"{var}Unified")
+        if unified is not None:
+            rows.append([var, "unified", unified.get("state", "unknown"), unified.get("entry_count", "-")])
+            continue
         for store, suffix in (("vendor", "Vendor"), ("customer", "Customer")):
             item = data.get(f"{var}{suffix}", {})
             rows.append([var, store, item.get("state", "unknown"), item.get("entry_count", "-")])
@@ -114,17 +100,34 @@ def keys_cmd():
 
 @secure_boot.command(name="key")
 @click.argument("variable", type=click.Choice(["PK", "KEK", "db", "dbx"], case_sensitive=False))
-@click.option("--store", type=click.Choice(["vendor", "customer", "unified"]), default="customer", show_default=True)
+@click.option("--store", type=click.Choice(["vendor", "customer", "unified"]), default=None)
 def key_cmd(variable, store):
     """Show one Secure Boot variable state."""
+    # Omitting --store lets the selected backend pick its natural default
+    # (unified for generic UEFI, customer for platform backends).
+    args = ["key", variable]
+    if store is not None:
+        args.extend(["--store", store])
     try:
-        data = run_backend("key", variable, "--store", store)
+        data = run_backend(tuple(args), TIMEOUT)
     except BackendError as exc:
         raise click.ClickException(str(exc))
-    item = next(iter(data.values()))
+    if not data:
+        raise click.ClickException("invalid empty backend response")
+    key_name, item = next(iter(data.items()))
+    if store is not None:
+        display_store = store
+    elif key_name.endswith("Unified"):
+        display_store = "unified"
+    elif key_name.endswith("Vendor"):
+        display_store = "vendor"
+    elif key_name.endswith("Customer"):
+        display_store = "customer"
+    else:
+        display_store = "unknown"
     rows = [
         ["Variable", variable],
-        ["Store", store],
+        ["Store", display_store],
         ["State", item.get("state", "unknown")],
         ["Entries", item.get("entry_count", "-")],
     ]

--- a/show/secure_boot.py
+++ b/show/secure_boot.py
@@ -53,8 +53,8 @@ def status():
     for var in ("PK", "KEK", "db", "dbx"):
         vendor=keys.get(f"{var}Vendor", {})
         customer=keys.get(f"{var}Customer", {})
-        rows.append([var, vendor.get("state","unknown"), vendor.get("certificate_count","-"), customer.get("state","unknown"), customer.get("certificate_count","-")])
-    click.echo(tabulate(rows, headers=["Variable","Vendor State","Vendor Certs","Customer State","Customer Certs"], tablefmt="simple"))
+        rows.append([var, vendor.get("state","unknown"), vendor.get("entry_count","-"), customer.get("state","unknown"), customer.get("entry_count","-")])
+    click.echo(tabulate(rows, headers=["Variable","Vendor State","Vendor Entries","Customer State","Customer Entries"], tablefmt="simple"))
 
 @secure_boot.command()
 def mode():
@@ -84,8 +84,8 @@ def keys_cmd():
     for var in ("PK","KEK","db","dbx"):
         for store,suffix in (("vendor","Vendor"),("customer","Customer")):
             item=data.get(f"{var}{suffix}", {})
-            rows.append([var,store,item.get("state","unknown"),item.get("certificate_count","-")])
-    click.echo(tabulate(rows, headers=["Variable","Store","State","Certificates"], tablefmt="simple"))
+            rows.append([var,store,item.get("state","unknown"),item.get("entry_count","-")])
+    click.echo(tabulate(rows, headers=["Variable","Store","State","Entries"], tablefmt="simple"))
 
 @secure_boot.command(name="key")
 @click.argument("variable", type=click.Choice(["PK","KEK","db","dbx"], case_sensitive=False))
@@ -97,5 +97,5 @@ def key_cmd(variable, store):
     except BackendError as exc:
         raise click.ClickException(str(exc))
     item = next(iter(data.values()))
-    rows = [["Variable", variable], ["Store", store], ["State", item.get("state","unknown")], ["Certificates", item.get("certificate_count","-")]]
+    rows = [["Variable", variable], ["Store", store], ["State", item.get("state","unknown")], ["Entries", item.get("entry_count","-")]]
     click.echo(tabulate(rows, tablefmt="plain"))

--- a/show/secure_boot.py
+++ b/show/secure_boot.py
@@ -1,0 +1,101 @@
+"""show secure-boot commands."""
+
+import json
+import subprocess
+
+import click
+from tabulate import tabulate
+
+try:
+    import utilities_common.cli as clicommon
+    GROUP_CLS = clicommon.AliasedGroup
+except Exception:  # pragma: no cover
+    GROUP_CLS = click.Group
+
+BACKEND = "/usr/sbin/tam-uefi-tool"
+TIMEOUT = 180
+
+class BackendError(RuntimeError):
+    pass
+
+def run_backend(*args):
+    try:
+        cp = subprocess.run([BACKEND] + list(args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=TIMEOUT, check=False)
+    except FileNotFoundError:
+        raise BackendError(f"{BACKEND} is not installed")
+    except subprocess.TimeoutExpired:
+        raise BackendError("secure boot backend timed out")
+    try:
+        data = json.loads(cp.stdout or "{}")
+    except json.JSONDecodeError:
+        raise BackendError("invalid backend response: {}".format((cp.stdout or "").strip()))
+    if cp.returncode != 0 or "error" in data:
+        raise BackendError(data.get("error", "secure boot backend failed"))
+    return data
+
+@click.group(name="secure-boot", cls=GROUP_CLS)
+def secure_boot():
+    """Show Secure Boot certificate backend state."""
+    pass
+
+@secure_boot.command()
+def status():
+    """Show Secure Boot backend mode and key state."""
+    try:
+        data = run_backend("status")
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    m = data["mode"]
+    click.echo("Secure Boot Backend: platform")
+    click.echo("UEFI Mode: {} ({}, {})".format(m["raw"], m["hex"], m["name"]))
+    click.echo("")
+    rows=[]; keys=data["keys"]
+    for var in ("PK", "KEK", "db", "dbx"):
+        vendor=keys.get(f"{var}Vendor", {})
+        customer=keys.get(f"{var}Customer", {})
+        rows.append([var, vendor.get("state","unknown"), vendor.get("certificate_count","-"), customer.get("state","unknown"), customer.get("certificate_count","-")])
+    click.echo(tabulate(rows, headers=["Variable","Vendor State","Vendor Certs","Customer State","Customer Certs"], tablefmt="simple"))
+
+@secure_boot.command()
+def mode():
+    """Show Secure Boot backend mode."""
+    try:
+        data = run_backend("mode")
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    rows = [
+        ["Mode", "{} ({})".format(data["raw"], data["name"])],
+        ["Mode Hex", data["hex"]],
+        ["Vendor store write", "yes" if data["policy"].get("vendor_store_write") else "no"],
+        ["Vendor store lock", "yes" if data["policy"].get("vendor_store_lock") else "no"],
+        ["Customer store write", "yes" if data["policy"].get("customer_store_write") else "no"],
+        ["Customer store lock", "yes" if data["policy"].get("customer_store_lock") else "no"],
+    ]
+    click.echo(tabulate(rows, tablefmt="plain"))
+
+@secure_boot.command(name="keys")
+def keys_cmd():
+    """Show PK/KEK/db/dbx state."""
+    try:
+        data = run_backend("keys")
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    rows=[]
+    for var in ("PK","KEK","db","dbx"):
+        for store,suffix in (("vendor","Vendor"),("customer","Customer")):
+            item=data.get(f"{var}{suffix}", {})
+            rows.append([var,store,item.get("state","unknown"),item.get("certificate_count","-")])
+    click.echo(tabulate(rows, headers=["Variable","Store","State","Certificates"], tablefmt="simple"))
+
+@secure_boot.command(name="key")
+@click.argument("variable", type=click.Choice(["PK","KEK","db","dbx"], case_sensitive=False))
+@click.option("--store", type=click.Choice(["vendor","customer"]), default="customer", show_default=True)
+def key_cmd(variable, store):
+    """Show one Secure Boot variable state."""
+    try:
+        data = run_backend("key", variable, "--store", store)
+    except BackendError as exc:
+        raise click.ClickException(str(exc))
+    item = next(iter(data.values()))
+    rows = [["Variable", variable], ["Store", store], ["State", item.get("state","unknown")], ["Certificates", item.get("certificate_count","-")]]
+    click.echo(tabulate(rows, tablefmt="plain"))

--- a/sonic-utilities-data/debian/install
+++ b/sonic-utilities-data/debian/install
@@ -1,3 +1,5 @@
 build/*                             /etc/bash_completion.d/
 templates/*.j2                      /usr/share/sonic/templates/
 templates/sonic-cli-gen/*.j2        /usr/share/sonic/templates/sonic-cli-gen/
+scripts/secure-boot-backend         /usr/sbin/
+scripts/generic-uefi-backend        /usr/lib/sonic/secure-boot/

--- a/sonic-utilities-data/scripts/generic-uefi-backend
+++ b/sonic-utilities-data/scripts/generic-uefi-backend
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+"""SONiC generic UEFI Secure Boot backend entry point."""
+
+import sys
+
+from secure_boot.generic_uefi_backend import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sonic-utilities-data/scripts/secure-boot-backend
+++ b/sonic-utilities-data/scripts/secure-boot-backend
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+"""SONiC Secure Boot backend selector entry point."""
+
+import sys
+
+from secure_boot.secure_boot_backend import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/secure_boot/test_generic_uefi_backend.py
+++ b/tests/secure_boot/test_generic_uefi_backend.py
@@ -1,0 +1,211 @@
+import io
+import struct
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch, mock_open
+
+from secure_boot import generic_uefi_backend as gb
+
+
+def _signature_list(sig_size=20, header_size=0, entries=2, sig_type=b"\x11" * 16):
+    payload = (b"\x22" * sig_size) * entries
+    list_size = 28 + header_size + len(payload)
+    return (
+        sig_type
+        + struct.pack("<III", list_size, header_size, sig_size)
+        + (b"\x33" * header_size)
+        + payload
+    )
+
+
+class TestSignatureCounting(unittest.TestCase):
+    def test_single_list(self):
+        self.assertEqual(gb._count_signature_entries(_signature_list(entries=3)), 3)
+
+    def test_multiple_lists(self):
+        payload = _signature_list(entries=2) + _signature_list(entries=1, sig_type=b"\x44" * 16)
+        self.assertEqual(gb._count_signature_entries(payload), 3)
+
+    def test_truncated_list_raises(self):
+        with self.assertRaises(gb.BackendError):
+            gb._count_signature_entries(b"\x00" * 10)
+
+    def test_zero_signature_size_raises(self):
+        bad = b"\x11" * 16 + struct.pack("<III", 28, 0, 0)
+        with self.assertRaises(gb.BackendError):
+            gb._count_signature_entries(bad)
+
+    def test_signature_list_invalid_header_size(self):
+        # SignatureHeaderSize pushes the entries start beyond the list end.
+        bad = b"\x11" * 16 + struct.pack("<III", 28, 100, 20)
+        with self.assertRaises(gb.BackendError):
+            gb._count_signature_entries(bad)
+
+
+class TestReadVariable(unittest.TestCase):
+    def test_missing_variable_is_empty(self):
+        with patch("os.path.exists", return_value=False):
+            self.assertEqual(
+                gb._read_variable("db"),
+                {"state": "empty", "entry_count": 0, "data_length": 0},
+            )
+
+    def test_present_variable_counts_entries(self):
+        payload = _signature_list(entries=2)
+        content = b"\x06\x00\x00\x00" + payload  # 4-byte attr word + payload
+        with patch("os.path.exists", return_value=True), \
+             patch("builtins.open", mock_open(read_data=content)):
+            result = gb._read_variable("db")
+        self.assertEqual(result["state"], "present")
+        self.assertEqual(result["entry_count"], 2)
+        self.assertEqual(result["data_length"], len(payload))
+
+    def test_attr_only_is_empty(self):
+        with patch("os.path.exists", return_value=True), \
+             patch("builtins.open", mock_open(read_data=b"\x06\x00\x00\x00")):
+            self.assertEqual(gb._read_variable("db")["state"], "empty")
+
+    def test_read_variable_invalid_attribute_only_length(self):
+        # Fewer than 4 bytes cannot contain the efivarfs attribute word.
+        with patch("os.path.exists", return_value=True), \
+             patch("builtins.open", mock_open(read_data=b"\x00\x00")):
+            with self.assertRaises(gb.BackendError):
+                gb._read_variable("db")
+
+
+class TestMode(unittest.TestCase):
+    def test_secure_boot_enabled(self):
+        def raw(name):
+            return {"SecureBoot": 1, "SetupMode": 0}[name]
+
+        with patch.object(gb, "_read_raw_byte_variable", side_effect=raw):
+            m = gb._mode()
+        self.assertEqual(m["raw"], 1)
+        self.assertEqual(m["name"], "Secure Boot Enabled")
+        self.assertFalse(m["policy"]["vendor_store_write"])
+
+    def test_setup_mode(self):
+        def raw(name):
+            return {"SecureBoot": 0, "SetupMode": 1}[name]
+
+        with patch.object(gb, "_read_raw_byte_variable", side_effect=raw):
+            self.assertEqual(gb._mode()["name"], "Setup Mode")
+
+    def test_mode_unavailable_raises(self):
+        with patch.object(gb, "_read_raw_byte_variable", return_value=None):
+            with self.assertRaises(gb.BackendError):
+                gb._mode()
+
+
+class TestCommands(unittest.TestCase):
+    def test_keys_uses_unified_suffix(self):
+        with patch.object(gb, "_read_variable", return_value={"state": "empty", "entry_count": 0}):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = gb.cmd_keys()
+        self.assertEqual(rc, 0)
+        self.assertIn("PKUnified", buf.getvalue())
+        self.assertNotIn("PKVendor", buf.getvalue())
+
+    def test_key_rejects_vendor_store(self):
+        with self.assertRaises(gb.BackendError):
+            gb.cmd_key("db", "vendor")
+
+    def test_key_rejects_customer_store(self):
+        with self.assertRaises(gb.BackendError):
+            gb.cmd_key("db", "customer")
+
+    def test_key_unified_ok(self):
+        with patch.object(gb, "_read_variable", return_value={"state": "present", "entry_count": 1}):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = gb.cmd_key("db", "unified")
+        self.assertEqual(rc, 0)
+        self.assertIn("dbUnified", buf.getvalue())
+
+
+class TestMain(unittest.TestCase):
+    def test_main_no_uefi_services(self):
+        with patch.object(gb, "_uefi_available", return_value=False):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = gb.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("not available", buf.getvalue())
+
+    def test_main_dispatches_keys(self):
+        with patch.object(gb, "_uefi_available", return_value=True), \
+             patch.object(gb.sys, "argv", ["x", "keys"]), \
+             patch.object(gb, "_read_variable", return_value={"state": "empty", "entry_count": 0}):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = gb.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("dbxUnified", buf.getvalue())
+
+    def test_main_backend_error_is_json(self):
+        with patch.object(gb, "_uefi_available", return_value=True), \
+             patch.object(gb.sys, "argv", ["x", "key", "db", "--store", "vendor"]):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = gb.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("not supported", buf.getvalue())
+
+
+class TestUpdate(unittest.TestCase):
+    def test_update_requires_root(self):
+        with patch("os.geteuid", return_value=1000):
+            with self.assertRaises(gb.BackendError):
+                gb._write_authenticated_variable("db", "/tmp/x.auth", "update")
+
+    def test_update_empty_file_rejected(self):
+        with patch("os.geteuid", return_value=0), \
+             patch("builtins.open", mock_open(read_data=b"")):
+            with self.assertRaises(gb.BackendError):
+                gb._write_authenticated_variable("db", "/tmp/x.auth", "update")
+
+    @staticmethod
+    def _run_update(variable, operation, payload=b"authpayload"):
+        written = {}
+        m = mock_open(read_data=payload)
+
+        def open_side_effect(path, mode="r", *args, **kwargs):
+            handle = m(path, mode, *args, **kwargs)
+            if "w" in mode:
+                def _capture(data):
+                    written["path"] = path
+                    written["data"] = data
+                handle.write.side_effect = _capture
+            return handle
+
+        with patch("os.geteuid", return_value=0), \
+             patch("builtins.open", side_effect=open_side_effect):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = gb._write_authenticated_variable(variable, "/tmp/x.auth", operation)
+        return rc, buf.getvalue(), written
+
+    def test_update_append_sets_attribute_and_writes(self):
+        rc, out, written = self._run_update("db", "append")
+        self.assertEqual(rc, 0)
+        self.assertIn("success", out)
+        attr = struct.unpack("<I", written["data"][:4])[0]
+        self.assertTrue(attr & gb.EFI_VARIABLE_APPEND_WRITE)
+        self.assertEqual(written["data"][4:], b"authpayload")
+
+    def test_update_remove_does_not_set_append(self):
+        rc, _, written = self._run_update("dbx", "remove")
+        self.assertEqual(rc, 0)
+        attr = struct.unpack("<I", written["data"][:4])[0]
+        self.assertFalse(attr & gb.EFI_VARIABLE_APPEND_WRITE)
+
+    def test_update_update_does_not_set_append(self):
+        rc, _, written = self._run_update("db", "update")
+        self.assertEqual(rc, 0)
+        attr = struct.unpack("<I", written["data"][:4])[0]
+        self.assertFalse(attr & gb.EFI_VARIABLE_APPEND_WRITE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/secure_boot/test_secure_boot_backend.py
+++ b/tests/secure_boot/test_secure_boot_backend.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import patch
+
+from secure_boot import secure_boot_backend
+
+
+class TestSelectBackend(unittest.TestCase):
+    def test_platform_backend_preferred(self):
+        with patch.object(
+            secure_boot_backend,
+            "_is_executable",
+            lambda path: path == secure_boot_backend.PLATFORM_BACKEND,
+        ), patch.object(
+            secure_boot_backend, "_uefi_services_available", lambda: True
+        ):
+            self.assertEqual(
+                secure_boot_backend._select_backend(),
+                secure_boot_backend.PLATFORM_BACKEND,
+            )
+
+    def test_platform_backend_preferred_when_both_available(self):
+        with patch.object(
+            secure_boot_backend,
+            "_is_executable",
+            lambda path: path in (
+                secure_boot_backend.PLATFORM_BACKEND,
+                secure_boot_backend.GENERIC_UEFI_BACKEND,
+            ),
+        ), patch.object(
+            secure_boot_backend, "_uefi_services_available", lambda: True
+        ):
+            self.assertEqual(
+                secure_boot_backend._select_backend(),
+                secure_boot_backend.PLATFORM_BACKEND,
+            )
+
+    def test_generic_backend_fallback(self):
+        def executable(path):
+            return path == secure_boot_backend.GENERIC_UEFI_BACKEND
+
+        with patch.object(
+            secure_boot_backend, "_is_executable", executable
+        ), patch.object(
+            secure_boot_backend, "_uefi_services_available", lambda: True
+        ):
+            self.assertEqual(
+                secure_boot_backend._select_backend(),
+                secure_boot_backend.GENERIC_UEFI_BACKEND,
+            )
+
+    def test_generic_backend_not_selected_without_uefi(self):
+        # Generic backend present but UEFI services unavailable -> unsupported.
+        def executable(path):
+            return path == secure_boot_backend.GENERIC_UEFI_BACKEND
+
+        with patch.object(
+            secure_boot_backend, "_is_executable", executable
+        ), patch.object(
+            secure_boot_backend, "_uefi_services_available", lambda: False
+        ):
+            self.assertIsNone(secure_boot_backend._select_backend())
+
+    def test_backend_unsupported(self):
+        with patch.object(
+            secure_boot_backend, "_is_executable", lambda path: False
+        ), patch.object(
+            secure_boot_backend, "_uefi_services_available", lambda: False
+        ):
+            self.assertIsNone(secure_boot_backend._select_backend())
+
+
+class TestMain(unittest.TestCase):
+    def test_main_unsupported_reports_error(self):
+        with patch.object(secure_boot_backend, "_select_backend", lambda: None):
+            with patch("builtins.print") as mock_print:
+                rc = secure_boot_backend.main()
+        self.assertEqual(rc, 1)
+        printed = mock_print.call_args[0][0]
+        self.assertIn("not supported", printed)
+
+    def test_main_execs_selected_backend(self):
+        with patch.object(
+            secure_boot_backend,
+            "_select_backend",
+            lambda: secure_boot_backend.PLATFORM_BACKEND,
+        ):
+            with patch("secure_boot.secure_boot_backend.os.execv") as execv:
+                with patch.object(secure_boot_backend.sys, "argv", ["x", "status"]):
+                    secure_boot_backend.main()
+        execv.assert_called_once_with(
+            secure_boot_backend.PLATFORM_BACKEND,
+            [secure_boot_backend.PLATFORM_BACKEND, "status"],
+        )
+
+    def test_main_exec_failure_reports_error(self):
+        with patch.object(
+            secure_boot_backend,
+            "_select_backend",
+            lambda: secure_boot_backend.PLATFORM_BACKEND,
+        ):
+            with patch(
+                "secure_boot.secure_boot_backend.os.execv",
+                side_effect=OSError("boom"),
+            ):
+                with patch("builtins.print") as mock_print:
+                    rc = secure_boot_backend.main()
+        self.assertEqual(rc, 1)
+        printed = mock_print.call_args[0][0]
+        self.assertIn("failed to execute", printed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/secure_boot/test_secure_boot_cli.py
+++ b/tests/secure_boot/test_secure_boot_cli.py
@@ -6,14 +6,18 @@ from click.testing import CliRunner
 
 from show.secure_boot import (
     secure_boot as show_secure_boot,
-    run_backend as show_run_backend,
-    BackendError as ShowBackendError,
 )
 from config.secure_boot import (
     secure_boot as config_secure_boot,
-    run_backend as config_run_backend,
-    BackendError as ConfigBackendError,
 )
+from utilities_common.secure_boot import (
+    run_backend,
+    BackendError,
+)
+
+# Backwards-compatible aliases used throughout the tests.
+ShowBackendError = BackendError
+ConfigBackendError = BackendError
 
 MODE = {
     "raw": 11,
@@ -35,6 +39,12 @@ KEYS = {
     "KEKCustomer": {"state": "empty", "entry_count": 0},
     "dbCustomer": {"state": "empty", "entry_count": 0},
     "dbxCustomer": {"state": "empty", "entry_count": 0},
+}
+KEYS_UNIFIED = {
+    "PKUnified": {"state": "present", "entry_count": 1},
+    "KEKUnified": {"state": "present", "entry_count": 2},
+    "dbUnified": {"state": "present", "entry_count": 3},
+    "dbxUnified": {"state": "empty", "entry_count": 0},
 }
 
 
@@ -69,6 +79,17 @@ class TestShowSecureBoot(unittest.TestCase):
         self.assertIn("boom", r.output)
 
     @patch("show.secure_boot.run_backend")
+    def test_show_status_unified(self, backend):
+        backend.return_value = {"mode": MODE, "keys": KEYS_UNIFIED}
+        r = CliRunner().invoke(show_secure_boot, ["status"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("PK", r.output)
+        self.assertIn("present", r.output)
+        # Unified rendering must not show vendor/customer columns.
+        self.assertNotIn("Vendor State", r.output)
+        self.assertNotIn("Customer State", r.output)
+
+    @patch("show.secure_boot.run_backend")
     def test_show_keys(self, backend):
         backend.return_value = KEYS
         r = CliRunner().invoke(show_secure_boot, ["keys"])
@@ -84,6 +105,15 @@ class TestShowSecureBoot(unittest.TestCase):
         self.assertIn("boom", r.output)
 
     @patch("show.secure_boot.run_backend")
+    def test_show_keys_unified(self, backend):
+        backend.return_value = KEYS_UNIFIED
+        r = CliRunner().invoke(show_secure_boot, ["keys"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("unified", r.output)
+        self.assertNotIn("vendor", r.output)
+        self.assertNotIn("customer", r.output)
+
+    @patch("show.secure_boot.run_backend")
     def test_show_key(self, backend):
         backend.return_value = {"dbCustomer": {"state": "present", "entry_count": 4}}
         r = CliRunner().invoke(show_secure_boot, ["key", "db", "--store", "customer"])
@@ -91,12 +121,27 @@ class TestShowSecureBoot(unittest.TestCase):
         self.assertIn("present", r.output)
 
     @patch("show.secure_boot.run_backend")
+    def test_show_key_without_store(self, backend):
+        backend.return_value = {"dbUnified": {"state": "present", "entry_count": 3}}
+        r = CliRunner().invoke(show_secure_boot, ["key", "db"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("unified", r.output)
+        backend.assert_called_once_with(("key", "db"), 180)
+
+    @patch("show.secure_boot.run_backend")
     def test_show_key_unified_store(self, backend):
         backend.return_value = {"dbUnified": {"state": "present", "entry_count": 5}}
         r = CliRunner().invoke(show_secure_boot, ["key", "db", "--store", "unified"])
         self.assertEqual(r.exit_code, 0)
         self.assertIn("unified", r.output)
-        backend.assert_called_once_with("key", "db", "--store", "unified")
+        backend.assert_called_once_with(("key", "db", "--store", "unified"), 180)
+
+    @patch("show.secure_boot.run_backend")
+    def test_show_key_empty_response(self, backend):
+        backend.return_value = {}
+        r = CliRunner().invoke(show_secure_boot, ["key", "db"])
+        self.assertNotEqual(r.exit_code, 0)
+        self.assertIn("invalid empty backend response", r.output)
 
     @patch("show.secure_boot.run_backend")
     def test_show_key_backend_error(self, backend):
@@ -133,71 +178,69 @@ class TestConfigSecureBoot(unittest.TestCase):
 
 class TestRunBackend(unittest.TestCase):
     @staticmethod
-    def _cp(stdout, rc=0):
+    def _cp(stdout, rc=0, stderr=""):
         cp = MagicMock()
         cp.stdout = stdout
+        cp.stderr = stderr
         cp.returncode = rc
         return cp
 
-    @patch("show.secure_boot.subprocess.run")
-    def test_show_run_backend_success(self, run):
+    @patch("utilities_common.secure_boot.subprocess.run")
+    def test_run_backend_success(self, run):
         run.return_value = self._cp('{"mode": "ok"}')
-        self.assertEqual(show_run_backend("mode"), {"mode": "ok"})
+        self.assertEqual(run_backend(("mode",), 180), {"mode": "ok"})
 
-    @patch("show.secure_boot.subprocess.run", side_effect=FileNotFoundError)
-    def test_show_run_backend_not_installed(self, run):
-        with self.assertRaises(ShowBackendError):
-            show_run_backend("mode")
-
-    @patch(
-        "show.secure_boot.subprocess.run",
-        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1),
-    )
-    def test_show_run_backend_timeout(self, run):
-        with self.assertRaises(ShowBackendError):
-            show_run_backend("mode")
-
-    @patch("show.secure_boot.subprocess.run")
-    def test_show_run_backend_bad_json(self, run):
-        run.return_value = self._cp("not json")
-        with self.assertRaises(ShowBackendError):
-            show_run_backend("mode")
-
-    @patch("show.secure_boot.subprocess.run")
-    def test_show_run_backend_error_field(self, run):
-        run.return_value = self._cp('{"error": "nope"}', rc=1)
-        with self.assertRaises(ShowBackendError):
-            show_run_backend("mode")
-
-    @patch("config.secure_boot.subprocess.run")
-    def test_config_run_backend_success(self, run):
-        run.return_value = self._cp('{"ok": true}')
-        self.assertEqual(config_run_backend("update"), {"ok": True})
-
-    @patch("config.secure_boot.subprocess.run", side_effect=FileNotFoundError)
-    def test_config_run_backend_not_installed(self, run):
-        with self.assertRaises(ConfigBackendError):
-            config_run_backend("update")
+    @patch("utilities_common.secure_boot.subprocess.run", side_effect=FileNotFoundError)
+    def test_run_backend_not_installed(self, run):
+        with self.assertRaises(BackendError):
+            run_backend(("mode",), 180)
 
     @patch(
-        "config.secure_boot.subprocess.run",
+        "utilities_common.secure_boot.subprocess.run",
         side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1),
     )
-    def test_config_run_backend_timeout(self, run):
-        with self.assertRaises(ConfigBackendError):
-            config_run_backend("update")
+    def test_run_backend_timeout(self, run):
+        with self.assertRaises(BackendError):
+            run_backend(("mode",), 180)
 
-    @patch("config.secure_boot.subprocess.run")
-    def test_config_run_backend_bad_json(self, run):
+    @patch("utilities_common.secure_boot.subprocess.run")
+    def test_run_backend_bad_json(self, run):
         run.return_value = self._cp("not json")
-        with self.assertRaises(ConfigBackendError):
-            config_run_backend("update")
+        with self.assertRaises(BackendError):
+            run_backend(("mode",), 180)
 
-    @patch("config.secure_boot.subprocess.run")
-    def test_config_run_backend_error_field(self, run):
+    @patch("utilities_common.secure_boot.subprocess.run")
+    def test_run_backend_bad_json_surfaces_stderr(self, run):
+        # Malformed stdout on a failed backend must not hide the stderr
+        # diagnostic.
+        run.return_value = self._cp("garbage", rc=1, stderr="useful platform error\n")
+        with self.assertRaises(BackendError) as ctx:
+            run_backend(("mode",), 180)
+        self.assertIn("useful platform error", str(ctx.exception))
+
+    @patch("utilities_common.secure_boot.subprocess.run")
+    def test_run_backend_error_field(self, run):
         run.return_value = self._cp('{"error": "nope"}', rc=1)
-        with self.assertRaises(ConfigBackendError):
-            config_run_backend("update")
+        with self.assertRaises(BackendError) as ctx:
+            run_backend(("mode",), 180)
+        self.assertIn("nope", str(ctx.exception))
+
+    @patch("utilities_common.secure_boot.subprocess.run")
+    def test_run_backend_stderr_fallback(self, run):
+        # Non-zero return code with valid JSON and no "error" field falls
+        # back to the stderr diagnostic.
+        run.return_value = self._cp("{}", rc=1, stderr="backend diagnostic\n")
+        with self.assertRaises(BackendError) as ctx:
+            run_backend(("update",), 300)
+        self.assertIn("backend diagnostic", str(ctx.exception))
+
+    @patch("utilities_common.secure_boot.subprocess.run")
+    def test_run_backend_failure_default_message(self, run):
+        # Non-zero return code with no error field and no stderr.
+        run.return_value = self._cp("{}", rc=1, stderr="")
+        with self.assertRaises(BackendError) as ctx:
+            run_backend(("update",), 300)
+        self.assertIn("secure boot backend failed", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/secure_boot/test_secure_boot_cli.py
+++ b/tests/secure_boot/test_secure_boot_cli.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch
+from click.testing import CliRunner
+from show.secure_boot import secure_boot as show_secure_boot
+from config.secure_boot import secure_boot as config_secure_boot
+
+MODE = {"raw": 11, "hex": "0x000b", "name": "Generic Mode", "policy": {"vendor_store_write": True, "vendor_store_lock": True, "customer_store_write": False, "customer_store_lock": True}}
+KEYS = {"PKVendor":{"state":"present","certificate_count":1},"KEKVendor":{"state":"present","certificate_count":2},"dbVendor":{"state":"present","certificate_count":3},"dbxVendor":{"state":"empty","certificate_count":0},"PKCustomer":{"state":"empty","certificate_count":0},"KEKCustomer":{"state":"empty","certificate_count":0},"dbCustomer":{"state":"empty","certificate_count":0},"dbxCustomer":{"state":"empty","certificate_count":0}}
+
+class TestShowSecureBoot(unittest.TestCase):
+    @patch("show.secure_boot.run_backend")
+    def test_show_mode(self, backend):
+        backend.return_value = MODE
+        r = CliRunner().invoke(show_secure_boot, ["mode"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("Generic Mode", r.output)
+
+    @patch("show.secure_boot.run_backend")
+    def test_show_status(self, backend):
+        backend.return_value = {"mode": MODE, "keys": KEYS}
+        r = CliRunner().invoke(show_secure_boot, ["status"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("PK", r.output)
+        self.assertIn("present", r.output)
+
+class TestConfigSecureBoot(unittest.TestCase):
+    @patch("config.secure_boot.run_backend")
+    def test_update(self, backend):
+        backend.return_value = {"result":"success", "variable":"db", "operation":"append"}
+        with CliRunner().isolated_filesystem():
+            with open("db.auth", "w") as f: f.write("dummy")
+            r = CliRunner().invoke(config_secure_boot, ["certificate","update","db","db.auth","--operation","append"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("submitted successfully", r.output)
+
+    def test_mode_set_requires_yes(self):
+        with CliRunner().isolated_filesystem():
+            with open("ov.cms", "w") as f: f.write("dummy")
+            r = CliRunner().invoke(config_secure_boot, ["mode","set","ov.cms"])
+        self.assertNotEqual(r.exit_code, 0)
+        self.assertIn("--yes", r.output)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/secure_boot/test_secure_boot_cli.py
+++ b/tests/secure_boot/test_secure_boot_cli.py
@@ -5,7 +5,7 @@ from show.secure_boot import secure_boot as show_secure_boot
 from config.secure_boot import secure_boot as config_secure_boot
 
 MODE = {"raw": 11, "hex": "0x000b", "name": "Generic Mode", "policy": {"vendor_store_write": True, "vendor_store_lock": True, "customer_store_write": False, "customer_store_lock": True}}
-KEYS = {"PKVendor":{"state":"present","certificate_count":1},"KEKVendor":{"state":"present","certificate_count":2},"dbVendor":{"state":"present","certificate_count":3},"dbxVendor":{"state":"empty","certificate_count":0},"PKCustomer":{"state":"empty","certificate_count":0},"KEKCustomer":{"state":"empty","certificate_count":0},"dbCustomer":{"state":"empty","certificate_count":0},"dbxCustomer":{"state":"empty","certificate_count":0}}
+KEYS = {"PKVendor":{"state":"present","entry_count":1},"KEKVendor":{"state":"present","entry_count":2},"dbVendor":{"state":"present","entry_count":3},"dbxVendor":{"state":"empty","entry_count":0},"PKCustomer":{"state":"empty","entry_count":0},"KEKCustomer":{"state":"empty","entry_count":0},"dbCustomer":{"state":"empty","entry_count":0},"dbxCustomer":{"state":"empty","entry_count":0}}
 
 class TestShowSecureBoot(unittest.TestCase):
     @patch("show.secure_boot.run_backend")

--- a/tests/secure_boot/test_secure_boot_cli.py
+++ b/tests/secure_boot/test_secure_boot_cli.py
@@ -1,11 +1,42 @@
+import subprocess
 import unittest
-from unittest.mock import patch
-from click.testing import CliRunner
-from show.secure_boot import secure_boot as show_secure_boot
-from config.secure_boot import secure_boot as config_secure_boot
+from unittest.mock import patch, MagicMock
 
-MODE = {"raw": 11, "hex": "0x000b", "name": "Generic Mode", "policy": {"vendor_store_write": True, "vendor_store_lock": True, "customer_store_write": False, "customer_store_lock": True}}
-KEYS = {"PKVendor":{"state":"present","entry_count":1},"KEKVendor":{"state":"present","entry_count":2},"dbVendor":{"state":"present","entry_count":3},"dbxVendor":{"state":"empty","entry_count":0},"PKCustomer":{"state":"empty","entry_count":0},"KEKCustomer":{"state":"empty","entry_count":0},"dbCustomer":{"state":"empty","entry_count":0},"dbxCustomer":{"state":"empty","entry_count":0}}
+from click.testing import CliRunner
+
+from show.secure_boot import (
+    secure_boot as show_secure_boot,
+    run_backend as show_run_backend,
+    BackendError as ShowBackendError,
+)
+from config.secure_boot import (
+    secure_boot as config_secure_boot,
+    run_backend as config_run_backend,
+    BackendError as ConfigBackendError,
+)
+
+MODE = {
+    "raw": 11,
+    "hex": "0x000b",
+    "name": "Generic Mode",
+    "policy": {
+        "vendor_store_write": True,
+        "vendor_store_lock": True,
+        "customer_store_write": False,
+        "customer_store_lock": True,
+    },
+}
+KEYS = {
+    "PKVendor": {"state": "present", "entry_count": 1},
+    "KEKVendor": {"state": "present", "entry_count": 2},
+    "dbVendor": {"state": "present", "entry_count": 3},
+    "dbxVendor": {"state": "empty", "entry_count": 0},
+    "PKCustomer": {"state": "empty", "entry_count": 0},
+    "KEKCustomer": {"state": "empty", "entry_count": 0},
+    "dbCustomer": {"state": "empty", "entry_count": 0},
+    "dbxCustomer": {"state": "empty", "entry_count": 0},
+}
+
 
 class TestShowSecureBoot(unittest.TestCase):
     @patch("show.secure_boot.run_backend")
@@ -16,6 +47,13 @@ class TestShowSecureBoot(unittest.TestCase):
         self.assertIn("Generic Mode", r.output)
 
     @patch("show.secure_boot.run_backend")
+    def test_show_mode_backend_error(self, backend):
+        backend.side_effect = ShowBackendError("boom")
+        r = CliRunner().invoke(show_secure_boot, ["mode"])
+        self.assertNotEqual(r.exit_code, 0)
+        self.assertIn("boom", r.output)
+
+    @patch("show.secure_boot.run_backend")
     def test_show_status(self, backend):
         backend.return_value = {"mode": MODE, "keys": KEYS}
         r = CliRunner().invoke(show_secure_boot, ["status"])
@@ -23,22 +61,144 @@ class TestShowSecureBoot(unittest.TestCase):
         self.assertIn("PK", r.output)
         self.assertIn("present", r.output)
 
+    @patch("show.secure_boot.run_backend")
+    def test_show_status_backend_error(self, backend):
+        backend.side_effect = ShowBackendError("boom")
+        r = CliRunner().invoke(show_secure_boot, ["status"])
+        self.assertNotEqual(r.exit_code, 0)
+        self.assertIn("boom", r.output)
+
+    @patch("show.secure_boot.run_backend")
+    def test_show_keys(self, backend):
+        backend.return_value = KEYS
+        r = CliRunner().invoke(show_secure_boot, ["keys"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("vendor", r.output)
+        self.assertIn("customer", r.output)
+
+    @patch("show.secure_boot.run_backend")
+    def test_show_keys_backend_error(self, backend):
+        backend.side_effect = ShowBackendError("boom")
+        r = CliRunner().invoke(show_secure_boot, ["keys"])
+        self.assertNotEqual(r.exit_code, 0)
+        self.assertIn("boom", r.output)
+
+    @patch("show.secure_boot.run_backend")
+    def test_show_key(self, backend):
+        backend.return_value = {"dbCustomer": {"state": "present", "entry_count": 4}}
+        r = CliRunner().invoke(show_secure_boot, ["key", "db", "--store", "customer"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("present", r.output)
+
+    @patch("show.secure_boot.run_backend")
+    def test_show_key_unified_store(self, backend):
+        backend.return_value = {"dbUnified": {"state": "present", "entry_count": 5}}
+        r = CliRunner().invoke(show_secure_boot, ["key", "db", "--store", "unified"])
+        self.assertEqual(r.exit_code, 0)
+        self.assertIn("unified", r.output)
+        backend.assert_called_once_with("key", "db", "--store", "unified")
+
+    @patch("show.secure_boot.run_backend")
+    def test_show_key_backend_error(self, backend):
+        backend.side_effect = ShowBackendError("boom")
+        r = CliRunner().invoke(show_secure_boot, ["key", "db"])
+        self.assertNotEqual(r.exit_code, 0)
+        self.assertIn("boom", r.output)
+
+
 class TestConfigSecureBoot(unittest.TestCase):
     @patch("config.secure_boot.run_backend")
     def test_update(self, backend):
-        backend.return_value = {"result":"success", "variable":"db", "operation":"append"}
+        backend.return_value = {"result": "success", "variable": "db", "operation": "append"}
         with CliRunner().isolated_filesystem():
-            with open("db.auth", "w") as f: f.write("dummy")
-            r = CliRunner().invoke(config_secure_boot, ["certificate","update","db","db.auth","--operation","append"])
+            with open("db.auth", "w") as f:
+                f.write("dummy")
+            r = CliRunner().invoke(
+                config_secure_boot,
+                ["certificate", "update", "db", "db.auth", "--operation", "append"],
+            )
         self.assertEqual(r.exit_code, 0)
         self.assertIn("submitted successfully", r.output)
 
-    def test_mode_set_requires_yes(self):
+    @patch("config.secure_boot.run_backend")
+    def test_update_backend_error(self, backend):
+        backend.side_effect = ConfigBackendError("boom")
         with CliRunner().isolated_filesystem():
-            with open("ov.cms", "w") as f: f.write("dummy")
-            r = CliRunner().invoke(config_secure_boot, ["mode","set","ov.cms"])
+            with open("db.auth", "w") as f:
+                f.write("dummy")
+            r = CliRunner().invoke(config_secure_boot, ["certificate", "update", "db", "db.auth"])
         self.assertNotEqual(r.exit_code, 0)
-        self.assertIn("--yes", r.output)
+        self.assertIn("boom", r.output)
+
+
+class TestRunBackend(unittest.TestCase):
+    @staticmethod
+    def _cp(stdout, rc=0):
+        cp = MagicMock()
+        cp.stdout = stdout
+        cp.returncode = rc
+        return cp
+
+    @patch("show.secure_boot.subprocess.run")
+    def test_show_run_backend_success(self, run):
+        run.return_value = self._cp('{"mode": "ok"}')
+        self.assertEqual(show_run_backend("mode"), {"mode": "ok"})
+
+    @patch("show.secure_boot.subprocess.run", side_effect=FileNotFoundError)
+    def test_show_run_backend_not_installed(self, run):
+        with self.assertRaises(ShowBackendError):
+            show_run_backend("mode")
+
+    @patch(
+        "show.secure_boot.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1),
+    )
+    def test_show_run_backend_timeout(self, run):
+        with self.assertRaises(ShowBackendError):
+            show_run_backend("mode")
+
+    @patch("show.secure_boot.subprocess.run")
+    def test_show_run_backend_bad_json(self, run):
+        run.return_value = self._cp("not json")
+        with self.assertRaises(ShowBackendError):
+            show_run_backend("mode")
+
+    @patch("show.secure_boot.subprocess.run")
+    def test_show_run_backend_error_field(self, run):
+        run.return_value = self._cp('{"error": "nope"}', rc=1)
+        with self.assertRaises(ShowBackendError):
+            show_run_backend("mode")
+
+    @patch("config.secure_boot.subprocess.run")
+    def test_config_run_backend_success(self, run):
+        run.return_value = self._cp('{"ok": true}')
+        self.assertEqual(config_run_backend("update"), {"ok": True})
+
+    @patch("config.secure_boot.subprocess.run", side_effect=FileNotFoundError)
+    def test_config_run_backend_not_installed(self, run):
+        with self.assertRaises(ConfigBackendError):
+            config_run_backend("update")
+
+    @patch(
+        "config.secure_boot.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=1),
+    )
+    def test_config_run_backend_timeout(self, run):
+        with self.assertRaises(ConfigBackendError):
+            config_run_backend("update")
+
+    @patch("config.secure_boot.subprocess.run")
+    def test_config_run_backend_bad_json(self, run):
+        run.return_value = self._cp("not json")
+        with self.assertRaises(ConfigBackendError):
+            config_run_backend("update")
+
+    @patch("config.secure_boot.subprocess.run")
+    def test_config_run_backend_error_field(self, run):
+        run.return_value = self._cp('{"error": "nope"}', rc=1)
+        with self.assertRaises(ConfigBackendError):
+            config_run_backend("update")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/secure_boot/test_secure_boot_packaging.py
+++ b/tests/secure_boot/test_secure_boot_packaging.py
@@ -1,0 +1,43 @@
+"""Packaging/wiring tests for the Secure Boot backend entry points.
+
+Proves the wrappers shipped by ``sonic-utilities-data`` delegate to the
+``secure_boot`` modules from the ``sonic-utilities`` wheel, and that
+``debian/install`` maps them to the exact HLD runtime locations.
+"""
+
+import importlib
+import os
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+DATA_SCRIPTS = os.path.join(REPO_ROOT, "sonic-utilities-data", "scripts")
+INSTALL_FILE = os.path.join(REPO_ROOT, "sonic-utilities-data", "debian", "install")
+
+# wrapper name -> (target module, debian/install destination directory)
+WRAPPERS = {
+    "secure-boot-backend": ("secure_boot.secure_boot_backend", "/usr/sbin/"),
+    "generic-uefi-backend": ("secure_boot.generic_uefi_backend", "/usr/lib/sonic/secure-boot/"),
+}
+
+
+class TestSecureBootPackaging(unittest.TestCase):
+    def test_wrappers_and_modules(self):
+        for name, (module, _dest) in WRAPPERS.items():
+            path = os.path.join(DATA_SCRIPTS, name)
+            self.assertTrue(os.access(path, os.X_OK), "wrapper not executable: {}".format(path))
+            with open(path) as fp:
+                content = fp.read()
+            self.assertTrue(content.startswith("#!/usr/bin/env python3\n"))
+            self.assertIn("from {} import main".format(module), content)
+            self.assertIn("sys.exit(main())", content)
+            self.assertTrue(callable(importlib.import_module(module).main))
+
+    def test_install_maps_exact_paths(self):
+        with open(INSTALL_FILE) as fp:
+            entries = dict(line.split() for line in fp if len(line.split()) == 2)
+        for name, (_module, dest) in WRAPPERS.items():
+            self.assertEqual(entries.get("scripts/" + name), dest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utilities_common/secure_boot.py
+++ b/utilities_common/secure_boot.py
@@ -1,0 +1,58 @@
+"""Shared helper for invoking the SONiC Secure Boot backend.
+
+The CLI talks to a single stable entry point, ``/usr/sbin/secure-boot-backend``,
+which is the SONiC Secure Boot backend selector. The selector chooses the
+platform backend, the generic UEFI backend, or reports that Secure Boot
+management is unsupported.
+
+The contract between the CLI and the backend is:
+
+    stdout -> JSON only
+    stderr -> diagnostics
+"""
+
+import json
+import subprocess
+
+BACKEND = "/usr/sbin/secure-boot-backend"
+
+
+class BackendError(RuntimeError):
+    pass
+
+
+def run_backend(args, timeout):
+    """Run the Secure Boot backend and return its parsed JSON response.
+
+    ``stdout`` is expected to carry JSON only; ``stderr`` carries diagnostics
+    and is only surfaced when the backend fails without a JSON ``error`` field.
+    """
+    try:
+        cp = subprocess.run(
+            [BACKEND] + list(args),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        raise BackendError("Secure Boot management is not supported on this platform")
+    except subprocess.TimeoutExpired:
+        raise BackendError("secure boot backend timed out")
+
+    try:
+        data = json.loads(cp.stdout or "{}")
+    except json.JSONDecodeError:
+        diagnostic = (cp.stderr or "").strip()
+        if diagnostic:
+            raise BackendError(diagnostic)
+        raise BackendError("invalid backend response: {}".format((cp.stdout or "").strip()))
+
+    if cp.returncode != 0 or "error" in data:
+        message = data.get("error")
+        if not message:
+            message = (cp.stderr or "").strip()
+        raise BackendError(message or "secure boot backend failed")
+
+    return data


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
#### What I did

Added platform-agnostic SONiC CLI support for Secure Boot certificate and authenticated-variable lifecycle management.

This PR introduces:

- `show secure-boot status`
- `show secure-boot mode`
- `show secure-boot keys`
- `show secure-boot key <PK|KEK|db|dbx> [--store vendor|customer|unified]`
- `config secure-boot certificate update <PK|KEK|db|dbx> <auth-var-file> [--operation append|update|remove]`

The CLI exposes a generic SONiC interface and keeps platform-specific Secure Boot storage and hardware implementation details behind a backend interface. SONiC references only the platform-neutral backend entry point `/usr/sbin/secure-boot-backend`; the implementation behind it is platform-specific.

A single `certificate update` command covers all authenticated-variable update operations (`append`, `update`, `remove`), so no separate install or revoke commands are added to the upstream API surface.

The show commands expose the state and entry count of the standard Secure Boot variables:

- `PK`
- `KEK`
- `db`
- `dbx`

The implementation uses `entry_count` rather than `certificate_count`, since a UEFI signature database may contain entries other than X.509 certificates.

Unit tests are included for Secure Boot show/config command handling and backend interaction.

Related HLD:

[SONiC HLD PR #2534 - Secure Boot Certificate Management CLI](https://github.com/sonic-net/SONiC/pull/2534)

#### How I did it

Added new Secure Boot command groups under `show` and `config`.

The SONiC CLI invokes a platform-provided Secure Boot backend helper and consumes structured JSON responses. This keeps the SONiC CLI independent of the underlying secure storage implementation.

The backend contract provides operations for:

- reading Secure Boot mode and policy
- reading `PK`, `KEK`, `db`, and `dbx` state
- distinguishing vendor/platform, customer, and unified stores when supported
- reporting variable state and entry count
- submitting authenticated-variable update files
- propagating backend validation and operation failures to the CLI

Authenticated-variable validation, ownership policy, replay/timestamp checks, and protected persistence remain the responsibility of the platform backend.

Private signing keys are not handled or stored by the SONiC CLI.

Added unit tests using a mocked backend to verify:

- Secure Boot mode display
- Secure Boot status display
- Secure Boot keys display
- single-variable display, including the `unified` store and the CLI-to-backend call contract
- authenticated-variable update submission
- backend error propagation to the CLI
- backend helper error handling (not installed, timeout, invalid JSON, non-zero/error responses)

#### How to verify it

Run the Secure Boot unit tests:

```bash
python3 -m pytest -v tests/secure_boot/test_secure_boot_cli.py
```
