### PR TITLE
[fdb]: Add CLI to select the MAC synchronization mode

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -10667,6 +10667,31 @@ def motd(message):
 
 
 #
+# 'fdb' group ('config fdb ...')
+#
+
+@config.group()
+def fdb():
+    """FDB (MAC) configuration tasks"""
+    pass
+
+
+@fdb.command('mac-sync-mode')
+@click.argument('mode', metavar='<kernel|fpm>', required=True, type=click.Choice(['kernel', 'fpm']))
+@clicommon.pass_db
+@click.pass_context
+def mac_sync_mode(ctx, db, mode):
+    """Select how MAC (FDB) state is synchronized with FRR"""
+
+    config_db = ValidatedConfigDBConnector(db.cfgdb)
+    try:
+        config_db.mod_entry(swsscommon.CFG_FDB_SYNC_TABLE_NAME, 'global',
+                            {'mac_sync_mode': mode})
+    except (ValueError, JsonPatchConflict) as e:
+        ctx.fail("Failed to save to ConfigDB. Error: {}".format(e))
+
+
+#
 # 'vnet' group ('config vnet ...')
 #
 

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -518,6 +518,7 @@ function backup_database()
                                           and not string.match(k, 'VXLAN_TUNNEL_TABLE|') \
                                           and not string.match(k, 'BUFFER_MAX_PARAM_TABLE|') \
                                           and not string.match(k, 'STORAGE_INFO|') \
+                                          and not string.match(k, 'FDB_SYNC_TABLE|') \
                                           and not string.match(k, 'FAST_RESTART_ENABLE_TABLE|') then
                 redis.call('del', k)
             end

--- a/show/main.py
+++ b/show/main.py
@@ -12,6 +12,7 @@ import utilities_common.multi_asic as multi_asic_util
 from importlib import reload
 from natsort import natsorted
 from sonic_py_common import device_info
+from swsscommon import swsscommon
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
 from tabulate import tabulate
 from utilities_common import util_base
@@ -1283,6 +1284,27 @@ def aging_time(ctx):
             click.echo("Aging time for {} is {} seconds".format(key.split(':')[-1], fdb_aging_time))
         else:
             click.echo("Aging time not configured for the {}".format(key.split(':')[-1]))
+
+
+#
+# 'fdb' group ("show fdb ...")
+#
+
+@cli.group(cls=clicommon.AliasedGroup)
+def fdb():
+    """Show FDB (MAC) configuration"""
+    pass
+
+
+@fdb.command('mac-sync-mode')
+@clicommon.pass_db
+def mac_sync_mode(db):
+    """Show how MAC (FDB) state is synchronized with FRR"""
+
+    fdb_sync = db.cfgdb.get_entry(swsscommon.CFG_FDB_SYNC_TABLE_NAME, 'global')
+    click.echo(fdb_sync.get('mac_sync_mode', 'kernel'))
+
+
 #
 # 'show route-map' command ("show route-map")
 #

--- a/tests/config_int_evpn_test.py
+++ b/tests/config_int_evpn_test.py
@@ -250,6 +250,38 @@ class TestEVPNEthernetSegmentConfig():
         configure_esi_w_failure(runner, db, ["PortChannel02", "00:01:02:03:04:05:06:07:08:FF"],
                                 "The ESI '00:01:02:03:04:05:06:07:08:ff' is already in use by 'PortChannel01'")
 
+    # An Ethernet Segment may be configured in either mac_sync_mode; guard
+    # against a restriction being reintroduced.
+    def test_add_es_allowed_when_mac_sync_mode_fpm(self, cli_db_connection):
+        runner, db = cli_db_connection
+        db['config_db'].set_entry('FDB_SYNC', 'global', {'mac_sync_mode': 'fpm'})
+
+        result = runner.invoke(
+            config.config.commands["interface"].commands['evpn-esi'].commands["add"],
+            ["PortChannel01", "auto-system-mac"],
+            obj=db)
+
+        assert result.exit_code == 0, (
+            f"Got exit code {result.exit_code} - {result.output}, expected success"
+        )
+        assert "PortChannel01" in db['config_db'].get_table(EVPN_ES_TABLE), (
+            "Ethernet Segment was not written to CONFIG_DB"
+        )
+
+    def test_add_es_allowed_when_mac_sync_mode_kernel(self, cli_db_connection):
+        runner, db = cli_db_connection
+        db['config_db'].set_entry('FDB_SYNC', 'global', {'mac_sync_mode': 'kernel'})
+
+        result = runner.invoke(
+            config.config.commands["interface"].commands['evpn-esi'].commands["add"],
+            ["PortChannel01", "auto-system-mac"],
+            obj=db)
+
+        assert result.exit_code == 0, (
+            f"Got exit code {result.exit_code} - {result.output}, expected 0"
+        )
+        assert "PortChannel01" in db['config_db'].get_table(EVPN_ES_TABLE)
+
 
 def configure_df_pref(runner, db, interface_name, df_pref_value, df_pref_expected_valid):
     evpn_es_table = db['config_db'].get_table(EVPN_ES_TABLE)

