### PR TITLE
syslog: Replace shell-based container lookup with exact matching

### DIFF
--- a/config/syslog.py
+++ b/config/syslog.py
@@ -561,6 +561,15 @@ def get_feature_names_to_proceed(db, service_name, namespace):
     return feature_list
 
 
+def get_running_container_names():
+    """Return the exact names of currently running containers."""
+    output, _ = clicommon.run_command(
+        ['docker', 'ps', '-f', 'status=running', '--format', '{{.Names}}'],
+        return_cmd=True
+    )
+    return set(output.splitlines()) if output else set()
+
+
 @rate_limit_feature.command("enable")
 @click.argument("service_name", required=False)
 @click.option('--namespace', '-n', 'namespace', default=None, 
@@ -570,11 +579,12 @@ def get_feature_names_to_proceed(db, service_name, namespace):
 def enable_rate_limit_feature(db, service_name, namespace):
     """ Enable syslog rate limit feature """
     feature_list = get_feature_names_to_proceed(db, service_name, namespace)
+    if not feature_list:
+        return
+    running_containers = get_running_container_names()
     for feature_name in feature_list:
         click.echo(f'Enabling syslog rate limit feature for {feature_name}')
-        shell_cmd = f'docker ps -f status=running --format "{{{{.Names}}}}" | grep -E "^{feature_name}$"'
-        output, _ = clicommon.run_command(shell_cmd, return_cmd=True, shell=True)
-        if not output:
+        if feature_name not in running_containers:
             click.echo(f'{feature_name} is not running, ignoring...')
             continue
         
@@ -612,11 +622,12 @@ def enable_rate_limit_feature(db, service_name, namespace):
 def disable_rate_limit_feature(db, service_name, namespace):
     """ Disable syslog rate limit feature """
     feature_list = get_feature_names_to_proceed(db, service_name, namespace)
+    if not feature_list:
+        return
+    running_containers = get_running_container_names()
     for feature_name in feature_list:
         click.echo(f'Disabling syslog rate limit feature for {feature_name}')
-        shell_cmd = f'docker ps -f status=running --format "{{{{.Names}}}}" | grep -E "^{feature_name}$"'
-        output, _ = clicommon.run_command(shell_cmd, return_cmd=True, shell=True)
-        if not output:
+        if feature_name not in running_containers:
             click.echo(f'{feature_name} is not running, ignoring...')
             continue
         

--- a/tests/syslog_test.py
+++ b/tests/syslog_test.py
@@ -20,6 +20,8 @@ from syslog_util.common import FEATURE_TABLE, \
                                SYSLOG_CONFIG_FEATURE_TABLE, \
                                SYSLOG_RATE_LIMIT_INTERVAL, \
                                SYSLOG_RATE_LIMIT_BURST, \
+                               FEATURE_HAS_GLOBAL_SCOPE, \
+                               FEATURE_HAS_PER_ASIC_SCOPE, \
                                SUPPORT_RATE_LIMIT
 
 from .mock_tables import dbconnector
@@ -505,6 +507,42 @@ class TestSyslog:
             ['docker', 'ps', '-f', 'status=running', '--format', '{{.Names}}'],
             return_cmd=True
         )
+
+    @mock.patch('config.syslog.clicommon.run_command')
+    @mock.patch('config.syslog.multi_asic.is_multi_asic', return_value=True)
+    @mock.patch('config.syslog.multi_asic.get_num_asics', return_value=2)
+    def test_enable_syslog_rate_limit_feature_multi_asic(
+            self, mock_get_num_asics, mock_is_multi_asic, mock_run):
+        db = Db()
+        db.cfgdb.set_entry(FEATURE_TABLE, 'swss', {
+            SUPPORT_RATE_LIMIT: 'true',
+            FEATURE_HAS_GLOBAL_SCOPE: 'false',
+            FEATURE_HAS_PER_ASIC_SCOPE: 'true',
+            'state': 'enabled'
+        })
+
+        def run_command(command, **kwargs):
+            if command[:2] == ['docker', 'ps']:
+                return 'swss0\nswss1\n', 0
+            return 'RUNNING', 0
+
+        mock_run.side_effect = run_command
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands['syslog'].commands['rate-limit-feature'].commands['enable'], obj=db
+        )
+
+        assert result.exit_code == SUCCESS
+        assert 'swss0 is not running' not in result.output
+        assert 'swss1 is not running' not in result.output
+        assert mock.call(
+            ['docker', 'exec', '-i', 'swss0', 'supervisorctl', 'status', 'containercfgd'],
+            ignore_error=True, return_cmd=True
+        ) in mock_run.call_args_list
+        assert mock.call(
+            ['docker', 'exec', '-i', 'swss1', 'supervisorctl', 'status', 'containercfgd'],
+            ignore_error=True, return_cmd=True
+        ) in mock_run.call_args_list
 
     @mock.patch('config.syslog.clicommon.run_command')
     def test_config_log_level(self, mock_run):

