### PR TITLE
[generate_dump] Collect get_component_versions.py on the NVIDIA BMC

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -2255,6 +2255,8 @@ echo CT_TABLE_DUMP_ENABLE=true >> "$profile"
 ###############################################################################
 collect_nvidia_bmc_dump() {
     trap 'handle_error $? $LINENO' ERR
+    # Ahead of the early return taken when the hw-mgmt dump script is absent.
+    save_cmd "get_component_versions.py" "component_versions"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local HW_BMC_DUMP_FILE=/usr/bin/hw-management-bmc-generate-dump.sh
 


### PR DESCRIPTION
#### What I did

`collect_mellanox()` (`scripts/generate_dump:1630`) and `collect_nvidia_bluefield()` (`:2239`) both save `get_component_versions.py` output into the techsupport tarball as `component_versions`. `collect_nvidia_bmc_dump()` did not, so a BMC techsupport was missing a file its switch counterpart has.

That was correct until the tool reached the BMC in sonic-net/sonic-buildimage#29339, which added aspeed support and reports `HW_MANAGEMENT` and `KERNEL` there.

#### How I did it

```sh
     save_cmd "fwutil show status"  "fwutil.status"
     save_cmd "fwutil show version" "fwutil.version"
+    save_cmd "get_component_versions.py" "component_versions"
```

Placement is deliberate: the function returns early when `/usr/bin/hw-management-bmc-generate-dump.sh` is missing, so appending at the end of the function would make the capture hostage to that script's presence. It sits with the existing `fwutil` captures, whose comment already records that they precede the hw-management dump for exactly this reason.

The output filename matches the mellanox and BlueField paths, so tooling that reads `component_versions` works unchanged across platforms.

#### How to verify it

On an NVIDIA BMC:

```
# show techsupport
# tar tzf /var/dump/sonic_dump_<host>_<ts>.tar.gz | grep component_versions
```

`component_versions` should be present and contain the component/compilation/actual table.

**Manually tested** on an NVIDIA BMC (Aspeed AST2700) running an image built from the
202608 branch: after `show techsupport`, the tarball contains `component_versions` with
the `HW_MANAGEMENT` and `KERNEL` rows. Without this change the file is absent from a BMC
techsupport. On an image whose `get_component_versions.py` does not support the platform, `save_cmd` records the command failure and the dump completes normally — the same behaviour as any other `save_cmd` whose command is unavailable.

#### Backport

No community backport requested. The change is needed on a 202608-based branch, which is
not a community release branch here; it will arrive there through the normal merge from
master rather than a cherry-pick.

#### Previous command output (if the output of a command-line utility has changed)

N/A — no CLI output changes; this only adds a file to the techsupport tarball.

#### New command output (if the output of a command-line utility has changed)

N/A
