### PR TITLE
7060CX device state migration via upgrade

### DIFF
--- a/scripts/arista_7060_prefdl_gen.py
+++ b/scripts/arista_7060_prefdl_gen.py
@@ -1,0 +1,11 @@
+from arista.components.eeprom import I2cEeprom
+from arista.core.platform import loadPrerequisites
+from arista.core.types import I2cBus
+
+IDENT_BUS_NAME = 'SMBus PIIX4 adapter port 1 at 0b20'
+
+loadPrerequisites()
+eeprom = I2cEeprom(addr=I2cBus(IDENT_BUS_NAME).i2cAddr(0x52))
+eeprom.setup()
+pfdl = eeprom.readPrefdl()
+pfdl.writeToFile("/host/.system-prefdl")

--- a/scripts/arista_7060_prefdl_gen.py
+++ b/scripts/arista_7060_prefdl_gen.py
@@ -2,6 +2,15 @@ from arista.components.eeprom import I2cEeprom
 from arista.core.platform import loadPrerequisites
 from arista.core.types import I2cBus
 
+"""Read system information from EEPROM via I2C
+
+This script reads system information from the EEPROM via I2C.
+
+This script is only intended to be ran on Arista-7060-32S
+  devices on or before the SONiC 202605 release.
+"""
+
+
 IDENT_BUS_NAME = 'SMBus PIIX4 adapter port 1 at 0b20'
 
 loadPrerequisites()

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -360,6 +360,22 @@ function filter_asic_list()
     fi
 }
 
+# Create and populate /host/.system-prefdl if it does not already exist
+# Should only apply to Arista-7060CX-32S-*
+function arista_7060_gen_system_prefdl()
+{
+    HWSKU=$(show platform summary --json | python -c 'import sys, json; print(json.load(sys.stdin)["hwsku"])')
+    if [ ! -f "/host/.system-prefdl" ]; then
+        if [ -f "/etc/sonic/.syseeprom" ]; then
+            cp /etc/sonic/.syseeprom /host/.system-prefdl
+            echo "/host/.system-prefdl not found - restored from /etc/sonic/.syseeprom"
+        elif [[ "${HWSKU}" == *"Arista-7060CX-32S-"* ]]; then
+            python3 ${READ_ARISTA_7060_EEPROM_SCRIPT}
+            echo "/host/.system-prefdl not found - restored by reading from EEPROM"
+        fi
+    fi 
+}
+
 function clear_boot()
 {
     # common_clear
@@ -644,6 +660,7 @@ function is_secureboot() {
 function setup_reboot_variables()
 {
     # Kernel and initrd image
+    HWSKU=$(show platform summary --json | python -c 'import sys, json; print(json.load(sys.stdin)["hwsku"])')
     CURR_SONIC_IMAGE=$(sonic-installer list | grep "Current: " | cut -d ' ' -f 2)
     NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
     IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
@@ -969,18 +986,8 @@ fi
 
 debug "Starting $REBOOT_TYPE"
 
-# Create and populate /host/.system-prefdl if it does not already exist
-# Should only apply to Arista-7060CX-32S-*
-HWSKU=$(show platform summary --json | python -c 'import sys, json; print(json.load(sys.stdin)["hwsku"])')
-if [ ! -f "/host/.system-prefdl" ]; then
-    if [ -f "/etc/sonic/.syseeprom" ]; then
-        cp /etc/sonic/.syseeprom /host/.system-prefdl
-        echo "/host/.system-prefdl not found - restored from /etc/sonic/.syseeprom"
-    elif [[ "${HWSKU}" == *"Arista-7060CX-32S-"* ]]; then
-        python3 ${READ_ARISTA_7060_EEPROM_SCRIPT}
-        echo "/host/.system-prefdl not found - restored by reading from EEPROM"
-    fi
-fi
+# Check if device is Arista-7060CX-32S and if system_prefdl generation is needed
+arista_7060_gen_system_prefdl
 
 # re-run the script in background mode with detaching from the terminal session
 if [[ x"${DETACH}" == x"yes" && x"${ALREADY_DETACHED}" == x"" ]]; then

--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -19,6 +19,7 @@ REBOOT_METHOD="/sbin/kexec -e"
 ASSISTANT_IP_LIST=""
 ASSISTANT_SCRIPT="/usr/local/bin/neighbor_advertiser"
 LAG_KEEPALIVE_SCRIPT="/usr/local/bin/lag_keepalive.py"
+READ_ARISTA_7060_EEPROM_SCRIPT="/usr/local/bin/arista_7060_prefdl_gen.py"
 WATCHDOG_UTIL="/usr/local/bin/watchdogutil"
 SKIP_ASIC_LIST=""
 DEVPATH="/usr/share/sonic/device"
@@ -643,7 +644,6 @@ function is_secureboot() {
 function setup_reboot_variables()
 {
     # Kernel and initrd image
-    HWSKU=$(show platform summary --json | python -c 'import sys, json; print(json.load(sys.stdin)["hwsku"])')
     CURR_SONIC_IMAGE=$(sonic-installer list | grep "Current: " | cut -d ' ' -f 2)
     NEXT_SONIC_IMAGE=$(sonic-installer list | grep "Next: " | cut -d ' ' -f 2)
     IMAGE_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}"
@@ -968,6 +968,19 @@ EOF
 fi
 
 debug "Starting $REBOOT_TYPE"
+
+# Create and populate /host/.system-prefdl if it does not already exist
+# Should only apply to Arista-7060CX-32S-*
+HWSKU=$(show platform summary --json | python -c 'import sys, json; print(json.load(sys.stdin)["hwsku"])')
+if [ ! -f "/host/.system-prefdl" ]; then
+    if [ -f "/etc/sonic/.syseeprom" ]; then
+        cp /etc/sonic/.syseeprom /host/.system-prefdl
+        echo "/host/.system-prefdl not found - restored from /etc/sonic/.syseeprom"
+    elif [[ "${HWSKU}" == *"Arista-7060CX-32S-"* ]]; then
+        python3 ${READ_ARISTA_7060_EEPROM_SCRIPT}
+        echo "/host/.system-prefdl not found - restored by reading from EEPROM"
+    fi
+fi
 
 # re-run the script in background mode with detaching from the terminal session
 if [[ x"${DETACH}" == x"yes" && x"${ALREADY_DETACHED}" == x"" ]]; then


### PR DESCRIPTION
#### What I did
Some 7060 devices need to have the ability to migrate its device state to make it compatible with future Arista driver code.

This migration only applies to 7060CX devices that has warm-upgraded from the 201811 release.

#### How I did it
The migration ensures the file /host/.system-prefdl exists on the machine. This is done by either copying from a cache file, or reading directly from EEPROM.

#### How to verify it

The expected behavior occurs on each of the 3 below scenarios:
(1) /host/.system-prefdl exists
- no action

(2) /host/.system-prefdl does not exist, /etc/sonic/.syseeprom exists
- Copy /etc/sonic/.syseeprom to /host/.system-prefdl, it has been tested
  that it is ok to direct copy even if the contents are slighlty
  different.

(3) /host/.sytem-prefdl and /etc/sonic/.syseeprom does not exist:
- Generate a /host/.system-prefdl by reading directly from EEPROM

This logic was tested on the following images:
- 20260510.10 -> 20260510.13

#### Backport

Needs backport to 202605.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

