### PR TITLE
Add EFI Secure Boot variable read utility

### DIFF
--- a/scripts/efiread_var
+++ b/scripts/efiread_var
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+"""
+SONiC helper to read standard UEFI Secure Boot variables.
+
+This utility intentionally uses the Linux/UEFI runtime-service path:
+
+    efiread-var
+        -> efi-readvar
+        -> efivarfs
+        -> Linux EFI runtime subsystem
+        -> BIOS RuntimeServices->GetVariable()
+        -> firmware/platform implementation
+
+It does not use the SONiC Secure Boot backend selector or any
+platform-specific API such as Cisco TAM.
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+EFI_READVAR = "/usr/bin/efi-readvar"
+
+SUPPORTED_VARIABLES = (
+    "PK",
+    "KEK",
+    "db",
+)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read a UEFI Secure Boot variable using the standard "
+            "Linux EFI runtime-service path"
+        )
+    )
+
+    parser.add_argument(
+        "variable",
+        choices=SUPPORTED_VARIABLES,
+        help="Secure Boot variable to read: PK, KEK, or db",
+    )
+
+    return parser
+
+
+def read_efi_variable(variable):
+    """
+    Read a Secure Boot variable using efi-readvar.
+
+    Return the efi-readvar process exit status.
+    stdout/stderr are inherited so the native efitools output is
+    displayed unchanged.
+    """
+
+    if variable not in SUPPORTED_VARIABLES:
+        print(
+            "Error: unsupported EFI variable '{}'".format(variable),
+            file=sys.stderr,
+        )
+        return 2
+
+    if not os.path.exists(EFI_READVAR):
+        print(
+            "Error: {} is not installed".format(EFI_READVAR),
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        return subprocess.call(
+            [
+                EFI_READVAR,
+                "-v",
+                variable,
+            ]
+        )
+    except OSError as exc:
+        print(
+            "Error: failed to execute {}: {}".format(
+                EFI_READVAR,
+                exc,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    return read_efi_variable(args.variable)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -198,6 +198,7 @@ setup(
         'scripts/storm_control.py',
         'scripts/verify_image_sign.sh',
         'scripts/verify_image_sign_common.sh',
+        'scripts/efiread_var',
         'scripts/check_db_integrity.py',
         'scripts/sysreadyshow',
         'scripts/wredstat',

--- a/tests/test_efiread_var.py
+++ b/tests/test_efiread_var.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import os
+
+
+SCRIPT_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "scripts",
+    "efiread-var",
+)
+
+spec = importlib.util.spec_from_file_location(
+    "efiread_var",
+    SCRIPT_PATH,
+)
+
+efiread_var = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(efiread_var)
+
+
+def test_supported_variables():
+    assert efi_readvar.SUPPORTED_VARIABLES == (
+        "PK",
+        "KEK",
+        "db",
+    )
+
+
+def test_read_pk(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        efi_readvar.os.path,
+        "exists",
+        lambda path: True,
+    )
+
+    def mock_call(cmd):
+        calls.append(cmd)
+        return 0
+
+    monkeypatch.setattr(
+        efi_readvar.subprocess,
+        "call",
+        mock_call,
+    )
+
+    rc = efi_readvar.read_efi_variable("PK")
+
+    assert rc == 0
+    assert calls == [
+        ["/usr/bin/efi-readvar", "-v", "PK"]
+    ]
+
+
+def test_read_kek(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        efi_readvar.os.path,
+        "exists",
+        lambda path: True,
+    )
+
+    def mock_call(cmd):
+        calls.append(cmd)
+        return 0
+
+    monkeypatch.setattr(
+        efi_readvar.subprocess,
+        "call",
+        mock_call,
+    )
+
+    rc = efi_readvar.read_efi_variable("KEK")
+
+    assert rc == 0
+    assert calls == [
+        ["/usr/bin/efi-readvar", "-v", "KEK"]
+    ]
+
+
+def test_read_db(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        efi_readvar.os.path,
+        "exists",
+        lambda path: True,
+    )
+
+    def mock_call(cmd):
+        calls.append(cmd)
+        return 0
+
+    monkeypatch.setattr(
+        efi_readvar.subprocess,
+        "call",
+        mock_call,
+    )
+
+    rc = efi_readvar.read_efi_variable("db")
+
+    assert rc == 0
+    assert calls == [
+        ["/usr/bin/efi-readvar", "-v", "db"]
+    ]
+
+
+def test_unsupported_variable(capsys):
+    rc = efi_readvar.read_efi_variable("dbx")
+
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert "unsupported EFI variable" in captured.err
+
+
+def test_efi_readvar_missing(monkeypatch, capsys):
+    monkeypatch.setattr(
+        efi_readvar.os.path,
+        "exists",
+        lambda path: False,
+    )
+
+    rc = efi_readvar.read_efi_variable("PK")
+
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "/usr/bin/efi-readvar is not installed" in captured.err
+
+
+def test_efi_readvar_failure_propagated(monkeypatch):
+    monkeypatch.setattr(
+        efi_readvar.os.path,
+        "exists",
+        lambda path: True,
+    )
+
+    monkeypatch.setattr(
+        efi_readvar.subprocess,
+        "call",
+        lambda cmd: 1,
+    )
+
+    assert efi_readvar.read_efi_variable("PK") == 1
+
+
+def test_exec_failure(monkeypatch, capsys):
+    monkeypatch.setattr(
+        efi_readvar.os.path,
+        "exists",
+        lambda path: True,
+    )
+
+    def mock_call(cmd):
+        raise OSError("exec failed")
+
+    monkeypatch.setattr(
+        efi_readvar.subprocess,
+        "call",
+        mock_call,
+    )
+
+    rc = efi_readvar.read_efi_variable("PK")
+
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "failed to execute" in captured.err


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
#### What I did

Added a new SONiC utility, `efiread_var`, that reads the standard UEFI Secure Boot variables — **PK**, **KEK**, and **db** — directly from platform firmware.

The utility intentionally uses the standard Linux/UEFI runtime-service path:

```
efiread_var
    -> efi-readvar (efitools)
    -> efivarfs
    -> Linux EFI runtime subsystem
    -> BIOS RuntimeServices->GetVariable()
    -> firmware/platform implementation
```

It does **not** go through the SONiC Secure Boot backend selector or any platform-specific API (e.g. Cisco TAM). This gives the firmware's own UEFI-variable view of the enrolled Secure Boot keys in a vendor-neutral way, which is useful for verifying/debugging what the platform firmware actually has enrolled.

This is the **read-only** first step. Write/enroll support (updating PK/KEK/db, which requires authenticated variable writes) is intentionally out of scope for this PR and will be added in a follow-up.

#### How I did it

- Added `scripts/efiread_var`, a small Python wrapper that shells out to `/usr/bin/efi-readvar -v <PK|KEK|db>` and inherits its stdout/stderr so the native efitools output is shown unchanged.
- Restricted the accepted variables to `PK`, `KEK`, `db` via `argparse` choices.
- Added defensive handling with distinct exit codes:
  - `2` — unsupported variable requested
  - `1` — `efi-readvar` not installed, or `efi-readvar` failed to execute
  - otherwise the `efi-readvar` process exit status is propagated
- Registered the script in `setup.py` (`scripts` list).
- Added unit tests in `tests/test_efiread_var.py` covering: supported-variable read (PK/KEK/db) and the correct command invocation, unsupported variable, `efi-readvar` missing, non-zero exit propagation, and exec (`OSError`) failure.

#### How to verify it

Run the unit tests:

```
pytest tests/test_efiread_var.py
```

On a device with Secure Boot / efitools available:

```
# efiread_var PK
# efiread_var KEK
# efiread_var db
```

Negative cases:

```
# efiread_var dbx          # unsupported -> exit code 2
# efiread_var db           # with efi-readvar absent -> "is not installed", exit code 1
```

#### Previous command output (if the output of a command-line utility has changed)

N/A — this is a new command; there is no previous output.

#### New command output (if the output of a command-line utility has changed)

```
# efiread_var PK
Variable PK, length 837
PK: List of 1 X509 certificates
...
```

(Output is passed through unchanged from `efi-readvar`; actual contents depend on the platform's enrolled keys.)