--- a/tests/fdb_mac_sync_mode_test.py
+++ b/tests/fdb_mac_sync_mode_test.py
@@ -1,0 +1,127 @@
+import os
+import pytest
+
+import show.main as show
+
+from click.testing import CliRunner
+from config.main import config
+from utilities_common.db import Db
+
+
+FDB_SYNC_TABLE = 'FDB_SYNC'
+EVPN_ES_TABLE = 'EVPN_ETHERNET_SEGMENT'
+FDB_SYNC_KEY = 'global'
+MAC_SYNC_MODE_FIELD = 'mac_sync_mode'
+MAC_SYNC_MODE_DEFAULT = 'kernel'
+
+
+@pytest.fixture
+def enable_click_ut_mode():
+    os.environ['UTILITIES_UNIT_TESTING'] = "1"
+    yield os.environ['UTILITIES_UNIT_TESTING']
+
+    os.environ['UTILITIES_UNIT_TESTING'] = "0"
+
+
+@pytest.fixture
+def cli_db_connection(enable_click_ut_mode):
+    db = Db()
+    return CliRunner(), db
+
+
+class TestFdbMacSyncModeConfig:
+    @pytest.mark.parametrize("mac_sync_mode", ["kernel", "fpm"])
+    def test_mac_sync_mode_config(self, cli_db_connection, mac_sync_mode):
+        runner, db = cli_db_connection
+
+        result = runner.invoke(config.commands["fdb"].commands["mac-sync-mode"], [mac_sync_mode], obj=db)
+        assert result.exit_code == 0, (
+            f"Got exit code {result.exit_code} - {result.output}, expected 0"
+        )
+
+        fdb_sync_table = db.cfgdb.get_table(FDB_SYNC_TABLE)
+        assert fdb_sync_table[FDB_SYNC_KEY][MAC_SYNC_MODE_FIELD] == mac_sync_mode, (
+            f"Found unexpected {MAC_SYNC_MODE_FIELD} "
+            f"{fdb_sync_table[FDB_SYNC_KEY][MAC_SYNC_MODE_FIELD]}, "
+            f"expected '{mac_sync_mode}'"
+        )
+
+    def test_mac_sync_mode_config_invalid(self, cli_db_connection):
+        runner, db = cli_db_connection
+
+        result = runner.invoke(config.commands["fdb"].commands["mac-sync-mode"], ["bridge"], obj=db)
+        assert result.exit_code != 0, (
+            f"Got zero exit code {result.exit_code} - {result.output}, expected non-zero"
+        )
+        assert "kernel" in result.output and "fpm" in result.output, (
+            f"Error output does not name the supported modes: {result.output}"
+        )
+
+        fdb_sync_table = db.cfgdb.get_table(FDB_SYNC_TABLE)
+        assert not fdb_sync_table, (
+            f"Invalid mac sync mode changed what is stored in config DB: "
+            f"{fdb_sync_table}, expected empty fdb_sync_table"
+        )
+
+    # Either mode is valid with an Ethernet Segment configured; guard against a
+    # restriction being reintroduced.
+    def test_mac_sync_mode_fpm_allowed_with_evpn_mh(self, cli_db_connection):
+        runner, db = cli_db_connection
+        db.cfgdb.set_entry(EVPN_ES_TABLE, "PortChannel0001", {"esi": "AUTO", "type": "TYPE_3_MAC_BASED"})
+
+        result = runner.invoke(config.commands["fdb"].commands["mac-sync-mode"], ["fpm"], obj=db)
+        assert result.exit_code == 0, (
+            f"Got exit code {result.exit_code} - {result.output}, expected success"
+        )
+
+        fdb_sync_table = db.cfgdb.get_table(FDB_SYNC_TABLE)
+        written_mode = fdb_sync_table.get(FDB_SYNC_KEY, {}).get(MAC_SYNC_MODE_FIELD)
+        assert written_mode == "fpm", (
+            f"mac_sync_mode was not written to ConfigDB: {fdb_sync_table}"
+        )
+
+    def test_mac_sync_mode_kernel_allowed_with_evpn_mh(self, cli_db_connection):
+        runner, db = cli_db_connection
+        db.cfgdb.set_entry(EVPN_ES_TABLE, "PortChannel0001", {"esi": "AUTO", "type": "TYPE_3_MAC_BASED"})
+
+        result = runner.invoke(config.commands["fdb"].commands["mac-sync-mode"], ["kernel"], obj=db)
+        assert result.exit_code == 0, (
+            f"Got exit code {result.exit_code} - {result.output}, expected 0"
+        )
+        assert db.cfgdb.get_table(FDB_SYNC_TABLE)[FDB_SYNC_KEY][MAC_SYNC_MODE_FIELD] == "kernel"
+
+
+class TestFdbMacSyncModeShow:
+    def test_mac_sync_mode_show_default(self, cli_db_connection):
+        runner, db = cli_db_connection
+
+        assert not db.cfgdb.get_table(FDB_SYNC_TABLE), (
+            "FDB_SYNC is expected to be absent from the mock CONFIG_DB"
+        )
+
+        result = runner.invoke(show.cli.commands["fdb"].commands["mac-sync-mode"], [], obj=db)
+        assert result.exit_code == 0, (
+            f"Got exit code {result.exit_code} - {result.output}, expected 0"
+        )
+        assert result.output.strip() == MAC_SYNC_MODE_DEFAULT, (
+            f"Found unexpected {MAC_SYNC_MODE_FIELD} {result.output.strip()}, "
+            f"expected the '{MAC_SYNC_MODE_DEFAULT}' default"
+        )
+
+    @pytest.mark.parametrize("mac_sync_mode", ["kernel", "fpm"])
+    def test_mac_sync_mode_show_configured(self, cli_db_connection, mac_sync_mode):
+        runner, db = cli_db_connection
+
+        config_result = runner.invoke(config.commands["fdb"].commands["mac-sync-mode"], [mac_sync_mode], obj=db)
+        assert config_result.exit_code == 0, (
+            f"Got exit code {config_result.exit_code} - {config_result.output}, expected 0"
+        )
+
+        result = runner.invoke(show.cli.commands["fdb"].commands["mac-sync-mode"], [], obj=db)
+        assert result.exit_code == 0, (
+            f"Got exit code {result.exit_code} - {result.output}, expected 0"
+        )
+        assert result.output.strip() == mac_sync_mode, (
+            f"Found unexpected {MAC_SYNC_MODE_FIELD} {result.output.strip()}, "
+            f"expected '{mac_sync_mode}'"
+        )