--- a/tests/syslog_test.py
+++ b/tests/syslog_test.py
@@ -405,13 +405,16 @@ class TestSyslog:
 
         runner = CliRunner()
 
-        mock_run.return_value = ('no such process', 0)
+        mock_run.side_effect = lambda command, **kwargs: (
+            ('bgp', 0) if command[:2] == ['docker', 'ps'] else ('no such process', 0)
+        )
         result = runner.invoke(
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["enable"], obj=db
         )
         assert result.exit_code == SUCCESS
         
         # container not run
+        mock_run.side_effect = None
         mock_run.return_value = ('', 0)
         result = runner.invoke(
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["enable"], obj=db
@@ -419,7 +422,9 @@ class TestSyslog:
         assert result.exit_code == SUCCESS
         
         # process already running
-        mock_run.return_value = ('something', 0)
+        mock_run.side_effect = lambda command, **kwargs: (
+            ('bgp', 0) if command[:2] == ['docker', 'ps'] else ('something', 0)
+        )
         result = runner.invoke(
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["enable"], obj=db
         )
@@ -428,7 +433,9 @@ class TestSyslog:
         # one command fail
         def side_effect(*args, **kwargs):
             side_effect.call_count += 1
-            if side_effect.call_count <= 2:
+            if side_effect.call_count == 1:
+                return 'bgp', 0
+            elif side_effect.call_count == 2:
                 return 'no such process', 0
             else:
                 return '', -1
@@ -448,13 +455,16 @@ class TestSyslog:
 
         runner = CliRunner()
 
-        mock_run.return_value = ('something', 0)
+        mock_run.side_effect = lambda command, **kwargs: (
+            ('bgp', 0) if command[:2] == ['docker', 'ps'] else ('something', 0)
+        )
         result = runner.invoke(
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"], obj=db
         )
         assert result.exit_code == SUCCESS
         
         # container not run
+        mock_run.side_effect = None
         mock_run.return_value = ('', 0)
         result = runner.invoke(
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"], obj=db
@@ -462,7 +472,9 @@ class TestSyslog:
         assert result.exit_code == SUCCESS
         
         # process already stopped
-        mock_run.return_value = ('no such process', 0)
+        mock_run.side_effect = lambda command, **kwargs: (
+            ('bgp', 0) if command[:2] == ['docker', 'ps'] else ('no such process', 0)
+        )
         result = runner.invoke(
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"], obj=db
         )
@@ -471,7 +483,9 @@ class TestSyslog:
         # one command fail
         def side_effect(*args, **kwargs):
             side_effect.call_count += 1
-            if side_effect.call_count <= 2:
+            if side_effect.call_count == 1:
+                return 'bgp', 0
+            elif side_effect.call_count == 2:
                 return 'something', 0
             else:
                 return '', -1
@@ -481,6 +495,16 @@ class TestSyslog:
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"], obj=db
         )
         assert result.exit_code == SUCCESS
+
+    @mock.patch('config.syslog.clicommon.run_command')
+    def test_get_running_container_names(self, mock_run):
+        mock_run.return_value = ('bgp\nswss0\n', 0)
+
+        assert config.syslog.get_running_container_names() == {'bgp', 'swss0'}
+        mock_run.assert_called_once_with(
+            ['docker', 'ps', '-f', 'status=running', '--format', '{{.Names}}'],
+            return_cmd=True
+        )
 
     @mock.patch('config.syslog.clicommon.run_command')
     def test_config_log_level(self, mock_run):


### PR DESCRIPTION
#### What I did

Updated the syslog rate-limit enable and disable commands to check running containers by exact name.

The existing implementation inserted each configured feature name into a shell-based `grep` expression. Container discovery only requires exact name matching, so interpreting the name as part of a shell command is unnecessary and can produce unexpected behavior for unusual input.

#### How I did it

Run `docker ps` with structured arguments, parse the returned container names into a set, and compare each configured feature name directly against that set.

This removes the shell and regular-expression dependency while preserving the existing behavior for valid feature names and containers that are not running.

#### How to verify it

`python3 -m pytest tests/syslog_test.py -q`

Result: 41 passed.

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

N/A