### PR TITLE
[generic_config_updater]: Preserve command log format

### DIFF
--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -32,7 +32,9 @@ def command_wrapper(command):
     """
     if command[0] == "systemctl":
         command = ["nsenter", "--target", "1", "--pid", "--mount", "--uts", "--ipc", "--net"] + command
+    command_text = "<unavailable>"
     try:
+        command_text = repr(command)
         command_text = " ".join(shlex.quote(arg) for arg in command)
         result = subprocess.run(command, capture_output=True, check=False, text=True)
 
@@ -51,7 +53,6 @@ def command_wrapper(command):
 
         return result.returncode
     except Exception as e:
-        command_text = locals().get("command_text", repr(command))
         logger.log(logger.LOG_PRIORITY_ERROR,
                    f"Command execution failed: '{command_text}', error: {e}",
                    print_to_console)

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -1,6 +1,7 @@
 import ipaddress
 import os
 import re
+import shlex
 import subprocess
 import time
 from .gu_common import genericUpdaterLogging
@@ -31,12 +32,13 @@ def command_wrapper(command):
     """
     if command[0] == "systemctl":
         command = ["nsenter", "--target", "1", "--pid", "--mount", "--uts", "--ipc", "--net"] + command
+    command_text = shlex.join(command)
     try:
         result = subprocess.run(command, capture_output=True, check=False, text=True)
 
         if result.returncode != 0:
             logger.log(logger.LOG_PRIORITY_ERROR,
-                       f"Command failed: {command!r}, returncode: {result.returncode}",
+                       f"Command failed: '{command_text}', returncode: {result.returncode}",
                        print_to_console)
             if result.stdout:
                 logger.log(logger.LOG_PRIORITY_ERROR,
@@ -50,7 +52,7 @@ def command_wrapper(command):
         return result.returncode
     except Exception as e:
         logger.log(logger.LOG_PRIORITY_ERROR,
-                   f"Command execution failed: {command}, error: {e}",
+                   f"Command execution failed: {command_text}, error: {e}",
                    print_to_console)
         return 1
 

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -32,8 +32,8 @@ def command_wrapper(command):
     """
     if command[0] == "systemctl":
         command = ["nsenter", "--target", "1", "--pid", "--mount", "--uts", "--ipc", "--net"] + command
-    command_text = " ".join(shlex.quote(arg) for arg in command)
     try:
+        command_text = " ".join(shlex.quote(arg) for arg in command)
         result = subprocess.run(command, capture_output=True, check=False, text=True)
 
         if result.returncode != 0:
@@ -51,8 +51,9 @@ def command_wrapper(command):
 
         return result.returncode
     except Exception as e:
+        command_text = locals().get("command_text", repr(command))
         logger.log(logger.LOG_PRIORITY_ERROR,
-                   f"Command execution failed: {command_text}, error: {e}",
+                   f"Command execution failed: '{command_text}', error: {e}",
                    print_to_console)
         return 1
 

--- a/generic_config_updater/services_validator.py
+++ b/generic_config_updater/services_validator.py
@@ -32,7 +32,7 @@ def command_wrapper(command):
     """
     if command[0] == "systemctl":
         command = ["nsenter", "--target", "1", "--pid", "--mount", "--uts", "--ipc", "--net"] + command
-    command_text = shlex.join(command)
+    command_text = " ".join(shlex.quote(arg) for arg in command)
     try:
         result = subprocess.run(command, capture_output=True, check=False, text=True)
 

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -398,8 +398,25 @@ class TestServiceValidator(unittest.TestCase):
         self.assertEqual(result, 1)
         mock_logger.log.assert_called_once_with(
             mock_logger.LOG_PRIORITY_ERROR,
-            "Command execution failed: nsenter --target 1 --pid --mount --uts --ipc --net "
-            "systemctl restart dhcp_relay, error: execution error",
+            "Command execution failed: 'nsenter --target 1 --pid --mount --uts --ipc --net "
+            "systemctl restart dhcp_relay', error: execution error",
+            False
+        )
+
+    @patch("generic_config_updater.services_validator.logger")
+    @patch("generic_config_updater.services_validator.subprocess.run")
+    def test_command_wrapper_handles_command_formatting_error(self, mock_subprocess, mock_logger):
+        with patch(
+            "generic_config_updater.services_validator.shlex.quote",
+            side_effect=TypeError("formatting error")
+        ):
+            result = command_wrapper(["echo", "value"])
+
+        self.assertEqual(result, 1)
+        mock_subprocess.assert_not_called()
+        mock_logger.log.assert_called_once_with(
+            mock_logger.LOG_PRIORITY_ERROR,
+            "Command execution failed: '['echo', 'value']', error: formatting error",
             False
         )
 

--- a/tests/generic_config_updater/service_validator_test.py
+++ b/tests/generic_config_updater/service_validator_test.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from generic_config_updater.services_validator import (
+    command_wrapper,
     vlan_validator,
     rsyslog_validator,
     caclmgrd_validator,
@@ -373,6 +374,34 @@ test_telemetry_data = [
 
 
 class TestServiceValidator(unittest.TestCase):
+
+    @patch("generic_config_updater.services_validator.logger")
+    @patch("generic_config_updater.services_validator.subprocess.run")
+    def test_command_wrapper_logs_stable_command_format(self, mock_subprocess, mock_logger):
+        mock_subprocess.return_value = MockSubprocessResult(1)
+
+        result = command_wrapper(["systemctl", "restart", "dhcp_relay"])
+
+        self.assertEqual(result, 1)
+        mock_logger.log.assert_called_once_with(
+            mock_logger.LOG_PRIORITY_ERROR,
+            "Command failed: 'nsenter --target 1 --pid --mount --uts --ipc --net "
+            "systemctl restart dhcp_relay', returncode: 1",
+            False
+        )
+
+        mock_logger.reset_mock()
+        mock_subprocess.side_effect = OSError("execution error")
+
+        result = command_wrapper(["systemctl", "restart", "dhcp_relay"])
+
+        self.assertEqual(result, 1)
+        mock_logger.log.assert_called_once_with(
+            mock_logger.LOG_PRIORITY_ERROR,
+            "Command execution failed: nsenter --target 1 --pid --mount --uts --ipc --net "
+            "systemctl restart dhcp_relay, error: execution error",
+            False
+        )
 
     @patch("generic_config_updater.services_validator.subprocess.run")
     def test_change_apply_subprocess_run(self, mock_subprocess):


### PR DESCRIPTION
#### What I did

Preserve the existing shell-style Generic Config Updater command log format while continuing to pass argument lists directly to `subprocess.run`.

Add unit coverage for non-zero command results and command execution exceptions.

#### Why I did it

PR #4805 changed `command_wrapper` to execute `List[str]` arguments, but also changed failure logs from a quoted shell-style command to Python list representation. Existing log consumers rely on the established format.

This caused `generic_config_updater/test_dhcp_relay.py` to fail during LogAnalyzer teardown in sonic-buildimage submodule advance PR sonic-net/sonic-buildimage#29194
https://dev.azure.com/mssonic/build/_build/results?buildId=1206690&view=logs&j=c4781836-bf04-5f60-aed4-f5b1830934f2&t=bfd3fecb-b6ef-58c5-e8da-46d5dea0fd31

#### How I did it

Use `shlex.join` only to construct the command text used for logging. Command execution remains list-based with `shell=False` behavior unchanged.

#### How to verify it

Ran the focused `test_command_wrapper_logs_stable_command_format` unit test and compiled the changed Python files successfully.