### PR DESCRIPTION
#### Why I did it

MAC (FDB) state can now be synchronized with FRR either through the Linux kernel
bridge FDB or directly over the FPM channel. Operators need a supported way to
select which transport is in use, and a way to roll back without reimaging.

#### How I did it

Add `config fdb mac-sync-mode <kernel|fpm>`, which writes
`FDB_SYNC|global mac_sync_mode`. The value is constrained to the two modes by
click, and the write goes through `ValidatedConfigDBConnector` so it is checked
against the YANG model.

The default is `kernel`, so behaviour is unchanged unless explicitly set.

#### How to verify it

```
make target/python-wheels/trixie/sonic_utilities-1.2-py3-none-any.whl
# 5409 passed
```

On a device:

```
config fdb mac-sync-mode fpm
config save -y
redis-cli -n 4 hgetall "FDB_SYNC|global"
```

Note that `config save -y` is required; without it the setting is lost on
reboot.

#### Dependency / merge order

Requires the `sonic-swss-common` FDB_SYNC schema PR to merge **first**, for
`CFG_FDB_SYNC_TABLE_NAME`.

#### Which release branch to backport

None requested at this time.

#### Tested branch

Built and tested against `sonic-net/sonic-buildimage` master.

#### Description for the changelog

Add `config fdb mac-sync-mode` to select how MAC state is synchronized with FRR.
